### PR TITLE
Hide sidebar search bar

### DIFF
--- a/cli/colors.nu
+++ b/cli/colors.nu
@@ -1,4 +1,5 @@
 # --- Color Constants ---
+
 export-env {
     $env.ALGA_COLOR_RESET = (ansi reset)
     $env.ALGA_COLOR_GREEN = (ansi green)

--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -116,8 +116,10 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }): JSX.E
         {sidebarOpen && <span className="text-xl font-semibold truncate">AlgaPSA</span>}
       </div>
 
+      {/* Temporarily hide the search bar since it is non-functional */}
+      {/*
       <div className="px-3 py-4">
-        <div 
+        <div
           className="relative w-full bg-[#2a2b32] text-gray-300 rounded-md"
           onClick={() => !sidebarOpen && setSidebarOpen(true)}
           style={{ cursor: sidebarOpen ? 'default' : 'pointer' }}
@@ -134,6 +136,7 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }): JSX.E
           )}
         </div>
       </div>
+      */}
 
       <nav className="mt-4 flex-grow overflow-y-auto">
         <ul className="space-y-1">


### PR DESCRIPTION
## Summary
- comment out the unused search bar in the main `Sidebar` component

## Testing
- `npm run test:local` *(fails: `dotenv` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68558e7369dc832a8f391b594f16ad8c