### PR TITLE
fix: temporarily disable invoice preview functionality

### DIFF
--- a/server/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/server/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -323,11 +323,12 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ periods, onGenera
             data={filteredPeriods}
             // Add onRowClick prop - implementation depends on DataTable component
             // Assuming it takes a function like this:
-            onRowClick={(record: Period) => {
-              if (record.billing_cycle_id) {
-                handlePreviewInvoice(record.billing_cycle_id);
-              }
-            }}
+            // Temporarily disabled invoice preview on row click
+            // onRowClick={(record: Period) => {
+            //   if (record.billing_cycle_id) {
+            //     handlePreviewInvoice(record.billing_cycle_id);
+            //   }
+            // }
             columns={[
               {
                 title: (
@@ -403,14 +404,15 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ periods, onGenera
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem
+                          {/* Temporarily disabled invoice preview */}
+                          {/* <DropdownMenuItem
                             id={`preview-invoice-${record.billing_cycle_id}`}
                             onClick={() => handlePreviewInvoice(record.billing_cycle_id || '')}
                             disabled={isPreviewLoading} // Disable only during preview loading
                           >
                             Preview
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
+                          </DropdownMenuItem> */}
+                          {/* <DropdownMenuSeparator /> */}
                           {/* Delete Option Moved Here */}
                           <DropdownMenuItem
                             id={`delete-billing-cycle-${record.billing_cycle_id}`}
@@ -435,8 +437,8 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ periods, onGenera
               }
             ]}
             pagination={false}
-            // Fixed rowClassName prop
-            rowClassName={() => "cursor-pointer hover:bg-muted/50"}
+            // Fixed rowClassName prop - removed cursor-pointer since row click is disabled
+            rowClassName={() => "hover:bg-muted/50"}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Temporarily disables the invoice preview feature when clicking on billing periods
- Removes the Preview option from the dropdown menu actions

## Changes
- Commented out the `onRowClick` handler on the DataTable to prevent preview on row click
- Commented out the Preview menu item in the dropdown actions
- Removed the menu separator that followed the Preview item
- Removed `cursor-pointer` style from table rows since they're no longer clickable

## Implementation Notes
All preview logic remains intact (preview dialog, state management, API calls, etc.) so this feature can be easily re-enabled in the future by uncommenting the relevant sections.

## Test plan
- [x] Verify clicking on a billing period row no longer triggers preview
- [x] Verify the dropdown menu no longer shows the Preview option
- [x] Verify the Delete Cycle option still works in the dropdown
- [x] Verify invoice generation still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)