### PR TITLE
Add weekday dropdown for weekly time periods

### DIFF
--- a/docs/time_entry.md
+++ b/docs/time_entry.md
@@ -127,6 +127,7 @@ To create semi-monthly periods (from the 1st to the 15th and from the 16th to th
 - The `end_day` field specifies the day on which the period ends.
 - If `end_day` is less than `start_day`, the period rolls over to the next month.
 - Using `end_day` as 0 or 31 indicates the period ends on the last day of the month, accommodating months with different lengths.
+- For **weekly** periods, the settings UI provides calendar-style dropdowns for selecting `start_day` and `end_day` (Monday through Sunday).
 
 #### Constraints and Validation
 

--- a/server/src/components/settings/billing/TimePeriodSettings.tsx
+++ b/server/src/components/settings/billing/TimePeriodSettings.tsx
@@ -26,6 +26,15 @@ const monthOptions = monthNames.map((name, index): { value: string; label: strin
   label: name
 }));
 
+const weekDayNames = [
+  'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'
+];
+
+const weekDayOptions = weekDayNames.map((name, index): { value: string; label: string } => ({
+  value: (index + 1).toString(),
+  label: name
+}));
+
 const frequencyUnitOptions: Array<{ value: FrequencyUnit; label: string }> = [
   { value: 'day', label: 'Day' },
   { value: 'week', label: 'Week' },
@@ -245,7 +254,9 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
   const handleSelectChange = (name: string) => (value: string) => {
     if (name === 'frequency_unit') {
       setNewSetting({ ...newSetting, [name]: value as FrequencyUnit });
-    } else if (name === 'start_month' || name === 'end_month') {
+    } else if (name === 'start_month' || name === 'end_month' ||
+               name === 'start_day' || name === 'end_day' ||
+               name === 'start_day_of_month' || name === 'end_day_of_month') {
       setNewSetting({ ...newSetting, [name]: parseInt(value, 10) });
     }
   };
@@ -297,17 +308,28 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
         <>
           <div className="space-y-2">
             <Label htmlFor="start_day">Start Day *</Label>
-            <Input
-              id="start_day"
-              name="start_day"
-              type="number"
-              min={1}
-              max={newSetting.frequency_unit === 'week' ? 7 : 31}
-              value={newSetting.start_day}
-              onChange={handleInputChange}
-              placeholder="Enter start day"
-              className={hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}
-            />
+            {newSetting.frequency_unit === 'week' ? (
+              <CustomSelect
+                id="start_day"
+                value={newSetting.start_day?.toString()}
+                onValueChange={handleSelectChange('start_day')}
+                options={weekDayOptions}
+                placeholder="Select day"
+                className={hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}
+              />
+            ) : (
+              <Input
+                id="start_day"
+                name="start_day"
+                type="number"
+                min={1}
+                max={31}
+                value={newSetting.start_day}
+                onChange={handleInputChange}
+                placeholder="Enter start day"
+                className={hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}
+              />
+            )}
           </div>
 
           <div className="space-y-2">
@@ -323,17 +345,28 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
             {!useEndOfPeriod && (
               <div className="space-y-2">
                 <Label htmlFor="end_day">End Day *</Label>
-                <Input
-                  id="end_day"
-                  name="end_day"
-                  type="number"
-                  min={1}
-                  max={newSetting.frequency_unit === 'week' ? 7 : 31}
-                  value={newSetting.end_day === END_OF_PERIOD ? '' : newSetting.end_day}
-                  onChange={handleInputChange}
-                  placeholder="Enter end day"
-                  className={hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}
-                />
+                {newSetting.frequency_unit === 'week' ? (
+                  <CustomSelect
+                    id="end_day"
+                    value={newSetting.end_day === END_OF_PERIOD ? '' : newSetting.end_day?.toString()}
+                    onValueChange={handleSelectChange('end_day')}
+                    options={weekDayOptions}
+                    placeholder="Select day"
+                    className={hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}
+                  />
+                ) : (
+                  <Input
+                    id="end_day"
+                    name="end_day"
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={newSetting.end_day === END_OF_PERIOD ? '' : newSetting.end_day}
+                    onChange={handleInputChange}
+                    placeholder="Enter end day"
+                    className={hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}
+                  />
+                )}
               </div>
             )}
           </div>
@@ -460,7 +493,9 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
   const handleSelectChange = (name: string) => (value: string) => {
     if (name === 'frequency_unit') {
       setEditedSetting({ ...editedSetting, [name]: value as FrequencyUnit });
-    } else if (name === 'start_month' || name === 'end_month') {
+    } else if (name === 'start_month' || name === 'end_month' ||
+               name === 'start_day' || name === 'end_day' ||
+               name === 'start_day_of_month' || name === 'end_day_of_month') {
       setEditedSetting({ ...editedSetting, [name]: parseInt(value, 10) });
     }
   };
@@ -506,6 +541,9 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
   const formatEndDay = (day: number | undefined, frequencyUnit: string): string => {
     if (day === END_OF_PERIOD) {
       return `End of ${frequencyUnit}`;
+    }
+    if (frequencyUnit === 'week' && day) {
+      return weekDayNames[day - 1];
     }
     return day?.toString() || 'Not set';
   };
@@ -556,17 +594,28 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
               <>
                 <div className="space-y-2">
                   <Label htmlFor="start_day">Start Day *</Label>
-                  <Input
-                    id="start_day"
-                    name="start_day"
-                    type="number"
-                    min={1}
-                    max={editedSetting.frequency_unit === 'week' ? 7 : 31}
-                    value={editedSetting.start_day}
-                    onChange={handleInputChange}
-                    placeholder="Enter start day"
-                    className={hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}
-                  />
+                  {editedSetting.frequency_unit === 'week' ? (
+                    <CustomSelect
+                      id="start_day"
+                      value={editedSetting.start_day?.toString()}
+                      onValueChange={handleSelectChange('start_day')}
+                      options={weekDayOptions}
+                      placeholder="Select day"
+                      className={hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}
+                    />
+                  ) : (
+                    <Input
+                      id="start_day"
+                      name="start_day"
+                      type="number"
+                      min={1}
+                      max={31}
+                      value={editedSetting.start_day}
+                      onChange={handleInputChange}
+                      placeholder="Enter start day"
+                      className={hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}
+                    />
+                  )}
                 </div>
 
                 <div className="space-y-2">
@@ -582,17 +631,28 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                   {!useEndOfPeriod && (
                     <div className="space-y-2">
                       <Label htmlFor="end_day">End Day *</Label>
-                      <Input
-                        id="end_day"
-                        name="end_day"
-                        type="number"
-                        min={1}
-                        max={editedSetting.frequency_unit === 'week' ? 7 : 31}
-                        value={editedSetting.end_day === END_OF_PERIOD ? '' : editedSetting.end_day}
-                        onChange={handleInputChange}
-                        placeholder="Enter end day"
-                        className={hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}
-                      />
+                      {editedSetting.frequency_unit === 'week' ? (
+                        <CustomSelect
+                          id="end_day"
+                          value={editedSetting.end_day === END_OF_PERIOD ? '' : editedSetting.end_day?.toString()}
+                          onValueChange={handleSelectChange('end_day')}
+                          options={weekDayOptions}
+                          placeholder="Select day"
+                          className={hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}
+                        />
+                      ) : (
+                        <Input
+                          id="end_day"
+                          name="end_day"
+                          type="number"
+                          min={1}
+                          max={31}
+                          value={editedSetting.end_day === END_OF_PERIOD ? '' : editedSetting.end_day}
+                          onChange={handleInputChange}
+                          placeholder="Enter end day"
+                          className={hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}
+                        />
+                      )}
                     </div>
                   )}
                 </div>
@@ -692,7 +752,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
           <p>Frequency: {setting.frequency} {setting.frequency_unit}(s)</p>
           {(setting.frequency_unit === 'week' || setting.frequency_unit === 'month') && (
             <>
-              <p>Start Day: {setting.start_day}</p>
+              <p>Start Day: {setting.frequency_unit === 'week' ? weekDayNames[setting.start_day - 1] : setting.start_day}</p>
               <p>End Day: {formatEndDay(setting.end_day, setting.frequency_unit)}</p>
             </>
           )}

--- a/server/src/components/settings/billing/TimePeriodSettings.tsx
+++ b/server/src/components/settings/billing/TimePeriodSettings.tsx
@@ -289,7 +289,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
           value={newSetting.frequency}
           onChange={handleInputChange}
           placeholder="Enter frequency"
-          className={hasAttemptedSubmit && (!newSetting.frequency || newSetting.frequency < 1) ? 'border-red-500' : ''}
+          className={`!w-24 ${hasAttemptedSubmit && (!newSetting.frequency || newSetting.frequency < 1) ? 'border-red-500' : ''}`}
         />
       </div>
 
@@ -300,7 +300,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
           onValueChange={handleSelectChange('frequency_unit')}
           options={frequencyUnitOptions}
           placeholder="Select frequency unit"
-          className={hasAttemptedSubmit && !newSetting.frequency_unit ? 'border-red-500' : ''}
+          className={`!w-fit ${hasAttemptedSubmit && !newSetting.frequency_unit ? 'border-red-500' : ''}`}
         />
       </div>
 
@@ -315,7 +315,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
                 onValueChange={handleSelectChange('start_day')}
                 options={weekDayOptions}
                 placeholder="Select day"
-                className={hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}
+                className={`!w-fit ${hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}`}
               />
             ) : (
               <Input
@@ -327,7 +327,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
                 value={newSetting.start_day}
                 onChange={handleInputChange}
                 placeholder="Enter start day"
-                className={hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}
+                className={`!w-20 ${hasAttemptedSubmit && !newSetting.start_day ? 'border-red-500' : ''}`}
               />
             )}
           </div>
@@ -352,7 +352,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
                     onValueChange={handleSelectChange('end_day')}
                     options={weekDayOptions}
                     placeholder="Select day"
-                    className={hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}
+                    className={`!w-fit ${hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}`}
                   />
                 ) : (
                   <Input
@@ -364,7 +364,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
                     value={newSetting.end_day === END_OF_PERIOD ? '' : newSetting.end_day}
                     onChange={handleInputChange}
                     placeholder="Enter end day"
-                    className={hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}
+                    className={`!w-20 ${hasAttemptedSubmit && (newSetting.end_day === undefined || newSetting.end_day === null) ? 'border-red-500' : ''}`}
                   />
                 )}
               </div>
@@ -381,6 +381,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
               value={(newSetting.start_month || 1).toString()}
               onValueChange={handleSelectChange('start_month')}
               options={monthOptions}
+              className="!w-fit"
             />
           </div>
 
@@ -395,7 +396,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
               value={newSetting.start_day_of_month}
               onChange={handleInputChange}
               placeholder="Enter start day"
-              className={hasAttemptedSubmit && !newSetting.start_day_of_month ? 'border-red-500' : ''}
+              className={`!w-20 ${hasAttemptedSubmit && !newSetting.start_day_of_month ? 'border-red-500' : ''}`}
             />
           </div>
 
@@ -405,6 +406,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
               value={(newSetting.end_month || 12).toString()}
               onValueChange={handleSelectChange('end_month')}
               options={monthOptions}
+              className="!w-fit"
             />
           </div>
 
@@ -430,7 +432,7 @@ const NewTimePeriodSettingForm: React.FC<NewTimePeriodSettingFormProps> = ({ new
                   value={newSetting.end_day_of_month === END_OF_PERIOD ? '' : newSetting.end_day_of_month}
                   onChange={handleInputChange}
                   placeholder="Enter end day"
-                  className={hasAttemptedSubmit && (newSetting.end_day_of_month === undefined || newSetting.end_day_of_month === null) ? 'border-red-500' : ''}
+                  className={`!w-20 ${hasAttemptedSubmit && (newSetting.end_day_of_month === undefined || newSetting.end_day_of_month === null) ? 'border-red-500' : ''}`}
                 />
               </div>
             )}
@@ -575,7 +577,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                 value={editedSetting.frequency}
                 onChange={handleInputChange}
                 placeholder="Enter frequency"
-                className={hasAttemptedSubmit && (!editedSetting.frequency || editedSetting.frequency < 1) ? 'border-red-500' : ''}
+                className={`!w-24 ${hasAttemptedSubmit && (!editedSetting.frequency || editedSetting.frequency < 1) ? 'border-red-500' : ''}`}
               />
             </div>
 
@@ -586,7 +588,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                 onValueChange={handleSelectChange('frequency_unit')}
                 options={frequencyUnitOptions}
                 placeholder="Select frequency unit"
-                className={hasAttemptedSubmit && !editedSetting.frequency_unit ? 'border-red-500' : ''}
+                className={`!w-fit ${hasAttemptedSubmit && !editedSetting.frequency_unit ? 'border-red-500' : ''}`}
               />
             </div>
 
@@ -601,7 +603,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                       onValueChange={handleSelectChange('start_day')}
                       options={weekDayOptions}
                       placeholder="Select day"
-                      className={hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}
+                      className={`!w-fit ${hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}`}
                     />
                   ) : (
                     <Input
@@ -613,7 +615,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                       value={editedSetting.start_day}
                       onChange={handleInputChange}
                       placeholder="Enter start day"
-                      className={hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}
+                      className={`!w-20 ${hasAttemptedSubmit && !editedSetting.start_day ? 'border-red-500' : ''}`}
                     />
                   )}
                 </div>
@@ -638,7 +640,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                           onValueChange={handleSelectChange('end_day')}
                           options={weekDayOptions}
                           placeholder="Select day"
-                          className={hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}
+                          className={`!w-fit ${hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}`}
                         />
                       ) : (
                         <Input
@@ -650,7 +652,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                           value={editedSetting.end_day === END_OF_PERIOD ? '' : editedSetting.end_day}
                           onChange={handleInputChange}
                           placeholder="Enter end day"
-                          className={hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}
+                          className={`!w-20 ${hasAttemptedSubmit && (editedSetting.end_day === undefined || editedSetting.end_day === null) ? 'border-red-500' : ''}`}
                         />
                       )}
                     </div>
@@ -667,6 +669,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                     value={(editedSetting.start_month || 1).toString()}
                     onValueChange={handleSelectChange('start_month')}
                     options={monthOptions}
+                    className="!w-fit"
                   />
                 </div>
 
@@ -681,7 +684,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                     value={editedSetting.start_day_of_month}
                     onChange={handleInputChange}
                     placeholder="Enter start day"
-                    className={hasAttemptedSubmit && !editedSetting.start_day_of_month ? 'border-red-500' : ''}
+                    className={`!w-20 ${hasAttemptedSubmit && !editedSetting.start_day_of_month ? 'border-red-500' : ''}`}
                   />
                 </div>
 
@@ -691,6 +694,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                     value={(editedSetting.end_month || 12).toString()}
                     onValueChange={handleSelectChange('end_month')}
                     options={monthOptions}
+                    className="!w-fit"
                   />
                 </div>
 
@@ -716,7 +720,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
                         value={editedSetting.end_day_of_month === END_OF_PERIOD ? '' : editedSetting.end_day_of_month}
                         onChange={handleInputChange}
                         placeholder="Enter end day"
-                        className={hasAttemptedSubmit && (editedSetting.end_day_of_month === undefined || editedSetting.end_day_of_month === null) ? 'border-red-500' : ''}
+                        className={`!w-20 ${hasAttemptedSubmit && (editedSetting.end_day_of_month === undefined || editedSetting.end_day_of_month === null) ? 'border-red-500' : ''}`}
                       />
                     </div>
                   )}
@@ -752,7 +756,7 @@ const TimePeriodSettingItem: React.FC<TimePeriodSettingItemProps> = ({ setting, 
           <p>Frequency: {setting.frequency} {setting.frequency_unit}(s)</p>
           {(setting.frequency_unit === 'week' || setting.frequency_unit === 'month') && (
             <>
-              <p>Start Day: {setting.frequency_unit === 'week' ? weekDayNames[setting.start_day - 1] : setting.start_day}</p>
+              <p>Start Day: {setting.frequency_unit === 'week' ? weekDayNames[(setting.start_day ?? 1) - 1] : setting.start_day}</p>
               <p>End Day: {formatEndDay(setting.end_day, setting.frequency_unit)}</p>
             </>
           )}


### PR DESCRIPTION
## Summary
- add note about calendar dropdown in docs
- replace numeric inputs with weekday dropdowns for weekly time period settings
- show weekday names in read-only view

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_68558eb67d4c832aa53a766a09e37282