### PR TITLE
Fix VNC redirect port preservation in AI automation nginx proxy

### DIFF
--- a/helm/templates/dev-env/ai-automation/nginx-configmap.yaml
+++ b/helm/templates/dev-env/ai-automation/nginx-configmap.yaml
@@ -24,6 +24,16 @@ data:
         '' close;
       }
       
+      map $http_x_forwarded_host $best_host {
+        default $http_host;
+        "~.+" $http_x_forwarded_host;
+      }
+
+      map $http_x_forwarded_proto $proxy_scheme {
+        default $scheme;
+        "~.+" $http_x_forwarded_proto;
+      }
+      
       server {
         listen 8080;
         
@@ -71,7 +81,7 @@ data:
         
         # Handle /vnc without trailing slash
         location = /vnc {
-          return 301 /vnc/;
+          return 301 "$proxy_scheme://$best_host/vnc/";
         }
         
         # Handle WebSocket connections specifically


### PR DESCRIPTION
## Summary
Fixes the VNC redirect issue where accessing `/vnc` would incorrectly redirect to port 8080 instead of preserving the original port.

## Changes
- Added nginx maps to properly handle `X-Forwarded-Host` and `X-Forwarded-Proto` headers
- Updated the `/vnc` redirect to use `$proxy_scheme://$best_host/vnc/` instead of a relative redirect
- Ensures port preservation when redirecting from `/vnc` to `/vnc/`

## Test plan
- Access VNC via `/vnc` endpoint on a non-8080 port (e.g., `localhost:30007/vnc`)
- Verify the redirect preserves the correct port and protocol
- Confirm VNC interface loads correctly after redirect

## Impact
This fixes VNC access in development environments where the AI automation service is exposed on ports other than 8080.