### PR TITLE
Fix invoice preview values in MSP portal

### DIFF
--- a/server/src/lib/adapters/invoiceAdapters.ts
+++ b/server/src/lib/adapters/invoiceAdapters.ts
@@ -64,12 +64,12 @@ export function mapDbInvoiceToWasmViewModel(inputData: DbInvoiceViewModel | Wasm
           id: String(item.item_id ?? ''), // Corrected property name
           description: String(item.description ?? ''),
           quantity: Number(item.quantity ?? 0),
-          unitPrice: Number(item.unit_price ?? 0),
-          total: Number(item.total_price ?? 0), // Corrected property name
+          unitPrice: Number(item.unit_price ?? 0) / 100,
+          total: Number(item.total_price ?? 0) / 100, // Corrected property name
         })),
-        subtotal: Number(dbData.subtotal ?? 0),
-        tax: Number(dbData.tax ?? 0),
-        total: Number(dbData.total ?? 0),
+        subtotal: Number(dbData.subtotal ?? 0) / 100,
+        tax: Number(dbData.tax ?? 0) / 100,
+        total: Number((dbData as any).total_amount ?? dbData.total ?? 0) / 100,
         // notes: dbData.notes, // Add if needed
       };
     }

--- a/server/src/test/unit/invoiceAdapter.test.ts
+++ b/server/src/test/unit/invoiceAdapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { mapDbInvoiceToWasmViewModel } from 'server/src/lib/adapters/invoiceAdapters';
+
+// Simple helper to create a minimal DbInvoiceViewModel-like object
+const sampleDbInvoice = {
+  invoice_number: 'INV-001',
+  invoice_date: '2024-01-01',
+  due_date: '2024-01-31',
+  company: {
+    name: 'Test Company',
+    address: '123 Test St'
+  },
+  invoice_items: [
+    {
+      item_id: 'item1',
+      description: 'Service',
+      quantity: 1,
+      unit_price: 12345, // cents
+      total_price: 12345,
+      is_manual: false
+    }
+  ],
+  subtotal: 12345,
+  tax: 1234,
+  total_amount: 13579,
+  credit_applied: 0,
+  is_manual: false
+} as any;
+
+describe('mapDbInvoiceToWasmViewModel', () => {
+  it('converts monetary fields from cents to dollars', () => {
+    const result = mapDbInvoiceToWasmViewModel(sampleDbInvoice);
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    expect(result.items[0].unitPrice).toBeCloseTo(123.45);
+    expect(result.items[0].total).toBeCloseTo(123.45);
+    expect(result.subtotal).toBeCloseTo(123.45);
+    expect(result.tax).toBeCloseTo(12.34);
+    expect(result.total).toBeCloseTo(135.79);
+  });
+});


### PR DESCRIPTION
## Summary
- convert money fields from cents to dollars when mapping database invoices to Wasm invoice data
- test adapter currency conversion

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862b3bf4344832a827aa35f7dfd488c