### PR TITLE
fix: improve schedule calendar month view default times

### DIFF
--- a/server/src/components/schedule/ScheduleCalendar.tsx
+++ b/server/src/components/schedule/ScheduleCalendar.tsx
@@ -213,8 +213,25 @@ const ScheduleCalendar: React.FC = (): React.ReactElement | null => {
   }, [fetchEvents]);
 
   const handleSelectSlot = (slotInfo: any) => {
+    // For month view, adjust the start time to 8am and end time to be 15 minutes after
+    let adjustedSlotInfo = { ...slotInfo };
+    if (view === 'month') {
+      const startDate = new Date(slotInfo.start);
+      // Set the start time to 8am
+      startDate.setHours(8, 0, 0, 0);
+      
+      const endDate = new Date(startDate);
+      endDate.setMinutes(startDate.getMinutes() + 15);
+      
+      adjustedSlotInfo = {
+        ...slotInfo,
+        start: startDate,
+        end: endDate
+      };
+    }
+    
     setSelectedSlot({
-      ...slotInfo,
+      ...adjustedSlotInfo,
       defaultAssigneeId: focusedTechnicianId
     });
     setShowEntryPopup(true);


### PR DESCRIPTION
## Summary
- Fixed month view in schedule calendar defaulting to midnight start time
- Changed default entry duration from 24 hours to 15 minutes for consistency

## Details
When creating a new schedule entry in month view:
- **Before**: Start time defaulted to midnight, end time was 24 hours later
- **After**: Start time defaults to 8am, end time is 15 minutes later (8:15am)

This matches the behavior of day and week views and provides more sensible defaults for typical working hours.

## Test plan
- [ ] Navigate to Schedule Calendar
- [ ] Switch to Month view
- [ ] Click on any date to create a new entry
- [ ] Verify the start time defaults to 8:00 AM
- [ ] Verify the end time defaults to 8:15 AM
- [ ] Test that day and week views still work as before

🤖 Generated with [Claude Code](https://claude.ai/code)