### PR TITLE
feat: implement proper form field naming and dialog hierarchy in UI reflection system

### DIFF
--- a/server/src/components/companies/QuickAddCompany.tsx
+++ b/server/src/components/companies/QuickAddCompany.tsx
@@ -19,9 +19,6 @@ import UserPicker from 'server/src/components/ui/UserPicker';
 import { getAllUsers } from 'server/src/lib/actions/user-actions/userActions';
 import { createCompany } from 'server/src/lib/actions/companyActions';
 import toast from 'react-hot-toast';
-import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
-import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
-import { DialogComponent, FormFieldComponent, ButtonComponent } from 'server/src/types/ui-reflection/types';
 
 type CreateCompanyData = Omit<ICompany, "company_id" | "created_at" | "updated_at" | "notes_document_id" | "status" | "tenant" | "deleted_at" | "address">;
 
@@ -64,138 +61,18 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Register key form elements for UI reflection with explicit parent
-  const dialogId = 'quick-add-company-dialog-dialog';
-  
-  const { automationIdProps: companyNameProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'company-name-input',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Company Name',
-    value: formData.company_name,
-    required: true,
-    parentId: dialogId,
-    helperText: "Name of the company or client"
-  });
 
-  const { automationIdProps: submitButtonProps } = useAutomationIdAndRegister<ButtonComponent>({
-    id: 'create-company-btn',
-    type: 'button',
-    label: 'Create Client',
-    variant: 'default',
-    parentId: dialogId,
-    helperText: "Submit the form to create the company"
-  });
 
-  // Register all form fields for UI reflection
-  const { automationIdProps: clientTypeProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'client_type_select',
-    type: 'formField',
-    fieldType: 'select',
-    label: 'Client Type',
-    value: formData.client_type,
-    parentId: dialogId,
-    helperText: "Type of client (Company or Individual)"
-  });
 
-  const { automationIdProps: phoneProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'phone_no',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Phone Number',
-    value: formData.phone_no,
-    parentId: dialogId,
-    helperText: "Phone number for the company"
-  });
 
-  const { automationIdProps: emailProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'email',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Email',
-    value: formData.email,
-    parentId: dialogId,
-    helperText: "Email address for the company"
-  });
 
-  const { automationIdProps: urlProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'url',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Website URL',
-    value: formData.url,
-    parentId: dialogId,
-    helperText: "Company website URL"
-  });
 
-  const { automationIdProps: industryProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'industry',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Industry',
-    value: formData.properties?.industry || '',
-    parentId: dialogId,
-    helperText: "Industry or business sector"
-  });
 
-  const { automationIdProps: companySizeProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'company_size',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Company Size',
-    value: formData.properties?.company_size || '',
-    parentId: dialogId,
-    helperText: "Number of employees or company size"
-  });
 
-  const { automationIdProps: annualRevenueProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'annual_revenue',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Annual Revenue',
-    value: formData.properties?.annual_revenue || '',
-    parentId: dialogId,
-    helperText: "Expected annual revenue"
-  });
 
-  const { automationIdProps: accountManagerProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'account_manager_picker',
-    type: 'formField',
-    fieldType: 'select',
-    label: 'Account Manager',
-    value: formData.account_manager_id || '',
-    parentId: dialogId,
-    helperText: "Select the account manager for this company"
-  });
 
-  const { automationIdProps: billingCycleProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'billing_cycle',
-    type: 'formField',
-    fieldType: 'select',
-    label: 'Billing Cycle',
-    value: formData.billing_cycle,
-    parentId: dialogId,
-    helperText: "How often the company is billed"
-  });
 
-  const { automationIdProps: notesProps } = useAutomationIdAndRegister<FormFieldComponent>({
-    id: 'notes',
-    type: 'formField',
-    fieldType: 'textField',
-    label: 'Notes',
-    value: formData.notes,
-    parentId: dialogId,
-    helperText: "Additional notes about the company"
-  });
 
-  const { automationIdProps: cancelButtonProps } = useAutomationIdAndRegister<ButtonComponent>({
-    id: 'cancel-quick-add-company-btn',
-    type: 'button',
-    label: 'Cancel',
-    variant: 'outline',
-    parentId: dialogId,
-    helperText: "Cancel company creation"
-  });
 
   useEffect(() => {
     if (open) {
@@ -292,7 +169,7 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
             <div>
               <Label htmlFor="company_name">Company Name *</Label>
               <Input
-                {...companyNameProps}
+                data-automation-id="company-name-input"
                 value={formData.company_name}
                 onChange={(e) => handleChange('company_name', e.target.value)}
                 required
@@ -300,9 +177,10 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               />
             </div>
 
-            <div {...clientTypeProps}>
+            <div>
               <Label htmlFor="client_type_select">Client Type</Label>
               <CustomSelect
+                data-automation-id="client_type_select"
                 options={[
                   { value: 'company', label: 'Company' },
                   { value: 'individual', label: 'Individual' }
@@ -313,9 +191,10 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               />
             </div>
 
-            <div {...accountManagerProps}>
+            <div>
               <Label htmlFor="account_manager_picker">Account Manager</Label>
               <UserPicker
+                data-automation-id="account_manager_picker"
                 value={formData.account_manager_id || ''}
                 onValueChange={(value) => handleChange('account_manager_id', value)}
                 users={internalUsers}
@@ -325,18 +204,20 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               />
             </div>
 
-            <div {...phoneProps}>
+            <div>
               <Label htmlFor="phone_no">Phone Number</Label>
               <Input
+                data-automation-id="phone_no"
                 value={formData.phone_no}
                 onChange={(e) => handleChange('phone_no', e.target.value)}
                 disabled={isSubmitting}
               />
             </div>
 
-            <div {...emailProps}>
+            <div>
               <Label htmlFor="email">Email</Label>
               <Input
+                data-automation-id="email"
                 type="email"
                 value={formData.email}
                 onChange={(e) => handleChange('email', e.target.value)}
@@ -344,9 +225,10 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               />
             </div>
 
-            <div {...urlProps}>
+            <div>
               <Label htmlFor="url">Website URL</Label>
               <Input
+                data-automation-id="url"
                 value={formData.url}
                 onChange={(e) => handleChange('url', e.target.value)}
                 placeholder="https://example.com"
@@ -357,36 +239,40 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               </p>
             </div>
 
-            <div {...industryProps}>
+            <div>
               <Label htmlFor="industry">Industry</Label>
               <Input
+                data-automation-id="industry"
                 value={formData.properties?.industry || ''}
                 onChange={(e) => handleChange('properties.industry', e.target.value)}
                 disabled={isSubmitting}
               />
             </div>
 
-            <div {...companySizeProps}>
+            <div>
               <Label htmlFor="company_size">Company Size</Label>
               <Input
+                data-automation-id="company_size"
                 value={formData.properties?.company_size || ''}
                 onChange={(e) => handleChange('properties.company_size', e.target.value)}
                 disabled={isSubmitting}
               />
             </div>
 
-            <div {...annualRevenueProps}>
+            <div>
               <Label htmlFor="annual_revenue">Annual Revenue</Label>
               <Input
+                data-automation-id="annual_revenue"
                 value={formData.properties?.annual_revenue || ''}
                 onChange={(e) => handleChange('properties.annual_revenue', e.target.value)}
                 disabled={isSubmitting}
               />
             </div>
 
-            <div {...billingCycleProps}>
+            <div>
               <Label htmlFor="billing_cycle">Billing Cycle</Label>
               <CustomSelect
+                data-automation-id="billing_cycle"
                 options={[
                   { value: 'weekly', label: 'Weekly' },
                   { value: 'bi-weekly', label: 'Bi-Weekly' },
@@ -401,9 +287,10 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
               />
             </div>
 
-            <div {...notesProps}>
+            <div>
               <Label htmlFor="notes">Notes</Label>
               <TextArea
+                data-automation-id="notes"
                 value={formData.notes}
                 onChange={(e) => handleChange('notes', e.target.value)}
                 placeholder="Add any initial notes (optional)"
@@ -415,14 +302,14 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
 
         <DialogFooter>
             <Button
-              {...cancelButtonProps}
+              id="cancel-quick-add-company-btn"
               type="button"
               variant="outline"
               disabled={isSubmitting}
               onClick={() => onOpenChange(false)}
             >Cancel</Button>
           <Button
-            {...submitButtonProps}
+            id="create-company-btn"
             type="submit"
             form="quick-add-company-form"
             disabled={isSubmitting || !formData.company_name}

--- a/server/src/components/ui/CustomSelect.tsx
+++ b/server/src/components/ui/CustomSelect.tsx
@@ -46,8 +46,10 @@ const CustomSelect: React.FC<CustomSelectProps & AutomationProps> = ({
   label,
   id,
   "data-automation-type": dataAutomationType = 'select',
+  "data-automation-id": dataAutomationId,
   required = false,
   allowClear = false, // Added default value
+  ...props
 }): JSX.Element => {
   // Register with UI reflection system if id is provided
   // Memoize the mapped options to prevent recreating on every render
@@ -57,16 +59,20 @@ const CustomSelect: React.FC<CustomSelectProps & AutomationProps> = ({
   })), [options]);
   
   
+  // Use provided data-automation-id or register normally
   const { automationIdProps: selectProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
     type: 'formField',
     fieldType: 'select',
-    id: id,
+    id,
     label,
     value: value || '',
     disabled,
     required,
     options: mappedOptions
-  });
+  }, true, dataAutomationId);
+  
+  // Always use the generated automation props (which include our override ID if provided)
+  const finalAutomationProps = { ...selectProps, ...props };
 
   // Update metadata when field props change - intentionally omitting updateMetadata from deps
   useEffect(() => {
@@ -106,6 +112,7 @@ const CustomSelect: React.FC<CustomSelectProps & AutomationProps> = ({
         required={required}
       >
         <RadixSelect.Trigger
+          {...finalAutomationProps}
           className={`
             inline-flex items-center justify-between
             rounded-lg p-2 h-10

--- a/server/src/components/ui/Dialog.tsx
+++ b/server/src/components/ui/Dialog.tsx
@@ -2,11 +2,9 @@
 import React, { ReactNode, useEffect } from 'react';
 import * as RadixDialog from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
-import { useRegisterUIComponent } from '../../types/ui-reflection/useRegisterUIComponent';
 import { ReflectionParentContext } from '../../types/ui-reflection/ReflectionParentContext';
 import { DialogComponent, AutomationProps } from '../../types/ui-reflection/types';
 import { withDataAutomationId } from '../../types/ui-reflection/withDataAutomationId';
-import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
 import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
 
 interface DialogProps {
@@ -41,14 +39,16 @@ export const Dialog: React.FC<DialogProps & AutomationProps> = ({ isOpen, onClos
     <RadixDialog.Root open={isOpen} onOpenChange={onClose}>
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <ReflectionContainer {...updateDialog}>
-          <RadixDialog.Content
-            className={`fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-lg p-6 w-full ${className || 'max-w-3xl'} z-50`}
-            onKeyDown={onKeyDown}
-            onOpenAutoFocus={onOpenAutoFocus}
-          >
+        <RadixDialog.Content
+          {...withDataAutomationId(updateDialog)}
+          className={`fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-lg p-6 w-full ${className || 'max-w-3xl'} z-50`}
+          onKeyDown={onKeyDown}
+          onOpenAutoFocus={onOpenAutoFocus}
+        >
               {title && <RadixDialog.Title className="text-xl font-semibold mb-4">{title}</RadixDialog.Title>}
-              {children}
+              <ReflectionParentContext.Provider value={updateDialog.id}>
+                {children}
+              </ReflectionParentContext.Provider>
             {!hideCloseButton && (
               <RadixDialog.Close asChild>
                 <button
@@ -60,7 +60,6 @@ export const Dialog: React.FC<DialogProps & AutomationProps> = ({ isOpen, onClos
               </RadixDialog.Close>
             )}
           </RadixDialog.Content>
-        </ReflectionContainer>
       </RadixDialog.Portal>
     </RadixDialog.Root>
   );

--- a/server/src/components/ui/Input.tsx
+++ b/server/src/components/ui/Input.tsx
@@ -28,6 +28,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps & AutomationProps>(
     disabled, 
     onChange,
     "data-automation-type": dataAutomationType = 'input',
+    "data-automation-id": dataAutomationId,
     ...props 
   }, forwardedRef) => {
     const inputRef = useRef<HTMLInputElement | null>(null);
@@ -46,11 +47,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps & AutomationProps>(
       [forwardedRef]
     );
 
+    // Use provided data-automation-id or register normally
     const { automationIdProps: textProps } = useAutomationIdAndRegister<FormFieldComponent>({
       id,
       type: 'formField',
       fieldType: 'textField'
-    });
+    }, true, dataAutomationId);
+    
+    // Always use the generated automation props (which include our override ID if provided)
+    const finalAutomationProps = textProps;
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!isComposing.current && preserveCursor) {
@@ -97,7 +102,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps & AutomationProps>(
           </label>
         )}
         <input
-          {...textProps}
+          {...finalAutomationProps}
           ref={(element) => {
             inputRef.current = element;
             handleRef(element);

--- a/server/src/components/ui/TextArea.tsx
+++ b/server/src/components/ui/TextArea.tsx
@@ -13,7 +13,7 @@ interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaEl
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps & AutomationProps>(
-  ({ label, onChange, className, value = '', id, disabled, required, ...props }, ref) => {
+  ({ label, onChange, className, value = '', id, disabled, required, "data-automation-id": dataAutomationId, ...props }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const combinedRef = (node: HTMLTextAreaElement) => {
       textareaRef.current = node;
@@ -64,7 +64,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps & Automati
       }
     }, [value]);
 
-    // Register with UI reflection system if id is provided
+    // Use provided data-automation-id or register normally
     const { automationIdProps: textAreaProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
       type: 'formField',
       fieldType: 'textField',
@@ -73,7 +73,10 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps & Automati
       value: typeof value === 'string' ? value : undefined,
       disabled,
       required
-    });
+    }, true, dataAutomationId);
+
+    // Always use the generated automation props (which include our override ID if provided)
+    const finalAutomationProps = textAreaProps;
 
     // Update metadata when field props change
     useEffect(() => {
@@ -128,7 +131,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps & Automati
           value={value}
           disabled={disabled}
           required={required}
-          {...textAreaProps}
+          {...finalAutomationProps}
           {...props}
         />
       </div>

--- a/server/src/types/ui-reflection/types.ts
+++ b/server/src/types/ui-reflection/types.ts
@@ -13,6 +13,8 @@
 export interface AutomationProps {
   /** Optional automation Type for testing purposes */
   'data-automation-type'?: string;
+  /** Optional automation ID for testing purposes */
+  'data-automation-id'?: string;
 }
 
 /**

--- a/server/src/types/ui-reflection/useAutomationIdAndRegister.ts
+++ b/server/src/types/ui-reflection/useAutomationIdAndRegister.ts
@@ -94,7 +94,9 @@ function formatComponentId(
  * ```
  */
 export function useAutomationIdAndRegister<T extends UIComponent>(
-  component: Omit<T, 'id'> & { id?: string }
+  component: Omit<T, 'id'> & { id?: string },
+  shouldRegister: boolean = true,
+  overrideId?: string
 ): {
   automationIdProps: { id: string; 'data-automation-id': string };
   updateMetadata: (partial: Partial<T>) => void;
@@ -111,24 +113,26 @@ export function useAutomationIdAndRegister<T extends UIComponent>(
   // Get parent ID from context
   const parentId = useContext(ReflectionParentContext);
 
-  // Generate or format component ID
-  const formattedId = formatComponentId(
+  // Use override ID if provided, otherwise format component ID
+  const finalId = overrideId || formatComponentId(
     component.id, 
     parentId, 
     component.type,
     registrationId.current
   );
 
-  // Register with reflection system
-  const updateMetadata = useRegisterChild<T>({
+  // Always register, but use the final ID (either provided or generated)
+  const componentToRegister = {
     ...component,
-    id: formattedId
-  } as T);
+    id: finalId
+  } as T;
+  
+  const updateMetadata = useRegisterChild<T>(componentToRegister);
 
   // Generate automation props
   const automationIdProps = {
-    id: formattedId,
-    'data-automation-id': formattedId,
+    id: finalId,
+    'data-automation-id': finalId,
   };
 
   return { automationIdProps, updateMetadata };

--- a/server/src/types/ui-reflection/useRegisterUIComponent.ts
+++ b/server/src/types/ui-reflection/useRegisterUIComponent.ts
@@ -53,6 +53,11 @@ export function useRegisterUIComponent<T extends UIComponent>(
 
   // Register on mount, unregister on unmount
   useEffect(() => {
+    // Skip registration for components with special prefix
+    if (component.id.startsWith('__skip_registration_')) {
+      return; // Don't register, but also don't need cleanup
+    }
+    
     const componentToRegister = parentId ? { ...component, parentId } : component;
     registerComponent(componentToRegister);
 


### PR DESCRIPTION
## Summary
- Implement support for `data-automation-id` override in UI reflection registration system
- Fix form field hierarchy to properly nest under dialog containers
- Replace duplicate registrations with clean `data-automation-id` pattern in QuickAddCompany
- Enable meaningful form field names (`company-name-input`, `client_type_select`, etc.)

## Test plan
- [x] Verify dialog shows as `Type: dialog` instead of container
- [x] Verify all form fields are properly nested under dialog in UI reflection
- [x] Verify form fields have meaningful names instead of generic auto-generated IDs
- [x] Verify no duplicate form field registrations
- [x] Test that dialog `open` property is available for automation

🤖 Generated with [Claude Code](https://claude.ai/code)