### PR TITLE
Fix timestamp on new client tickets

### DIFF
--- a/server/src/lib/actions/client-portal-actions/client-tickets.ts
+++ b/server/src/lib/actions/client-portal-actions/client-tickets.ts
@@ -610,7 +610,7 @@ export async function createClientTicket(data: FormData): Promise<ITicket> {
         company_id: contact.company_id,
         contact_name_id: user.contact_id,
         entered_by: session.user.id,
-        entered_at: new Date().toISOString(),
+        entered_at: trx.fn.now(),
         attributes: {
           description: validatedData.description
         },

--- a/server/src/lib/actions/ticket-actions/ticketActions.ts
+++ b/server/src/lib/actions/ticket-actions/ticketActions.ts
@@ -85,7 +85,7 @@ export async function createTicketFromAsset(data: CreateTicketFromAssetData, use
             status_id: await getDefaultStatusId(trx, tenant),
             entered_by: user.user_id,
             priority_id: validatedData.priority_id,
-            entered_at: new Date().toISOString(),
+            entered_at: trx.fn.now(),
             attributes: {
               description: validatedData.description
             },
@@ -205,7 +205,7 @@ export async function addTicket(data: FormData, user: IUser): Promise<ITicket|un
             priority_id: validatedData.priority_id,
             category_id: validatedData.category_id,
             subcategory_id: validatedData.subcategory_id,
-            entered_at: new Date().toISOString(),
+            entered_at: trx.fn.now(),
             attributes: {
               description: validatedData.description
             },


### PR DESCRIPTION
## Summary
- use `trx.fn.now()` when creating tickets to ensure timestamps persist

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862a4086860832a8aee874bb2a6eb0c