### PR TITLE
feat: Add configurable number padding and improve number generation

### DIFF
--- a/server/migrations/20250220164843_add_padding_to_next_number.cjs
+++ b/server/migrations/20250220164843_add_padding_to_next_number.cjs
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('next_number', function(table) {
+    table.integer('padding_length').defaultTo(6);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('next_number', function(table) {
+    table.dropColumn('padding_length');
+  });
+};

--- a/server/migrations/20250220165247_update_generate_next_number_function.cjs
+++ b/server/migrations/20250220165247_update_generate_next_number_function.cjs
@@ -1,0 +1,91 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    CREATE OR REPLACE FUNCTION public.generate_next_number(p_tenant_id uuid, p_entity_type text)
+    RETURNS text
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+        new_number BIGINT;
+        number_prefix TEXT;
+        initial_val BIGINT;
+        padding_len INTEGER;
+        formatted_number TEXT;
+    BEGIN
+        -- Use advisory lock for concurrency control
+        PERFORM pg_advisory_xact_lock(hashtext(p_tenant_id::text || p_entity_type));
+        
+        -- Always include tenant in WHERE clauses for CitusDB compatibility
+        INSERT INTO next_number (tenant, entity_type)
+        VALUES (p_tenant_id, p_entity_type)
+        ON CONFLICT (tenant, entity_type) DO UPDATE
+        SET last_number = 
+            CASE 
+                WHEN next_number.last_number = 0 THEN next_number.initial_value
+                ELSE next_number.last_number + 1
+            END
+        RETURNING last_number, initial_value, prefix, padding_length 
+        INTO new_number, initial_val, number_prefix, padding_len;
+        
+        IF new_number = initial_val AND new_number != 1 THEN
+        ELSE
+            -- Include tenant in WHERE clause
+            UPDATE next_number
+            SET last_number = new_number
+            WHERE tenant = p_tenant_id AND entity_type = p_entity_type;
+        END IF;
+
+        -- Format number with padding
+        formatted_number := LPAD(new_number::TEXT, COALESCE(padding_len, 1), '0');
+        
+        -- Add prefix if exists
+        IF number_prefix IS NOT NULL THEN
+            formatted_number := number_prefix || formatted_number;
+        END IF;
+        
+        RETURN formatted_number;
+    END;
+    $function$;
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.raw(`
+    CREATE OR REPLACE FUNCTION public.generate_next_number(p_tenant_id uuid, p_entity_type text)
+    RETURNS text
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+        new_number BIGINT;
+        number_prefix TEXT;
+        initial_val BIGINT;
+    BEGIN
+        -- Use advisory lock for concurrency control
+        PERFORM pg_advisory_xact_lock(hashtext(p_tenant_id::text || p_entity_type));
+        
+        INSERT INTO next_number (tenant, entity_type)
+        VALUES (p_tenant_id, p_entity_type)
+        ON CONFLICT (tenant, entity_type) DO UPDATE
+        SET last_number = 
+            CASE 
+                WHEN next_number.last_number = 0 THEN next_number.initial_value
+                ELSE next_number.last_number + 1
+            END
+        RETURNING last_number, initial_value, prefix
+        INTO new_number, initial_val, number_prefix;
+        
+        IF new_number = initial_val AND new_number != 1 THEN
+        ELSE
+            UPDATE next_number
+            SET last_number = new_number
+            WHERE tenant = p_tenant_id AND entity_type = p_entity_type;
+        END IF;
+
+        IF number_prefix IS NOT NULL THEN
+            RETURN number_prefix || new_number::TEXT;
+        END IF;
+        
+        RETURN new_number::TEXT;
+    END;
+    $function$;
+  `);
+};

--- a/server/src/components/settings/general/NumberingSettings.tsx
+++ b/server/src/components/settings/general/NumberingSettings.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/Input';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { Button } from '@/components/ui/Button';
+import { Edit2 } from 'lucide-react';
+import { ConfirmationDialog } from '@/components/ui/ConfirmationDialog';
+import { getCurrentUser } from '@/lib/actions/user-actions/userActions';
+import type { EntityType } from '@/lib/services/numberingService';
+import { getNumberSettings, updateNumberSettings, type NumberSettings } from '@/lib/actions/number-actions/numberingActions';
+
+interface NumberingSettingsProps {
+  entityType: EntityType;
+}
+
+const NumberingSettings: React.FC<NumberingSettingsProps> = ({ entityType }) => {
+  // General state
+  const [settings, setSettings] = useState<NumberSettings | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Editing state
+  const [isEditing, setIsEditing] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  // Form state
+  const [formState, setFormState] = useState<Partial<NumberSettings>>({});
+
+  const entityLabel = entityType.charAt(0) + entityType.slice(1).toLowerCase();
+  const entityId = entityType.toLowerCase();
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const [numberSettings, user] = await Promise.all([
+          getNumberSettings(entityType),
+          getCurrentUser()
+        ]);
+        
+        if (!numberSettings) {
+          // Initialize with default values for new settings
+          const defaultSettings = {
+            prefix: entityType === 'TICKET' ? 'TK-' : 'INV-',
+            padding_length: 6,
+            last_number: 0,
+            initial_value: 1
+          };
+          setSettings(defaultSettings);
+          setFormState(defaultSettings);
+          setIsEditing(true); // Automatically enter edit mode for new settings
+        } else {
+          setSettings(numberSettings);
+          setFormState(numberSettings);
+        }
+        setIsAdmin(user?.roles?.some(role => role.role_name.toLowerCase() === 'admin') ?? false);
+      } catch (err) {
+        setError(`Failed to load ${entityType.toLowerCase()} numbering settings`);
+        console.error('Error:', err);
+      }
+    };
+
+    init();
+  }, [entityType]);
+
+  const handleInputChange = (field: keyof NumberSettings, value: string) => {
+    setFormState(prev => ({
+      ...prev,
+      [field]: field === 'prefix' ? value : parseInt(value, 10)
+    }));
+  };
+
+  const handleSave = async () => {
+    try {
+      setError(null);
+      setSuccessMessage(null);
+
+      const result = await updateNumberSettings(entityType, formState);
+      
+      if (result.success && result.settings) {
+        setSettings(result.settings);
+        setFormState(result.settings);
+        setSuccessMessage('Settings updated successfully');
+        setIsEditing(false);
+        setShowConfirmation(false);
+      } else {
+        throw new Error(result.error || 'Failed to update settings');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update settings');
+      console.error(err);
+    }
+  };
+
+  const handleCancel = () => {
+    setError(null);
+    setFormState(settings || {});
+    setIsEditing(false);
+  };
+
+  const nextNumber = isEditing
+    ? parseInt((formState.last_number?.toString() ?? '0'), 10) + 1
+    : settings
+      ? parseInt(settings.last_number.toString(), 10) + 1
+      : 0;
+
+  const paddingLength = isEditing
+    ? formState.padding_length ?? 6
+    : settings?.padding_length ?? 6;
+
+  const prefix = isEditing
+    ? formState.prefix ?? (entityType === 'TICKET' ? 'TK-' : 'INV-')
+    : settings?.prefix ?? '';
+
+  const paddedNumber = nextNumber.toString().padStart(paddingLength, '0');
+  const previewNumber = `${prefix}${paddedNumber}`;
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm">
+      <h3 className="text-lg font-semibold mb-4 text-gray-800">{entityLabel} Numbering</h3>
+      
+      {error && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      
+      {successMessage && (
+        <Alert className="mb-4">
+          <AlertDescription>{successMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {entityLabel} Number Prefix
+          </label>
+          <div className="flex space-x-2">
+            <Input
+              id={`${entityId}-prefix-input`}
+              value={isEditing ? formState.prefix : settings?.prefix ?? ''}
+              onChange={(e) => handleInputChange('prefix', e.target.value)}
+              disabled={!isEditing}
+              className="w-32"
+            />
+            {!isEditing && isAdmin && (
+              <Button
+                id={`edit-${entityId}-settings-button`}
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsEditing(true)}
+              >
+                <Edit2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Padding Length
+          </label>
+          <div className="flex space-x-2">
+            <Input
+              id={`${entityId}-padding-length-input`}
+              type="number"
+              value={isEditing ? formState.padding_length : settings?.padding_length ?? 6}
+              onChange={(e) => handleInputChange('padding_length', e.target.value)}
+              disabled={!isEditing}
+              className="w-32"
+              min={1}
+              max={10}
+            />
+          </div>
+        </div>
+
+        {settings?.initial_value === null && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Initial Value
+            </label>
+            <div className="flex space-x-2">
+              <Input
+                id={`${entityId}-initial-value-input`}
+                type="number"
+                value={isEditing ? formState.initial_value : ''}
+                onChange={(e) => handleInputChange('initial_value', e.target.value)}
+                disabled={!isEditing}
+                className="w-32"
+                min={1}
+                placeholder="Enter value"
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Last Used Number
+          </label>
+          <div className="flex space-x-2">
+            <Input
+              id={`${entityId}-last-number-input`}
+              type="number"
+              value={isEditing ? formState.last_number : settings?.last_number ?? 0}
+              onChange={(e) => handleInputChange('last_number', e.target.value)}
+              disabled={!isEditing}
+              className="w-32"
+              min={settings?.initial_value ?? 1}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Next {entityLabel} Number Preview
+          </label>
+          <div className="text-lg font-mono bg-gray-50 p-2 rounded border">
+            {previewNumber}
+          </div>
+        </div>
+
+        {isEditing && (
+          <div className="flex space-x-2 mt-4">
+            <Button
+              id={`save-${entityId}-settings-button`}
+              variant="default"
+              onClick={() => setShowConfirmation(true)}
+              disabled={!isAdmin}
+            >
+              Save Changes
+            </Button>
+            <Button
+              id={`cancel-${entityId}-settings-button`}
+              variant="outline"
+              onClick={handleCancel}
+            >
+              Cancel
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <ConfirmationDialog
+        id={`${entityId}-settings-confirmation-dialog`}
+        isOpen={showConfirmation}
+        onClose={() => setShowConfirmation(false)}
+        onConfirm={handleSave}
+        title={`Update ${entityLabel} Number Settings`}
+        message={`Changing these settings will affect how new ${entityType.toLowerCase()} numbers are generated. This change will not affect existing ${entityType.toLowerCase()}s. Are you sure you want to proceed?`}
+        confirmLabel="Update Settings"
+      />
+    </div>
+  );
+};
+
+export default NumberingSettings;

--- a/server/src/components/settings/general/SettingsPage.tsx
+++ b/server/src/components/settings/general/SettingsPage.tsx
@@ -12,6 +12,7 @@ import UserManagement from './UserManagement';
 import TeamManagement from './TeamManagement';
 import InteractionTypesSettings from './InteractionTypeSettings';
 import TimePeriodSettings from '../billing/TimePeriodSettings';
+import NumberingSettings from './NumberingSettings';
 import NotificationsTab from './NotificationsTab';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
@@ -108,7 +109,10 @@ const SettingsPage = (): JSX.Element =>  {
             <CardDescription>Manage your billing and subscription</CardDescription>
           </CardHeader>
           <CardContent>
-            {/* Add more billing management components */}
+            <div className="space-y-6">
+              <NumberingSettings entityType="INVOICE" />
+              {/* Add more billing management components */}
+            </div>
           </CardContent>
         </Card>
       ),

--- a/server/src/components/settings/general/TicketingSettings.tsx
+++ b/server/src/components/settings/general/TicketingSettings.tsx
@@ -13,7 +13,7 @@ import { IChannel } from '@/interfaces/channel.interface';
 import { IStatus, ItemType } from '@/interfaces/status.interface';
 import { IPriority, ITicketCategory } from '@/interfaces/ticket.interfaces';
 import { getCurrentUser } from '@/lib/actions/user-actions/userActions';
-import TicketNumberingSettings from './TicketNumberingSettings';
+import NumberingSettings from './NumberingSettings';
 import { Switch } from '@/components/ui/Switch';
 import { DataTable } from '@/components/ui/DataTable';
 import { ColumnDefinition } from '@/interfaces/dataTable.interfaces';
@@ -850,7 +850,7 @@ const TicketingSettings = (): JSX.Element => {
   const tabs = [
     {
       label: "Ticket Numbering",
-      content: <TicketNumberingSettings />
+      content: <NumberingSettings entityType="TICKET" />
     },
     {
       label: "Channels",

--- a/server/src/lib/actions/number-actions/numberingActions.ts
+++ b/server/src/lib/actions/number-actions/numberingActions.ts
@@ -1,0 +1,103 @@
+'use server';
+
+import { createTenantKnex } from '@/lib/db';
+import type { EntityType } from '@/lib/services/numberingService';
+
+export interface NumberSettings {
+  prefix: string;
+  last_number: number;
+  initial_value: number;
+  padding_length: number;
+}
+
+export interface UpdateResponse {
+  success: boolean;
+  error?: string;
+  settings?: NumberSettings;
+}
+
+export async function getNumberSettings(entityType: EntityType): Promise<NumberSettings> {
+  const { knex: db, tenant } = await createTenantKnex();
+  const settings = await db('next_number')
+    .where('entity_type', entityType)
+    .andWhere('tenant', tenant)
+    .first();
+  return settings;
+}
+
+export async function updateNumberSettings(
+  entityType: EntityType,
+  updates: Partial<NumberSettings>
+): Promise<UpdateResponse> {
+  const { knex: db, tenant } = await createTenantKnex();
+  
+  try {
+    // Get current settings if they exist
+    const currentSettings = await getNumberSettings(entityType);
+    const isNewSettings = !currentSettings;
+
+    // Combine current settings with updates
+    const finalSettings = {
+      ...(currentSettings || {
+        prefix: entityType === 'TICKET' ? 'TK-' : 'INV-',
+        padding_length: 6,
+        last_number: 0,
+        initial_value: 1
+      }),
+      ...updates
+    };
+
+    // Validate settings
+    // Validate all fields using finalSettings
+    if (!Number.isInteger(finalSettings.initial_value) || finalSettings.initial_value < 1) {
+      return { success: false, error: 'Initial value must be a positive integer' };
+    }
+
+    if (!Number.isInteger(finalSettings.last_number) || finalSettings.last_number < 1) {
+      return { success: false, error: 'Last number must be a positive integer' };
+    }
+
+    if (finalSettings.last_number < finalSettings.initial_value) {
+      return { success: false, error: 'Last number cannot be less than the initial value' };
+    }
+
+    // Only check for decreasing last_number if we're updating existing settings
+    if (!isNewSettings && currentSettings && finalSettings.last_number < currentSettings.last_number) {
+      return { success: false, error: 'New number must be greater than the current last number' };
+    }
+
+    if (!Number.isInteger(finalSettings.padding_length) ||
+        finalSettings.padding_length < 1 ||
+        finalSettings.padding_length > 10) {
+      return { success: false, error: 'Padding length must be a positive integer between 1 and 10' };
+    }
+
+    if (!finalSettings.prefix || typeof finalSettings.prefix !== 'string') {
+      return { success: false, error: 'Prefix is required' };
+    }
+
+    // Insert or update settings
+    if (isNewSettings) {
+      await db('next_number').insert({
+        tenant,
+        entity_type: entityType,
+        ...finalSettings
+      });
+    } else {
+      await db('next_number')
+        .where('entity_type', entityType)
+        .andWhere('tenant', tenant)
+        .update(finalSettings);
+    }
+
+    const updatedSettings = await getNumberSettings(entityType);
+    return { success: true, settings: updatedSettings };
+  } catch (error) {
+    console.error(`Error updating ${entityType} number settings:`, error);
+    return { success: false, error: 'Failed to update number settings' };
+  }
+}
+
+// Legacy support
+export const getTicketNumberSettings = () => getNumberSettings('TICKET');
+export const getInvoiceNumberSettings = () => getNumberSettings('INVOICE');

--- a/server/src/lib/services/numberingService.ts
+++ b/server/src/lib/services/numberingService.ts
@@ -1,35 +1,51 @@
 import { createTenantKnex } from '@/lib/db';
 import type { Knex } from 'knex';
 
+// Define supported entity types
+export type EntityType = 'TICKET' | 'INVOICE';
+
 export class NumberingService {
-  async getNextTicketNumber(): Promise<string> {
+  /**
+   * Generates the next sequential number for a given entity type
+   * @param entityType The type of entity to generate a number for ('TICKET' | 'INVOICE')
+   * @returns A formatted string containing the next number with prefix and padding
+   * @throws Error if tenant context is missing or number generation fails
+   */
+  async getNextNumber(entityType: EntityType): Promise<string> {
     const { knex, tenant } = await createTenantKnex();
     
     if (!tenant) {
-      throw new Error('Tenant context is required for generating ticket numbers');
+      throw new Error(`Tenant context is required for generating ${entityType.toLowerCase()} numbers`);
     }
 
     try {
-      // Use a prepared statement for better performance
+      // Use parameterized query for CitusDB compatibility
       const result = await knex.raw(
         'SELECT generate_next_number(:tenant::uuid, :type::text) as number',
-        { tenant, type: 'TICKET' }
+        { tenant, type: entityType }
       );
       const number = result?.rows?.[0]?.number;
       
       if (!number) {
-        const error = `Failed to generate ticket number for tenant ${tenant}`;
+        const error = `Failed to generate ${entityType.toLowerCase()} number for tenant ${tenant}`;
         console.error(error);
         throw new Error(error);
       }
 
       return number;
     } catch (error: unknown) {
-      console.error(`Error generating ticket number for tenant ${tenant}:`, error);
+      console.error(`Error generating ${entityType.toLowerCase()} number for tenant ${tenant}:`, error);
       if (error instanceof Error) {
-        throw new Error(`Failed to generate ticket number in tenant ${tenant}: ${error.message}`);
+        throw new Error(`Failed to generate ${entityType.toLowerCase()} number in tenant ${tenant}: ${error.message}`);
       }
-      throw new Error(`Failed to generate ticket number in tenant ${tenant}: Unknown error`);
+      throw new Error(`Failed to generate ${entityType.toLowerCase()} number in tenant ${tenant}: Unknown error`);
     }
+  }
+
+  /**
+   * @deprecated Use getNextNumber('TICKET') instead
+   */
+  async getNextTicketNumber(): Promise<string> {
+    return this.getNextNumber('TICKET');
   }
 }


### PR DESCRIPTION
Adds support for configurable number padding and enhances number generation system:

- Add padding_length column to next_number table with default of 6 digits
- Update generate_next_number function to support padded numbers
- Create reusable NumberingSettings component for both tickets and invoices
- Add number management UI with preview, validation, and admin controls
- Add server actions for managing number settings
- Enhance NumberingService to handle multiple entity types
- Deprecate getNextTicketNumber in favor of generic getNextNumber method

This change allows administrators to configure:
- Number prefixes (e.g. TK-, INV-)
- Padding length (1-10 digits)
- Initial and current number values

The system now generates properly formatted numbers like "TK-000123" or "INV-000456" with consistent padding and validation.

"But how many digits should it be?" asked Alice.
"Six to start, six to end, and six in the middle," replied the Mad Hatter. "But that's eighteen digits!" exclaimed Alice.
"Precisely why we made it configurable," smiled the Cheshire Cat, slowly disappearing until only the zero-padding remained.