### PR TITLE
Add toast confirmation when profile details saved

### DIFF
--- a/server/src/components/settings/general/UserProfile.tsx
+++ b/server/src/components/settings/general/UserProfile.tsx
@@ -19,6 +19,7 @@ import PasswordChangeForm from './PasswordChangeForm';
 import ApiKeysSetup from '../api/ApiKeysSetup';
 import UserAvatarUpload from 'server/src/components/settings/profile/UserAvatarUpload';
 import { getUserAvatarUrl } from 'server/src/lib/utils/avatarUtils';
+import { toast } from 'react-hot-toast';
 
 interface UserProfileProps {
   userId?: string; // Optional - if not provided, uses current user
@@ -134,6 +135,9 @@ export default function UserProfile({ userId }: UserProfileProps) {
           );
         })
       );
+
+      // Show success confirmation
+      toast.success('Profile updated successfully');
 
     } catch (err) {
       console.error('Error saving profile:', err);


### PR DESCRIPTION
## Summary
- show a toast success message when saving user profile settings

## Testing
- `npm run test:local` *(fails: `dotenv: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6855b44412d0832a86815f4f8d70f564