### PR TITLE
refactor: improve TypeScript configuration and import paths

### DIFF
--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -7,10 +7,10 @@ import { Message } from "@ee/components/message/Message";
 import { IChat } from "@ee/interfaces/chat.interface";
 import { createNewChatAction, addMessageToChatAction } from '@ee/lib/chat-actions/chatActions';
 import { getCurrentUser } from '@/lib/actions/user-actions/userActions';
-import { ChatModelInterface, ChatMessage } from '../../interfaces/ChatModelInterface';
+import { ChatModelInterface, ChatMessage } from '@ee/interfaces/ChatModelInterface';
 import { HfInference } from '@huggingface/inference';
 
-import "./chat.css";
+import "@ee/components/chat/chat.css";
 
 type ChatProps = {
   companyUrl: string,

--- a/ee/server/src/components/flow/DnDFlow.tsx
+++ b/ee/server/src/components/flow/DnDFlow.tsx
@@ -21,17 +21,17 @@ import ReactFlow, {
 } from 'reactflow';
 import { v4 as uuidv4 } from 'uuid';
 import 'reactflow/dist/style.css';
-import './styles/DarkTheme.css';
-import { NodeTypes, CustomNode } from '../../services/flow/types/nodes';
-import ThinkingNode from './nodes/ThinkingNode';
-import ActionNode from './nodes/ActionNode';
-import Office365ReceiverNode from './nodes/Office365ReceiverNode';
-import ClassifierNode from './nodes/ClassifierNode';
-import TicketCreatorNode from './nodes/TicketCreatorNode';
-import DecisionNode from './nodes/DecisionNode';
-import SelectorNode from './nodes/SelectorNode';
-import Sidebar from './Sidebar';
-import TopBar from './TopBar';
+import '@ee/components/flow/styles/DarkTheme.css';
+import { NodeTypes, CustomNode } from '@ee/services/flow/types/nodes';
+import ThinkingNode from '@ee/components/flow/nodes/ThinkingNode';
+import ActionNode from '@ee/components/flow/nodes/ActionNode';
+import Office365ReceiverNode from '@ee/components/flow/nodes/Office365ReceiverNode';
+import ClassifierNode from '@ee/components/flow/nodes/ClassifierNode';
+import TicketCreatorNode from '@ee/components/flow/nodes/TicketCreatorNode';
+import DecisionNode from '@ee/components/flow/nodes/DecisionNode';
+import SelectorNode from '@ee/components/flow/nodes/SelectorNode';
+import Sidebar from '@ee/components/flow/Sidebar';
+import TopBar from '@ee/components/flow/TopBar';
 import {
   ThinkingNodeData,
   ActionNodeData,
@@ -42,7 +42,7 @@ import {
   SelectorNodeData,
   Template,
   ConditionType
-} from '../../services/flow/types/workflowTypes';
+} from '@ee/services/flow/types/workflowTypes';
 
 interface WorkflowNode {
   id: string;

--- a/ee/server/src/services/flow/types/nodes.ts
+++ b/ee/server/src/services/flow/types/nodes.ts
@@ -8,7 +8,7 @@ import {
   SelectorNodeData,
   DecisionNodeData,
   TicketCreatorNodeData
-} from './workflowTypes';
+} from '@ee/services/flow/types/workflowTypes';
 
 export interface PickerOption {
   id: string;

--- a/ee/server/tsconfig.json
+++ b/ee/server/tsconfig.json
@@ -1,20 +1,15 @@
 {
-  "extends": "../../server/tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "bundler",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["../../server/src/*"],
-      "@ee/*": ["./src/*"]
-    }
+    "outDir": "dist"
   },
   "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
     ".next/types/**/*.ts"
-,   "../../server/src/middleware/middleware.ts"  ],
+  ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,7 @@ export default [
         ecmaFeatures: {
           jsx: true
         },
-        tsconfigRootDir: ".",
+        tsconfigRootDir: process.cwd(),
       },
     },
 

--- a/server/src/components/companies/CompanyPicker.tsx
+++ b/server/src/components/companies/CompanyPicker.tsx
@@ -9,7 +9,6 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { ReflectionContainer } from '../../types/ui-reflection/ReflectionContainer';
 import { useAutomationIdAndRegister } from '@/types/ui-reflection/useAutomationIdAndRegister';
 import { AutomationProps, ContainerComponent, FormFieldComponent } from '@/types/ui-reflection/types';
-import { up } from 'migrations/20241125124900_add_credit_system.cjs';
 import { withDataAutomationId } from '@/types/ui-reflection/withDataAutomationId';
 
 interface CompanyPickerProps {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,54 +1,19 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2020",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": false,
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"],
-      "@ee/*": [
-        "../ee/server/src/*",
-        "./src/empty/*"
-      ]
-    },
-    "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "."
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
     "src/types/**/*.d.ts",
     ".next/types/**/*.ts",
-    "../ee/server/src/interfaces/chat.interface.tsx",
-    "../ee/server/src/interfaces/message.interface.ts",
-    "../ee/server/src/models/chat.ts",
-    "../ee/server/src/models/message.ts",
-    "migrations/20241125124900_add_credit_system.cjs",
-    "migrations/20241130113000_add_tenant_to_billing_cycles.cjs",
-    "migrations/20241130113200_add_pk_to_billing_cycles.cjs"
+    "migrations/*.cjs"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["server/src/*"],
+      "@ee/*": ["ee/server/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
- Create shared base TypeScript config (tsconfig.base.json)
- Update server and ee/server TypeScript configs to extend base
- Standardize import paths using @/ and @ee/ aliases
- Clean up unnecessary TypeScript config options
- Remove unused import in CompanyPicker
- Fix tsconfigRootDir in ESLint config to use process.cwd()