### PR TITLE
Fix inactive client filter

### DIFF
--- a/server/src/components/companies/Companies.tsx
+++ b/server/src/components/companies/Companies.tsx
@@ -130,7 +130,7 @@ const Companies: React.FC = () => {
       const response = await getAllCompaniesPaginated({
         page: currentPage,
         pageSize,
-        includeInactive: filterStatus !== 'active',
+        statusFilter: filterStatus,
         searchTerm: searchTerm || undefined,
         clientTypeFilter,
         loadLogos: true // Load logos for displayed companies only

--- a/server/src/lib/actions/company-actions/companyActions.ts
+++ b/server/src/lib/actions/company-actions/companyActions.ts
@@ -293,6 +293,13 @@ export interface CompanyPaginationParams {
   searchTerm?: string;
   clientTypeFilter?: 'all' | 'company' | 'individual';
   loadLogos?: boolean; // Option to load logos or not
+  /**
+   * Optional status filter. Overrides includeInactive if provided.
+   *  - 'active'   -> only active companies
+   *  - 'inactive' -> only inactive companies
+   *  - 'all'      -> include both active and inactive
+   */
+  statusFilter?: 'all' | 'active' | 'inactive';
 }
 
 export interface PaginatedCompaniesResponse {
@@ -310,7 +317,8 @@ export async function getAllCompaniesPaginated(params: CompanyPaginationParams =
     includeInactive = true,
     searchTerm,
     clientTypeFilter = 'all',
-    loadLogos = true
+    loadLogos = true,
+    statusFilter
   } = params;
 
   const {knex: db, tenant} = await createTenantKnex();
@@ -331,7 +339,11 @@ export async function getAllCompaniesPaginated(params: CompanyPaginationParams =
         })
         .where({ 'c.tenant': tenant });
 
-      if (!includeInactive) {
+      if (statusFilter === 'active') {
+        baseQuery = baseQuery.andWhere('c.is_inactive', false);
+      } else if (statusFilter === 'inactive') {
+        baseQuery = baseQuery.andWhere('c.is_inactive', true);
+      } else if (!statusFilter && !includeInactive) {
         baseQuery = baseQuery.andWhere('c.is_inactive', false);
       }
 


### PR DESCRIPTION
## Summary
- add statusFilter option when retrieving companies
- wire up filter on the companies page so inactive filter works

## Testing
- `npm run test:local` *(fails: `dotenv` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851956ded88832a8bbd3fdd5602be66