### PR TITLE
Hardcode NEXTAUTH_URL for code server to use internal service name

### DIFF
--- a/helm/templates/dev-env/code-server/deployment.yaml
+++ b/helm/templates/dev-env/code-server/deployment.yaml
@@ -336,7 +336,9 @@ spec:
               value: "{{ .Values.token.expire }}"
 
             # ----------- AUTH ----------------
-            # NEXTAUTH_URL is configured via .env file to allow dynamic updates during port forwarding
+            # NEXTAUTH_URL hardcoded to internal service for browser testing within the environment
+            - name: NEXTAUTH_URL
+              value: "http://code-server:3000"
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Hardcode NEXTAUTH_URL environment variable in code server deployment to use internal service name
- Remove dynamic .env file writing logic for code server pods during port forwarding
- Improve browser testing reliability within the Kubernetes environment

## Changes Made

### Code Server Deployment (`helm/templates/dev-env/code-server/deployment.yaml`)
- Added `NEXTAUTH_URL=http://code-server:3000` as a hardcoded environment variable
- Updated comment to reflect the change from dynamic .env file configuration

### CLI Dev Environment (`cli/dev-env.nu`)
- Removed logic that writes NEXTAUTH_URL to .env files in code server pods
- Kept .env file logic for main app pods (still needed for external port forwarding)
- Updated comments and user messages to explain the new behavior

## Why This Change?

Previously, the dev environment setup wrote NEXTAUTH_URL to .env files based on external port numbers. However, browser automation testing happens *inside* the Kubernetes environment, so it should use internal service names rather than external localhost URLs.

The code server service alias already exists (`code-server` → full service name), so using `http://code-server:3000` provides reliable internal connectivity for browser testing.

## Test Plan

- [ ] Deploy a dev environment and verify code server starts successfully
- [ ] Check that NEXTAUTH_URL environment variable is set correctly in code server pods
- [ ] Verify browser automation can authenticate using the internal URL
- [ ] Confirm main app pods still get external URLs for port forwarding access