### PR TITLE
Fix AssemblyScript dependencies in dev environment

### DIFF
--- a/docker/dev-env/Dockerfile.code-server
+++ b/docker/dev-env/Dockerfile.code-server
@@ -97,6 +97,7 @@ RUN chmod +x /usr/local/bin/start-dev-env.sh
 COPY --chown=coder:coder package*.json /home/coder/alga-psa/
 COPY --chown=coder:coder server/package*.json /home/coder/alga-psa/server/
 COPY --chown=coder:coder tools/ai-automation/package*.json /home/coder/alga-psa/tools/ai-automation/
+COPY --chown=coder:coder server/src/invoice-templates/assemblyscript/package*.json /home/coder/alga-psa/server/src/invoice-templates/assemblyscript/
 
 # Ensure coder owns the entire directory structure
 RUN chown -R coder:coder /home/coder/alga-psa
@@ -115,7 +116,10 @@ RUN echo "📦 Pre-installing root dependencies..." && \
     cd .. && \
     echo "🤖 Pre-installing AI automation dependencies..." && \
     cd tools/ai-automation && npm ci --prefer-offline --no-audit && \
-    cd ..
+    cd ../.. && \
+    echo "📄 Pre-installing AssemblyScript template dependencies..." && \
+    cd server/src/invoice-templates/assemblyscript && npm ci --prefer-offline --no-audit && \
+    cd ../..
 
 # Switch back to root for final setup
 USER root

--- a/docker/dev-env/start-dev-env.sh
+++ b/docker/dev-env/start-dev-env.sh
@@ -54,6 +54,16 @@ if [ -f "tools/ai-automation/package.json" ]; then
     fi
 fi
 
+# Install AssemblyScript template dependencies if they exist
+if [ -f "server/src/invoice-templates/assemblyscript/package.json" ]; then
+    if [ ! -d "server/src/invoice-templates/assemblyscript/node_modules" ] || [ "server/src/invoice-templates/assemblyscript/package.json" -nt "server/src/invoice-templates/assemblyscript/node_modules" ]; then
+        echo "📄 Installing/updating AssemblyScript template dependencies..."
+        cd server/src/invoice-templates/assemblyscript && npm install && cd ../../../..
+    else
+        echo "✅ AssemblyScript template dependencies already installed"
+    fi
+fi
+
 # Start code-server
 echo "🖥️  Starting code-server..."
 exec /usr/bin/entrypoint.sh --bind-addr 0.0.0.0:8080 /home/coder/alga-psa

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,10 @@ COPY server/package.json ./server/
 
 COPY server/src/invoice-templates/assemblyscript ./server/src/invoice-templates/assemblyscript
 
-RUN npm install
+RUN npm install && \
+    cd server/src/invoice-templates/assemblyscript && \
+    npm install && \
+    cd /app
 
 COPY tsconfig.base.json ./
 


### PR DESCRIPTION
## Summary
- Fixes the "Cannot find module 'json-as/transform'" error that occurs during invoice template compilation on startup
- Ensures AssemblyScript dependencies are properly installed in both development and production environments

## Changes
- **Updated code-server Dockerfile** to copy and install AssemblyScript package dependencies during build
- **Updated startup script** to check and install AssemblyScript dependencies if they're missing or outdated
- **Updated server Dockerfile** to include AssemblyScript dependency installation in production builds

## Test plan
- [ ] Build the dev environment Docker image: `docker build -f docker/dev-env/Dockerfile.code-server .`
- [ ] Run `dev-env-create` command to create a new development environment
- [ ] Verify that invoice template compilation works without errors on startup
- [ ] Check that the AssemblyScript dependencies are installed in `/server/src/invoice-templates/assemblyscript/node_modules`

🤖 Generated with [Claude Code](https://claude.ai/code)