### PR TITLE
Fix workflow task UUID type casting in activity aggregation

### DIFF
--- a/server/src/lib/actions/activity-actions/activityAggregationActions.ts
+++ b/server/src/lib/actions/activity-actions/activityAggregationActions.ts
@@ -666,7 +666,7 @@ export async function fetchWorkflowTaskActivities(
         "we.status as execution_status"
       )
       .leftJoin("workflow_executions as we", function() {
-        this.on(db.raw("wt.execution_id::text = we.execution_id::text"))
+        this.on(db.raw("wt.execution_id::uuid = we.execution_id"))
             .andOn(db.raw("wt.tenant = we.tenant"));
       })
       .where("wt.tenant", tenant)


### PR DESCRIPTION
## Summary
- Fixed UUID type casting issue in workflow task activity aggregation query

## Changes Made
- Changed `execution_id::text = we.execution_id::text` to `execution_id::uuid = we.execution_id` for proper type matching
- Ensures consistent UUID comparison without unnecessary string conversion

## Issues Resolved
- Fixes potential type mismatch issues in workflow task queries
- Improves query performance by using proper UUID comparison

## Test Plan
- [x] Workflow task activity queries work correctly
- [x] No type casting errors in database operations

🤖 Generated with [Claude Code](https://claude.ai/code)