### PR TITLE
fix: invoice rendering loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ cli
 prod.config.ini
 secrets/
 .clinerules
+data/

--- a/server/src/services/pdf-generation.service.ts
+++ b/server/src/services/pdf-generation.service.ts
@@ -3,7 +3,7 @@ import puppeteer from 'puppeteer';
 import type { Browser, Page } from 'puppeteer';
 import { FileStore } from '../types/storage';
 import { getInvoiceForRendering, getInvoiceTemplates } from '../lib/actions/invoiceActions';
-import { TemplateRenderer } from '../components/billing-dashboard/TemplateRenderer';
+import { renderTemplateCore } from '../components/billing-dashboard/TemplateRendererCore';
 import React from 'react';
 
 interface PDFGenerationOptions {
@@ -62,12 +62,16 @@ export class PDFGenerationService {
       throw new Error('No invoice templates found');
     }
 
-    // Render template directly using server component
-    const fullHtml = await TemplateRenderer({
-      template,
-      invoiceId
-    });
-    return fullHtml;
+    // Render template using core renderer
+    const rendered = renderTemplateCore(template, invoiceData);
+    return `
+      <html>
+        <head>
+          <style>${rendered.styles}</style>
+        </head>
+        <body>${rendered.html}</body>
+      </html>
+    `;
   }
 
   private async generatePDFBuffer(content: string): Promise<Uint8Array> {


### PR DESCRIPTION
feat: add PDF generation for invoices

- Add PDF generation service using Puppeteer
- Implement server-side template rendering for PDF export
- Add PDF download option to invoice actions menu
- Add metadata support to storage service
- Update TemplateRenderer to support server-side rendering
- Add getCurrentUser integration for storage operations

The changes enable PDF generation and download for invoices using the existing template system, rendered server-side with Puppeteer. Includes necessary storage service updates and improved error handling.

wip

fix: invoice rendering loops