### PR TITLE
feat(billing): separate billing method from service type (work in pro…

### DIFF
--- a/server/migrations/20250326011924_update_service_catalog_for_billing_method.cjs
+++ b/server/migrations/20250326011924_update_service_catalog_for_billing_method.cjs
@@ -1,0 +1,41 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  // First, drop the old constraint
+  await knex.raw('ALTER TABLE service_catalog DROP CONSTRAINT IF EXISTS service_type_check;');
+
+  // Then, add the new column and the new constraint
+  await knex.schema.alterTable('service_catalog', function(table) {
+    table.string('billing_method'); // Add the new column
+  });
+
+  // Add the check constraint for the new column
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    ADD CONSTRAINT billing_method_check CHECK (billing_method IN ('fixed', 'per_unit'));
+  `);
+
+  // Note: Data migration (populating billing_method) will be handled separately.
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  // Drop the new constraint first
+  await knex.raw('ALTER TABLE service_catalog DROP CONSTRAINT IF EXISTS billing_method_check;');
+
+  // Remove the billing_method column
+  await knex.schema.alterTable('service_catalog', function(table) {
+    table.dropColumn('billing_method');
+  });
+
+  // Re-add the old service_type constraint
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    ADD CONSTRAINT service_type_check CHECK ((service_type = ANY (ARRAY['Fixed'::text, 'Time'::text, 'Usage'::text, 'Product'::text, 'License'::text])));
+  `);
+};

--- a/server/migrations/20250326023334_populate_billing_method_from_service_type.cjs
+++ b/server/migrations/20250326023334_populate_billing_method_from_service_type.cjs
@@ -1,0 +1,58 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  console.log('Populating billing_method based on old service_type...');
+
+  // Fetch all services with their old service_type and tenant
+  const services = await knex('service_catalog').select('service_id', 'service_type', 'tenant');
+
+  console.log(`Found ${services.length} services to update.`);
+
+  // Update billing_method based on old service_type
+  for (const service of services) {
+    let billingMethod = null;
+
+    switch (service.service_type) {
+      case 'Fixed':
+      case 'License':
+        billingMethod = 'fixed';
+        break;
+      case 'Time':
+      case 'Usage':
+      case 'Product':
+        billingMethod = 'per_unit';
+        break;
+      default:
+        console.warn(`Unknown service_type '${service.service_type}' for service_id ${service.service_id}. Setting billing_method to NULL.`);
+        // Keep billingMethod as null or decide on a default
+        break;
+    }
+
+    if (billingMethod) {
+      try {
+        await knex('service_catalog')
+          .where({ service_id: service.service_id, tenant: service.tenant }) // Include tenant for CitusDB
+          .update({ billing_method: billingMethod });
+      } catch (error) {
+         console.error(`Error updating service ${service.service_id} (tenant: ${service.tenant}):`, error);
+         // Decide if you want to throw the error and stop, or continue
+         // throw error; 
+      }
+    }
+  }
+  console.log('Finished populating billing_method.');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  // Revert billing_method to NULL. A true rollback is complex as the original state isn't stored.
+  console.log('Reverting billing_method population (setting to NULL)...');
+  await knex('service_catalog')
+    .update({ billing_method: null });
+  console.log('Finished reverting billing_method population.');
+};

--- a/server/src/components/billing-dashboard/BillingPlanDialog.tsx
+++ b/server/src/components/billing-dashboard/BillingPlanDialog.tsx
@@ -27,6 +27,11 @@ import { HourlyPlanConfigPanel } from './plan-types/HourlyPlanConfigPanel';
 import { UsagePlanConfigPanel } from './plan-types/UsagePlanConfigPanel';
 import { BucketPlanConfigPanel } from './plan-types/BucketPlanConfigPanel';
 
+// Define billing method options
+const BILLING_METHOD_OPTIONS: Array<{ value: 'fixed' | 'per_unit'; label: string }> = [
+  { value: 'fixed', label: 'Fixed Price' },
+  { value: 'per_unit', label: 'Per Unit' }
+];
 interface BillingPlanDialogProps {
   onPlanAdded: () => void;
   editingPlan?: IBillingPlan | null;
@@ -699,10 +704,13 @@ export function BillingPlanDialog({ onPlanAdded, editingPlan, onClose, triggerBu
                                 }
                               }}
                             />
-                            <label htmlFor={`service-${service.service_id}`} className="flex-grow cursor-pointer">
-                              {service.service_name}
+                            <label htmlFor={`service-${service.service_id}`} className="flex-grow cursor-pointer flex flex-col">
+                              <span>{service.service_name}</span>
+                              <span className="text-xs text-gray-400">
+                                Category: {service.service_type} | Method: {BILLING_METHOD_OPTIONS.find((opt: { value: string; label: string }) => opt.value === service.billing_method)?.label || service.billing_method}
+                              </span>
                             </label>
-                            <span className="text-sm text-gray-500">${parseFloat(service.default_rate.toString()).toFixed(2)}</span>
+                            <span className="text-sm text-gray-600">${(service.default_rate / 100).toFixed(2)}</span> {/* Display rate in dollars */}
                           </div>
                         ))}
                       </div>

--- a/server/src/components/billing-dashboard/ServiceForm.tsx
+++ b/server/src/components/billing-dashboard/ServiceForm.tsx
@@ -5,14 +5,15 @@ import { Button } from 'server/src/components/ui/Button'
 import { Input } from 'server/src/components/ui/Input'
 import CustomSelect from 'server/src/components/ui/CustomSelect'
 import { createService } from 'server/src/lib/actions/serviceActions'
-import { ServiceType } from 'server/src/interfaces'
+// Removed ServiceType import
 import { UnitOfMeasureInput } from './UnitOfMeasureInput'
 
 export const ServiceForm: React.FC = () => {
   const [serviceName, setServiceName] = useState('')
-  const [serviceType, setServiceType] = useState<ServiceType>('Time')
+  const [serviceType, setServiceType] = useState<string>('Time') // Changed type to string
   const [defaultRate, setDefaultRate] = useState('')
   const [unitOfMeasure, setUnitOfMeasure] = useState('')
+  const [billingMethod, setBillingMethod] = useState<'fixed' | 'per_unit'>('fixed') // Added state for billing method
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -22,13 +23,15 @@ export const ServiceForm: React.FC = () => {
         service_type: serviceType,
         default_rate: parseFloat(defaultRate),
         unit_of_measure: unitOfMeasure,
-        category_id: ''
+        category_id: '',
+        billing_method: billingMethod // Added billing method to payload
       })
       // Clear form fields after successful submission
       setServiceName('')
-      setServiceType('Time')
+      setServiceType('Time') // No change needed here, already string
       setDefaultRate('')
       setUnitOfMeasure('')
+      setBillingMethod('fixed') // Reset billing method state
     } catch (error) {
       console.error('Error creating service:', error)
       // Handle error (e.g., show error message to user)
@@ -51,8 +54,18 @@ export const ServiceForm: React.FC = () => {
           { value: 'Usage', label: 'Usage-Based' }
         ]}
         value={serviceType}
-        onValueChange={(value) => setServiceType(value as ServiceType)}
+        onValueChange={(value) => setServiceType(value)} // Removed 'as ServiceType' cast
         placeholder="Select Service Type"
+      />
+      
+      <CustomSelect
+        options={[
+          { value: 'fixed', label: 'Fixed Price' },
+          { value: 'per_unit', label: 'Per Unit' }
+        ]}
+        value={billingMethod}
+        onValueChange={(value) => setBillingMethod(value as 'fixed' | 'per_unit')}
+        placeholder="Select Billing Method"
       />
 
       <Input

--- a/server/src/components/billing-dashboard/billing-plans/BillingPlanServiceForm.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BillingPlanServiceForm.tsx
@@ -95,25 +95,23 @@ const BillingPlanServiceForm: React.FC<BillingPlanServiceFormProps> = ({
             custom_rate: planService.custom_rate
           });
           
-          // Set default type config based on service type
+          // Set default type config based on service billing_method and category (service_type)
           if (service) {
-            let configType: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket' = 'Fixed';
-            
-            switch (service.service_type) {
-              case 'Time':
-                configType = 'Hourly';
-                break;
-              case 'Usage':
-                configType = 'Usage';
-                break;
-              case 'Fixed':
-              case 'Product':
-              case 'License':
-              default:
-                configType = 'Fixed';
-                break;
+            let configType: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket' = 'Fixed'; // Default to Fixed
+
+            if (service.billing_method === 'fixed') {
+              configType = 'Fixed';
+            } else if (service.billing_method === 'per_unit') {
+              // Check category for per_unit services
+              const laborCategories = ['Labor - Support', 'Labor - Project', 'Consulting'];
+              if (laborCategories.includes(service.service_type)) {
+                configType = 'Hourly'; // Default labor categories to Hourly
+              } else {
+                configType = 'Usage'; // Default other per_unit categories to Usage
+              }
             }
-            
+            // Note: 'Bucket' type is not set as a default here, it must be explicitly chosen.
+
             setBaseConfig(prev => ({
               ...prev,
               configuration_type: configType

--- a/server/src/components/billing-dashboard/billing-plans/BillingPlanServices.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BillingPlanServices.tsx
@@ -30,6 +30,12 @@ import BillingPlanServiceForm from './BillingPlanServiceForm';
 import { Badge } from 'server/src/components/ui/Badge';
 import { IPlanServiceConfiguration } from 'server/src/interfaces/planServiceConfiguration.interfaces';
 
+// Define billing method options
+const BILLING_METHOD_OPTIONS: Array<{ value: 'fixed' | 'per_unit'; label: string }> = [
+  { value: 'fixed', label: 'Fixed Price' },
+  { value: 'per_unit', label: 'Per Unit' }
+];
+
 interface BillingPlanServicesProps {
   plan: IBillingPlan;
 }
@@ -168,6 +174,22 @@ const BillingPlanServices: React.FC<BillingPlanServicesProps> = ({ plan }) => {
       },
     },
     {
+      title: 'Category',
+      dataIndex: 'service_id',
+      render: (value) => {
+        const service = availableServices.find(s => s.service_id === value);
+        return service?.service_type || 'N/A';
+      },
+    },
+    {
+      title: 'Billing Method',
+      dataIndex: 'service_id',
+      render: (value) => {
+        const service = availableServices.find(s => s.service_id === value);
+        return BILLING_METHOD_OPTIONS.find(opt => opt.value === service?.billing_method)?.label || service?.billing_method || 'N/A';
+      },
+    },
+    {
       title: 'Configuration Type',
       dataIndex: 'configurationType',
       render: (value) => (
@@ -285,11 +307,16 @@ const BillingPlanServices: React.FC<BillingPlanServicesProps> = ({ plan }) => {
                             }
                           }}
                         />
-                        <label htmlFor={`service-${service.service_id}`} className="flex-grow">
-                          {service.service_name}
-                          {isAlreadyInPlan && <span className="ml-2 text-xs text-blue-600">(Already in plan)</span>}
+                        <label htmlFor={`service-${service.service_id}`} className="flex-grow cursor-pointer flex flex-col">
+                          <span>
+                            {service.service_name}
+                            {isAlreadyInPlan && <span className="ml-2 text-xs text-blue-600">(Already in plan)</span>}
+                          </span>
+                          <span className="text-xs text-gray-400">
+                            Category: {service.service_type} | Method: {BILLING_METHOD_OPTIONS.find(opt => opt.value === service.billing_method)?.label || service.billing_method}
+                          </span>
                         </label>
-                        <span className="text-sm text-gray-500">${parseFloat(service.default_rate.toString()).toFixed(2)}</span>
+                        <span className="text-sm text-gray-600">${(service.default_rate / 100).toFixed(2)}</span> {/* Display rate in dollars */}
                       </div>
                     );
                   })}

--- a/server/src/components/billing-dashboard/service-configurations/BaseServiceConfigPanel.tsx
+++ b/server/src/components/billing-dashboard/service-configurations/BaseServiceConfigPanel.tsx
@@ -55,7 +55,7 @@ export function BaseServiceConfigPanel({
   }, [configuration.custom_rate, configuration.quantity]);
 
   const handleCustomRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value === '' ? undefined : Number(e.target.value);
+    const value = e.target.value === '' ? undefined : Math.round(Number(e.target.value) * 100); // Store in cents
     onConfigurationChange({ custom_rate: value });
   };
 
@@ -129,9 +129,9 @@ export function BaseServiceConfigPanel({
             <Input
               id="service-custom-rate"
               type="number"
-              value={configuration.custom_rate?.toString() || ''}
+              value={(configuration.custom_rate !== undefined ? configuration.custom_rate / 100 : '').toString()} // Display in dollars
               onChange={handleCustomRateChange}
-              placeholder={service?.default_rate ? `Default: $${service.default_rate.toFixed(2)}` : 'Enter rate'}
+              placeholder={service?.default_rate !== undefined ? `Default: $${(service.default_rate / 100).toFixed(2)}` : 'Enter rate'} // Display default in dollars
               disabled={disabled}
               min={0}
               step={0.01}
@@ -142,7 +142,7 @@ export function BaseServiceConfigPanel({
             ) : (
               <p className="text-sm text-gray-500 mt-1">
                 {service?.default_rate 
-                  ? `Leave blank to use default rate ($${service.default_rate.toFixed(2)})`
+                  ? `Leave blank to use default rate ($${(service.default_rate / 100).toFixed(2)})` // Display default in dollars
                   : 'Custom rate for this service'}
               </p>
             )}

--- a/server/src/components/billing-dashboard/service-configurations/BucketServiceConfigPanel.tsx
+++ b/server/src/components/billing-dashboard/service-configurations/BucketServiceConfigPanel.tsx
@@ -69,7 +69,7 @@ export function BucketServiceConfigPanel({
   };
 
   const handleOverageRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
+    const value = Math.round(Number(e.target.value) * 100); // Store in cents
     setOverageRate(value);
     onConfigurationChange({ overage_rate: value });
   };
@@ -128,7 +128,7 @@ export function BucketServiceConfigPanel({
             <Input
               id="bucket-overage-rate"
               type="number"
-              value={overageRate.toString()}
+              value={(overageRate / 100).toString()} // Display in dollars
               onChange={handleOverageRateChange}
               placeholder="Enter overage rate"
               disabled={disabled}

--- a/server/src/components/billing-dashboard/service-configurations/HourlyServiceConfigPanel.tsx
+++ b/server/src/components/billing-dashboard/service-configurations/HourlyServiceConfigPanel.tsx
@@ -123,7 +123,7 @@ export function HourlyServiceConfigPanel({
   };
 
   const handleOvertimeRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value === '' ? undefined : Number(e.target.value);
+    const value = e.target.value === '' ? undefined : Math.round(Number(e.target.value) * 100); // Store in cents
     setOvertimeRate(value);
     onConfigurationChange({ overtime_rate: value });
   };
@@ -146,7 +146,7 @@ export function HourlyServiceConfigPanel({
   };
 
   const handleNewUserTypeRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value === '' ? undefined : Number(e.target.value);
+    const value = e.target.value === '' ? undefined : Math.round(Number(e.target.value) * 100); // Store in cents
     setNewUserTypeRate(value);
   };
 
@@ -157,7 +157,7 @@ export function HourlyServiceConfigPanel({
 
     const newRate: Partial<IUserTypeRate> = {
       user_type: newUserType,
-      rate: newUserTypeRate
+      rate: newUserTypeRate // Already in cents from state
     };
 
     onUserTypeRatesChange([...userTypeRates, newRate as IUserTypeRate]);
@@ -245,7 +245,7 @@ export function HourlyServiceConfigPanel({
                   {userTypeRates.map((item, index) => (
                     <div key={index} className="grid grid-cols-3 gap-2 items-center mb-1">
                       <div>{userTypeOptions.find(opt => opt.value === item.user_type)?.label || item.user_type}</div>
-                      <div>${item.rate.toFixed(2)}</div>
+                      <div>${(item.rate / 100).toFixed(2)}</div> {/* Display in dollars */}
                       <Button
                         type="button"
                         onClick={() => handleRemoveUserTypeRate(index)}
@@ -279,7 +279,7 @@ export function HourlyServiceConfigPanel({
                   <Input
                     id="new-user-type-rate"
                     type="number"
-                    value={newUserTypeRate?.toString() || ''}
+                    value={(newUserTypeRate !== undefined ? newUserTypeRate / 100 : '').toString()} // Display in dollars
                     onChange={handleNewUserTypeRateChange}
                     placeholder="Enter rate"
                     disabled={disabled}
@@ -323,7 +323,7 @@ export function HourlyServiceConfigPanel({
                 <Input
                   id="overtime-rate"
                   type="number"
-                  value={overtimeRate?.toString() || ''}
+                  value={(overtimeRate !== undefined ? overtimeRate / 100 : '').toString()} // Display in dollars
                   onChange={handleOvertimeRateChange}
                   placeholder="Enter overtime rate"
                   disabled={disabled}

--- a/server/src/components/billing-dashboard/service-configurations/UsageServiceConfigPanel.tsx
+++ b/server/src/components/billing-dashboard/service-configurations/UsageServiceConfigPanel.tsx
@@ -143,7 +143,7 @@ export function UsageServiceConfigPanel({
       id: Date.now().toString(),
       min_quantity: tiers.length > 0 ? (tiers[tiers.length - 1].max_quantity || 0) + 1 : 1,
       max_quantity: tiers.length > 0 ? (tiers[tiers.length - 1].max_quantity || 0) + 100 : 100,
-      rate: 0
+      rate: 0 // Rate is stored in cents
     };
     
     // If this is the first tier, set min_quantity to 0
@@ -160,7 +160,7 @@ export function UsageServiceConfigPanel({
       config_id: '', // This will be set by the backend
       min_quantity: tier.min_quantity,
       max_quantity: tier.max_quantity === null ? undefined : tier.max_quantity,
-      rate: tier.rate,
+      rate: tier.rate, // Already in cents
       tenant: '', // This will be set by the backend
       created_at: new Date(),
       updated_at: new Date()
@@ -181,7 +181,7 @@ export function UsageServiceConfigPanel({
       config_id: '', // This will be set by the backend
       min_quantity: tier.min_quantity,
       max_quantity: tier.max_quantity === null ? undefined : tier.max_quantity,
-      rate: tier.rate,
+      rate: tier.rate, // Already in cents
       tenant: '', // This will be set by the backend
       created_at: new Date(),
       updated_at: new Date()
@@ -195,7 +195,8 @@ export function UsageServiceConfigPanel({
     
     const updatedTiers = tiers.map(tier => {
       if (tier.id === id) {
-        return { ...tier, [field]: value };
+        // Store rate in cents if the field is 'rate'
+        return { ...tier, [field]: field === 'rate' && typeof value === 'number' ? Math.round(value * 100) : value };
       }
       return tier;
     });
@@ -208,7 +209,7 @@ export function UsageServiceConfigPanel({
       config_id: '', // This will be set by the backend
       min_quantity: tier.min_quantity,
       max_quantity: tier.max_quantity === null ? undefined : tier.max_quantity,
-      rate: tier.rate,
+      rate: tier.rate, // Already in cents
       tenant: '', // This will be set by the backend
       created_at: new Date(),
       updated_at: new Date()
@@ -342,8 +343,8 @@ export function UsageServiceConfigPanel({
                         <Input
                           id={`tier-${tier.id}-rate`}
                           type="number"
-                          value={tier.rate}
-                          onChange={(e) => handleTierChange(tier.id, 'rate', Number(e.target.value))}
+                          value={(tier.rate / 100).toString()} // Display in dollars
+                          onChange={(e) => handleTierChange(tier.id, 'rate', Number(e.target.value))} // handleTierChange will convert to cents
                           disabled={disabled}
                           min={0}
                           step={0.01}

--- a/server/src/components/companies/BillingConfiguration.tsx
+++ b/server/src/components/companies/BillingConfiguration.tsx
@@ -11,7 +11,7 @@ import ContactModel from 'server/src/lib/models/contact';
 import { getCompanyBillingPlan, updateCompanyBillingPlan, addCompanyBillingPlan, removeCompanyBillingPlan, editCompanyBillingPlan } from '../../lib/actions/companyBillingPlanActions';
 import { getBillingPlans } from '../../lib/actions/billingPlanAction';
 import { getServiceCategories } from '../../lib/actions/serviceCategoryActions';
-import { ICompanyBillingPlan, IBillingPlan, IServiceCategory, ServiceType, BillingCycleType } from '../../interfaces/billing.interfaces';
+import { ICompanyBillingPlan, IBillingPlan, IServiceCategory, BillingCycleType } from '../../interfaces/billing.interfaces';
 import { getServices, createService, updateService, deleteService } from '../../lib/actions/serviceActions';
 import { IService } from '../../interfaces/billing.interfaces';
 import { getTaxRates } from '../../lib/actions/taxRateActions';
@@ -63,7 +63,7 @@ const BillingConfiguration: React.FC<BillingConfigurationProps> = ({ company, on
     const [services, setServices] = useState<IService[]>([]);
     const [newService, setNewService] = useState<Partial<IService>>({
         unit_of_measure: 'hour',
-        service_type: 'Time' as ServiceType,
+        service_type: 'Time', // Removed 'as ServiceType' cast
         service_name: '',
         default_rate: 0,
         category_id: '',
@@ -263,7 +263,7 @@ const BillingConfiguration: React.FC<BillingConfigurationProps> = ({ company, on
             await createService(newService as IService);
             setNewService({
                 unit_of_measure: 'hour',
-                service_type: 'Time' as ServiceType,
+                service_type: 'Time', // Removed 'as ServiceType' cast
                 service_name: '',
                 default_rate: 0,
                 category_id: '',

--- a/server/src/interfaces/billing.interfaces.ts
+++ b/server/src/interfaces/billing.interfaces.ts
@@ -108,8 +108,6 @@ export interface IServiceCategory extends TenantEntity {
   description?: string;
 }
 
-export type ServiceType = 'Fixed' | 'Time' | 'Usage' | 'Product' | 'License';
-
 export interface IProductCharge extends IBillingCharge, TenantEntity {
   serviceId: string;
   serviceName: string;
@@ -133,7 +131,8 @@ export interface ILicenseCharge extends IBillingCharge, TenantEntity {
 export interface IService extends TenantEntity {
   service_id: string;
   service_name: string;
-  service_type: ServiceType;
+  service_type: string; // Repurposed for category
+  billing_method: 'fixed' | 'per_unit';
   default_rate: number;
   category_id: string | null;
   unit_of_measure: string;

--- a/server/src/lib/billing/billingEngine.ts
+++ b/server/src/lib/billing/billingEngine.ts
@@ -923,7 +923,7 @@ export class BillingEngine {
         'company_billing_plans.company_id': companyId,
         'company_billing_plans.company_billing_plan_id': companyBillingPlan.company_billing_plan_id,
         'company_billing_plans.tenant': company.tenant,
-        'service_catalog.service_type': 'Product'
+        'service_catalog.service_type': 'Hardware' // Updated filter to use new category
       })
       .select(
         'service_catalog.*',
@@ -989,7 +989,7 @@ export class BillingEngine {
         'company_billing_plans.company_id': companyId,
         'company_billing_plans.company_billing_plan_id': companyBillingPlan.company_billing_plan_id,
         'company_billing_plans.tenant': company.tenant,
-        'service_catalog.service_type': 'License'
+        'service_catalog.service_type': 'Software License' // Updated filter to use new category
       })
       .select(
         'service_catalog.*',

--- a/server/src/lib/models/service.ts
+++ b/server/src/lib/models/service.ts
@@ -23,7 +23,8 @@ export const serviceSchema = z.object({
   service_id: z.string(),
   tenant: z.string().min(1, 'Tenant is required'),
   service_name: z.string(),
-  service_type: z.enum(['Fixed', 'Time', 'Usage']),
+  service_type: z.string(), // Changed from enum to string
+  billing_method: z.enum(['fixed', 'per_unit']), // Added billing_method
   default_rate: z.number(),
   unit_of_measure: z.string(),
   category_id: z.string().nullable()
@@ -55,6 +56,7 @@ const Service = {
           'service_id',
           'service_name',
           'service_type',
+          'billing_method', // Added billing_method
           db.raw('CAST(default_rate AS FLOAT) as default_rate'),
           'unit_of_measure',
           'category_id',
@@ -97,6 +99,7 @@ const Service = {
           'service_id',
           'service_name',
           'service_type',
+          'billing_method', // Added billing_method
           db.raw('CAST(default_rate AS FLOAT) as default_rate'),
           'unit_of_measure',
           'category_id',
@@ -137,7 +140,8 @@ const Service = {
       category_id: serviceData.category_id || null,
       // Optional fields
       is_taxable: serviceData.is_taxable || false,
-      tax_region: serviceData.tax_region || null
+      tax_region: serviceData.tax_region || null,
+      billing_method: serviceData.billing_method // Added billing_method
     };
 
     log.info('[Service.create] Constructed newService object:', newService);
@@ -179,6 +183,7 @@ const Service = {
           'service_id',
           'service_name',
           'service_type',
+          'billing_method', // Added billing_method
           db.raw('CAST(default_rate AS FLOAT) as default_rate'),
           'unit_of_measure',
           'category_id',
@@ -243,6 +248,7 @@ const Service = {
           'service_id',
           'service_name',
           'service_type',
+          'billing_method', // Added billing_method
           db.raw('CAST(default_rate AS FLOAT) as default_rate'),
           'unit_of_measure',
           'category_id',


### PR DESCRIPTION
…gress!)

Restructure service catalog to improve clarity and flexibility by:
- Adding new `billing_method` field with 'fixed' or 'per_unit' values
- Repurposing existing `service_type` field for service categorization
- Updating database schema with appropriate migrations
- Modifying backend logic to handle the new structure
- Refactoring frontend components to display and edit the new fields

This change enhances service definition clarity, improves reporting, ensures billing accuracy, and better aligns with billing plan configurations.