### PR TITLE
Fix tenant not being passed to plan service config models

### DIFF
--- a/server/src/lib/services/planServiceConfigurationService.ts
+++ b/server/src/lib/services/planServiceConfigurationService.ts
@@ -31,10 +31,10 @@ export class PlanServiceConfigurationService {
     this.tenant = tenant as string;
     if (knex) {
       this.planServiceConfigModel = new PlanServiceConfiguration(knex, tenant);
-      this.fixedConfigModel = new PlanServiceFixedConfig(knex);
+      this.fixedConfigModel = new PlanServiceFixedConfig(knex, tenant);
       this.hourlyConfigModel = new PlanServiceHourlyConfig(knex);
       this.usageConfigModel = new PlanServiceUsageConfig(knex);
-      this.bucketConfigModel = new PlanServiceBucketConfig(knex);
+      this.bucketConfigModel = new PlanServiceBucketConfig(knex, tenant);
     } else {
       // These will be initialized in initKnex
       this.planServiceConfigModel = {} as PlanServiceConfiguration;
@@ -60,10 +60,10 @@ export class PlanServiceConfigurationService {
       
       // Initialize models with knex connection
       this.planServiceConfigModel = new PlanServiceConfiguration(knex, tenant);
-      this.fixedConfigModel = new PlanServiceFixedConfig(knex);
+      this.fixedConfigModel = new PlanServiceFixedConfig(knex, tenant);
       this.hourlyConfigModel = new PlanServiceHourlyConfig(knex);
       this.usageConfigModel = new PlanServiceUsageConfig(knex);
-      this.bucketConfigModel = new PlanServiceBucketConfig(knex);
+      this.bucketConfigModel = new PlanServiceBucketConfig(knex, tenant);
       // Removed billingPlanModel initialization
     }
   }
@@ -153,10 +153,10 @@ export class PlanServiceConfigurationService {
     return await this.knex.transaction(async (trx) => {
       // Create models with transaction
       const planServiceConfigModel = new PlanServiceConfiguration(trx, this.tenant);
-      const fixedConfigModel = new PlanServiceFixedConfig(trx);
+      const fixedConfigModel = new PlanServiceFixedConfig(trx, this.tenant);
       const hourlyConfigModel = new PlanServiceHourlyConfig(trx);
       const usageConfigModel = new PlanServiceUsageConfig(trx);
-      const bucketConfigModel = new PlanServiceBucketConfig(trx);
+      const bucketConfigModel = new PlanServiceBucketConfig(trx, this.tenant);
       
       // Create base configuration
       const configId = await planServiceConfigModel.create(baseConfig);
@@ -257,10 +257,10 @@ export class PlanServiceConfigurationService {
     return await this.knex.transaction(async (trx) => {
       // Create models with transaction
       const planServiceConfigModel = new PlanServiceConfiguration(trx, this.tenant);
-      const fixedConfigModel = new PlanServiceFixedConfig(trx);
+      const fixedConfigModel = new PlanServiceFixedConfig(trx, this.tenant);
       const hourlyConfigModel = new PlanServiceHourlyConfig(trx);
       const usageConfigModel = new PlanServiceUsageConfig(trx);
-      const bucketConfigModel = new PlanServiceBucketConfig(trx);
+      const bucketConfigModel = new PlanServiceBucketConfig(trx, this.tenant);
       
       // Update base configuration if provided
       if (baseConfig) {
@@ -348,10 +348,10 @@ export class PlanServiceConfigurationService {
     return await this.knex.transaction(async (trx) => {
       // Create models with transaction
       const planServiceConfigModel = new PlanServiceConfiguration(trx, this.tenant);
-      const fixedConfigModel = new PlanServiceFixedConfig(trx);
+      const fixedConfigModel = new PlanServiceFixedConfig(trx, this.tenant);
       const hourlyConfigModel = new PlanServiceHourlyConfig(trx);
       const usageConfigModel = new PlanServiceUsageConfig(trx);
-      const bucketConfigModel = new PlanServiceBucketConfig(trx);
+      const bucketConfigModel = new PlanServiceBucketConfig(trx, this.tenant);
 
       // Explicitly delete type-specific configuration first (no CASCADE)
       switch (currentConfig.configuration_type) {
@@ -411,7 +411,7 @@ export class PlanServiceConfigurationService {
     return await this.knex.transaction(async (trx) => {
       // Create models with transaction
       const planServiceConfigModel = new PlanServiceConfiguration(trx, this.tenant);
-      const bucketConfigModel = new PlanServiceBucketConfig(trx);
+      const bucketConfigModel = new PlanServiceBucketConfig(trx, this.tenant);
 
       // 1. Find existing base configuration
       let baseConfig = await planServiceConfigModel.getByPlanAndServiceId(planId, serviceId);


### PR DESCRIPTION
When adding a service to a billing plan, the application was throwing an error: "null value in column 'tenant' of relation 'plan_service_fixed_config' violates not-null constraint"

This was happening because:
1. PlanServiceFixedConfig and PlanServiceBucketConfig constructors accept a tenant parameter
2. These models were being instantiated without passing the tenant parameter in PlanServiceConfigurationService
3. This caused the tenant field to be undefined/null when inserting records into the database

The fix updates all instantiations of PlanServiceFixedConfig and PlanServiceBucketConfig to properly pass the tenant parameter that's available in the PlanServiceConfigurationService.

🤖 Generated with [Claude Code](https://claude.ai/code)