### PR TITLE
Add enter key handler for checklist items

### DIFF
--- a/server/src/components/projects/TaskForm.tsx
+++ b/server/src/components/projects/TaskForm.tsx
@@ -629,9 +629,10 @@ export default function TaskForm({
     setIsEditingChecklist(!isEditingChecklist);
   };
 
-  const addChecklistItem = () => {
+  const addChecklistItem = (): string => {
+    const newItemId = `temp-${Date.now()}`;
     const newItem: Omit<ITaskChecklistItem, 'tenant'> = {
-      checklist_item_id: `temp-${Date.now()}`,
+      checklist_item_id: newItemId,
       task_id: task?.task_id || tempTaskId,
       item_name: '',
       description: null,
@@ -642,7 +643,19 @@ export default function TaskForm({
       updated_at: new Date(),
       order_number: checklistItems.length + 1,
     };
-    setChecklistItems([...checklistItems, newItem]);
+    setChecklistItems((items) => [...items, newItem]);
+    return newItemId;
+  };
+
+  const handleChecklistItemKeyDown = (
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
+    index: number
+  ) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      const newId = addChecklistItem();
+      setEditingChecklistItemId(newId);
+    }
   };
 
   const updateChecklistItem = (index: number, field: keyof ITaskChecklistItem, value: any) => {
@@ -1105,6 +1118,7 @@ export default function TaskForm({
                               placeholder="Checklist item"
                               className="w-full"
                               onBlur={() => setEditingChecklistItemId(null)} // Stop editing when focus is lost
+                              onKeyDown={(e) => handleChecklistItemKeyDown(e, index)}
                             />
                           </div>
                           <button


### PR DESCRIPTION
## Summary
- allow Enter key to add a new checklist item in TaskForm

## Testing
- `npm run lint -w server` *(fails: `next` not found)*
- `npm run test:local` *(fails: `dotenv` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850c3bd9f2c832a967653250744544e