### PR TITLE
Refactor loading indicators to use consistent UI components

### DIFF
--- a/server/src/components/billing-dashboard/EditPlanServiceQuantityDialog.tsx
+++ b/server/src/components/billing-dashboard/EditPlanServiceQuantityDialog.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Label } from '../ui/Label';
-import { Loader2 } from 'lucide-react'; // For loading spinner
+import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 
 export interface EditPlanServiceQuantityDialogProps {
   isOpen: boolean;
@@ -159,8 +159,7 @@ export function EditPlanServiceQuantityDialog({
           >
             {isSaving ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving...
+                <LoadingIndicator spinnerProps={{ size: "xs" }} text="Saving..." className="mr-2" />
               </>
             ) : (
               'Save Quantity'

--- a/server/src/components/billing-dashboard/FixedPlanServicesList.tsx
+++ b/server/src/components/billing-dashboard/FixedPlanServicesList.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Card, Box } from '@radix-ui/themes';
 import { Button } from 'server/src/components/ui/Button';
-import { Plus, MoreVertical, Loader2, HelpCircle } from 'lucide-react'; // Added Loader2, HelpCircle
+import { Plus, MoreVertical, HelpCircle } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/
 import { Switch } from 'server/src/components/ui/Switch';
 import CustomSelect from 'server/src/components/ui/CustomSelect';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
-import { AlertCircle, Loader2 } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 import { Button } from 'server/src/components/ui/Button';
 import Spinner from 'server/src/components/ui/Spinner';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';

--- a/server/src/components/billing-dashboard/billing-plans/PlanTypeRouter.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/PlanTypeRouter.tsx
@@ -2,7 +2,8 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import { getBillingPlanById } from 'server/src/lib/actions/billingPlanAction';
 import { IBillingPlan } from 'server/src/interfaces/billing.interfaces';
@@ -45,7 +46,7 @@ export function PlanTypeRouter({ planId }: PlanTypeRouterProps) {
   }, [fetchPlanType]);
 
   if (loading) {
-    return <div className="flex justify-center items-center p-8"><Loader2 className="h-8 w-8 animate-spin" /> Loading Plan...</div>;
+    return <div className="flex justify-center items-center p-8"><LoadingIndicator spinnerProps={{ size: "sm" }} text="Loading Plan..." /></div>;
   }
 
   if (error) {

--- a/server/src/components/ui/EntityAvatar.tsx
+++ b/server/src/components/ui/EntityAvatar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { generateEntityColor } from 'server/src/utils/colorUtils';
 import { cn } from 'server/src/lib/utils';
-import { Loader2 } from 'lucide-react';
+import Spinner from 'server/src/components/ui/Spinner';
 
 export type EntityAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number;
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
@@ -137,7 +137,7 @@ export const EntityAvatar: React.FC<EntityAvatarProps> = ({
           {/* Loading shimmer effect */}
           {showShimmer && (
             <div className="absolute inset-0 flex items-center justify-center bg-gray-100 animate-pulse rounded-full overflow-hidden">
-              <Loader2 className="h-1/3 w-1/3 text-gray-400 animate-spin opacity-70" />
+              <Spinner size="xs" className="opacity-70" />
             </div>
           )}
           

--- a/server/src/components/ui/EntityImageUpload.tsx
+++ b/server/src/components/ui/EntityImageUpload.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useState, useRef, useTransition } from 'react';
 import { toast } from 'react-hot-toast';
-import { Pen, Loader2, Trash2, Upload } from 'lucide-react';
+import { Pen, Trash2, Upload } from 'lucide-react';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 import { Button } from 'server/src/components/ui/Button';
 import UserAvatar from 'server/src/components/ui/UserAvatar';
@@ -289,7 +289,7 @@ const EntityImageUpload: React.FC<EntityImageUploadProps> = ({
                   className="w-fit"
                   data-automation-id={`delete-${entityType}-image-button`}
                 >
-                  {isPendingDelete ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+                  {isPendingDelete ? <LoadingIndicator spinnerProps={{ size: "xs" }} text="Deleting..." className="mr-2" /> : <Trash2 className="mr-2 h-4 w-4" />}
                   Delete
                 </Button>
               )}

--- a/server/src/components/user-activities/ActivityDetailViewerDrawer.tsx
+++ b/server/src/components/user-activities/ActivityDetailViewerDrawer.tsx
@@ -8,7 +8,8 @@ import { useDrawer } from "server/src/context/DrawerContext";
 import { useActivitiesCache } from "server/src/hooks/useActivitiesCache";
 import { getConsolidatedTicketData } from "server/src/lib/actions/ticket-actions/optimizedTicketActions";
 import { useTenant } from "server/src/components/TenantProvider";
-import { Loader2, AlertCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import Spinner from 'server/src/components/ui/Spinner';
 import { getTicketById } from "server/src/lib/actions/ticket-actions/ticketActions";
 import { getTaskWithDetails } from "server/src/lib/actions/project-actions/projectTaskActions";
 import { getTaskDetails } from "server/src/lib/actions/workflow-actions/taskInboxActions";
@@ -381,7 +382,7 @@ export function ActivityDetailViewerDrawer({
     if (isLoading) {
       return (
         <div className="flex items-center justify-center h-full">
-          <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+          <Spinner size="sm" />
         </div>
       );
     }


### PR DESCRIPTION
Replaced various Lucide Loader2 spinners with centralized LoadingIndicator and Spinner components Updated loading states in billing dashboard components (EditPlanServiceQuantityDialog, FixedPlanServicesList, PlanTypeRouter) Standardized loading indicators in UI components (EntityAvatar, EntityImageUpload) Improved ActivityDetailViewerDrawer loading state with new Spinner component Impacts:

More consistent loading UI across the application
Easier to modify loading indicators globally
Reduced direct dependency on Lucide icons

There's a couple that slipped through my thrift last time, but most spinners now dance to the same tune. 🎩♫🌀