### PR TITLE
Add top pagination to client lists

### DIFF
--- a/server/src/components/companies/CompaniesGrid.tsx
+++ b/server/src/components/companies/CompaniesGrid.tsx
@@ -47,6 +47,17 @@ const CompaniesGrid = ({
 
     return (
         <div className="flex flex-col gap-6">
+            <Pagination
+                id="companies-pagination-top"
+                totalItems={totalCount}
+                itemsPerPage={pageSize as ItemsPerPage}
+                currentPage={currentPage}
+                onPageChange={onPageChange}
+                onItemsPerPageChange={onPageSizeChange}
+                variant="companies"
+                itemLabel="companies"
+                itemsPerPageOptions={itemsPerPageOptions}
+            />
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {filteredCompanies.map((company): JSX.Element => (
                     <div key={company.company_id} className="relative">

--- a/server/src/components/companies/CompaniesList.tsx
+++ b/server/src/components/companies/CompaniesList.tsx
@@ -260,6 +260,7 @@ const CompaniesList = ({
                 pageSize={pageSize}
                 totalItems={totalCount}
                 onPageChange={onPageChange}
+                showTopPagination={true}
             />
         </div>
     );

--- a/server/src/components/ui/DataTable.tsx
+++ b/server/src/components/ui/DataTable.tsx
@@ -129,6 +129,8 @@ const ReflectedTableCell: React.FC<ReflectedTableCellProps> = ({
 export interface ExtendedDataTableProps<T extends object> extends DataTableProps<T>, AutomationProps {
   /** Unique identifier for UI reflection system */
   id?: string;
+  /** Show pagination controls above the table */
+  showTopPagination?: boolean;
 }
 
 export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): React.ReactElement => {
@@ -142,7 +144,8 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     onPageChange,
     pageSize = 10,
     totalItems,
-    editableConfig
+    editableConfig,
+    showTopPagination = false
   } = props;
   
   // Reference to the table container for measuring available width
@@ -413,6 +416,30 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               </svg>
               {columns.length - visibleColumnIds.length} columns hidden due to limited space. Resize browser to see more.
             </span>
+          </div>
+        )}
+        {pagination && data.length > 0 && showTopPagination && (
+          <div className="px-6 py-4 border-b border-gray-100 bg-white">
+            <div className="flex items-center justify-between">
+              <button
+                onClick={handlePreviousPage}
+                disabled={!table.getCanPreviousPage()}
+                className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-[rgb(var(--color-text-700))]">
+                Page {pageIndex + 1} of{' '}
+                {totalPages} ({total} total records)
+              </span>
+              <button
+                onClick={handleNextPage}
+                disabled={!table.getCanNextPage()}
+                className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Next
+              </button>
+            </div>
           </div>
         )}
         <div className="overflow-x-auto">

--- a/server/src/interfaces/dataTable.interfaces.ts
+++ b/server/src/interfaces/dataTable.interfaces.ts
@@ -30,6 +30,8 @@ export interface DataTableProps<T> {
   onPageChange?: (page: number) => void;
   pageSize?: number;
   totalItems?: number;
+  /** When true, renders pagination controls above the table as well */
+  showTopPagination?: boolean;
   editableConfig?: EditableConfig;
   /** Custom class name for table rows */
   rowClassName?: (record: T) => string;


### PR DESCRIPTION
## Summary
- allow DataTable to show pagination controls at the top
- enable top pagination on the Companies list
- add a second Pagination component above the grid view

## Testing
- `npm run test:local` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862ef566204832a9e4b3dbd26298d8e