### PR TITLE
Rename dashboard path to /msp/home

### DIFF
--- a/.github/workflows/e2e-fresh-install-tests.yaml
+++ b/.github/workflows/e2e-fresh-install-tests.yaml
@@ -465,11 +465,11 @@ jobs:
               // Wait for navigation to the dashboard (or other expected page)
               // Adjust the expected URL or path as necessary
               console.log(`Current URL before waiting for dashboard: ${page.url()}`);
-              console.log(`Waiting for URL: ${baseUrl}/msp/dashboard with 30s timeout.`);
-              await page.waitForURL(\`\${baseUrl}/msp/dashboard\`, { timeout: 30000 });
+              console.log(`Waiting for URL: ${baseUrl}/msp/home with 30s timeout.`);
+              await page.waitForURL(\`\${baseUrl}/msp/home\`, { timeout: 30000 });
 
               // Assert that the URL is the dashboard URL
-              expect(page.url()).toBe(\`\${baseUrl}/msp/dashboard\`);
+              expect(page.url()).toBe(\`\${baseUrl}/msp/home\`);
 
               // Optional: Add more assertions, e.g., check for a welcome message or specific element
               // await expect(page.locator('h1')).toContainText('Dashboard');

--- a/docs/ui_navigation_structure.md
+++ b/docs/ui_navigation_structure.md
@@ -19,9 +19,9 @@ Based on `server/src/config/menuConfig.ts`:
 
 ### Main Menu Items
 
-#### 1. Dashboard
-- **Route**: `/msp/dashboard`
-- **File**: `server/src/app/msp/dashboard/page.tsx`
+#### 1. Home
+- **Route**: `/msp/home`
+- **File**: `server/src/app/msp/home/page.tsx`
 - **Menu ID**: `menu-dashboard`
 
 #### 2. User Activities ⭐ (DOCUMENTED)
@@ -494,4 +494,4 @@ When documenting new screens, include:
 
 **Last Updated**: Based on codebase analysis as of current date
 **Documented Screens**: User Activities, Clients/Companies, Tickets (3/13+ screens)
-**Next to Document**: Dashboard, Projects, Contacts, Documents, etc.
+**Next to Document**: Home, Projects, Contacts, Documents, etc.

--- a/ee/server/src/app/msp/extensions/[extensionId]/[...path]/layout.tsx
+++ b/ee/server/src/app/msp/extensions/[extensionId]/[...path]/layout.tsx
@@ -37,8 +37,8 @@ export default function ExtensionPageLayout({
       <nav className="mb-4">
         <ol className="flex flex-wrap items-center text-sm text-gray-500">
           <li>
-            <Link href="/msp/dashboard" className="hover:text-primary-600">
-              Dashboard
+            <Link href="/msp/home" className="hover:text-primary-600">
+              Home
             </Link>
           </li>
           <li className="mx-2">

--- a/ee/server/src/lib/extensions/example-integration/SidebarWithExtensions.tsx
+++ b/ee/server/src/lib/extensions/example-integration/SidebarWithExtensions.tsx
@@ -38,9 +38,9 @@ export function SidebarWithExtensions({ sidebarOpen, setSidebarOpen }: SidebarPr
   // This would be provided by menuConfig.ts in real implementation
   const menuItems: MenuItem[] = [
     {
-      name: 'Dashboard',
+      name: 'Home',
       icon: RadixIcons.BarChartIcon,
-      href: '/msp/dashboard'
+      href: '/msp/home'
     },
     {
       name: 'Tickets',

--- a/server/src/app/msp/home/page.tsx
+++ b/server/src/app/msp/home/page.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Dashboard from 'server/src/components/dashboard/Dashboard';
 
-const DashboardPage: React.FC = () => {
+const HomePage: React.FC = () => {
   return (
     <Dashboard />
   );
 };
 
-export default DashboardPage;
+export default HomePage;

--- a/server/src/app/msp/route.tsx
+++ b/server/src/app/msp/route.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export async function GET() {
-  redirect('/msp/dashboard');
+  redirect('/msp/home');
 }

--- a/server/src/app/route.tsx
+++ b/server/src/app/route.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export async function GET() {
-  redirect('/msp/dashboard');
+  redirect('/msp/home');
 }

--- a/server/src/components/auth/MspLoginForm.tsx
+++ b/server/src/components/auth/MspLoginForm.tsx
@@ -18,6 +18,7 @@ interface MspLoginFormProps {
 }
 
 export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired }: MspLoginFormProps) {
+  const targetCallbackUrl = callbackUrl || '/msp/home';
   const [showPassword, setShowPassword] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -37,7 +38,7 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
         email,
         password,
         redirect: false,
-        callbackUrl,
+        callbackUrl: targetCallbackUrl,
       });
 
       if (result?.error === '2FA_REQUIRED') {
@@ -66,8 +67,8 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
   const handleGoogleSignIn = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     try {
-      await signIn('google', { 
-        callbackUrl,
+      await signIn('google', {
+        callbackUrl: targetCallbackUrl,
         redirect: true
       });
     } catch (error) {

--- a/server/src/components/billing-dashboard/alias-overhaul-project.md
+++ b/server/src/components/billing-dashboard/alias-overhaul-project.md
@@ -67,7 +67,7 @@
  - [ ] server/src/app/msp/contacts/[id]/activity/page.tsx
  - [ ] server/src/app/msp/contacts/[id]/page.tsx
  - [ ] server/src/app/msp/contacts/page.tsx
- - [ ] server/src/app/msp/dashboard/page.tsx
+ - [ ] server/src/app/msp/home/page.tsx
  - [ ] server/src/app/msp/jobs/page.tsx
  - [ ] server/src/app/msp/layout.tsx
  - [ ] server/src/app/msp/profile/page.tsx

--- a/server/src/components/dashboard/Dashboard.tsx
+++ b/server/src/components/dashboard/Dashboard.tsx
@@ -68,7 +68,7 @@ const QuickStartCard = ({ icon: Icon, step, title, description, href }: { icon: 
 
 const WelcomeDashboard = () => {
   return (
-    <ReflectionContainer id="dashboard-main" label="MSP Dashboard">
+    <ReflectionContainer id="dashboard-main" label="MSP Home">
       <div className="p-6 min-h-screen" style={{ background: 'rgb(var(--background))' }}>
       {/* Welcome Banner */}
       <div className="rounded-lg mb-6 p-6" 

--- a/server/src/components/layout/Header.tsx
+++ b/server/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ interface HeaderProps {
 }
 
 const getMenuItemNameByPath = (path: string | null | undefined): string => {
-  if (!path) return 'Dashboard';
+  if (!path) return 'Home';
   
   const allMenuItems = [...menuItems, ...bottomMenuItems];
   
@@ -47,7 +47,7 @@ const getMenuItemNameByPath = (path: string | null | undefined): string => {
     return null;
   };
 
-  return findMenuItem(allMenuItems) || 'Dashboard';
+  return findMenuItem(allMenuItems) || 'Home';
 };
 
 const Header: React.FC<HeaderProps> = ({

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -12,9 +12,9 @@ export interface MenuItem {
 
 export const menuItems: MenuItem[] = [
   {
-    name: 'Dashboard',
+    name: 'Home',
     icon: RadixIcons.BarChartIcon,
-    href: '/msp/dashboard'  // Updated to point to our new dashboard page
+    href: '/msp/home'  // Updated to point to our new home page
   },
   {
     name: 'User Activities',

--- a/tools/ai-automation/src/tools/getNavigationHelp.ts
+++ b/tools/ai-automation/src/tools/getNavigationHelp.ts
@@ -14,9 +14,9 @@ class GetNavigationHelpTool implements Tool {
         overview: "Read docs/ui_navigation_structure.md for complete navigation hierarchy",
         
         commonScreens: {
-          "dashboard": {
-            route: "/msp/dashboard",
-            navigation: "Click 'Dashboard' in sidebar (menu-dashboard)"
+          "home": {
+            route: "/msp/home",
+            navigation: "Click 'Home' in sidebar (menu-dashboard)"
           },
           "user-activities": {
             route: "/msp/user-activities", 


### PR DESCRIPTION
## Summary
- switch menuConfig and docs to `/msp/home`
- redirect root and `/msp` routes to `/msp/home`
- default MSP login redirect to `/msp/home`
- update extension examples and tests for new path

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm run test:local` *(fails: `dotenv` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e09ae7d4483308f02c4e88d50af71