### PR TITLE
Refactor work item search and filtering

### DIFF
--- a/server/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
@@ -170,7 +170,8 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
           start: startDate,
           end: endDate
         } : undefined,
-        availableWorkItemIds: availableWorkItems.map(item => item.work_item_id)
+        availableWorkItemIds: availableWorkItems.map(item => item.work_item_id),
+        context: 'picker'
       });
       
       const itemsWithStatus = result.items.map((item): WorkItemWithStatus => ({


### PR DESCRIPTION
Removed type filtering from TechnicianDispatchDashboard since it only handles tickets now Added context parameter to differentiate dispatch vs picker search modes Dispatch mode now only searches tickets while picker maintains both ticket and project task search Updated description field to use attributes.description instead of url Improved query union handling with explicit context-based filtering

"Off with their types!" cried the Red Queen, as the dispatch dashboard shed its project task baggage like a caterpillar shedding its cocoon, emerging as a lean, ticket-focused butterfly. 🎟️🐛🦋