### PR TITLE
Fix timer persistence across tabs

### DIFF
--- a/server/src/components/tickets/ticket/TicketDetails.tsx
+++ b/server/src/components/tickets/ticket/TicketDetails.tsx
@@ -225,6 +225,27 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
         initialTicket.title || '',
         userId || ''
     );
+
+    // Restore timer if an open interval exists (e.g., when opening in a new tab)
+    useEffect(() => {
+        if (!initialTicket.ticket_id || !userId) return;
+
+        const restoreTimer = async () => {
+            try {
+                const openInterval = await intervalService.getOpenInterval(initialTicket.ticket_id!, userId);
+                if (openInterval && openInterval.startTime) {
+                    const start = new Date(openInterval.startTime);
+                    const elapsed = Math.floor((Date.now() - start.getTime()) / 1000);
+                    setElapsedTime(elapsed);
+                    setIsRunning(true);
+                }
+            } catch (error) {
+                console.error('Error restoring timer from open interval:', error);
+            }
+        };
+
+        restoreTimer();
+    }, [initialTicket.ticket_id, userId, intervalService]);
     
     // Function to close the current interval before navigation
     // Enhanced function to close the interval - will find and close any open interval for this ticket


### PR DESCRIPTION
## Summary
- restore ticket timer when opening a new tab

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685ac2f71ba8832aa7eda21e890d4ed7