### PR TITLE
Implemented server-side pagination and batch logo loading for companies

### DIFF
--- a/server/src/components/companies/CompaniesGrid.tsx
+++ b/server/src/components/companies/CompaniesGrid.tsx
@@ -9,28 +9,28 @@ interface CompaniesGridProps {
     handleCheckboxChange: (companyId: string) => void;
     handleEditCompany: (companyId: string) => void;
     handleDeleteCompany: (company: ICompany) => void;
+    currentPage: number;
+    pageSize: number;
+    totalCount: number;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (size: number) => void;
 }
 
 type ItemsPerPage = 9 | 18 | 27 | 36;
 
-const CompaniesGrid = ({ filteredCompanies, selectedCompanies, handleCheckboxChange, handleEditCompany, handleDeleteCompany }: CompaniesGridProps) => {
-    const [currentPage, setCurrentPage] = useState(1);
-    const [itemsPerPage, setItemsPerPage] = useState<ItemsPerPage>(9); // Show 9 cards per page
+const CompaniesGrid = ({ 
+    filteredCompanies, 
+    selectedCompanies, 
+    handleCheckboxChange, 
+    handleEditCompany, 
+    handleDeleteCompany,
+    currentPage,
+    pageSize,
+    totalCount,
+    onPageChange,
+    onPageSizeChange
+}: CompaniesGridProps) => {
     
-    // Calculate pagination indexes
-    const lastItemIndex = currentPage * itemsPerPage;
-    const firstItemIndex = lastItemIndex - itemsPerPage;
-    const currentItems = filteredCompanies.slice(firstItemIndex, lastItemIndex);
-
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page);
-    };
-
-    const handleItemsPerPageChange = (items: number) => {
-        setItemsPerPage(items as ItemsPerPage);
-        setCurrentPage(1); // Reset to first page when changing items per page
-    };
-
     const itemsPerPageOptions = [
         { value: '9', label: '9 cards/page' },
         { value: '18', label: '18 cards/page' },
@@ -41,7 +41,7 @@ const CompaniesGrid = ({ filteredCompanies, selectedCompanies, handleCheckboxCha
     return (
         <div className="flex flex-col gap-6">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {currentItems.map((company): JSX.Element => (
+                {filteredCompanies.map((company): JSX.Element => (
                     <div key={company.company_id} className="relative">
                         <CompanyGridCard
                             company={company}
@@ -56,11 +56,11 @@ const CompaniesGrid = ({ filteredCompanies, selectedCompanies, handleCheckboxCha
 
             <Pagination
                 id="companies-pagination"
-                totalItems={filteredCompanies.length}
-                itemsPerPage={itemsPerPage}
+                totalItems={totalCount}
+                itemsPerPage={pageSize as ItemsPerPage}
                 currentPage={currentPage}
-                onPageChange={handlePageChange}
-                onItemsPerPageChange={handleItemsPerPageChange}
+                onPageChange={onPageChange}
+                onItemsPerPageChange={onPageSizeChange}
                 variant="companies"
                 itemLabel="companies"
                 itemsPerPageOptions={itemsPerPageOptions}

--- a/server/src/components/companies/CompaniesList.tsx
+++ b/server/src/components/companies/CompaniesList.tsx
@@ -17,6 +17,10 @@ interface CompaniesListProps {
     handleCheckboxChange: (companyId: string) => void;
     handleEditCompany: (companyId: string) => void;
     handleDeleteCompany: (company: ICompany) => void;
+    currentPage?: number;
+    pageSize?: number;
+    totalCount?: number;
+    onPageChange?: (page: number) => void;
 }
 
 // Component for company selection checkbox
@@ -77,7 +81,18 @@ const CompanyLink: React.FC<CompanyLinkProps> = ({ company, onClick }) => {
   );
 };
 
-const CompaniesList = ({ selectedCompanies, filteredCompanies, setSelectedCompanies, handleCheckboxChange, handleEditCompany, handleDeleteCompany }: CompaniesListProps) => {
+const CompaniesList = ({ 
+  selectedCompanies, 
+  filteredCompanies, 
+  setSelectedCompanies, 
+  handleCheckboxChange, 
+  handleEditCompany, 
+  handleDeleteCompany,
+  currentPage,
+  pageSize,
+  totalCount,
+  onPageChange
+}: CompaniesListProps) => {
   const router = useRouter(); // Get router instance
 
   const handleRowClick = (company: ICompany) => {
@@ -213,6 +228,11 @@ const CompaniesList = ({ selectedCompanies, filteredCompanies, setSelectedCompan
                 }))}
                 columns={columns}
                 onRowClick={handleRowClick} // Use the original onRowClick signature
+                pagination={true}
+                currentPage={currentPage}
+                pageSize={pageSize}
+                totalItems={totalCount}
+                onPageChange={onPageChange}
             />
         </div>
     );

--- a/server/src/lib/utils/avatarUtils.ts
+++ b/server/src/lib/utils/avatarUtils.ts
@@ -42,11 +42,16 @@ export async function getEntityImageUrl(
       
       // If no association found, return null
       if (!association?.document_id) {
-        console.log(`[getEntityImageUrl] No document association found for ${entityType} ${entityId} with is_entity_logo=true`);
+        // Use debug level logging to reduce noise - missing logos are common and expected
+        if (process.env.NODE_ENV === 'development') {
+          console.debug(`[getEntityImageUrl] No document association found for ${entityType} ${entityId} with is_entity_logo=true`);
+        }
         return null;
       }
       
-      console.log(`[getEntityImageUrl] Found document association for ${entityType} ${entityId}:`, association);
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(`[getEntityImageUrl] Found document association for ${entityType} ${entityId}:`, association);
+      }
       
       // Get the file_id from the documents table within the same transaction
       const documentRecord = await trx('documents')
@@ -63,7 +68,9 @@ export async function getEntityImageUrl(
         return null;
       }
       
-      console.log(`[getEntityImageUrl] Found file_id ${documentRecord.file_id} for document ${association.document_id}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(`[getEntityImageUrl] Found file_id ${documentRecord.file_id} for document ${association.document_id}`);
+      }
       
       return documentRecord.file_id;
     });
@@ -80,11 +87,15 @@ export async function getEntityImageUrl(
     if (imageUrl) {
       const timestamp = Date.now();
       const urlWithTimestamp = `${imageUrl}${imageUrl.includes('?') ? '&' : '?'}t=${timestamp}`;
-      console.log(`Generated image URL for ${entityType} ${entityId}: ${urlWithTimestamp}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(`Generated image URL for ${entityType} ${entityId}: ${urlWithTimestamp}`);
+      }
       return urlWithTimestamp;
     }
     
-    console.log(`No image URL generated for ${entityType} ${entityId}`);
+    if (process.env.NODE_ENV === 'development') {
+      console.debug(`No image URL generated for ${entityType} ${entityId}`);
+    }
     return null;
   } catch (error) {
     console.error(`[AvatarUtils] Failed to retrieve image URL for ${entityType} (ID: ${entityId}):`, {
@@ -131,6 +142,99 @@ export async function getCompanyLogoUrl(
 }
 
 /**
+ * Batch function to get image URLs for multiple entities at once.
+ * This is more efficient than calling getEntityImageUrl multiple times in a loop.
+ *
+ * @param entityType The type of entity ('user', 'contact', or 'company')
+ * @param entityIds Array of entity IDs
+ * @param tenant The tenant context
+ * @returns A promise resolving to a Map of entityId -> imageUrl (or null)
+ */
+export async function getEntityImageUrlsBatch(
+  entityType: EntityType,
+  entityIds: string[],
+  tenant: string
+): Promise<Map<string, string | null>> {
+  const result = new Map<string, string | null>();
+  
+  // Initialize all IDs with null
+  entityIds.forEach(id => result.set(id, null));
+  
+  if (entityIds.length === 0) {
+    return result;
+  }
+
+  try {
+    const { knex } = await createTenantKnex();
+
+    // Get all associations in one query
+    const associations = await knex('document_associations')
+      .select('entity_id', 'document_id')
+      .whereIn('entity_id', entityIds)
+      .andWhere({
+        entity_type: entityType,
+        is_entity_logo: true,
+        tenant
+      });
+
+    if (associations.length === 0) {
+      return result;
+    }
+
+    // Get all documents in one query
+    const documentIds = associations.map(a => a.document_id);
+    const documents = await knex('documents')
+      .select('document_id', 'file_id')
+      .whereIn('document_id', documentIds)
+      .andWhere({ tenant });
+
+    // Create maps for quick lookup
+    const docToFileMap = new Map(documents.map(d => [d.document_id, d.file_id]));
+    const entityToDocMap = new Map(associations.map(a => [a.entity_id, a.document_id]));
+
+    // Process each entity
+    for (const [entityId, documentId] of entityToDocMap) {
+      const fileId = docToFileMap.get(documentId);
+      if (fileId) {
+        try {
+          const imageUrl = await getImageUrl(fileId);
+          if (imageUrl) {
+            const timestamp = Date.now();
+            const urlWithTimestamp = `${imageUrl}${imageUrl.includes('?') ? '&' : '?'}t=${timestamp}`;
+            result.set(entityId, urlWithTimestamp);
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV === 'development') {
+            console.error(`[getEntityImageUrlsBatch] Failed to get image URL for ${entityType} ${entityId}:`, error);
+          }
+        }
+      }
+    }
+
+    return result;
+  } catch (error) {
+    console.error(`[getEntityImageUrlsBatch] Failed to retrieve image URLs for ${entityType}:`, {
+      operation: 'getEntityImageUrlsBatch',
+      entityType,
+      entityCount: entityIds.length,
+      tenant,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error'
+    });
+    return result;
+  }
+}
+
+/**
+ * Convenience function to get multiple company logo URLs at once
+ */
+export async function getCompanyLogoUrlsBatch(
+  companyIds: string[],
+  tenant: string
+): Promise<Map<string, string | null>> {
+  return getEntityImageUrlsBatch('company', companyIds, tenant);
+}
+
+/**
  * Example usage:
  *
  * // Using the general function:
@@ -140,6 +244,11 @@ export async function getCompanyLogoUrl(
  * const userAvatarUrl = await getUserAvatarUrl(userId, tenant);
  * const contactAvatarUrl = await getContactAvatarUrl(contactId, tenant);
  * const companyLogoUrl = await getCompanyLogoUrl(companyId, tenant);
+ *
+ * // Batch loading:
+ * const companyIds = ['id1', 'id2', 'id3'];
+ * const logoUrls = await getCompanyLogoUrlsBatch(companyIds, tenant);
+ * const logoUrl1 = logoUrls.get('id1'); // string | null
  *
  * // Then use the URL in a component:
  * <UserAvatar


### PR DESCRIPTION
- Added getAllCompaniesPaginated endpoint with filtering and pagination support
- Modified Companies component to use server-side pagination
- Updated CompaniesGrid and CompaniesList to support pagination props
- Implemented batch logo loading with getCompanyLogoUrlsBatch
- Optimized document queries by splitting joins into separate queries
- Added debug logging for development environment only

Impacts:

- Reduces database load by implementing server-side pagination
- Improves performance by batch loading company logos
- More efficient document queries by avoiding complex joins
- Better scalability for large company lists

"Down the rabbit hole we go, where companies multiply like mad hatters and logos appear in batches like a deck of cards dealt by the Cheshire Cat!" 🐇🎩🃏