### PR TITLE
Fix nushell parsing error in dev-env-force-cleanup

### DIFF
--- a/cli/dev-env.nu
+++ b/cli/dev-env.nu
@@ -622,7 +622,7 @@ export def dev-env-connect [
             }
             
             print $"($env.ALGA_COLOR_GREEN)NEXTAUTH_URL configuration completed.($env.ALGA_COLOR_RESET)"
-            print $"($env.ALGA_COLOR_CYAN)Note: Code server uses hardcoded internal URL (http://code-server:3000) for browser testing within the environment.($env.ALGA_COLOR_RESET)"
+            print $"($env.ALGA_COLOR_CYAN)Note: Code server uses hardcoded internal URL \(http://code-server:3000\) for browser testing within the environment.($env.ALGA_COLOR_RESET)"
         
         print $"($env.ALGA_COLOR_GREEN)Port forwarding active!($env.ALGA_COLOR_RESET)"
         


### PR DESCRIPTION
## Summary
Fix parsing error in nushell CLI where parentheses around URL were being interpreted as a command to execute.

## Changes
- Escape parentheses in string interpolation around `http://code-server:3000` URL
- Prevents nushell from treating the URL as an executable command

## Test plan
- [x] Run `nu main.nu dev-env-connect <branch>` without parsing errors
- [x] Verify URL display shows correctly with literal parentheses