### PR TITLE
refactor: migrate date handling to Temporal.PlainDate for time period…

### DIFF
--- a/server/src/components/tickets/TicketDetails.tsx
+++ b/server/src/components/tickets/TicketDetails.tsx
@@ -1,7 +1,20 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
-import { ITicket, IComment, ITimeSheet, ITimePeriod, ITimeEntry, ICompany, IContact, IUser, IUserWithRoles, ITeam, ITicketResource } from '../../interfaces';
+import { 
+    ITicket, 
+    IComment, 
+    ITimeSheet, 
+    ITimePeriod,
+    ITimePeriodView, 
+    ITimeEntry, 
+    ICompany, 
+    IContact, 
+    IUser, 
+    IUserWithRoles, 
+    ITeam, 
+    ITicketResource 
+} from '../../interfaces';
 import TicketInfo from './TicketInfo';
 import TicketProperties from './TicketProperties';
 import TicketConversation from './TicketConversation';
@@ -69,7 +82,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     const [isRunning, setIsRunning] = useState(true);
     const [timeDescription, setTimeDescription] = useState('');
     const [currentTimeSheet, setCurrentTimeSheet] = useState<ITimeSheet | null>(null);
-    const [currentTimePeriod, setCurrentTimePeriod] = useState<ITimePeriod | null>(null);
+    const [currentTimePeriod, setCurrentTimePeriod] = useState<ITimePeriodView | null>(null);
 
     const [availableAgents, setAvailableAgents] = useState<IUserWithRoles[]>([]);
     const [additionalAgents, setAdditionalAgents] = useState<ITicketResource[]>([]);
@@ -472,7 +485,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                     workItem={workItem}
                     date={new Date()}
                     existingEntries={[]}
-                    timePeriod={currentTimePeriod!}
+                    timePeriod={currentTimePeriod!} // Already a view type from getCurrentTimePeriod
                     isEditable={true}
                     defaultStartTime={startTime}
                     defaultEndTime={endTime}

--- a/server/src/components/tickets/TicketProperties.tsx
+++ b/server/src/components/tickets/TicketProperties.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ITicket, ITimeSheet, ITimePeriod, ITimeEntry } from '../../interfaces';
+import { ITicket, ITimeSheet, ITimePeriod, ITimePeriodView, ITimeEntry } from '../../interfaces';
 import { IUserWithRoles, ITeam } from '../../interfaces/auth.interfaces';
 import { ITicketResource } from '../../interfaces/ticketResource.interfaces';
 import { Button } from '../ui/Button';
@@ -30,7 +30,7 @@ interface TicketPropertiesProps {
   additionalAgents: ITicketResource[];
   availableAgents: IUserWithRoles[];
   currentTimeSheet: ITimeSheet | null;
-  currentTimePeriod: ITimePeriod | null;
+  currentTimePeriod: ITimePeriodView | null;
   userId: string;
   tenant: string;
   contacts: any[];

--- a/server/src/components/time-management/approvals/TimeSheetApproval.tsx
+++ b/server/src/components/time-management/approvals/TimeSheetApproval.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { ITimeSheet, ITimeEntry, ITimeSheetComment, ITimeSheetApproval, ITimeEntryWithWorkItem, TimeSheetStatus } from '@/interfaces/timeEntry.interfaces';
+import { 
+  ITimeSheet, 
+  ITimeEntry, 
+  ITimeSheetComment, 
+  ITimeSheetApproval, 
+  ITimeSheetApprovalView,
+  ITimeEntryWithWorkItem, 
+  TimeSheetStatus 
+} from '@/interfaces/timeEntry.interfaces';
 import { addCommentToTimeSheet, fetchTimeSheetComments } from '@/lib/actions/timeSheetActions';
 import { FaCheck, FaTimes, FaClock, FaUndo, FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import { IWorkItem } from '@/interfaces/workItem.interfaces';
@@ -9,9 +17,10 @@ import { TextArea } from '@/components/ui/TextArea';
 import { IUser } from '@/interfaces/auth.interfaces';
 import { fetchWorkItemsForTimeSheet, saveTimeEntry } from '@/lib/actions/timeEntryActions';
 import { parseISO } from 'date-fns';
+import { Temporal } from '@js-temporal/polyfill';
 
 interface TimeSheetApprovalProps {
-  timeSheet: ITimeSheetApproval;
+  timeSheet: ITimeSheetApprovalView;
   timeEntries: ITimeEntry[];
   currentUser: IUser;
   onApprove: () => void;
@@ -114,7 +123,7 @@ export function TimeSheetApproval({
   onRequestChanges,
   onReverseApproval
 }: TimeSheetApprovalProps) {
-  const [timeSheet, setTimeSheet] = useState<ITimeSheetApproval>(initialTimeSheet);
+  const [timeSheet, setTimeSheet] = useState<ITimeSheetApprovalView>(initialTimeSheet);
   const [newComment, setNewComment] = useState('');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [workItems, setWorkItems] = useState<IWorkItem[]>([]);
@@ -252,7 +261,7 @@ export function TimeSheetApproval({
           <CardTitle>Time Sheet Approval for {timeSheet.employee_name}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p>Period: { (timeSheet.time_period?.start_date) ? parseISO(timeSheet.time_period?.start_date).toLocaleDateString() : "N/A"} - { (timeSheet.time_period?.end_date) ? parseISO(timeSheet.time_period?.end_date).toLocaleDateString() : "N/A"}</p>
+          <p>Period: { timeSheet.time_period?.start_date ? timeSheet.time_period.start_date.toString() : "N/A"} - { timeSheet.time_period?.end_date ? timeSheet.time_period.end_date.toString() : "N/A"}</p>
           <p>Status: {timeSheet.approval_status}</p>
           <p>Submitted: {timeSheet.submitted_at?.toLocaleString()}</p>
         </CardContent>

--- a/server/src/components/time-management/time-entry/TimeTracking.tsx
+++ b/server/src/components/time-management/time-entry/TimeTracking.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import { TimeSheet } from './time-sheet/TimeSheet';
 import { TimePeriodList } from './TimePeriodList';
 import { SkeletonTimeSheet } from './SkeletonTimeSheet';
-import { ITimeSheet, ITimePeriodWithStatus, ITimeEntry } from '@/interfaces/timeEntry.interfaces';
+import { ITimeSheetView, ITimePeriodWithStatus, ITimeEntry } from '@/interfaces/timeEntry.interfaces';
 import { IUserWithRoles } from '@/interfaces/auth.interfaces';
 import { fetchTimePeriods, fetchOrCreateTimeSheet, saveTimeEntry } from '@/lib/actions/timeEntryActions';
 import { useTeamAuth } from '@/hooks/useTeamAuth';
@@ -18,7 +18,7 @@ interface TimeTrackingProps {
 
 export default function TimeTracking({ currentUser, isManager }: TimeTrackingProps) {
   const [timePeriods, setTimePeriods] = useState<ITimePeriodWithStatus[]>([]);
-  const [selectedTimeSheet, setSelectedTimeSheet] = useState<ITimeSheet | null>(null);
+  const [selectedTimeSheet, setSelectedTimeSheet] = useState<ITimeSheetView | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -1,13 +1,21 @@
 'use client';
 
 import { useState, useRef, useCallback, memo, useEffect } from 'react';
+import { Temporal } from '@js-temporal/polyfill';
 import { formatISO, parseISO } from 'date-fns';
 import { toast } from 'react-hot-toast';
 import { Dialog, DialogContent, DialogFooter } from '@/components/ui/Dialog';
 import { ConfirmationDialog } from '@/components/ui/ConfirmationDialog';
 import { deleteTimeEntry, fetchTimeEntriesForTimeSheet } from '@/lib/actions/timeEntryActions';
 import { Button } from '@/components/ui/Button';
-import { ITimeEntry, ITimeEntryWithWorkItem, ITimePeriod, TimeSheetStatus, ITimeEntryWithWorkItemString } from '@/interfaces/timeEntry.interfaces';
+import { 
+  ITimeEntry, 
+  ITimeEntryWithWorkItem, 
+  ITimePeriod,
+  ITimePeriodView, 
+  TimeSheetStatus, 
+  ITimeEntryWithWorkItemString 
+} from '@/interfaces/timeEntry.interfaces';
 import { IWorkItem } from '@/interfaces/workItem.interfaces';
 import { TimeEntryProvider, useTimeEntry } from './TimeEntryProvider';
 import { ReflectionContainer } from '@/types/ui-reflection/ReflectionContainer';
@@ -24,7 +32,7 @@ interface TimeEntryDialogProps {
   workItem: Omit<IWorkItem, 'tenant'>;
   date: Date;
   existingEntries?: ITimeEntryWithWorkItem[];
-  timePeriod: ITimePeriod;
+  timePeriod: ITimePeriodView;
   isEditable: boolean;
   defaultStartTime?: Date;
   defaultEndTime?: Date;
@@ -66,6 +74,13 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     setEditingIndex,
     updateTimeInputs,
   } = useTimeEntry();
+
+  // Convert string dates to Temporal.PlainDate for internal use
+  const timePeriod: ITimePeriod = {
+    ...props.timePeriod,
+    start_date: Temporal.PlainDate.from(props.timePeriod.start_date),
+    end_date: Temporal.PlainDate.from(props.timePeriod.end_date)
+  };
 
   const lastNoteInputRef = useRef<HTMLInputElement>(null);
   const [shouldFocusNotes, setShouldFocusNotes] = useState(false);

--- a/server/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useReducer, useEffect } from 'react';
-import { ITimeEntry, ITimeEntryWithWorkItem, ITimePeriod } from '@/interfaces/timeEntry.interfaces';
+import { ITimeEntry, ITimeEntryWithWorkItem, ITimePeriod, ITimePeriodView } from '@/interfaces/timeEntry.interfaces';
 import { IWorkItem } from '@/interfaces/workItem.interfaces';
 import { TaxRegion } from '@/types/types.d';
 import { fetchCompanyTaxRateForWorkItem, fetchServicesForTimeEntry, fetchTaxRegions } from '@/lib/actions/timeEntryActions';
@@ -140,13 +140,13 @@ export function TimeEntryProvider({ children }: { children: React.ReactNode }): 
       dispatch({ type: 'SET_LOADING', payload: true });
       
       // Load all required data in parallel
-      const [services, taxRegions, defaultTaxRegionFromCompany] = await Promise.all([
-        fetchServicesForTimeEntry(workItem.type),
-        fetchTaxRegions(),
-        (workItem.type === 'ticket' || workItem.type === 'project_task') 
-          ? fetchCompanyTaxRateForWorkItem(workItem.work_item_id, workItem.type)
-          : Promise.resolve(undefined)
-      ]);
+  const [services, taxRegions, defaultTaxRegionFromCompany] = await Promise.all([
+    fetchServicesForTimeEntry(workItem.type),
+    fetchTaxRegions(),
+    (workItem.type === 'ticket' || workItem.type === 'project_task') 
+      ? fetchCompanyTaxRateForWorkItem(workItem.work_item_id, workItem.type)
+      : Promise.resolve(undefined)
+  ]);
 
       dispatch({
         type: 'SET_INITIAL_DATA',

--- a/server/src/interfaces/timeEntry.interfaces.ts
+++ b/server/src/interfaces/timeEntry.interfaces.ts
@@ -2,6 +2,7 @@ import { IUser } from './auth.interfaces';
 import { WorkItemType, IWorkItem } from './workItem.interfaces';
 import { TenantEntity } from '.';
 import { ISO8601String } from '../types/types.d';
+import { Temporal } from '@js-temporal/polyfill';
 
 export type TimeSheetStatus = 'DRAFT' | 'SUBMITTED' | 'APPROVED' | 'CHANGES_REQUESTED';
 
@@ -56,8 +57,8 @@ export interface ITimeSheetComment extends TenantEntity  {
 
 export interface ITimePeriod extends TenantEntity  {
   period_id: string;
-  start_date: ISO8601String;
-  end_date: ISO8601String;
+  start_date: Temporal.PlainDate;
+  end_date: Temporal.PlainDate;
 }
 
 export interface ITimePeriodWithStatus extends ITimePeriod {
@@ -93,4 +94,17 @@ export interface ITimeSheetWithUserInfo extends ITimeSheet {
 export interface ITimeEntryWithWorkItemString extends Omit<ITimeEntryWithWorkItem, 'start_time' | 'end_time'> {
   start_time: string;
   end_time: string;
+}
+
+export interface ITimePeriodView extends Omit<ITimePeriod, 'start_date' | 'end_date'> {
+  start_date: string;
+  end_date: string;
+}
+
+export interface ITimeSheetView extends Omit<ITimeSheet, 'time_period'> {
+  time_period?: ITimePeriodView;
+}
+
+export interface ITimeSheetApprovalView extends Omit<ITimeSheetApproval, 'time_period'> {
+  time_period?: ITimePeriodView;
 }

--- a/server/src/lib/actions/timePeriodsActions.ts
+++ b/server/src/lib/actions/timePeriodsActions.ts
@@ -5,14 +5,19 @@ import { TimePeriod } from '../models/timePeriod'
 import { TimePeriodSettings } from '../models/timePeriodSettings';
 import { v4 as uuidv4 } from 'uuid';
 import { ISO8601String } from '../../types/types.d';
-import { ITimePeriod, ITimePeriodSettings } from '../../interfaces/timeEntry.interfaces';
+import { 
+  ITimePeriod, 
+  ITimePeriodView,
+  ITimePeriodSettings 
+} from '../../interfaces/timeEntry.interfaces';
 import { TimePeriodSuggester } from '../timePeriodSuggester';
 import { addDays, addMonths, format, differenceInHours, parseISO, startOfDay, formatISO, endOfMonth, AddMonthsOptions, differenceInDays } from 'date-fns';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { validateData, validateArray } from '../utils/validation';
 import { timePeriodSchema, timePeriodSettingsSchema } from '../schemas/timeSheet.schemas';
-import { formatUtcDateNoTime } from '../utils/dateTimeUtils';
+import { formatUtcDateNoTime, toPlainDate } from '../utils/dateTimeUtils';
 import { parse } from 'path';
+import { Temporal } from '@js-temporal/polyfill';
 
 // Special value to indicate end of period
 const END_OF_PERIOD = 0;
@@ -98,16 +103,11 @@ export async function fetchAllTimePeriods(): Promise<ITimePeriod[]> {
 
     const timePeriods = await TimePeriod.getAll();
 
-    const periods = timePeriods.map((period: ITimePeriod): ITimePeriod => {
-      const startDate = new Date(period.start_date);
-      const endDate = new Date(period.end_date);
-
-      return {
-        ...period,
-        start_date: formatUtcDateNoTime(startDate),
-        end_date: formatUtcDateNoTime(endDate)
-      };
-    });
+    const periods = timePeriods.map((period: ITimePeriod): ITimePeriod => ({
+      ...period,
+      start_date: period.start_date,  // Already a Temporal.PlainDate
+      end_date: period.end_date       // Already a Temporal.PlainDate
+    }));
 
     console.log('periods', periods);
 
@@ -118,25 +118,23 @@ export async function fetchAllTimePeriods(): Promise<ITimePeriod[]> {
   }
 }
 
-// Utility function to get current date as ISO8601 string
-function getCurrentDateISO(): ISO8601String {
-  const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(now.getUTCDate()).padStart(2, '0');
-  const hours = String(now.getUTCHours()).padStart(2, '0');
-  const minutes = String(now.getUTCMinutes()).padStart(2, '0');
-  const seconds = String(now.getUTCSeconds()).padStart(2, '0');
-  const milliseconds = String(now.getUTCMilliseconds()).padStart(3, '0');
-
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}Z`;
+// Utility function to get current date as Temporal.PlainDate
+function getCurrentDate(): Temporal.PlainDate {
+  return Temporal.Now.plainDateISO();
 }
 
-export async function getCurrentTimePeriod(): Promise<ITimePeriod | null> {
+export async function getCurrentTimePeriod(): Promise<ITimePeriodView | null> {
   try {
-    const currentDate = getCurrentDateISO();
+    const currentDate = getCurrentDate().toString();
     const currentPeriod = await TimePeriod.findByDate(currentDate);
-    return currentPeriod ? validateData(timePeriodSchema, currentPeriod) : null;
+    if (!currentPeriod) return null;
+
+    // Convert Temporal.PlainDate to string for view type
+    return {
+      ...currentPeriod,
+      start_date: currentPeriod.start_date.toString(),
+      end_date: currentPeriod.end_date.toString()
+    };
   } catch (error) {
     console.error('Error fetching current time period:', error)
     throw new Error('Failed to fetch current time period')
@@ -144,75 +142,50 @@ export async function getCurrentTimePeriod(): Promise<ITimePeriod | null> {
 }
 
 // Helper function to get the end of a period based on frequency unit
-function getEndOfPeriod(startDate: ISO8601String, setting: ITimePeriodSettings): Date {
+function getEndOfPeriod(startDate: string, setting: ITimePeriodSettings): Temporal.PlainDate {
   const frequency = setting.frequency || 1;
-  const startDateObj = parseISO(startDate);
+  const startDatePlain = Temporal.PlainDate.from(startDate);
 
   // Special handling for frequency = 0 (end of period)
   if (frequency === END_OF_PERIOD) {
     switch (setting.frequency_unit) {
       case 'week': {
         // End of week (Sunday) + 1 day
-        const daysUntilEndOfWeek = 7 - startDateObj.getUTCDay();
-        return addDays(startDateObj, daysUntilEndOfWeek + 1);
+        const daysUntilEndOfWeek = 7 - startDatePlain.dayOfWeek;
+        return startDatePlain.add({ days: daysUntilEndOfWeek + 1 });
       }
 
       case 'month': {
         // End of month + 1 day
-        const nextMonth = new Date(startDateObj);
-        nextMonth.setUTCMonth(startDateObj.getUTCMonth() + 1, 1);
-        return nextMonth;
+        return startDatePlain.add({ months: 1 }).with({ day: 1 });
       }
       case 'year': {
-        const nextYear = new Date(startDateObj);
-        nextYear.setUTCFullYear(startDateObj.getUTCFullYear() + 1, 0, 1);
-        return nextYear;
+        return startDatePlain.add({ years: 1 }).with({ month: 1, day: 1 });
       }
 
       default: // day
-        return addDays(startDateObj, 1);
+        return startDatePlain.add({ days: 1 });
     }
   }
 
   // Regular frequency handling
   switch (setting.frequency_unit) {
     case 'week':
-      return addDays(startDateObj, 7 * frequency);
+      return startDatePlain.add({ days: 7 * frequency });
 
     case 'month': {
-      let year = startDateObj.getUTCFullYear();
-      let month = startDateObj.getUTCMonth() + frequency;
-
       if (setting.end_day && setting.end_day !== END_OF_PERIOD) {
-        const endDateObj = new Date(startDate);
-        endDateObj.setUTCFullYear(year);
-        endDateObj.setUTCMonth(month-1);
-        endDateObj.setUTCDate(setting.end_day!);
-        return endDateObj;
+        return startDatePlain.add({ months: frequency - 1 }).with({ day: setting.end_day });
       }
-
-      if (month >= 12) {
-        const additionalYears = Math.floor(month / 12);
-        year += additionalYears;
-        month = month % 12;
-      }
-
-      const endDateObj = new Date(startDate);
-      endDateObj.setUTCFullYear(year);
-      endDateObj.setUTCMonth(month);
-      endDateObj.setUTCDate(1);
-
-      return endDateObj;
+      return startDatePlain.add({ months: frequency }).with({ day: 1 });
     }
 
     case 'year': {
-      const nextPeriodStart = new Date(startDate);
-      nextPeriodStart.setUTCFullYear(startDateObj.getUTCFullYear() + frequency);
-      return nextPeriodStart;
+      return startDatePlain.add({ years: frequency });
     }
 
     default: // day
-      return addDays(startDateObj, frequency);
+      return startDatePlain.add({ days: frequency });
   }
 }
 
@@ -221,177 +194,93 @@ export async function generateTimePeriods(
   settings: ITimePeriodSettings[],
   startDateStr: ISO8601String,
   endDateStr: ISO8601String
-): Promise<ITimePeriod[]> {
-  const periods: ITimePeriod[] = [];
+): Promise<ITimePeriodView[]> {
+  const periods: ITimePeriodView[] = [];
+  const startDate = toPlainDate(startDateStr);
+  const endDate = toPlainDate(endDateStr);
 
   for (const setting of settings) {
-    let currentDateStr = startDateStr;
+    let currentDate = startDate;
 
-    if (currentDateStr < setting.effective_from) {
-      currentDateStr = setting.effective_from;
+    if (setting.effective_from) {
+      const effectiveFrom = toPlainDate(setting.effective_from);
+      if (Temporal.PlainDate.compare(currentDate, effectiveFrom) < 0) {
+        currentDate = effectiveFrom;
+      }
     }
 
     // Align currentDate to the next occurrence of start_day if provided
     if (setting.start_day !== undefined && setting.frequency_unit !== 'year') {
       switch (setting.frequency_unit) {
         case 'week':
-          currentDateStr = alignToWeekday(currentDateStr, setting.start_day);
+          currentDate = Temporal.PlainDate.from(alignToWeekday(currentDate.toString(), setting.start_day));
           break;
         case 'month':
-          currentDateStr = alignToMonthDay(currentDateStr, setting.start_day);
+          currentDate = Temporal.PlainDate.from(alignToMonthDay(currentDate.toString(), setting.start_day));
           break;
       }
     }
 
-    while (currentDateStr < endDateStr) {
-      if (setting.effective_to && currentDateStr > setting.effective_to) {
+    while (Temporal.PlainDate.compare(currentDate, endDate) < 0) {
+      if (setting.effective_to) {
+        const effectiveTo = toPlainDate(setting.effective_to);
+        if (Temporal.PlainDate.compare(currentDate, effectiveTo) > 0) {
+          break;
+        }
+      }
+
+      const periodEndDate = getEndOfPeriod(currentDate.toString(), setting);
+
+      if (Temporal.PlainDate.compare(periodEndDate, endDate) >= 0) {
         break;
       }
 
-      const currentDateObj = parseISO(currentDateStr);
-      const periodStartDate = formatUtcDateNoTime(currentDateObj);
-      const periodEndDateObj = getEndOfPeriod(periodStartDate, setting);
-      const periodEndStr = formatUtcDateNoTime(periodEndDateObj);
-
-      if (periodEndStr >= endDateStr) {
-        break;
+      if (setting.effective_to) {
+        const effectiveTo = toPlainDate(setting.effective_to);
+        if (Temporal.PlainDate.compare(periodEndDate, effectiveTo) >= 0) {
+          break;
+        }
       }
 
-      if (setting.effective_to && periodEndStr >= setting.effective_to) {
-        break;
-      }
-
-      const newPeriod: ITimePeriod = {
+      const newPeriod: ITimePeriodView = {
         period_id: uuidv4(),
-        start_date: periodStartDate,
-        end_date: periodEndStr,
+        start_date: currentDate.toString(),
+        end_date: periodEndDate.toString(),
         tenant: setting.tenant_id,
       };
       periods.push(newPeriod);
 
       if (setting.end_day !== END_OF_PERIOD) {
         // if the end day is not END_OF_PERIOD, we need to adjust the current date to the end of the period
-        // and continue to the next period, the other portion of the current period will be handled in the next iteration of the parent loop
-        currentDateStr = formatUtcDateNoTime(getEndOfPeriod(periodEndStr, {...setting, end_day: END_OF_PERIOD})); 
+        currentDate = periodEndDate;
         continue;
       }
 
-      currentDateStr = periodEndStr;
+      currentDate = periodEndDate;
     }
   }
 
   return periods;
 }
 
-function getFirstDayOfNextMonth(dateStr: ISO8601String, monthsToAdvance: number = 1): ISO8601String {
-  const date = new Date(dateStr);
-  date.setUTCMonth(date.getUTCMonth() + monthsToAdvance, 1);
-  date.setUTCHours(0, 0, 0, 0);
-  return date.toISOString() as ISO8601String;
-}
-
 // Helper function to align date to the next occurrence of a weekday
-function alignToWeekday(dateStr: ISO8601String, targetDay: number): ISO8601String {
-  const dayOfWeek = getDayOfWeek(dateStr);
-  const daysToAdd = (targetDay - dayOfWeek + 7) % 7;
-  return addDaysToISOString(dateStr, daysToAdd);
+function alignToWeekday(dateStr: string, targetDay: number): string {
+  const date = Temporal.PlainDate.from(dateStr);
+  const daysToAdd = (targetDay - date.dayOfWeek + 7) % 7;
+  return date.add({ days: daysToAdd }).toString();
 }
 
 // Helper function to align date to the specified day of the month
-function alignToMonthDay(dateStr: ISO8601String, targetDay: number): ISO8601String {
-  const [year, month] = dateStr.split('-');
-  let alignedDate = `${year}-${month}-${String(targetDay).padStart(2, '0')}T00:00:00Z`;
+function alignToMonthDay(dateStr: string, targetDay: number): string {
+  const date = Temporal.PlainDate.from(dateStr);
+  let alignedDate = date.with({ day: targetDay });
 
-  if (alignedDate < dateStr) {
+  if (Temporal.PlainDate.compare(alignedDate, date) < 0) {
     // Move to next month
-    alignedDate = addMonthsToISOString(alignedDate, 1);
+    alignedDate = alignedDate.add({ months: 1 });
   }
 
-  const daysInMonth = getDaysInMonth(alignedDate);
-
-  if (targetDay > daysInMonth) {
-    // Set to last day of month
-    alignedDate = `${year}-${month}-${String(daysInMonth).padStart(2, '0')}T00:00:00Z`;
-  }
-
-  return alignedDate as ISO8601String;
-}
-
-// Adjust end date to the last day of the month if necessary
-function adjustEndDateForMonth(dateStr: ISO8601String): ISO8601String {
-  const [year, month, day] = dateStr.split('T')[0].split('-').map(Number);
-  const daysInMonth = getDaysInMonth(dateStr);
-
-  if (day > daysInMonth) {
-    return `${year}-${String(month).padStart(2, '0')}-${String(daysInMonth).padStart(2, '0')}T23:59:59.999Z`;
-  }
-
-  return dateStr;
-}
-
-// Helper function to add days to an ISO8601 string
-function addDaysToISOString(dateStr: ISO8601String, days: number): ISO8601String {
-  const [datePart, timePart] = dateStr.split('T');
-  const [year, month, day] = datePart.split('-').map(Number);
-
-  let newYear = year;
-  let newMonth = month;
-  let newDay = day + days;
-
-  while (newDay > getDaysInMonth(`${newYear}-${String(newMonth).padStart(2, '0')}-01T00:00:00Z`)) {
-    newDay -= getDaysInMonth(`${newYear}-${String(newMonth).padStart(2, '0')}-01T00:00:00Z`);
-    newMonth++;
-    if (newMonth > 12) {
-      newMonth = 1;
-      newYear++;
-    }
-  }
-
-  while (newDay < 1) {
-    newMonth--;
-    if (newMonth < 1) {
-      newMonth = 12;
-      newYear--;
-    }
-    newDay += getDaysInMonth(`${newYear}-${String(newMonth).padStart(2, '0')}-01T00:00:00Z`);
-  }
-
-  return `${newYear}-${String(newMonth).padStart(2, '0')}-${String(newDay).padStart(2, '0')}T${timePart}`;
-}
-
-// Helper function to add months to an ISO8601 string
-function addMonthsToISOString(dateStr: ISO8601String, months: number): ISO8601String {
-  return format(toZonedTime(addMonths(dateStr, months), 'UTC'), "yyyy-MM-dd'T'HH:mm:ss'Z'") as ISO8601String;
-}
-
-// Helper function to get the day of the week (0-6, where 0 is Sunday)
-function getDayOfWeek(dateStr: ISO8601String): number {
-  const [year, month, day] = dateStr.split('T')[0].split('-').map(Number);
-  const a = Math.floor((14 - month) / 12);
-  const y = year - a;
-  const m = month + 12 * a - 2;
-  return (day + y + Math.floor(y / 4) - Math.floor(y / 100) + Math.floor(y / 400) + Math.floor((31 * m) / 12)) % 7;
-}
-
-// Helper function to get the number of days in a month
-function getDaysInMonth(dateStr: ISO8601String): number {
-  const [year, month] = dateStr.split('-').map(Number);
-  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
-  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  return daysInMonth[month - 1];
-}
-
-function alignToNearestMidnight(dateStr: ISO8601String): ISO8601String {
-  const parsedDate = parseISO(dateStr);
-  const previousMidnight = startOfDay(parsedDate);
-  const nextMidnight = addDays(previousMidnight, 1);
-
-  const hoursToPreviousMidnight = differenceInHours(parsedDate, previousMidnight);
-  const hoursToNextMidnight = differenceInHours(nextMidnight, parsedDate);
-
-  const nearestMidnight = hoursToPreviousMidnight <= hoursToNextMidnight ? previousMidnight : nextMidnight;
-
-  return format(nearestMidnight, "yyyy-MM-dd'T'HH:mm:ss'Z'") as ISO8601String;
+  return alignedDate.toString();
 }
 
 export async function deleteTimePeriod(periodId: string): Promise<void> {
@@ -476,14 +365,24 @@ export async function generateAndSaveTimePeriods(startDate: ISO8601String, endDa
 
     // Check for overlapping periods before saving
     for (const period of generatedPeriods) {
-      const overlappingPeriod = await TimePeriod.findOverlapping(period.start_date, period.end_date);
+      const overlappingPeriod = await TimePeriod.findOverlapping(
+        toPlainDate(period.start_date),
+        toPlainDate(period.end_date)
+      );
       if (overlappingPeriod) {
         throw new Error(`Cannot create time period: overlaps with existing period from ${overlappingPeriod.start_date} to ${overlappingPeriod.end_date}`);
       }
     }
 
     // Save generated periods to the database
-    const savedPeriods = await Promise.all(generatedPeriods.map((period: ITimePeriod): Promise<ITimePeriod> => TimePeriod.create(period)));
+    const savedPeriods = await Promise.all(generatedPeriods.map((period: ITimePeriodView): Promise<ITimePeriod> => {
+      // Convert string dates to Temporal.PlainDate for database
+      return TimePeriod.create({
+        ...period,
+        start_date: toPlainDate(period.start_date),
+        end_date: toPlainDate(period.end_date)
+      });
+    }));
     const validatedPeriods = validateArray(timePeriodSchema, savedPeriods);
 
     revalidatePath('/msp/time-entry');
@@ -505,14 +404,13 @@ export async function createNextTimePeriod(settings: ITimePeriodSettings[], days
 
     // Get the latest period end date
     const lastPeriod = existingPeriods.sort((a, b) =>
-      parseISO(b.end_date).getTime() - parseISO(a.end_date).getTime()
+      Temporal.PlainDate.compare(b.end_date, a.end_date)
     )[0];
     const newStartDate = lastPeriod.end_date;
 
     // Check if we're within the threshold days of the new period
-    const currentDate = new Date();
-    const startDateObj = parseISO(newStartDate);
-    const daysUntilStart = differenceInDays(startDateObj, currentDate);
+    const currentDate = getCurrentDate();
+    const daysUntilStart = newStartDate.since(currentDate).days;
 
     // Only create the period if we're within the threshold
     if (daysUntilStart > daysThreshold) {
@@ -523,10 +421,10 @@ export async function createNextTimePeriod(settings: ITimePeriodSettings[], days
     // Use TimePeriodSuggester to create the new period
     const newPeriodData = TimePeriodSuggester.suggestNewTimePeriod(settings, existingPeriods);
     
-    // Create the new time period
+    // Convert string dates to Temporal.PlainDate
     const newPeriod = await createTimePeriod({
-      start_date: newPeriodData.start_date,
-      end_date: newPeriodData.end_date
+      start_date: toPlainDate(newPeriodData.start_date),
+      end_date: toPlainDate(newPeriodData.end_date)
     });
 
     return newPeriod;

--- a/server/src/lib/schemas/timeSheet.schemas.ts
+++ b/server/src/lib/schemas/timeSheet.schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { iso8601Schema, tenantSchema } from '@/lib/utils/validation';
+import { iso8601Schema, tenantSchema, plainDateSchema } from '@/lib/utils/validation';
 
 export const timeSheetStatusSchema = z.enum(['DRAFT', 'SUBMITTED', 'APPROVED', 'CHANGES_REQUESTED']);
 export const workItemTypeSchema = z.enum(['ticket', 'project_task', 'non_billable_category', 'ad_hoc'] as const);
@@ -7,26 +7,8 @@ export const workItemTypeSchema = z.enum(['ticket', 'project_task', 'non_billabl
 // Core schemas
 export const timePeriodSchema = tenantSchema.extend({
   period_id: z.string(),
-  start_date: iso8601Schema,
-  end_date: iso8601Schema
-});
-
-export const timePeriodSettingsSchema = tenantSchema.extend({
-  time_period_settings_id: z.string(),
-  frequency: z.number().positive(),
-  frequency_unit: z.enum(['day', 'week', 'month', 'year']),
-  is_active: z.boolean(),
-  effective_from: iso8601Schema,
-  effective_to: iso8601Schema.optional(),
-  created_at: iso8601Schema,
-  updated_at: iso8601Schema,
-  tenant_id: z.string(),
-  start_day: z.number().min(1).max(31).optional(),
-  end_day: z.number().min(0).max(31).optional(),
-  start_month: z.number().min(1).max(12).optional(),
-  start_day_of_month: z.number().min(1).max(31).optional(),
-  end_month: z.number().min(1).max(12).optional(),
-  end_day_of_month: z.number().min(0).max(31).optional()
+  start_date: plainDateSchema,
+  end_date: plainDateSchema
 });
 
 export const timeSheetCommentSchema = tenantSchema.extend({
@@ -54,6 +36,39 @@ export const timeSheetApprovalSchema = timeSheetSchema.extend({
   employee_name: z.string(),
   employee_email: z.string(),
   comments: z.array(timeSheetCommentSchema)
+});
+
+// View schemas
+export const timePeriodViewSchema = tenantSchema.extend({
+  period_id: z.string(),
+  start_date: z.string(),
+  end_date: z.string()
+});
+
+export const timeSheetViewSchema = timeSheetSchema.omit({ time_period: true }).extend({
+  time_period: timePeriodViewSchema.optional()
+});
+
+export const timeSheetApprovalViewSchema = timeSheetApprovalSchema.omit({ time_period: true }).extend({
+  time_period: timePeriodViewSchema.optional()
+});
+
+export const timePeriodSettingsSchema = tenantSchema.extend({
+  time_period_settings_id: z.string(),
+  frequency: z.number().positive(),
+  frequency_unit: z.enum(['day', 'week', 'month', 'year']),
+  is_active: z.boolean(),
+  effective_from: iso8601Schema,
+  effective_to: iso8601Schema.optional(),
+  created_at: iso8601Schema,
+  updated_at: iso8601Schema,
+  tenant_id: z.string(),
+  start_day: z.number().min(1).max(31).optional(),
+  end_day: z.number().min(0).max(31).optional(),
+  start_month: z.number().min(1).max(12).optional(),
+  start_day_of_month: z.number().min(1).max(31).optional(),
+  end_month: z.number().min(1).max(12).optional(),
+  end_day_of_month: z.number().min(0).max(31).optional()
 });
 
 export const timeEntrySchema = tenantSchema.extend({

--- a/server/src/lib/utils/dateTimeUtils.ts
+++ b/server/src/lib/utils/dateTimeUtils.ts
@@ -40,10 +40,13 @@ export function getUserTimeZone(): string {
 }
 
 /**
- * Convert a date string or Date object to a Temporal.PlainDate
+ * Convert a date string, Date object, or Temporal.PlainDate to a Temporal.PlainDate
  * Handles both date-only strings and full ISO timestamps
  */
-export function toPlainDate(date: string | Date): Temporal.PlainDate {
+export function toPlainDate(date: string | Date | Temporal.PlainDate): Temporal.PlainDate {
+  if (date instanceof Temporal.PlainDate) {
+    return date;
+  }
   if (typeof date === 'string') {
     // If it's a full ISO timestamp (contains 'T' or 'Z')
     if (date.includes('T') || date.includes('Z')) {

--- a/server/src/lib/utils/validation.ts
+++ b/server/src/lib/utils/validation.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ISO8601String } from '@/types/types.d';
+import { Temporal } from '@js-temporal/polyfill';
 
 // Basic validation utilities
 export function validateData<T>(schema: z.ZodSchema<T>, data: unknown): T {
@@ -21,6 +22,9 @@ export const iso8601Schema = z.string().refine((val): val is ISO8601String => {
   const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?([+-]\d{2}:?\d{2}|Z)$/;
   return iso8601Regex.test(val);
 }, "Invalid ISO8601 date string");
+
+// Schema for Temporal.PlainDate
+export const plainDateSchema = z.instanceof(Temporal.PlainDate);
 
 // Common schema patterns
 export const tenantSchema = z.object({


### PR DESCRIPTION
… management

- Replace Date and ISO8601String date handling with Temporal.PlainDate
- Introduce view types (ITimePeriodView, ITimeSheetView) for API responses
- Add proper type safety for date conversions between DB and API layers
- Update time period calculations to use Temporal arithmetic
- Simplify date comparison logic in period overlap checks
- Add validation schemas for new view types
- Fix timezone handling issues by using calendar dates

This change improves date handling accuracy and type safety while preparing for the Temporal API standard. The separation of storage and view types allows for cleaner data flow between layers.