### PR TITLE
Add currency formatting for plan base rate input

### DIFF
--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Input } from 'server/src/components/ui/Input';
+import { CurrencyInput } from 'server/src/components/ui/CurrencyInput';
 import { Label } from 'server/src/components/ui/Label';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 import { Switch } from 'server/src/components/ui/Switch';
@@ -112,8 +112,7 @@ export function FixedPlanConfiguration({
     setValidationErrors(errors);
   }, [baseRate]);
 
-  const handleBaseRateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value === '' ? undefined : Number(e.target.value);
+  const handleBaseRateChange = (value: number | undefined) => {
     setBaseRate(value);
   };
 
@@ -222,15 +221,12 @@ export function FixedPlanConfiguration({
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <Label htmlFor="fixed-plan-base-rate">Base Rate</Label>
-              <Input
+              <CurrencyInput
                 id="fixed-plan-base-rate"
-                type="number"
-                value={baseRate?.toString() || ''}
+                value={baseRate}
                 onChange={handleBaseRateChange}
                 placeholder="Enter base rate"
                 disabled={saving}
-                min={0}
-                step={0.01}
               />
               <p className="text-sm text-muted-foreground mt-1">
                 The base rate for this fixed plan. This rate will be applied to all services associated with this plan.

--- a/server/src/components/ui/CurrencyInput.tsx
+++ b/server/src/components/ui/CurrencyInput.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import { Input } from './Input';
+
+interface CurrencyInputProps {
+  id?: string;
+  value?: number;
+  onChange?: (value: number | undefined) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function CurrencyInput({
+  id,
+  value,
+  onChange,
+  disabled = false,
+  placeholder = '0.00',
+  className = '',
+}: CurrencyInputProps) {
+  const [displayValue, setDisplayValue] = useState('');
+
+  useEffect(() => {
+    if (value === undefined || value === null || isNaN(value)) {
+      setDisplayValue('');
+    } else {
+      setDisplayValue(formatNumber(value));
+    }
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    setDisplayValue(raw);
+
+    const numeric = parseFloat(raw.replace(/,/g, ''));
+    if (raw === '' || isNaN(numeric)) {
+      onChange?.(undefined);
+    } else {
+      onChange?.(numeric);
+    }
+  };
+
+  const handleBlur = () => {
+    const numeric = parseFloat(displayValue.replace(/,/g, ''));
+    if (!isNaN(numeric)) {
+      setDisplayValue(formatNumber(numeric));
+    } else {
+      setDisplayValue('');
+    }
+  };
+
+  return (
+    <Input
+      id={id}
+      type="text"
+      value={displayValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `CurrencyInput` component to format values as standard currency
- use `CurrencyInput` in fixed plan configuration form

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'zod')*
- `npx eslint server/src/components/ui/CurrencyInput.tsx` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6851b71df890832ab289e6c0200af49f