### PR TITLE
Fix technician dispatch admin access and scroll behavior

### DIFF
--- a/server/src/components/technician-dispatch/DailyTechnicianScheduleGrid.tsx
+++ b/server/src/components/technician-dispatch/DailyTechnicianScheduleGrid.tsx
@@ -117,7 +117,7 @@ const DailyTechnicianScheduleGrid: React.FC<DailyTechnicianScheduleGridProps> = 
   const [hasScrolled, setHasScrolled] = useState(false);
 
   useEffect(() => {
-    if (!hasScrolled && events.length > 0 && gridRef.current) {
+    if (!hasScrolled && gridRef.current) {
       const scrollToBusinessHours = () => {
         const pixelsPerHour = 120; // 4 slots * 30px each
         const scrollToHour = 8;
@@ -130,9 +130,10 @@ const DailyTechnicianScheduleGrid: React.FC<DailyTechnicianScheduleGridProps> = 
         setHasScrolled(true);
       };
 
-      scrollToBusinessHours();
+      // Small delay to ensure the DOM is ready
+      setTimeout(scrollToBusinessHours, 100);
     }
-  }, [events, hasScrolled]); // Only run when events load and haven't scrolled yet
+  }, [hasScrolled]); // Run when component mounts
 
   const isSyncingScroll = useRef(false);
 

--- a/server/src/components/technician-dispatch/WeeklyTechnicianScheduleGrid.tsx
+++ b/server/src/components/technician-dispatch/WeeklyTechnicianScheduleGrid.tsx
@@ -164,7 +164,7 @@ const WeeklyTechnicianScheduleGrid: React.FC<WeeklyTechnicianScheduleGridProps> 
   
   // Auto-scroll to business hours when the calendar loads
   useEffect(() => {
-    if (!hasScrolled && calendarRef.current && events.length > 0) {
+    if (!hasScrolled && calendarRef.current) {
       const scrollToBusinessHours = () => {
         const timeGridContainer = calendarRef.current?.querySelector('.rbc-time-content');
         if (timeGridContainer) {
@@ -182,7 +182,7 @@ const WeeklyTechnicianScheduleGrid: React.FC<WeeklyTechnicianScheduleGridProps> 
       
       setTimeout(scrollToBusinessHours, 100);
     }
-  }, [events, hasScrolled]);
+  }, [hasScrolled]);
 
   // Get the technicians to display
   const displayedTechnicians = useMemo(() => {


### PR DESCRIPTION
## Summary
- Ensures admin users can always access the technician dispatch dashboard
- Fixes scroll-to-8am behavior to work even when there are no items on the dispatch board

## Changes Made

### 1. Admin Access to Technician Dispatch
- Added admin status check to `TechnicianDispatchDashboard.tsx`
- Admin users now bypass permission restrictions and get full view/edit access
- Uses the standard pattern from other components to check for admin role

### 2. Fixed Scroll to Working Hours (8am)
- Removed the `events.length > 0` condition that prevented scrolling when no items were present
- Updated both `DailyTechnicianScheduleGrid.tsx` and `WeeklyTechnicianScheduleGrid.tsx`
- Added a small 100ms delay to ensure DOM is ready before scrolling
- Now scrolls to 8am position on startup regardless of whether there are dispatch items

## Test Plan
- [ ] Verify admin users can access technician dispatch even without specific permissions
- [ ] Verify non-admin users still require proper permissions
- [ ] Verify dispatch board scrolls to 8am on startup with items present
- [ ] Verify dispatch board scrolls to 8am on startup with no items present
- [ ] Test in both daily and weekly view modes

🤖 Generated with [Claude Code](https://claude.ai/code)