### PR TITLE
Fix default DB username

### DIFF
--- a/hocuspocus/server.js
+++ b/hocuspocus/server.js
@@ -20,7 +20,8 @@ const server = Server.configure({
             host: process.env.DB_HOST ||  'localhost',
             port: process.env.DB_PORT || 5432,
             database: process.env.DB_NAME_HOCUSPOCUS || 'hocuspocus',
-            username: process.env.DB_USER_HOCUSPOCUS || 'postrgres',
+            // Use a sane default username for local development
+            username: process.env.DB_USER_HOCUSPOCUS || 'postgres',
             password: process.env.DB_PASSWORD_HOCUSPOCUS || 'sebastian123',
         }),
         new Logger({


### PR DESCRIPTION
## Summary
- correct typo in hocuspocus default database username

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_68507a45014c832a9264118ca6b4a1b3