### PR TITLE
Enable billing plan name editing

### DIFF
--- a/server/src/components/billing-dashboard/billing-plans/BucketPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/BucketPlanConfiguration.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import { AlertCircle, ChevronDown } from 'lucide-react';
 import { Button } from 'server/src/components/ui/Button';
+import { BillingPlanDialog } from '../BillingPlanDialog';
 import Spinner from 'server/src/components/ui/Spinner';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 import { getPlanServicesWithConfigurations } from 'server/src/lib/actions/planServiceActions';
@@ -291,8 +292,16 @@ export function BucketPlanConfiguration({
   return (
     <div className={`space-y-6 ${className}`}>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex items-center justify-between">
           <CardTitle>Edit Plan: {plan?.plan_name || '...'} (Bucket) - Service Configurations</CardTitle>
+          {plan && (
+            <BillingPlanDialog
+              editingPlan={plan}
+              onPlanAdded={() => fetchPlanData()}
+              triggerButton={<Button variant="outline" size="sm">Edit Plan Basics</Button>}
+              allServiceTypes={[]}
+            />
+          )}
         </CardHeader>
         <CardContent>
           {planServices.length === 0 ? (

--- a/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/FixedPlanConfiguration.tsx
@@ -10,6 +10,7 @@ import CustomSelect from 'server/src/components/ui/CustomSelect';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import { AlertCircle } from 'lucide-react';
 import { Button } from 'server/src/components/ui/Button';
+import { BillingPlanDialog } from '../BillingPlanDialog';
 import Spinner from 'server/src/components/ui/Spinner';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 import { getServices } from 'server/src/lib/actions/serviceActions';
@@ -195,8 +196,16 @@ export function FixedPlanConfiguration({
   return (
     <div className={`space-y-6 ${className}`}>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex items-center justify-between">
           <CardTitle>Edit Plan: {plan?.plan_name || '...'} (Fixed)</CardTitle>
+          {plan && (
+            <BillingPlanDialog
+              editingPlan={plan}
+              onPlanAdded={() => fetchPlanData()}
+              triggerButton={<Button variant="outline" size="sm">Edit Plan Basics</Button>}
+              allServiceTypes={[]}
+            />
+          )}
         </CardHeader>
         <CardContent className="space-y-4">
           {saveError && (

--- a/server/src/components/billing-dashboard/billing-plans/HourlyPlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/HourlyPlanConfiguration.tsx
@@ -10,6 +10,7 @@ import CustomSelect from 'server/src/components/ui/CustomSelect';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import { AlertCircle, Trash2, Info, ChevronDown } from 'lucide-react';
 import { Button, ButtonProps } from 'server/src/components/ui/Button'; // Import ButtonProps
+import { BillingPlanDialog } from '../BillingPlanDialog';
 import Spinner from 'server/src/components/ui/Spinner';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
 import * as Accordion from '@radix-ui/react-accordion';
@@ -552,8 +553,16 @@ export function HourlyPlanConfiguration({
 
             {/* Service Specific Settings */}
             <Card>
-                <CardHeader>
+                <CardHeader className="flex items-center justify-between">
                     <CardTitle>Edit Plan: {plan?.plan_name || '...'} (Hourly) - Service Rates & Settings</CardTitle>
+                    {plan && (
+                        <BillingPlanDialog
+                            editingPlan={plan}
+                            onPlanAdded={() => fetchPlanData()}
+                            triggerButton={<Button variant="outline" size="sm">Edit Plan Basics</Button>}
+                            allServiceTypes={[]}
+                        />
+                    )}
                 </CardHeader>
                 <CardContent>
                     {serviceConfigs.length > 0 ? (

--- a/server/src/components/billing-dashboard/billing-plans/UsagePlanConfiguration.tsx
+++ b/server/src/components/billing-dashboard/billing-plans/UsagePlanConfiguration.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 import { Button } from 'server/src/components/ui/Button';
+import { BillingPlanDialog } from '../BillingPlanDialog';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import Spinner from 'server/src/components/ui/Spinner';
@@ -404,8 +405,16 @@ export function UsagePlanConfiguration({
       return (
           <div className={`space-y-6 ${className}`}>
               <Card>
-                  <CardHeader>
+                  <CardHeader className="flex items-center justify-between">
                       <CardTitle>Edit Plan: {plan?.plan_name || '...'} (Usage)</CardTitle>
+                      {plan && (
+                        <BillingPlanDialog
+                          editingPlan={plan}
+                          onPlanAdded={() => fetchPlanData()}
+                          triggerButton={<Button variant="outline" size="sm">Edit Plan Basics</Button>}
+                          allServiceTypes={[]}
+                        />
+                      )}
                   </CardHeader>
                   <CardContent>
                       <p className="text-muted-foreground mb-4">No services are currently associated with this usage plan. Add services below to configure their pricing.</p>
@@ -420,8 +429,16 @@ export function UsagePlanConfiguration({
   return (
     <div className={`space-y-6 ${className}`}>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex items-center justify-between">
           <CardTitle>Edit Plan: {plan?.plan_name || '...'} (Usage) - Service Pricing</CardTitle>
+          {plan && (
+            <BillingPlanDialog
+              editingPlan={plan}
+              onPlanAdded={() => fetchPlanData()}
+              triggerButton={<Button variant="outline" size="sm">Edit Plan Basics</Button>}
+              allServiceTypes={[]}
+            />
+          )}
         </CardHeader>
         <CardContent className="space-y-4">
           {saveError && (


### PR DESCRIPTION
## Summary
- allow editing billing plan names from plan configuration screens

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855b9f311d4832ab77c6879786667a0