### PR TITLE
Improve drawer component consistency and behavior

### DIFF
--- a/server/src/components/documents/Documents.tsx
+++ b/server/src/components/documents/Documents.tsx
@@ -371,13 +371,15 @@ const Documents = ({
               <h2 className="text-lg font-semibold">
                 {isCreatingNew ? 'New Document' : 'Edit Document'}
               </h2>
-              <Button
-                id={`${id}-close-drawer-btn`}
-                onClick={() => setIsDrawerOpen(false)}
-                variant="ghost"
-              >
-                ×
-              </Button>
+              {!isInDrawer && (
+                <Button
+                  id={`${id}-close-drawer-btn`}
+                  onClick={() => setIsDrawerOpen(false)}
+                  variant="ghost"
+                >
+                  ×
+                </Button>
+              )}
             </div>
 
             <div className="flex-1 overflow-hidden flex flex-col">

--- a/server/src/components/schedule/EntryPopup.tsx
+++ b/server/src/components/schedule/EntryPopup.tsx
@@ -575,9 +575,12 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
           </div>
         )}
       <div className="mt-6 flex justify-end space-x-3">
-        <Button id="cancel-entry-btn" onClick={onClose} variant="outline">
-          Cancel
-        </Button>
+        {/* Only show Cancel button if not in a drawer, since the drawer will have its own close button */}
+        {!isInDrawer && (
+          <Button id="cancel-entry-btn" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+        )}
         <Button id="save-entry-btn" onClick={handleSave}>Save</Button>
       </div>
       </DialogContent>

--- a/server/src/components/ui/Drawer.tsx
+++ b/server/src/components/ui/Drawer.tsx
@@ -1,7 +1,7 @@
 // server/src/components/ui/Drawer.tsx
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Cross2Icon } from '@radix-ui/react-icons';
+import { X } from 'lucide-react';
 import { SessionProvider } from "next-auth/react";
 import { Theme } from '@radix-ui/themes';
 
@@ -58,7 +58,7 @@ const Drawer: React.FC<DrawerProps & AutomationProps> = ({
             aria-label="Close"
             onClick={onClose}
           >
-            <Cross2Icon />
+            <X />
           </button>
         </Dialog.Content>
       </Dialog.Portal>

--- a/server/src/components/user-activities/ActivityDetailsDrawer.tsx
+++ b/server/src/components/user-activities/ActivityDetailsDrawer.tsx
@@ -14,13 +14,15 @@ interface ActivityDetailsDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   onActionComplete?: () => void;
+  isInDrawer?: boolean;
 }
 
 export function ActivityDetailsDrawer({ 
   activity, 
   isOpen, 
   onClose,
-  onActionComplete
+  onActionComplete,
+  isInDrawer = false
 }: ActivityDetailsDrawerProps) {
   // Format date to a readable format
   const formatDate = (dateString?: string) => {
@@ -315,6 +317,7 @@ export function ActivityDetailsDrawer({
       id={`activity-details-drawer-${activity.id}`}
       isOpen={isOpen}
       onClose={onClose}
+      isInDrawer={isInDrawer}
     >
       <div className="min-w-[640px] max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-6">
@@ -325,9 +328,6 @@ export function ActivityDetailsDrawer({
               onActionComplete={onActionComplete}
               onViewDetails={() => {}} // Self-reference to prevent navigation
             />
-            <Button id="close-drawer-button" variant="ghost" size="sm" onClick={onClose}>
-              <X className="h-4 w-4" />
-            </Button>
           </div>
         </div>
         

--- a/server/src/context/DrawerContext.tsx
+++ b/server/src/context/DrawerContext.tsx
@@ -376,15 +376,18 @@ export const DrawerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                     <ChevronRight className="h-4 w-4" />
                   </Button>
                 )}
-                <Button
-                  id="drawer-close-button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={closeDrawer}
-                  aria-label="Close drawer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
+                {/* Only show the close button if this is the root drawer (not nested) */}
+                {state.history.length <= 1 && (
+                  <Button
+                    id="drawer-close-button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={closeDrawer}
+                    aria-label="Close drawer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
               </div>
             </div>
             <div className="flex-1 overflow-auto">


### PR DESCRIPTION
- Added conditional rendering of close buttons based on `isInDrawer` prop to prevent duplicate close buttons in nested drawers
- Updated Drawer component to use Lucide's X icon instead of Radix UI's Cross2Icon for consistency
- Modified Documents, EntryPopup, and ActivityDetailsDrawer components to properly handle drawer context
- Simplified close button logic in DrawerContext to only show for root-level drawers

These changes create a more consistent drawer experience and prevent UI clutter from duplicate close buttons. The Mad Hatter would approve of this much cleaner tea party setup! 🎩☕