### PR TITLE
Fix base rate validation flash

### DIFF
--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -101,8 +101,9 @@ export function FixedPlanConfiguration({
     fetchServices(); // Fetch services initially
   }, [fetchPlanData, fetchServices]);
 
-  // Validate inputs
+  // Validate inputs only after initial data loads
   useEffect(() => {
+    if (loading) return; // avoid showing errors before data is fetched
     const errors: { baseRate?: string } = {};
     if (baseRate === undefined || baseRate === null) {
       errors.baseRate = 'Base rate is required';
@@ -110,7 +111,7 @@ export function FixedPlanConfiguration({
       errors.baseRate = 'Base rate cannot be negative';
     }
     setValidationErrors(errors);
-  }, [baseRate]);
+  }, [baseRate, loading]);
 
   const handleBaseRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value === '' ? undefined : Number(e.target.value);

--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -39,7 +39,8 @@ export function FixedPlanConfiguration({
   const [billingCycleAlignment, setBillingCycleAlignment] = useState<string>('start');
 
   const [services, setServices] = useState<IService[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [planLoading, setPlanLoading] = useState(true);
+  const [servicesLoading, setServicesLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -49,7 +50,7 @@ export function FixedPlanConfiguration({
   }>({});
 
   const fetchPlanData = useCallback(async () => {
-    setLoading(true);
+    setPlanLoading(true);
     setError(null);
     try {
       // Fetch the basic plan data
@@ -77,13 +78,13 @@ export function FixedPlanConfiguration({
       console.error('Error fetching plan data:', err);
       setError('Failed to load plan configuration. Please try again.');
     } finally {
-      setLoading(false);
+      setPlanLoading(false);
     }
   }, [planId]);
 
   const fetchServices = useCallback(async () => {
     // Fetch services for the service list component
-    setLoading(true); // Consider separate loading state for services
+    setServicesLoading(true);
     try {
         const response = await getServices();
         // Extract the services array from the paginated response
@@ -92,7 +93,7 @@ export function FixedPlanConfiguration({
         console.error('Error fetching services:', err);
         setError(prev => prev ? `${prev}\nFailed to load services.` : 'Failed to load services.');
     } finally {
-        setLoading(false); // Adjust loading state management
+        setServicesLoading(false);
     }
   }, []); // No dependencies needed
 
@@ -101,9 +102,9 @@ export function FixedPlanConfiguration({
     fetchServices(); // Fetch services initially
   }, [fetchPlanData, fetchServices]);
 
-  // Validate inputs only after initial data loads
+  // Validate inputs only after plan data loads
   useEffect(() => {
-    if (loading) return; // avoid showing errors before data is fetched
+    if (planLoading) return; // avoid showing errors before data is fetched
     const errors: { baseRate?: string } = {};
     if (baseRate === undefined || baseRate === null) {
       errors.baseRate = 'Base rate is required';
@@ -111,7 +112,7 @@ export function FixedPlanConfiguration({
       errors.baseRate = 'Base rate cannot be negative';
     }
     setValidationErrors(errors);
-  }, [baseRate, loading]);
+  }, [baseRate, planLoading]);
 
   const handleBaseRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value === '' ? undefined : Number(e.target.value);
@@ -175,7 +176,7 @@ export function FixedPlanConfiguration({
     label: service.service_name
   })) : [];
 
-  if (loading && !plan) {
+  if (planLoading && !plan) {
     return <div className="flex justify-center items-center p-8"><Spinner size="sm" /></div>;
   }
 


### PR DESCRIPTION
## Summary
- avoid showing validation errors in billing plan editor before data loads

## Testing
- `npm run test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_68517c14a918832abb7357a99b04a54d