### PR TITLE
Fix schedule entry assignee

### DIFF
--- a/server/src/components/schedule/ScheduleCalendar.tsx
+++ b/server/src/components/schedule/ScheduleCalendar.tsx
@@ -302,10 +302,13 @@ const ScheduleCalendar: React.FC = (): React.ReactElement | null => {
           return;
         }
       } else {
-        const result = await addScheduleEntry({
-          ...entryData,
-          recurrence_pattern: entryData.recurrence_pattern || null,
-        });
+        const result = await addScheduleEntry(
+          {
+            ...entryData,
+            recurrence_pattern: entryData.recurrence_pattern || null,
+          },
+          { assignedUserIds: entryData.assigned_user_ids }
+        );
         if (result.success && result.entry) {
           updatedEntry = result.entry;
           console.log('Added new entry:', updatedEntry);


### PR DESCRIPTION
## Summary
- pass assigned user IDs when creating schedule entries so the entry is assigned correctly

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_68507fb94a54832aa53809ec0d2ca45a