### PR TITLE
fix(ci): enable Docker image publishing for main branch commits

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v'))
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'create' && github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')) || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -105,8 +105,8 @@ jobs:
             # This is a tag create event: use the tag name for both editions
             CE_TAGS="ghcr.io/nine-minds/alga-psa-ce:${{ github.event.ref }}"
             EE_TAGS="ghcr.io/nine-minds/alga-psa-ee:${{ github.event.ref }},ghcr.io/nine-minds/alga-psa:${{ github.event.ref }}"
-          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            # This is a workflow_run event (e.g., after PR merge to main): use latest and short SHA for both editions
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]] || [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # This is a workflow_run event or push to main: use latest and short SHA for both editions
             CE_TAGS="ghcr.io/nine-minds/alga-psa-ce:latest,ghcr.io/nine-minds/alga-psa-ce:${{ steps.sha.outputs.short_sha }}"
             EE_TAGS="ghcr.io/nine-minds/alga-psa-ee:latest,ghcr.io/nine-minds/alga-psa-ee:${{ steps.sha.outputs.short_sha }},ghcr.io/nine-minds/alga-psa:latest,ghcr.io/nine-minds/alga-psa:${{ steps.sha.outputs.short_sha }}"
           else


### PR DESCRIPTION
## Summary
Enable Docker image publishing for every commit to the main branch, not just tagged releases.

## Changes
- ✅ Add condition to publish job for pushes to main branch
- ✅ Update Docker tagging logic to handle main branch pushes with latest + SHA tags  
- ✅ Maintains existing behavior for tagged releases (version tags only)

## Test plan
- [ ] Verify workflow triggers on main branch pushes
- [ ] Confirm Docker images are published with both `latest` and short SHA tags
- [ ] Ensure tagged releases still work correctly with version tags only
- [ ] Check that no other events trigger unintended publishes

This ensures continuous delivery of Docker images for development while preserving release versioning for production deployments.