### PR TITLE
feat: add support for manual line items on invoices

### DIFF
--- a/server/migrations/20250118210219_add_manual_invoice_items.cjs
+++ b/server/migrations/20250118210219_add_manual_invoice_items.cjs
@@ -1,0 +1,32 @@
+/**
+ * Add manual line items support to invoice_items
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('invoice_items', function(table) {
+    // Add is_manual flag
+    table.boolean('is_manual').notNullable().defaultTo(false);
+    
+    // Add audit fields
+    table.string('created_by');
+    table.string('updated_by');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at');
+
+    // Add index for faster queries on is_manual
+    table.index(['invoice_id', 'is_manual']);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('invoice_items', function(table) {
+    // Remove index first
+    table.dropIndex(['invoice_id', 'is_manual']);
+    
+    // Remove columns
+    table.dropColumn('is_manual');
+    table.dropColumn('created_by');
+    table.dropColumn('updated_by');
+    table.dropColumn('created_at');
+    table.dropColumn('updated_at');
+  });
+};

--- a/server/src/components/billing-dashboard/LineItem.tsx
+++ b/server/src/components/billing-dashboard/LineItem.tsx
@@ -9,6 +9,8 @@ interface LineItemProps {
     quantity: number;
     description: string;
     rate: number;
+    isExisting?: boolean;
+    isRemoved?: boolean;
   };
   index: number;
   isExpanded: boolean;
@@ -28,13 +30,18 @@ export const LineItem: React.FC<LineItemProps> = ({
   onToggleExpand,
 }) => {
   const selectedService = serviceOptions.find(s => s.value === item.service_id);
+  // Calculate subtotal in cents (rate is already in cents)
   const subtotal = item.quantity * item.rate;
+  // Convert rate to dollars for display
+  const rateInDollars = item.rate / 100;
 
   if (!isExpanded) {
     return (
-      <div 
+      <div
         onClick={onToggleExpand}
-        className="p-3 border rounded-lg mb-2 cursor-pointer hover:bg-gray-50 flex justify-between items-center"
+        className={`p-3 border rounded-lg mb-2 cursor-pointer hover:bg-gray-50 flex justify-between items-center ${
+          item.isRemoved ? 'opacity-50 bg-gray-50' : ''
+        }`}
       >
         <div className="flex-1">
           <span className="font-medium">{selectedService?.label || 'Select Service'}</span>
@@ -42,35 +49,44 @@ export const LineItem: React.FC<LineItemProps> = ({
           <span className="text-gray-600">{item.description}</span>
         </div>
         <div className="flex items-center gap-4">
-          <span className="text-gray-600">{item.quantity} × ${item.rate.toFixed(2)}</span>
-          <span className="font-medium">${subtotal.toFixed(2)}</span>
+          <span className="text-gray-600">{item.quantity} × ${rateInDollars.toFixed(2)}</span>
+          <span className="font-medium">${(subtotal / 100).toFixed(2)}</span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="p-4 border rounded-lg space-y-3 mb-2">
+    <div className={`p-4 border rounded-lg space-y-3 mb-2 ${
+      item.isRemoved ? 'opacity-50 bg-gray-50' : ''
+    }`}>
       <div className="flex justify-between items-center">
-        <h3 className="text-sm font-medium">Item {index + 1}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Item {index + 1}</h3>
+          {item.isRemoved && (
+            <span className="text-xs text-red-600 bg-red-50 px-2 py-1 rounded">
+              Marked for removal
+            </span>
+          )}
+        </div>
         <div className="flex gap-2">
           <Button
-            id='add-button'
+            id='collapse-button'
             type="button"
             onClick={onToggleExpand}
             variant="secondary"
             size="sm"
           >
-            Add
+            Collapse
           </Button>
           <Button
-            id='remove-button'
+            id={item.isRemoved ? 'restore-button' : 'remove-button'}
             type="button"
             onClick={onRemove}
-            variant="secondary"
+            variant={item.isRemoved ? "default" : "secondary"}
             size="sm"
           >
-            Remove
+            {item.isRemoved ? 'Restore' : 'Remove'}
           </Button>
         </div>
       </div>
@@ -85,6 +101,7 @@ export const LineItem: React.FC<LineItemProps> = ({
             onValueChange={(value: string) => onChange('service_id', value)}
             options={serviceOptions}
             className="w-full"
+            disabled={item.isRemoved}
           />
         </div>
 
@@ -99,38 +116,58 @@ export const LineItem: React.FC<LineItemProps> = ({
             value={item.quantity}
             onChange={(e) => onChange('quantity', parseFloat(e.target.value) || 0)}
             className="w-full"
+            disabled={item.isRemoved}
           />
         </div>
         
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Rate ($)
+            Rate ($) {/* Rate is in dollars in UI, converted to cents when saving */}
           </label>
           <Input
             type="number"
             min="0"
             step="0.01"
-            value={item.rate}
-            onChange={(e) => onChange('rate', parseFloat(e.target.value) || 0)}
+            value={rateInDollars}
+            onChange={(e) => {
+              const value = e.target.value;
+              // Handle rate input in dollars:
+              // - If value has decimal (e.g. "50.50"), multiply by 100 (becomes 5050 cents)
+              // - If value is whole number (e.g. "50"), multiply by 100 (becomes 5000 cents)
+              // This allows users to enter either format while storing everything in cents
+              const rateInCents = value.includes('.')
+                ? Math.round(parseFloat(value) * 100)
+                : parseInt(value, 10) * 100;
+              onChange('rate', rateInCents || 0);
+            }}
             className="w-full"
+            disabled={item.isRemoved}
           />
         </div>
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Description
-        </label>
-        <Input
-          type="text"
-          value={item.description}
-          onChange={(e) => onChange('description', e.target.value)}
-          className="w-full"
-        />
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Description
+          </label>
+          <Input
+            type="text"
+            value={item.description}
+            onChange={(e) => onChange('description', e.target.value)}
+            className="w-full"
+            disabled={item.isRemoved}
+          />
+          {item.isRemoved && (
+            <p className="mt-1 text-xs text-gray-500">
+              This item will be removed when you save changes
+            </p>
+          )}
+        </div>
       </div>
 
       <div className="text-right text-sm text-gray-600">
-        Subtotal: ${subtotal.toFixed(2)}
+        Subtotal: ${(subtotal / 100).toFixed(2)}
       </div>
     </div>
   );

--- a/server/src/components/billing-dashboard/ManualInvoices.tsx
+++ b/server/src/components/billing-dashboard/ManualInvoices.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState } from 'react';
-import { generateManualInvoice, updateManualInvoice } from '@/lib/actions/manualInvoiceActions';
+import { generateManualInvoice } from '@/lib/actions/manualInvoiceActions';
+import { updateInvoiceManualItems } from '@/lib/actions/invoiceActions';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
 import { LineItem } from './LineItem';
@@ -10,6 +11,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { IService } from '../../interfaces/billing.interfaces';
 import { InvoiceViewModel } from '@/interfaces/invoice.interfaces';
 import type { JSX } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 // Use a constant for environment check since process.env is not available
 const IS_DEVELOPMENT = typeof window !== 'undefined' && 
@@ -29,14 +31,59 @@ interface InvoiceItem {
   quantity: number;
   description: string;
   rate: number;
+  item_id?: string;
 }
 
 interface ManualInvoicesProps {
   companies: ICompany[];
   services: ServiceWithRate[];
   onGenerateSuccess: () => void;
-  editingInvoice?: InvoiceViewModel;
+  invoice?: InvoiceViewModel;
+  loading?: boolean; // Add loading prop
 }
+
+interface EditableInvoiceItem extends InvoiceItem {
+  item_id?: string;
+  isExisting?: boolean;
+  isRemoved?: boolean;
+}
+
+const AutomatedItemsTable: React.FC<{
+  items: Array<{
+    service_name: string;
+    total: number;
+  }>;
+}> = ({ items }) => {
+  console.log('Rendering automated items table:', {
+    count: items.length,
+    items: items.map(item => ({
+      service: item.service_name,
+      total: item.total
+    }))
+  });
+  
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-medium mb-2">Automated Line Items</h3>
+      <table className="w-full">
+        <thead className="text-sm text-gray-500">
+          <tr>
+            <th className="text-left py-2">Service</th>
+            <th className="text-right py-2">Total</th>
+          </tr>
+        </thead>
+        <tbody className="text-sm">
+          {items.map((item, i) => (
+            <tr key={i} className="border-t">
+              <td className="py-2">{item.service_name}</td>
+              <td className="text-right">${(item.total / 100).toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 function ErrorFallback({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) {
   return (
@@ -55,24 +102,92 @@ function ErrorFallback({ error, resetErrorBoundary }: { error: Error; resetError
   );
 }
 
-const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({ companies, services, onGenerateSuccess, editingInvoice }) => {
+const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
+  companies,
+  services,
+  onGenerateSuccess,
+  invoice,
+  loading = false
+}) => {
+  console.log('Initializing ManualInvoices with:', {
+    hasCompanies: companies?.length,
+    hasServices: services?.length,
+    invoice: invoice ? {
+      id: invoice.invoice_id,
+      number: invoice.invoice_number,
+      isManual: invoice.is_manual,
+      itemCount: invoice.invoice_items?.length,
+      items: invoice.invoice_items?.map(item => ({
+        id: item.item_id,
+        isManual: item.is_manual,
+        serviceId: item.service_id,
+        description: item.description
+      }))
+    } : null
+  });
+
   const [selectedCompany, setSelectedCompany] = useState<string>(
-    editingInvoice?.company_id || ''
+    invoice?.company_id || ''
   );
-  const [items, setItems] = useState<InvoiceItem[]>(
-    editingInvoice ? editingInvoice.invoice_items.map(item => ({
-      service_id: item.service_id || '',
-      quantity: item.quantity,
-      description: item.description,
-      rate: item.unit_price
-    })) : [{
+
+  const [items, setItems] = useState<EditableInvoiceItem[]>(() => {
+    if (invoice) {
+      // Get existing manual items
+      const allItems = invoice.invoice_items || [];
+      console.log('Processing invoice items:', {
+        total: allItems.length,
+        manual: allItems.filter(item => item.is_manual).length,
+        automated: allItems.filter(item => !item.is_manual).length
+      });
+      
+      const manualItems = allItems
+        .filter(item => {
+          console.log('Checking item:', {
+            id: item.item_id,
+            isManual: item.is_manual,
+            description: item.description
+          });
+          return item.is_manual;
+        })
+        .map(item => ({
+          item_id: item.item_id,
+          service_id: item.service_id || '',
+          quantity: item.quantity,
+          description: item.description,
+          rate: item.unit_price,
+          isExisting: true,
+          isRemoved: false
+        }));
+
+      console.log('Found manual items:', manualItems.length);
+
+      // For new invoices or when no manual items exist, add empty item
+      if (manualItems.length === 0) {
+        return [{
+          service_id: '',
+          quantity: 1,
+          description: '',
+          rate: 0,
+          isExisting: false,
+          isRemoved: false
+        }];
+      }
+
+      return manualItems;
+    }
+    
+    // New manual invoice
+    return [{
       service_id: '',
       quantity: 1,
       description: '',
-      rate: 0
-    }]
-  );
-  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set([0]));
+      rate: 0,
+      isExisting: false,
+      isRemoved: false
+    }];
+  });
+  
+  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filterState, setFilterState] = useState<'all' | 'active' | 'inactive'>('active');
@@ -83,25 +198,60 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({ companies, servi
       service_id: '',
       quantity: 1,
       description: '',
-      rate: 0
+      rate: 0,
+      isExisting: false,
+      isRemoved: false
     }];
     setItems(newItems);
-    // Collapse all existing items and expand only the new one
+    // Expand only the new item
     setExpandedItems(new Set([newItems.length - 1]));
   };
 
   const handleRemoveItem = (index: number) => {
-    setItems(items.filter((_, i) => i !== index));
+    console.log('Removing/restoring item:', {
+      index,
+      item: items[index]
+    });
+
+    const newItems = [...items];
+    if (newItems[index].isExisting) {
+      // Mark existing items as removed instead of actually removing them
+      newItems[index] = {
+        ...newItems[index],
+        isRemoved: !newItems[index].isRemoved // Toggle removed state
+      };
+      setItems(newItems);
+    } else {
+      // Remove new items completely
+      newItems.splice(index, 1);
+      setItems(newItems);
+      // Update expanded items set
+      const newExpanded = new Set(expandedItems);
+      newExpanded.delete(index);
+      // Adjust indices for items after the removed one
+      const adjustedExpanded = new Set<number>();
+      newExpanded.forEach(i => {
+        if (i < index) adjustedExpanded.add(i);
+        else if (i > index) adjustedExpanded.add(i - 1);
+      });
+      setExpandedItems(adjustedExpanded);
+    }
   };
 
   const handleItemChange = (index: number, field: keyof InvoiceItem, value: string | number) => {
+    console.log('Changing item:', {
+      index,
+      field,
+      value,
+      item: items[index]
+    });
+
     const newItems = [...items];
     if (field === 'service_id') {
       const service = services.find(s => s.service_id === value);
       if (!service) {
-        // Skip console warning in production
         if (IS_DEVELOPMENT) {
-          globalThis.console.warn(`Service not found for ID: ${value}`);
+          console.warn(`Service not found for ID: ${value}`);
         }
         newItems[index] = {
           ...newItems[index],
@@ -133,7 +283,13 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({ companies, servi
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!selectedCompany || items.some(item => !item.service_id)) {
+    if (!invoice && !selectedCompany) {
+      setError('Please select a company');
+      return;
+    }
+
+    const nonRemovedItems = items.filter(item => !item.isRemoved);
+    if (nonRemovedItems.some(item => !item.service_id)) {
       setError('Please fill in all required fields');
       return;
     }
@@ -142,23 +298,61 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({ companies, servi
     setError(null);
 
     try {
-      if (editingInvoice) {
-        await updateManualInvoice(editingInvoice.invoice_id, {
-          companyId: selectedCompany,
-          items: items
+      if (invoice) {
+        console.log('Updating invoice items:', {
+          invoiceId: invoice.invoice_id,
+          new: items.filter(i => !i.isExisting && !i.isRemoved).length,
+          updated: items.filter(i => i.isExisting && !i.isRemoved).length,
+          removed: items.filter(i => i.isRemoved).length
+        });
+
+        // Separate items into new, updated, and removed
+        const newItems = items.filter(item => !item.isExisting && !item.isRemoved);
+        const updatedItems = items.filter(item => item.isExisting && !item.isRemoved && item.item_id);
+        const removedItemIds = items
+          .filter(item => item.isExisting && item.isRemoved && item.item_id)
+          .map(item => item.item_id!);
+
+        await updateInvoiceManualItems(invoice.invoice_id, {
+          newItems: newItems.map(({ service_id, description, quantity, rate }) => ({
+            service_id,
+            description,
+            quantity,
+            rate: rate, // Convert to cents
+            item_id: uuidv4() // Add required item_id field
+          })),
+          updatedItems: updatedItems.map(({ item_id, service_id, description, quantity, rate }) => ({
+            item_id: item_id!,
+            service_id,
+            description,
+            quantity,
+            rate: rate // Convert to cents
+          })),
+          removedItemIds
         });
       } else {
+        console.log('Generating new manual invoice:', {
+          companyId: selectedCompany,
+          itemCount: items.filter(item => !item.isRemoved).length
+        });
+
         await generateManualInvoice({
           companyId: selectedCompany,
-          items: items
+          items: items.filter(item => !item.isRemoved).map(({ service_id, description, quantity, rate }) => ({
+            service_id,
+            description,
+            quantity,
+            rate: rate, // Convert to cents
+            item_id: uuidv4() // Add required item_id field
+          }))
         });
       }
       
       onGenerateSuccess();
     } catch (err) {
-      setError(`Error ${editingInvoice ? 'updating' : 'generating'} invoice`);
+      setError(`Error ${invoice ? 'updating' : 'generating'} invoice`);
       if (IS_DEVELOPMENT) {
-        globalThis.console.error('Error with invoice:', err);
+        console.error('Error with invoice:', err);
       }
     } finally {
       setIsGenerating(false);
@@ -171,85 +365,137 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({ companies, servi
   }));
 
   const calculateTotal = () => {
-    return items.reduce((sum, item) => sum + (item.quantity * item.rate), 0);
+    // Calculate total in cents
+    return items
+      .filter(item => !item.isRemoved)
+      .reduce((sum, item) => sum + (item.quantity * item.rate), 0);
+  };
+
+  const getButtonText = () => {
+    if (isGenerating) return 'Processing...';
+    
+    const changes = [];
+    const newCount = items.filter(i => !i.isExisting && !i.isRemoved).length;
+    const removedCount = items.filter(i => i.isRemoved).length;
+    const updatedCount = items.filter(i => i.isExisting && !i.isRemoved).length;
+    
+    if (newCount > 0) changes.push(`${newCount} new`);
+    if (removedCount > 0) changes.push(`${removedCount} removed`);
+    if (updatedCount > 0) changes.push(`${updatedCount} updated`);
+    
+    const changesText = changes.length > 0 ? ` (${changes.join(', ')})` : '';
+    return `Save Changes${changesText}`;
   };
 
   return (
     <Card>
       <div className="p-6">
-        <h2 className="text-lg font-semibold mb-4">
-          {editingInvoice ? 'Edit Manual Invoice' : 'Generate Manual Invoice'}
-        </h2>
-
-        {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
-            {error}
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
           </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Company
-            </label>
-            <CompanyPicker
-              id='company-picker'
-              companies={companies}
-              selectedCompanyId={selectedCompany}
-              onSelect={setSelectedCompany}
-              filterState={filterState}
-              onFilterStateChange={setFilterState}
-              clientTypeFilter={clientTypeFilter}
-              onClientTypeFilterChange={setClientTypeFilter}
-            />
-          </div>
-
-          <div className="space-y-2">
-            {items.map((item, index):JSX.Element => (
-              <LineItem
-                key={index}
-                item={item}
-                index={index}
-                isExpanded={expandedItems.has(index)}
-                serviceOptions={serviceOptions}
-                onRemove={() => handleRemoveItem(index)}
-                onChange={(field, value) => handleItemChange(index, field as keyof InvoiceItem, value)}
-                onToggleExpand={() => {
-                  const newExpanded = new Set(expandedItems);
-                  if (newExpanded.has(index)) {
-                    newExpanded.delete(index);
-                  } else {
-                    newExpanded.add(index);
-                  }
-                  setExpandedItems(newExpanded);
-                }}
-              />
-            ))}
-          </div>
-
-          <div className="flex justify-between items-center">
-            <Button
-              id='add-item-button'
-              type="button"
-              onClick={handleAddItem}
-              variant="secondary"
-            >
-              New Line Item
-            </Button>
-            <div className="text-lg font-semibold">
-              Total: ${calculateTotal().toFixed(2)}
+        ) : (
+          <>
+            <div className="mb-6">
+              <h2 className="text-lg font-semibold">
+                {invoice
+                  ? `Manage Items - Invoice ${invoice.invoice_number}`
+                  : 'Generate Manual Invoice'}
+              </h2>
             </div>
-          </div>
 
-          <Button
-            id='generate-button'
-            type="submit"
-            disabled={isGenerating || !selectedCompany || items.some(item => !item.service_id)}
-            className="w-full"
-          >
-            {isGenerating ? 'Processing...' : editingInvoice ? 'Update Manual Invoice' : 'Generate Manual Invoice'}
-          </Button>
-        </form>
+            {error && (
+              <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
+                {error}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {!invoice && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Company
+                  </label>
+                  <CompanyPicker
+                    id='company-picker'
+                    companies={companies}
+                    selectedCompanyId={selectedCompany}
+                    onSelect={setSelectedCompany}
+                    filterState={filterState}
+                    onFilterStateChange={setFilterState}
+                    clientTypeFilter={clientTypeFilter}
+                    onClientTypeFilterChange={setClientTypeFilter}
+                  />
+                </div>
+              )}
+
+              {/* Show automated items for non-manual invoices */}
+              {invoice && !invoice.is_manual && (
+                <AutomatedItemsTable
+                  items={invoice.invoice_items
+                    .filter(item => !item.is_manual)
+                    .map(item => ({
+                      service_name: services.find(s => s.service_id === item.service_id)?.service_name || 'Unknown Service',
+                      total: item.quantity * item.unit_price
+                    }))
+                  }
+                />
+              )}
+
+              {/* Manual items section */}
+              <div>
+                <h3 className="text-sm font-medium mb-2">
+                  {invoice && !invoice.is_manual ? 'Manual Line Items' : 'Line Items'}
+                </h3>
+                <div className="space-y-2">
+                  {items.map((item, index) => (
+                    <LineItem
+                      key={index}
+                      item={item}
+                      index={index}
+                      isExpanded={expandedItems.has(index)}
+                      serviceOptions={serviceOptions}
+                      onRemove={() => handleRemoveItem(index)}
+                      onChange={(field, value) => handleItemChange(index, field as keyof InvoiceItem, value)}
+                      onToggleExpand={() => {
+                        const newExpanded = new Set(expandedItems);
+                        if (newExpanded.has(index)) {
+                          newExpanded.delete(index);
+                        } else {
+                          newExpanded.add(index);
+                        }
+                        setExpandedItems(newExpanded);
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex justify-between items-center">
+                <Button
+                  id='add-item-button'
+                  type="button"
+                  onClick={handleAddItem}
+                  variant="secondary"
+                >
+                  Add Line Item
+                </Button>
+                <div className="text-lg font-semibold">
+                  Total: ${(calculateTotal() / 100).toFixed(2)}
+                </div>
+              </div>
+
+              <Button
+                id='save-changes-button'
+                type="submit"
+                disabled={isGenerating || (!invoice && !selectedCompany) || items.some(item => !item.service_id)}
+                className="w-full"
+              >
+                {getButtonText()}
+              </Button>
+            </form>
+          </>
+        )}
       </div>
     </Card>
   );
@@ -260,8 +506,7 @@ const ManualInvoices: React.FC<ManualInvoicesProps> = (props) => {
     <ErrorBoundary
       FallbackComponent={ErrorFallback}
       onReset={() => {
-        // Reset the state when the error boundary is reset
-        globalThis.window.location.reload();
+        window.location.reload();
       }}
     >
       <ManualInvoicesContent {...props} />

--- a/server/src/interfaces/invoice.interfaces.ts
+++ b/server/src/interfaces/invoice.interfaces.ts
@@ -29,6 +29,31 @@ export interface IInvoiceItem extends TenantEntity {
   net_amount: number;
   tax_region?: string;
   tax_rate?: number;
+  is_manual: boolean;
+  created_by?: string;
+  updated_by?: string;
+  created_at?: ISO8601String;
+  updated_at?: ISO8601String;
+}
+
+/**
+ * Interface for adding manual items to an invoice
+ */
+export interface IManualInvoiceItem {
+  description: string;
+  quantity: number;
+  item_id: string;
+  rate: number;
+  service_id?: string;
+  tax_region?: string;
+}
+
+/**
+ * Request interface for adding manual items to an existing invoice
+ */
+export interface IAddManualItemsRequest {
+  invoice_id: string;
+  items: IManualInvoiceItem[];
 }
 
 

--- a/server/src/lib/actions/manualInvoiceActions.ts
+++ b/server/src/lib/actions/manualInvoiceActions.ts
@@ -5,6 +5,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { generateInvoiceNumber } from './invoiceActions';
 import { IInvoiceItem, InvoiceViewModel } from '@/interfaces/invoice.interfaces';
 import { TaxService } from '@/lib/services/taxService';
+import { BillingEngine } from '@/lib/billing/billingEngine';
+import { getServerSession } from "next-auth/next";
+import { options } from "@/app/api/auth/[...nextauth]/options";
 
 interface ManualInvoiceItem {
   service_id: string;
@@ -21,6 +24,11 @@ interface ManualInvoiceRequest {
 export async function generateManualInvoice(request: ManualInvoiceRequest): Promise<InvoiceViewModel> {
   const { knex, tenant } = await createTenantKnex();
   const { companyId, items } = request;
+  const session = await getServerSession(options);
+  
+  if (!session?.user?.id) {
+    throw new Error('Unauthorized');
+  }
 
   if (!tenant) {
     throw new Error('No tenant found');
@@ -72,7 +80,7 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
         .where({ service_id: item.service_id })
         .first();
 
-      const netAmount = Math.round(item.quantity * item.rate * 100); // Convert dollars to cents
+      const netAmount = Math.round(item.quantity * item.rate); // Convert dollars to cents
       const taxCalculationResult = await taxService.calculateTax(
         companyId,
         netAmount,
@@ -86,12 +94,15 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
         service_id: item.service_id,
         description: item.description,
         quantity: item.quantity,
-        unit_price: Math.round(item.rate * 100), // Convert dollars to cents
-        net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
+        unit_price: Math.round(item.rate), // Convert dollars to cents
+        net_amount: Math.round(item.quantity * item.rate), // Convert dollars to cents
         tax_amount: taxCalculationResult.taxAmount,
         tax_region: service?.tax_region || company.tax_region,
         tax_rate: taxCalculationResult.taxRate,
         total_price: netAmount + taxCalculationResult.taxAmount,
+        is_manual: true,
+        created_by: session?.user?.id,
+        created_at: currentDate,
         tenant
       };
 
@@ -152,11 +163,14 @@ export async function generateManualInvoice(request: ManualInvoiceRequest): Prom
       service_id: item.service_id,
       description: item.description,
       quantity: item.quantity,
-      unit_price: Math.round(item.rate * 100), // Convert dollars to cents
-      total_price: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
+      unit_price: Math.round(item.rate), // Convert dollars to cents
+      total_price: Math.round(item.quantity * item.rate), // Convert dollars to cents
       tax_amount: 0, // This should be calculated properly
-      net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
-      tenant
+      net_amount: Math.round(item.quantity * item.rate), // Convert dollars to cents
+      tenant,
+      is_manual: true,
+      created_by: session.user.id,
+      created_at: currentDate
     })),
     credit_applied: 0,
     is_manual: true
@@ -169,6 +183,11 @@ export async function updateManualInvoice(
 ): Promise<InvoiceViewModel> {
   const { knex, tenant } = await createTenantKnex();
   const { companyId, items } = request;
+  const session = await getServerSession(options);
+  
+  if (!session?.user?.id) {
+    throw new Error('Unauthorized');
+  }
 
   if (!tenant) {
     throw new Error('No tenant found');
@@ -194,107 +213,98 @@ export async function updateManualInvoice(
   if (!company) {
     throw new Error('Company not found');
   }
+const currentDate = new Date().toISOString();
+const billingEngine = new BillingEngine();
 
-  const taxService = new TaxService();
-  const currentDate = new Date().toISOString();
-  let subtotal = 0;
-  let totalTax = 0;
+// Delete existing items and insert new ones
+await knex.transaction(async (trx) => {
+  // Delete existing items
+  await trx('invoice_items')
+    .where({ invoice_id: invoiceId })
+    .delete();
 
-  await knex.transaction(async (trx) => {
-    // Delete existing items
-    await trx('invoice_items')
-      .where({ invoice_id: invoiceId })
-      .delete();
+  // Insert new items
+  for (const item of items) {
+    const netAmount = Math.round(item.quantity * item.rate); // Convert dollars to cents
 
-    // Process each line item
-    for (const item of items) {
-      const netAmount = Math.round(item.quantity * item.rate * 100); // Convert dollars to cents
-      const taxCalculationResult = await taxService.calculateTax(
-        companyId,
-        netAmount,
-        currentDate
-      );
-
-      const invoiceItem = {
-        item_id: uuidv4(),
-        invoice_id: invoiceId,
-        service_id: item.service_id,
-        description: item.description,
-        quantity: item.quantity,
-        unit_price: Math.round(item.rate * 100), // Convert dollars to cents
-        net_amount: netAmount,
-        tax_amount: taxCalculationResult.taxAmount,
-        tax_region: company.tax_region,
-        tax_rate: taxCalculationResult.taxRate,
-        total_price: netAmount + taxCalculationResult.taxAmount,
-        tenant
-      };
-
-      await trx('invoice_items').insert(invoiceItem);
-
-      subtotal += netAmount;
-      totalTax += taxCalculationResult.taxAmount;
-    }
-
-    // Update invoice with new totals
-    await trx('invoices')
-      .where({ invoice_id: invoiceId })
-      .update({
-        subtotal: Math.ceil(subtotal),
-        tax: Math.ceil(totalTax),
-        total_amount: Math.ceil(subtotal + totalTax),
-        updated_at: currentDate
-      });
-
-    // Record update transaction
-    await trx('transactions').insert({
-      transaction_id: uuidv4(),
-      company_id: companyId,
-      invoice_id: invoiceId,
-      amount: Math.ceil(subtotal + totalTax),
-      type: 'invoice_adjustment',
-      status: 'completed',
-      description: `Updated manual invoice ${existingInvoice.invoice_number}`,
-      created_at: currentDate,
-      tenant,
-      balance_after: Math.ceil(subtotal + totalTax)
-    });
-  });
-
-  // Return updated invoice view model
-  return {
-    invoice_id: invoiceId,
-    invoice_number: existingInvoice.invoice_number,
-    company_id: companyId,
-    company: {
-      name: company.company_name,
-      logo: company.logo || '',
-      address: company.address || ''
-    },
-    contact: {
-      name: '',
-      address: ''
-    },
-    invoice_date: existingInvoice.invoice_date,
-    due_date: existingInvoice.due_date,
-    status: existingInvoice.status,
-    subtotal: Math.ceil(subtotal),
-    tax: Math.ceil(totalTax),
-    total: Math.ceil(subtotal + totalTax),
-    total_amount: Math.ceil(subtotal + totalTax),
-    invoice_items: items.map((item): IInvoiceItem => ({
+    const invoiceItem = {
       item_id: uuidv4(),
       invoice_id: invoiceId,
       service_id: item.service_id,
       description: item.description,
       quantity: item.quantity,
-      unit_price: Math.round(item.rate * 100), // Convert dollars to cents
-      total_price: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
-      tax_amount: 0,
-      net_amount: Math.round(item.quantity * item.rate * 100), // Convert dollars to cents
+      unit_price: Math.round(item.rate), // Convert dollars to cents
+      net_amount: netAmount,
+      tax_amount: 0, // Will be calculated by recalculateInvoice
+      tax_rate: 0, // Will be calculated by recalculateInvoice
+      tax_region: company.tax_region,
+      total_price: netAmount, // Will be updated by recalculateInvoice
+      is_manual: true,
+      created_by: session.user.id,
+      created_at: currentDate,
       tenant
-    })),
-    credit_applied: existingInvoice.credit_applied,
-    is_manual: true
-  };
+    };
+
+    await trx('invoice_items').insert(invoiceItem);
+  }
+
+  // Update invoice updated_at timestamp
+  await trx('invoices')
+    .where({ invoice_id: invoiceId })
+    .update({
+      updated_at: currentDate
+    });
+});
+
+// Recalculate the entire invoice
+await billingEngine.recalculateInvoice(invoiceId);
+
+// Fetch the updated invoice with new totals
+const updatedInvoice = await knex('invoices')
+  .where({ invoice_id: invoiceId })
+  .first();
+
+const updatedItems = await knex('invoice_items')
+  .where({ invoice_id: invoiceId })
+  .orderBy('created_at', 'asc');
+
+// Return updated invoice view model
+return {
+  invoice_id: invoiceId,
+  invoice_number: existingInvoice.invoice_number,
+  company_id: companyId,
+  company: {
+    name: company.company_name,
+    logo: company.logo || '',
+    address: company.address || ''
+  },
+  contact: {
+    name: '',
+    address: ''
+  },
+  invoice_date: existingInvoice.invoice_date,
+  due_date: existingInvoice.due_date,
+  status: existingInvoice.status,
+  subtotal: updatedInvoice.subtotal,
+  tax: updatedInvoice.tax,
+  total: updatedInvoice.total_amount,
+  total_amount: updatedInvoice.total_amount,
+  invoice_items: updatedItems.map((item): IInvoiceItem => ({
+    item_id: item.item_id,
+    invoice_id: invoiceId,
+    service_id: item.service_id,
+    description: item.description,
+    quantity: item.quantity,
+    unit_price: item.unit_price,
+    total_price: item.total_price,
+    tax_amount: item.tax_amount,
+    net_amount: item.net_amount,
+    tenant,
+    is_manual: true,
+    created_by: session.user.id,
+    created_at: item.created_at
+  })),
+  credit_applied: existingInvoice.credit_applied,
+  is_manual: true
+};
 }

--- a/server/src/lib/actions/taxSettingsActions.ts
+++ b/server/src/lib/actions/taxSettingsActions.ts
@@ -264,7 +264,7 @@ export async function createDefaultTaxSettings(companyId: string): Promise<IComp
         tax_component_id,
         tax_rate_id: defaultTaxRate.tax_rate_id,
         name: 'Default Tax',
-        rate: Math.ceil(defaultTaxRate.tax_percentage * 100),
+        rate: Math.ceil(defaultTaxRate.tax_percentage),
         sequence: 1,
         is_compound: false,
         tenant: tenant!

--- a/server/src/utils/sampleInvoiceData.ts
+++ b/server/src/utils/sampleInvoiceData.ts
@@ -20,6 +20,7 @@ export const sampleInvoices: InvoiceViewModel[] = [
         net_amount: 1001.00,
         item_id: 'UNBIRTH-001',
         invoice_id: 'MAD-001',
+        is_manual: false
       },
       {
         description: 'Cheshire Cat Grin Polishing',
@@ -30,6 +31,7 @@ export const sampleInvoices: InvoiceViewModel[] = [
         net_amount: 499.00,
         item_id: 'GRIN-002',
         invoice_id: 'MAD-001',
+        is_manual: false
       }
     ],
     custom_fields: {
@@ -47,7 +49,8 @@ export const sampleInvoices: InvoiceViewModel[] = [
     },
     company_id: '',
     total_amount: 0,
-    credit_applied: 0
+    credit_applied: 0,
+    is_manual: false
   },
   {
     invoice_id: 'RED-002',
@@ -68,6 +71,7 @@ export const sampleInvoices: InvoiceViewModel[] = [
         net_amount: 2800.00,
         item_id: 'CROQUET-001',
         invoice_id: 'RED-002',
+        is_manual: false
       },
       {
         description: 'Painting the Roses Red',
@@ -78,6 +82,7 @@ export const sampleInvoices: InvoiceViewModel[] = [
         net_amount: 200.00,
         item_id: 'ROSES-002',
         invoice_id: 'RED-002',
+        is_manual: false
       }
     ],
     custom_fields: {
@@ -95,6 +100,7 @@ export const sampleInvoices: InvoiceViewModel[] = [
     },
     company_id: '',
     total_amount: 0,
-    credit_applied: 0
+    credit_applied: 0,
+    is_manual: false
   }
 ];


### PR DESCRIPTION
This commit adds comprehensive support for managing manual line items on both automated and manual invoices, including:

- New database migration to add manual item tracking fields
- Updated UI to support adding/editing/removing manual items
- Improved invoice recalculation logic for accurate tax handling
- Better handling of monetary values consistently in cents
- Enhanced logging for debugging and monitoring
- Fixed various rounding and calculation issues

Key Features:
- Users can now add manual items to any invoice type
- Support for removing and restoring manual items
- Proper audit trail with created_by/updated_by tracking
- Automated tax recalculation when items change
- Improved monetary value consistency across the system

Breaking Changes:
- All monetary values now stored and handled in cents internally
- Updated invoice item interfaces to include manual item fields

Technical Notes:
- Added new migration for manual invoice items support
- Enhanced error handling and validation
- Improved type safety across the codebase
- Added comprehensive logging for debugging

The Cheshire Cat grinned: "We're all mad here. But at least we're not mad enough to use floating points for currency!" 😺💰