### PR TITLE
refactor(billing/bucket-plan): Implement per-service configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@hocuspocus/provider": "^2.13.5",
         "@huggingface/inference": "^2.8.0",
         "@js-temporal/polyfill": "^0.4.4",
+        "@mantine/core": "^7.17.3",
+        "@mantine/form": "^7.17.3",
         "@nestjs/common": "^11.0.3",
         "@nestjs/config": "^4.0.0",
         "@radix-ui/react-checkbox": "^1.1.1",
@@ -4168,9 +4170,9 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.16.3.tgz",
-      "integrity": "sha512-cxhIpfd2i0Zmk9TKdejYAoIvWouMGhzK3OOX+VRViZ5HEjnTQCGl2h3db56ThqB6NfVPCno6BPbt5lwekTtmuQ==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.3.tgz",
+      "integrity": "sha512-N/AfV5eMnfEMx9WzI7AU5pNFBEzAfT/KtE2XDKS+0ht6RifUmolIxyIvoGMYz2yUEsCBMJZqmBq33Rabf5W7Ug==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
@@ -4181,15 +4183,28 @@
         "type-fest": "^4.27.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "7.16.3",
+        "@mantine/hooks": "7.17.3",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
+    "node_modules/@mantine/form": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-7.17.3.tgz",
+      "integrity": "sha512-ktERldD8f9lrjjz6wIbwMnNbAZq8XEWPx4K5WuFyjXaK0PI8D+gsXIGKMtA5rVrAUFHCWCdbK3yLgtjJNki8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.6"
+      },
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
     "node_modules/@mantine/hooks": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.16.3.tgz",
-      "integrity": "sha512-B94FBWk5Sc81tAjV+B3dGh/gKzfqzpzVC/KHyBRWOOyJRqeeRbI/FAaJo4zwppyQo1POSl5ArdyjtDRrRIj2SQ==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.3.tgz",
+      "integrity": "sha512-6o65Rbfl8jd1C1nF9icvungqL0qZViEOmrZgkyKXxBYkC3x91fz4zftwQgNjt1tZHWDNO6Bo4GpRjJyAdwl48g==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
@@ -16839,6 +16854,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/knex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
@@ -27541,6 +27565,7 @@
         "@hocuspocus/provider": "^2.15.2",
         "@huggingface/inference": "^3.3.3",
         "@js-temporal/polyfill": "^0.4.4",
+        "@mantine/form": "^7.17.3",
         "@monaco-editor/react": "^4.7.0",
         "@nestjs/common": "^11.0.4",
         "@nestjs/core": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@hocuspocus/provider": "^2.13.5",
     "@huggingface/inference": "^2.8.0",
     "@js-temporal/polyfill": "^0.4.4",
+    "@mantine/core": "^7.17.3",
+    "@mantine/form": "^7.17.3",
     "@nestjs/common": "^11.0.3",
     "@nestjs/config": "^4.0.0",
     "@radix-ui/react-checkbox": "^1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "@hocuspocus/provider": "^2.15.2",
     "@huggingface/inference": "^3.3.3",
     "@js-temporal/polyfill": "^0.4.4",
+    "@mantine/form": "^7.17.3",
     "@monaco-editor/react": "^4.7.0",
     "@nestjs/common": "^11.0.4",
     "@nestjs/core": "^11.0.4",

--- a/server/src/components/billing-dashboard/billing-plans/BucketPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BucketPlanConfiguration.tsx
@@ -1,29 +1,42 @@
-// server/src/components/billing-dashboard/BucketPlanConfiguration.tsx
+// server/src/components/billing-dashboard/billing-plans/BucketPlanConfiguration.tsx
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Input } from 'server/src/components/ui/Input';
-import { Label } from 'server/src/components/ui/Label';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
-import CustomSelect from 'server/src/components/ui/CustomSelect';
-import { Switch } from 'server/src/components/ui/Switch';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
-import { AlertCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, Loader2, ChevronDown } from 'lucide-react';
 import { Button } from 'server/src/components/ui/Button';
-import { BILLING_FREQUENCY_OPTIONS } from 'server/src/constants/billing';
-import { getServices } from 'server/src/lib/actions/serviceActions';
-import { getBillingPlanById } from 'server/src/lib/actions/billingPlanAction';
-import { updateBucketPlan } from 'server/src/lib/actions/bucketPlanAction'; // Corrected action name
-import { getPlanServices } from 'server/src/lib/actions/planServiceActions';
+import { getPlanServicesWithConfigurations } from 'server/src/lib/actions/planServiceActions';
 import GenericPlanServicesList from './GenericPlanServicesList';
-import { IService, IBillingPlan, IPlanService } from 'server/src/interfaces/billing.interfaces'; // Removed IBucketPlanConfig
+import { IService } from 'server/src/interfaces/billing.interfaces';
+import {
+  IPlanServiceConfiguration,
+  IPlanServiceBucketConfig,
+  // Removed PlanServiceConfigType import
+} from 'server/src/interfaces/planServiceConfiguration.interfaces';
+import * as RadixAccordion from '@radix-ui/react-accordion';
+import { ServiceBucketConfigForm } from './ServiceBucketConfigForm';
+import { getConfigurationWithDetails, upsertPlanServiceBucketConfigurationAction } from 'server/src/lib/actions/planServiceConfigurationActions'; // Use upsertPlanServiceBucketConfigurationAction
+import { toast } from 'react-hot-toast'; // Use react-hot-toast
 
-// Define the expected shape of the plan object returned by getBillingPlanById for Bucket
-type BucketPlanData = IBillingPlan & {
-    total_hours?: number;
-    overage_rate?: number;
-    allow_rollover?: boolean;
-    // service_catalog_id might be derived from associated services
+// Type for the state holding configurations for all services
+type ServiceConfigsState = {
+  [serviceId: string]: Partial<IPlanServiceBucketConfig>;
+};
+
+// Type for validation errors
+type ServiceValidationErrors = {
+  [serviceId: string]: {
+    total_hours?: string;
+    overage_rate?: string;
+    // Add other fields if needed
+  };
+};
+
+// Type for the combined service and configuration data used for rendering
+type PlanServiceWithDetails = {
+  service: IService & { unit_of_measure?: string }; // Ensure unit_of_measure is available
+  configuration: IPlanServiceConfiguration; // Base configuration
 };
 
 interface BucketPlanConfigurationProps {
@@ -31,147 +44,228 @@ interface BucketPlanConfigurationProps {
   className?: string;
 }
 
+const DEFAULT_BUCKET_CONFIG: Partial<IPlanServiceBucketConfig> = {
+  total_hours: 0,
+  overage_rate: 0,
+  allow_rollover: false,
+};
+
 export function BucketPlanConfiguration({
   planId,
   className = '',
 }: BucketPlanConfigurationProps) {
-  const [plan, setPlan] = useState<BucketPlanData | null>(null);
-  const [totalHours, setTotalHours] = useState<number | undefined>(undefined);
-  const [billingPeriod, setBillingPeriod] = useState<string>(''); // Should match plan's billing_frequency
-  const [overageRate, setOverageRate] = useState<number | undefined>(undefined);
-  const [serviceCatalogId, setServiceCatalogId] = useState<string | undefined>(undefined); // Assuming one primary service for the bucket
-  const [allowRollover, setAllowRollover] = useState<boolean>(false);
-
-  const [services, setServices] = useState<IService[]>([]);
+  const [planServices, setPlanServices] = useState<PlanServiceWithDetails[]>([]);
+  const [serviceConfigs, setServiceConfigs] = useState<ServiceConfigsState>({});
+  const [initialServiceConfigs, setInitialServiceConfigs] = useState<ServiceConfigsState>({});
+  const [serviceValidationErrors, setServiceValidationErrors] = useState<ServiceValidationErrors>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [validationErrors, setValidationErrors] = useState<{
-    totalHours?: string;
-    billingPeriod?: string; // Usually inherited from plan, but might be configurable?
-    overageRate?: string;
-    serviceCatalogId?: string;
-  }>({});
+  const [saveAttempted, setSaveAttempted] = useState(false);
 
-  const fetchPlanData = useCallback(async () => {
+  const fetchAndInitializeConfigs = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const fetchedPlan = await getBillingPlanById(planId) as BucketPlanData; // Cast to expected type
-      if (fetchedPlan && fetchedPlan.plan_type === 'Bucket') { // Match enum case
-        setPlan(fetchedPlan);
-        // Assume config fields are returned directly on the plan object
-        setTotalHours(fetchedPlan.total_hours);
-        setBillingPeriod(fetchedPlan.billing_frequency); // Use plan's frequency
-        setOverageRate(fetchedPlan.overage_rate);
-        setAllowRollover(fetchedPlan.allow_rollover ?? false);
+      const fetchedPlanServices = await getPlanServicesWithConfigurations(planId);
+      // NO filtering - We want to show ALL services associated with this Bucket Plan
+      setPlanServices(fetchedPlanServices); // Use all fetched services
 
-        // Fetch associated services separately
-        const associatedServices: IPlanService[] = await getPlanServices(planId);
-        // Assuming the first service is the relevant one for a bucket plan's config
-        if (associatedServices.length > 0) {
-            setServiceCatalogId(associatedServices[0].service_id);
-        } else {
-            setServiceCatalogId(undefined); // No service associated
+      const initialConfigs: ServiceConfigsState = {};
+      const currentConfigs: ServiceConfigsState = {};
+      const fetchPromises = fetchedPlanServices.map(async (ps: PlanServiceWithDetails) => { // Use fetchedPlanServices and add type
+        const serviceId = ps.service.service_id;
+        const configId = ps.configuration.config_id; // Corrected property access
+
+        try {
+          // Fetch detailed config
+          const detailedResult = await getConfigurationWithDetails(configId);
+          const bucketConfig = detailedResult?.typeConfig as IPlanServiceBucketConfig | null; // Access typeConfig and cast
+
+          const configData = bucketConfig
+            ? {
+                total_hours: bucketConfig.total_hours ?? DEFAULT_BUCKET_CONFIG.total_hours,
+                overage_rate: bucketConfig.overage_rate ?? DEFAULT_BUCKET_CONFIG.overage_rate,
+                allow_rollover: bucketConfig.allow_rollover ?? DEFAULT_BUCKET_CONFIG.allow_rollover,
+              }
+            : { ...DEFAULT_BUCKET_CONFIG }; // Use defaults if no specific config exists
+
+          initialConfigs[serviceId] = { ...configData };
+          currentConfigs[serviceId] = { ...configData };
+
+        } catch (configErr) {
+          console.error(`Error fetching config details for service ${serviceId} (configId: ${configId}):`, configErr);
+          initialConfigs[serviceId] = { ...DEFAULT_BUCKET_CONFIG };
+          currentConfigs[serviceId] = { ...DEFAULT_BUCKET_CONFIG };
         }
-      } else {
-        setError('Invalid plan type or plan not found.');
-      }
+      });
+
+      await Promise.all(fetchPromises);
+
+      setInitialServiceConfigs(initialConfigs);
+      setServiceConfigs(currentConfigs);
+      setServiceValidationErrors({});
+      setSaveAttempted(false);
+
     } catch (err) {
-      console.error('Error fetching plan data:', err);
-      setError('Failed to load plan configuration. Please try again.');
+      console.error('Error fetching plan services or configurations:', err);
+      setError('Failed to load service configurations. Please try again.');
+      setPlanServices([]);
+      setInitialServiceConfigs({});
+      setServiceConfigs({});
     } finally {
       setLoading(false);
     }
   }, [planId]);
 
-  // Fetch services if needed for selection
-  const fetchServices = useCallback(async () => {
-     // Only fetch if service selection is part of this config
-     // setLoading(true); // Consider separate loading state
-     try {
-         const fetchedServices = await getServices();
-         setServices(fetchedServices);
-     } catch (err) {
-         console.error('Error fetching services:', err);
-         setError(prev => prev ? `${prev}\nFailed to load services.` : 'Failed to load services.');
-     } finally {
-        // setLoading(false);
-     }
+  useEffect(() => {
+    fetchAndInitializeConfigs();
+  }, [fetchAndInitializeConfigs]);
+
+  const handleConfigChange = useCallback((serviceId: string, field: keyof IPlanServiceBucketConfig, value: any) => {
+    setServiceConfigs(prev => ({
+      ...prev,
+      [serviceId]: {
+        ...prev[serviceId],
+        [field]: value,
+      },
+    }));
+    setServiceValidationErrors(prev => {
+      const updatedErrors = { ...prev };
+      if (updatedErrors[serviceId]) {
+        delete updatedErrors[serviceId][field as keyof ServiceValidationErrors[string]];
+        if (Object.keys(updatedErrors[serviceId]).length === 0) {
+          delete updatedErrors[serviceId];
+        }
+      }
+      return updatedErrors;
+    });
   }, []);
 
+  const validateConfig = (config: Partial<IPlanServiceBucketConfig>): ServiceValidationErrors['string'] => {
+    const errors: ServiceValidationErrors['string'] = {};
+    // Ensure values are treated as numbers, handling null/undefined from state
+    const totalHours = config.total_hours === null || config.total_hours === undefined ? null : Number(config.total_hours);
+    const overageRate = config.overage_rate === null || config.overage_rate === undefined ? null : Number(config.overage_rate);
 
-  useEffect(() => {
-    fetchPlanData();
-    fetchServices(); // Fetch services initially
-  }, [fetchPlanData, fetchServices]);
-
-  // Validation logic moved to handleSave
+    if (totalHours === null || isNaN(totalHours) || totalHours < 0) {
+      errors.total_hours = 'Total hours must be a non-negative number.';
+    }
+    if (overageRate === null || isNaN(overageRate) || overageRate < 0) {
+      errors.overage_rate = 'Overage rate must be a non-negative number.';
+    }
+    return errors;
+  };
 
   const handleSave = async () => {
-    // Perform validation on save attempt
-    const errors: typeof validationErrors = {};
-    if (totalHours === undefined || totalHours <= 0) errors.totalHours = 'Total hours must be greater than zero';
-    if (overageRate === undefined || overageRate < 0) errors.overageRate = 'Overage rate cannot be negative';
-    // billingPeriod comes from plan, no need to validate here
-    // if (!serviceCatalogId) errors.serviceCatalogId = 'Please select a service'; // Add if service selection is mandatory
-
-    setValidationErrors(errors); // Update errors state
-
-    if (Object.keys(errors).length > 0) {
-        setSaveError("Cannot save, please fix the validation errors.");
-        return; // Stop saving if errors exist
-    }
-
-    if (!plan) {
-        setSaveError("Cannot save, plan not loaded.");
-        return;
-    }
-
+    setSaveAttempted(true);
     setSaving(true);
-    setSaveError(null);
+    setError(null);
+
+    const changedServices: { serviceId: string; configId: string; config: Partial<IPlanServiceBucketConfig> }[] = [];
+    const validationPromises: Promise<{ serviceId: string; errors: ServiceValidationErrors['string'] }>[] = [];
+
+    for (const serviceId in serviceConfigs) {
+      const planServiceDetail = planServices.find(ps => ps.service.service_id === serviceId);
+      if (!planServiceDetail || !planServiceDetail.configuration) continue; // Skip if service details not found
+
+      const configId = planServiceDetail.configuration.config_id;
+      const currentConfig = serviceConfigs[serviceId];
+      const initialConfig = initialServiceConfigs[serviceId];
+
+      if (JSON.stringify(currentConfig) !== JSON.stringify(initialConfig)) {
+        changedServices.push({ serviceId, configId, config: currentConfig });
+        validationPromises.push(
+          Promise.resolve().then(() => ({
+            serviceId,
+            errors: validateConfig(currentConfig),
+          }))
+        );
+      }
+    }
+
+    if (changedServices.length === 0) {
+      toast("No changes detected."); // Use toast() directly for info
+      setSaving(false);
+      setSaveAttempted(false);
+      return;
+    }
+
+    const validationResults = await Promise.all(validationPromises);
+    const newValidationErrors: ServiceValidationErrors = {};
+    let hasErrors = false;
+
+    validationResults.forEach(({ serviceId, errors }) => {
+      if (Object.keys(errors).length > 0) {
+        newValidationErrors[serviceId] = errors;
+        hasErrors = true;
+      }
+    });
+
+    setServiceValidationErrors(newValidationErrors);
+
+    if (hasErrors) {
+      toast.error("Validation errors found. Please correct the highlighted fields.");
+      setSaving(false);
+      return;
+    }
+
+    // Proceed with saving using upsertPlanServiceBucketConfigurationAction
+    const savePromises = changedServices.map(({ serviceId, config }) => // Removed configId from destructuring
+      upsertPlanServiceBucketConfigurationAction({ // CALL CORRECT ACTION
+        planId, // Pass planId
+        serviceId, // Pass serviceId
+        ...config // Spread the bucket config fields
+      })
+        .catch((err: Error) => { // Added type for err
+          console.error(`Error saving config for service ${serviceId}:`, err); // Removed configId from log
+          return { error: err, serviceId }; // Removed configId from return
+        })
+    );
+
     try {
-        // Construct payload with correct field names expected by updateBillingPlan
-        const updatePayload: Partial<BucketPlanData> = {
-            total_hours: totalHours,
-            // billing_period: billingPeriod, // Usually not part of config, but plan itself
-            overage_rate: overageRate,
-            allow_rollover: allowRollover,
-            // Service association updates likely handled separately
-        };
-        // Update bucket plan config using the specific action
-        await updateBucketPlan(planId, updatePayload); // Use the correct action and payload type
-        // Optionally re-fetch or show success
+      const results = await Promise.all(savePromises);
+      // Filter results that are error objects
+      const failedSaves = results.filter((r): r is { error: Error; serviceId: string } => r !== undefined && r !== null && typeof r === 'object' && 'error' in r); // Removed configId from type guard
+
+      if (failedSaves.length > 0) {
+        const failedServiceNames = failedSaves.map(f => planServices.find(p => p.service.service_id === f.serviceId)?.service.service_name || f.serviceId).join(', '); // No change needed here, already using serviceId
+        setError(`Failed to save configurations for: ${failedServiceNames}. Please try again.`);
+        toast.error(`Failed to save configurations for: ${failedServiceNames}.`);
+        await fetchAndInitializeConfigs(); // Refetch to reset state
+      } else {
+        toast.success("All configurations saved successfully!");
+        // Update initial state
+        setInitialServiceConfigs(prev => {
+            const updatedInitial = {...prev};
+            changedServices.forEach(({serviceId, config}) => {
+                // Ensure we are saving the validated/processed config if necessary
+                updatedInitial[serviceId] = {...config};
+            });
+            return updatedInitial;
+        });
+        setSaveAttempted(false);
+        setServiceValidationErrors({});
+      }
     } catch (err) {
-        console.error('Error saving bucket plan configuration:', err);
-        setSaveError('Failed to save configuration. Please try again.');
+      console.error('Unexpected error during save operation:', err);
+      setError('An unexpected error occurred while saving. Please try again.');
+      toast.error('An unexpected error occurred while saving.');
     } finally {
-        setSaving(false);
+      setSaving(false);
     }
   };
 
-  // Simplified number input handler
-  const handleNumberInputChange = (setter: React.Dispatch<React.SetStateAction<number | undefined>>) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value === '' ? undefined : Number(e.target.value);
-       if (!isNaN(value as number) && (value as number) >= 0) {
-           setter(value);
-       } else if (e.target.value === '') {
-            setter(undefined); // Allow clearing the input
-       }
-  };
+  const handleServicesChanged = useCallback(() => {
+    fetchAndInitializeConfigs();
+  }, [fetchAndInitializeConfigs]);
 
-  const serviceOptions = services.map(service => ({
-    value: service.service_id,
-    label: service.service_name
-  }));
 
-  if (loading && !plan) {
+  if (loading) {
     return <div className="flex justify-center items-center p-8"><Loader2 className="h-8 w-8 animate-spin" /></div>;
   }
 
-  if (error) {
+  if (error && !loading) {
     return (
       <Alert variant="destructive" className={`m-4 ${className}`}>
         <AlertCircle className="h-4 w-4" />
@@ -180,110 +274,73 @@ export function BucketPlanConfiguration({
     );
   }
 
-   if (!plan) {
-      return <div className="p-4">Plan not found or invalid type.</div>;
-  }
-
   return (
     <div className={`space-y-6 ${className}`}>
       <Card>
         <CardHeader>
-          <CardTitle>Bucket Plan Configuration</CardTitle>
+          <CardTitle>Bucket Service Configurations</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4">
-          {saveError && (
-            <Alert variant="destructive" className="mb-4">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>{saveError}</AlertDescription>
-            </Alert>
+        <CardContent>
+          {planServices.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No services are currently configured for this bucket plan.</p>
+          ) : (
+            <RadixAccordion.Root type="multiple" className="w-full space-y-2">
+              {planServices.map(({ service }) => {
+                const serviceId = service.service_id;
+                const config = serviceConfigs[serviceId] || DEFAULT_BUCKET_CONFIG;
+                const validationErrors = serviceValidationErrors[serviceId] || {};
+                const unitName = service.unit_of_measure || 'Units';
+
+                return (
+                  <RadixAccordion.Item key={serviceId} value={serviceId} className="border rounded overflow-hidden odd:bg-slate-100">
+                    <RadixAccordion.Header className="flex">
+                      <RadixAccordion.Trigger className="flex flex-1 items-center justify-between p-3 font-medium transition-all hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180 bg-muted/20 w-full text-left">
+                        <span>{service.service_name} ({unitName})</span>
+                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+                      </RadixAccordion.Trigger>
+                    </RadixAccordion.Header>
+                    <RadixAccordion.Content className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                      <div className="p-4 border-t">
+                        <ServiceBucketConfigForm
+                          serviceId={serviceId}
+                          config={config} // Prop name is correct
+                          unit_of_measure={unitName}
+                          validationErrors={validationErrors}
+                          saveAttempted={saveAttempted}
+                          disabled={saving}
+                          onConfigChange={handleConfigChange}
+                        />
+                      </div>
+                    </RadixAccordion.Content>
+                  </RadixAccordion.Item>
+                );
+              })}
+            </RadixAccordion.Root>
           )}
-          <p className="text-sm text-muted-foreground">* Indicates required fields</p>
-  
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <Label htmlFor="bucket-plan-total-hours">Total Hours in Bucket <span className="text-destructive">*</span></Label>
-              <Input
-                id="bucket-plan-total-hours" type="number"
-                value={totalHours?.toString() || ''}
-                onChange={handleNumberInputChange(setTotalHours)}
-                placeholder="Enter total hours" disabled={saving} min={0} step={1}
-                className={validationErrors.totalHours ? 'border-red-500' : ''}
-              />
-              {validationErrors.totalHours && <p className="text-sm text-red-500 mt-1">{validationErrors.totalHours}</p>}
-              {!validationErrors.totalHours && <p className="text-sm text-muted-foreground mt-1">Hours included per billing period.</p>}
-            </div>
-
-            <div>
-              <Label htmlFor="bucket-plan-billing-period">Billing Period</Label>
-              {/* Display as text since it's derived from the plan and not editable here */}
-              <div className="mt-1 text-sm font-medium p-2 border border-input bg-muted rounded-md min-h-[calc(1.5rem+0.75rem+2px)] flex items-center">
-                {BILLING_FREQUENCY_OPTIONS.find(opt => opt.value === billingPeriod)?.label || billingPeriod || 'N/A'}
+          {planServices.length > 0 && (
+             <div className="mt-6 flex justify-end">
+                {/* Added id and data-testid */}
+                <Button id="save-all-bucket-configs-button" data-testid="save-all-bucket-configs-button" onClick={handleSave} disabled={saving}>
+                  {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Save All Configurations
+                </Button>
               </div>
-              <p className="text-sm text-muted-foreground mt-1">Frequency the bucket resets (set on plan).</p>
-            </div>
-
-            <div>
-              <Label htmlFor="bucket-plan-overage-rate">Overage Rate per Hour <span className="text-destructive">*</span></Label>
-              <Input
-                id="bucket-plan-overage-rate" type="number"
-                value={overageRate?.toString() || ''}
-                onChange={handleNumberInputChange(setOverageRate)}
-                placeholder="Enter overage rate" disabled={saving} min={0} step={0.01}
-                className={validationErrors.overageRate ? 'border-red-500' : ''}
-              />
-              {validationErrors.overageRate && <p className="text-sm text-red-500 mt-1">{validationErrors.overageRate}</p>}
-              {!validationErrors.overageRate && <p className="text-sm text-muted-foreground mt-1">Rate for hours exceeding the bucket.</p>}
-            </div>
-
-            {/* Service Selection - Include if the primary bucket service is set here */}
-            {/* <div>
-              <Label htmlFor="bucket-plan-service">Primary Service</Label>
-              <CustomSelect
-                id="bucket-plan-service"
-                options={serviceOptions}
-                onValueChange={setServiceCatalogId} // Adjust state update logic
-                value={serviceCatalogId}
-                placeholder={loading ? "Loading services..." : "Select service"}
-                className={`w-full ${validationErrors.serviceCatalogId ? 'border-red-500' : ''}`}
-                disabled={saving || loading || services.length === 0}
-              />
-              {validationErrors.serviceCatalogId && <p className="text-sm text-red-500 mt-1">{validationErrors.serviceCatalogId}</p>}
-              {!validationErrors.serviceCatalogId && <p className="text-sm text-muted-foreground mt-1">The main service this bucket applies to.</p>}
-            </div> */}
-          </div>
-
-          <div className="flex items-center space-x-2 pt-4">
-            <Switch
-              id="bucket-plan-rollover"
-              checked={allowRollover}
-              onCheckedChange={setAllowRollover}
-              disabled={saving}
-            />
-            <Label htmlFor="bucket-plan-rollover" className="cursor-pointer">
-              Allow unused hours to roll over
-            </Label>
-          </div>
-           <p className="text-sm text-muted-foreground pl-8">If enabled, unused hours carry over to the next billing period.</p>
-
-
-          {/* Save Button */}
-          <div className="flex justify-end pt-4">
-            <Button id="save-bucket-config-button" onClick={handleSave} disabled={saving || Object.values(validationErrors).some(e => e)}>
-              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Save Configuration
-            </Button>
-          </div>
+          )}
         </CardContent>
       </Card>
 
-      {/* Placeholder for Services List */}
+      {/* Services List */}
       <Card>
-          <CardHeader>
-              <CardTitle>Applicable Services</CardTitle>
-          </CardHeader>
-          <CardContent>
-              <GenericPlanServicesList planId={planId} />
-          </CardContent>
+        <CardHeader>
+          <CardTitle>Services Included in Plan</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <GenericPlanServicesList
+            planId={planId}
+            onServicesChanged={handleServicesChanged}
+            disableEditing={true}
+          />
+        </CardContent>
       </Card>
     </div>
   );

--- a/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
@@ -284,6 +284,10 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planI
       // For Usage plans, exclude services with 'fixed' billing method
       return availService.billing_method !== 'fixed';
     }
+    else if (planType === 'Bucket') {
+      // For Bucket plans, exclude services with 'fixed' billing method
+      return availService.billing_method !== 'fixed';
+    }
 
     // TODO: Add filtering logic for other plan types if needed (using availService.billing_method)
     // Example:

--- a/server/src/components/billing-dashboard/billing-plans/ServiceBucketConfigForm.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/ServiceBucketConfigForm.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+import { IPlanServiceBucketConfig } from 'server/src/interfaces/planServiceConfiguration.interfaces';
+import { Input } from '../../ui/Input';
+import { Checkbox } from '../../ui/Checkbox';
+import { Label } from '../../ui/Label';
+import { Info } from 'lucide-react';
+import { Tooltip } from '../../ui/Tooltip';
+
+// Define type for validation errors passed from parent
+type FormErrors = {
+  total_hours?: string;
+  overage_rate?: string;
+  // Add other fields if needed
+};
+
+interface ServiceBucketConfigFormProps {
+  serviceId: string; // Keep serviceId for context if needed, or for the callback
+  config: Partial<IPlanServiceBucketConfig>; // Current config state from parent
+  unit_of_measure: string; // Renamed from unitOfMeasure for consistency
+  validationErrors: FormErrors; // Validation errors from parent
+  saveAttempted: boolean; // Flag from parent indicating save attempt
+  disabled: boolean; // Flag from parent to disable form during save
+  onConfigChange: (serviceId: string, field: keyof IPlanServiceBucketConfig, value: any) => void; // Callback to update parent state
+}
+
+export function ServiceBucketConfigForm({
+  serviceId,
+  config,
+  unit_of_measure,
+  validationErrors,
+  saveAttempted,
+  disabled,
+  onConfigChange,
+}: ServiceBucketConfigFormProps) {
+
+  // --- Pluralization Helper ---
+  const pluralizeUnit = (unit: string): string => {
+    if (!unit) return 'Units'; // Fallback
+    if (unit.toLowerCase().endsWith('s')) {
+      return unit;
+    }
+    return `${unit}s`;
+  };
+
+  const unitNameSingular = unit_of_measure || 'Unit';
+  const unitNamePlural = pluralizeUnit(unit_of_measure || 'Units');
+  const unitNameSingularLower = unitNameSingular.toLowerCase();
+  const unitNamePluralLower = unitNamePlural.toLowerCase();
+
+  // --- Input Handlers ---
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type } = e.target;
+    const field = name as keyof IPlanServiceBucketConfig;
+    const isNumberInput = type === 'number';
+    const processedValue = isNumberInput ? (value === '' ? null : parseFloat(value)) : value;
+    onConfigChange(serviceId, field, processedValue);
+  };
+
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    const field = name as keyof IPlanServiceBucketConfig;
+    onConfigChange(serviceId, field, checked);
+  };
+
+  // Determine if a field has an error
+  const hasError = (field: keyof FormErrors): boolean => {
+    return saveAttempted && !!validationErrors[field];
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Total Hours Input */}
+      <div>
+        <div className="flex items-center space-x-1">
+          <Label htmlFor={`total-${unitNamePluralLower}-input-${serviceId}`}>
+            Total {unitNamePlural} in Bucket
+          </Label>
+          <Tooltip content={`The total number of ${unitNamePluralLower} included in this bucket per billing period.`}>
+             <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+          </Tooltip>
+        </div>
+        <Input
+          id={`total-${unitNamePluralLower}-input-${serviceId}`}
+          data-testid={`total-${unitNamePluralLower}-input-${serviceId}`}
+          type="number"
+          placeholder={`Enter total ${unitNamePluralLower}`}
+          min={0}
+          name="total_hours"
+          value={config.total_hours ?? ''} // Use value from prop, handle null/undefined
+          onChange={handleInputChange}
+          disabled={disabled}
+          className={`mt-1 ${hasError('total_hours') ? 'border-red-500' : ''}`}
+          aria-invalid={hasError('total_hours')}
+          aria-describedby={hasError('total_hours') ? `total-hours-error-${serviceId}` : undefined}
+        />
+        {hasError('total_hours') && (
+          <p id={`total-hours-error-${serviceId}`} className="text-xs text-red-500 mt-1">
+            {validationErrors.total_hours}
+          </p>
+        )}
+      </div>
+
+      {/* Overage Rate Input */}
+      <div>
+        <div className="flex items-center space-x-1">
+          <Label htmlFor={`overage-rate-${unitNameSingularLower}-input-${serviceId}`}>
+            Overage Rate per {unitNameSingular}
+          </Label>
+           <Tooltip content={`The rate charged for each ${unitNameSingularLower} used beyond the included amount. (e.g., $)`}>
+             <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+          </Tooltip>
+        </div>
+        <Input
+          id={`overage-rate-${unitNameSingularLower}-input-${serviceId}`}
+          data-testid={`overage-rate-${unitNameSingularLower}-input-${serviceId}`}
+          type="number"
+          placeholder="Enter overage rate"
+          min={0}
+          step={0.01}
+          name="overage_rate"
+          value={config.overage_rate ?? ''} // Use value from prop, handle null/undefined
+          onChange={handleInputChange}
+          disabled={disabled}
+          className={`mt-1 ${hasError('overage_rate') ? 'border-red-500' : ''}`}
+          aria-invalid={hasError('overage_rate')}
+          aria-describedby={hasError('overage_rate') ? `overage-rate-error-${serviceId}` : undefined}
+        />
+        {hasError('overage_rate') && (
+          <p id={`overage-rate-error-${serviceId}`} className="text-xs text-red-500 mt-1">
+            {validationErrors.overage_rate}
+          </p>
+        )}
+      </div>
+
+      {/* Allow Rollover Checkbox */}
+      <div className="flex items-center space-x-2 pt-2">
+        <Checkbox
+          id={`allow-rollover-${unitNamePluralLower}-checkbox-${serviceId}`}
+          data-testid={`allow-rollover-${unitNamePluralLower}-checkbox-${serviceId}`}
+          name="allow_rollover" // Add name attribute for handler
+          checked={config.allow_rollover ?? false} // Use value from prop, handle null/undefined
+          onChange={handleCheckboxChange} // Use standard onChange
+          disabled={disabled}
+        />
+        <div className="flex items-center space-x-1">
+          <Label htmlFor={`allow-rollover-${unitNamePluralLower}-checkbox-${serviceId}`} className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+            Allow unused {unitNamePluralLower} to roll over
+          </Label>
+           <Tooltip content={`If checked, unused ${unitNamePluralLower} from one period can be used in the next.`}>
+             <Info className="h-4 w-4 text-muted-foreground ml-1 cursor-help" />
+          </Tooltip>
+        </div>
+      </div>
+      {/* No specific error message for boolean usually needed */}
+    </div>
+  );
+}


### PR DESCRIPTION
Refactors the Bucket Plan configuration UI to use an accordion, allowing individual configuration (total units, overage, rollover) for each service within the plan. Replaces the previous plan-wide settings model.

Includes fixes for dynamic unit display, tooltip usage, and filtering applicable services.