### PR TITLE
fix(tickets): update resource assignments when ticket assignee changes

### DIFF
--- a/server/src/components/tickets/TicketDetails.tsx
+++ b/server/src/components/tickets/TicketDetails.tsx
@@ -320,6 +320,18 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
             const result = await updateTicket(ticket.ticket_id || '', { [field]: newValue }, user);
             if (result === 'success') {
                 console.log(`${field} changed to: ${newValue}`);
+                
+                // If we're changing the assigned_to field, refresh the additional resources
+                if (field === 'assigned_to') {
+                    try {
+                        // Refresh the additional resources
+                        const resources = await getTicketResources(ticket.ticket_id!, user);
+                        setAdditionalAgents(resources);
+                        console.log('Additional resources refreshed after assignment change');
+                    } catch (resourceError) {
+                        console.error('Error refreshing additional resources:', resourceError);
+                    }
+                }
             } else {
                 console.error(`Failed to update ticket ${field}`);
                 setTicket(prevTicket => ({ ...prevTicket, [field]: ticket[field] }));

--- a/server/src/lib/eventBus/consumers/emailNotificationConsumer.ts
+++ b/server/src/lib/eventBus/consumers/emailNotificationConsumer.ts
@@ -75,7 +75,7 @@ export async function initializeEmailNotificationConsumer(tenantId: string) {
       case 'TICKET_COMMENT_ADDED': {
         const ticket = await knex('tickets as t')
           .select(
-            't.assigned_user_id',
+            't.assigned_to',
             't.ticket_number',
             't.title',
             'c.email as company_email',
@@ -116,10 +116,10 @@ export async function initializeEmailNotificationConsumer(tenantId: string) {
         }
         
         // Fallback to assigned user's email
-        if (ticket?.assigned_user_id) {
+        if (ticket?.assigned_to) {
           const user = await knex('users')
             .select('email')
-            .where('id', ticket.assigned_user_id)
+            .where('user_id', ticket.assigned_to)
             .first();
           return user?.email || null;
         }


### PR DESCRIPTION
This commit improves the ticket assignment process by properly managing ticket resources when the assigned agent changes. The changes:

- Automatically refresh additional resources after assignment change in UI
- Implement transaction-based assignment change in ticket actions API
- Fix field name references in email notification consumer (assigned_user_id → assigned_to)

This resolves issues where ticket resources could become invalid or out of sync when changing the ticket assignee.