### PR TITLE
feat: Add support for invoice discounts

### DIFF
--- a/server/migrations/20250119202505_add_discount_fields_to_invoice_items.cjs
+++ b/server/migrations/20250119202505_add_discount_fields_to_invoice_items.cjs
@@ -1,0 +1,32 @@
+/**
+ * Add discount support to invoice items
+ */
+exports.up = async function(knex) {
+  await knex.schema.alterTable('invoice_items', table => {
+    // Add discount-specific columns
+    table.boolean('is_discount').defaultTo(false);
+    table.enum('discount_type', ['percentage', 'fixed']).nullable();
+    table.uuid('applies_to_item_id')
+      .nullable();
+    
+    // Add foreign key that references both tenant and item_id
+    table.foreign(['tenant', 'applies_to_item_id'])
+      .references(['tenant', 'item_id'])
+      .inTable('invoice_items')
+      .onDelete('SET NULL');
+
+    // Add index for better query performance on common filters
+    table.index(['is_discount', 'invoice_id', 'tenant']);
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('invoice_items', table => {
+    table.dropIndex(['is_discount', 'invoice_id', 'tenant']);
+    // Drop the foreign key constraint before dropping the column
+    table.dropForeign(['tenant', 'applies_to_item_id']);
+    table.dropColumn('applies_to_item_id');
+    table.dropColumn('discount_type');
+    table.dropColumn('is_discount');
+  });
+};

--- a/server/migrations/20250119232202_add_discount_percentage_to_invoice_items.cjs
+++ b/server/migrations/20250119232202_add_discount_percentage_to_invoice_items.cjs
@@ -1,0 +1,17 @@
+/**
+ * Add discount_percentage field to invoice_items table
+ * This separates the storage of percentage values from monetary values in unit_price
+ */
+exports.up = async function(knex) {
+  await knex.schema.alterTable('invoice_items', table => {
+    // Add discount_percentage column as numeric to properly store percentage values
+    // Nullable since it's only used for percentage-type discounts
+    table.decimal('discount_percentage', 10, 4).nullable();
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('invoice_items', table => {
+    table.dropColumn('discount_percentage');
+  });
+};

--- a/server/src/components/billing-dashboard/LineItem.tsx
+++ b/server/src/components/billing-dashboard/LineItem.tsx
@@ -1,56 +1,202 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import CustomSelect, { SelectOption } from '../ui/CustomSelect';
+import { DiscountType } from '@/interfaces/invoice.interfaces';
+
+// Extend SelectOption to include rate
+interface ServiceOption extends SelectOption {
+  rate?: number;
+}
+
+interface EditableItem {
+  service_id: string;
+  quantity: number;
+  description: string;
+  rate: number;
+  item_id?: string;
+  isExisting?: boolean;
+  isRemoved?: boolean;
+  is_discount?: boolean;
+  discount_type?: DiscountType;
+  discount_percentage?: number;
+  applies_to_item_id?: string;
+}
 
 interface LineItemProps {
-  item: {
-    service_id: string;
-    quantity: number;
-    description: string;
-    rate: number;
-    isExisting?: boolean;
-    isRemoved?: boolean;
-  };
+  item: EditableItem;
   index: number;
   isExpanded: boolean;
   serviceOptions: SelectOption[];
+  invoiceItems?: Array<{ item_id: string; description: string }>;
   onRemove: () => void;
-  onChange: (field: string, value: string | number) => void;
+  onChange: (updatedItem: EditableItem) => void;
   onToggleExpand: () => void;
 }
+
+const discountTypeOptions: SelectOption[] = [
+  { value: 'percentage', label: 'Percentage' },
+  { value: 'fixed', label: 'Fixed Amount' }
+];
 
 export const LineItem: React.FC<LineItemProps> = ({
   item,
   index,
   isExpanded,
   serviceOptions,
+  invoiceItems,
   onRemove,
   onChange,
   onToggleExpand,
 }) => {
-  const selectedService = serviceOptions.find(s => s.value === item.service_id);
-  // Calculate subtotal in cents (rate is already in cents)
-  const subtotal = item.quantity * item.rate;
-  // Convert rate to dollars for display
-  const rateInDollars = item.rate / 100;
+  // Internal state for editing
+  const [editState, setEditState] = useState<EditableItem>(() => ({
+    ...item,
+    // For discounts, ensure we have valid initial state
+    discount_type: item.is_discount ? (item.discount_type || 'fixed') : undefined,
+    discount_percentage: item.discount_percentage
+  }));
+
+  // Reset edit state when item changes
+  useEffect(() => {
+    setEditState({
+      ...item,
+      discount_type: item.is_discount ? (item.discount_type || 'fixed') : undefined,
+      discount_percentage: item.discount_percentage
+    });
+  }, [item]);
+
+  const selectedService = serviceOptions.find(s => s.value === editState.service_id) as ServiceOption | undefined;
+  
+  // Calculate subtotal
+  let subtotal = editState.quantity * editState.rate;
+  
+  // For percentage discounts, we don't calculate a monetary value here
+  // since it will be calculated by the billing engine based on the total
+  if (editState.is_discount && editState.discount_type === 'percentage') {
+    subtotal = 0; // The actual amount will be calculated server-side
+  }
+
+  // Convert rate to dollars for display (only for non-percentage discounts)
+  const rateInDollars = editState.rate / 100;
+
+  // Handle local state changes
+  const handleLocalChange = (field: keyof EditableItem, value: string | number | boolean | undefined) => {
+    setEditState(prev => {
+      const newState = { ...prev } as EditableItem;
+      
+      switch (field) {
+        case 'discount_type':
+          newState.discount_type = value as DiscountType;
+          // Reset values when switching discount types
+          if (value === 'percentage') {
+            // When switching to percentage, initialize with current rate if it's a valid percentage
+            const currentRate = Math.abs(prev.rate);
+            newState.discount_percentage = currentRate > 0 && currentRate <= 100 ? currentRate : 0;
+            newState.rate = 0;
+          } else {
+            // When switching to fixed, convert percentage to monetary value if possible
+            const currentPercentage = prev.discount_percentage;
+            newState.discount_percentage = undefined;
+            newState.rate = currentPercentage ? -(currentPercentage / 100) : 0;
+          }
+          break;
+        case 'service_id': {
+          newState.service_id = value as string;
+          const service = serviceOptions.find(s => s.value === value) as ServiceOption;
+          if (service?.rate !== undefined) {
+            newState.rate = service.rate;
+            newState.description = service.label.toString();
+          }
+        }
+          break;
+        case 'quantity':
+          newState.quantity = value as number;
+          break;
+        case 'rate': {
+          const numericValue = value as number;
+          newState.rate = newState.is_discount ? -Math.abs(numericValue) : numericValue;
+          break;
+        }
+        case 'discount_percentage':
+          newState.discount_percentage = value as number;
+          break;
+        case 'description':
+        case 'applies_to_item_id':
+          newState[field] = value as string;
+          break;
+        case 'is_discount':
+          newState.is_discount = value as boolean;
+          if (value) {
+            newState.discount_type = 'fixed';
+            newState.rate = 0;
+          } else {
+            newState.discount_type = undefined;
+            newState.discount_percentage = undefined;
+            newState.rate = Math.abs(newState.rate);
+          }
+          break;
+      }
+
+      return newState;
+    });
+  };
+
+  // Save changes when collapsing
+  const handleCollapse = () => {
+    onChange(editState);
+    onToggleExpand();
+  };
 
   if (!isExpanded) {
     return (
       <div
         onClick={onToggleExpand}
         className={`p-3 border rounded-lg mb-2 cursor-pointer hover:bg-gray-50 flex justify-between items-center ${
-          item.isRemoved ? 'opacity-50 bg-gray-50' : ''
-        }`}
+          editState.isRemoved ? 'opacity-50 bg-gray-50' : ''
+        } ${editState.is_discount ? 'border-blue-200 bg-blue-50' : ''}`}
       >
         <div className="flex-1">
-          <span className="font-medium">{selectedService?.label || 'Select Service'}</span>
-          <span className="mx-2 text-gray-400">|</span>
-          <span className="text-gray-600">{item.description}</span>
+          {editState.is_discount ? (
+            <>
+              <span className="font-medium text-blue-600">
+                {editState.applies_to_item_id ? 'Item Discount' : 'Invoice Discount'}
+              </span>
+              <span className="mx-2 text-gray-400">|</span>
+              <span className="text-gray-600">
+                {editState.discount_type === 'percentage' 
+                  ? `${editState.discount_percentage}%` 
+                  : `$${(Math.abs(editState.rate) / 100).toFixed(2)}`}
+                {editState.applies_to_item_id && (
+                  <>
+                    <span className="mx-2 text-gray-400">|</span>
+                    <span>Applied to: {invoiceItems?.find(i => i.item_id === editState.applies_to_item_id)?.description}</span>
+                  </>
+                )}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="font-medium">{selectedService?.label || 'Select Service'}</span>
+              <span className="mx-2 text-gray-400">|</span>
+              <span className="text-gray-600">{editState.description}</span>
+            </>
+          )}
         </div>
         <div className="flex items-center gap-4">
-          <span className="text-gray-600">{item.quantity} × ${rateInDollars.toFixed(2)}</span>
-          <span className="font-medium">${(subtotal / 100).toFixed(2)}</span>
+          {!editState.is_discount && (
+            <span className="text-gray-600">{editState.quantity} × ${rateInDollars.toFixed(2)}</span>
+          )}
+          <span className="font-medium">
+            {editState.discount_type === 'percentage'
+              ? `${editState.discount_percentage || 0}%`
+              : `$${Math.abs(subtotal / 100).toFixed(2)}`}
+          </span>
+          {editState.discount_type === 'percentage' && (
+            <span className="text-sm text-gray-500 ml-1">
+              (calculated on save)
+            </span>
+          )}
         </div>
       </div>
     );
@@ -58,12 +204,14 @@ export const LineItem: React.FC<LineItemProps> = ({
 
   return (
     <div className={`p-4 border rounded-lg space-y-3 mb-2 ${
-      item.isRemoved ? 'opacity-50 bg-gray-50' : ''
-    }`}>
+      editState.isRemoved ? 'opacity-50 bg-gray-50' : ''
+    } ${editState.is_discount ? 'border-blue-200 bg-blue-50' : ''}`}>
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium">Item {index + 1}</h3>
-          {item.isRemoved && (
+          <h3 className="text-sm font-medium">
+            {editState.is_discount ? 'Discount' : `Item ${index + 1}`}
+          </h3>
+          {editState.isRemoved && (
             <span className="text-xs text-red-600 bg-red-50 px-2 py-1 rounded">
               Marked for removal
             </span>
@@ -71,103 +219,225 @@ export const LineItem: React.FC<LineItemProps> = ({
         </div>
         <div className="flex gap-2">
           <Button
-            id='collapse-button'
+            id='collapse-line-item-button'
             type="button"
-            onClick={onToggleExpand}
+            onClick={handleCollapse}
             variant="secondary"
             size="sm"
           >
             Collapse
           </Button>
           <Button
-            id={item.isRemoved ? 'restore-button' : 'remove-button'}
+            id={editState.isRemoved ? 'restore-line-item-button' : 'remove-line-item-button'}
             type="button"
             onClick={onRemove}
-            variant={item.isRemoved ? "default" : "secondary"}
+            variant={editState.isRemoved ? "default" : "secondary"}
             size="sm"
           >
-            {item.isRemoved ? 'Restore' : 'Remove'}
+            {editState.isRemoved ? 'Restore' : 'Remove'}
           </Button>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Service
-          </label>
-          <CustomSelect
-            value={item.service_id}
-            onValueChange={(value: string) => onChange('service_id', value)}
-            options={serviceOptions}
-            className="w-full"
-            disabled={item.isRemoved}
-          />
-        </div>
+        {!editState.is_discount ? (
+          // Regular line item fields
+          <>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Service
+              </label>
+              <CustomSelect
+                id='service-select'
+                value={editState.service_id}
+                onValueChange={(value) => handleLocalChange('service_id', value)}
+                options={serviceOptions}
+                className="w-full"
+                disabled={editState.isRemoved}
+              />
+            </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Quantity
-          </label>
-          <Input
-            type="number"
-            min="0.01"
-            step="0.01"
-            value={item.quantity}
-            onChange={(e) => onChange('quantity', parseFloat(e.target.value) || 0)}
-            className="w-full"
-            disabled={item.isRemoved}
-          />
-        </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Quantity
+              </label>
+              <Input
+                id='quantity-input'
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={editState.quantity}
+                onChange={(e) => handleLocalChange('quantity', parseFloat(e.target.value) || 0)}
+                className="w-full"
+                disabled={editState.isRemoved}
+              />
+            </div>
+          </>
+        ) : (
+          // Discount fields
+          <>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Discount Type
+              </label>
+              <CustomSelect
+                id='discount-type-select'
+                value={editState.discount_type || 'fixed'}
+                onValueChange={(value) => handleLocalChange('discount_type', value)}
+                options={discountTypeOptions}
+                className="w-full"
+                disabled={editState.isRemoved}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {editState.discount_type === 'percentage' ? 'Percentage' : 'Amount ($)'}
+              </label>
+              <Input
+                id='discount-value-input'
+                type="number"
+                min="0"
+                step={editState.discount_type === 'percentage' ? '1' : '0.01'}
+                max={editState.discount_type === 'percentage' ? '100' : undefined}
+                value={editState.discount_type === 'percentage' 
+                  ? editState.discount_percentage || 0
+                  : rateInDollars}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (editState.discount_type === 'percentage') {
+                    const percentage = parseFloat(value) || 0;
+                    handleLocalChange('discount_percentage', Math.min(Math.max(percentage, 0), 100));
+                    // Set rate to 0 since we're using discount_percentage for calculations
+                    handleLocalChange('rate', 0);
+                  } else {
+                    const rateInCents = value.includes('.')
+                      ? Math.round(parseFloat(value) * 100)
+                      : parseInt(value, 10) * 100;
+                    handleLocalChange('rate', -Math.abs(rateInCents || 0));
+                    // Clear discount_percentage when using fixed amount
+                    handleLocalChange('discount_percentage', undefined);
+                  }
+                }}
+                className="w-full"
+                disabled={editState.isRemoved}
+              />
+            </div>
+          </>
+        )}
         
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Rate ($) {/* Rate is in dollars in UI, converted to cents when saving */}
-          </label>
-          <Input
-            type="number"
-            min="0"
-            step="0.01"
-            value={rateInDollars}
-            onChange={(e) => {
-              const value = e.target.value;
-              // Handle rate input in dollars:
-              // - If value has decimal (e.g. "50.50"), multiply by 100 (becomes 5050 cents)
-              // - If value is whole number (e.g. "50"), multiply by 100 (becomes 5000 cents)
-              // This allows users to enter either format while storing everything in cents
-              const rateInCents = value.includes('.')
-                ? Math.round(parseFloat(value) * 100)
-                : parseInt(value, 10) * 100;
-              onChange('rate', rateInCents || 0);
-            }}
-            className="w-full"
-            disabled={item.isRemoved}
-          />
-        </div>
+        {editState.is_discount ? (
+          <>
+            <div className="col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Discount Description
+              </label>
+              <Input
+                id='discount-description-input'
+                type="text"
+                value={editState.description}
+                onChange={(e) => handleLocalChange('description', e.target.value)}
+                className="w-full"
+                disabled={editState.isRemoved}
+                placeholder="e.g., Early Payment Discount"
+              />
+            </div>
+
+            {invoiceItems && invoiceItems.length > 0 && (
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Apply Discount To
+                </label>
+                <CustomSelect
+                  id='applies-to-item-select'
+                  value={editState.applies_to_item_id || 'INVOICE'}
+                  onValueChange={(value) => {
+                    const applies_to_item_id = value === 'INVOICE' ? undefined : value;
+                    handleLocalChange('applies_to_item_id', applies_to_item_id || '');
+                  }}
+                  options={[
+                    { value: 'INVOICE', label: 'Entire Invoice' },
+                    ...invoiceItems.map(item => ({
+                      value: item.item_id,
+                      label: item.description
+                    }))
+                  ]}
+                  className="w-full"
+                  disabled={editState.isRemoved}
+                />
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="col-span-1">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Rate ($)
+            </label>
+            <Input
+              id='rate-input'
+              type="number"
+              min="0"
+              step="0.01"
+              value={rateInDollars}
+              onChange={(e) => {
+                const value = e.target.value;
+                const rateInCents = value.includes('.')
+                  ? Math.round(parseFloat(value) * 100)
+                  : parseInt(value, 10) * 100;
+                handleLocalChange('rate', rateInCents || 0);
+              }}
+              className="w-full"
+              disabled={editState.isRemoved}
+            />
+          </div>
+        )}
       </div>
 
-      <div>
+      {!editState.is_discount && (
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Description
           </label>
           <Input
+            id='description-input'
             type="text"
-            value={item.description}
-            onChange={(e) => onChange('description', e.target.value)}
+            value={editState.description}
+            onChange={(e) => handleLocalChange('description', e.target.value)}
             className="w-full"
-            disabled={item.isRemoved}
+            disabled={editState.isRemoved}
           />
-          {item.isRemoved && (
+          {editState.isRemoved && (
             <p className="mt-1 text-xs text-gray-500">
               This item will be removed when you save changes
             </p>
           )}
         </div>
-      </div>
+      )}
 
       <div className="text-right text-sm text-gray-600">
-        Subtotal: ${(subtotal / 100).toFixed(2)}
+        {editState.is_discount ? (
+          <>
+            <span className="text-blue-600 font-medium">
+              {editState.discount_type === 'percentage' ? 'Percentage Discount' : 'Fixed Discount'}
+            </span>
+            <span className="mx-2">|</span>
+            <span>
+              {editState.discount_type === 'percentage'
+                ? `${editState.discount_percentage || 0}% of ${editState.applies_to_item_id ? 'item' : 'invoice'} total`
+                : `Amount: -$${(Math.abs(subtotal) / 100).toFixed(2)}`}
+              {editState.applies_to_item_id && (
+                <>
+                  <span className="mx-2">|</span>
+                  <span className="text-gray-500">
+                    Applied to: {invoiceItems?.find(i => i.item_id === editState.applies_to_item_id)?.description}
+                  </span>
+                </>
+              )}
+            </span>
+          </>
+        ) : (
+          <>Subtotal: ${(subtotal / 100).toFixed(2)}</>
+        )}
       </div>
     </div>
   );

--- a/server/src/interfaces/invoice.interfaces.ts
+++ b/server/src/interfaces/invoice.interfaces.ts
@@ -30,11 +30,17 @@ export interface IInvoiceItem extends TenantEntity {
   tax_region?: string;
   tax_rate?: number;
   is_manual: boolean;
+  is_discount?: boolean;
+  discount_type?: DiscountType;
+  discount_percentage?: number;
+  applies_to_item_id?: string;
   created_by?: string;
   updated_by?: string;
   created_at?: ISO8601String;
   updated_at?: ISO8601String;
 }
+
+export type DiscountType = 'percentage' | 'fixed';
 
 /**
  * Interface for adding manual items to an invoice
@@ -46,6 +52,10 @@ export interface IManualInvoiceItem {
   rate: number;
   service_id?: string;
   tax_region?: string;
+  is_discount?: boolean;
+  discount_type?: DiscountType;
+  discount_percentage?: number;
+  applies_to_item_id?: string;
 }
 
 /**
@@ -55,7 +65,6 @@ export interface IAddManualItemsRequest {
   invoice_id: string;
   items: IManualInvoiceItem[];
 }
-
 
 export type BlockType = 'text' | 'dynamic' | 'image';
 
@@ -212,18 +221,10 @@ export interface IInvoiceDesignerState {
 
 export interface IConditionalRule {
   rule_id: string;
-  condition: string; // This could be a complex type for advanced conditions
+  condition: string;
   action: 'show' | 'hide' | 'format';
-  target: string; // Field or section to apply the action to
-  format?: any; // Formatting options if action is 'format'
-}
-export interface IInvoiceAnnotation {
-  annotation_id: string;
-  invoice_id: string;
-  user_id: string;
-  content: string;
-  is_internal: boolean;
-  created_at: Date;
+  target: string;
+  format?: any;
 }
 
 export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled' | 'pending' | 'prepayment' | 'partially_applied';

--- a/server/src/lib/models/invoice.ts
+++ b/server/src/lib/models/invoice.ts
@@ -3,6 +3,7 @@
 import { createTenantKnex } from '../db';
 import { IInvoice, IInvoiceItem, IInvoiceTemplate, LayoutSection, ICustomField, IConditionalRule, IInvoiceAnnotation, InvoiceViewModel } from '../../interfaces/invoice.interfaces';
 import { format } from 'date-fns';
+import { is } from 'date-fns/locale';
 
 export default class Invoice {
   static async create(invoice: Omit<IInvoice, 'invoice_id' | 'tenant'>): Promise<IInvoice> {
@@ -86,6 +87,7 @@ export default class Invoice {
         'service_id',
         'description as name',
         'description',
+        'is_discount',
         knex.raw('CAST(quantity AS INTEGER) as quantity'),
         knex.raw('CAST(unit_price AS INTEGER) as unit_price'),
         knex.raw('CAST(total_price AS INTEGER) as total_price'),
@@ -133,7 +135,7 @@ export default class Invoice {
         isManual: item.is_manual,
         serviceId: item.service_id,
         description: item.description,
-        unitPrice: item.unit_price
+        unitPrice: item.unit_price,
       }))
     });
 


### PR DESCRIPTION
This change enables users to add both percentage and fixed-amount discounts to invoices, either applying to specific line items or the entire invoice.

Key changes:
- Add discount fields to invoice_items table
- Support both percentage and fixed-amount discounts
- Update billing engine to handle discount calculations
- Add UI controls for adding and managing discounts
- Preserve original percentages for percentage-based discounts
- Ensure proper tax handling (discounts are not taxed)

Technical details:
- Added is_discount, discount_type, and discount_percentage fields
- Added applies_to_item_id for item-specific discounts
- Updated BillingEngine to process discounts after regular items
- Enhanced recalculation logic to handle percentage discounts

👑 "Off with their prices!" declared the Queen of Hearts. "But maybe just 10% off," whispered the White Rabbit sensibly 🐇