### PR TITLE
Fix: Enable UI state visibility for companies DataTable

### DIFF
--- a/server/src/components/companies/CompaniesList.tsx
+++ b/server/src/components/companies/CompaniesList.tsx
@@ -149,6 +149,7 @@ const CompaniesList = ({ selectedCompanies, filteredCompanies, setSelectedCompan
     return (
         <div className="w-full">
             <DataTable
+                id="companies-table"
                 data={filteredCompanies.map((company): ICompany => ({
                     ...company,
                     company_id: company.company_id


### PR DESCRIPTION
## Summary
- Add missing `id` prop to DataTable component in CompaniesList to enable UI reflection system registration
- Ensures companies table data appears in UI state dumps, making it consistent with contacts table behavior

## Test plan
- [x] Navigate to companies page in list view
- [x] Run `node tools/ai-automation/dump-ui-state.js` to verify companies table data is now visible
- [x] Confirm companies-table component appears in UI state with proper hierarchy

🤖 Generated with [Claude Code](https://claude.ai/code)