### PR TITLE
feat: Add company-specific invoice template selection

### DIFF
--- a/server/migrations/20250130181441_add_invoice_template_selection.cjs
+++ b/server/migrations/20250130181441_add_invoice_template_selection.cjs
@@ -1,0 +1,27 @@
+exports.up = async function(knex) {
+  // Add unique constraint to ensure only one default template per tenant
+  await knex.raw(`
+    CREATE UNIQUE INDEX unique_default_template_per_tenant
+    ON invoice_templates (tenant)
+    WHERE is_default = true
+  `);
+
+  await knex.schema.alterTable('companies', table => {
+    table.uuid('invoice_template_id').nullable();
+    table.foreign(['tenant', 'invoice_template_id'])
+      .references(['tenant', 'template_id'])
+      .inTable('invoice_templates')
+      .onDelete('SET NULL');
+  });
+};
+
+exports.down = async function(knex) {
+  await knex.schema.alterTable('companies', table => {
+    table.dropForeign(['tenant', 'invoice_template_id']);
+    table.dropColumn('invoice_template_id');
+  });
+
+  await knex.raw(`
+    DROP INDEX IF EXISTS unique_default_template_per_tenant
+  `);
+};

--- a/server/src/components/billing-dashboard/InvoiceTemplates.tsx
+++ b/server/src/components/billing-dashboard/InvoiceTemplates.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card, CardHeader, CardContent } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { getInvoiceTemplates, saveInvoiceTemplate } from '@/lib/actions/invoiceActions';
+import { getInvoiceTemplates, saveInvoiceTemplate, setDefaultTemplate } from '@/lib/actions/invoiceActions';
 import { IInvoiceTemplate } from '@/interfaces/invoice.interfaces';
 import InvoiceTemplateManager from './InvoiceTemplateManager';
 import CustomSelect from '../ui/CustomSelect';
@@ -29,6 +29,17 @@ const InvoiceTemplates: React.FC = () => {
     } catch (error) {
       console.error('Error cloning template:', error);
       setError('Failed to clone template');
+    }
+  };
+
+  const handleSetDefaultTemplate = async (template: IInvoiceTemplate) => {
+    try {
+      await setDefaultTemplate(template.template_id);
+      await fetchTemplates();
+      setError(null);
+    } catch (error) {
+      console.error('Error setting default template:', error);
+      setError('Failed to set default template');
     }
   };
 
@@ -85,7 +96,11 @@ const InvoiceTemplates: React.FC = () => {
                       {template.isStandard ? (
                         <><FileTextIcon className="w-4 h-4" /> {template.name} (Standard)</>
                       ) : (
-                        <><GearIcon className="w-4 h-4" /> {template.name}</>
+                        <div className="flex items-center gap-1">
+                          <GearIcon className="w-4 h-4" /> 
+                          {template.name}
+                          {template.is_default && <span className="text-blue-500">(Default)</span>}
+                        </div>
                       )}
                     </div>
                   )
@@ -96,14 +111,27 @@ const InvoiceTemplates: React.FC = () => {
               />
             </div>
             {selectedTemplate && (
-              <Button
-                id='clone-template-button'
-                onClick={() => handleCloneTemplate(selectedTemplate)}
-                variant="outline"
-                size="sm"
-              >
-                Clone Template
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  id="clone-template-button"
+                  onClick={() => handleCloneTemplate(selectedTemplate)}
+                  variant="outline"
+                  size="sm"
+                >
+                  Clone Template
+                </Button>
+                {!selectedTemplate.isStandard && (
+                  <Button
+                    id="set-default-template-button"
+                    onClick={() => handleSetDefaultTemplate(selectedTemplate)}
+                    variant="outline"
+                    size="sm"
+                    disabled={selectedTemplate.is_default}
+                  >
+                    {selectedTemplate.is_default ? 'Default Template' : 'Set as Default'}
+                  </Button>
+                )}
+              </div>
             )}
           </div>
           {selectedTemplate && (

--- a/server/src/components/companies/BillingConfigForm.tsx
+++ b/server/src/components/companies/BillingConfigForm.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Text } from '@radix-ui/themes';
 import CustomSelect from '@/components/ui/CustomSelect';
+import { getInvoiceTemplates, getDefaultTemplate } from '@/lib/actions/invoiceActions';
+import { IInvoiceTemplate } from '@/interfaces/invoice.interfaces';
+import { FileTextIcon } from 'lucide-react';
+import { GearIcon } from '@radix-ui/react-icons';
 
 interface BillingConfigFormProps {
     billingConfig: {
@@ -8,6 +12,7 @@ interface BillingConfigFormProps {
         billing_cycle: string;
         preferred_payment_method: string;
         invoice_delivery_method: string;
+        invoice_template_id?: string;
     };
     handleSelectChange: (name: string) => (value: string) => void;
 }
@@ -16,6 +21,49 @@ const BillingConfigForm: React.FC<BillingConfigFormProps> = ({
     billingConfig,
     handleSelectChange
 }) => {
+    const [templates, setTemplates] = useState<IInvoiceTemplate[]>([]);
+    const [defaultTemplate, setDefaultTemplate] = useState<IInvoiceTemplate | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const loadTemplates = async () => {
+            try {
+                const [loadedTemplates, loadedDefault] = await Promise.all([
+                    getInvoiceTemplates(),
+                    getDefaultTemplate()
+                ]);
+                setTemplates(loadedTemplates);
+                setDefaultTemplate(loadedDefault);
+            } catch (error) {
+                console.error('Error loading templates:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        loadTemplates();
+    }, []);
+
+    const templateOptions = templates.map(template => ({
+        value: template.template_id,
+        label: (
+            <div className="flex items-center gap-2">
+                {template.isStandard ? (
+                    <div className="flex items-center gap-1">
+                        <FileTextIcon className="w-4 h-4" /> 
+                        {template.name} 
+                        <span className="text-gray-500">(Standard)</span>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-1">
+                        <GearIcon className="w-4 h-4" /> 
+                        {template.name}
+                        {template.is_default && <span className="text-blue-500">(Default)</span>}
+                    </div>
+                )}
+            </div>
+        )
+    }));
+
     const paymentTermsOptions = [
         { value: 'net_30', label: 'Net 30' },
         { value: 'net_15', label: 'Net 15' },
@@ -42,6 +90,20 @@ const BillingConfigForm: React.FC<BillingConfigFormProps> = ({
 
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-2">
+                <CustomSelect
+                    id="company-invoice-template-select"
+                    label="Invoice Template"
+                    value={billingConfig.invoice_template_id || (defaultTemplate?.template_id || '')}
+                    placeholder={!billingConfig.invoice_template_id && defaultTemplate 
+                        ? `Using default template: ${defaultTemplate.name}`
+                        : 'Select a template or use default'}
+                    onValueChange={handleSelectChange('invoice_template_id')}
+                    options={templateOptions}
+                    disabled={isLoading}
+                />
+            </div>
+
             <div className="space-y-2">
                 <CustomSelect
                     label="Payment Terms"
@@ -77,7 +139,6 @@ const BillingConfigForm: React.FC<BillingConfigFormProps> = ({
                     options={deliveryMethodOptions}
                 />
             </div>
-
         </div>
     );
 };

--- a/server/src/interfaces/company.interfaces.tsx
+++ b/server/src/interfaces/company.interfaces.tsx
@@ -45,6 +45,7 @@ export interface ICompany extends TenantEntity {
   is_tax_exempt: boolean;
   tax_exemption_certificate?: string;
   timezone?: string;
+  invoice_template_id?: string;
 }
 
 export interface ICompanyLocation extends TenantEntity {

--- a/server/src/interfaces/invoice.interfaces.ts
+++ b/server/src/interfaces/invoice.interfaces.ts
@@ -95,6 +95,7 @@ export interface IInvoiceTemplate extends TenantEntity {
   };
   isStandard?: boolean;
   isClone?: boolean;
+  is_default?: boolean;
 }
 
 export interface GlobalCalculation {


### PR DESCRIPTION
Adds ability to select and manage invoice templates per company with default template support.

Key changes:
- Added invoice_template_id to companies table with foreign key constraint
- Created unique index to ensure only one default template per tenant
- Added UI for setting default templates and selecting company-specific templates
- Enhanced PDF generation to respect company template preferences
- Updated billing configuration to include template selection
- Added fallback logic: company template -> default template -> first available

The changes improve invoice customization by allowing companies to use specific templates while maintaining a default template system-wide.

"Pay no attention to that default template behind the curtain! Each company can now choose their own Great and Powerful invoice design! 🎭"