### PR TITLE
Fix: Close invoice preview when switching between Draft and Finalized tabs

### DIFF
--- a/server/src/components/billing-dashboard/Invoices.tsx
+++ b/server/src/components/billing-dashboard/Invoices.tsx
@@ -70,6 +70,13 @@ const Invoices: React.FC = () => {
   const handleTabChange = (value: string) => {
     setActiveTab(value as 'Draft' | 'Finalized');
     setSelectedInvoices(new Set());
+    // Clear the invoice preview when switching tabs
+    setDetailedInvoiceData(null); // Clear the preview data immediately
+    updateUrlParams({
+      invoiceId: null,
+      templateId: null,
+      managingInvoiceId: null
+    });
   };
   const selectedTemplateId = searchParams?.get('templateId');
   const managingInvoiceId = searchParams?.get('managingInvoiceId');


### PR DESCRIPTION
## Summary
- Fixed invoice preview persistence when switching between Draft and Finalized tabs
- Added immediate clearing of preview data to prevent user confusion

## Problem
When users switched between the Draft and Finalized tabs in the billing dashboard, the previously selected invoice would remain visible in the preview pane. This could cause confusion as users might think they're viewing an invoice from the current tab when it's actually from the previous tab.

## Solution
Modified the `handleTabChange` function in the Invoices component to:
1. Clear the `detailedInvoiceData` state immediately when switching tabs
2. Reset all URL parameters (invoiceId, templateId, managingInvoiceId) to null
3. Clear selected invoice checkboxes (existing behavior)

This ensures a clean slate when switching between invoice states, preventing any confusion about which invoice is being previewed.

## Test plan
- [ ] Navigate to the billing dashboard invoices section
- [ ] Select an invoice in the Draft tab to view its preview
- [ ] Switch to the Finalized tab
- [ ] Verify that the invoice preview is closed and no invoice is selected
- [ ] Select an invoice in the Finalized tab
- [ ] Switch back to the Draft tab
- [ ] Verify that the invoice preview is closed again

🤖 Generated with [Claude Code](https://claude.ai/code)