### PR TITLE
feat: default time entry tax region dropdowns appropriately + fixes

### DIFF
--- a/server/src/components/companies/CompanyTaxRates.tsx
+++ b/server/src/components/companies/CompanyTaxRates.tsx
@@ -32,7 +32,6 @@ const CompanyTaxRates: React.FC<CompanyTaxRatesProps> = ({
     onRemove
 }) => {
     const tableData: TaxRateTableData[] = companyTaxRates
-        .filter(companyTaxRate => companyTaxRate.company_tax_rate_id)
         .map((companyTaxRate): TaxRateTableData => {
             const taxRate = taxRates.find(tr => tr.tax_rate_id === companyTaxRate.tax_rate_id);
             return {

--- a/server/src/lib/actions/taxSettingsActions.ts
+++ b/server/src/lib/actions/taxSettingsActions.ts
@@ -264,7 +264,7 @@ export async function createDefaultTaxSettings(companyId: string): Promise<IComp
         tax_component_id,
         tax_rate_id: defaultTaxRate.tax_rate_id,
         name: 'Default Tax',
-        rate: (defaultTaxRate.tax_percentage * 100) as number,
+        rate: Math.ceil(defaultTaxRate.tax_percentage * 100),
         sequence: 1,
         is_compound: false,
         tenant: tenant!


### PR DESCRIPTION
- Auto-populate tax regions for tickets based on company defaults
- Fix tax region value to use name instead of ID in select options
- Correct tax rate calculation rounding
- Add comprehensive logging for tax rate fetching
- Remove unnecessary company tax rate filtering

"Under ze sea, ze taxes are better! Take it from me! Up on ze shore they work all day, calculating rates ze hard way, while we've got natural automation! 🦀 🐠 🐟"