### PR TITLE
feat(billing): enforce service type billing methods and migrate data

### DIFF
--- a/server/migrations/20250405231703_populate_enforce_billing_method_on_types.cjs
+++ b/server/migrations/20250405231703_populate_enforce_billing_method_on_types.cjs
@@ -1,0 +1,71 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  // Step 1: Populate standard_service_types.billing_method based on mapping
+  await knex('standard_service_types').where({ name: 'Managed Services' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Project/Professional Services' }).whereNull('billing_method').update({ billing_method: 'per_unit' });
+  await knex('standard_service_types').where({ name: 'Break-Fix and Reactive Support' }).whereNull('billing_method').update({ billing_method: 'per_unit' });
+  await knex('standard_service_types').where({ name: 'Cloud and Hosting' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Hardware and Software' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Cybersecurity Services' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Telecommunications' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Backup and Disaster Recovery (BDR)' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'User Support and Training' }).whereNull('billing_method').update({ billing_method: 'per_unit' });
+  await knex('standard_service_types').where({ name: 'Hourly Time' }).whereNull('billing_method').update({ billing_method: 'per_unit' });
+  await knex('standard_service_types').where({ name: 'Fixed Price' }).whereNull('billing_method').update({ billing_method: 'fixed' });
+  await knex('standard_service_types').where({ name: 'Usage Based' }).whereNull('billing_method').update({ billing_method: 'per_unit' });
+  
+  // Fallback: Update any remaining standard service types with NULL billing_method
+  await knex('standard_service_types').whereNull('billing_method').update({ billing_method: 'per_unit' });
+
+  // Step 2: Add CHECK constraint to standard_service_types.billing_method
+  await knex.raw(`
+    ALTER TABLE standard_service_types
+    ADD CONSTRAINT standard_service_types_billing_method_check CHECK (billing_method IN ('fixed', 'per_unit'));
+  `);
+
+  // Step 3: Make standard_service_types.billing_method NOT NULL and change type
+  await knex.schema.alterTable('standard_service_types', (table) => {
+    table.string('billing_method', 10).notNullable().alter();
+  });
+
+  // Step 4: Add billing_method column to service_types (initially nullable)
+  await knex.schema.alterTable('service_types', (table) => {
+    table.string('billing_method', 10).nullable(); // Add as nullable first
+  });
+  
+  // Step 5: Populate billing_method for existing service_types
+  await knex('service_types').whereNull('billing_method').update({ billing_method: 'per_unit' });
+  
+  // Step 6: Add constraint and make billing_method NOT NULL
+  await knex.raw(`
+    ALTER TABLE service_types
+    ADD CONSTRAINT service_types_billing_method_check CHECK (billing_method IN ('fixed', 'per_unit'));
+  `);
+  
+  await knex.schema.alterTable('service_types', (table) => {
+    table.string('billing_method', 10).notNullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  // Drop constraint and column from service_types
+  await knex.raw('ALTER TABLE service_types DROP CONSTRAINT IF EXISTS service_types_billing_method_check;');
+  await knex.schema.alterTable('service_types', (table) => {
+    table.dropColumn('billing_method');
+  });
+
+  // Drop constraint and alter column back in standard_service_types
+  await knex.raw('ALTER TABLE standard_service_types DROP CONSTRAINT IF EXISTS standard_service_types_billing_method_check;');
+  await knex.schema.alterTable('standard_service_types', (table) => {
+    // Alter back to nullable and original wider varchar for rollback safety
+    table.string('billing_method', 255).nullable().alter();
+  });
+  // Note: Populated values are not automatically reverted to NULL on rollback.
+};

--- a/server/migrations/20250405231739_enforce_service_billing_method.cjs
+++ b/server/migrations/20250405231739_enforce_service_billing_method.cjs
@@ -1,0 +1,124 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  // Step 1: Add new nullable FK columns
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.uuid('standard_service_type_id').nullable().references('id').inTable('standard_service_types').onDelete('SET NULL');
+    table.uuid('custom_service_type_id').nullable().references('id').inTable('service_types').onDelete('SET NULL'); // FK to service_types
+  });
+
+  // Step 2: Populate new FK columns based on old service_type_id
+  await knex.raw(`
+    UPDATE service_catalog s
+    SET standard_service_type_id = s.service_type_id
+    FROM standard_service_types sst
+    WHERE s.service_type_id = sst.id;
+  `);
+  await knex.raw(`
+    UPDATE service_catalog s
+    SET custom_service_type_id = s.service_type_id
+    FROM service_types st
+    WHERE s.service_type_id = st.id AND s.tenant = st.tenant_id; -- Ensure tenant match for custom types
+  `);
+
+  // Step 3: Populate NULL billing_method (using the same logic as before, just in case)
+  await knex.raw(`
+    UPDATE service_catalog s
+    SET billing_method = sst.billing_method
+    FROM standard_service_types sst
+    WHERE s.standard_service_type_id = sst.id AND s.billing_method IS NULL;
+  `);
+  await knex.raw(`
+    UPDATE service_catalog s
+    SET billing_method = st.billing_method
+    FROM service_types st
+    WHERE s.custom_service_type_id = st.id AND s.tenant = st.tenant_id AND s.billing_method IS NULL;
+  `);
+  // Fallback update if any billing_method is still NULL - this is critical to prevent NOT NULL constraint violation
+  await knex('service_catalog').whereNull('billing_method').update({ billing_method: 'per_unit' });
+
+
+  // Step 3.5: Verify that all services have exactly one FK populated
+  // If a service has neither FK populated, we'll set standard_service_type_id to a default value
+  // This ensures the CHECK constraint in the next step won't fail
+  await knex.raw(`
+    UPDATE service_catalog
+    SET standard_service_type_id = (SELECT id FROM standard_service_types WHERE name = 'Managed Services' LIMIT 1)
+    WHERE standard_service_type_id IS NULL AND custom_service_type_id IS NULL;
+  `);
+
+  // Step 4: Add CHECK constraint to ensure exactly one FK is populated
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    ADD CONSTRAINT service_catalog_check_one_type_id
+    CHECK (
+      (standard_service_type_id IS NOT NULL AND custom_service_type_id IS NULL)
+      OR
+      (standard_service_type_id IS NULL AND custom_service_type_id IS NOT NULL)
+    );
+  `);
+
+  // Step 5: Add CHECK constraint to services.billing_method and make it NOT NULL
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    ADD CONSTRAINT service_catalog_billing_method_check CHECK (billing_method IN ('fixed', 'per_unit'));
+  `);
+  
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.string('billing_method', 10).notNullable().alter();
+  });
+
+  // Step 6: Drop the old service_type_id column
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.dropColumn('service_type_id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  // Step 1: Add service_type_id column back (nullable initially)
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.uuid('service_type_id').nullable();
+  });
+
+  // Step 2: Populate service_type_id from the two FK columns
+  await knex.raw(`
+    UPDATE service_catalog
+    SET service_type_id = COALESCE(standard_service_type_id, custom_service_type_id);
+  `);
+
+  // Step 3: Drop the CHECK constraint
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    DROP CONSTRAINT IF EXISTS service_catalog_check_one_type_id;
+  `);
+
+  // Step 4: Drop the foreign key constraints and columns
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.dropForeign('standard_service_type_id');
+    table.dropForeign('custom_service_type_id');
+    table.dropColumn('standard_service_type_id');
+    table.dropColumn('custom_service_type_id');
+  });
+
+  // Step 5: Drop the CHECK constraint and make billing_method nullable again
+  await knex.raw(`
+    ALTER TABLE service_catalog
+    DROP CONSTRAINT IF EXISTS service_catalog_billing_method_check;
+  `);
+  
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.string('billing_method', 10).nullable().alter();
+  });
+
+  // Step 6: Make service_type_id NOT NULL (assuming it was originally)
+  // If the original column could be null, remove .notNullable()
+  await knex.schema.alterTable('service_catalog', (table) => {
+    table.uuid('service_type_id').notNullable().alter();
+  });
+};

--- a/server/src/components/billing-dashboard/BillingPlanDialog.tsx
+++ b/server/src/components/billing-dashboard/BillingPlanDialog.tsx
@@ -28,7 +28,7 @@ interface BillingPlanDialogProps {
   editingPlan?: IBillingPlan | null;
   onClose?: () => void;
   triggerButton?: React.ReactNode;
-  allServiceTypes: (IServiceType & { is_standard?: boolean })[]; // Kept for potential future use, though not used in simplified version
+  allServiceTypes: { id: string; name: string; billing_method: 'fixed' | 'per_unit'; is_standard: boolean }[]; // Updated to match getServiceTypesForSelection return type
 }
 
 export function BillingPlanDialog({ onPlanAdded, editingPlan, onClose, triggerButton }: BillingPlanDialogProps) {

--- a/server/src/components/billing-dashboard/BillingPlans.tsx
+++ b/server/src/components/billing-dashboard/BillingPlans.tsx
@@ -39,7 +39,7 @@ const BillingPlans: React.FC<BillingPlansProps> = ({ initialServices }) => {
   const [error, setError] = useState<string | null>(null);
   const [editingPlan, setEditingPlan] = useState<IBillingPlan | null>(null);
   // Add state for all service types (standard + tenant-specific)
-  const [allServiceTypes, setAllServiceTypes] = useState<(IServiceType & { is_standard?: boolean })[]>([]);
+  const [allServiceTypes, setAllServiceTypes] = useState<{ id: string; name: string; billing_method: 'fixed' | 'per_unit'; is_standard: boolean }[]>([]);
   const tenant = useTenant();
 
   useEffect(() => {

--- a/server/src/components/billing-dashboard/FixedPlanServicesList.tsx
+++ b/server/src/components/billing-dashboard/FixedPlanServicesList.tsx
@@ -83,7 +83,7 @@ const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId })
           created_at: configInfo.configuration.created_at,
           updated_at: configInfo.configuration.updated_at,
           service_name: configInfo.service.service_name || 'Unknown Service',
-          service_category: configInfo.service.service_type_name || 'N/A', // Use service_type_name directly
+          service_category: configInfo.service.service_type_name || 'N/A', // Now using service_type_name from IService
           billing_method: configInfo.service.billing_method,
           default_rate: configInfo.service.default_rate
         };
@@ -161,7 +161,7 @@ const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId })
     {
       title: 'Default Rate', // Show default rate for reference
       dataIndex: 'default_rate',
-      render: (value) => value !== undefined ? `$${(value / 100).toFixed(2)}` : 'N/A', // Assuming rate is in cents
+      render: (value) => value !== undefined ? `$${Number(value).toFixed(2)}` : 'N/A', // Display rate directly as dollars
     },
     {
       title: 'Actions',
@@ -194,9 +194,13 @@ const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId })
     },
   ];
 
-  // Filter out services already in the plan from the add list
+  // Filter out services already in the plan from the add list and only include services with 'fixed' billing method
   const servicesAvailableToAdd = availableServices.filter(
-    availService => !planServices.some(ps => ps.service_id === availService.service_id)
+    availService =>
+      // Check if service is not already added to the plan
+      !planServices.some(ps => ps.service_id === availService.service_id) &&
+      // Only include services with 'fixed' billing method for Fixed plans
+      availService.billing_method === 'fixed'
   );
 
   return (
@@ -231,9 +235,8 @@ const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId })
                     <div className="mb-3">
                         <div className="grid grid-cols-1 gap-2 max-h-60 overflow-y-auto border rounded p-2">
                         {servicesAvailableToAdd.map(service => {
-                            // Use service_type_name directly from the service object if available
-                            // Cast to any since IService might not have service_type_name yet
-                            const serviceTypeName = (service as any).service_type_name || 'N/A';
+                            // Use service_type_name directly from the service object
+                            const serviceTypeName = service.service_type_name || 'N/A';
                             return (
                                 <div
                                 key={service.service_id}
@@ -255,7 +258,7 @@ const FixedPlanServicesList: React.FC<FixedPlanServicesListProps> = ({ planId })
                                 <label htmlFor={`add-service-${service.service_id}`} className="flex-grow cursor-pointer flex flex-col text-sm">
                                     <span>{service.service_name}</span>
                                     <span className="text-xs text-muted-foreground">
-                                    Service Type: {serviceTypeName} | Method: {BILLING_METHOD_OPTIONS.find(opt => opt.value === service.billing_method)?.label || service.billing_method} | Rate: ${ (service.default_rate / 100).toFixed(2)}
+                                    Service Type: {serviceTypeName} | Method: {BILLING_METHOD_OPTIONS.find(opt => opt.value === service.billing_method)?.label || service.billing_method} | Rate: ${ Number(service.default_rate).toFixed(2)}
                                     </span>
                                 </label>
                                 </div>

--- a/server/src/components/billing-dashboard/ServiceForm.tsx
+++ b/server/src/components/billing-dashboard/ServiceForm.tsx
@@ -1,37 +1,87 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button } from 'server/src/components/ui/Button'
 import { Input } from 'server/src/components/ui/Input'
 import CustomSelect from 'server/src/components/ui/CustomSelect'
-import { createService } from 'server/src/lib/actions/serviceActions'
-// Removed ServiceType import
+import { createService, getServiceTypesForSelection } from 'server/src/lib/actions/serviceActions'
 import { UnitOfMeasureInput } from './UnitOfMeasureInput'
 
 export const ServiceForm: React.FC = () => {
   const [serviceName, setServiceName] = useState('')
-  const [serviceType, setServiceType] = useState<string>('Time') // Changed type to string
+  const [serviceTypeId, setServiceTypeId] = useState<string>('') // Store the selected service type ID
   const [defaultRate, setDefaultRate] = useState('')
   const [unitOfMeasure, setUnitOfMeasure] = useState('')
-  const [billingMethod, setBillingMethod] = useState<'fixed' | 'per_unit'>('fixed') // Added state for billing method
+  const [billingMethod, setBillingMethod] = useState<'fixed' | 'per_unit'>('fixed')
+  const [description, setDescription] = useState('')
+  const [serviceTypes, setServiceTypes] = useState<{ id: string; name: string; billing_method: 'fixed' | 'per_unit'; is_standard: boolean }[]>([])
+  const [error, setError] = useState<string | null>(null)
+  
+  // Fetch service types on component mount
+  useEffect(() => {
+    const fetchServiceTypes = async () => {
+      try {
+        const types = await getServiceTypesForSelection()
+        setServiceTypes(types)
+      } catch (error) {
+        console.error('Error fetching service types:', error)
+        setError('Failed to fetch service types')
+      }
+    }
+    
+    fetchServiceTypes()
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    
+    if (!serviceTypeId) {
+      setError('Please select a service type')
+      return
+    }
+    
     try {
-      await createService({
+      // Find the selected service type to determine if it's standard or custom
+      const selectedServiceType = serviceTypes.find(t => t.id === serviceTypeId)
+      
+      if (!selectedServiceType) {
+        setError('Selected service type not found')
+        return
+      }
+      
+      // Create base data
+      const baseData = {
         service_name: serviceName,
-        service_type_id: serviceType, // Corrected property name
-        default_rate: parseFloat(defaultRate),
+        default_rate: parseFloat(defaultRate) || 0,
         unit_of_measure: unitOfMeasure,
-        category_id: '',
-        billing_method: billingMethod // Added billing method to payload
-      })
+        category_id: null,
+        billing_method: billingMethod,
+        description: description
+      }
+      
+      // Create the final data with the correct service type ID based on is_standard flag
+      let submitData
+      if (selectedServiceType.is_standard) {
+        submitData = {
+          ...baseData,
+          standard_service_type_id: serviceTypeId,
+        }
+      } else {
+        submitData = {
+          ...baseData,
+          custom_service_type_id: serviceTypeId,
+        }
+      }
+      
+      await createService(submitData)
+      setError(null)
       // Clear form fields after successful submission
       setServiceName('')
-      setServiceType('Time') // No change needed here, already string
+      setServiceTypeId('')
       setDefaultRate('')
       setUnitOfMeasure('')
-      setBillingMethod('fixed') // Reset billing method state
+      setBillingMethod('fixed')
+      setDescription('')
     } catch (error) {
       console.error('Error creating service:', error)
       // Handle error (e.g., show error message to user)
@@ -40,6 +90,7 @@ export const ServiceForm: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {error && <div className="text-red-500 mb-4">{error}</div>}
       <Input
         value={serviceName}
         onChange={(e) => setServiceName(e.target.value)}
@@ -48,13 +99,16 @@ export const ServiceForm: React.FC = () => {
       />
 
       <CustomSelect
-        options={[
-          { value: 'Fixed', label: 'Fixed Price' },
-          { value: 'Time', label: 'Time-Based' },
-          { value: 'Usage', label: 'Usage-Based' }
-        ]}
-        value={serviceType}
-        onValueChange={(value) => setServiceType(value)} // Removed 'as ServiceType' cast
+        options={serviceTypes.map(type => ({ value: type.id, label: type.name }))}
+        value={serviceTypeId}
+        onValueChange={(value) => {
+          setServiceTypeId(value)
+          // Optionally update billing method based on selected service type
+          const selectedType = serviceTypes.find(t => t.id === value)
+          if (selectedType) {
+            setBillingMethod(selectedType.billing_method)
+          }
+        }}
         placeholder="Select Service Type"
       />
       
@@ -83,6 +137,16 @@ export const ServiceForm: React.FC = () => {
         className="w-full"
         required
       />
+
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description</label>
+        <Input
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Service Description"
+        />
+      </div>
 
       <Button id='add-service-button' type="submit">Add Service</Button>
     </form>

--- a/server/src/components/billing-dashboard/billing-plans/BillingPlanServiceForm.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BillingPlanServiceForm.tsx
@@ -126,10 +126,8 @@ const BillingPlanServiceForm: React.FC<BillingPlanServiceFormProps> = ({
               // Check service type name for per_unit services
               const laborServiceTypes = ['Labor - Support', 'Labor - Project', 'Consulting']; // Assuming these are potential service type names
               // Use service_type_name directly from the service object
-              // Note: The 'service' object here comes from the 'services' prop.
-              // We need to ensure 'service_type_name' is included there.
-              // For now, we'll cast to 'any' as a temporary measure.
-              const serviceTypeName = (service as any).service_type_name;
+              // The 'service' object comes from the 'services' prop which now includes service_type_name
+              const serviceTypeName = service.service_type_name;
               if (serviceTypeName && laborServiceTypes.includes(serviceTypeName)) {
                 configType = 'Hourly'; // Default labor service types to Hourly
               } else {

--- a/server/src/components/billing-dashboard/billing-plans/BillingPlansOverview.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BillingPlansOverview.tsx
@@ -23,7 +23,7 @@ const BillingPlansOverview: React.FC = () => {
   const [billingPlans, setBillingPlans] = useState<IBillingPlan[]>([]);
   const [editingPlan, setEditingPlan] = useState<IBillingPlan | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [allServiceTypes, setAllServiceTypes] = useState<(IServiceType & { is_standard?: boolean })[]>([]); // Added state for service types
+  const [allServiceTypes, setAllServiceTypes] = useState<{ id: string; name: string; billing_method: 'fixed' | 'per_unit'; is_standard: boolean }[]>([]); // Added state for service types
   const router = useRouter();
 
   useEffect(() => {

--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -115,7 +115,9 @@ export function FixedPlanConfiguration({
   // Validate inputs
   useEffect(() => {
     const errors: { baseRate?: string; serviceCatalogId?: string } = {};
-    if (baseRate !== undefined && baseRate < 0) {
+    if (baseRate === undefined || baseRate === null) {
+      errors.baseRate = 'Base rate is required';
+    } else if (baseRate < 0) {
       errors.baseRate = 'Base rate cannot be negative';
     }
     // Add validation for serviceCatalogId if it's mandatory and editable here
@@ -131,8 +133,14 @@ export function FixedPlanConfiguration({
   };
 
   const handleSave = async () => {
-    if (!plan || Object.keys(validationErrors).length > 0 || !serviceCatalogId) {
-        setSaveError("Cannot save, validation errors exist, plan not loaded, or no service selected.");
+    // Prioritize checking for a selected service
+    if (!serviceCatalogId) {
+        setSaveError("Please select a primary service for the base rate before saving.");
+        return;
+    }
+    // Check for other validation errors or if the plan hasn't loaded
+    if (!plan || Object.keys(validationErrors).length > 0) {
+        setSaveError("Cannot save due to validation errors or plan not being loaded.");
         return;
     }
     setSaving(true);
@@ -215,6 +223,21 @@ export function FixedPlanConfiguration({
               <AlertDescription>{saveError}</AlertDescription>
             </Alert>
           )}
+
+          {/* Validation Error Alert */}
+          {Object.keys(validationErrors).length > 0 && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Please fix the following errors:
+                <ul className="list-disc pl-5 mt-1">
+                  {Object.values(validationErrors).map((errorMsg, index) => (
+                    <li key={index}>{errorMsg}</li>
+                  ))}
+                </ul>
+              </AlertDescription>
+            </Alert>
+          )}
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <Label htmlFor="fixed-plan-base-rate">Base Rate</Label>
@@ -227,15 +250,12 @@ export function FixedPlanConfiguration({
                 disabled={saving}
                 min={0}
                 step={0.01}
-                className={validationErrors.baseRate ? 'border-red-500' : ''}
+                // className={validationErrors.baseRate ? 'border-red-500' : ''} // Removed inline error style
               />
-              {validationErrors.baseRate ? (
-                <p className="text-sm text-red-500 mt-1">{validationErrors.baseRate}</p>
-              ) : (
-                <p className="text-sm text-muted-foreground mt-1">
-                  The base rate for this fixed plan.
-                </p>
-              )}
+              {/* Removed inline error display */}
+              <p className="text-sm text-muted-foreground mt-1">
+                The base rate for this fixed plan.
+              </p>
             </div>
 
             {/* Service Selection - Keep only if the primary service is changeable here */}

--- a/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/GenericPlanServicesList.tsx
@@ -288,13 +288,10 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planI
       // For Bucket plans, exclude services with 'fixed' billing method
       return availService.billing_method !== 'fixed';
     }
-
-    // TODO: Add filtering logic for other plan types if needed (using availService.billing_method)
-    // Example:
-    // if (planType === 'Fixed') {
-    //   // Only allow services with 'fixed' billing method?
-    //   return availService.billing_method === 'fixed';
-    // }
+    else if (planType === 'Fixed') {
+      // For Fixed plans, only allow services with 'fixed' billing method
+      return availService.billing_method === 'fixed';
+    }
 
     // Default: allow service if not already added and no specific filter applies
     return true;
@@ -337,7 +334,7 @@ const GenericPlanServicesList: React.FC<GenericPlanServicesListProps> = ({ planI
                   <div className="grid grid-cols-1 gap-2 max-h-60 overflow-y-auto border rounded p-2">
                     {servicesAvailableToAdd.map(service => {
                       // Use service_type_name directly from the service object (fetched via updated getServices)
-                      const serviceTypeName = (service as any).service_type_name || 'N/A'; // Cast needed as IService doesn't have it yet
+                      const serviceTypeName = service.service_type_name || 'N/A'; // No cast needed now that IService includes service_type_name
                       return (
                         <div
                           key={service.service_id}

--- a/server/src/components/billing-dashboard/service-config/ServiceConfigurationPanel.tsx
+++ b/server/src/components/billing-dashboard/service-config/ServiceConfigurationPanel.tsx
@@ -117,7 +117,7 @@ export function ServiceConfigurationPanel({ serviceId, onUpdate }: ServiceConfig
                 onChange={() => {}} // Handled internally by the component
                 serviceId={service.service_id}
                 onSaveComplete={handleServiceUpdate}
-                serviceType={service.service_type_id}
+                serviceType={service.service_type_name}
                 required
               />
             </div>

--- a/server/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
+++ b/server/src/components/billing-dashboard/service-config/ServiceSelectionDialog.tsx
@@ -82,9 +82,9 @@ export function ServiceSelectionDialog({
     
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(service => 
+      filtered = filtered.filter(service =>
         service.service_name.toLowerCase().includes(query) ||
-        (service.service_type_id || '').toLowerCase().includes(query) || // Use service_type_id
+        (service.service_type_name || '').toLowerCase().includes(query) ||
         service.unit_of_measure.toLowerCase().includes(query)
       );
     }
@@ -145,7 +145,9 @@ export function ServiceSelectionDialog({
   // Group services by type for quick selection
   const serviceTypes = React.useMemo(() => {
     const types = new Set<string>();
-    services.forEach(service => { if (service.service_type_id) types.add(service.service_type_id) }); // Use service_type_id
+    services.forEach(service => {
+      if (service.service_type_name) types.add(service.service_type_name);
+    });
     return Array.from(types);
   }, [services]);
 
@@ -226,7 +228,7 @@ export function ServiceSelectionDialog({
                         </div>
                       </TableCell>
                       <TableCell>{service.service_name}</TableCell>
-                      <TableCell>{service.service_type_id}</TableCell>
+                      <TableCell>{service.service_type_name || 'Unknown'}</TableCell>
                       <TableCell>{service.unit_of_measure}</TableCell>
                       <TableCell>${service.default_rate}</TableCell>
                     </TableRow>
@@ -249,7 +251,7 @@ export function ServiceSelectionDialog({
                 onClick={() => {
                   // Find all services of this type and select them
                   const serviceIdsOfType = services
-                    .filter(s => s.service_type_id === type) // Use service_type_id
+                    .filter(s => s.service_type_name === type)
                     .map(s => s.service_id);
                   
                   setSelectedServices(prev => {

--- a/server/src/components/companies/CompanyServiceOverlapMatrix.tsx
+++ b/server/src/components/companies/CompanyServiceOverlapMatrix.tsx
@@ -246,7 +246,7 @@ const CompanyServiceOverlapMatrix: React.FC<CompanyServiceOverlapMatrixProps> = 
                           )}
                         </div>
                         <div className="text-xs text-gray-500">
-                          {service.service_type_id} • {service.unit_of_measure}
+                          {service.service_type_name || 'Unknown Type'} • {service.unit_of_measure}
                         </div>
                       </TableCell>
                       

--- a/server/src/interfaces/billing.interfaces.ts
+++ b/server/src/interfaces/billing.interfaces.ts
@@ -131,24 +131,25 @@ export interface ILicenseCharge extends IBillingCharge, TenantEntity {
 export interface IService extends TenantEntity {
   service_id: string;
   service_name: string;
-  service_type_id: string; // Changed from service_type: string
-  service_type_billing_method?: 'fixed' | 'per_unit' | null; // Billing method from the standard type (optional, allow null)
-  billing_method: 'fixed' | 'per_unit' | null; // Billing method specific to this service instance (Allow null temporarily)
+  // service_type_id: string; // Removed
+  standard_service_type_id?: string | null; // FK to standard_service_types
+  custom_service_type_id?: string | null;   // FK to service_types
+  billing_method: 'fixed' | 'per_unit'; // Billing method specific to this service instance (Now required)
   default_rate: number;
   category_id: string | null;
   unit_of_measure: string;
   is_taxable?: boolean;
   tax_region?: string | null;
-  sku?: string;               // For products
-  inventory_count?: number;   // For products
-  seat_limit?: number;        // For licenses
-  license_term?: string;      // For licenses (e.g., 'monthly', 'annual')
+  description?: string | null; // Added: Description field from the database
+  service_type_name?: string; // Added: Name of the service type (from standard or custom)
+  // Note: The CHECK constraint ensures exactly one of standard_service_type_id or custom_service_type_id is non-null.
 }
 
 // New interface for standard service types (cross-tenant)
 export interface IStandardServiceType {
   id: string;
   name: string;
+  billing_method: 'fixed' | 'per_unit'; // Added
   created_at: ISO8601String;
   updated_at: ISO8601String;
 }
@@ -157,7 +158,8 @@ export interface IStandardServiceType {
 export interface IServiceType extends TenantEntity {
   id: string;
   name: string;
-  standard_service_type_id?: string | null; // Link to standard type if applicable
+  billing_method: 'fixed' | 'per_unit'; // Now required for custom types
+  // standard_service_type_id removed
   is_active: boolean;
   description?: string | null;
   created_at: ISO8601String;

--- a/server/src/lib/actions/planServiceActions.ts
+++ b/server/src/lib/actions/planServiceActions.ts
@@ -71,7 +71,7 @@ export async function addServiceToPlan(
 
   // Get service details and join with standard_service_types to get the type's billing_method
   const serviceWithType = await knex('service_catalog as sc')
-    .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id')
+    .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
     .where({
       'sc.service_id': serviceId,
       'sc.tenant': tenant
@@ -283,9 +283,9 @@ export async function getPlanServicesWithConfigurations(planId: string): Promise
   for (const config of configurations) {
     // Join service_catalog with standard_service_types to get the name
     const service = await knex('service_catalog as sc')
-      .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id') // Join standard types
+      .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id') // Join standard types
       .leftJoin('service_types as tst', function() { // Join tenant-specific types
-        this.on('sc.service_type_id', '=', 'tst.id')
+        this.on('sc.custom_service_type_id', '=', 'tst.id')
             .andOn('sc.tenant', '=', 'tst.tenant_id'); // Corrected column name
       })
       .where({

--- a/server/src/lib/actions/serviceActions.ts
+++ b/server/src/lib/actions/serviceActions.ts
@@ -1,15 +1,49 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import Service from 'server/src/lib/models/service'
-import { IService, IServiceType } from '../../interfaces/billing.interfaces'; // Added IServiceType import
-import { validateArray } from 'server/src/lib/utils/validation'
-import { serviceSchema } from 'server/src/lib/models/service'
+import Service, { serviceSchema, refinedServiceSchema } from 'server/src/lib/models/service'; // Import both schemas
+import { IService, IServiceType, IStandardServiceType } from '../../interfaces/billing.interfaces';
+import { validateArray } from 'server/src/lib/utils/validation';
+import { ServiceTypeModel } from '../models/serviceType'; // Import ServiceTypeModel
+import { createTenantKnex } from '../db'; // Import createTenantKnex for direct DB access if needed
 
 export async function getServices(): Promise<IService[]> {
     try {
-        const services = await Service.getAll()
-        return validateArray(serviceSchema, services)
+        const { knex, tenant } = await createTenantKnex();
+        if (!tenant) {
+            throw new Error('Tenant context is required for fetching services');
+        }
+
+        // Fetch services with service type names by joining with both standard and custom service type tables
+        const servicesData = await knex('service_catalog as sc')
+            .where({ 'sc.tenant': tenant })
+            .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+            .leftJoin('service_types as st', function() {
+                this.on('sc.custom_service_type_id', '=', 'st.id')
+                    .andOn('sc.tenant', '=', 'st.tenant_id');
+            })
+            .select(
+                'sc.service_id',
+                'sc.service_name',
+                'sc.standard_service_type_id',
+                'sc.custom_service_type_id',
+                'sc.billing_method',
+                knex.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
+                'sc.unit_of_measure',
+                'sc.category_id',
+                'sc.is_taxable',
+                'sc.tax_region',
+                'sc.tenant',
+                'sc.description',
+                knex.raw('COALESCE(sst.name, st.name) as service_type_name') // Add service type name
+            );
+
+        // Validate and transform the data
+        const validatedServices = servicesData.map(service => {
+            return serviceSchema.parse(service);
+        });
+
+        return validatedServices;
     } catch (error) {
         console.error('Error fetching services:', error)
         throw new Error('Failed to fetch services')
@@ -26,19 +60,95 @@ export async function getServiceById(serviceId: string): Promise<IService | null
     }
 }
 
+// Define a type for the input data, accepting one of the two IDs
+type CreateServiceInput = Omit<IService, 'service_id' | 'tenant' | 'standard_service_type_id' | 'custom_service_type_id'> &
+  (
+    | { standard_service_type_id: string; custom_service_type_id?: never }
+    | { standard_service_type_id?: never; custom_service_type_id: string }
+  );
+
+
 export async function createService(
-    serviceData: Omit<IService, 'service_id' | 'tenant'>
+    serviceData: CreateServiceInput
 ): Promise<IService> {
     try {
-        console.log('[serviceActions] createService called with data:', serviceData)
-        console.log('[serviceActions] service_type_id value:', serviceData.service_type_id) // Changed from service_type
-        const service = await Service.create({ ...serviceData })
-        console.log('[serviceActions] Service created successfully:', service)
-        revalidatePath('/msp/billing') // Revalidate the billing page
-        return service
+        console.log('[serviceActions] createService called with data:', serviceData);
+        const { standard_service_type_id, custom_service_type_id } = serviceData;
+
+        if (!standard_service_type_id && !custom_service_type_id) {
+            throw new Error('Either standard_service_type_id or custom_service_type_id is required to create a service.');
+        }
+        if (standard_service_type_id && custom_service_type_id) {
+             throw new Error('Provide either standard_service_type_id or custom_service_type_id, not both.');
+        }
+
+        const { knex, tenant } = await createTenantKnex(); // Get knex and tenant context
+
+        // Ensure tenant context exists before proceeding
+        if (!tenant) {
+          throw new Error('Tenant context could not be determined. Cannot create service.');
+        }
+
+        // 1. Determine the billing method based on the provided ID
+        let derivedBillingMethod: 'fixed' | 'per_unit' | undefined | null = null;
+        let typeId: string;
+
+        if (standard_service_type_id) {
+            typeId = standard_service_type_id;
+            const standardServiceType = await knex<IStandardServiceType>('standard_service_types')
+                .where({ id: typeId })
+                .first();
+            if (!standardServiceType) {
+                 throw new Error(`Standard ServiceType ID '${typeId}' not found.`);
+            }
+            derivedBillingMethod = standardServiceType.billing_method;
+            console.log(`[serviceActions] Billing method '${derivedBillingMethod}' derived from standard type: ${typeId}`);
+        } else if (custom_service_type_id) {
+            typeId = custom_service_type_id;
+            const customServiceType = await knex<IServiceType>('service_types')
+                .where('id', typeId)
+                .andWhere('tenant_id', tenant) // Match tenant
+                .first();
+             if (!customServiceType) {
+                 throw new Error(`Custom ServiceType ID '${typeId}' not found for tenant '${tenant}'.`);
+            }
+            derivedBillingMethod = customServiceType.billing_method;
+            console.log(`[serviceActions] Billing method '${derivedBillingMethod}' derived from custom type: ${typeId} for tenant ${tenant}`);
+        } else {
+             // This case is already handled by the initial check, but added for completeness
+             throw new Error('No service type ID provided.');
+        }
+
+
+        // 2. Ensure a billing method was determined (as it's required on IService)
+        // This check might be redundant if the source tables enforce non-null billing_method, but good for safety.
+        if (!derivedBillingMethod) {
+            throw new Error(`Could not determine billing method for ServiceType ID '${typeId}'. The source type might lack a billing method.`);
+        }
+
+        // 3. Prepare final data, ensuring derived billing_method and correct FK ID is used
+        const finalServiceData = {
+            ...serviceData,
+            tenant: tenant, // Explicitly add tenant to the data
+            billing_method: derivedBillingMethod, // Use the derived billing method
+            // Ensure only the correct FK field is included based on input
+            standard_service_type_id: standard_service_type_id || null,
+            custom_service_type_id: custom_service_type_id || null,
+            // Ensure default_rate is a number
+            default_rate: typeof serviceData.default_rate === 'string'
+                ? parseFloat(serviceData.default_rate) || 0
+                : serviceData.default_rate,
+        };
+
+        // 4. Create the service using the model
+        // Assuming Service.create accepts the IService structure (or relevant parts)
+        const service = await Service.create(finalServiceData as Omit<IService, 'service_id' | 'tenant'>); // Cast might be needed depending on model input type
+        console.log('[serviceActions] Service created successfully:', service);
+        revalidatePath('/msp/billing'); // Revalidate the billing page
+        return service; // Assuming Service.create returns the full IService object
     } catch (error) {
-        console.error('[serviceActions] Error creating service:', error)
-        throw error
+        console.error('[serviceActions] Error creating service:', error);
+        throw error; // Re-throw the error
     }
 }
 
@@ -82,7 +192,7 @@ export async function getServicesByCategory(categoryId: string): Promise<IServic
 }
 
 // New action to get combined service types for UI selection
-export async function getServiceTypesForSelection(): Promise<(IServiceType & { is_standard?: boolean })[]> {
+export async function getServiceTypesForSelection(): Promise<{ id: string; name: string; billing_method: 'fixed' | 'per_unit'; is_standard: boolean }[]> {
    try {
        // Assuming ServiceTypeModel is imported or available
        // Need to import ServiceTypeModel from '../models/serviceType'

--- a/server/src/lib/actions/timeEntryActions.ts
+++ b/server/src/lib/actions/timeEntryActions.ts
@@ -213,9 +213,9 @@ export async function fetchTimeEntriesForTimeSheet(timeSheetId: string): Promise
 
     // Fetch service information with new schema (using billing_method instead of service_type)
     const [service] = await db('service_catalog as sc')
-      .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id')
+      .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
       .leftJoin('service_types as tst', function() {
-        this.on('sc.service_type_id', '=', 'tst.id')
+        this.on('sc.custom_service_type_id', '=', 'tst.id')
             .andOn('sc.tenant', '=', 'tst.tenant_id');
       })
       .where({
@@ -1201,9 +1201,9 @@ export async function fetchServicesForTimeEntry(workItemType?: string): Promise<
   const {knex: db, tenant} = await createTenantKnex();
 
   let query = db('service_catalog as sc')
-    .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id')
+    .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
     .leftJoin('service_types as tst', function() {
-      this.on('sc.service_type_id', '=', 'tst.id')
+      this.on('sc.custom_service_type_id', '=', 'tst.id')
           .andOn('sc.tenant', '=', 'tst.tenant_id');
     })
     .where({ 'sc.tenant': tenant })

--- a/server/src/lib/models/service.ts
+++ b/server/src/lib/models/service.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { validateData } from '../utils/validation';
 
 // Use a constant for environment check
-const IS_DEVELOPMENT = typeof window !== 'undefined' && 
+const IS_DEVELOPMENT = typeof window !== 'undefined' &&
   globalThis.window.location.hostname === 'localhost';
 
 const log = {
@@ -19,30 +19,88 @@ const log = {
   }
 };
 
-export const serviceSchema = z.object({
-  service_id: z.string(),
+// Base schema definition - aligns closely with DB nullability where appropriate
+const baseServiceSchema = z.object({
+  service_id: z.string().uuid(),
   tenant: z.string().min(1, 'Tenant is required'),
   service_name: z.string(),
-  service_type_id: z.string(), // Changed from service_type
-  service_type_name: z.string().nullable().optional(), // Allow null or undefined
-  service_type_billing_method: z.enum(['fixed', 'per_unit']).nullable().optional(), // Billing method from the standard type
-  billing_method: z.enum(['fixed', 'per_unit']).nullable(), // Billing method specific to this service instance (Allow null temporarily)
-  default_rate: z.number(),
+  standard_service_type_id: z.string().uuid().nullable(), // Matches DB FK (nullable)
+  custom_service_type_id: z.string().uuid().nullable(),   // Matches DB FK (nullable)
+  billing_method: z.enum(['fixed', 'per_unit']),
+  default_rate: z.union([z.string(), z.number()]).transform(val =>
+    typeof val === 'string' ? parseFloat(val) || 0 : val
+  ),
   unit_of_measure: z.string(),
-  category_id: z.string().nullable()
-    .transform(val => val === undefined ? null : val),
-  is_taxable: z.boolean().optional().default(false)
-    .transform(val => val === undefined ? false : val),
-  tax_region: z.string().nullable().optional()
-    .transform(val => val === undefined ? null : val)
+  category_id: z.string().uuid().nullable(), // Matches DB FK (nullable) - IService allows string | null
+  is_taxable: z.boolean().optional().default(false), // Optional in interface, default false
+  tax_region: z.string().nullable(), // Matches DB (nullable) - IService allows string | null
+  description: z.string().nullable(), // Added: Description field from the database
+  service_type_name: z.string().optional(), // Add service_type_name to the schema
 });
 
-export const createServiceSchema = serviceSchema.omit({ service_id: true });
+// Refine check for exactly one FK ID being non-null
+// Export this schema as it's needed for validation before transformation
+export const refinedServiceSchema = baseServiceSchema.refine(
+  (data) => (data.standard_service_type_id != null) !== (data.custom_service_type_id != null), {
+  message: "Exactly one of standard_service_type_id or custom_service_type_id must be provided",
+  path: ["standard_service_type_id", "custom_service_type_id"], // Specify path for clarity
+}
+);
+
+// Final schema for validation, transforming nulls to match IService interface
+// IService uses string | null for category_id, tax_region
+// IService uses string | undefined, number | undefined for others
+export const serviceSchema = refinedServiceSchema.transform((data) => {
+  // Explicitly type the input 'data' to the transform based on the refined schema
+  const inputData = data as z.infer<typeof refinedServiceSchema>;
+  return {
+    ...inputData,
+    // Keep null for fields that are string | null in IService
+    category_id: inputData.category_id,
+    tax_region: inputData.tax_region,
+    description: inputData.description,
+    // Map null to undefined for fields that are optional (T | undefined) in IService
+    standard_service_type_id: inputData.standard_service_type_id ?? undefined,
+    custom_service_type_id: inputData.custom_service_type_id ?? undefined,
+  };
+});
+
+// Infer the final type matching IService structure
+export type ServiceSchemaType = z.infer<typeof serviceSchema>;
+
+// Create schema: Omit service_id and tenant from the *base* schema first
+// We omit tenant because it will be added by the server-side code after validation
+const baseCreateServiceSchema = baseServiceSchema.omit({ service_id: true, tenant: true });
+
+// Apply the refine check to the base create schema
+const refinedCreateServiceSchema = baseCreateServiceSchema.refine(
+  (data) => (data.standard_service_type_id != null) !== (data.custom_service_type_id != null), {
+  message: "Exactly one of standard_service_type_id or custom_service_type_id must be provided",
+  path: ["standard_service_type_id", "custom_service_type_id"],
+}
+);
+
+// Apply the same transformation logic to the create schema
+export const createServiceSchema = refinedCreateServiceSchema.transform((data) => {
+  // Explicitly type the input 'data'
+  const inputData = data as z.infer<typeof refinedCreateServiceSchema>;
+  return {
+    ...inputData,
+    category_id: inputData.category_id,
+    tax_region: inputData.tax_region,
+    description: inputData.description,
+    standard_service_type_id: inputData.standard_service_type_id ?? undefined,
+    custom_service_type_id: inputData.custom_service_type_id ?? undefined,
+  };
+});
+
+// Infer the creation type
+export type CreateServiceSchemaType = z.infer<typeof createServiceSchema>;
 
 const Service = {
   getAll: async (): Promise<IService[]> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
+    const { knex: db, tenant } = await createTenantKnex();
+
     if (!tenant) {
       const error = new Error('Tenant context is required for fetching services');
       log.error(`[Service.getAll] ${error.message}`);
@@ -51,36 +109,41 @@ const Service = {
 
     log.info(`[Service.getAll] Fetching all services for tenant: ${tenant}`);
 
-    
-        try {
-          const services = await db('service_catalog as sc') // Alias service_catalog as sc
-            .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id') // Join standard types
-            .leftJoin('service_types as tst', function() { // Join tenant-specific types
-              this.on('sc.service_type_id', '=', 'tst.id')
-                  .andOn('sc.tenant', '=', 'tst.tenant_id'); // Corrected column name
-            })
-            .where({ 'sc.tenant': tenant }) // Use alias for where clause
-            .select(
-              'sc.service_id',
-              'sc.service_name',
-              'sc.service_type_id',
-              db.raw('COALESCE(sst.name, tst.name) as service_type_name'), // Use COALESCE for name
-              'sst.billing_method as service_type_billing_method', // Keep billing method from standard for now
-              'sc.billing_method', // Keep the service's specific billing method too
-              db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
-              'sc.unit_of_measure',
-              'sc.category_id',
-              'sc.is_taxable',
-              'sc.tax_region',
-              'sc.tenant'
-            );
-          log.info(`[Service.getAll] Found ${services.length} services`);
-          
-          // Adjust the type hint for the map function if necessary, though validateData should handle it
-          const validatedServices = services.map((service): IService & { service_type_name?: string } =>
-            validateData(serviceSchema, service) as IService & { service_type_name?: string } // Cast result of validation
-          );
-          log.info(`[Service.getAll] Services data validated successfully`);
+
+    try {
+      // Fetch services, joining with both standard and custom service types to get type names
+      const servicesData = await db('service_catalog as sc')
+        .where({ 'sc.tenant': tenant })
+        .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+        .leftJoin('service_types as ct', function() {
+          this.on('sc.custom_service_type_id', '=', 'ct.id')
+              .andOn('ct.tenant_id', '=', db.raw('?', [tenant]));
+        })
+        .select(
+          'sc.service_id',
+          'sc.service_name',
+          'sc.standard_service_type_id',
+          'sc.custom_service_type_id',
+          'sc.billing_method',
+          db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
+          'sc.unit_of_measure',
+          'sc.category_id',
+          'sc.is_taxable',
+          'sc.tax_region',
+          'sc.description',
+          'sc.tenant',
+          // Select the service type name from either standard or custom type
+          db.raw('COALESCE(sst.name, ct.name) as service_type_name')
+        );
+      log.info(`[Service.getAll] Found ${servicesData.length} services`);
+
+      // Validate and transform using the final schema's parse method
+      const validatedServices = servicesData.map((service) => {
+        // .parse() validates against the refined schema AND applies the transform
+        return serviceSchema.parse(service);
+      });
+
+      log.info(`[Service.getAll] Services data validated successfully`);
       return validatedServices;
     } catch (error) {
       log.error(`[Service.getAll] Error fetching services:`, error);
@@ -89,8 +152,8 @@ const Service = {
   },
 
   getById: async (service_id: string): Promise<IService | null> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
+    const { knex: db, tenant } = await createTenantKnex();
+
     if (!tenant) {
       const error = new Error('Tenant context is required for fetching service');
       log.error(`[Service.getById] ${error.message}`);
@@ -100,40 +163,49 @@ const Service = {
     log.info(`[Service.getById] Fetching service with ID: ${service_id} for tenant: ${tenant}`);
 
     try {
-      const [service] = await db('service_catalog as sc') // Alias service_catalog as sc
-        .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id') // Join standard types
-        .leftJoin('service_types as tst', function() { // Join tenant-specific types
-          this.on('sc.service_type_id', '=', 'tst.id')
-              .andOn('sc.tenant', '=', 'tst.tenant_id'); // Corrected column name
-        })
+      // Fetch service by ID, joining with both standard and custom service types
+      const serviceData = await db('service_catalog as sc')
         .where({
-          'sc.service_id': service_id, // Use alias
-          'sc.tenant': tenant // Use alias
+          'sc.service_id': service_id,
+          'sc.tenant': tenant
+        })
+        .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+        .leftJoin('service_types as ct', function() {
+          this.on('sc.custom_service_type_id', '=', 'ct.id')
+              .andOn('ct.tenant_id', '=', db.raw('?', [tenant]));
         })
         .select(
           'sc.service_id',
           'sc.service_name',
-          'sc.service_type_id',
-          db.raw('COALESCE(sst.name, tst.name) as service_type_name'), // Use COALESCE for name
-          'sst.billing_method as service_type_billing_method', // Keep billing method from standard for now
-          'sc.billing_method', // Keep the service's specific billing method too
+          'sc.standard_service_type_id',
+          'sc.custom_service_type_id',
+          'sc.billing_method',
           db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
           'sc.unit_of_measure',
           'sc.category_id',
           'sc.is_taxable',
           'sc.tax_region',
-          'sc.tenant'
-        );
+          'sc.description',
+          'sc.tenant',
+          // Select the service type name from either standard or custom type
+          db.raw('COALESCE(sst.name, ct.name) as service_type_name')
+        )
+        .first(); // Use .first() as we expect only one
 
-      if (!service) {
+      if (!serviceData) {
         log.info(`[Service.getById] No service found with ID: ${service_id} for tenant: ${tenant}`);
         return null;
       }
 
-      log.info(`[Service.getById] Found service: ${service.service_name}`);
-      const validatedService = validateData(serviceSchema, service);
+      log.info(`[Service.getById] Found service: ${serviceData.service_name}`);
+      // Validate the fetched data against the updated schema
+      // Validate the fetched data (which now transforms to match IService)
+      // Validate against the schema expecting nulls, then transform
+      // Validate against the schema expecting nulls
+      // Validate and transform using the final schema's parse method
+      const validatedService = serviceSchema.parse(serviceData);
       log.info(`[Service.getById] Service data validated successfully`);
-      
+
       return validatedService;
     } catch (error) {
       log.error(`[Service.getById] Error fetching service ${service_id}:`, error);
@@ -141,36 +213,103 @@ const Service = {
     }
   },
 
-  create: async (serviceData: Omit<IService, 'service_id' | 'tenant'>): Promise<IService> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
-    // Validate the input data using creation schema
-    validateData(createServiceSchema, serviceData);
-    
+  // Note: Input type validation (exactly one ID) is expected to be handled by the caller (e.g., serviceAction)
+  // or potentially by refining createServiceSchema further if desired.
+  create: async (serviceData: Omit<IService, 'service_id'> & { tenant?: string }): Promise<IService> => {
+    const { knex: db, tenant: dbTenant } = await createTenantKnex();
+
+    // Use the tenant from the serviceData if provided, otherwise use the one from createTenantKnex
+    const effectiveTenant = serviceData.tenant || dbTenant;
+
+    if (!effectiveTenant) {
+      throw new Error('Tenant context is required for creating a service');
+    }
+
+    // Remove service_type_name from the input data as it's a virtual field
+    const { service_type_name, ...dataWithoutTypeName } = serviceData;
+
+    // Validate the input data using the updated creation schema
+    // The refine check in the schema ensures one ID is present.
+    // Explicitly type validatedData using the inferred type
+    // Validate against the create schema expecting nulls
+    // Note: We use the validated data *before* transformation to build the DB object
+    // Validate against the refined create schema (expects nulls)
+    // Validate and transform the input using the final create schema
+    // The result 'validatedData' will match CreateServiceSchemaType
+    // Ensure default_rate is a number before validation
+    const dataToValidate = {
+      ...dataWithoutTypeName,
+      default_rate: typeof dataWithoutTypeName.default_rate === 'string'
+        ? parseFloat(dataWithoutTypeName.default_rate) || 0
+        : dataWithoutTypeName.default_rate,
+    };
+
+    const validatedData = createServiceSchema.parse(dataToValidate);
+
     const newService = {
       service_id: uuidv4(),
-      tenant: tenant!,
-      service_name: serviceData.service_name,
-      service_type_id: serviceData.service_type_id, // Changed from service_type
-      default_rate: serviceData.default_rate,
-      unit_of_measure: serviceData.unit_of_measure,
-      category_id: serviceData.category_id || null,
-      // Optional fields
-      is_taxable: serviceData.is_taxable || false,
-      tax_region: serviceData.tax_region || null,
-      billing_method: serviceData.billing_method // Added billing_method
+      tenant: effectiveTenant,
+      service_name: validatedData.service_name,
+      // Use validatedData fields. Nullish coalescing handles undefined -> null for DB.
+      standard_service_type_id: validatedData.standard_service_type_id ?? null,
+      custom_service_type_id: validatedData.custom_service_type_id ?? null,
+      billing_method: validatedData.billing_method,
+      default_rate: validatedData.default_rate,
+      unit_of_measure: validatedData.unit_of_measure,
+      category_id: validatedData.category_id ?? null, // category_id is string | null in IService
+      is_taxable: validatedData.is_taxable ?? false, // Use ?? false for boolean
+      tax_region: validatedData.tax_region ?? null,
+      description: validatedData.description ?? '', // Add description field with default empty string
     };
 
     log.info('[Service.create] Constructed newService object:', newService);
-    log.info('[Service.create] About to execute insert with service_type_id:', newService.service_type_id); // Changed from service_type
 
     try {
+      // Insert into service_catalog (assuming this is the correct table name)
       const [createdService] = await db('service_catalog')
         .insert(newService)
-        .returning('*');
+        .returning('*'); // Return all columns to match IService
 
       log.info('[Service.create] Successfully created service:', createdService);
-      return createdService;
+      
+      // After creation, fetch the complete service with type name by joining with type tables
+      const completeService = await db('service_catalog as sc')
+        .where({
+          'sc.service_id': createdService.service_id,
+          'sc.tenant': effectiveTenant
+        })
+        .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+        .leftJoin('service_types as ct', function() {
+          this.on('sc.custom_service_type_id', '=', 'ct.id')
+              .andOn('ct.tenant_id', '=', db.raw('?', [effectiveTenant]));
+        })
+        .select(
+          'sc.service_id',
+          'sc.service_name',
+          'sc.standard_service_type_id',
+          'sc.custom_service_type_id',
+          'sc.billing_method',
+          db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
+          'sc.unit_of_measure',
+          'sc.category_id',
+          'sc.is_taxable',
+          'sc.tax_region',
+          'sc.description',
+          'sc.tenant',
+          // Select the service type name from either standard or custom type
+          db.raw('COALESCE(sst.name, ct.name) as service_type_name')
+        )
+        .first();
+
+      if (!completeService) {
+        log.info(`[Service.create] Failed to fetch complete service after creation: ${createdService.service_id}`);
+        return serviceSchema.parse(createdService); // Fall back to the original service data
+      }
+
+      // Validate the returned data against the main serviceSchema before returning
+      // Validate the returned data against the schema (which transforms to match IService)
+      // Validate and transform the DB result using the final schema's parse method
+      return serviceSchema.parse(completeService);
     } catch (error) {
       log.error('[Service.create] Database error:', error);
       throw error;
@@ -178,8 +317,8 @@ const Service = {
   },
 
   update: async (service_id: string, serviceData: Partial<IService>): Promise<IService | null> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
+    const { knex: db, tenant } = await createTenantKnex();
+
     if (!tenant) {
       const error = new Error('Tenant context is required for updating service');
       log.error(`[Service.update] ${error.message}`);
@@ -187,34 +326,78 @@ const Service = {
     }
 
     try {
-      // Remove tenant from update data to prevent modification
-      const { tenant: _, ...updateData } = serviceData;
+      // Remove tenant and service_type_name from update data to prevent modification
+      // service_type_name is a virtual field from JOIN and doesn't exist in the table
+      const { tenant: _, service_type_name, ...updateData } = serviceData;
 
-      const [updatedService] = await db<IService>('service_catalog')
+      // Handle service type ID changes to ensure exactly one type ID is set
+      let finalUpdateData = { ...updateData };
+      
+      // If custom_service_type_id is being set, ensure standard_service_type_id is null
+      if ('custom_service_type_id' in updateData && updateData.custom_service_type_id) {
+        finalUpdateData.standard_service_type_id = null;
+        log.info(`[Service.update] Setting custom_service_type_id and clearing standard_service_type_id`);
+      }
+      
+      // If standard_service_type_id is being set, ensure custom_service_type_id is null
+      if ('standard_service_type_id' in updateData && updateData.standard_service_type_id) {
+        finalUpdateData.custom_service_type_id = null;
+        log.info(`[Service.update] Setting standard_service_type_id and clearing custom_service_type_id`);
+      }
+
+      // Ensure updateData conforms to Partial<IService> based on the *new* interface
+      // Zod validation could be added here too if needed for partial updates.
+      const [updatedServiceData] = await db<IService>('service_catalog')
         .where({
           service_id,
           tenant
         })
-        .update(updateData)
-        .returning([
-          'service_id',
-          'service_name',
-          'service_type_id', // Changed from service_type
-          'billing_method', // Added billing_method
-          db.raw('CAST(default_rate AS FLOAT) as default_rate'),
-          'unit_of_measure',
-          'category_id',
-          'is_taxable',
-          'tax_region',
-          'tenant'
-        ]);
+        .update(finalUpdateData) // Use finalUpdateData instead of updateData
+        .returning('*'); // Return all fields to validate against the schema
 
-      if (!updatedService) {
-        log.info(`[Service.update] No service found with ID: ${service_id} for tenant: ${tenant}`);
+      if (!updatedServiceData) {
+        log.info(`[Service.update] No service found with ID: ${service_id} or tenant mismatch`);
         return null;
       }
 
-      return validateData(serviceSchema, updatedService);
+      // After update, fetch the complete service with type name by joining with type tables
+      const completeService = await db('service_catalog as sc')
+        .where({
+          'sc.service_id': service_id,
+          'sc.tenant': tenant
+        })
+        .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+        .leftJoin('service_types as ct', function() {
+          this.on('sc.custom_service_type_id', '=', 'ct.id')
+              .andOn('ct.tenant_id', '=', db.raw('?', [tenant]));
+        })
+        .select(
+          'sc.service_id',
+          'sc.service_name',
+          'sc.standard_service_type_id',
+          'sc.custom_service_type_id',
+          'sc.billing_method',
+          db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
+          'sc.unit_of_measure',
+          'sc.category_id',
+          'sc.is_taxable',
+          'sc.tax_region',
+          'sc.description',
+          'sc.tenant',
+          // Select the service type name from either standard or custom type
+          db.raw('COALESCE(sst.name, ct.name) as service_type_name')
+        )
+        .first();
+
+      if (!completeService) {
+        log.info(`[Service.update] Failed to fetch complete service after update: ${service_id}`);
+        return null;
+      }
+
+      // Validate the result against the updated schema
+      // Validate the result against the schema (which transforms to match IService)
+      // Validate and transform the DB result using the final schema's parse method
+      return serviceSchema.parse(completeService);
     } catch (error) {
       log.error(`[Service.update] Error updating service ${service_id}:`, error);
       throw error;
@@ -222,8 +405,8 @@ const Service = {
   },
 
   delete: async (service_id: string): Promise<boolean> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
+    const { knex: db, tenant } = await createTenantKnex();
+
     if (!tenant) {
       const error = new Error('Tenant context is required for deleting service');
       log.error(`[Service.delete] ${error.message}`);
@@ -247,8 +430,8 @@ const Service = {
   },
 
   getByCategoryId: async (category_id: string): Promise<IService[]> => {
-    const {knex: db, tenant} = await createTenantKnex();
-    
+    const { knex: db, tenant } = await createTenantKnex();
+
     if (!tenant) {
       const error = new Error('Tenant context is required for fetching services by category');
       log.error(`[Service.getByCategoryId] ${error.message}`);
@@ -256,33 +439,43 @@ const Service = {
     }
 
     try {
-      const services = await db('service_catalog as sc') // Alias service_catalog as sc
-        .leftJoin('standard_service_types as sst', 'sc.service_type_id', 'sst.id') // Join standard types
-        .leftJoin('service_types as tst', function() { // Join tenant-specific types
-          this.on('sc.service_type_id', '=', 'tst.id')
-              .andOn('sc.tenant', '=', 'tst.tenant_id'); // Corrected column name
-        })
+      // Fetch services by category ID, joining with both standard and custom service types
+      const servicesData = await db('service_catalog as sc')
         .where({
-          'sc.category_id': category_id, // Use alias
-          'sc.tenant': tenant // Use alias
+          'sc.category_id': category_id,
+          'sc.tenant': tenant
+        })
+        .leftJoin('standard_service_types as sst', 'sc.standard_service_type_id', 'sst.id')
+        .leftJoin('service_types as ct', function() {
+          this.on('sc.custom_service_type_id', '=', 'ct.id')
+              .andOn('ct.tenant_id', '=', db.raw('?', [tenant]));
         })
         .select(
           'sc.service_id',
           'sc.service_name',
-          'sc.service_type_id',
-          db.raw('COALESCE(sst.name, tst.name) as service_type_name'), // Use COALESCE for name
-          'sst.billing_method as service_type_billing_method', // Keep billing method from standard for now
-          'sc.billing_method', // Keep the service's specific billing method too
+          'sc.standard_service_type_id',
+          'sc.custom_service_type_id',
+          'sc.billing_method',
           db.raw('CAST(sc.default_rate AS FLOAT) as default_rate'),
           'sc.unit_of_measure',
           'sc.category_id',
           'sc.is_taxable',
           'sc.tax_region',
-          'sc.tenant'
+          'sc.description',
+          'sc.tenant',
+          // Select the service type name from either standard or custom type
+          db.raw('COALESCE(sst.name, ct.name) as service_type_name')
         );
 
-      log.info(`[Service.getByCategoryId] Found ${services.length} services for category ${category_id}`);
-      return services.map(service => validateData(serviceSchema, service));
+      log.info(`[Service.getByCategoryId] Found ${servicesData.length} services for category ${category_id}`);
+      // Validate each service against the updated schema
+      // Validate each service against the schema (which transforms to match IService)
+      // Validate against the schema expecting nulls, then transform
+      // Validate against the schema expecting nulls, then transform
+      // Validate and transform using the final schema's parse method
+      return servicesData.map(service => {
+        return serviceSchema.parse(service);
+      });
     } catch (error) {
       log.error(`[Service.getByCategoryId] Error fetching services for category ${category_id}:`, error);
       throw error;

--- a/server/src/lib/utils/planDisambiguation.ts
+++ b/server/src/lib/utils/planDisambiguation.ts
@@ -71,7 +71,7 @@ export async function getEligibleBillingPlans(
       'service_catalog.service_id': serviceId,
       'service_catalog.tenant': tenant
     })
-    .first('category_id', 'service_type_id');
+    .first('category_id', knex.raw('COALESCE(standard_service_type_id, custom_service_type_id) as service_type_id'));
   
   if (!serviceInfo) {
     console.warn(`Service not found: ${serviceId}`);


### PR DESCRIPTION
- Added migrations to populate and enforce billing methods on service types:
  - `20250405231703_populate_enforce_billing_method_on_types.cjs`:
    - Populates billing_method on standard_service_types
    - Adds CHECK constraints for billing_method values
    - Migrates data to service_types table
  - `20250405231739_enforce_service_billing_method.cjs`:
    - Restructures service_catalog to use separate FKs for standard/custom types
    - Enforces billing method constraints
- Updated UI components to handle new billing method requirements:
  - FixedPlanServicesList.tsx: Filters services by billing method
  - QuickAddService.tsx: Supports standard/custom type selection
  - ServiceCatalogManager.tsx: Handles new type ID structure
  - ServiceForm.tsx: Updated for new type selection logic
- Enhanced service models and interfaces:
  - billing.interfaces.ts: Updated IService with new type fields
  - service.ts: Added schema validation for new structure
  - serviceType.ts: Simplified type fetching logic
- Updated reporting and other dependent components to work with new structure