### PR TITLE
Add success dialog on invoice generation

### DIFF
--- a/server/src/components/billing-dashboard/GenerateInvoices.tsx
+++ b/server/src/components/billing-dashboard/GenerateInvoices.tsx
@@ -11,6 +11,7 @@ import { getServices } from '../../lib/actions/serviceActions';
 import AutomaticInvoices from './AutomaticInvoices';
 import PrepaymentInvoices from './PrepaymentInvoices';
 import ManualInvoices from './ManualInvoices';
+import SuccessDialog from '../ui/SuccessDialog';
 
 type InvoiceType = 'automatic' | 'manual' | 'prepayment';
 
@@ -41,6 +42,7 @@ const GenerateInvoices: React.FC = () => {
   })[]>([]);
   const [companies, setCompanies] = useState<ICompany[]>([]);
   const [services, setServices] = useState<Service[]>([]);
+  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   useEffect(() => {
     loadData();
@@ -75,6 +77,7 @@ const GenerateInvoices: React.FC = () => {
 
   const handleGenerateSuccess = () => {
     loadData();
+    setShowSuccessDialog(true);
   };
 
   const renderContent = () => {
@@ -107,17 +110,18 @@ const GenerateInvoices: React.FC = () => {
   };
 
   return (
-    <div className="space-y-4">
-      <Card>
-        <div className="p-4">
-          <div className="mb-6">
-            <CustomSelect
-              value={invoiceType}
-              onValueChange={(value: string) => setInvoiceType(value as InvoiceType)}
-              options={invoiceTypeOptions}
-              className="w-full md:w-64"
-            />
-          </div>
+    <>
+      <div className="space-y-4">
+        <Card>
+          <div className="p-4">
+            <div className="mb-6">
+              <CustomSelect
+                value={invoiceType}
+                onValueChange={(value: string) => setInvoiceType(value as InvoiceType)}
+                options={invoiceTypeOptions}
+                className="w-full md:w-64"
+              />
+            </div>
 
           {error && (
             <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
@@ -128,7 +132,14 @@ const GenerateInvoices: React.FC = () => {
           {renderContent()}
         </div>
       </Card>
-    </div>
+      </div>
+      <SuccessDialog
+        isOpen={showSuccessDialog}
+        onClose={() => setShowSuccessDialog(false)}
+        message="Invoice generated successfully!"
+        id="invoice-success-dialog"
+      />
+    </>
   );
 };
 

--- a/server/src/components/ui/SuccessDialog.tsx
+++ b/server/src/components/ui/SuccessDialog.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { Dialog, DialogContent, DialogFooter } from './Dialog';
+import { Button } from './Button';
+
+interface SuccessDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+  id?: string;
+}
+
+const SuccessDialog: React.FC<SuccessDialogProps> = ({ isOpen, onClose, message, id = 'success-dialog' }) => (
+  <Dialog isOpen={isOpen} onClose={onClose} title="Success" className="max-w-sm" id={id}>
+    <DialogContent>
+      <p className="text-center">{message}</p>
+    </DialogContent>
+    <DialogFooter>
+      <Button id="success-dialog-ok" onClick={onClose}>OK</Button>
+    </DialogFooter>
+  </Dialog>
+);
+
+export default SuccessDialog;


### PR DESCRIPTION
## Summary
- show a success dialog after generating invoices
- implement SuccessDialog component for generic success messages

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862ce374d2c832a9444c36977eb7523