### PR TITLE
Remove date of birth from contacts

### DIFF
--- a/server/migrations/202409071803_initial_schema.cjs
+++ b/server/migrations/202409071803_initial_schema.cjs
@@ -83,7 +83,6 @@ exports.up = async function(knex) {
         table.text('email');
         table.text('role');
         table.boolean('approver');
-        table.timestamp('date_of_birth');
         table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
         table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
         table.primary(['tenant', 'contact_name_id']);

--- a/server/src/components/companies/QuickAddCompany.tsx
+++ b/server/src/components/companies/QuickAddCompany.tsx
@@ -91,7 +91,6 @@ const QuickAddCompany: React.FC<QuickAddCompanyProps> = ({
     phone_number: '',
     email: '',
     role: '',
-    date_of_birth: '',
     notes: '',
   };
 

--- a/server/src/components/contacts/ContactDetails.tsx
+++ b/server/src/components/contacts/ContactDetails.tsx
@@ -386,11 +386,6 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
               value={editedContact.phone_number || ''}
               onEdit={(value) => handleFieldChange('phone_number', value)}
             />
-            <DateDetailItem
-              label="Date of Birth"
-              value={editedContact.date_of_birth || null}
-              onEdit={(value) => handleFieldChange('date_of_birth', value)}
-            />
             <SwitchDetailItem
               value={!editedContact.is_inactive || false}
               onEdit={(isActive) => handleFieldChange('is_inactive', !isActive)}

--- a/server/src/components/contacts/ContactDetailsEdit.tsx
+++ b/server/src/components/contacts/ContactDetailsEdit.tsx
@@ -185,13 +185,6 @@ const ContactDetailsEdit: React.FC<ContactDetailsEditProps> = ({
                 />
               </td>
             </tr>
-            <TableRow 
-              id={`${id}-dob`}
-              label="Date of Birth" 
-              value={contact.date_of_birth || ''} 
-              onChange={(value) => handleInputChange('date_of_birth', value)} 
-              type="date"
-            />
             <tr>
               <td className="py-2 font-semibold">Status:</td>
               <td className="py-2">

--- a/server/src/components/contacts/ContactDetailsView.tsx
+++ b/server/src/components/contacts/ContactDetailsView.tsx
@@ -290,7 +290,6 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
               onClick={handleCompanyClick}
             />
             <TableRow label="Role" value={contact.role || 'Not set'} />
-            <TableRow label="Date of Birth" value={formatDateForDisplay(contact.date_of_birth)} />
             <TableRow label="Status" value={contact.is_inactive ? 'Inactive' : 'Active'} />
             <TableRow label="Created At" value={new Date(contact.created_at).toLocaleString()} />
             <TableRow label="Updated At" value={new Date(contact.updated_at).toLocaleString()} />

--- a/server/src/components/contacts/ContactsImportDialog.tsx
+++ b/server/src/components/contacts/ContactsImportDialog.tsx
@@ -27,7 +27,6 @@ const CONTACT_FIELDS = {
   phone_number: 'Phone Number',
   company_name: 'Company',
   tags: 'Tags',
-  date_of_birth: 'Date of Birth',
   role: 'Role',
   notes: 'Notes'
 } as const;
@@ -113,7 +112,6 @@ const ContactsImportDialog: React.FC<ContactsImportDialogProps> = ({
         else if (headerLower.includes('phone')) contactField = 'phone_number';
         else if (headerLower.includes('company')) contactField = 'company_name';
         else if (headerLower.includes('tag')) contactField = 'tags';
-        else if (headerLower.includes('birth')) contactField = 'date_of_birth';
         else if (headerLower.includes('role')) contactField = 'role';
         else if (headerLower.includes('note')) contactField = 'notes';
 
@@ -213,7 +211,6 @@ const ContactsImportDialog: React.FC<ContactsImportDialogProps> = ({
         email: record.email,
         phone_number: record.phone_number,
         company_id: company?.company_id || null,
-        date_of_birth: record.date_of_birth || undefined,
         role: record.role,
         notes: record.notes,
         is_inactive: false
@@ -268,7 +265,6 @@ const ContactsImportDialog: React.FC<ContactsImportDialogProps> = ({
           phone_number: result.data.phone_number || '',
           company_name: result.data.company_name || '',
           tags: result.data.tags || '',
-          date_of_birth: result.data.date_of_birth || '',
           role: result.data.role || '',
           notes: result.data.notes || ''
         };
@@ -575,7 +571,6 @@ const ContactsImportDialog: React.FC<ContactsImportDialogProps> = ({
               phone_number: result.data.phone_number || '',
               company_name: result.data.company_name || '',
               tags: result.data.tags || '',
-              date_of_birth: result.data.date_of_birth || '',
               role: result.data.role || '',
               notes: result.data.notes || ''
             }));

--- a/server/src/interfaces/contact.interfaces.tsx
+++ b/server/src/interfaces/contact.interfaces.tsx
@@ -7,7 +7,6 @@ export interface IContact extends TenantEntity, ITaggable {
   phone_number: string;
   email: string;
   role: string;
-  date_of_birth?: string;
   created_at: string;
   updated_at: string;
   is_inactive: boolean;
@@ -54,11 +53,10 @@ export interface ImportContactResult {
   originalData: Record<string, any>;
 }
 
-export type MappableField = 
+export type MappableField =
   | 'full_name'
   | 'phone_number'
   | 'email'
-  | 'date_of_birth'
   | 'company_name'
   | 'role'
   | 'notes'

--- a/server/src/lib/actions/contact-actions/contactActions.tsx
+++ b/server/src/lib/actions/contact-actions/contactActions.tsx
@@ -540,7 +540,7 @@ export async function updateContact(contactData: Partial<IContact>): Promise<ICo
     // Define valid fields
     const validFields: (keyof IContact)[] = [
       'contact_name_id', 'full_name', 'company_id', 'phone_number',
-      'email', 'date_of_birth', 'created_at', 'updated_at', 'is_inactive',
+      'email', 'created_at', 'updated_at', 'is_inactive',
       'role', 'notes'
     ];
 
@@ -680,7 +680,6 @@ export async function updateContactsForCompany(companyId: string, updateData: Pa
           break;
 
         case 'notes':
-        case 'date_of_birth':
           // These fields are optional strings
           if (value === null) {
             acc[contactKey] = undefined;
@@ -887,7 +886,6 @@ export async function importContactsFromCSV(
               phone_number: contactData.phone_number?.trim() || '',
               company_id: contactData.company_id,
               is_inactive: contactData.is_inactive || false,
-              date_of_birth: contactData.date_of_birth,
               role: contactData.role?.trim() || '',
               notes: contactData.notes?.trim() || '',
               tenant: tenant,

--- a/server/src/lib/api/schemas/contact.ts
+++ b/server/src/lib/api/schemas/contact.ts
@@ -21,7 +21,6 @@ export const createContactSchema = z.object({
   phone_number: phoneSchema,
   email: emailSchema,
   role: z.string().max(100).optional(),
-  date_of_birth: z.string().datetime().optional(),
   notes: z.string().optional(),
   is_inactive: z.boolean().optional().default(false),
   tags: z.array(z.string()).optional()
@@ -39,7 +38,6 @@ export const contactFilterSchema = baseFilterSchema.extend({
   role: z.string().optional(),
   is_inactive: booleanTransform.optional(),
   has_company: booleanTransform.optional(),
-  birth_month: z.string().transform(val => parseInt(val)).pipe(z.number().min(1).max(12)).optional(),
   company_name: z.string().optional()
 });
 
@@ -54,7 +52,6 @@ export const contactResponseSchema = z.object({
   phone_number: z.string().nullable(),
   email: z.string(),
   role: z.string().nullable(),
-  date_of_birth: z.string().datetime().nullable(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
   is_inactive: z.boolean(),

--- a/server/src/lib/api/services/ContactService.ts
+++ b/server/src/lib/api/services/ContactService.ts
@@ -158,7 +158,6 @@ export class ContactService extends BaseService<IContact> {
           phone_number: data.phone_number || '',
           email: data.email,
           role: data.role || '',
-          date_of_birth: data.date_of_birth,
           notes: data.notes,
           is_inactive: data.is_inactive || false,
           tenant: context.tenant,
@@ -390,7 +389,6 @@ export class ContactService extends BaseService<IContact> {
       'c.email',
       'c.phone_number',
       'c.role',
-      'c.date_of_birth',
       'c.is_inactive',
       'c.created_at',
       'comp.company_name'
@@ -401,8 +399,8 @@ export class ContactService extends BaseService<IContact> {
     } else {
       // Convert to CSV format
       const headers = [
-        'ID', 'Full Name', 'Email', 'Phone', 'Role', 
-        'Date of Birth', 'Company', 'Inactive', 'Created At'
+        'ID', 'Full Name', 'Email', 'Phone', 'Role',
+        'Company', 'Inactive', 'Created At'
       ];
       
       const rows = contacts.map(contact => [
@@ -411,7 +409,6 @@ export class ContactService extends BaseService<IContact> {
         contact.email,
         contact.phone_number,
         contact.role || '',
-        contact.date_of_birth || '',
         contact.company_name || '',
         contact.is_inactive ? 'Yes' : 'No',
         contact.created_at
@@ -455,9 +452,6 @@ export class ContactService extends BaseService<IContact> {
           } else {
             query.whereNull('c.company_id');
           }
-          break;
-        case 'birth_month':
-          query.whereRaw('EXTRACT(month FROM c.date_of_birth) = ?', [value]);
           break;
         case 'company_name':
           query.whereILike('comp.company_name', `%${value}%`);


### PR DESCRIPTION
## Summary
- remove the date_of_birth field from contact interfaces and schemas
- drop date_of_birth usage in components and actions
- update contact service and import logic
- adjust initial migration to omit date_of_birth from contacts table

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c131aa6a4832a92c5f14d98c8ec2c