### PR TITLE
Fix PDF generation storage initialization

### DIFF
--- a/server/src/services/pdf-generation.service.ts
+++ b/server/src/services/pdf-generation.service.ts
@@ -316,9 +316,10 @@ export class PDFGenerationService {
 
 // Factory function to create a PDF generation service with the specified tenant
 export const createPDFGenerationService = (tenant: string) => {
-  // Create a new instance with the StorageService singleton
+  // Create a new instance using the StorageService class
+  const storageService = new StorageService();
   return new PDFGenerationService(
-    StorageService as any,
+    storageService,
     browserPoolService,
     { tenant }
   );


### PR DESCRIPTION
## Summary
- create `StorageService` instance when generating PDFs so files upload correctly

## Testing
- `npx tsc --noEmit server/src/services/pdf-generation.service.ts` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684edd5526808330853516492a4add29