### PR TITLE
feat: Add zero-dollar invoice handling settings and configuration

### DIFF
--- a/server/migrations/20250222004732_create_zero_dollar_invoice_settings_tables.cjs
+++ b/server/migrations/20250222004732_create_zero_dollar_invoice_settings_tables.cjs
@@ -1,0 +1,26 @@
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('default_billing_settings', (table) => {
+      table.uuid('tenant').notNullable().references('tenant').inTable('tenants');
+      table.enu('zero_dollar_invoice_handling', ['normal', 'finalized']).notNullable().defaultTo('normal');
+      table.boolean('suppress_zero_dollar_invoices').notNullable().defaultTo(false);
+      table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+      table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+      table.primary(['tenant']);
+    })
+    .createTable('company_billing_settings', (table) => {
+      table.uuid('company_id').notNullable().references('company_id').inTable('companies');
+      table.enu('zero_dollar_invoice_handling', ['normal', 'finalized']).notNullable();
+      table.boolean('suppress_zero_dollar_invoices').notNullable();
+      table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+      table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+      table.uuid('tenant').notNullable();
+      table.primary(['company_id']);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTableIfExists('company_billing_settings')
+    .dropTableIfExists('default_billing_settings');
+};

--- a/server/src/components/companies/BillingConfiguration.tsx
+++ b/server/src/components/companies/BillingConfiguration.tsx
@@ -21,6 +21,7 @@ import { setCompanyTemplate } from '../../lib/actions/invoiceActions';
 import BillingConfigForm from './BillingConfigForm';
 import CompanyTaxRates from './CompanyTaxRates';
 import BillingPlans from './BillingPlans';
+import CompanyZeroDollarInvoiceSettings from './CompanyZeroDollarInvoiceSettings';
 
 interface BillingConfigurationProps {
     company: ICompany;
@@ -347,6 +348,10 @@ const BillingConfiguration: React.FC<BillingConfigurationProps> = ({ company, on
                 billingConfig={billingConfig}
                 handleSelectChange={handleSelectChange}
                 contacts={contacts}
+                companyId={company.company_id}
+            />
+
+            <CompanyZeroDollarInvoiceSettings
                 companyId={company.company_id}
             />
 

--- a/server/src/components/companies/CompanyZeroDollarInvoiceSettings.tsx
+++ b/server/src/components/companies/CompanyZeroDollarInvoiceSettings.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import CustomSelect from '@/components/ui/CustomSelect';
+import { Switch } from '@/components/ui/Switch';
+import { Label } from '@/components/ui/Label';
+import toast from 'react-hot-toast';
+import { getCompanyBillingSettings, updateCompanyBillingSettings, type BillingSettings } from "@/lib/actions/billingSettingsActions";
+
+interface CompanyZeroDollarInvoiceSettingsProps {
+  companyId: string;
+}
+
+const CompanyZeroDollarInvoiceSettings: React.FC<CompanyZeroDollarInvoiceSettingsProps> = ({ companyId }) => {
+  const [settings, setSettings] = useState<BillingSettings | null>(null);
+  const [useDefault, setUseDefault] = useState(true);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const companySettings = await getCompanyBillingSettings(companyId);
+        if (companySettings) {
+          setSettings(companySettings);
+          setUseDefault(false);
+        } else {
+          setUseDefault(true);
+        }
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to load settings");
+      }
+    };
+
+    loadSettings();
+  }, [companyId]);
+
+  const handleHandlingChange = async (value: string) => {
+    try {
+      const newSettings: BillingSettings = {
+        zeroDollarInvoiceHandling: value as 'normal' | 'finalized',
+        suppressZeroDollarInvoices: settings?.suppressZeroDollarInvoices || false,
+      };
+      const result = await updateCompanyBillingSettings(companyId, newSettings);
+      if (result.success) {
+        setSettings(newSettings);
+        setUseDefault(false);
+        toast.success("Zero-dollar invoice settings have been updated.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save settings");
+    }
+  };
+
+  const handleSuppressionChange = async (checked: boolean) => {
+    try {
+      const newSettings: BillingSettings = {
+        zeroDollarInvoiceHandling: settings?.zeroDollarInvoiceHandling || 'normal',
+        suppressZeroDollarInvoices: checked,
+      };
+      const result = await updateCompanyBillingSettings(companyId, newSettings);
+      if (result.success) {
+        setSettings(newSettings);
+        setUseDefault(false);
+        toast.success("Zero-dollar invoice settings have been updated.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save settings");
+    }
+  };
+
+  const handleUseDefaultChange = async (checked: boolean) => {
+    try {
+      if (checked) {
+        // Remove company override
+        const result = await updateCompanyBillingSettings(companyId, null);
+        if (result.success) {
+          setSettings(null);
+          setUseDefault(true);
+          toast.success("Company will now use default zero-dollar invoice settings.");
+        }
+      } else {
+        // Create company override with current settings
+        const newSettings: BillingSettings = {
+          zeroDollarInvoiceHandling: settings?.zeroDollarInvoiceHandling || 'normal',
+          suppressZeroDollarInvoices: settings?.suppressZeroDollarInvoices || false,
+        };
+        const result = await updateCompanyBillingSettings(companyId, newSettings);
+        if (result.success) {
+          setSettings(newSettings);
+          setUseDefault(false);
+          toast.success("Company-specific zero-dollar invoice settings enabled.");
+        }
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update settings");
+    }
+  };
+
+  const handlingOptions = [
+    { value: 'normal', label: 'Create as Draft' },
+    { value: 'finalized', label: 'Create and Finalize' }
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium mb-4">Zero-Dollar Invoice Settings</h3>
+        <div className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="use-default"
+              checked={useDefault}
+              onCheckedChange={handleUseDefaultChange}
+            />
+            <div className="space-y-1">
+              <Label htmlFor="use-default">Use Default Settings</Label>
+              <p className="text-sm text-muted-foreground">
+                Use the system-wide default settings for zero-dollar invoices
+              </p>
+            </div>
+          </div>
+
+          <div className={useDefault ? 'opacity-50 pointer-events-none' : ''}>
+            <div className="space-y-2">
+              <CustomSelect
+                id="zero-dollar-invoice-handling"
+                options={handlingOptions}
+                value={settings?.zeroDollarInvoiceHandling || 'normal'}
+                onValueChange={handleHandlingChange}
+                placeholder="Select handling option"
+                label="Invoice Handling"
+                disabled={useDefault}
+              />
+              <p className="text-sm text-muted-foreground">
+                Choose how zero-dollar invoices should be handled when generated
+              </p>
+            </div>
+
+            <div className="flex items-center space-x-2 mt-4">
+              <Switch
+                id="suppress"
+                checked={settings?.suppressZeroDollarInvoices || false}
+                onCheckedChange={handleSuppressionChange}
+                disabled={useDefault}
+              />
+              <div className="space-y-1">
+                <Label htmlFor="suppress">Suppress Empty Invoices</Label>
+                <p className="text-sm text-muted-foreground">
+                  Skip creation of invoices with no line items
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompanyZeroDollarInvoiceSettings;

--- a/server/src/components/settings/billing/ZeroDollarInvoiceSettings.tsx
+++ b/server/src/components/settings/billing/ZeroDollarInvoiceSettings.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import CustomSelect from "@/components/ui/CustomSelect";
+import { Switch } from "@/components/ui/Switch";
+import { Label } from "@/components/ui/Label";
+import toast from 'react-hot-toast';
+import { getDefaultBillingSettings, updateDefaultBillingSettings, type BillingSettings } from "@/lib/actions/billingSettingsActions";
+
+const ZeroDollarInvoiceSettings = (): JSX.Element => {
+  const [settings, setSettings] = React.useState<BillingSettings>({
+    zeroDollarInvoiceHandling: 'normal',
+    suppressZeroDollarInvoices: false
+  });
+
+  React.useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const currentSettings = await getDefaultBillingSettings();
+        setSettings(currentSettings);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to load settings");
+      }
+    };
+
+    loadSettings();
+  }, []);
+
+  const handleHandlingChange = async (value: string) => {
+    try {
+      const newSettings = {
+        ...settings,
+        zeroDollarInvoiceHandling: value as 'normal' | 'finalized',
+      };
+      const result = await updateDefaultBillingSettings(newSettings);
+      if (result.success) {
+        setSettings(newSettings);
+        toast.success("Zero-dollar invoice settings have been updated.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save settings");
+    }
+  };
+
+  const handleSuppressionChange = async (checked: boolean) => {
+    try {
+      const newSettings = {
+        ...settings,
+        suppressZeroDollarInvoices: checked,
+      };
+      const result = await updateDefaultBillingSettings(newSettings);
+      if (result.success) {
+        setSettings(newSettings);
+        toast.success("Zero-dollar invoice settings have been updated.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save settings");
+    }
+  };
+
+  const handlingOptions = [
+    { value: 'normal', label: 'Create as Draft' },
+    { value: 'finalized', label: 'Create and Finalize' }
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium mb-4">Zero-Dollar Invoice Settings</h3>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <CustomSelect
+              id="zero-dollar-invoice-handling"
+              options={handlingOptions}
+              value={settings.zeroDollarInvoiceHandling}
+              onValueChange={handleHandlingChange}
+              placeholder="Select handling option"
+              label="Invoice Handling"
+            />
+            <p className="text-sm text-muted-foreground">
+              Choose how zero-dollar invoices should be handled when generated
+            </p>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="suppress"
+              checked={settings.suppressZeroDollarInvoices}
+              onCheckedChange={handleSuppressionChange}
+            />
+            <div className="space-y-1">
+              <Label htmlFor="suppress">Suppress Empty Invoices</Label>
+              <p className="text-sm text-muted-foreground">
+                Skip creation of invoices with no line items
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ZeroDollarInvoiceSettings;

--- a/server/src/components/settings/general/SettingsPage.tsx
+++ b/server/src/components/settings/general/SettingsPage.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import React from 'react';
+import ZeroDollarInvoiceSettings from '../billing/ZeroDollarInvoiceSettings';
 import CustomTabs, { TabContent } from "@/components/ui/CustomTabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
@@ -110,8 +111,10 @@ const SettingsPage = (): JSX.Element =>  {
           </CardHeader>
           <CardContent>
             <div className="space-y-6">
-              <NumberingSettings entityType="INVOICE" />
-              {/* Add more billing management components */}
+              <div className="space-y-6">
+                <NumberingSettings entityType="INVOICE" />
+                <ZeroDollarInvoiceSettings />
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/server/src/lib/actions/billingSettingsActions.ts
+++ b/server/src/lib/actions/billingSettingsActions.ts
@@ -1,0 +1,162 @@
+'use server'
+
+import { createTenantKnex } from "@/lib/db";
+import { getServerSession } from "next-auth/next";
+import { options } from "@/app/api/auth/[...nextauth]/options";
+
+export interface BillingSettings {
+  zeroDollarInvoiceHandling: 'normal' | 'finalized';
+  suppressZeroDollarInvoices: boolean;
+}
+
+export async function getDefaultBillingSettings(): Promise<BillingSettings> {
+  const session = await getServerSession(options);
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("No tenant found");
+  }
+
+  const settings = await knex('default_billing_settings')
+    .where({ tenant })
+    .first();
+
+  if (!settings) {
+    // Return default settings if none exist
+    return {
+      zeroDollarInvoiceHandling: 'normal',
+      suppressZeroDollarInvoices: false,
+    };
+  }
+
+  return {
+    zeroDollarInvoiceHandling: settings.zero_dollar_invoice_handling,
+    suppressZeroDollarInvoices: settings.suppress_zero_dollar_invoices,
+  };
+}
+
+export async function updateDefaultBillingSettings(data: BillingSettings): Promise<{ success: boolean }> {
+  const session = await getServerSession(options);
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("No tenant found");
+  }
+
+  await knex.transaction(async (trx) => {
+    const existingSettings = await trx('default_billing_settings')
+      .where({ tenant })
+      .first();
+
+    if (existingSettings) {
+      await trx('default_billing_settings')
+        .where({ tenant })
+        .update({
+          zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
+          suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices,
+          updated_at: trx.fn.now()
+        });
+    } else {
+      await trx('default_billing_settings').insert({
+        tenant,
+        zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
+        suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices
+        // created_at and updated_at will be set by default values
+      });
+    }
+  });
+
+  return { success: true };
+}
+
+export async function getCompanyBillingSettings(companyId: string): Promise<BillingSettings | null> {
+  const session = await getServerSession(options);
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("No tenant found");
+  }
+
+  const settings = await knex('company_billing_settings')
+    .where({ 
+      company_id: companyId,
+      tenant 
+    })
+    .first();
+
+  if (!settings) {
+    return null;
+  }
+
+  return {
+    zeroDollarInvoiceHandling: settings.zero_dollar_invoice_handling,
+    suppressZeroDollarInvoices: settings.suppress_zero_dollar_invoices,
+  };
+}
+
+export async function updateCompanyBillingSettings(
+  companyId: string,
+  data: BillingSettings | null // null to remove override
+): Promise<{ success: boolean }> {
+  const session = await getServerSession(options);
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("No tenant found");
+  }
+
+  await knex.transaction(async (trx) => {
+    // If data is null, remove the company override
+    if (data === null) {
+      await trx('company_billing_settings')
+        .where({ 
+          company_id: companyId,
+          tenant 
+        })
+        .delete();
+      return;
+    }
+
+    const existingSettings = await trx('company_billing_settings')
+      .where({ 
+        company_id: companyId,
+        tenant 
+      })
+      .first();
+
+    if (existingSettings) {
+      await trx('company_billing_settings')
+        .where({ 
+          company_id: companyId,
+          tenant 
+        })
+        .update({
+          zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
+          suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices,
+          updated_at: trx.fn.now()
+        });
+    } else {
+      await trx('company_billing_settings').insert({
+        company_id: companyId,
+        tenant,
+        zero_dollar_invoice_handling: data.zeroDollarInvoiceHandling,
+        suppress_zero_dollar_invoices: data.suppressZeroDollarInvoices
+        // created_at and updated_at will be set by default values
+      });
+    }
+  });
+
+  return { success: true };
+}

--- a/server/src/test/infrastructure/invoiceNumberGeneration_part1.test.ts
+++ b/server/src/test/infrastructure/invoiceNumberGeneration_part1.test.ts
@@ -191,6 +191,9 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 1)', ()
 
     // First successful generation
     const invoice1 = await generateInvoice(successCycle1);
+    if (!invoice1) {
+      throw new Error('Failed to generate first invoice');
+    }
     expect(invoice1.invoice_number).toBe('INV-000001');
 
     // Failed generation attempt (no billing plan for this company)
@@ -203,6 +206,9 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 1)', ()
 
     // Second successful generation - should be next in sequence
     const invoice2 = await generateInvoice(successCycle2);
+    if (!invoice2) {
+      throw new Error('Failed to generate second invoice');
+    }
     expect(invoice2.invoice_number).toBe('INV-000002');
 
     // Verify the sequence in next_number table
@@ -294,6 +300,9 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 1)', ()
 
       // Generate invoice and verify prefix handling
       const invoice = await generateInvoice(billingCycle);
+      if (!invoice) {
+        throw new Error(`Failed to generate invoice for prefix: ${testCase.prefix}`);
+      }
       expect(invoice.invoice_number).toBe(testCase.expected);
     }
   });
@@ -377,6 +386,14 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 1)', ()
     // Generate invoices and verify they increment correctly from initial value
     const invoice1 = await generateInvoice(billingCycle1);
     const invoice2 = await generateInvoice(billingCycle2);
+
+    if (!invoice1) {
+      throw new Error(`Failed to generate invoice1`);
+    }
+
+    if (!invoice2) {
+      throw new Error(`Failed to generate invoice2`);
+    }
 
     // Verify numbers start from initial value and increment
     expect(invoice1.invoice_number).toBe('INV-1000000');


### PR DESCRIPTION
This commit adds functionality to manage how zero-dollar invoices are handled:

- Adds migration for default_billing_settings and company_billing_settings tables
- Implements company-specific and default tenant-wide settings
- Adds UI components for configuring settings at both levels
- Introduces options to:
  - Create zero-dollar invoices as draft or finalized
  - Suppress zero-dollar invoices entirely
- Updates invoice generation logic to respect these settings
- Includes UI components for both global and company-specific settings
- Adds null safety checks in invoice tests

The feature allows fine-grained control over zero-dollar invoice behavior at both the system and company level, with company settings taking precedence over defaults.

🎩 "Would you tell me, please, which way I should handle these zero-dollar invoices?" "That depends a good deal on where you want them to go," said the Mad Hatter 💫