### PR TITLE
Add clear option for phase dates

### DIFF
--- a/server/src/components/documents/DocumentFilters.tsx
+++ b/server/src/components/documents/DocumentFilters.tsx
@@ -120,10 +120,12 @@ export default function DocumentFilters({
           </label>
           <DatePicker
             value={filters.updated_at_start ? new Date(filters.updated_at_start) : undefined}
-            onChange={(date: Date | null) => onFiltersChange({ 
-              ...filters, 
-              updated_at_start: date ? date.toISOString().split('T')[0] : '' 
-            })}
+            onChange={(date: Date | undefined) =>
+              onFiltersChange({
+                ...filters,
+                updated_at_start: date ? date.toISOString().split('T')[0] : ''
+              })
+            }
             placeholder="Select start date"
             className="w-full"
           />
@@ -135,10 +137,12 @@ export default function DocumentFilters({
           </label>
           <DatePicker
             value={filters.updated_at_end ? new Date(filters.updated_at_end) : undefined}
-            onChange={(date: Date | null) => onFiltersChange({ 
-              ...filters, 
-              updated_at_end: date ? date.toISOString().split('T')[0] : '' 
-            })}
+            onChange={(date: Date | undefined) =>
+              onFiltersChange({
+                ...filters,
+                updated_at_end: date ? date.toISOString().split('T')[0] : ''
+              })
+            }
             placeholder="Select end date"
             className="w-full"
           />

--- a/server/src/components/projects/PhaseListItem.tsx
+++ b/server/src/components/projects/PhaseListItem.tsx
@@ -262,6 +262,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
                 onChange={(date: Date | undefined) => onStartDateChange?.(date)}
                 placeholder="Start date"
                 className="w-full"
+                clearable={true}
               />
             </div>
             {/* End Date Input */}
@@ -272,6 +273,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
                 onChange={(date: Date | undefined) => onEndDateChange?.(date)}
                 placeholder="End date"
                 className="w-full"
+                clearable={true}
               />
             </div>
           </div>

--- a/server/src/components/projects/PhaseQuickAdd.tsx
+++ b/server/src/components/projects/PhaseQuickAdd.tsx
@@ -107,6 +107,7 @@ const PhaseQuickAdd: React.FC<PhaseQuickAddProps> = ({
                     value={startDate}
                     onChange={setStartDate}
                     placeholder="Select start date"
+                    clearable={true}
                   />
                 </div>
                 <div>
@@ -115,6 +116,7 @@ const PhaseQuickAdd: React.FC<PhaseQuickAddProps> = ({
                     value={endDate}
                     onChange={setEndDate}
                     placeholder="Select end date"
+                    clearable={true}
                   />
                 </div>
               </div>

--- a/server/src/components/ui/DatePicker.tsx
+++ b/server/src/components/ui/DatePicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { format } from 'date-fns';
-import { Calendar as CalendarIcon } from 'lucide-react';
+import { Calendar as CalendarIcon, X } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
 import { DatePickerComponent } from 'server/src/types/ui-reflection/types';
@@ -8,7 +8,7 @@ import { Calendar } from 'server/src/components/ui/Calendar';
 
 export interface DatePickerProps {
   value?: Date;
-  onChange: (date: Date) => void;
+  onChange: (date: Date | undefined) => void;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -18,10 +18,12 @@ export interface DatePickerProps {
   label?: string;
   /** Whether the field is required */
   required?: boolean;
+  /** Whether the value can be cleared */
+  clearable?: boolean;
 }
 
 export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
-  ({ value, onChange, placeholder = 'Select date', className, disabled, id, label, required }, ref) => {
+  ({ value, onChange, placeholder = 'Select date', className, disabled, id, label, required, clearable = false }, ref) => {
     const [open, setOpen] = React.useState(false);
     
     // Register with UI reflection system if id is provided
@@ -65,6 +67,19 @@ export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
             <span className="flex-1 text-left">
               {value ? format(value, 'MM/dd/yyyy') : placeholder}
             </span>
+            {clearable && value && !disabled && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onChange(undefined);
+                }}
+                className="mr-2 text-gray-400 hover:text-gray-600"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
             <CalendarIcon className="h-4 w-4 opacity-50" />
           </Popover.Trigger>
 
@@ -82,6 +97,8 @@ export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
                     if (date) {
                       onChange(new Date(date)); // Ensure we pass a new Date object
                       setOpen(false);
+                    } else {
+                      onChange(undefined);
                     }
                   }}
                   defaultMonth={value}


### PR DESCRIPTION
## Summary
- allow DatePicker to clear a selected value
- use the new `clearable` prop in phase editing components
- update document filter usage for new DatePicker API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855b3a246ec832aa145d0f63c6317a6