### PR TITLE
Center client portal metrics cards

### DIFF
--- a/server/src/components/client-portal/dashboard/ClientDashboard.tsx
+++ b/server/src/components/client-portal/dashboard/ClientDashboard.tsx
@@ -70,9 +70,9 @@ export function ClientDashboard() {
       </div>
 
       {/* Metrics Overview */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3 justify-center">
         <Card className="bg-white">
-          <CardContent className="p-8 flex flex-col justify-center h-full">
+          <CardContent className="p-8 flex flex-col items-center justify-center text-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Open Support Tickets
             </div>
@@ -88,7 +88,7 @@ export function ClientDashboard() {
         </Card>
 
         <Card className="bg-white">
-          <CardContent className="p-8 flex flex-col justify-center h-full">
+          <CardContent className="p-8 flex flex-col items-center justify-center text-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Open Projects
             </div>
@@ -104,7 +104,7 @@ export function ClientDashboard() {
         </Card>
 
         <Card className="bg-white">
-          <CardContent className="p-8 flex flex-col justify-center h-full">
+          <CardContent className="p-8 flex flex-col items-center justify-center text-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Pending Invoices
             </div>

--- a/server/src/components/client-portal/dashboard/ClientDashboard.tsx
+++ b/server/src/components/client-portal/dashboard/ClientDashboard.tsx
@@ -72,7 +72,7 @@ export function ClientDashboard() {
       {/* Metrics Overview */}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
         <Card className="bg-white">
-          <CardContent className="p-8">
+          <CardContent className="p-8 flex flex-col justify-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Open Support Tickets
             </div>
@@ -88,7 +88,7 @@ export function ClientDashboard() {
         </Card>
 
         <Card className="bg-white">
-          <CardContent className="p-8">
+          <CardContent className="p-8 flex flex-col justify-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Open Projects
             </div>
@@ -104,7 +104,7 @@ export function ClientDashboard() {
         </Card>
 
         <Card className="bg-white">
-          <CardContent className="p-8">
+          <CardContent className="p-8 flex flex-col justify-center h-full">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">
               Pending Invoices
             </div>

--- a/server/src/components/client-portal/dashboard/ClientDashboard.tsx
+++ b/server/src/components/client-portal/dashboard/ClientDashboard.tsx
@@ -70,7 +70,7 @@ export function ClientDashboard() {
       </div>
 
       {/* Metrics Overview */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-4">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
         <Card className="bg-white">
           <CardContent className="p-8">
             <div className="text-lg font-medium text-[rgb(var(--color-text-600))] truncate">


### PR DESCRIPTION
## Summary
- adjust grid columns so dashboard metric cards center properly

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_685eb089a4f4832ab81c166966ee6a3c