### PR TITLE
Fix external entity mapping unique constraint logic

### DIFF
--- a/server/migrations/20250522184453_fix_external_mapping_unique_constraint.cjs
+++ b/server/migrations/20250522184453_fix_external_mapping_unique_constraint.cjs
@@ -1,0 +1,23 @@
+exports.up = async function(knex) {
+  // Drop the existing incorrect unique constraint
+  // This constraint prevents multiple Alga services from mapping to the same QuickBooks product
+  await knex.raw('DROP INDEX IF EXISTS idx_unique_external_mapping;');
+  
+  // Create the correct unique constraint that ensures each Alga entity can only be mapped once
+  // but allows multiple Alga entities to map to the same external entity
+  await knex.raw(`
+    CREATE UNIQUE INDEX idx_unique_alga_entity_mapping 
+    ON tenant_external_entity_mappings (tenant, integration_type, alga_entity_type, alga_entity_id, COALESCE(external_realm_id, ''));
+  `);
+};
+
+exports.down = async function(knex) {
+  // Drop the new constraint
+  await knex.raw('DROP INDEX IF EXISTS idx_unique_alga_entity_mapping;');
+  
+  // Recreate the old (incorrect) constraint for rollback
+  await knex.raw(`
+    CREATE UNIQUE INDEX idx_unique_external_mapping 
+    ON tenant_external_entity_mappings (tenant, integration_type, external_entity_id, COALESCE(external_realm_id, ''));
+  `);
+};


### PR DESCRIPTION
## Summary

Fixes the unique constraint logic for external entity mappings to allow proper many-to-one relationships between Alga entities and external system entities (like QuickBooks products).

## Problem

The current unique constraint prevents multiple Alga services from mapping to the same QuickBooks product:
```sql
-- INCORRECT: Prevents multiple Alga products → same QB product
UNIQUE (tenant, integration_type, external_entity_id, external_realm_id)
```

This is incorrect business logic. Multiple Alga products should be able to map to the same external product.

## Solution

Replace with a constraint that ensures each Alga entity can only have one external mapping:
```sql
-- CORRECT: Prevents duplicate mappings for the same Alga entity
UNIQUE (tenant, integration_type, alga_entity_type, alga_entity_id, external_realm_id)
```

## Business Logic Impact

### Before (Incorrect)
- ❌ Alga Product A → QB Product 1 ✓
- ❌ Alga Product B → QB Product 1 ✗ (blocked by constraint)

### After (Correct)  
- ✅ Alga Product A → QB Product 1 ✓
- ✅ Alga Product B → QB Product 1 ✓ (allowed many-to-one)
- ❌ Alga Product A → QB Product 2 ✗ (blocked, prevents duplicates)

## Migration Details

- **Up**: Drops old constraint, creates new correct constraint
- **Down**: Drops new constraint, recreates old constraint for rollback safety
- **Safe**: Uses `IF EXISTS` clauses to handle missing constraints gracefully

## Test Plan

- [x] Verify migration runs successfully
- [x] Test multiple Alga products can map to same QB product
- [x] Test same Alga product cannot have multiple mappings
- [x] Verify rollback migration works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)