### PR TITLE
feat: Refactor Hourly Plan Configuration and Service Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9139,6 +9139,13 @@
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
@@ -27642,6 +27649,7 @@
         "@testing-library/react": "^16.2.0",
         "@types/archiver": "^6.0.3",
         "@types/jsonwebtoken": "^9.0.8",
+        "@types/lodash": "^4.17.16",
         "@types/node": "^20.11.0",
         "@types/parsimmon": "^1.10.9",
         "@types/qrcode": "^1.5.5",

--- a/server/migrations/20250318200000_create_plan_service_configuration_tables.cjs
+++ b/server/migrations/20250318200000_create_plan_service_configuration_tables.cjs
@@ -7,7 +7,7 @@ exports.up = function(knex) {
     // Base configuration table
     .createTable('plan_service_configuration', function(table) {
       // Primary key
-      table.uuid('config_id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+      table.uuid('config_id').notNullable().defaultTo(knex.raw('gen_random_uuid()')); // Remove .primary() here
       
       // Foreign keys
       table.uuid('plan_id').notNullable();
@@ -31,6 +31,8 @@ exports.up = function(knex) {
       
       // Constraints
       table.unique(['plan_id', 'service_id', 'tenant']);
+      // Define composite primary key including tenant
+      table.primary(['tenant', 'config_id']);
       
       // Indexes
       table.index(['plan_id']);
@@ -41,8 +43,9 @@ exports.up = function(knex) {
     // Fixed price configuration
     .createTable('plan_service_fixed_config', function(table) {
       // Primary key (same as config_id)
-      table.uuid('config_id').primary();
-      table.foreign('config_id').references('config_id').inTable('plan_service_configuration').onDelete('CASCADE');
+      table.uuid('config_id').notNullable(); // Remove .primary()
+      // Composite Foreign Key
+      table.foreign(['tenant', 'config_id']).references(['tenant', 'config_id']).inTable('plan_service_configuration').onDelete('CASCADE');
       
       // Configuration fields
       table.boolean('enable_proration').notNullable().defaultTo(false);
@@ -61,8 +64,9 @@ exports.up = function(knex) {
     // Hourly configuration
     .createTable('plan_service_hourly_config', function(table) {
       // Primary key (same as config_id)
-      table.uuid('config_id').primary();
-      table.foreign('config_id').references('config_id').inTable('plan_service_configuration').onDelete('CASCADE');
+      table.uuid('config_id').notNullable(); // Remove .primary()
+      // Composite Foreign Key
+      table.foreign(['tenant', 'config_id']).references(['tenant', 'config_id']).inTable('plan_service_configuration').onDelete('CASCADE');
       
       // Configuration fields
       table.integer('minimum_billable_time').notNullable().defaultTo(15);
@@ -86,8 +90,9 @@ exports.up = function(knex) {
     // Usage-based configuration
     .createTable('plan_service_usage_config', function(table) {
       // Primary key (same as config_id)
-      table.uuid('config_id').primary();
-      table.foreign('config_id').references('config_id').inTable('plan_service_configuration').onDelete('CASCADE');
+      table.uuid('config_id').notNullable(); // Remove .primary()
+      // Composite Foreign Key
+      table.foreign(['tenant', 'config_id']).references(['tenant', 'config_id']).inTable('plan_service_configuration').onDelete('CASCADE');
       
       // Configuration fields
       table.string('unit_of_measure', 50).notNullable().defaultTo('Unit');
@@ -107,8 +112,9 @@ exports.up = function(knex) {
     // Bucket configuration
     .createTable('plan_service_bucket_config', function(table) {
       // Primary key (same as config_id)
-      table.uuid('config_id').primary();
-      table.foreign('config_id').references('config_id').inTable('plan_service_configuration').onDelete('CASCADE');
+      table.uuid('config_id').notNullable(); // Remove .primary()
+      // Composite Foreign Key
+      table.foreign(['tenant', 'config_id']).references(['tenant', 'config_id']).inTable('plan_service_configuration').onDelete('CASCADE');
       
       // Configuration fields
       table.integer('total_hours').notNullable();
@@ -133,7 +139,8 @@ exports.up = function(knex) {
       
       // Foreign key to configuration
       table.uuid('config_id').notNullable();
-      table.foreign('config_id').references('config_id').inTable('plan_service_configuration').onDelete('CASCADE');
+      // Composite Foreign Key
+      table.foreign(['tenant', 'config_id']).references(['tenant', 'config_id']).inTable('plan_service_configuration').onDelete('CASCADE');
       
       // Tier range
       table.integer('min_quantity').notNullable();
@@ -163,7 +170,7 @@ exports.up = function(knex) {
       
       // Foreign key to hourly configuration
       table.uuid('config_id').notNullable();
-      table.foreign('config_id').references('config_id').inTable('plan_service_hourly_config').onDelete('CASCADE');
+      table.foreign('config_id').references('config_id').inTable('plan_service_hourly_configs').onDelete('CASCADE'); // Corrected referenced table name (plural)
       
       // User type and rate
       table.string('user_type', 50).notNullable();

--- a/server/migrations/20250327144330_rename_service_categories_to_ticket_categories.cjs
+++ b/server/migrations/20250327144330_rename_service_categories_to_ticket_categories.cjs
@@ -1,8 +1,10 @@
 
 exports.up = function(knex) {
-  
+    // Return a resolved promise for empty migration
+    return Promise.resolve();
 };
 
 exports.down = function(knex) {
-  
+    // Return a resolved promise for empty migration
+    return Promise.resolve();
 };

--- a/server/migrations/20250331164116_alter_plan_service_configuration_pk.cjs
+++ b/server/migrations/20250331164116_alter_plan_service_configuration_pk.cjs
@@ -1,0 +1,144 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  // Define dependent tables and their FK constraint names
+  const dependents = [
+    { table: 'plan_service_fixed_config', constraint: 'plan_service_fixed_config_config_id_foreign' },
+    { table: 'plan_service_hourly_config', constraint: 'plan_service_hourly_config_config_id_foreign' }, // Note: This table might not exist yet when this runs first time, handle potential error
+    { table: 'plan_service_usage_config', constraint: 'plan_service_usage_config_config_id_foreign' },
+    { table: 'plan_service_bucket_config', constraint: 'plan_service_bucket_config_config_id_foreign' },
+    { table: 'plan_service_rate_tiers', constraint: 'plan_service_rate_tiers_config_id_foreign' },
+    // Add user_type_rates if it also depends directly on plan_service_configuration PK (check its migration)
+    // Based on 20250318200000 migration, user_type_rates depends on plan_service_hourly_config, so it's indirectly handled.
+  ];
+
+  // 1. Drop dependent foreign key constraints
+  for (const dep of dependents) {
+    await knex.schema.alterTable(dep.table, function(table) {
+      try {
+        console.log(`Dropping FK constraint ${dep.constraint} on table ${dep.table}`);
+        table.dropForeign(['config_id'], dep.constraint); // Assuming simple FK on config_id initially
+      } catch (e) {
+         // If the FK was already composite or named differently, this might fail.
+         // Attempt dropping composite FK as a fallback for tables potentially created with composite FKs already
+         try {
+            console.warn(`Failed to drop simple FK ${dep.constraint}, attempting composite drop...`);
+            table.dropForeign(['tenant', 'config_id'], dep.constraint);
+         } catch (e2) {
+            console.error(`Error dropping FK constraint ${dep.constraint} on table ${dep.table}: ${e2.message}. Manual check might be needed if schema diverged.`);
+            // If the table doesn't exist yet (like plan_service_hourly_config on first run), ignore error
+            if (!e2.message.includes('does not exist')) {
+                 throw e2; // Re-throw if it's not a "table doesn't exist" error
+            } else {
+                 console.log(`Table ${dep.table} likely doesn't exist yet, skipping FK drop.`);
+            }
+         }
+      }
+    });
+  }
+
+  // 2. Drop the existing primary key constraint on plan_service_configuration
+  await knex.schema.alterTable('plan_service_configuration', function(table) {
+    try {
+      console.log("Dropping old PK constraint plan_service_configuration_pkey");
+      table.dropPrimary('plan_service_configuration_pkey');
+    } catch (e) {
+      console.error(`Error dropping PK constraint plan_service_configuration_pkey: ${e.message}. Manual check needed.`);
+      throw e;
+    }
+  });
+
+  // 3. Add the new composite primary key
+  await knex.schema.alterTable('plan_service_configuration', function(table) {
+    console.log("Adding new composite PK (tenant, config_id)");
+    table.primary(['tenant', 'config_id']);
+  });
+
+  // 4. Re-add the foreign key constraints referencing the new composite key
+  for (const dep of dependents) {
+     // Check if table exists before trying to add constraint (for plan_service_hourly_config case)
+     const tableExists = await knex.schema.hasTable(dep.table);
+     if (tableExists) {
+        await knex.schema.alterTable(dep.table, function(table) {
+            console.log(`Re-adding composite FK constraint ${dep.constraint} on table ${dep.table}`);
+            table.foreign(['tenant', 'config_id'], dep.constraint) // Use original constraint name
+                 .references(['tenant', 'config_id'])
+                 .inTable('plan_service_configuration')
+                 .onDelete('CASCADE'); // Ensure CASCADE is reapplied if needed
+        });
+     } else {
+         console.log(`Table ${dep.table} does not exist, skipping FK re-add.`);
+     }
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  // Reverse order of operations for rollback
+
+  const dependents = [
+    { table: 'plan_service_fixed_config', constraint: 'plan_service_fixed_config_config_id_foreign' },
+    { table: 'plan_service_hourly_config', constraint: 'plan_service_hourly_config_config_id_foreign' },
+    { table: 'plan_service_usage_config', constraint: 'plan_service_usage_config_config_id_foreign' },
+    { table: 'plan_service_bucket_config', constraint: 'plan_service_bucket_config_config_id_foreign' },
+    { table: 'plan_service_rate_tiers', constraint: 'plan_service_rate_tiers_config_id_foreign' },
+  ];
+
+  // 1. Drop the composite foreign key constraints
+  for (const dep of dependents) {
+     const tableExists = await knex.schema.hasTable(dep.table);
+     if (tableExists) {
+        await knex.schema.alterTable(dep.table, function(table) {
+          try {
+            console.log(`Rolling back: Dropping composite FK ${dep.constraint} on ${dep.table}`);
+            table.dropForeign(['tenant', 'config_id'], dep.constraint);
+          } catch (e) {
+            console.error(`Error dropping composite FK ${dep.constraint} on ${dep.table} during rollback: ${e.message}`);
+            // Don't throw, try to continue rollback
+          }
+        });
+     }
+  }
+
+  // 2. Drop the composite primary key constraint
+  await knex.schema.alterTable('plan_service_configuration', function(table) {
+    try {
+      console.log("Rolling back: Dropping composite PK");
+      // Default name might be plan_service_configuration_pkey again, or based on columns
+      table.dropPrimary(['tenant', 'config_id']); // Try dropping by columns
+    } catch (e) {
+       try {
+           console.warn("Failed dropping composite PK by columns, trying default name...");
+           table.dropPrimary('plan_service_configuration_pkey');
+       } catch (e2) {
+           console.error(`Error dropping composite PK during rollback: ${e2.message}`);
+           // Don't throw, try to continue rollback
+       }
+    }
+  });
+
+  // 3. Add the old single primary key back
+  await knex.schema.alterTable('plan_service_configuration', function(table) {
+    console.log("Rolling back: Re-adding old single PK on config_id");
+    table.primary('config_id'); // Constraint name will likely be default 'plan_service_configuration_pkey'
+  });
+
+  // 4. Re-add the old simple foreign key constraints
+  for (const dep of dependents) {
+     const tableExists = await knex.schema.hasTable(dep.table);
+     if (tableExists) {
+        await knex.schema.alterTable(dep.table, function(table) {
+          console.log(`Rolling back: Re-adding simple FK ${dep.constraint} on ${dep.table}`);
+          table.foreign('config_id', dep.constraint) // Use original constraint name
+               .references('config_id')
+               .inTable('plan_service_configuration')
+               .onDelete('CASCADE');
+        });
+     }
+  }
+};

--- a/server/migrations/20250331164117_create_plan_service_hourly_configs_table.cjs
+++ b/server/migrations/20250331164117_create_plan_service_hourly_configs_table.cjs
@@ -1,0 +1,53 @@
+const { Knex } = require('knex');
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable('plan_service_hourly_configs', (table) => {
+    table.uuid('tenant').notNullable(); // Corrected type to UUID
+    table
+      .uuid('config_id') // Corrected type to UUID
+      // .unsigned() // Not applicable for UUID
+      .notNullable()
+      .comment('Foreign key referencing plan_service_configuration.id');
+
+    table
+      .decimal('hourly_rate', 10, 2)
+      .notNullable()
+      .comment('The hourly rate for the service');
+    table
+      .integer('minimum_billable_time')
+      .unsigned()
+      .notNullable()
+      .comment('Minimum billable time in minutes');
+    table
+      .integer('round_up_to_nearest')
+      .unsigned()
+      .notNullable()
+      .comment('Round up time entries to the nearest specified minutes');
+
+    // Composite primary key including tenant
+    table.primary(['tenant', 'config_id']);
+
+    // Composite foreign key including tenant (NO CASCADE)
+    table
+      .foreign(['tenant', 'config_id'])
+      .references(['tenant', 'config_id']) // Corrected to reference config_id
+      .inTable('plan_service_configuration');
+      // Removed .onDelete('CASCADE') and .onUpdate('CASCADE')
+
+    // Index tenant for performance
+    table.index('tenant');
+    
+    // Timestamps
+    table.timestamps(true, true); // Add created_at and updated_at
+  });
+};
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists('plan_service_hourly_configs');
+};

--- a/server/migrations/20250331181202_add_plan_wide_hourly_settings_to_billing_plans.cjs
+++ b/server/migrations/20250331181202_add_plan_wide_hourly_settings_to_billing_plans.cjs
@@ -1,0 +1,27 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('billing_plans', function(table) {
+    table.boolean('enable_overtime').defaultTo(false);
+    table.decimal('overtime_rate', 10, 2).nullable(); // Precision 10, Scale 2
+    table.integer('overtime_threshold').nullable().defaultTo(40);
+    table.boolean('enable_after_hours_rate').defaultTo(false);
+    table.decimal('after_hours_multiplier', 5, 2).nullable().defaultTo(1.0); // Precision 5, Scale 2
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('billing_plans', function(table) {
+    table.dropColumn('enable_overtime');
+    table.dropColumn('overtime_rate');
+    table.dropColumn('overtime_threshold');
+    table.dropColumn('enable_after_hours_rate');
+    table.dropColumn('after_hours_multiplier');
+  });
+};

--- a/server/migrations/20250331190508_fix_user_type_rates_fk.cjs
+++ b/server/migrations/20250331190508_fix_user_type_rates_fk.cjs
@@ -1,0 +1,53 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  await knex.schema.alterTable('user_type_rates', function(table) {
+    // Drop the incorrect foreign key constraint
+    try {
+      console.log("Dropping incorrect FK user_type_rates_config_id_foreign referencing plan_service_hourly_config");
+      table.dropForeign(['config_id'], 'user_type_rates_config_id_foreign');
+    } catch (e) {
+      console.error(`Could not drop FK user_type_rates_config_id_foreign: ${e.message}. It might not exist or have a different name.`);
+      // Optionally re-throw if the error is unexpected
+    }
+
+    // Add the correct foreign key constraint referencing plan_service_hourly_configs (plural)
+    // Note: This assumes the target table plan_service_hourly_configs uses config_id as its primary key part.
+    // If plan_service_hourly_configs uses a composite key like (tenant, config_id), this needs adjustment.
+    // Based on migration 20250331164117, it uses (tenant, config_id) as PK.
+    // Therefore, the FK here should also be composite.
+    console.log("Adding correct composite FK user_type_rates_config_id_foreign referencing plan_service_hourly_configs(tenant, config_id)");
+    table.foreign(['tenant', 'config_id'], 'user_type_rates_config_id_foreign') // Use the same constraint name for simplicity
+         .references(['tenant', 'config_id'])
+         .inTable('plan_service_hourly_configs'); // Reference the correct table (plural), removed cascade
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  await knex.schema.alterTable('user_type_rates', function(table) {
+    // Drop the corrected foreign key constraint
+    try {
+      console.log("Rolling back: Dropping corrected composite FK user_type_rates_config_id_foreign");
+      table.dropForeign(['tenant', 'config_id'], 'user_type_rates_config_id_foreign');
+    } catch (e) {
+       console.error(`Could not drop corrected composite FK user_type_rates_config_id_foreign during rollback: ${e.message}`);
+    }
+
+    // Re-add the original incorrect foreign key constraint (referencing singular table)
+    // This might fail if the singular table doesn't exist anymore, handle potential error
+    try {
+        console.log("Rolling back: Re-adding incorrect FK user_type_rates_config_id_foreign referencing plan_service_hourly_config (singular)");
+        table.foreign('config_id', 'user_type_rates_config_id_foreign')
+             .references('config_id')
+             .inTable('plan_service_hourly_config'); // Reference the original incorrect table (singular), removed cascade
+    } catch (e) {
+        console.error(`Could not re-add original incorrect FK during rollback (maybe plan_service_hourly_config doesn't exist?): ${e.message}`);
+    }
+  });
+};

--- a/server/package.json
+++ b/server/package.json
@@ -100,6 +100,7 @@
     "@testing-library/react": "^16.2.0",
     "@types/archiver": "^6.0.3",
     "@types/jsonwebtoken": "^9.0.8",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^20.11.0",
     "@types/parsimmon": "^1.10.9",
     "@types/qrcode": "^1.5.5",

--- a/server/src/components/billing-dashboard/billing-plans/ServiceHourlyConfigForm.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/ServiceHourlyConfigForm.tsx
@@ -1,0 +1,331 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Input } from 'server/src/components/ui/Input';
+import { Label } from 'server/src/components/ui/Label';
+import { Button } from 'server/src/components/ui/Button'; // Import Button
+import * as RadixTooltip from '@radix-ui/react-tooltip'; // Use Radix Tooltip directly
+import { Info, Trash2 } from 'lucide-react'; // Import Trash2
+import { IPlanServiceHourlyConfig, IUserTypeRate } from 'server/src/interfaces/planServiceConfiguration.interfaces'; // Use correct interfaces
+import CustomSelect from 'server/src/components/ui/CustomSelect'; // Import CustomSelect
+
+// Define the structure for the configuration object (using imported interface)
+// export interface IServiceHourlyConfig { ... } // Removed local definition
+
+// Define the structure for validation errors (using imported interface fields)
+export interface IServiceHourlyConfigValidationErrors {
+  hourly_rate?: string;
+  minimum_billable_time?: string;
+  round_up_to_nearest?: string;
+  // Add validation for user type rates if needed at this level
+}
+
+// Define the structure for validation errors
+export interface IServiceHourlyConfigValidationErrors {
+  hourly_rate?: string;
+  minimum_billable_time?: string;
+  round_up_to_nearest?: string;
+}
+
+interface ServiceHourlyConfigFormProps {
+  configId: string; // Make configId required
+  config: Partial<IPlanServiceHourlyConfig>; // Use imported interface
+  userTypeRates: IUserTypeRate[]; // Add user type rates prop
+  validationErrors?: Partial<IServiceHourlyConfigValidationErrors>;
+  disabled?: boolean;
+  onHourlyFieldChange: (field: keyof IPlanServiceHourlyConfig, value: number | null) => void; // Renamed prop
+  onUserTypeRatesChange: (newUserTypeRates: IUserTypeRate[]) => void; // Add handler for rates array
+  className?: string;
+}
+
+export function ServiceHourlyConfigForm({
+  configId, // Destructure configId
+  config,
+  userTypeRates, // Destructure new prop
+  validationErrors = {},
+  disabled = false,
+  onHourlyFieldChange, // Use renamed prop
+  onUserTypeRatesChange, // Destructure new prop
+  className = '',
+}: ServiceHourlyConfigFormProps) {
+  // Local state for input values (hourly_rate is handled specially for display)
+  // Local state for input values (hourly_rate is handled specially for display)
+  const [displayHourlyRate, setDisplayHourlyRate] = useState<string>('');
+  // Removed local state for other fields, use props directly
+  // const [minimumBillableTime, setMinimumBillableTime] = useState<string>('');
+  // const [roundUpToNearest, setRoundUpToNearest] = useState<string>('');
+
+  // State for adding a new user type rate within this form
+  const [newUserType, setNewUserType] = useState('');
+  const [newUserTypeRateValue, setNewUserTypeRateValue] = useState<number | undefined>(undefined);
+  const [userTypeError, setUserTypeError] = useState<string | null>(null);
+
+  // Sync local display state with props
+  useEffect(() => {
+    // Convert cents to dollars for display
+    const rateInDollars = config?.hourly_rate !== null && config?.hourly_rate !== undefined
+      ? (config.hourly_rate / 100).toFixed(2)
+      : '';
+    setDisplayHourlyRate(rateInDollars);
+    // Other fields are directly bound to config prop below
+  }, [config?.hourly_rate]); // Depend only on the relevant prop field
+
+  // --- Input Handlers ---
+
+  // --- Input Handlers ---
+
+  // Update local display state on every change
+  const handleHourlyRateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const displayValue = e.target.value;
+    // Allow typing numbers, decimal point, and potentially empty string
+    if (/^\d*\.?\d*$/.test(displayValue)) {
+        setDisplayHourlyRate(displayValue);
+    }
+  }, []);
+
+  // Process and update parent state on blur
+  const handleHourlyRateBlur = useCallback(() => {
+    const numericValue = parseFloat(displayHourlyRate);
+    let valueInCents: number | null = null;
+    let formattedDisplayValue = '';
+
+    if (!isNaN(numericValue)) {
+        valueInCents = Math.round(numericValue * 100);
+        formattedDisplayValue = (valueInCents / 100).toFixed(2); // Format to 2 decimal places
+    } else {
+        // Handle cases like empty string or invalid input -> treat as null
+        valueInCents = null;
+        formattedDisplayValue = '';
+    }
+
+    // Update local display state with formatted value
+    setDisplayHourlyRate(formattedDisplayValue);
+    // Update parent state with value in cents
+    onHourlyFieldChange('hourly_rate', valueInCents);
+  }, [displayHourlyRate, onHourlyFieldChange]);
+
+  // Generic handler for simple numeric fields (minutes)
+  const handleMinutesInputChange = useCallback((field: keyof IPlanServiceHourlyConfig) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const numericValue = value === '' ? null : parseInt(value, 10);
+    // Allow only non-negative integers or null
+    if (numericValue === null || (!isNaN(numericValue) && numericValue >= 0 && Number.isInteger(numericValue))) {
+        onHourlyFieldChange(field, numericValue); // Use new handler
+    }
+  }, [onHourlyFieldChange]);
+
+  // Removed handleRoundUpToNearestChange, covered by handleMinutesInputChange
+
+  // --- Helper for Tooltips (using the project's custom Tooltip) ---
+  // --- User Type Rate Handlers ---
+  const handleAddUserTypeRate = () => {
+    if (!newUserType || newUserTypeRateValue === undefined || newUserTypeRateValue < 0) {
+        setUserTypeError('Please select a user type and enter a valid non-negative rate.');
+        return;
+    }
+    if (userTypeRates.some(rate => rate.user_type === newUserType)) {
+        setUserTypeError('This user type already has a specific rate.');
+        return;
+    }
+
+    // Create new rate object (rate_id will be assigned by backend)
+    const newRate: IUserTypeRate = {
+        rate_id: `new-${Date.now()}`, // Temporary client-side ID for key prop
+        config_id: configId, // Use configId from props
+        user_type: newUserType,
+        rate: newUserTypeRateValue,
+        tenant: config?.tenant || '', // Get tenant from config prop if available
+        created_at: new Date(), // Placeholder
+        updated_at: new Date(), // Placeholder
+    };
+
+    onUserTypeRatesChange([...userTypeRates, newRate]); // Update parent state
+
+    // Reset form
+    setNewUserType('');
+    setNewUserTypeRateValue(undefined);
+    setUserTypeError(null);
+  };
+
+  const handleRemoveUserTypeRate = (index: number) => {
+    const updatedRates = [...userTypeRates];
+    updatedRates.splice(index, 1);
+    onUserTypeRatesChange(updatedRates); // Update parent state
+  };
+
+   const handleNewRateInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value === '' ? undefined : Number(e.target.value);
+      if (value === undefined || (!isNaN(value) && value >= 0)) { // Allow 0 rate
+          setNewUserTypeRateValue(value);
+          if (userTypeError) setUserTypeError(null); // Clear error on input change
+      }
+    };
+
+   const userTypeOptions = [
+     { value: 'technician', label: 'Technician' },
+     { value: 'engineer', label: 'Engineer' },
+     { value: 'consultant', label: 'Consultant' },
+     { value: 'project_manager', label: 'Project Manager' },
+     { value: 'admin', label: 'Administrator' }
+     // Add other relevant user types here
+   ];
+
+  // --- Helper for Tooltips (using Radix UI Tooltip) ---
+  const renderTooltip = (tooltipContent: string, triggerIdSuffix?: string) => {
+    // Generate a guaranteed string ID for the button
+    const buttonId = triggerIdSuffix ? `tooltip-trigger-${configId}-${triggerIdSuffix}` : `tooltip-trigger-${configId}-default`;
+    return (
+      <RadixTooltip.Root delayDuration={100}>
+        <RadixTooltip.Trigger asChild>
+           <Button id={buttonId} variant="ghost" size="sm" className="ml-1 h-5 w-5 p-0 align-middle">
+            <Info className="h-4 w-4 text-muted-foreground" />
+         </Button>
+      </RadixTooltip.Trigger>
+      <RadixTooltip.Content side="top" className="max-w-xs bg-gray-800 text-white p-2 rounded shadow-lg text-sm z-50">
+          <p>{tooltipContent}</p>
+      </RadixTooltip.Content>
+    </RadixTooltip.Root>
+  );
+}; // Added missing closing brace for renderTooltip function
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {/* Hourly Rate */}
+      <div>
+        <div className="flex items-center">
+          <Label htmlFor="hourly-rate">Hourly Rate ($)</Label>
+          {renderTooltip('The standard rate charged per hour for this service.', `hourly-rate-tooltip-${configId}`)}
+        </div>
+
+        {/* This section was incorrectly placed here by the previous diff, removing it */}
+        <Input
+          id="hourly-rate"
+          type="number"
+          value={displayHourlyRate} // Use local state for display formatting
+          onChange={handleHourlyRateChange} // Update display state on change
+          onBlur={handleHourlyRateBlur} // Process value and update parent on blur
+          placeholder="e.g., 100.00"
+          disabled={disabled}
+          min={0}
+          step={0.01}
+          className={validationErrors.hourly_rate ? 'border-red-500' : ''}
+        />
+        {validationErrors.hourly_rate && (
+          <p className="text-sm text-red-500 mt-1">{validationErrors.hourly_rate}</p>
+        )}
+      </div>
+
+      {/* Minimum Billable Time */}
+      <div>
+        <div className="flex items-center">
+          <Label htmlFor="minimum-billable-time">Minimum Billable Time (minutes)</Label>
+          {renderTooltip('The minimum duration (in minutes) that will be billed for any time entry, regardless of actual duration.', `min-time-tooltip-${configId}`)}
+        </div>
+        <Input
+          id="minimum-billable-time"
+          type="number"
+          value={config.minimum_billable_time?.toString() ?? ''} // Bind directly to prop
+          onChange={handleMinutesInputChange('minimum_billable_time')} // Use generic handler
+          placeholder="e.g., 15"
+          disabled={disabled}
+          min={0}
+          step={1}
+          className={validationErrors.minimum_billable_time ? 'border-red-500' : ''}
+        />
+        {validationErrors.minimum_billable_time && (
+          <p className="text-sm text-red-500 mt-1">{validationErrors.minimum_billable_time}</p>
+        )}
+      </div>
+
+      {/* Round Up To Nearest */}
+      <div>
+        <div className="flex items-center">
+          <Label htmlFor="round-up-to-nearest">Round Up To Nearest (minutes)</Label>
+          {renderTooltip('Time entries will be rounded up to the nearest specified minute interval (e.g., 15 minutes). Set to 1 or 0 to disable rounding.', `round-up-tooltip-${configId}`)}
+        </div>
+        <Input
+          id="round-up-to-nearest"
+          type="number"
+          value={config.round_up_to_nearest?.toString() ?? ''} // Bind directly to prop
+          onChange={handleMinutesInputChange('round_up_to_nearest')} // Use generic handler
+          placeholder="e.g., 15"
+          disabled={disabled}
+          min={0} // Allow 0 or 1 for no rounding
+          step={1}
+          className={validationErrors.round_up_to_nearest ? 'border-red-500' : ''}
+        />
+        {validationErrors.round_up_to_nearest && (
+          <p className="text-sm text-red-500 mt-1">{validationErrors.round_up_to_nearest}</p>
+        )}
+      </div>
+
+      {/* User Type Specific Rates Section (Moved Here) */}
+      <div className="space-y-4 pt-4 border-t">
+           <Label className="font-medium text-base flex items-center">
+               User Type Specific Rates
+               {renderTooltip('Define different hourly rates for specific user types working on this service. These override the service\'s default hourly rate.', `user-type-rate-tooltip-${configId}`)}
+           </Label>
+
+           {/* List existing rates */}
+           {userTypeRates.length > 0 && (
+               <div className="space-y-2">
+               {userTypeRates.map((item, index) => (
+                   <div key={item.rate_id || `new-${index}`} className="flex items-center justify-between gap-2 p-2 border rounded bg-background">
+                       <span className="font-medium">
+                           {userTypeOptions.find(opt => opt.value === item.user_type)?.label || item.user_type}: ${Number(item.rate).toFixed(2)}/hr {/* Convert rate to number before toFixed */}
+                       </span>
+                       <Button id={`remove-user-type-rate-${configId}-${index}`} variant="ghost" size="sm" onClick={() => handleRemoveUserTypeRate(index)} disabled={disabled}>
+                           <Trash2 className="h-4 w-4 text-destructive" />
+                       </Button>
+                   </div>
+               ))}
+               </div>
+           )}
+
+           {/* Add new rate form */}
+           <div className="space-y-2 pt-2">
+               <Label className="text-sm font-medium">Add New Rate</Label>
+               <div className="space-y-2"> {/* Removed flex classes, added space-y */}
+                   <div> {/* Removed flex-1 and min-w */}
+                       <Label htmlFor={`new-user-type-${configId}`} className="sr-only">User Type</Label>
+                       <CustomSelect
+                           id={`new-user-type-${configId}`}
+                           options={userTypeOptions}
+                           onValueChange={setNewUserType}
+                           value={newUserType}
+                           placeholder="Select type"
+                           disabled={disabled}
+                           className="mt-1"
+                       />
+                   </div>
+                   <div className="mt-2"> {/* Removed flex-1 and min-w, added margin */}
+                       <Label htmlFor={`new-user-type-rate-${configId}`} className="sr-only">Rate ($/hr)</Label>
+                       <Input
+                           id={`new-user-type-rate-${configId}`}
+                           type="number"
+                           value={newUserTypeRateValue?.toString() || ''}
+                           onChange={handleNewRateInputChange}
+                           placeholder="Rate"
+                           disabled={disabled}
+                           min={0}
+                           step={0.01}
+                           className={`mt-1 ${userTypeError ? 'border-red-500' : ''}`}
+                       />
+                   </div>
+                   <Button
+                       id={`add-user-type-rate-button-${configId}`}
+                       type="button"
+                       onClick={handleAddUserTypeRate}
+                       disabled={disabled || !newUserType || newUserTypeRateValue === undefined || (newUserTypeRateValue < 0) || !!userTypeError} // Check < 0 only if defined
+                       className="mt-2 w-full" // Added margin and full width
+                   >
+                       Add
+                   </Button>
+               </div>
+                {userTypeError && <p className="text-sm text-red-500 mt-1">{userTypeError}</p>}
+           </div>
+      </div>
+
+    </div>
+  );
+}

--- a/server/src/components/companies/BillingConfigForm.tsx
+++ b/server/src/components/companies/BillingConfigForm.tsx
@@ -110,18 +110,16 @@ const BillingConfigForm: React.FC<BillingConfigFormProps> = ({
                         <ContactPicker
                             id="company-billing-contact-select"
                             contacts={contacts}
-                            onSelect={(contactId) => {
+                            onValueChange={(contactId: string) => { // Use onValueChange and add type
                                 handleSelectChange('billing_contact_id')(contactId);
                                 // Clear billing email if contact is selected, keep it if contact is cleared
                                 if (contactId) {
                                     handleSelectChange('billing_email')('');
                                 }
                             }}
-                            selectedContactId={billingConfig.billing_contact_id || null}
+                            value={billingConfig.billing_contact_id || ''}
                             companyId={companyId}
-                            filterState={contactFilterState}
-                            onFilterStateChange={setContactFilterState}
-                            fitContent={false}
+                            // Removed filterState, onFilterStateChange, and fitContent props
                         />
                     </div>
                     <div className="space-y-2">

--- a/server/src/interfaces/billing.interfaces.ts
+++ b/server/src/interfaces/billing.interfaces.ts
@@ -171,6 +171,19 @@ export interface IBillingPlan extends TenantEntity {
   is_custom: boolean;
   service_category?: string;
   plan_type: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket';
+  // Add potentially existing hourly fields (to be deprecated for Hourly type)
+  hourly_rate?: number | null;
+  minimum_billable_time?: number | null;
+  round_up_to_nearest?: number | null;
+  // Add other plan-wide fields that might exist (like overtime, etc.)
+  enable_overtime?: boolean | null;
+  overtime_rate?: number | null;
+  overtime_threshold?: number | null; // Assuming threshold is numeric
+  enable_after_hours_rate?: boolean | null;
+  after_hours_multiplier?: number | null;
+  // user_type_rates might be handled differently (e.g., separate table/JSON)
+  // If it's a JSONB column in billing_plans, it could be:
+  // user_type_rates?: Record<string, number> | null;
 }
 
 export interface IPlanService extends TenantEntity {

--- a/server/src/interfaces/planServiceConfiguration.interfaces.ts
+++ b/server/src/interfaces/planServiceConfiguration.interfaces.ts
@@ -34,13 +34,10 @@ export interface IPlanServiceFixedConfig extends TenantEntity {
  */
 export interface IPlanServiceHourlyConfig extends TenantEntity {
   config_id: string;
+  hourly_rate: number; // Added
   minimum_billable_time: number;
   round_up_to_nearest: number;
-  enable_overtime: boolean;
-  overtime_rate?: number;
-  overtime_threshold?: number;
-  enable_after_hours_rate: boolean;
-  after_hours_multiplier?: number;
+  // Removed plan-wide fields: enable_overtime, overtime_rate, overtime_threshold, enable_after_hours_rate, after_hours_multiplier
   tenant: string;
   created_at: Date;
   updated_at: Date;


### PR DESCRIPTION
This commit introduces significant changes to the Hourly Plan configuration:

-   **Database Migration:**
    -   Modifies the `plan_service_configuration` table to use a composite primary key (`tenant`, `config_id`).
    -   Creates a new table `plan_service_hourly_configs` to store hourly-specific settings.
    -   Adds plan-wide hourly settings (overtime, after-hours) to the `billing_plans` table.
    -   Fixes the foreign key in `user_type_rates` to correctly reference `plan_service_hourly_configs`.
-   **Frontend Refactor:**
    -   Replaces plan-wide hourly settings with service-specific configurations.
    -   Implements a new `ServiceHourlyConfigForm` component to manage hourly rates and user type rates for individual services.
    -   Uses `lodash/isEqual` for deep object comparison to detect changes.
    -   Improves input validation and error handling using Zod.
    -   Enhances UI with tooltips and accordions for better organization.
-   **Backend Logic:**
    -   Updates actions and services to handle the new database schema.
    -   Introduces `upsertPlanServiceHourlyConfiguration` and `upsertUserTypeRatesForConfig` actions for saving service-specific hourly settings.
    -   Modifies `getPlanServicesWithConfigurations` to fetch user type rates for hourly services.
    -   Adjusts the `BillingPlan` update action to prevent overwriting service-specific fields.

These changes aim to provide more granular control over hourly billing settings at the service level and improve the overall maintainability and scalability of the billing system.