### PR TITLE
Remove node selector from dev environments

### DIFF
--- a/helm/values-dev-env.yaml
+++ b/helm/values-dev-env.yaml
@@ -120,10 +120,7 @@ devEnv:
     tls:
       enabled: true
       secretName: "alga-dev-tls"
-  
-  # Node selector and tolerations for dev environments
-  nodeSelector: 
-    kubernetes.io/hostname: cloudlab-26
+
   tolerations: []
   affinity: {}
 


### PR DESCRIPTION
## Summary
- Remove node selector that was pinning dev environment pods to cloudlab-26
- Allow dev environment workloads to be scheduled on any available node

## Test plan
- [ ] Deploy dev environment and verify pods can be scheduled on different nodes
- [ ] Confirm dev environment functionality remains intact