### PR TITLE
Fix workflow task query performance by removing unnecessary type casting

### DIFF
--- a/server/src/lib/actions/activity-actions/activityAggregationActions.ts
+++ b/server/src/lib/actions/activity-actions/activityAggregationActions.ts
@@ -666,8 +666,8 @@ export async function fetchWorkflowTaskActivities(
         "we.status as execution_status"
       )
       .leftJoin("workflow_executions as we", function() {
-        this.on(db.raw("wt.execution_id::text = we.execution_id::text"))
-            .andOn(db.raw("wt.tenant = we.tenant"));
+        this.on("wt.execution_id", "we.execution_id")
+            .andOn("wt.tenant", "we.tenant");
       })
       .where("wt.tenant", tenant)
       .modify(function(queryBuilder) {


### PR DESCRIPTION
## Summary

Optimizes the database query performance in `fetchWorkflowTaskActivities` by removing unnecessary type casting in the workflow executions join.

## Changes

- Remove `db.raw("wt.execution_id::text = we.execution_id::text")` type casting
- Replace with direct column comparison `"wt.execution_id", "we.execution_id"`
- Remove `db.raw("wt.tenant = we.tenant")` and use direct comparison

## Performance Impact

The explicit `::text` casting is unnecessary since both `execution_id` columns are UUIDs. This change:

- **Improves query performance** by allowing the database to use indexes more efficiently
- **Reduces query complexity** by eliminating unnecessary type conversions
- **Maintains functionality** since the join logic remains identical

## Test Plan

- [x] Verify workflow task activities still load correctly
- [x] Confirm join results are identical to previous behavior
- [x] Check for any performance improvements in activity aggregation queries

🤖 Generated with [Claude Code](https://claude.ai/code)