### PR TITLE
feat(billing): Implement service-level tiered pricing for usage plans

### DIFF
--- a/server/migrations/20250328030000_add_base_rate_to_plan_service_usage_config.cjs
+++ b/server/migrations/20250328030000_add_base_rate_to_plan_service_usage_config.cjs
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('plan_service_usage_config', function(table) {
+    table.decimal('base_rate', 19, 4).nullable(); // Using decimal for precision, adjust precision/scale if needed
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('plan_service_usage_config', function(table) {
+    table.dropColumn('base_rate');
+  });
+};

--- a/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
@@ -40,6 +40,7 @@ const BILLING_METHOD_OPTIONS: Array<{ value: 'fixed' | 'per_unit'; label: string
 
 interface GenericPlanServicesListProps {
   planId: string; // Changed from plan object to just planId
+  onServicesChanged?: () => void; // Optional callback when services are added/removed
 }
 
 
@@ -54,7 +55,7 @@ interface EnhancedPlanService extends IPlanService {
   default_rate?: number;
 }
 
-const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planId }) => {
+const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planId, onServicesChanged }) => {
   const [planServices, setPlanServices] = useState<EnhancedPlanService[]>([]);
   const [availableServices, setAvailableServices] = useState<IService[]>([]);
   // Removed serviceCategories state
@@ -138,8 +139,9 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planI
           );
         }
       }
-      fetchData();
+      await fetchData(); // Ensure data is fetched before calling callback
       setSelectedServicesToAdd([]);
+      onServicesChanged?.(); // Call the callback if provided
     } catch (error) {
       console.error('Error adding services:', error);
       setError('Failed to add services');
@@ -151,7 +153,8 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planI
 
     try {
       await removePlanService(planId, serviceId);
-      fetchData();
+      await fetchData(); // Ensure data is fetched before calling callback
+      onServicesChanged?.(); // Call the callback if provided
     } catch (error) {
       console.error('Error removing service:', error);
       setError('Failed to remove service');

--- a/server/src/components/billing-dashboard/billing-plans/ServiceTierEditor.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/ServiceTierEditor.tsx
@@ -1,0 +1,207 @@
+// server/src/components/billing-dashboard/billing-plans/ServiceTierEditor.tsx
+'use client';
+
+import React from 'react';
+import { Input } from 'server/src/components/ui/Input';
+import { Button } from 'server/src/components/ui/Button';
+import { Trash2, Plus, AlertCircle } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
+import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
+
+// Define TierConfig locally or import if available globally
+export interface TierConfig {
+  id: string; // Use a unique ID for React keys, could be generated or from DB
+  fromAmount: number;
+  toAmount: number | null; // null represents infinity
+  rate: number;
+}
+
+interface ServiceTierEditorProps {
+  serviceId: string;
+  tiers: TierConfig[];
+  unitOfMeasure: string;
+  baseRate?: number; // Used for defaulting new tier rate
+  validationError?: string; // Specific error message for tiers of this service
+  disabled?: boolean;
+  onTiersChange: (serviceId: string, tiers: TierConfig[]) => void;
+}
+
+export function ServiceTierEditor({
+  serviceId,
+  tiers,
+  unitOfMeasure,
+  baseRate,
+  validationError,
+  disabled = false,
+  onTiersChange,
+}: ServiceTierEditorProps) {
+
+  const handleAddTier = () => {
+    const sortedTiers = [...tiers].sort((a, b) => a.fromAmount - b.fromAmount);
+    const lastTier = sortedTiers.length > 0 ? sortedTiers[sortedTiers.length - 1] : null;
+    const newFromAmount = lastTier ? (lastTier.toAmount !== null ? lastTier.toAmount + 1 : (lastTier.fromAmount + 1)) : 0;
+
+    const newTier: TierConfig = {
+      id: `new-${Date.now()}`,
+      fromAmount: newFromAmount,
+      toAmount: null, // New tier is always the last one initially
+      rate: baseRate || 0, // Default to base rate or 0
+    };
+
+    // Update the previous last tier's toAmount if it was null
+    const updatedPreviousTiers = sortedTiers.map((tier, index) => {
+      if (index === sortedTiers.length - 1 && tier.toAmount === null) {
+        // Set 'to' amount to one less than the new tier's 'from', ensuring it's not negative
+        return { ...tier, toAmount: Math.max(0, newFromAmount - 1) };
+      }
+      return tier;
+    });
+
+    onTiersChange(serviceId, [...updatedPreviousTiers, newTier]);
+  };
+
+  const handleRemoveTier = (idToRemove: string) => {
+    const filteredTiers = tiers.filter(tier => tier.id !== idToRemove);
+    // Ensure the new last tier has toAmount = null if it exists
+    if (filteredTiers.length > 0) {
+      const lastIndex = filteredTiers.length - 1;
+      // Make sure tiers remain sorted before adjusting the last one
+      const sortedFilteredTiers = filteredTiers.sort((a, b) => a.fromAmount - b.fromAmount);
+      sortedFilteredTiers[lastIndex] = { ...sortedFilteredTiers[lastIndex], toAmount: null };
+      onTiersChange(serviceId, sortedFilteredTiers);
+    } else {
+      onTiersChange(serviceId, []); // Return empty array if all tiers were removed
+    }
+  };
+
+  const handleTierFieldChange = (tierId: string, field: keyof TierConfig, value: string) => {
+    const updatedTiers = tiers.map(tier => {
+      if (tier.id === tierId) {
+        let processedValue: number | null;
+        if (field === 'toAmount') {
+          processedValue = value === '' ? null : Number(value); // Allow empty string for null 'toAmount'
+        } else {
+          processedValue = Number(value); // For fromAmount and rate
+        }
+
+        // Basic validation within the change handler
+        if (isNaN(processedValue as number) && processedValue !== null) {
+          console.warn(`Invalid number input ignored: ${value}`);
+          return tier; // Ignore invalid number input
+        }
+
+        // Ensure 'fromAmount' of the first tier remains 0
+        const isFirstTier = tiers.sort((a, b) => a.fromAmount - b.fromAmount)[0]?.id === tierId;
+        if (field === 'fromAmount' && isFirstTier) {
+          processedValue = 0;
+        }
+
+        return { ...tier, [field]: processedValue };
+      }
+      return tier;
+    });
+    onTiersChange(serviceId, updatedTiers);
+  };
+
+  const sortedTiers = [...tiers].sort((a, b) => a.fromAmount - b.fromAmount);
+
+  return (
+    <Card className="bg-muted/40">
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-base">Pricing Tiers</CardTitle>
+        <Button
+          id={`add-tier-button-${serviceId}`}
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={handleAddTier}
+          disabled={disabled}
+        >
+          <Plus className="h-4 w-4 mr-1" /> Add Tier
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {validationError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{validationError}</AlertDescription>
+          </Alert>
+        )}
+        {tiers.length === 0 && !validationError ? (
+          <p className="text-sm text-muted-foreground">No tiers defined. Click "Add Tier".</p>
+        ) : null}
+        {tiers.length > 0 && (
+          <div className="space-y-2">
+            {/* Header Row */}
+            <div className="grid grid-cols-11 gap-2 items-center font-medium text-xs text-muted-foreground px-2">
+              <div className="col-span-3">From ({unitOfMeasure || 'Units'})</div>
+              <div className="col-span-3">To ({unitOfMeasure || 'Units'})</div>
+              <div className="col-span-4">Rate per {unitOfMeasure || 'Unit'}</div>
+              <div className="col-span-1"></div> {/* Spacer for delete button */}
+            </div>
+            {/* Tier Rows */}
+            {sortedTiers.map((tier, index) => (
+              <div key={tier.id} className="grid grid-cols-11 gap-2 items-center border p-2 rounded bg-background">
+                <div className="col-span-3">
+                  <Input
+                    id={`tier-${serviceId}-${tier.id}-from`}
+                    type="number"
+                    value={tier.fromAmount.toString()}
+                    onChange={(e) => handleTierFieldChange(tier.id, 'fromAmount', e.target.value)}
+                    disabled={disabled || index === 0} // First tier 'from' is always 0
+                    min={0}
+                    step={1}
+                    aria-label={`Tier ${index + 1} From Amount`}
+                  />
+                </div>
+                <div className="col-span-3">
+                  <Input
+                    id={`tier-${serviceId}-${tier.id}-to`}
+                    type="number"
+                    value={tier.toAmount === null ? '' : tier.toAmount.toString()}
+                    onChange={(e) => handleTierFieldChange(tier.id, 'toAmount', e.target.value)}
+                    placeholder={index === sortedTiers.length - 1 ? "Unlimited" : ""}
+                    // Allow editing 'To' amount for intermediate tiers to fix gaps/overlaps
+                    disabled={disabled}
+                    min={tier.fromAmount}
+                    step={1}
+                    aria-label={`Tier ${index + 1} To Amount`}
+                  />
+                </div>
+                <div className="col-span-4">
+                  <Input
+                    id={`tier-${serviceId}-${tier.id}-rate`}
+                    type="number"
+                    value={tier.rate.toString()}
+                    onChange={(e) => handleTierFieldChange(tier.id, 'rate', e.target.value)}
+                    disabled={disabled}
+                    min={0}
+                    step={0.01}
+                    aria-label={`Tier ${index + 1} Rate`}
+                  />
+                </div>
+                <div className="col-span-1 flex justify-end">
+                  <Button
+                    id={`remove-tier-${serviceId}-${tier.id}-button`}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemoveTier(tier.id)}
+                    disabled={disabled || tiers.length <= 1} // Cannot remove if only one tier exists
+                    className="text-destructive hover:bg-destructive/10"
+                    aria-label={`Remove Tier ${index + 1}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground pt-2">
+          Define usage ranges and their corresponding rates. Leave 'To' blank for the last tier to represent unlimited usage. The first tier must start from 0. Tiers must be contiguous.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/server/src/components/billing-dashboard/billing-plans/ServiceUsageConfigForm.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/ServiceUsageConfigForm.tsx
@@ -1,0 +1,168 @@
+// server/src/components/billing-dashboard/billing-plans/ServiceUsageConfigForm.tsx
+'use client';
+
+import React from 'react';
+import { Input } from 'server/src/components/ui/Input';
+import { Label } from 'server/src/components/ui/Label';
+import { Switch } from 'server/src/components/ui/Switch';
+import { UnitOfMeasureInput } from '../UnitOfMeasureInput';
+import { Tooltip } from 'server/src/components/ui/Tooltip';
+import { Info } from 'lucide-react';
+import { ServiceTierEditor, TierConfig } from './ServiceTierEditor'; // Import the tier editor and its config type
+
+// Define the shape of the configuration for a single service
+export interface ServiceUsageConfig {
+    base_rate?: number;
+    unit_of_measure?: string;
+    enable_tiered_pricing?: boolean;
+    minimum_usage?: number;
+    tiers?: TierConfig[]; // Use the imported TierConfig
+}
+
+// Define validation errors specific to one service's config
+export type ServiceValidationErrors = {
+    base_rate?: string;
+    unit_of_measure?: string;
+    minimum_usage?: string;
+    tiers?: string; // Single string for tier-related errors for this service
+};
+
+interface ServiceUsageConfigFormProps {
+    serviceId: string;
+    serviceName: string;
+    config: ServiceUsageConfig;
+    validationErrors?: ServiceValidationErrors;
+    saveAttempted: boolean;
+    disabled?: boolean;
+    onConfigChange: (serviceId: string, field: keyof ServiceUsageConfig, value: any) => void;
+    onTiersChange: (serviceId: string, tiers: TierConfig[]) => void; // Specific handler for tiers array
+}
+
+export function ServiceUsageConfigForm({
+    serviceId,
+    serviceName, // Use serviceName for labels/IDs if needed
+    config,
+    validationErrors = {},
+    saveAttempted,
+    disabled = false,
+    onConfigChange,
+    onTiersChange,
+}: ServiceUsageConfigFormProps) {
+
+    const handleInputChange = (field: keyof ServiceUsageConfig) =>
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const value = e.target.value;
+            onConfigChange(serviceId, field, value);
+        };
+
+    const handleNumberInputChange = (field: keyof ServiceUsageConfig) =>
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const value = e.target.value === '' ? undefined : Number(e.target.value);
+             if (!isNaN(value as number) && (value as number) >= 0) {
+                 onConfigChange(serviceId, field, value);
+             } else if (e.target.value === '') {
+                  onConfigChange(serviceId, field, undefined); // Allow clearing
+             }
+        };
+
+    const handleSwitchChange = (field: keyof ServiceUsageConfig) =>
+        (checked: boolean) => {
+            onConfigChange(serviceId, field, checked);
+        };
+
+    const handleUnitOfMeasureChange = (value: string) => {
+        onConfigChange(serviceId, 'unit_of_measure', value);
+    };
+
+    const isTiered = config.enable_tiered_pricing ?? false;
+    const unit = config.unit_of_measure || '';
+
+    return (
+        <div className="space-y-4">
+            {/* Basic Usage Settings */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <Label htmlFor={`usage-plan-base-rate-${serviceId}`} className="inline-flex items-center">
+                        Default Rate per Unit { !isTiered && <span className="text-destructive">*</span>}
+                        <Tooltip content="Rate per unit (used if tiered pricing is off).">
+                            <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+                        </Tooltip>
+                    </Label>
+                    <Input
+                        id={`usage-plan-base-rate-${serviceId}`}
+                        type="number"
+                        value={config.base_rate?.toString() || ''}
+                        onChange={handleNumberInputChange('base_rate')}
+                        placeholder="Enter base rate"
+                        disabled={disabled || isTiered}
+                        min={0} step={0.01}
+                        className={saveAttempted && validationErrors.base_rate ? 'border-red-500' : ''}
+                    />
+                    {saveAttempted && validationErrors.base_rate && <p className="text-sm text-red-500 mt-1">{validationErrors.base_rate}</p>}
+                </div>
+                <div>
+                    <Label htmlFor={`usage-plan-unit-of-measure-${serviceId}`} className="inline-flex items-center">
+                        Unit of Measure <span className="text-destructive">*</span>
+                        <Tooltip content="e.g., GB, User, Device.">
+                            <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+                        </Tooltip>
+                    </Label>
+                    <UnitOfMeasureInput
+                        value={unit}
+                        onChange={handleUnitOfMeasureChange}
+                        placeholder="Select unit"
+                        disabled={disabled}
+                        serviceType="Usage" // Assuming Usage type for now
+                        className={saveAttempted && validationErrors.unit_of_measure ? 'border-red-500' : ''}
+                    />
+                    {saveAttempted && validationErrors.unit_of_measure && <p className="text-sm text-red-500 mt-1">{validationErrors.unit_of_measure}</p>}
+                </div>
+                <div>
+                    <Label htmlFor={`minimum-usage-${serviceId}`} className="inline-flex items-center">
+                        Minimum Usage
+                        <Tooltip content="Minimum billable units per period.">
+                            <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+                        </Tooltip>
+                    </Label>
+                    <Input
+                        id={`minimum-usage-${serviceId}`}
+                        type="number"
+                        value={config.minimum_usage?.toString() || ''}
+                        onChange={handleNumberInputChange('minimum_usage')}
+                        placeholder="0"
+                        disabled={disabled}
+                        min={0} step={1}
+                        className={saveAttempted && validationErrors.minimum_usage ? 'border-red-500' : ''}
+                    />
+                    {saveAttempted && validationErrors.minimum_usage && <p className="text-sm text-red-500 mt-1">{validationErrors.minimum_usage}</p>}
+                </div>
+            </div>
+             <p className="text-xs text-muted-foreground pt-2"><span className="text-destructive">*</span> Indicates a required field.</p>
+
+            {/* Tiered Pricing Section */}
+            <div className="space-y-3 pt-3">
+                <div className="flex items-center space-x-2">
+                    <Switch
+                        id={`enable-tiered-pricing-${serviceId}`}
+                        checked={isTiered}
+                        onCheckedChange={handleSwitchChange('enable_tiered_pricing')}
+                        disabled={disabled}
+                    />
+                    <Label htmlFor={`enable-tiered-pricing-${serviceId}`} className="cursor-pointer">Enable Tiered Pricing for {serviceName}</Label>
+                </div>
+
+                {isTiered && (
+                    <ServiceTierEditor
+                        serviceId={serviceId}
+                        tiers={config.tiers || []}
+                        unitOfMeasure={unit}
+                        baseRate={config.base_rate} // Pass base rate for default new tier rate
+                        validationError={saveAttempted ? validationErrors.tiers : undefined} // Only show tier error after save attempt
+                        disabled={disabled}
+                        onTiersChange={onTiersChange} // Pass the specific tier change handler
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/server/src/components/billing-dashboard/billing-plans/UsagePlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/UsagePlanConfiguration.tsx
@@ -1,94 +1,147 @@
-// server/src/components/billing-dashboard/UsagePlanConfiguration.tsx
+// server/src/components/billing-dashboard/billing-plans/UsagePlanConfiguration.tsx
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Input } from 'server/src/components/ui/Input';
-import { Label } from 'server/src/components/ui/Label';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
-import { Switch } from 'server/src/components/ui/Switch';
-import { UnitOfMeasureInput } from '../UnitOfMeasureInput'; // Assuming this path is correct relative to the new file
 import { Button } from 'server/src/components/ui/Button';
-import { Trash2, Plus, Loader2, AlertCircle, Info } from 'lucide-react'; // Added Info
+import { Loader2, AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
-import { getBillingPlanById, updateBillingPlan } from 'server/src/lib/actions/billingPlanAction'; // Corrected path
-import GenericPlanServicesList from './GenericPlanServicesList'; // Import the generic list
-import { IBillingPlan } from 'server/src/interfaces/billing.interfaces';
-import { Tooltip } from 'server/src/components/ui/Tooltip'; // Added Tooltip import
+import * as Accordion from '@radix-ui/react-accordion'; // Import Radix Accordion
+import { ChevronDownIcon } from '@radix-ui/react-icons'; // Icon for Accordion
 
-// Define ValidationErrors locally
-type ValidationErrors = {
-  [key: string]: string | undefined;
-};
+// Import actions and types
+import { getPlanServicesWithConfigurations } from 'server/src/lib/actions/planServiceActions'; // Get list of services
+import { getPlanServiceConfiguration } from 'server/src/lib/actions/planServiceConfigurationActions'; // Get config per service
+// Import specific interfaces needed
+import { IPlanServiceConfiguration, IPlanServiceUsageConfig, IPlanServiceRateTier, IService } from 'server/src/interfaces';
+import { upsertPlanServiceConfiguration } from 'server/src/lib/actions/planServiceConfigurationActions'; // Import the upsert action
+import { ServiceUsageConfigForm, ServiceUsageConfig, ServiceValidationErrors } from './ServiceUsageConfigForm'; // Import the new form component and types
+import { TierConfig } from './ServiceTierEditor'; // Import TierConfig type
 
-// Define TierConfig locally or import if available globally
-interface TierConfig {
-  id: string; // Use a unique ID for React keys, could be generated or from DB
-  fromAmount: number;
-  toAmount: number | null; // null represents infinity
-  rate: number;
-}
-
-// Define the expected shape of the plan object returned by getBillingPlanById for Usage
-// And the shape expected by updateBillingPlan (without client-side tier IDs)
-type UsagePlanConfigFields = {
-    base_rate?: number;
-    unit_of_measure?: string;
-    enable_tiered_pricing?: boolean;
-    minimum_usage?: number;
-    tiers?: Omit<TierConfig, 'id'>[]; // Backend expects tiers without the client-side 'id'
-};
-type UsagePlanData = IBillingPlan & UsagePlanConfigFields;
-
+// Keep GenericPlanServicesList for now, might remove in Phase 3
+import GenericPlanServicesList from './GenericPlanServicesList';
 
 interface UsagePlanConfigurationProps {
   planId: string;
   className?: string;
-  // Removed validationErrors prop
-  // Removed onConfigChange prop
 }
+
+// Define the structure returned by getPlanServicesWithConfigurations locally
+// Based on its usage in GenericPlanServicesList.tsx and the action definition
+type PlanServiceWithConfig = {
+  service: IService & { service_type_name?: string };
+  configuration: IPlanServiceConfiguration;
+  // typeConfig might also be present, but we primarily need service_id and service_name
+};
+
+
+// State structure for all service configurations
+type AllServiceConfigs = {
+  [serviceId: string]: ServiceUsageConfig;
+};
+
+// State structure for all service validation errors
+type AllServiceValidationErrors = {
+  [serviceId: string]: ServiceValidationErrors;
+};
+
+// Define the expected result type for getPlanServiceConfiguration
+// Combining relevant fields from the interfaces file
+type FetchedServiceConfig = IPlanServiceConfiguration & IPlanServiceUsageConfig & {
+    tiers?: IPlanServiceRateTier[];
+};
 
 export function UsagePlanConfiguration({
   planId,
   className = '',
-  // Removed validationErrors prop usage
-  // Removed onConfigChange prop usage
 }: UsagePlanConfigurationProps) {
-  const [plan, setPlan] = useState<UsagePlanData | null>(null);
-  const [baseRate, setBaseRate] = useState<number | undefined>(undefined);
-  const [unitOfMeasure, setUnitOfMeasure] = useState<string>('');
-  const [enableTieredPricing, setEnableTieredPricing] = useState<boolean>(false);
-  const [minimumUsage, setMinimumUsage] = useState<number | undefined>(0);
-  const [tiers, setTiers] = useState<TierConfig[]>([]);
+  // State for the list of services associated with the plan
+  const [planServices, setPlanServices] = useState<PlanServiceWithConfig[]>([]);
+  // State to hold configuration for each service, keyed by serviceId (current state)
+  const [serviceConfigs, setServiceConfigs] = useState<AllServiceConfigs>({});
+  // State to hold the initial configuration fetched from the server
+  const [initialServiceConfigs, setInitialServiceConfigs] = useState<AllServiceConfigs>({});
+  // State to hold validation errors for each service, keyed by serviceId
+  const [serviceValidationErrors, setServiceValidationErrors] = useState<AllServiceValidationErrors>({});
 
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false); // Keep for disabling fields during load/internal ops?
+  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null); // Keep for internal errors?
-  // Re-add local validation state
-  const [validationErrors, setValidationErrors] = useState<ValidationErrors>({});
-  const [saveAttempted, setSaveAttempted] = useState<boolean>(false); // State to track save attempt
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveAttempted, setSaveAttempted] = useState<boolean>(false);
 
-
+  // --- Data Fetching ---
   const fetchPlanData = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setServiceConfigs({}); // Reset current configs on fetch
+    setInitialServiceConfigs({}); // Reset initial configs on fetch
+    setPlanServices([]); // Reset services on fetch
+
     try {
-      const fetchedPlan = await getBillingPlanById(planId) as UsagePlanData; // Cast to expected type
-      if (fetchedPlan && fetchedPlan.plan_type === 'Usage') { // Match enum case
-        setPlan(fetchedPlan);
-        // Assume config fields are returned directly on the plan object
-        setBaseRate(fetchedPlan.base_rate);
-        setUnitOfMeasure(fetchedPlan.unit_of_measure || '');
-        setEnableTieredPricing(fetchedPlan.enable_tiered_pricing ?? false);
-        setMinimumUsage(fetchedPlan.minimum_usage ?? 0);
-        // Ensure tiers have unique IDs for React state management if not provided by backend
-        setTiers((fetchedPlan.tiers || []).map((tier: any, index: number) => ({ ...tier, id: tier.id || `tier-${index}-${Date.now()}` })));
-      } else {
-        setError('Invalid plan type or plan not found.');
+      // 1. Fetch the list of services associated with the plan
+      const servicesList = await getPlanServicesWithConfigurations(planId);
+      setPlanServices(servicesList);
+
+      if (servicesList.length === 0) {
+        setLoading(false);
+        return; // No services to configure
       }
+
+      // 2. Fetch configuration for each service concurrently
+      const configPromises = servicesList.map(service =>
+        // Use service.configuration.service_id as it's guaranteed by PlanServiceWithConfig type
+        getPlanServiceConfiguration(planId, service.configuration.service_id)
+          .then(config => ({ serviceId: service.configuration.service_id, config: config as FetchedServiceConfig | null })) // Cast result
+          .catch(err => {
+            console.error(`Error fetching config for service ${service.configuration.service_id}:`, err);
+            // Return null config on error for this specific service
+            return { serviceId: service.configuration.service_id, config: null };
+          })
+      );
+
+      const results = await Promise.all(configPromises);
+
+      // 3. Populate the serviceConfigs state
+      const initialConfigs: AllServiceConfigs = {};
+      results.forEach(({ serviceId, config }) => {
+        if (config) {
+          // Ensure tiers have client-side IDs
+          // Map backend tier structure to frontend TierConfig
+          const tiersWithIds = (config.tiers || []).map((tier, index) => ({
+            id: `tier-${serviceId}-${index}-${Date.now()}`, // Generate unique ID
+            fromAmount: tier.min_quantity, // Map min_quantity
+            toAmount: tier.max_quantity === undefined || tier.max_quantity === null ? null : tier.max_quantity, // Map max_quantity (handle undefined/null)
+            rate: tier.rate,
+          }));
+          initialConfigs[serviceId] = {
+            // Handle potential null values from DB by converting to undefined for state
+            base_rate: config.base_rate === null ? undefined : config.base_rate,
+            unit_of_measure: config.unit_of_measure,
+            enable_tiered_pricing: config.enable_tiered_pricing,
+            minimum_usage: config.minimum_usage === null ? undefined : config.minimum_usage,
+            tiers: tiersWithIds, // Use mapped tiers
+          };
+        } else {
+          // Handle case where config fetch failed or service has no config yet
+          // Initialize with default/empty values
+          initialConfigs[serviceId] = {
+             // Access nested service properties correctly
+             base_rate: servicesList.find(s => s.configuration.service_id === serviceId)?.service?.default_rate,
+             unit_of_measure: servicesList.find(s => s.configuration.service_id === serviceId)?.service?.unit_of_measure || '',
+             enable_tiered_pricing: false,
+             minimum_usage: 0,
+             tiers: [],
+          };
+          console.warn(`Using default config for service ${serviceId}`);
+        }
+      });
+      setServiceConfigs(initialConfigs);
+      setInitialServiceConfigs(JSON.parse(JSON.stringify(initialConfigs))); // Deep copy for initial state
+
     } catch (err) {
-      console.error('Error fetching plan data:', err);
-      setError('Failed to load plan configuration. Please try again.');
+      console.error('Error fetching plan services or configurations:', err);
+      setError('Failed to load plan services or configurations. Please try again.');
     } finally {
       setLoading(false);
     }
@@ -98,239 +151,231 @@ export function UsagePlanConfiguration({
     fetchPlanData();
   }, [fetchPlanData]);
 
-  // Re-add local validation useEffect
-  useEffect(() => {
-    const errors: ValidationErrors = {};
-    // Use backend field names for keys if they differ
-    if (baseRate !== undefined && baseRate < 0) errors.base_rate = 'Base rate cannot be negative';
-    if (minimumUsage !== undefined && minimumUsage < 0) errors.minimum_usage = 'Minimum usage cannot be negative';
-    if (!unitOfMeasure) errors.unit_of_measure = 'Unit of measure is required';
-
-    if (enableTieredPricing && tiers.length > 0) {
-      const sortedTiers = [...tiers].sort((a, b) => a.fromAmount - b.fromAmount);
-      let tierErrorFound = false;
-      for (let i = 0; i < sortedTiers.length; i++) {
-        const currentTier = sortedTiers[i];
-        if (currentTier.rate < 0) {
-            errors.tiers = 'Tier rates cannot be negative.';
-            tierErrorFound = true; break;
-        }
-        if (currentTier.toAmount !== null && currentTier.toAmount < currentTier.fromAmount) {
-            errors.tiers = `Tier ${i + 1}: Upper bound must be greater than or equal to lower bound.`;
-            tierErrorFound = true; break;
-        }
-        if (i < sortedTiers.length - 1) {
-            const nextTier = sortedTiers[i + 1];
-            if (currentTier.toAmount === null) {
-                errors.tiers = 'Only the last tier can have an unlimited upper bound (leave "To" blank).';
-                tierErrorFound = true; break;
-            }
-            // Allow adjacent tiers: upper bound can equal next lower bound
-            if (currentTier.toAmount > nextTier.fromAmount) {
-                errors.tiers = `Tier ${i + 1} overlaps with Tier ${i + 2}. Upper bound must be less than or equal to the next tier's lower bound.`;
-                tierErrorFound = true; break;
-            }
-             // Check for gaps between tiers
-            if (currentTier.toAmount + 1 < nextTier.fromAmount) {
-                 errors.tiers = `Gap detected between Tier ${i + 1} and Tier ${i + 2}. Tiers must be contiguous.`;
-                 tierErrorFound = true; break;
-            }
-        }
+  // --- Event Handlers ---
+  const handleConfigChange = useCallback((serviceId: string, field: keyof ServiceUsageConfig, value: any) => {
+    setServiceConfigs(prevConfigs => ({
+      ...prevConfigs,
+      [serviceId]: {
+        ...prevConfigs[serviceId],
+        [field]: value,
       }
-       if (!tierErrorFound && sortedTiers[0]?.fromAmount !== 0) {
-           errors.tiers = 'The first tier must start from 0.';
-       }
-    } else if (enableTieredPricing && tiers.length === 0) {
-        errors.tiers = 'At least one tier is required when tiered pricing is enabled.';
-    }
-
-    setValidationErrors(errors);
-  }, [baseRate, minimumUsage, unitOfMeasure, tiers, enableTieredPricing]);
-
-  // Re-add handleSave function
-  const handleSave = async () => {
-    // Validation logic moved inside handleSave or called from here
-    // Set saveAttempted = true here
-    if (!plan) {
-        setSaveError("Plan data not loaded.");
-        return;
-    }
-
-    // Trigger validation check on save attempt
-    const errors = validateUsagePlan(); // Assuming a validation function
-    setValidationErrors(errors);
-    setSaveAttempted(true); // Mark that save was attempted
-
-    if (Object.keys(errors).length > 0) {
-        setSaveError("Cannot save, validation errors exist.");
-        return; // Stop if validation fails
-    }
-
-
-    setSaving(true);
-    setSaveError(null);
-    try {
-        const tiersToSave = tiers
-            .sort((a, b) => a.fromAmount - b.fromAmount)
-            .map(({ id, ...rest }) => rest);
-
-        const updatePayload: Partial<UsagePlanConfigFields> = {
-            base_rate: enableTieredPricing ? undefined : baseRate,
-            unit_of_measure: unitOfMeasure,
-            enable_tiered_pricing: enableTieredPricing,
-            minimum_usage: minimumUsage,
-            tiers: enableTieredPricing ? tiersToSave : [],
-        };
-        // TODO: Implement correct saving logic for Usage Plan Configuration.
-        // This likely involves calling actions that update service-level configuration tables
-        // (e.g., plan_service_usage_config, plan_service_rate_tiers) via planServiceConfigurationActions.ts,
-        // NOT the generic updateBillingPlan action.
-        // await updateBillingPlan(planId, updatePayload as Partial<IBillingPlan>); // Incorrect: updateBillingPlan targets billing_plans table
-        console.log("TODO: Implement save for Usage Plan Config:", updatePayload); // Placeholder
-        // Simulate success for UI feedback for now
-        await new Promise(resolve => setTimeout(resolve, 500)); // Simulate async operation
-
-        fetchPlanData(); // Re-fetch data after simulated save
-    } catch (err) {
-        console.error('Error saving usage plan configuration:', err);
-        setSaveError('Failed to save configuration. Please try again.');
-    } finally {
-        setSaving(false);
-    }
-  };
-
-  // Define the validation function used in handleSave
-  const validateUsagePlan = (): ValidationErrors => {
-      const errors: ValidationErrors = {};
-      if (baseRate !== undefined && baseRate < 0) errors.base_rate = 'Base rate cannot be negative';
-      if (!enableTieredPricing && baseRate === undefined) errors.base_rate = 'Base rate is required when tiered pricing is off.'; // Added required check
-      if (minimumUsage !== undefined && minimumUsage < 0) errors.minimum_usage = 'Minimum usage cannot be negative';
-      if (!unitOfMeasure) errors.unit_of_measure = 'Unit of measure is required';
-
-      if (enableTieredPricing && tiers.length > 0) {
-        const sortedTiers = [...tiers].sort((a, b) => a.fromAmount - b.fromAmount);
-        let tierErrorFound = false;
-        for (let i = 0; i < sortedTiers.length; i++) {
-          const currentTier = sortedTiers[i];
-          if (currentTier.rate < 0) {
-              errors.tiers = 'Tier rates cannot be negative.';
-              tierErrorFound = true; break;
-          }
-          if (currentTier.toAmount !== null && currentTier.toAmount < currentTier.fromAmount) {
-              errors.tiers = `Tier ${i + 1}: Upper bound must be greater than or equal to lower bound.`;
-              tierErrorFound = true; break;
-          }
-          if (i < sortedTiers.length - 1) {
-              const nextTier = sortedTiers[i + 1];
-              if (currentTier.toAmount === null) {
-                  errors.tiers = 'Only the last tier can have an unlimited upper bound (leave "To" blank).';
-                  tierErrorFound = true; break;
-              }
-              if (currentTier.toAmount > nextTier.fromAmount) {
-                  errors.tiers = `Tier ${i + 1} overlaps with Tier ${i + 2}. Upper bound must be less than or equal to the next tier's lower bound.`;
-                  tierErrorFound = true; break;
-              }
-              if (currentTier.toAmount + 1 < nextTier.fromAmount) {
-                   errors.tiers = `Gap detected between Tier ${i + 1} and Tier ${i + 2}. Tiers must be contiguous.`;
-                   tierErrorFound = true; break;
-              }
-          }
-        }
-         if (!tierErrorFound && sortedTiers[0]?.fromAmount !== 0) {
-             errors.tiers = 'The first tier must start from 0.';
-         }
-      } else if (enableTieredPricing && tiers.length === 0) {
-          errors.tiers = 'At least one tier is required when tiered pricing is enabled.';
-      }
-      return errors;
-  };
-
-
- const handleAddTier = () => {
-    setTiers(prevTiers => {
-        const sortedTiers = [...prevTiers].sort((a, b) => a.fromAmount - b.fromAmount);
-        const lastTier = sortedTiers.length > 0 ? sortedTiers[sortedTiers.length - 1] : null;
-        const newFromAmount = lastTier ? (lastTier.toAmount !== null ? lastTier.toAmount + 1 : (lastTier.fromAmount + 1)) : 0;
-
-        const newTier: TierConfig = {
-            id: `new-${Date.now()}`,
-            fromAmount: newFromAmount,
-            toAmount: null, // New tier is always the last one initially
-            rate: baseRate || 0, // Default to base rate or 0
-        };
-
-        // Update the previous last tier's toAmount if it was null
-        const updatedPreviousTiers = sortedTiers.map((tier, index) => {
-            if (index === sortedTiers.length - 1 && tier.toAmount === null) {
-                // Set 'to' amount to one less than the new tier's 'from', ensuring it's not negative
-                return { ...tier, toAmount: Math.max(0, newFromAmount - 1) };
-            }
-            return tier;
-        });
-
-        return [...updatedPreviousTiers, newTier];
-    });
-};
-
-
-  const handleRemoveTier = (id: string) => {
-    setTiers(prevTiers => {
-        const filteredTiers = prevTiers.filter(tier => tier.id !== id);
-        // Ensure the new last tier has toAmount = null if it exists
-        if (filteredTiers.length > 0) {
-            const lastIndex = filteredTiers.length - 1;
-            // Make sure tiers remain sorted before adjusting the last one
-            const sortedFilteredTiers = filteredTiers.sort((a, b) => a.fromAmount - b.fromAmount);
-            sortedFilteredTiers[lastIndex] = { ...sortedFilteredTiers[lastIndex], toAmount: null };
-            return sortedFilteredTiers;
-        }
-        return filteredTiers; // Return empty array if all tiers were removed
-    });
-  };
-
-
- const handleTierChange = (id: string, field: keyof TierConfig, value: string) => {
-     setTiers(prevTiers => prevTiers.map(tier => {
-        if (tier.id === id) {
-            let processedValue: number | null;
-            if (field === 'toAmount') {
-                processedValue = value === '' ? null : Number(value); // Allow empty string for null 'toAmount'
-            } else {
-                processedValue = Number(value); // For fromAmount and rate
-            }
-
-            // Basic validation within the change handler
-            if (isNaN(processedValue as number) && processedValue !== null) {
-                console.warn(`Invalid number input ignored: ${value}`);
-                return tier; // Ignore invalid number input
-            }
-
-            // Ensure 'fromAmount' of the first tier remains 0
-            const isFirstTier = prevTiers.sort((a,b) => a.fromAmount - b.fromAmount)[0]?.id === id;
-            if (field === 'fromAmount' && isFirstTier) {
-                 processedValue = 0;
-            }
-
-            return { ...tier, [field]: processedValue };
-        }
-        return tier;
     }));
+    // Clear validation error for the specific field when changed
+    setServiceValidationErrors(prevErrors => ({
+        ...prevErrors,
+        [serviceId]: {
+            ...prevErrors[serviceId],
+            [field]: undefined, // Clear error for this field
+            ...(field === 'enable_tiered_pricing' && { tiers: undefined }) // Clear tier error if switch toggled
+        }
+    }));
+    setSaveAttempted(false); // Reset save attempt state on change
+    setSaveError(null); // Clear global save error
+  }, []);
+
+  const handleTiersChange = useCallback((serviceId: string, tiers: TierConfig[]) => {
+    setServiceConfigs(prevConfigs => ({
+      ...prevConfigs,
+      [serviceId]: {
+        ...prevConfigs[serviceId],
+        tiers: tiers,
+      }
+    }));
+     // Clear validation error for tiers when changed
+    setServiceValidationErrors(prevErrors => ({
+        ...prevErrors,
+        [serviceId]: {
+            ...prevErrors[serviceId],
+            tiers: undefined,
+        }
+    }));
+    setSaveAttempted(false); // Reset save attempt state on change
+    setSaveError(null); // Clear global save error
+  }, []);
+
+  // Callback to refresh data when services are added/removed in the child component
+  const handleServicesChanged = useCallback(() => {
+    console.log('Services changed, refetching plan data...');
+    fetchPlanData();
+  }, [fetchPlanData]);
+
+  // --- Validation ---
+  const validateSingleServiceConfig = (config: ServiceUsageConfig): ServiceValidationErrors => {
+    const errors: ServiceValidationErrors = {};
+    const isTiered = config.enable_tiered_pricing ?? false;
+
+    if (!isTiered && (config.base_rate === undefined || config.base_rate === null)) {
+        errors.base_rate = 'Base rate is required when tiered pricing is off.';
+    } else if (config.base_rate !== undefined && config.base_rate < 0) {
+        errors.base_rate = 'Base rate cannot be negative.';
+    }
+
+    if (config.minimum_usage !== undefined && config.minimum_usage < 0) {
+        errors.minimum_usage = 'Minimum usage cannot be negative.';
+    }
+    if (!config.unit_of_measure) {
+        errors.unit_of_measure = 'Unit of measure is required.';
+    }
+
+    if (isTiered) {
+        const tiers = config.tiers || [];
+        if (tiers.length === 0) {
+            errors.tiers = 'At least one tier is required when tiered pricing is enabled.';
+        } else {
+            const sortedTiers = [...tiers].sort((a, b) => a.fromAmount - b.fromAmount);
+            let tierErrorFound = false;
+            for (let i = 0; i < sortedTiers.length; i++) {
+                const currentTier = sortedTiers[i];
+                if (currentTier.rate < 0) {
+                    errors.tiers = 'Tier rates cannot be negative.';
+                    tierErrorFound = true; break;
+                }
+                if (currentTier.toAmount !== null && currentTier.toAmount < currentTier.fromAmount) {
+                    errors.tiers = `Tier ${i + 1}: Upper bound must be >= lower bound.`;
+                    tierErrorFound = true; break;
+                }
+                if (i < sortedTiers.length - 1) {
+                    const nextTier = sortedTiers[i + 1];
+                    if (currentTier.toAmount === null) {
+                        errors.tiers = 'Only the last tier can have an unlimited upper bound.';
+                        tierErrorFound = true; break;
+                    }
+                    // Allow adjacent: toAmount can equal next fromAmount
+                    // Allow adjacent tiers: upper bound can equal next lower bound
+                    if (currentTier.toAmount !== null && currentTier.toAmount > nextTier.fromAmount) {
+                         errors.tiers = `Tier ${i + 1} overlaps with Tier ${i + 2}.`;
+                         tierErrorFound = true; break;
+                    }
+                    // Check for gaps
+                    // Check for gaps (ensure toAmount is not null before adding 1)
+                    if (currentTier.toAmount !== null && currentTier.toAmount + 1 < nextTier.fromAmount) {
+                         errors.tiers = `Gap detected between Tier ${i + 1} and Tier ${i + 2}.`;
+                         tierErrorFound = true; break;
+                    }
+                }
+            }
+            if (!tierErrorFound && sortedTiers[0]?.fromAmount !== 0) {
+                errors.tiers = 'The first tier must start from 0.';
+            }
+        }
+    }
+    return errors;
+  };
+
+  const validateAllServiceConfigs = (): AllServiceValidationErrors => {
+    const allErrors: AllServiceValidationErrors = {};
+    let hasErrors = false;
+    for (const serviceId in serviceConfigs) {
+      const config = serviceConfigs[serviceId];
+      const serviceErrors = validateSingleServiceConfig(config);
+      if (Object.keys(serviceErrors).length > 0) {
+        allErrors[serviceId] = serviceErrors;
+        hasErrors = true;
+      }
+    }
+    return allErrors;
   };
 
 
-  // Simplified number input handler
-  const handleNumberInputChange = (setter: React.Dispatch<React.SetStateAction<number | undefined>>) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value === '' ? undefined : Number(e.target.value);
-       if (!isNaN(value as number) && (value as number) >= 0) {
-           setter(value);
-       } else if (e.target.value === '') {
-            setter(undefined); // Allow clearing the input
-       }
+  // --- Save Logic (Phase 3: Save Changed Configurations) ---
+  const handleSave = async () => {
+    setSaveAttempted(true);
+    setSaveError(null);
+    setServiceValidationErrors({}); // Clear previous errors
+
+    // 1. Identify changed services
+    const changedServiceIds = Object.keys(serviceConfigs).filter(serviceId => {
+      // Simple deep comparison using JSON stringify (consider lodash.isEqual for robustness)
+      return JSON.stringify(serviceConfigs[serviceId]) !== JSON.stringify(initialServiceConfigs[serviceId]);
+    });
+
+    if (changedServiceIds.length === 0) {
+      setSaveError("No changes detected to save.");
+      setSaveAttempted(false); // No actual save attempt needed
+      return;
+    }
+
+    // 2. Validate *only* changed services
+    const validationErrorsForChanged: AllServiceValidationErrors = {};
+    let hasErrors = false;
+    for (const serviceId of changedServiceIds) {
+      const config = serviceConfigs[serviceId];
+      const serviceErrors = validateSingleServiceConfig(config);
+      if (Object.keys(serviceErrors).length > 0) {
+        validationErrorsForChanged[serviceId] = serviceErrors;
+        hasErrors = true;
+      }
+    }
+
+    // 3. Handle validation errors
+    if (hasErrors) {
+      setServiceValidationErrors(validationErrorsForChanged);
+      setSaveError("Cannot save, validation errors exist in the modified services.");
+      // TODO: Consider focusing/opening the first accordion item with an error
+      console.log("Validation failed for changed services:", Object.keys(validationErrorsForChanged));
+      return;
+    }
+
+    // 4. Prepare payloads and execute upserts
+    setSaving(true);
+    try {
+      const savePromises = changedServiceIds.map(serviceId => {
+        const config = serviceConfigs[serviceId];
+
+        // Prepare backend tier structure
+        const tiersToSave = (config.tiers || [])
+          .sort((a, b) => a.fromAmount - b.fromAmount)
+          .map(tier => ({
+            min_quantity: tier.fromAmount,
+            // Map null back to undefined for the backend if necessary, or handle null in backend
+            max_quantity: tier.toAmount === null ? undefined : tier.toAmount,
+            rate: tier.rate,
+          }));
+
+        const payload = {
+          planId: planId,
+          serviceId: serviceId,
+          // tenantId is handled by the backend action
+          base_rate: config.enable_tiered_pricing ? undefined : config.base_rate,
+          unit_of_measure: config.unit_of_measure,
+          minimum_usage: config.minimum_usage,
+          enable_tiered_pricing: config.enable_tiered_pricing,
+          tiers: config.enable_tiered_pricing ? tiersToSave : [],
+        };
+
+        console.log(`Saving config for service ${serviceId}:`, payload);
+        return upsertPlanServiceConfiguration(payload);
+      });
+
+      // Execute all save operations concurrently
+      await Promise.all(savePromises);
+
+      // 5. Handle success
+      console.log("Successfully saved configurations for services:", changedServiceIds);
+      // Update initial state to reflect the saved state
+      setInitialServiceConfigs(JSON.parse(JSON.stringify(serviceConfigs)));
+      setSaveAttempted(false); // Reset save attempt on success
+      setSaveError(null); // Clear any previous save error
+      // Optionally: Show a success toast/message
+
+    } catch (err: any) {
+      // 6. Handle errors
+      console.error('Error saving service configurations:', err);
+      // Attempt to parse Zod validation errors if available
+      let errorMessage = 'Failed to save one or more service configurations. Please check the details and try again.';
+      if (err.issues && Array.isArray(err.issues)) {
+          errorMessage = `Validation Error: ${err.issues.map((issue: any) => `${issue.path.join('.')} - ${issue.message}`).join(', ')}`;
+      } else if (err.message) {
+          errorMessage = `Error: ${err.message}`;
+      }
+      setSaveError(errorMessage);
+    } finally {
+      setSaving(false);
+    }
   };
 
-
-  if (loading && !plan) {
+  // --- Rendering ---
+  if (loading) {
     return <div className="flex justify-center items-center p-8"><Loader2 className="h-8 w-8 animate-spin" /></div>;
   }
 
@@ -343,15 +388,28 @@ export function UsagePlanConfiguration({
     );
   }
 
-   if (!plan) {
-      return <div className="p-4">Plan not found or invalid type.</div>;
+  if (planServices.length === 0) {
+      return (
+          <div className={`space-y-6 ${className}`}>
+              <Card>
+                  <CardHeader>
+                      <CardTitle>Usage-Based Plan Configuration</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                      <p className="text-muted-foreground mb-4">No services are currently associated with this usage plan. Add services below to configure their pricing.</p>
+                      {/* Keep the GenericPlanServicesList to allow adding services */}
+                      <GenericPlanServicesList planId={planId} onServicesChanged={handleServicesChanged} />
+                  </CardContent>
+              </Card>
+          </div>
+      );
   }
 
   return (
     <div className={`space-y-6 ${className}`}>
       <Card>
         <CardHeader>
-          <CardTitle>Usage-Based Plan Configuration</CardTitle>
+          <CardTitle>Usage-Based Service Pricing</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {saveError && (
@@ -361,167 +419,66 @@ export function UsagePlanConfiguration({
             </Alert>
           )}
 
-          {/* Basic Usage Settings */}
-          <div className="flex flex-col gap-4">
-            <div>
-              <Label htmlFor="usage-plan-base-rate" className="inline-flex items-center">Default Rate per Unit <span className="text-destructive">*</span>
-                <Tooltip content="Rate per unit (used if tiered pricing is off).">
-                  <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
-                </Tooltip>
-              </Label>
-              <Input
-                id="usage-plan-base-rate" type="number"
-                value={baseRate?.toString() || ''}
-                onChange={handleNumberInputChange(setBaseRate)}
-                placeholder="Enter base rate" disabled={saving || enableTieredPricing} // Keep saving disable
-                min={0} step={0.01}
-                className={saveAttempted && validationErrors.base_rate ? 'border-red-500' : ''} // Conditional error class
-              />
-              {saveAttempted && validationErrors.base_rate && <p className="text-sm text-red-500 mt-1">{validationErrors.base_rate}</p>}
-              {/* Removed description paragraph */}
-            </div>
-            <div>
-              <Label htmlFor="usage-plan-unit-of-measure" className="inline-flex items-center">Unit of Measure <span className="text-destructive">*</span>
-                <Tooltip content="e.g., GB, User, Device.">
-                  <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
-                </Tooltip>
-              </Label>
-              <UnitOfMeasureInput
-                value={unitOfMeasure}
-                onChange={setUnitOfMeasure}
-                placeholder="Select unit" /*required removed*/ disabled={saving} // Keep saving disable
-                serviceType="Usage" // Or dynamically set based on service if needed
-                className={saveAttempted && validationErrors.unit_of_measure ? 'border-red-500' : ''} // Conditional error class
-              />
-               {saveAttempted && validationErrors.unit_of_measure && <p className="text-sm text-red-500 mt-1">{validationErrors.unit_of_measure}</p>}
-               {/* Removed description paragraph */}
-            </div>
-             <div>
-              <Label htmlFor="minimum-usage" className="inline-flex items-center">Minimum Usage
-                <Tooltip content="Minimum billable units per period.">
-                  <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
-                </Tooltip>
-              </Label>
-              <Input
-                id="minimum-usage" type="number"
-                value={minimumUsage?.toString() || ''}
-                onChange={handleNumberInputChange(setMinimumUsage)}
-                placeholder="0" disabled={saving} min={0} step={1} // Keep saving disable
-                className={saveAttempted && validationErrors.minimum_usage ? 'border-red-500' : ''} // Conditional error class
-              />
-              {saveAttempted && validationErrors.minimum_usage && <p className="text-sm text-red-500 mt-1">{validationErrors.minimum_usage}</p>}
-              {/* Removed description paragraph */}
-            </div>
-             <p className="text-xs text-muted-foreground pt-2"><span className="text-destructive">*</span> Indicates a required field.</p>
-          </div>
+          <Accordion.Root
+            type="multiple" // Allow multiple items open
+            className="w-full space-y-2"
+            // Consider managing open state if needed to auto-open on error
+          >
+            {planServices.sort((a, b) => (a.service?.service_name || '').localeCompare(b.service?.service_name || '')).map((service) => (
+              <Accordion.Item key={service.configuration.service_id} value={service.configuration.service_id} className="border rounded overflow-hidden">
+                <Accordion.Header className="flex">
+                  <Accordion.Trigger
+                    id={`accordion-trigger-${service.configuration.service_id}`} // Corrected ID
+                    className="flex flex-1 items-center justify-between p-3 font-medium transition-all hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180 bg-muted/20" // Corrected HTML entity
+                  >
+                    {service.service?.service_name || `Service ID: ${service.configuration.service_id}`} {/* Corrected name and ID access */}
+                    <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+                  </Accordion.Trigger>
+                </Accordion.Header>
+                <Accordion.Content
+                  id={`accordion-content-${service.configuration.service_id}`}
+                  className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+                >
+                  <div className="p-4 border-t">
+                    {serviceConfigs[service.configuration.service_id] ? (
+                      <ServiceUsageConfigForm
+                        serviceId={service.configuration.service_id}
+                        serviceName={service.service?.service_name || ''}
+                        config={serviceConfigs[service.configuration.service_id]}
+                        validationErrors={serviceValidationErrors[service.configuration.service_id]}
+                        saveAttempted={saveAttempted}
+                        disabled={saving} // Disable form while saving
+                        onConfigChange={handleConfigChange}
+                        onTiersChange={handleTiersChange}
+                      />
+                    ) : (
+                      <div className="text-muted-foreground">Loading configuration...</div>
+                    )}
+                  </div>
+                </Accordion.Content>
+              </Accordion.Item>
+            ))}
+          </Accordion.Root>
 
-
-          {/* Tiered Pricing */}
-          <div className="space-y-3 pt-3">
-            <div className="flex items-center space-x-2">
-              <Switch id="enable-tiered-pricing" checked={enableTieredPricing} onCheckedChange={setEnableTieredPricing} disabled={saving} />
-              <Label htmlFor="enable-tiered-pricing" className="cursor-pointer">Enable Tiered Pricing</Label>
-            </div>
-
-            {enableTieredPricing && (
-              <Card className="bg-muted/40">
-                <CardHeader className="flex flex-row items-center justify-between pb-2">
-                    <CardTitle className="text-base">Pricing Tiers</CardTitle>
-                    <Button id="add-tier-button" type="button" size="sm" variant="outline" onClick={handleAddTier} disabled={saving}>
-                      <Plus className="h-4 w-4 mr-1" /> Add Tier
-                    </Button>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                   {saveAttempted && validationErrors.tiers && ( // Conditional error display
-                    <Alert variant="destructive">
-                      <AlertCircle className="h-4 w-4" />
-                      <AlertDescription>{validationErrors.tiers}</AlertDescription>
-                    </Alert>
-                  )}
-                  {tiers.length === 0 && !(saveAttempted && validationErrors.tiers) ? ( // Hide if showing tier error
-                    <p className="text-sm text-muted-foreground">No tiers defined. Click "Add Tier".</p>
-                  ) : null}
-                  {tiers.length > 0 && ( // Only show tier inputs if tiers exist
-                    <div className="space-y-2">
-                      {/* Header Row */}
-                       <div className="grid grid-cols-11 gap-2 items-center font-medium text-xs text-muted-foreground px-2">
-                           <div className="col-span-3">From ({unitOfMeasure || 'Units'})</div>
-                           <div className="col-span-3">To ({unitOfMeasure || 'Units'})</div>
-                           <div className="col-span-4">Rate per {unitOfMeasure || 'Unit'}</div>
-                           <div className="col-span-1"></div> {/* Spacer for delete button */}
-                       </div>
-                      {/* Tier Rows */}
-                      {tiers.sort((a, b) => a.fromAmount - b.fromAmount).map((tier, index, sortedTiers) => (
-                        <div key={tier.id} className="grid grid-cols-11 gap-2 items-center border p-2 rounded bg-background">
-                          <div className="col-span-3">
-                            <Input
-                              id={`tier-${tier.id}-from`} type="number"
-                              value={tier.fromAmount.toString()}
-                              onChange={(e) => handleTierChange(tier.id, 'fromAmount', e.target.value)}
-                              disabled={saving || index === 0} // First tier 'from' is always 0
-                              min={0} step={1} aria-label={`Tier ${index + 1} From Amount`}
-                            />
-                          </div>
-                          <div className="col-span-3">
-                            <Input
-                              id={`tier-${tier.id}-to`} type="number"
-                              value={tier.toAmount === null ? '' : tier.toAmount.toString()}
-                              onChange={(e) => handleTierChange(tier.id, 'toAmount', e.target.value)}
-                              placeholder={index === sortedTiers.length - 1 ? "Unlimited" : ""}
-                              disabled={saving || index !== sortedTiers.length - 1}
-                              min={tier.fromAmount} step={1} aria-label={`Tier ${index + 1} To Amount`}
-                            />
-                          </div>
-                          <div className="col-span-4">
-                            <Input
-                              id={`tier-${tier.id}-rate`} type="number"
-                              value={tier.rate.toString()}
-                              onChange={(e) => handleTierChange(tier.id, 'rate', e.target.value)}
-                              disabled={saving} min={0} step={0.01} aria-label={`Tier ${index + 1} Rate`}
-                            />
-                          </div>
-                          <div className="col-span-1 flex justify-end">
-                            <Button
-                              id={`remove-tier-${tier.id}-button`} type="button" variant="ghost" size="sm"
-                              onClick={() => handleRemoveTier(tier.id)}
-                              disabled={saving || tiers.length <= 1} // Cannot remove if only one tier exists
-                              className="text-destructive hover:bg-destructive/10"
-                              aria-label={`Remove Tier ${index + 1}`}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                   <p className="text-xs text-muted-foreground pt-2">
-                    Define usage ranges and their corresponding rates. Leave 'To' blank for the last tier to represent unlimited usage. The first tier must start from 0. Tiers must be contiguous.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
-          </div>
-
-          {/* Restore Save Button */}
+          {/* Save Button */}
           <div className="flex justify-end pt-4">
-            <Button id="save-usage-config-button" onClick={handleSave} disabled={saving}>
+            <Button id="save-all-service-configs-button" onClick={handleSave} disabled={saving || loading}>
               {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Save Configuration
+              Save All Configurations
             </Button>
           </div>
         </CardContent>
       </Card>
 
-      {/* Placeholder for Services List */}
-      <Card>
-          <CardHeader>
-              <CardTitle>Applicable Services</CardTitle>
-          </CardHeader>
-          <CardContent>
-              <GenericPlanServicesList planId={planId} />
-          </CardContent>
-      </Card>
+      {/* Keep Services List for adding/removing services */}
+       <Card>
+           <CardHeader>
+               <CardTitle>Manage Plan Services</CardTitle>
+           </CardHeader>
+           <CardContent>
+               <GenericPlanServicesList planId={planId} onServicesChanged={handleServicesChanged} />
+           </CardContent>
+       </Card>
     </div>
   );
 }

--- a/server/src/interfaces/index.ts
+++ b/server/src/interfaces/index.ts
@@ -23,3 +23,4 @@ export * from './interaction.interfaces';
 export * from './ticketResource.interfaces';
 export * from './asset.interfaces';
 export * from './status.interface';
+export * from './planServiceConfiguration.interfaces';

--- a/server/src/interfaces/planServiceConfiguration.interfaces.ts
+++ b/server/src/interfaces/planServiceConfiguration.interfaces.ts
@@ -53,7 +53,8 @@ export interface IPlanServiceUsageConfig extends TenantEntity {
   config_id: string;
   unit_of_measure: string;
   enable_tiered_pricing: boolean;
-  minimum_usage: number;
+  minimum_usage?: number | null; // Make nullable to match DB and input
+  base_rate?: number | null; // Add the new base_rate field
   tenant: string;
   created_at: Date;
   updated_at: Date;
@@ -85,6 +86,15 @@ export interface IPlanServiceRateTier extends TenantEntity {
   tenant: string;
   created_at: Date;
   updated_at: Date;
+}
+
+/**
+ * Input interface for creating/updating rate tiers (omits DB-generated fields)
+ */
+export interface IPlanServiceRateTierInput {
+  min_quantity: number;
+  max_quantity?: number | null; // Allow null for the last tier
+  rate: number;
 }
 
 /**

--- a/server/src/lib/actions/planServiceConfigurationActions.ts
+++ b/server/src/lib/actions/planServiceConfigurationActions.ts
@@ -8,7 +8,8 @@ import {
   IPlanServiceUsageConfig,
   IPlanServiceBucketConfig,
   IPlanServiceRateTier, // Import the rate tier interface
-  IUserTypeRate
+  IUserTypeRate, // Added comma
+  IPlanServiceRateTierInput
 } from 'server/src/interfaces/planServiceConfiguration.interfaces';
 import { PlanServiceConfigurationService } from 'server/src/lib/services/planServiceConfigurationService';
 
@@ -204,4 +205,286 @@ export async function deleteUserTypeRate(rateId: string): Promise<boolean> {
   const hourlyConfigModel = new (await import('server/src/lib/models/planServiceHourlyConfig')).default(knex, tenant);
   
   return await hourlyConfigModel.deleteUserTypeRate(rateId);
+}
+
+// --- New Actions for Tiered Service Pricing ---
+
+/**
+ * Interface combining base service config, usage config, and tiers.
+ */
+export interface IFullPlanServiceUsageConfiguration extends IPlanServiceConfiguration, Omit<IPlanServiceUsageConfig, 'config_id' | 'created_at' | 'updated_at' | 'tenant'> {
+  tiers?: IPlanServiceRateTier[];
+}
+
+/**
+ * Fetches the full service-level configuration (base, usage details, and tiers) for a specific service within a plan.
+ * Corresponds to Phase 1 Task: Backend fetch action (`getPlanServiceConfiguration`)
+ */
+export async function getPlanServiceConfiguration(planId: string, serviceId: string): Promise<IFullPlanServiceUsageConfiguration | null> {
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("tenant context not found");
+  }
+  const configService = new PlanServiceConfigurationService(knex, tenant);
+
+  // TODO: Implement logic using configService or direct queries
+  // 1. Get base config using configService.getConfigurationForService(planId, serviceId)
+  // 2. If base config exists and is 'Usage' type:
+  //    a. Get usage config using config_id
+  //    b. If enable_tiered_pricing, get tiers using config_id
+  // 3. Combine and return, ensuring tenant filtering
+
+  console.log(`Fetching config for planId: ${planId}, serviceId: ${serviceId}, tenant: ${tenant}`); // Placeholder
+  // Placeholder implementation - replace with actual logic
+  const baseConfig = await configService.getConfigurationForService(planId, serviceId);
+  if (!baseConfig || baseConfig.configuration_type !== 'Usage') {
+    return null;
+  }
+
+  try {
+    const usageConfig = await knex<IPlanServiceUsageConfig>('plan_service_usage_config')
+      .where({ config_id: baseConfig.config_id, tenant: tenant })
+      .first();
+
+    if (!usageConfig) {
+      // This case might indicate data inconsistency if baseConfig type is 'Usage'
+      console.error(`Usage config not found for config_id: ${baseConfig.config_id}, tenant: ${tenant}`);
+      return null; // Return null as the full configuration couldn't be retrieved
+    }
+
+    let tiers: IPlanServiceRateTier[] = [];
+    if (usageConfig.enable_tiered_pricing) {
+      tiers = await knex<IPlanServiceRateTier>('plan_service_rate_tiers')
+        .where({ config_id: baseConfig.config_id, tenant: tenant })
+        .orderBy('min_quantity', 'asc');
+    }
+
+    // Combine results
+    const fullConfig: IFullPlanServiceUsageConfiguration = {
+      ...baseConfig,
+      unit_of_measure: usageConfig.unit_of_measure,
+      minimum_usage: usageConfig.minimum_usage,
+      enable_tiered_pricing: usageConfig.enable_tiered_pricing,
+      base_rate: usageConfig.base_rate, // Include the new base_rate
+      tiers: tiers,
+    };
+    return fullConfig;
+
+  } catch (error) {
+    console.error("Error fetching plan service configuration details:", error);
+    throw new Error("Failed to fetch plan service configuration details.");
+  }
+}
+
+
+/**
+ * Input type for upserting plan service usage configuration.
+ */
+export interface IUpsertPlanServiceUsageConfigurationInput {
+  planId: string;
+  serviceId: string;
+  // Fields from IPlanServiceUsageConfig (including base_rate)
+  unit_of_measure?: string | null;
+  minimum_usage?: number | null;
+  enable_tiered_pricing?: boolean;
+  base_rate?: number | null; // Added base_rate
+  // Tiers array (using input type)
+  tiers?: IPlanServiceRateTierInput[];
+}
+
+/**
+ * Validates the input for upserting plan service usage configuration.
+ * Throws an error if validation fails.
+ */
+function validatePlanServiceUsageConfigurationInput(input: IUpsertPlanServiceUsageConfigurationInput): void {
+  const { base_rate, minimum_usage, enable_tiered_pricing, tiers } = input;
+
+  if (base_rate !== undefined && base_rate !== null && base_rate < 0) {
+    throw new Error("Base rate cannot be negative.");
+  }
+
+  if (minimum_usage !== undefined && minimum_usage !== null && minimum_usage < 0) {
+    throw new Error("Minimum usage cannot be negative.");
+  }
+
+  if (enable_tiered_pricing) {
+    if (!tiers || tiers.length === 0) {
+      throw new Error("Tiered pricing is enabled, but no tiers were provided.");
+    }
+
+    // Sort tiers by min_quantity to ensure correct order for validation
+    const sortedTiers = [...tiers].sort((a, b) => a.min_quantity - b.min_quantity);
+
+    if (sortedTiers[0].min_quantity !== 0) {
+      throw new Error("The first tier must start at quantity 0.");
+    }
+
+    for (let i = 0; i < sortedTiers.length; i++) {
+      const tier = sortedTiers[i];
+
+      if (tier.min_quantity < 0) {
+        throw new Error(`Tier ${i + 1} (starting at ${tier.min_quantity}) minimum quantity cannot be negative.`);
+      }
+      if (tier.rate < 0) {
+        throw new Error(`Tier ${i + 1} (starting at ${tier.min_quantity}) rate cannot be negative.`);
+      }
+
+      // Check max_quantity validity
+      if (tier.max_quantity !== undefined && tier.max_quantity !== null) {
+        if (tier.max_quantity < tier.min_quantity) {
+          throw new Error(`Tier ${i + 1} maximum quantity (${tier.max_quantity}) cannot be less than minimum quantity (${tier.min_quantity}).`);
+        }
+        // Check contiguity with the next tier
+        if (i < sortedTiers.length - 1) {
+          const nextTier = sortedTiers[i+1];
+          // Allow for floating point inaccuracies slightly if needed, but strict equality is better for integers
+          if (tier.max_quantity + 1 !== nextTier.min_quantity) {
+             throw new Error(`Tiers are not contiguous. Gap or overlap found between tier ending at ${tier.max_quantity} and tier starting at ${nextTier.min_quantity}.`);
+          }
+        }
+      } else {
+        // max_quantity is null or undefined, should be the last tier
+        if (i < sortedTiers.length - 1) {
+          throw new Error(`Tier ${i + 1} (starting at ${tier.min_quantity}) has no maximum quantity but is not the last tier.`);
+        }
+      }
+    }
+  }
+}
+
+
+/**
+ * Upserts the service-level configuration (base, usage details, base rate, and tiers) for a specific service within a plan.
+ * Handles creation or update within a transaction and includes validation.
+ * Corresponds to Phase 1 Tasks:
+ * - Backend upsert action (`upsertPlanServiceConfiguration`)
+ * - Backend validation within upsert
+ * - Backend data type handling and tenant filtering
+ */
+export async function upsertPlanServiceConfiguration(input: IUpsertPlanServiceUsageConfigurationInput): Promise<IFullPlanServiceUsageConfiguration> {
+  const { knex, tenant } = await createTenantKnex();
+  if (!tenant) {
+    throw new Error("tenant context not found");
+  }
+  const configService = new PlanServiceConfigurationService(knex, tenant); // May not be fully used if direct transaction is needed
+
+  // --- Validation (Phase 1 Task) ---
+  try {
+    validatePlanServiceUsageConfigurationInput(input);
+  } catch (validationError: any) {
+    console.error("Validation failed for upsertPlanServiceConfiguration:", validationError.message);
+    // Re-throw or handle as a specific validation error response
+    throw new Error(`Validation Error: ${validationError.message}`);
+  }
+  // --- End Validation ---
+
+  const { planId, serviceId, tiers, ...usageConfigInput } = input;
+
+  try {
+    const updatedConfig = await knex.transaction(async (trx) => {
+      const trxConfigService = new PlanServiceConfigurationService(trx, tenant); // Use transaction knex
+
+      // 1. Upsert plan_service_configuration
+      let baseConfig = await trxConfigService.getConfigurationForService(planId, serviceId);
+      let configId: string;
+
+      if (baseConfig) {
+        // Update if exists (though only type is relevant here, maybe updated_at)
+        configId = baseConfig.config_id;
+        await trx('plan_service_configuration')
+          .where({ config_id: configId, tenant: tenant })
+          .update({ updated_at: new Date() }); // Touch updated_at
+      } else {
+        // Create if not exists
+        const newBaseConfig: Omit<IPlanServiceConfiguration, 'config_id' | 'created_at' | 'updated_at'> = {
+          plan_id: planId,
+          service_id: serviceId,
+          configuration_type: 'Usage', // Explicitly set type
+          tenant: tenant,
+          custom_rate: undefined, // Use undefined instead of null
+        };
+        const insertedIds = await trx('plan_service_configuration')
+          .insert(newBaseConfig)
+          .returning('config_id');
+        configId = insertedIds[0].config_id;
+      }
+
+      // 2. Upsert plan_service_usage_config
+      const usageConfigPayload = {
+        ...usageConfigInput,
+        config_id: configId,
+        tenant: tenant,
+        // Ensure numeric types are handled correctly
+        base_rate: usageConfigInput.base_rate !== undefined && usageConfigInput.base_rate !== null ? Number(usageConfigInput.base_rate) : null,
+        minimum_usage: usageConfigInput.minimum_usage !== undefined && usageConfigInput.minimum_usage !== null ? Number(usageConfigInput.minimum_usage) : null,
+      };
+
+      // Use explicit insert/update with conflict handling for upsert
+      await trx('plan_service_usage_config')
+        .insert(usageConfigPayload)
+        .onConflict(['config_id', 'tenant']) // Assumes this unique constraint exists
+        .merge() // Update existing row on conflict
+        .returning('*'); // Get the updated/inserted row if needed
+
+
+      // 3. Handle Tiers
+      // Always delete existing tiers first for simplicity in upsert
+      await trx('plan_service_rate_tiers')
+        .where({ config_id: configId, tenant: tenant })
+        .del();
+
+      if (usageConfigInput.enable_tiered_pricing && tiers && tiers.length > 0) {
+        // Insert new tiers if enabled and provided
+        const tiersToInsert = tiers.map(tier => ({
+          ...tier,
+          config_id: configId,
+          tenant: tenant,
+          // Ensure numeric/integer types
+          min_quantity: Number(tier.min_quantity),
+          max_quantity: tier.max_quantity !== undefined && tier.max_quantity !== null ? Number(tier.max_quantity) : null,
+          rate: Number(tier.rate),
+        }));
+        await trx('plan_service_rate_tiers').insert(tiersToInsert);
+      }
+
+      // Fetch the final combined configuration to return
+      // Re-use the logic from getPlanServiceConfiguration but with the transaction trx
+      const finalBaseConfig = await trx<IPlanServiceConfiguration>('plan_service_configuration')
+        .where({ config_id: configId, tenant: tenant })
+        .first();
+
+      if (!finalBaseConfig) throw new Error("Failed to retrieve base config after upsert"); // Should not happen
+
+      const finalUsageConfig = await trx<IPlanServiceUsageConfig>('plan_service_usage_config')
+        .where({ config_id: configId, tenant: tenant })
+        .first();
+
+      if (!finalUsageConfig) throw new Error("Failed to retrieve usage config after upsert"); // Should not happen
+
+      let finalTiers: IPlanServiceRateTier[] = [];
+      if (finalUsageConfig.enable_tiered_pricing) {
+        finalTiers = await trx<IPlanServiceRateTier>('plan_service_rate_tiers')
+          .where({ config_id: configId, tenant: tenant })
+          .orderBy('min_quantity', 'asc');
+      }
+
+      const result: IFullPlanServiceUsageConfiguration = {
+        ...finalBaseConfig,
+        unit_of_measure: finalUsageConfig.unit_of_measure,
+        minimum_usage: finalUsageConfig.minimum_usage,
+        enable_tiered_pricing: finalUsageConfig.enable_tiered_pricing,
+        base_rate: finalUsageConfig.base_rate,
+        tiers: finalTiers,
+      };
+      return result;
+
+    }); // End transaction
+
+    return updatedConfig;
+
+  } catch (error) {
+    console.error("Error upserting plan service configuration:", error);
+    // TODO: Improve error handling, maybe return specific validation errors
+    throw new Error("Failed to upsert plan service configuration.");
+  }
 }


### PR DESCRIPTION
This commit introduces the ability to configure tiered pricing specifically for individual services within a usage plan, moving away from plan-level tiered pricing. This provides greater flexibility in defining billing structures.

Key changes include:

**Database:**
- Added a `base_rate` column (numeric, nullable) to the `plan_service_usage_config` table via migration to support non-tiered pricing per service.

**Backend:**
- Created `getPlanServiceConfiguration` action to fetch detailed configuration (base rate, tiers, etc.) for a specific service within a plan.
- Created `upsertPlanServiceConfiguration` action to save service-level configuration, handling base rate and tiers within a database transaction.
- Implemented server-side validation for rates, usage limits, and tier structures within the upsert action.
- Ensured correct data type handling and mandatory tenant filtering in all backend database operations.

**Frontend:**
- Refactored `UsagePlanConfiguration` component state to manage configuration data on a per-service ID basis.
- Adapted data fetching logic to use the new `getPlanServiceConfiguration` backend action.
- Restructured the UI (using Accordion) to display and manage configuration for each service individually.
- Extracted reusable `ServiceUsageConfigForm` and `ServiceTierEditor` components for better modularity.
- Modified event handlers and validation logic to operate contextually for the specific service being edited.
- Updated the save process (`handleSave`) to iterate through modified service configurations, validate, and call the `upsertPlanServiceConfiguration` action for each.
- Implemented a refresh mechanism to reload service configurations when the list of services changes.

**Documentation:**
- Updated `billing.md` to reflect the service-level configuration structure and the addition of the `base_rate` field.