### PR TITLE
feat: Add support for editing manual invoices

### DIFF
--- a/server/migrations/20250118150946_add_is_manual_to_invoices.cjs
+++ b/server/migrations/20250118150946_add_is_manual_to_invoices.cjs
@@ -1,0 +1,17 @@
+exports.up = async function(knex) {
+  await knex.schema.alterTable('invoices', (table) => {
+    table.boolean('is_manual').notNullable().defaultTo(false);
+  });
+
+  // Update existing manual invoices - identify them by checking if they have no billing_cycle_id
+  // and were created through the manual invoice process
+  await knex('invoices')
+    .whereNull('billing_cycle_id')
+    .update({ is_manual: true });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('invoices', (table) => {
+    table.dropColumn('is_manual');
+  });
+};

--- a/server/src/interfaces/invoice.interfaces.ts
+++ b/server/src/interfaces/invoice.interfaces.ts
@@ -14,6 +14,7 @@ export interface IInvoice extends TenantEntity {
   finalized_at?: Date | ISO8601String;
   credit_applied: number;
   billing_cycle_id?: string;
+  is_manual: boolean;
 }
 
 export interface IInvoiceItem extends TenantEntity {
@@ -235,4 +236,5 @@ export interface InvoiceViewModel {
   finalized_at?: Date;
   credit_applied: number;
   billing_cycle_id?: string;
+  is_manual: boolean;
 }

--- a/server/src/lib/actions/manualInvoiceActions.ts
+++ b/server/src/lib/actions/manualInvoiceActions.ts
@@ -57,7 +57,8 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
     subtotal: 0,
     tax: 0,
     total_amount: 0,
-    credit_applied: 0
+    credit_applied: 0,
+    is_manual: true
   };
 
   await knex.transaction(async (trx) => {
@@ -71,7 +72,7 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
         .where({ service_id: item.service_id })
         .first();
 
-      const netAmount = Math.ceil(item.quantity * item.rate);
+      const netAmount = Math.round(item.quantity * item.rate * 100); // Convert dollars to cents
       const taxCalculationResult = await taxService.calculateTax(
         companyId,
         netAmount,
@@ -85,8 +86,8 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
         service_id: item.service_id,
         description: item.description,
         quantity: item.quantity,
-        unit_price: item.rate,
-        net_amount: netAmount,
+        unit_price: Math.round(item.rate * 100), // Convert dollars to cents
+        net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
         tax_amount: taxCalculationResult.taxAmount,
         tax_region: service?.tax_region || company.tax_region,
         tax_rate: taxCalculationResult.taxRate,
@@ -151,12 +152,149 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
       service_id: item.service_id,
       description: item.description,
       quantity: item.quantity,
-      unit_price: item.rate,
-      total_price: Math.ceil(item.quantity * item.rate),
+      unit_price: Math.round(item.rate * 100), // Convert dollars to cents
+      total_price: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
       tax_amount: 0, // This should be calculated properly
-      net_amount: Math.ceil(item.quantity * item.rate),
+      net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
       tenant
     })),
-    credit_applied: 0
+    credit_applied: 0,
+    is_manual: true
+  };
+}
+
+export async function updateManualInvoice(
+  invoiceId: string,
+  request: ManualInvoiceRequest
+): Promise<InvoiceViewModel> {
+  const { knex, tenant } = await createTenantKnex();
+  const { companyId, items } = request;
+
+  if (!tenant) {
+    throw new Error('No tenant found');
+  }
+
+  // Verify invoice exists and is manual
+  const existingInvoice = await knex('invoices')
+    .where({ 
+      invoice_id: invoiceId,
+      is_manual: true 
+    })
+    .first();
+
+  if (!existingInvoice) {
+    throw new Error('Manual invoice not found');
+  }
+
+  // Get company details
+  const company = await knex('companies')
+    .where({ company_id: companyId })
+    .first();
+
+  if (!company) {
+    throw new Error('Company not found');
+  }
+
+  const taxService = new TaxService();
+  const currentDate = new Date().toISOString();
+  let subtotal = 0;
+  let totalTax = 0;
+
+  await knex.transaction(async (trx) => {
+    // Delete existing items
+    await trx('invoice_items')
+      .where({ invoice_id: invoiceId })
+      .delete();
+
+    // Process each line item
+    for (const item of items) {
+      const netAmount = Math.round(item.quantity * item.rate * 100); // Convert dollars to cents
+      const taxCalculationResult = await taxService.calculateTax(
+        companyId,
+        netAmount,
+        currentDate
+      );
+
+      const invoiceItem = {
+        item_id: uuidv4(),
+        invoice_id: invoiceId,
+        service_id: item.service_id,
+        description: item.description,
+        quantity: item.quantity,
+        unit_price: Math.round(item.rate * 100), // Convert dollars to cents
+        net_amount: netAmount,
+        tax_amount: taxCalculationResult.taxAmount,
+        tax_region: company.tax_region,
+        tax_rate: taxCalculationResult.taxRate,
+        total_price: netAmount + taxCalculationResult.taxAmount,
+        tenant
+      };
+
+      await trx('invoice_items').insert(invoiceItem);
+
+      subtotal += netAmount;
+      totalTax += taxCalculationResult.taxAmount;
+    }
+
+    // Update invoice with new totals
+    await trx('invoices')
+      .where({ invoice_id: invoiceId })
+      .update({
+        subtotal: Math.ceil(subtotal),
+        tax: Math.ceil(totalTax),
+        total_amount: Math.ceil(subtotal + totalTax),
+        updated_at: currentDate
+      });
+
+    // Record update transaction
+    await trx('transactions').insert({
+      transaction_id: uuidv4(),
+      company_id: companyId,
+      invoice_id: invoiceId,
+      amount: Math.ceil(subtotal + totalTax),
+      type: 'invoice_adjustment',
+      status: 'completed',
+      description: `Updated manual invoice ${existingInvoice.invoice_number}`,
+      created_at: currentDate,
+      tenant,
+      balance_after: Math.ceil(subtotal + totalTax)
+    });
+  });
+
+  // Return updated invoice view model
+  return {
+    invoice_id: invoiceId,
+    invoice_number: existingInvoice.invoice_number,
+    company_id: companyId,
+    company: {
+      name: company.company_name,
+      logo: company.logo || '',
+      address: company.address || ''
+    },
+    contact: {
+      name: '',
+      address: ''
+    },
+    invoice_date: existingInvoice.invoice_date,
+    due_date: existingInvoice.due_date,
+    status: existingInvoice.status,
+    subtotal: Math.ceil(subtotal),
+    tax: Math.ceil(totalTax),
+    total: Math.ceil(subtotal + totalTax),
+    total_amount: Math.ceil(subtotal + totalTax),
+    invoice_items: items.map((item): IInvoiceItem => ({
+      item_id: uuidv4(),
+      invoice_id: invoiceId,
+      service_id: item.service_id,
+      description: item.description,
+      quantity: item.quantity,
+      unit_price: Math.round(item.rate * 100), // Convert dollars to cents
+      total_price: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
+      tax_amount: 0,
+      net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
+      tenant
+    })),
+    credit_applied: existingInvoice.credit_applied,
+    is_manual: true
   };
 }

--- a/server/src/lib/models/invoice.ts
+++ b/server/src/lib/models/invoice.ts
@@ -80,10 +80,11 @@ export default class Invoice {
     const query = knex('invoice_items')
       .select(
         'invoice_id',
+        'service_id',
         'description as name',
         'description',
         'quantity',
-        'unit_price',
+        knex.raw('unit_price::float / 100 as unit_price'), // Convert cents to dollars
         'total_price',
         'tax_amount',
         'net_amount')
@@ -258,7 +259,8 @@ export default class Invoice {
       })),
       custom_fields: invoice.custom_fields,
       finalized_at: invoice.finalized_at,
-      credit_applied: invoice.credit_applied || 0
+      credit_applied: invoice.credit_applied || 0,
+      is_manual: invoice.is_manual,
     };
   }
 


### PR DESCRIPTION
This commit adds functionality to edit manually created invoices, including:

- Added `is_manual` flag to invoices table to identify manual invoices
- Added UI controls to edit manual invoices in the billing dashboard
- Implemented backend support for updating existing manual invoices
- Fixed currency handling by storing amounts in cents consistently
- Added proper type definitions and interfaces for manual invoices
- Improved error handling and validation for invoice operations

This change allows users to modify previously created manual invoices while maintaining proper audit trails and data consistency.

Because 'oops' shouldn't be a permanent state in your billing system 🎭