### PR TITLE
fix: enable real-time UI state updates for form field value changes

### DIFF
--- a/server/src/components/companies/CompanyDetails.tsx
+++ b/server/src/components/companies/CompanyDetails.tsx
@@ -92,7 +92,7 @@ const TextDetailItem: React.FC<{
   const [localValue, setLocalValue] = useState(value);
 
   // Register for UI automation with meaningful label
-  const { automationIdProps } = useAutomationIdAndRegister<FormFieldComponent>({
+  const { automationIdProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
     id: automationId,
     type: 'formField',
     fieldType: 'textField',
@@ -100,6 +100,16 @@ const TextDetailItem: React.FC<{
     value: localValue,
     helperText: `Input field for ${label}`
   });
+
+  // Update metadata when localValue changes
+  useEffect(() => {
+    if (updateMetadata) {
+      updateMetadata({
+        value: localValue,
+        label: label
+      });
+    }
+  }, [localValue, updateMetadata, label]);
 
   const handleBlur = () => {
     if (localValue !== value) {

--- a/server/src/components/ui/Input.tsx
+++ b/server/src/components/ui/Input.tsx
@@ -48,14 +48,30 @@ export const Input = forwardRef<HTMLInputElement, InputProps & AutomationProps>(
     );
 
     // Use provided data-automation-id or register normally
-    const { automationIdProps: textProps } = useAutomationIdAndRegister<FormFieldComponent>({
+    const { automationIdProps: textProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
       id,
       type: 'formField',
-      fieldType: 'textField'
+      fieldType: 'textField',
+      label,
+      value: typeof value === 'string' ? value : undefined,
+      disabled,
+      required
     }, true, dataAutomationId);
     
     // Always use the generated automation props (which include our override ID if provided)
     const finalAutomationProps = textProps;
+
+    // Update metadata when field props change
+    useEffect(() => {
+      if (updateMetadata) {
+        updateMetadata({
+          value: typeof value === 'string' ? value : undefined,
+          label,
+          disabled,
+          required
+        });
+      }
+    }, [value, updateMetadata, label, disabled, required]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!isComposing.current && preserveCursor) {

--- a/server/src/components/ui/SearchInput.tsx
+++ b/server/src/components/ui/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, InputHTMLAttributes } from 'react';
+import React, { forwardRef, InputHTMLAttributes, useEffect } from 'react';
 import { Search } from 'lucide-react';
 import { FormFieldComponent, AutomationProps } from '../../types/ui-reflection/types';
 import { useAutomationIdAndRegister } from '../../types/ui-reflection/useAutomationIdAndRegister';
@@ -13,11 +13,21 @@ interface SearchInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, '
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps & AutomationProps>(
   ({ className, value, onChange, id, ...props }, ref) => {
-    const { automationIdProps: textProps } = useAutomationIdAndRegister<FormFieldComponent>({
+    const { automationIdProps: textProps, updateMetadata } = useAutomationIdAndRegister<FormFieldComponent>({
       id,
       type: 'formField',
-      fieldType: 'textField'
+      fieldType: 'textField',
+      value: typeof value === 'string' ? value : undefined
     });
+
+    // Update metadata when field props change
+    useEffect(() => {
+      if (updateMetadata) {
+        updateMetadata({
+          value: typeof value === 'string' ? value : undefined
+        });
+      }
+    }, [value, updateMetadata]);
 
     return (
       <div className="relative">


### PR DESCRIPTION
## Summary
- Fix UI state system to capture real-time form field value changes instead of just initial values
- Enable automation tools and LLM interactions to see current field state as users type

## Changes Made
- **Input.tsx**: Added `updateMetadata` call with `useEffect` to track value changes in real-time
- **SearchInput.tsx**: Added real-time value tracking for search fields  
- **CompanyDetails.tsx**: Fixed `TextDetailItem` component to update UI state when local values change

## Problem Solved
Previously, the UI state would only capture initial field values when components mounted. Field value changes during user interaction were not reflected in the UI state, making automation tools see stale data.

## Test Results
✅ **Round-trip test confirmed**: 
- Before: Phone field showed `"value": ""`
- After: Phone field shows `"value": "555-999-8888"` when changed
- Real-time updates working with 100ms debounce

## Technical Details
The UI reflection system uses `updateMetadata` to broadcast state changes via WebSocket. Form components need to call this function when their values change to ensure the UI state stays current.

🤖 Generated with [Claude Code](https://claude.ai/code)