### PR TITLE
Added private scheduling functionality with visibility controls

### DIFF
--- a/server/migrations/20250515104157_add_private_flag_to_schedule_entries.cjs
+++ b/server/migrations/20250515104157_add_private_flag_to_schedule_entries.cjs
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('schedule_entries', function(table) {
+    table.boolean('is_private').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('schedule_entries', function(table) {
+    table.dropColumn('is_private');
+  });
+};

--- a/server/src/components/technician-dispatch/WeeklyScheduleEvent.tsx
+++ b/server/src/components/technician-dispatch/WeeklyScheduleEvent.tsx
@@ -137,8 +137,15 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
   const formattedDate = startMoment.toLocaleDateString();
   const formattedTime = `${startMoment.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - ${endMoment.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 
-  // Construct detailed tooltip
-  const tooltipTitle = `${event.title}\nAssigned to: ${assignedTechnicians}\nDate: ${formattedDate}\nTime: ${formattedTime}`;
+  // Check if this is a private event that the user doesn't own
+  const isPrivateEvent = event.is_private;
+  const isCreator = isPrimary && event.assigned_user_ids?.length === 1;
+  const isPrivateNonOwner = isPrivateEvent && !isCreator;
+  
+  // Construct detailed tooltip - show limited info for private events
+  const tooltipTitle = isPrivateNonOwner
+    ? `Busy\nDate: ${formattedDate}\nTime: ${formattedTime}`
+    : `${event.title}\nAssigned to: ${assignedTechnicians}\nDate: ${formattedDate}\nTime: ${formattedTime}`;
 
   return (
     <div
@@ -164,8 +171,8 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
       }}
       tabIndex={-1}
     >
-      {/* Top resize handle */}
-      {onResizeStart && (
+      {/* Top resize handle - only show if not a private event or user is creator */}
+      {onResizeStart && !isPrivateNonOwner && (
         <div
           className="absolute top-0 left-0 right-0 h-1 bg-[rgb(var(--color-border-300))] cursor-ns-resize rounded-t resize-handle"
           style={{ zIndex: 150 }}
@@ -176,8 +183,8 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
         ></div>
       )}
       
-      {/* Bottom resize handle */}
-      {onResizeStart && (
+      {/* Bottom resize handle - only show if not a private event or user is creator */}
+      {onResizeStart && !isPrivateNonOwner && (
         <div
           className="absolute bottom-0 left-0 right-0 h-1 bg-[rgb(var(--color-border-300))] cursor-ns-resize rounded-b resize-handle"
           style={{ zIndex: 150 }}
@@ -187,10 +194,10 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
           }}
         ></div>
       )}
-      {/* Buttons container */}
+      {/* Buttons container - only show if not a private event or user is creator */}
       <div className="flex justify-end gap-1 mt-0.5" style={{ zIndex: 200 }}>
-          {/* Show individual buttons if not narrow */}
-          {!isNarrow && (
+          {/* Show individual buttons if not narrow and not a private event or user is creator */}
+          {!isNarrow && !isPrivateNonOwner && (
             <div className="flex gap-1">
               <Button
                 id={`view-details-${event.entry_id}`}
@@ -218,8 +225,8 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
             </div>
           )}
 
-          {/* Show dropdown menu if narrow */}
-          {isNarrow && (
+          {/* Show dropdown menu if narrow and not a private event or user is creator */}
+          {isNarrow && !isPrivateNonOwner && (
             <div>
               <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
                 <DropdownMenuTrigger asChild>
@@ -274,8 +281,13 @@ const WeeklyScheduleEvent: React.FC<WeeklyScheduleEventProps> = ({
           )}
         </div>
 
-      <div className="font-semibold truncate">{event.title?.split(':')[0] || 'Untitled'}</div>
-      <div className="truncate text-xs">{event.title?.split(':').slice(1).join(':').trim() || ''}</div>
+      {/* Event content - show limited info for private events */}
+      <div className="font-semibold truncate">
+        {isPrivateNonOwner ? "Busy" : (event.title?.split(':')[0] || 'Untitled')}
+      </div>
+      <div className="truncate text-xs">
+        {isPrivateNonOwner ? "" : (event.title?.split(':').slice(1).join(':').trim() || '')}
+      </div>
 
       {/* Confirmation Dialog for Delete */}
       <ConfirmationDialog

--- a/server/src/components/technician-dispatch/WeeklyTechnicianScheduleGrid.tsx
+++ b/server/src/components/technician-dispatch/WeeklyTechnicianScheduleGrid.tsx
@@ -416,8 +416,21 @@ const WeeklyTechnicianScheduleGrid: React.FC<WeeklyTechnicianScheduleGridProps> 
 
   const draggableAccessor = useCallback((event: object) => {
     const scheduleEvent = event as IScheduleEntry;
-    return primaryTechnicianId !== null && 
-           scheduleEvent?.assigned_user_ids && 
+    
+    // Check if the event is private and the user is not the creator
+    const isPrivateEvent = scheduleEvent.is_private;
+    const isCreator = primaryTechnicianId !== null &&
+                     scheduleEvent?.assigned_user_ids &&
+                     scheduleEvent.assigned_user_ids.length === 1 &&
+                     scheduleEvent.assigned_user_ids[0] === primaryTechnicianId;
+    
+    // If the event is private and the user is not the creator, it cannot be dragged
+    if (isPrivateEvent && !isCreator) {
+      return false;
+    }
+    
+    return primaryTechnicianId !== null &&
+           scheduleEvent?.assigned_user_ids &&
            scheduleEvent.assigned_user_ids.includes(primaryTechnicianId);
   }, [primaryTechnicianId]);
 

--- a/server/src/components/ui/DateTimePicker.tsx
+++ b/server/src/components/ui/DateTimePicker.tsx
@@ -155,7 +155,7 @@ export const DateTimePicker = React.forwardRef<HTMLDivElement, DateTimePickerPro
             disabled={disabled}
             aria-label={label || placeholder}
             className={`
-              flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm
+              flex h-10 w-full min-w-[200px] rounded-md border border-gray-300 bg-white px-3 py-2 text-sm
               file:border-0 file:bg-transparent file:text-sm file:font-medium 
               placeholder:text-gray-500
               hover:border-gray-400
@@ -164,7 +164,7 @@ export const DateTimePicker = React.forwardRef<HTMLDivElement, DateTimePickerPro
               ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
             `}
           >
-            <span className="flex-1 text-left">{displayValue}</span>
+            <span className="flex-1 text-left truncate">{displayValue}</span>
             <div className="flex gap-2">
               <Clock className="h-4 w-4 opacity-50" />
             </div>

--- a/server/src/interfaces/schedule.interfaces.ts
+++ b/server/src/interfaces/schedule.interfaces.ts
@@ -37,6 +37,7 @@ export interface IScheduleEntry extends TenantEntity {
   is_recurring?: boolean;
   original_entry_id?: string;
   updateType?: IEditScope;
+  is_private?: boolean;
 }
 
 export interface IResource extends TenantEntity {

--- a/server/src/lib/models/scheduleEntry.ts
+++ b/server/src/lib/models/scheduleEntry.ts
@@ -265,7 +265,8 @@ class ScheduleEntry {
         recurrence_pattern: (entry.recurrence_pattern && typeof entry.recurrence_pattern === 'object' && Object.keys(entry.recurrence_pattern).length > 0)
           ? JSON.stringify(entry.recurrence_pattern)
           : null,
-        is_recurring: !!(entry.recurrence_pattern && typeof entry.recurrence_pattern === 'object' && Object.keys(entry.recurrence_pattern).length > 0)
+        is_recurring: !!(entry.recurrence_pattern && typeof entry.recurrence_pattern === 'object' && Object.keys(entry.recurrence_pattern).length > 0),
+        is_private: entry.is_private || false
       };
 
       console.log('Creating schedule entry:', entryData);
@@ -748,6 +749,7 @@ class ScheduleEntry {
       if (entry.status !== undefined) updateData.status = entry.status;
       if (entry.work_item_id !== undefined) updateData.work_item_id = entry.work_item_id;
       if (entry.work_item_type !== undefined) updateData.work_item_type = entry.work_item_type;
+      if (entry.is_private !== undefined) updateData.is_private = entry.is_private;
       if (entry.recurrence_pattern !== undefined) {
         // Only stringify if it's a valid recurrence pattern object
         if (entry.work_item_type !== undefined) updateData.work_item_type = entry.work_item_type;
@@ -810,6 +812,7 @@ class ScheduleEntry {
           scheduled_end: entry.scheduled_end || originalEntry.scheduled_end,
           is_recurring: true,
           original_entry_id: masterEntryId,
+          is_private: entry.is_private !== undefined ? entry.is_private : originalEntry.is_private,
           // Use provided assigned users or inherit from master
           assigned_user_ids: entry.assigned_user_ids || assignedUserIds[masterEntryId] || []
         };


### PR DESCRIPTION
- Added is_private flag to schedule entries with database migration
- Implemented private entry visibility rules across all schedule components
- Restricted editing/deletion of private entries to creators only
- Show "Busy" placeholder for private entries viewed by others
- Added private toggle switch in EntryPopup (visible only for self-assigned entries)
- Updated schedule actions to enforce private entry permissions

Impacts:

- Affects all schedule views and entry management
- Changes IScheduleEntry interface and database schema
- Modifies permission checks in scheduleActions
- Updates display logic across multiple components

"Private parties require private calendars," declared the Cheshire Cat, vanishing all but the approved guests from view 🎩🐱👤