### PR TITLE
Add version tag triggers and dynamic Docker tagging to publish workflow

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -11,10 +11,15 @@ on:
       - main
     workflows: ["E2E Fresh Install Tests"]    # must match the name: of your test workflow
     types: [ completed ]
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v1.2.3-alpha
+  create:
+    tags: ['v*.*.*']
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -95,12 +100,30 @@ jobs:
         id: sha
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
 
+      - name: Determine Docker tags
+        id: docker_tags
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            # This is a tag push event: use only the tag name
+            TAGS="ghcr.io/nine-minds/alga-psa:${{ github.ref_name }}"
+          elif [[ "${{ github.event_name }}" == "create" && "${{ github.event.ref_type }}" == "tag" ]]; then
+            # This is a tag create event: use the tag name
+            TAGS="ghcr.io/nine-minds/alga-psa:${{ github.event.ref }}"
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # This is a workflow_run event (e.g., after PR merge to main): use latest and short SHA
+            TAGS="ghcr.io/nine-minds/alga-psa:latest,ghcr.io/nine-minds/alga-psa:${{ steps.sha.outputs.short_sha }}"
+          else
+            # Should not happen due to job's `if` condition, but good to have a fallback
+            echo "::error:: Unknown event (${{ github.event_name }}) or condition for determining Docker tags."
+            exit 1
+          fi
+          echo "tags_list=$TAGS" >> $GITHUB_OUTPUT
+          echo "Determined tags: $TAGS"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile.prod
           push: true
-          tags: |
-            ghcr.io/nine-minds/alga-psa:latest
-            ghcr.io/nine-minds/alga-psa:${{ steps.sha.outputs.short_sha }}
+          tags: ${{ steps.docker_tags.outputs.tags_list }}


### PR DESCRIPTION
- Added push/create triggers for version tags (v*.*.*)
- Modified publish job condition to handle multiple event types
- Implemented dynamic Docker tag determination based on event type
- Consolidated tag output into single step

Impact: More flexible publishing options for both CI and manual version releases.

Like a mad scientist's experiment, these tags shall now multiply uncontrollably! May the version gods have mercy on our CI pipeline! 🧪🔖🤪