### PR TITLE
Remove custom billing plan checkbox

### DIFF
--- a/server/src/components/billing-dashboard/BillingPlanDialog.tsx
+++ b/server/src/components/billing-dashboard/BillingPlanDialog.tsx
@@ -222,16 +222,6 @@ export function BillingPlanDialog({ onPlanAdded, editingPlan, onClose, triggerBu
                 />
                 {/* Removed CustomSelect */}
               </div>
-              <div className="flex items-center space-x-2 pt-2">
-                <Checkbox
-                  id="is-custom"
-                  checked={isCustom}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsCustom(e.target.checked)}
-                />
-                <Label htmlFor="is-custom" className="cursor-pointer">
-                  Is Custom Plan
-                </Label>
-              </div>
             </div>
 
             {/* Removed Config Tab Content and Service Selection */}


### PR DESCRIPTION
## Summary
- remove the `Is Custom Plan` checkbox from the Add Billing Plan dialog

## Testing
- `npm run test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_68556a08f064832aa81cc281b9b6a4c2