### PR TITLE
feat: Prevent duplicate tags on entities

### DIFF
--- a/server/src/components/tags/TagInput.tsx
+++ b/server/src/components/tags/TagInput.tsx
@@ -1,16 +1,18 @@
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Plus } from 'lucide-react';
-import { generateEntityColor } from '../../utils/colorUtils';
-import { useAutomationIdAndRegister } from '../../types/ui-reflection/useAutomationIdAndRegister';
-import { ReflectionContainer } from '../../types/ui-reflection/ReflectionContainer';
-import { ButtonComponent, FormFieldComponent } from '../../types/ui-reflection/types';
+import { generateEntityColor } from 'server/src/utils/colorUtils';
+import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
+import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
+import { ButtonComponent, FormFieldComponent } from 'server/src/types/ui-reflection/types';
 import { Input } from 'server/src/components/ui/Input';
 import { Button } from 'server/src/components/ui/Button';
+import { ITag } from 'server/src/interfaces/tag.interfaces';
 
 interface TagInputProps {
   id?: string; // Made optional to maintain backward compatibility
   existingTags: string[];
+  currentTags?: ITag[];
   onAddTag: (tagText: string) => Promise<void>;
   className?: string;
   placeholder?: string;
@@ -19,6 +21,7 @@ interface TagInputProps {
 export const TagInput: React.FC<TagInputProps> = ({
   id = 'tag-input',
   existingTags,
+  currentTags = [],
   onAddTag,
   className = '',
   placeholder = 'New tag'
@@ -34,15 +37,21 @@ export const TagInput: React.FC<TagInputProps> = ({
 
   useEffect(() => {
     if (inputValue.trim()) {
-      // Filter existing tags that include the input value
+      // Get current tag texts (case-insensitive for comparison)
+      const currentTagTexts = currentTags.map(tag => tag.tag_text.toLowerCase());
+      
+      // Filter existing tags that:
+      // 1. Include the input value
+      // 2. Are not already on the current entity
       const filtered = existingTags.filter(tag => 
-        tag.toLowerCase().includes(inputValue.toLowerCase())
+        tag.toLowerCase().includes(inputValue.toLowerCase()) &&
+        !currentTagTexts.includes(tag.toLowerCase())
       );
       setSuggestions(filtered);
     } else {
       setSuggestions([]);
     }
-  }, [inputValue, existingTags]);
+  }, [inputValue, existingTags, currentTags]);
 
   // Update dropdown position when suggestions change or input is focused
   useLayoutEffect(() => {

--- a/server/src/components/tags/TagManager.tsx
+++ b/server/src/components/tags/TagManager.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { ITag, TaggedEntityType } from '../../interfaces/tag.interfaces';
-import { createTag, deleteTag } from '../../lib/actions/tagActions';
+import { ITag, TaggedEntityType } from 'server/src/interfaces/tag.interfaces';
+import { createTag, deleteTag } from 'server/src/lib/actions/tagActions';
 import { TagList } from './TagList';
 import { TagInput } from './TagInput';
-import { useAutomationIdAndRegister } from '../../types/ui-reflection/useAutomationIdAndRegister';
-import { ReflectionContainer } from '../../types/ui-reflection/ReflectionContainer';
-import { ContainerComponent } from '../../types/ui-reflection/types';
+import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
+import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
+import { ContainerComponent } from 'server/src/types/ui-reflection/types';
+import { toast } from 'react-hot-toast';
 
 interface TagManagerProps {
   id?: string; // Made optional to maintain backward compatibility
@@ -34,6 +35,16 @@ export const TagManager: React.FC<TagManagerProps> = ({
   }, [initialTags]);
 
   const handleAddTag = async (tagText: string) => {
+    // Check if tag already exists on this entity
+    const isDuplicate = tags.some(tag => 
+      tag.tag_text.toLowerCase() === tagText.toLowerCase()
+    );
+    
+    if (isDuplicate) {
+      toast.error(`Tag "${tagText}" already exists on this item`);
+      return;
+    }
+
     try {
       const newTag = await createTag({
         tag_text: tagText,
@@ -46,6 +57,7 @@ export const TagManager: React.FC<TagManagerProps> = ({
       onTagsChange?.(updatedTags);
     } catch (error) {
       console.error('Error adding tag:', error);
+      toast.error('Failed to add tag');
     }
   };
 
@@ -71,6 +83,7 @@ export const TagManager: React.FC<TagManagerProps> = ({
         <TagInput
           id={`${id}-input`}
           existingTags={existingTags}
+          currentTags={tags}
           onAddTag={handleAddTag}
         />
       </div>


### PR DESCRIPTION
  - Add duplicate tag validation in TagManager with case-insensitive checking
  - Filter existing entity tags from suggestions in TagInput component
  - Show toast error when attempting to add duplicate tags
  - Improve UX by only showing applicable tags in suggestions dropdown

  No more tag déjà vu - because seeing double is only fun at parties! 🏷️🏷️