### PR TITLE
fix: preserve volumeName in PVC templates to avoid immutability errors

### DIFF
--- a/helm/templates/dev-env/code-server/pvc.yaml
+++ b/helm/templates/dev-env/code-server/pvc.yaml
@@ -12,6 +12,10 @@ metadata:
     dev-environment: "true"
     branch: "{{ .Values.devEnv.sanitizedBranch }}"
 spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" .Values.devEnv.namespace (printf "%s-code-server-workspace" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/helm/templates/local-storage-pvc.yaml
+++ b/helm/templates/local-storage-pvc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "sebastian.labels" . | nindent 4 }}
 spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" (include "sebastian.namespace" .) (printf "%s-local-storage" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   storageClassName: {{ .Values.persistence.storageClass | quote }}

--- a/helm/templates/postgres/pvc.yaml
+++ b/helm/templates/postgres/pvc.yaml
@@ -9,6 +9,10 @@ metadata:
     "helm.sh/resource-policy": keep
   {{- end }}
 spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" (include "sebastian.namespace" .) (printf "%s-postgres-data" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/helm/templates/redis/pvc.yaml
+++ b/helm/templates/redis/pvc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "sebastian.fullname" . }}-redis-data
   namespace: {{ include "sebastian.namespace" . }}
 spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" (include "sebastian.namespace" .) (printf "%s-redis-data" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/helm/templates/storage-pvc.yaml
+++ b/helm/templates/storage-pvc.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" (include "sebastian.namespace" .) (printf "%s-storage" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
   accessModes:
     {{- range .Values.server.persistence.accessModes }}
     - {{ . | quote }}


### PR DESCRIPTION
## Summary
- Add Helm lookup logic to preserve existing volumeName in all PVC templates
- Prevents "spec is immutable" errors during Helm upgrades when PVCs are already bound
- Applied to storage, redis, postgres, local-storage, and dev-env code-server PVCs

## Problem
Helm was attempting to modify the volumeName field in existing PersistentVolumeClaims from bound volume names to empty strings, which is forbidden since volumeName is immutable after PVC creation.

## Solution
Added lookup logic to each PVC template that:
1. Checks if the PVC already exists using Helm's lookup function
2. Preserves the existing volumeName if it was previously set by Kubernetes
3. Allows new PVCs to be created without volumeName (letting Kubernetes assign it dynamically)

## Test Plan
- [x] Verified with `helm upgrade --dry-run` that no volumeName conflicts occur
- [x] Confirmed new PVCs work normally without volumeName field
- [x] Tested that existing PVCs preserve their bound volume names