### PR TITLE
fix: Service Type Editing, Catalog Management, Quick Add Improvements…

### DIFF
--- a/server/seeds/dev/23_service_catalog.cjs
+++ b/server/seeds/dev/23_service_catalog.cjs
@@ -89,7 +89,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Locating and tracking white rabbits',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
             billing_method: 'per_unit', // Add required billing_method
-            default_rate: 75.00,
+            default_rate: 7500,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Network Services' }).select('category_id').first()
         },
@@ -99,7 +99,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Cleaning and repairing magical mirrors',
             custom_service_type_id: typeMap['Fixed Price'], // Use fetched ID
             billing_method: 'fixed', // Add required billing_method
-            default_rate: 150.00,
+            default_rate: 15000,
             unit_of_measure: 'Service',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Security Services' }).select('category_id').first()
         },
@@ -109,7 +109,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Potion to reduce size',
             custom_service_type_id: typeMap['Usage Based'], // Use fetched ID
             billing_method: 'per_unit', // Add required billing_method
-            default_rate: 25.00,
+            default_rate: 2500,
             unit_of_measure: 'Dose',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Cloud Services' }).select('category_id').first()
         },
@@ -119,7 +119,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Fixing and maintaining the yellow brick road',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
             billing_method: 'per_unit', // Add required billing_method
-            default_rate: 100.00,
+            default_rate: 10000,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Network Services' }).select('category_id').first()
         },
@@ -129,7 +129,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: '24/7 magical security for Emerald City',
             custom_service_type_id: typeMap['Fixed Price'], // Use fetched ID
             billing_method: 'fixed', // Add required billing_method
-            default_rate: 5000.00,
+            default_rate: 500000,
             unit_of_measure: 'Month',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Security Services' }).select('category_id').first()
         },
@@ -139,7 +139,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Standard support package',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
             billing_method: 'per_unit', // Add required billing_method
-            default_rate: 100.00,
+            default_rate: 10000,
             unit_of_measure: 'Hour',
             tax_region: 'US-NY',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Support Services' }).select('category_id').first()
@@ -150,7 +150,7 @@ exports.seed = async function (knex) { // Changed to async function
             description: 'Premium support package with priority response',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
             billing_method: 'per_unit', // Add required billing_method
-            default_rate: 150.00,
+            default_rate: 15000,
             unit_of_measure: 'Hour',
             tax_region: 'US-NY',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Support Services' }).select('category_id').first() // Corrected tenant reference in subquery

--- a/server/src/components/billing-dashboard/ServiceCatalogManager.tsx
+++ b/server/src/components/billing-dashboard/ServiceCatalogManager.tsx
@@ -285,7 +285,11 @@ const ServiceCatalogManager: React.FC = () => {
             </DropdownMenuItem>
             <DropdownMenuItem
               id={`delete-service-${record.service_id}`}
-              onClick={() => handleDeleteService(record.service_id!)}
+              className="text-red-600 focus:text-red-600"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDeleteService(record.service_id!);
+              }}
             >
               Delete
             </DropdownMenuItem>

--- a/server/src/components/ui/SearchableSelect.tsx
+++ b/server/src/components/ui/SearchableSelect.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import React, { useState, useEffect, useMemo } from 'react';
+import { Command } from 'cmdk';
+import { Check, ChevronsUpDown, Search } from 'lucide-react';
+import { cn } from 'server/src/lib/utils';
+import { Button } from 'server/src/components/ui/Button';
+import { FormFieldComponent, AutomationProps } from '../../types/ui-reflection/types';
+import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SearchableSelectProps {
+  options: SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  label?: string;
+  /** Unique identifier for UI reflection system */
+  id?: string;
+  /** Whether the select is required */
+  required?: boolean;
+  /** Empty message to display when no options match the search */
+  emptyMessage?: string;
+}
+
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select...',
+  className = '',
+  disabled = false,
+  label,
+  id,
+  required = false,
+  emptyMessage = 'No results found',
+}: SearchableSelectProps & AutomationProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+
+  // Memoize the mapped options to prevent recreating on every render
+  const mappedOptions = useMemo(() => options.map((opt: SelectOption): { value: string; label: string } => ({
+    value: opt.value,
+    label: typeof opt.label === 'string' ? opt.label : 'Complex Label'
+  })), [options]);
+
+  const { automationIdProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
+    type: 'formField',
+    fieldType: 'select',
+    id: id,
+    label,
+    value: value || '',
+    disabled,
+    required,
+    options: mappedOptions
+  });
+
+  // Update metadata when field props change
+  useEffect(() => {
+    if (updateMetadata) {
+      updateMetadata({
+        value: value || '',
+        label,
+        disabled,
+        required,
+        options: mappedOptions
+      });
+    }
+  }, [value, disabled, label, required, mappedOptions, updateMetadata]);
+
+  // Filter options based on search
+  const filteredOptions = useMemo(() => {
+    if (!search) return options;
+    
+    const searchLower = search.toLowerCase();
+    return options.filter((option: SelectOption) => 
+      option.label.toString().toLowerCase().includes(searchLower)
+    );
+  }, [options, search]);
+
+  // Find the selected option label
+  const selectedOption = options.find((option: SelectOption) => option.value === value);
+
+  return (
+    <div className={label ? 'mb-4' : ''} id={id} data-automation-type="searchable-select">
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      
+      <div className="relative">
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-between",
+            disabled && "opacity-50 cursor-not-allowed",
+            className
+          )}
+          onClick={() => !disabled && setOpen(!open)}
+          disabled={disabled}
+          {...automationIdProps}
+        >
+          <span className="truncate">
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+        
+        {open && !disabled && (
+          <div className="absolute z-50 w-full mt-1">
+            <Command
+              className="rounded-md border border-gray-200 bg-white shadow-md overflow-hidden"
+              shouldFilter={false}
+            >
+              <div className="flex items-center border-b px-3 py-2">
+                <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                <Command.Input
+                  value={search}
+                  onValueChange={setSearch}
+                  className="flex h-9 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-gray-500"
+                  placeholder={`Search ${placeholder.toLowerCase()}...`}
+                />
+              </div>
+              <Command.List className="max-h-60 overflow-y-auto p-1">
+                {filteredOptions.length > 0 ? (
+                  filteredOptions.map((option: SelectOption) => (
+                    <Command.Item
+                      key={option.value}
+                      value={option.value}
+                      onSelect={() => {
+                        onChange(option.value);
+                        setOpen(false);
+                        setSearch('');
+                      }}
+                      className={cn(
+                        "flex items-center px-2 py-1.5 text-sm rounded-sm cursor-pointer",
+                        "hover:bg-gray-100",
+                        "aria-selected:bg-gray-100",
+                        value === option.value && "bg-gray-100"
+                      )}
+                    >
+                      <span className="flex-1">{option.label}</span>
+                      {value === option.value && (
+                        <Check className="w-4 h-4 text-primary-600" />
+                      )}
+                    </Command.Item>
+                  ))
+                ) : (
+                  <div className="py-6 text-center text-sm text-gray-500">
+                    {emptyMessage}
+                  </div>
+                )}
+              </Command.List>
+            </Command>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SearchableSelect;


### PR DESCRIPTION
…, and Seed Data Corrections

fix(service-settings): enable row click to edit service type

- Implemented `onRowClick` in `ServiceTypeSettings.tsx` to trigger edit dialog
- Added event propagation handling to prevent dropdown conflicts

fix(service-catalog): resolve delete dialog issues and styling

- Fixed delete action triggering edit dialog in `ServiceCatalogManager.tsx`
- Added red text styling to delete option per coding standards
- Ensured proper event propagation handling for dropdown actions

fix(quick-add-service): improve service type and unit selection

- Updated billing method sync when service type changes in `QuickAddService.tsx`
- Added "Hour" to unit dropdown presets in `UnitOfMeasureInput.tsx`
- Fixed custom unit input functionality with state management fixes
- Replaced `CustomSelect` with `SearchableSelect` for better usability

fix(seeds): correct pricing and service type data

- Updated seed data to store prices as cents in `23_service_catalog.cjs`
- Verified and normalized service type/billing method consistency

fix(service-type): improve delete error handling

- Enhanced error messages for service type deletion failures
- Added pre-deletion checks for usage in services

Components modified:
- server/src/components/settings/billing/ServiceTypeSettings.tsx
- server/src/components/billing-dashboard/ServiceCatalogManager.tsx
- server/src/components/billing-dashboard/QuickAddService.tsx
- server/src/components/ui/UnitOfMeasureInput.tsx
- server/seeds/dev/23_service_catalog.cjs
- server/src/lib/actions/serviceActions.ts