### PR TITLE
Fix user list defaults

### DIFF
--- a/server/src/app/msp/users/page.tsx
+++ b/server/src/app/msp/users/page.tsx
@@ -19,7 +19,10 @@ export default function UsersPage() {
       setLoading(true);
       setError(null);
       const fetchedUsers = await getMultipleUsersWithRoles([]);  // Fetch all users
-      setUsers(fetchedUsers);
+      const sortedUsers = [...fetchedUsers].sort((a, b) =>
+        (a.first_name || '').localeCompare(b.first_name || '')
+      );
+      setUsers(sortedUsers);
     } catch (err) {
       console.error('Failed to fetch users:', err);
       setError('Failed to load users. Please try again later.');

--- a/server/src/app/msp/users/page.tsx
+++ b/server/src/app/msp/users/page.tsx
@@ -20,7 +20,7 @@ export default function UsersPage() {
       setError(null);
       const fetchedUsers = await getMultipleUsersWithRoles([]);  // Fetch all users
       const sortedUsers = [...fetchedUsers].sort((a, b) =>
-        (a.first_name || '').localeCompare(b.first_name || '')
+        (a.first_name || '').toLowerCase().localeCompare((b.first_name || '').toLowerCase())
       );
       setUsers(sortedUsers);
     } catch (err) {

--- a/server/src/components/settings/general/UserManagement.tsx
+++ b/server/src/components/settings/general/UserManagement.tsx
@@ -32,7 +32,7 @@ const UserManagement = (): JSX.Element => {
     try {
       const fetchedUsers = await getAllUsers(true);
       const sortedUsers = [...fetchedUsers].sort((a, b) =>
-        (a.first_name || '').localeCompare(b.first_name || '')
+        (a.first_name || '').toLowerCase().localeCompare((b.first_name || '').toLowerCase())
       );
       setUsers(sortedUsers);
       setLoading(false);

--- a/server/src/components/settings/general/UserManagement.tsx
+++ b/server/src/components/settings/general/UserManagement.tsx
@@ -31,7 +31,10 @@ const UserManagement = (): JSX.Element => {
   const fetchUsers = async (): Promise<void> => {
     try {
       const fetchedUsers = await getAllUsers(true);
-      setUsers(fetchedUsers);
+      const sortedUsers = [...fetchedUsers].sort((a, b) =>
+        (a.first_name || '').localeCompare(b.first_name || '')
+      );
+      setUsers(sortedUsers);
       setLoading(false);
     } catch (err) {
       console.error('Error fetching users:', err);

--- a/server/src/components/ui/DataTable.tsx
+++ b/server/src/components/ui/DataTable.tsx
@@ -331,6 +331,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     pageCount: totalPages,
+    enableSortingRemoval: false,
     state: {
       pagination: {
         pageIndex,

--- a/server/src/components/ui/DataTable.tsx
+++ b/server/src/components/ui/DataTable.tsx
@@ -435,7 +435,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               ))}
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {table.getPaginationRowModel().rows.map((row): JSX.Element => {
+              {table.getPaginationRowModel().rows.map((row, rowIndex): JSX.Element => {
                 // Use the id property if it exists in the data, otherwise use row.id
                 const rowId = ('id' in row.original) ? (row.original as { id: string }).id : row.id;
                 return (
@@ -443,7 +443,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                     key={`row_${rowId}`}
                     onClick={() => handleRowClick(row)}
                     className={`
-                    ${row.index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}
+                    ${rowIndex % 2 === 0 ? 'bg-gray-50' : 'bg-white'}
                     hover:bg-blue-50 transition-colors cursor-pointer
                   `}
                   >

--- a/server/src/components/ui/DataTable.tsx
+++ b/server/src/components/ui/DataTable.tsx
@@ -13,6 +13,7 @@ import {
   flexRender,
   ColumnDef,
   Row,
+  SortingFn,
 } from '@tanstack/react-table';
 import { ColumnDefinition, DataTableProps } from 'server/src/interfaces/dataTable.interfaces';
 import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
@@ -74,6 +75,13 @@ const getDisplayText = (columnDef: ColumnDefinition<any> | undefined, cellValue:
   }
   
   return String(cellValue);
+};
+
+// Custom case-insensitive sorting function for all columns
+const caseInsensitiveSort: SortingFn<any> = (rowA, rowB, columnId) => {
+  const a = rowA.getValue(columnId);
+  const b = rowB.getValue(columnId);
+  return String(a ?? '').toLowerCase().localeCompare(String(b ?? '').toLowerCase());
 };
 
 // Component to register table cell content with UI reflection system
@@ -293,6 +301,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
           accessorFn: (row) => getNestedValue(row, col.dataIndex),
           header: () => col.title,
           cell: (info) => col.render ? col.render(info.getValue(), info.row.original, info.row.index) : info.getValue(),
+          sortingFn: caseInsensitiveSort,
         })),
     [columns, visibleColumnIds]
   );


### PR DESCRIPTION
## Summary
- sort initial user lists alphabetically by first name
- keep alternating table row colors when sorting

## Testing
- `npm run test:local` *(fails: dotenv not found)*
- `npx vitest run` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6859a793a330832a9d3929a9ec331ea4