### PR TITLE
fix: disable onboarding wizard showing on login

### DIFF
--- a/server/src/components/onboarding/OnboardingProvider.tsx
+++ b/server/src/components/onboarding/OnboardingProvider.tsx
@@ -30,7 +30,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
       
       // TODO: Only show onboarding for admin users
       // Need to fetch user roles separately as they're not in the session
-      const isAdmin = true; // Temporarily allow all users
+      const isAdmin = false; // Temporarily disabled - onboarding feature not ready
       
       if (settings && !settings.onboarding_completed && !settings.onboarding_skipped && isAdmin) {
         setShowOnboarding(true);


### PR DESCRIPTION
## Problem
The onboarding wizard was incorrectly showing up for all users on login, even though it's a future feature that should be inactive.

## Root Cause
- `OnboardingProvider` is wrapped around all MSP pages in the layout
- The provider had a hardcoded `isAdmin = true` which triggered the wizard for any user who hadn't completed onboarding
- This caused the wizard to appear inappropriately since the feature isn't ready yet

## Solution
- Changed `isAdmin` from `true` to `false` in `OnboardingProvider.tsx`
- Updated comment to clarify the feature is temporarily disabled
- Preserves the infrastructure for future activation

## Testing
- Users should no longer see the onboarding wizard on login
- The onboarding infrastructure remains in place for when the feature is ready

## Files Changed
- `server/src/components/onboarding/OnboardingProvider.tsx`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update