### PR TITLE
feat(plan-config): Add unique constraint and refine usage config hand…

### DIFF
--- a/server/migrations/20250328074800_add_unique_constraint_to_plan_service_usage_config.cjs
+++ b/server/migrations/20250328074800_add_unique_constraint_to_plan_service_usage_config.cjs
@@ -1,0 +1,16 @@
+/**
+ * Migration to add a unique constraint on (config_id, tenant) to plan_service_usage_config
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('plan_service_usage_config', function(table) {
+    // Add the unique constraint required for the upsert operation
+    table.unique(['config_id', 'tenant'], { indexName: 'plan_service_usage_config_config_id_tenant_unique' });
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('plan_service_usage_config', function(table) {
+    // Remove the unique constraint
+    table.dropUnique(['config_id', 'tenant'], 'plan_service_usage_config_config_id_tenant_unique');
+  });
+};

--- a/server/src/components/billing-dashboard/service-configurations/UsageServiceConfigPanel.tsx
+++ b/server/src/components/billing-dashboard/service-configurations/UsageServiceConfigPanel.tsx
@@ -139,6 +139,12 @@ export function UsageServiceConfigPanel({
   const handleAddTier = () => {
     if (!onRateTiersChange) return;
     
+    // Ensure tiered pricing is enabled when adding tiers
+    if (!enableTieredPricing) {
+      setEnableTieredPricing(true);
+      onConfigurationChange({ enable_tiered_pricing: true });
+    }
+    
     const newTier: TierData = {
       id: Date.now().toString(),
       min_quantity: tiers.length > 0 ? (tiers[tiers.length - 1].max_quantity || 0) + 1 : 1,

--- a/server/src/lib/actions/planServiceConfigurationActions.ts
+++ b/server/src/lib/actions/planServiceConfigurationActions.ts
@@ -393,7 +393,8 @@ export async function upsertPlanServiceConfiguration(input: IUpsertPlanServiceUs
         configId = baseConfig.config_id;
         await trx('plan_service_configuration')
           .where({ config_id: configId, tenant: tenant })
-          .update({ updated_at: new Date() }); // Touch updated_at
+          // Ensure type is 'Usage' on update as well
+          .update({ configuration_type: 'Usage', updated_at: new Date() });
       } else {
         // Create if not exists
         const newBaseConfig: Omit<IPlanServiceConfiguration, 'config_id' | 'created_at' | 'updated_at'> = {


### PR DESCRIPTION
…ling

- Adds a DB migration for a unique constraint (config_id, tenant) on `plan_service_usage_config` to enable upserts.
- Ensures `configuration_type` is set to 'Usage' during upsert updates in `planServiceConfigurationActions`.
- Fixes `UsageServiceConfigPanel` UI to auto-enable tiered pricing when adding a tier.