### PR TITLE
Fix tax_rate_id validation error when creating service catalog entries

### DIFF
--- a/server/src/lib/actions/serviceActions.ts
+++ b/server/src/lib/actions/serviceActions.ts
@@ -164,6 +164,8 @@ export async function createService(
             default_rate: typeof serviceData.default_rate === 'string'
                 ? parseFloat(serviceData.default_rate) || 0
                 : serviceData.default_rate,
+            // Explicitly handle tax_rate_id to ensure it's null rather than undefined
+            tax_rate_id: serviceData.tax_rate_id || null,
         };
 
             // 4. Create the service using the model


### PR DESCRIPTION
When creating a new service catalog entry with a blank tax rate field, the application was throwing a ZodError indicating that tax_rate_id was required and received undefined. This was happening because:

1. The IService interface defines tax_rate_id as optional (tax_rate_id?: string | null)
2. When the property is not provided, TypeScript treats it as undefined
3. The Zod schema was expecting either a string UUID or null, but not undefined

The fix includes:
- Updated the Zod schema to accept string, null, or undefined for tax_rate_id
- Added explicit handling in serviceActions to convert undefined to null
- Added data cleaning step in the service model to ensure all nullable fields are properly set to null instead of undefined before validation

This ensures that when users leave the tax rate field blank during service creation, it properly passes null through validation and into the database.

🤖 Generated with [Claude Code](https://claude.ai/code)