### PR TITLE
Add ITIL priority matrix settings

### DIFF
--- a/server/migrations/20250710120000_add_ticket_priority_settings.cjs
+++ b/server/migrations/20250710120000_add_ticket_priority_settings.cjs
@@ -1,0 +1,22 @@
+const { Knex } = require('knex');
+
+exports.up = async function(knex) {
+  await knex.schema.createTable('ticket_priority_settings', table => {
+    table.uuid('tenant').notNullable();
+    table.boolean('use_priority_matrix').notNullable().defaultTo(false);
+    table.jsonb('priority_matrix').nullable();
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    table.primary(['tenant']);
+    table.foreign('tenant').references('tenant').inTable('tenants');
+  });
+
+  const tenants = await knex('tenants').select('tenant');
+  for (const { tenant } of tenants) {
+    await knex('ticket_priority_settings').insert({ tenant });
+  }
+};
+
+exports.down = async function(knex) {
+  await knex.schema.dropTableIfExists('ticket_priority_settings');
+};

--- a/server/src/components/settings/general/PriorityMatrixSettings.tsx
+++ b/server/src/components/settings/general/PriorityMatrixSettings.tsx
@@ -82,7 +82,7 @@ const PriorityMatrixSettings: React.FC = () => {
                   {LEVELS.map(urgency => (
                     <td key={urgency} className="p-2 border">
                       <CustomSelect
-                        value={matrix[impact][urgency] || ''}
+                        value={matrix?.[impact]?.[urgency] || ''}
                         onValueChange={(val) => handleSelect(impact, urgency, val)}
                         options={priorityOptions}
                         className="w-32"

--- a/server/src/components/settings/general/PriorityMatrixSettings.tsx
+++ b/server/src/components/settings/general/PriorityMatrixSettings.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import React, { useEffect, useState } from 'react';
+import { Switch } from 'server/src/components/ui/Switch';
+import { Label } from 'server/src/components/ui/Label';
+import { Button } from 'server/src/components/ui/Button';
+import CustomSelect from 'server/src/components/ui/CustomSelect';
+import { toast } from 'react-hot-toast';
+import { getAllPrioritiesWithStandard } from 'server/src/lib/actions/priorityActions';
+import { getTicketPrioritySettings, updateTicketPrioritySettings, PriorityMatrix, DEFAULT_MATRIX } from 'server/src/lib/actions/ticketPrioritySettingsActions';
+import { IPriority, IStandardPriority, PriorityLevel } from 'server/src/interfaces';
+
+const LEVELS: PriorityLevel[] = ['low', 'medium', 'high'];
+
+const PriorityMatrixSettings: React.FC = () => {
+  const [priorities, setPriorities] = useState<(IPriority | IStandardPriority)[]>([]);
+  const [matrix, setMatrix] = useState<PriorityMatrix>(DEFAULT_MATRIX);
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [p, s] = await Promise.all([
+          getAllPrioritiesWithStandard(),
+          getTicketPrioritySettings()
+        ]);
+        setPriorities(p);
+        setMatrix(s.priorityMatrix);
+        setEnabled(s.usePriorityMatrix);
+      } catch (e) {
+        console.error(e);
+        toast.error('Failed to load priority settings');
+      }
+    };
+    load();
+  }, []);
+
+  const handleSelect = (impact: PriorityLevel, urgency: PriorityLevel, value: string) => {
+    setMatrix(prev => ({
+      ...prev,
+      [impact]: { ...prev[impact], [urgency]: value }
+    }));
+  };
+
+  const save = async () => {
+    try {
+      await updateTicketPrioritySettings({ usePriorityMatrix: enabled, priorityMatrix: matrix });
+      toast.success('Priority matrix updated');
+    } catch (e) {
+      console.error(e);
+      toast.error('Failed to save settings');
+    }
+  };
+
+  const priorityOptions = priorities.map(p => ({ value: p.priority_id, label: p.priority_name }));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <Switch id="enable-priority-matrix" checked={enabled} onCheckedChange={setEnabled} />
+        <div className="space-y-1">
+          <Label htmlFor="enable-priority-matrix">Enable ITIL Priority Matrix</Label>
+          <p className="text-sm text-muted-foreground">Calculate priority from impact and urgency</p>
+        </div>
+      </div>
+
+      {enabled && (
+        <div className="space-y-2">
+          <table className="min-w-full border text-sm">
+            <thead>
+              <tr>
+                <th className="p-2 border" />
+                {LEVELS.map(u => (
+                  <th key={u} className="p-2 border capitalize">{u}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {LEVELS.map(impact => (
+                <tr key={impact}>
+                  <td className="p-2 border capitalize font-medium">{impact}</td>
+                  {LEVELS.map(urgency => (
+                    <td key={urgency} className="p-2 border">
+                      <CustomSelect
+                        value={matrix[impact][urgency] || ''}
+                        onValueChange={(val) => handleSelect(impact, urgency, val)}
+                        options={priorityOptions}
+                        className="w-32"
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <Button id="save-priority-matrix" onClick={save} className="mt-2">Save</Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PriorityMatrixSettings;

--- a/server/src/components/settings/general/TicketingSettings.tsx
+++ b/server/src/components/settings/general/TicketingSettings.tsx
@@ -14,6 +14,7 @@ import { IStatus, ItemType } from 'server/src/interfaces/status.interface';
 import { IPriority, IStandardPriority, ITicketCategory } from 'server/src/interfaces/ticket.interfaces';
 import { getCurrentUser } from 'server/src/lib/actions/user-actions/userActions';
 import NumberingSettings from './NumberingSettings';
+import PriorityMatrixSettings from './PriorityMatrixSettings';
 import { Switch } from 'server/src/components/ui/Switch';
 import { DataTable } from 'server/src/components/ui/DataTable';
 import { ColumnDefinition } from 'server/src/interfaces/dataTable.interfaces';
@@ -1202,6 +1203,16 @@ const TicketingSettings = (): JSX.Element => {
                 <Plus className="h-4 w-4 mr-2" /> Add Priority
               </Button>
             </div>
+          </div>
+        </div>
+      )
+    },
+    {
+      label: "Priority Matrix",
+      content: (
+        <div>
+          <div className="bg-white p-6 rounded-lg shadow-sm">
+            <PriorityMatrixSettings />
           </div>
         </div>
       )

--- a/server/src/interfaces/ticket.interfaces.tsx
+++ b/server/src/interfaces/ticket.interfaces.tsx
@@ -94,3 +94,18 @@ export interface IAgentSchedule {
   userId: string;
   minutes: number;
 }
+
+export type PriorityLevel = 'low' | 'medium' | 'high';
+
+export interface IPriorityMatrixEntry {
+  impact: PriorityLevel;
+  urgency: PriorityLevel;
+  priority_id: string;
+}
+
+export interface ITicketPrioritySettings extends TenantEntity {
+  use_priority_matrix: boolean;
+  priority_matrix: IPriorityMatrixEntry[];
+  created_at?: Date;
+  updated_at?: Date;
+}

--- a/server/src/lib/actions/ticketPrioritySettingsActions.ts
+++ b/server/src/lib/actions/ticketPrioritySettingsActions.ts
@@ -1,0 +1,70 @@
+'use server'
+
+import { createTenantKnex } from 'server/src/lib/db';
+import { withTransaction } from '@shared/db';
+import { Knex } from 'knex';
+import { ITicketPrioritySettings, PriorityLevel, IPriorityMatrixEntry } from 'server/src/interfaces';
+
+export type PriorityMatrix = Record<PriorityLevel, Record<PriorityLevel, string>>;
+
+export const DEFAULT_MATRIX: PriorityMatrix = {
+  low: { low: '', medium: '', high: '' },
+  medium: { low: '', medium: '', high: '' },
+  high: { low: '', medium: '', high: '' }
+};
+
+function matrixToArray(matrix: PriorityMatrix): IPriorityMatrixEntry[] {
+  const entries: IPriorityMatrixEntry[] = [];
+  (['low','medium','high'] as PriorityLevel[]).forEach(impact => {
+    (['low','medium','high'] as PriorityLevel[]).forEach(urgency => {
+      entries.push({ impact, urgency, priority_id: matrix[impact][urgency] });
+    });
+  });
+  return entries;
+}
+
+function arrayToMatrix(entries: IPriorityMatrixEntry[] | null): PriorityMatrix {
+  const matrix: PriorityMatrix = JSON.parse(JSON.stringify(DEFAULT_MATRIX));
+  if (!entries) return matrix;
+  for (const e of entries) {
+    if (matrix[e.impact]) {
+      matrix[e.impact][e.urgency] = e.priority_id;
+    }
+  }
+  return matrix;
+}
+
+export async function getTicketPrioritySettings(): Promise<{ usePriorityMatrix: boolean; priorityMatrix: PriorityMatrix }> {
+  const { knex, tenant } = await createTenantKnex();
+  const row = await withTransaction(knex, async (trx: Knex.Transaction) => {
+    return await trx('ticket_priority_settings').where({ tenant }).first();
+  });
+
+  if (!row) {
+    return { usePriorityMatrix: false, priorityMatrix: DEFAULT_MATRIX };
+  }
+
+  return {
+    usePriorityMatrix: row.use_priority_matrix,
+    priorityMatrix: arrayToMatrix(row.priority_matrix)
+  };
+}
+
+export async function updateTicketPrioritySettings(settings: { usePriorityMatrix: boolean; priorityMatrix: PriorityMatrix }): Promise<{ success: boolean }> {
+  const { knex, tenant } = await createTenantKnex();
+  await withTransaction(knex, async (trx: Knex.Transaction) => {
+    const existing = await trx('ticket_priority_settings').where({ tenant }).first();
+    const data = {
+      use_priority_matrix: settings.usePriorityMatrix,
+      priority_matrix: JSON.stringify(matrixToArray(settings.priorityMatrix)),
+      updated_at: trx.fn.now()
+    };
+    if (existing) {
+      await trx('ticket_priority_settings').where({ tenant }).update(data);
+    } else {
+      await trx('ticket_priority_settings').insert({ ...data, tenant });
+    }
+  });
+
+  return { success: true };
+}


### PR DESCRIPTION
## Summary
- add migration for ticket priority settings table
- add interfaces and server actions for ITIL priority matrix
- create PriorityMatrixSettings component
- integrate matrix settings into Ticketing settings

## Testing
- `npm run test:local` *(fails: `dotenv: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6855bb02f944832aab2f49edd327eb11