### PR TITLE
Fix session timeout in dev environments

### DIFF
--- a/helm/values-dev-env.yaml
+++ b/helm/values-dev-env.yaml
@@ -224,7 +224,7 @@ logging:
 
 # Authentication configuration for dev environments
 auth:
-  nextauth_session_expires: "30"
+  nextauth_session_expires: "86400"
 
 # Cryptography configuration for dev environments  
 crypto:


### PR DESCRIPTION
## Summary
• Increase NextAuth session expiry from 30 seconds to 24 hours in development environments
• Prevents frequent re-authentication interruptions during development work

## Test plan
- [ ] Deploy to dev environment and verify sessions persist for 24 hours
- [ ] Confirm no impact on production environment configuration
- [ ] Test authentication flow works as expected