### PR TITLE
Hide client portal advanced billing tabs

### DIFF
--- a/server/src/components/client-portal/billing/BillingOverview.tsx
+++ b/server/src/components/client-portal/billing/BillingOverview.tsx
@@ -73,6 +73,9 @@ const UsageMetricsTab = dynamic(() => import('./UsageMetricsTab'), {
     </div>
   </div>
 });
+
+// Flag to control visibility of advanced usage tabs and metrics
+const SHOW_USAGE_FEATURES = false;
 export default function BillingOverview() {
   const [currentTab, setCurrentTab] = useState('Overview');
   const [billingPlan, setBillingPlan] = useState<ICompanyBillingPlan | null>(null);
@@ -321,35 +324,37 @@ export default function BillingOverview() {
       });
     }
 
-    // Add Hours by Service tab (all users have access)
-    tabsArray.push({
-      label: 'Hours by Service',
-      content: (
-        <div id="hours-service-tab">
-          <HoursByServiceTab
-            hoursByService={hoursByService}
-            isHoursLoading={isHoursLoading}
-            dateRange={dateRange}
-            handleDateRangeChange={handleDateRangeChange}
-          />
-        </div>
-      ),
-    });
+    if (SHOW_USAGE_FEATURES) {
+      // Add Hours by Service tab
+      tabsArray.push({
+        label: 'Hours by Service',
+        content: (
+          <div id="hours-service-tab">
+            <HoursByServiceTab
+              hoursByService={hoursByService}
+              isHoursLoading={isHoursLoading}
+              dateRange={dateRange}
+              handleDateRangeChange={handleDateRangeChange}
+            />
+          </div>
+        ),
+      });
 
-    // Add Usage Metrics tab (all users have access)
-    tabsArray.push({
-      label: 'Usage Metrics',
-      content: (
-        <div id="usage-metrics-tab">
-          <UsageMetricsTab
-            usageMetrics={usageMetrics}
-            isUsageMetricsLoading={isUsageMetricsLoading}
-            dateRange={dateRange}
-            handleDateRangeChange={handleDateRangeChange}
-          />
-        </div>
-      ),
-    });
+      // Add Usage Metrics tab
+      tabsArray.push({
+        label: 'Usage Metrics',
+        content: (
+          <div id="usage-metrics-tab">
+            <UsageMetricsTab
+              usageMetrics={usageMetrics}
+              isUsageMetricsLoading={isUsageMetricsLoading}
+              dateRange={dateRange}
+              handleDateRangeChange={handleDateRangeChange}
+            />
+          </div>
+        ),
+      });
+    }
     
     return tabsArray;
   }, [

--- a/server/src/components/client-portal/billing/BillingOverviewTab.tsx
+++ b/server/src/components/client-portal/billing/BillingOverviewTab.tsx
@@ -13,6 +13,9 @@ import type { ClientBucketUsageResult } from 'server/src/lib/actions/client-port
 import { Skeleton } from 'server/src/components/ui/Skeleton';
 import PlanDetailsDialog from './PlanDetailsDialog';
 
+// Flag to control visibility of bucket usage metrics
+const SHOW_USAGE_FEATURES = false;
+
 interface BillingOverviewTabProps {
   billingPlan: ICompanyBillingPlan | null;
   invoices: InvoiceViewModel[];
@@ -115,7 +118,8 @@ const BillingOverviewTab: React.FC<BillingOverviewTabProps> = React.memo(({
           {invoiceCard}
         </div>
 
-        {/* Enhanced Bucket Usage Visualization - Client-side only rendering */}
+        {/* Enhanced Bucket Usage Visualization - optionally hidden */}
+        {SHOW_USAGE_FEATURES && (
         <Card id="bucket-usage-card" className="p-6">
           <h3 className="text-lg font-semibold mb-4">Bucket Usage</h3>
           {!isClient ? (
@@ -170,6 +174,7 @@ const BillingOverviewTab: React.FC<BillingOverviewTabProps> = React.memo(({
             </div>
           )}
         </Card>
+        )}
       </div>
 
       {/* Plan Details Dialog */}


### PR DESCRIPTION
## Summary
- add SHOW_USAGE_FEATURES flag on billing overview pages
- hide Hours by Service/Usage Metrics tabs
- hide bucket usage card

## Testing
- `npm run test:local` *(fails: `dotenv` not found)*
- `npx tsc -p server/tsconfig.json` *(fails: missing modules like `zod`)*

------
https://chatgpt.com/codex/tasks/task_b_685eb11268b4832a93c90efdb3d0220d