### PR TITLE
Open clients and contacts in drawer

### DIFF
--- a/server/src/components/companies/CompaniesList.tsx
+++ b/server/src/components/companies/CompaniesList.tsx
@@ -2,8 +2,9 @@ import { DataTable } from 'server/src/components/ui/DataTable';
 import { ColumnDefinition } from 'server/src/interfaces/dataTable.interfaces';
 import { ICompany } from 'server/src/interfaces/company.interfaces';
 import { ITag } from 'server/src/interfaces/tag.interfaces';
-import { useRouter } from 'next/navigation';
 import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { useDrawer } from 'server/src/context/DrawerContext';
+import CompanyDetails from './CompanyDetails';
 import { ReflectedDropdownMenu } from 'server/src/components/ui/ReflectedDropdownMenu';
 import { Button } from 'server/src/components/ui/Button';
 import CompanyAvatar from 'server/src/components/ui/CompanyAvatar';
@@ -76,7 +77,7 @@ const CompanyLink: React.FC<CompanyLinkProps> = ({ company, onClick }) => {
   return (
     <a
       data-automation-id={linkId}
-      href={`/msp/companies/${company.company_id}`}
+      href="#"
       onClick={onClick}
       className="text-blue-600 hover:underline font-medium truncate"
       title={company.company_name}
@@ -101,10 +102,17 @@ const CompaniesList = ({
   allUniqueTags = [],
   onTagsChange
 }: CompaniesListProps) => {
-  const router = useRouter(); // Get router instance
+  const { openDrawer } = useDrawer();
 
   const handleRowClick = (company: ICompany) => {
-    router.push(`/msp/companies/${company.company_id}`);
+    openDrawer(
+      <CompanyDetails
+        company={company}
+        documents={[]}
+        contacts={[]}
+        isInDrawer={true}
+      />
+    );
   };
 
     const columns: ColumnDefinition<ICompany>[] = [

--- a/server/src/components/companies/CompanyDetails.tsx
+++ b/server/src/components/companies/CompanyDetails.tsx
@@ -21,6 +21,7 @@ import { updateCompany, uploadCompanyLogo, deleteCompanyLogo, getCompanyById } f
 import CustomTabs from 'server/src/components/ui/CustomTabs';
 import { QuickAddTicket } from '../tickets/QuickAddTicket';
 import { Button } from 'server/src/components/ui/Button';
+import { ExternalLink } from 'lucide-react';
 import BackNav from 'server/src/components/ui/BackNav';
 import TaxSettingsForm from 'server/src/components/TaxSettingsForm';
 import InteractionsFeed from '../interactions/InteractionsFeed';
@@ -855,6 +856,18 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
         <BackNav href={!isInDrawer ? "/msp/companies" : undefined}>
           {isInDrawer ? 'Back' : 'Back to Clients'}
         </BackNav>
+        {isInDrawer && (
+          <Button
+            id={`${id}-go-to-company-button`}
+            onClick={() => window.open(`/msp/companies/${company.company_id}`, '_blank')}
+            variant="soft"
+            size="sm"
+            className="flex items-center"
+          >
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Go to client
+          </Button>
+        )}
         
         {/* Logo Display and Edit Container */}
         <div className="flex items-center space-x-3">

--- a/server/src/components/companies/CompanyDetails.tsx
+++ b/server/src/components/companies/CompanyDetails.tsx
@@ -855,23 +855,11 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
 
   return (
     <ReflectionContainer id={id} label="Company Details">
-      <div className="flex items-center space-x-5 mb-4 pt-2">
+      <div className="flex items-center space-x-5 mb-2 pt-2">
         {!isInDrawer && (
           <BackNav href="/msp/companies">Back to Clients</BackNav>
         )}
-        {isInDrawer && (
-          <Button
-            id={`${id}-go-to-company-button`}
-            onClick={() => window.open(`/msp/companies/${company.company_id}`, '_blank')}
-            variant="soft"
-            size="sm"
-            className="flex items-center"
-          >
-            <ExternalLink className="h-4 w-4 mr-2" />
-            Go to client
-          </Button>
-        )}
-        
+
         {/* Logo Display and Edit Container */}
         <div className="flex items-center space-x-3">
           <EntityImageUpload
@@ -901,8 +889,24 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
           />
         </div>
 
+
         <Heading size="6">{editedCompany.company_name}</Heading>
       </div>
+
+      {isInDrawer && (
+        <div className="mb-4">
+          <Button
+            id={`${id}-go-to-company-button`}
+            onClick={() => window.open(`/msp/companies/${company.company_id}`, '_blank')}
+            variant="soft"
+            size="sm"
+            className="flex items-center"
+          >
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Go to client
+          </Button>
+        </div>
+      )}
 
       {/* Content Area */}
       <div>

--- a/server/src/components/companies/CompanyDetails.tsx
+++ b/server/src/components/companies/CompanyDetails.tsx
@@ -850,12 +850,15 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
     return matchingTab?.label || 'Details';
   };
 
+  // When rendered inside a drawer, only show the Details tab content
+  const detailsTab = tabContent.find(tab => tab.label === 'Details');
+
   return (
     <ReflectionContainer id={id} label="Company Details">
       <div className="flex items-center space-x-5 mb-4 pt-2">
-        <BackNav href={!isInDrawer ? "/msp/companies" : undefined}>
-          {isInDrawer ? 'Back' : 'Back to Clients'}
-        </BackNav>
+        {!isInDrawer && (
+          <BackNav href="/msp/companies">Back to Clients</BackNav>
+        )}
         {isInDrawer && (
           <Button
             id={`${id}-go-to-company-button`}
@@ -903,11 +906,15 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
 
       {/* Content Area */}
       <div>
-        <CustomTabs
-          tabs={tabContent}
-          defaultTab={findTabLabel(searchParams?.get('tab'))}
-          onTabChange={handleTabChange}
-        />
+        {isInDrawer ? (
+          detailsTab?.content || null
+        ) : (
+          <CustomTabs
+            tabs={tabContent}
+            defaultTab={findTabLabel(searchParams?.get('tab'))}
+            onTabChange={handleTabChange}
+          />
+        )}
 
         <QuickAddTicket
           id={`${id}-quick-add-ticket`}

--- a/server/src/components/companies/CompanyGridCard.tsx
+++ b/server/src/components/companies/CompanyGridCard.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import { Button } from 'server/src/components/ui/Button';
 import { ReflectedDropdownMenu } from "server/src/components/ui/ReflectedDropdownMenu";
 import { MoreVertical, Pencil, Trash2 } from 'lucide-react';
@@ -7,6 +6,8 @@ import { ICompany } from "server/src/interfaces/company.interfaces";
 import { ITag } from 'server/src/interfaces/tag.interfaces';
 import CompanyAvatar from 'server/src/components/ui/CompanyAvatar';
 import { TagManager } from 'server/src/components/tags';
+import { useDrawer } from 'server/src/context/DrawerContext';
+import CompanyDetails from './CompanyDetails';
 
 interface CompanyGridCardProps {
     company: ICompany;
@@ -29,10 +30,17 @@ const CompanyGridCard = ({
     allUniqueTags = [],
     onTagsChange
 }: CompanyGridCardProps) => {
-    const router = useRouter();
+    const { openDrawer } = useDrawer();
 
     const handleCardClick = () => {
-        router.push(`/msp/companies/${company.company_id}`);
+        openDrawer(
+            <CompanyDetails
+                company={company}
+                documents={[]}
+                contacts={[]}
+                isInDrawer={true}
+            />
+        );
     };
 
     const stopPropagation = (e: MouseEvent) => {
@@ -72,8 +80,8 @@ const CompanyGridCard = ({
                 <div className="flex-1 min-w-0">
                     <h2 className="text-md font-semibold text-gray-800 truncate" title={company.company_name}>
                         <a
-                          href={`/msp/companies/${company.company_id}`}
-                          onClick={stopPropagation}
+                          href="#"
+                          onClick={(e) => { e.preventDefault(); }}
                           className="text-blue-600 hover:underline"
                         >
                             {company.company_name}

--- a/server/src/components/contacts/ContactDetailsView.tsx
+++ b/server/src/components/contacts/ContactDetailsView.tsx
@@ -32,6 +32,11 @@ interface ContactDetailsViewProps {
   userId?: string;
   documents?: IDocument[];
   onDocumentCreated?: () => Promise<void>;
+  /**
+   * Whether to include extended sections like documents and interactions.
+   * Defaults to `false` when rendered inside a drawer and `true` otherwise.
+   */
+  showExtended?: boolean;
 }
 
 interface TableRowProps {
@@ -58,14 +63,15 @@ const TableRow: React.FC<TableRowProps> = ({ label, value, onClick }) => (
   </tr>
 );
 
-const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({ 
+const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
   id = 'contact-details',
-  initialContact, 
+  initialContact,
   companies,
   isInDrawer = false,
   userId,
   documents: initialDocuments = [],
-  onDocumentCreated
+  onDocumentCreated,
+  showExtended = !isInDrawer
 }) => {
   const [contact, setContact] = useState<IContact>(initialContact);
   const [interactions, setInteractions] = useState<IInteraction[]>([]);
@@ -313,7 +319,7 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
           </tbody>
         </table>
 
-        {userId && (
+        {showExtended && userId && (
           <div className="mt-6">
             <Heading size="4" className="mb-4">Documents</Heading>
             <Documents
@@ -328,16 +334,18 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
           </div>
         )}
 
-        <div className="mt-6">
-          <InteractionsFeed 
-            id={`${id}-interactions`}
-            entityId={contact.contact_name_id} 
-            entityType="contact"
-            companyId={contact.company_id!}
-            interactions={interactions}
-            setInteractions={setInteractions}
-          />
-        </div>
+        {showExtended && (
+          <div className="mt-6">
+            <InteractionsFeed
+              id={`${id}-interactions`}
+              entityId={contact.contact_name_id}
+              entityType="contact"
+              companyId={contact.company_id!}
+              interactions={interactions}
+              setInteractions={setInteractions}
+            />
+          </div>
+        )}
       </div>
     </ReflectionContainer>
   );

--- a/server/src/components/contacts/ContactDetailsView.tsx
+++ b/server/src/components/contacts/ContactDetailsView.tsx
@@ -232,7 +232,7 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
           </div>
         )}
         <div className="mb-6">
-          <div className="flex justify-between items-center mb-4">
+          <div className="flex justify-between items-start mb-2">
             <div className="flex items-center">
               {/* Contact Avatar */}
               {userId && (
@@ -247,8 +247,8 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
               )}
               <Heading size="6">{contact.full_name}</Heading>
             </div>
-            <div className="flex items-center space-x-2">
-              {!isInDrawer && (
+            {!isInDrawer && (
+              <div className="flex items-center space-x-2">
                 <Button
                   id={`${id}-back-button`}
                   onClick={goBack}
@@ -259,20 +259,6 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
                   <ArrowLeft className="mr-2 h-4 w-4" />
                   Back
                 </Button>
-              )}
-              {isInDrawer && (
-                <Button
-                  id={`${id}-go-to-contact-button`}
-                  onClick={() => window.open(`/msp/contacts/${contact.contact_name_id}`, '_blank')}
-                  variant="soft"
-                  size="sm"
-                  className="flex items-center"
-                >
-                  <ExternalLink className="h-4 w-4 mr-2" />
-                  Go to contact
-                </Button>
-              )}
-              {!isInDrawer && (
                 <Button
                   id={`${id}-edit-button`}
                   variant="soft"
@@ -283,9 +269,24 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
                   <Pen className="h-4 w-4 mr-2" />
                   Edit
                 </Button>
-              )}
-            </div>
+              </div>
+            )}
           </div>
+
+          {isInDrawer && (
+            <div className="mb-4">
+              <Button
+                id={`${id}-go-to-contact-button`}
+                onClick={() => window.open(`/msp/contacts/${contact.contact_name_id}`, '_blank')}
+                variant="soft"
+                size="sm"
+                className="flex items-center"
+              >
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Go to contact
+              </Button>
+            </div>
+          )}
         </div>
         <table className="min-w-full">
           <tbody>

--- a/server/src/components/contacts/ContactDetailsView.tsx
+++ b/server/src/components/contacts/ContactDetailsView.tsx
@@ -248,16 +248,18 @@ const ContactDetailsView: React.FC<ContactDetailsViewProps> = ({
               <Heading size="6">{contact.full_name}</Heading>
             </div>
             <div className="flex items-center space-x-2">
-              <Button
-                id={`${id}-back-button`}
-                onClick={goBack}
-                variant="ghost"
-                size="sm"
-                className="flex items-center"
-              >
-                <ArrowLeft className="mr-2 h-4 w-4" />
-                Back
-              </Button>
+              {!isInDrawer && (
+                <Button
+                  id={`${id}-back-button`}
+                  onClick={goBack}
+                  variant="ghost"
+                  size="sm"
+                  className="flex items-center"
+                >
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Back
+                </Button>
+              )}
               {isInDrawer && (
                 <Button
                   id={`${id}-go-to-contact-button`}

--- a/server/src/components/contacts/Contacts.tsx
+++ b/server/src/components/contacts/Contacts.tsx
@@ -27,7 +27,6 @@ import { getCurrentUser } from 'server/src/lib/actions/user-actions/userActions'
 import { getDocumentsByEntity } from 'server/src/lib/actions/document-actions/documentActions';
 import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
 import ContactAvatar from 'server/src/components/ui/ContactAvatar';
-import { useRouter } from 'next/navigation';
 
 interface ContactsProps {
   initialContacts: IContact[];
@@ -49,7 +48,6 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, companyId, preSele
   const [currentPage, setCurrentPage] = useState(1);
   const [isFiltered, setIsFiltered] = useState(false);
   const { openDrawer } = useDrawer();
-  const router = useRouter();
   const contactTagsRef = useRef<Record<string, ITag[]>>({});
   const [allUniqueTags, setAllUniqueTags] = useState<string[]>([]);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -154,11 +152,7 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, companyId, preSele
   };
 
   const handleViewDetails = async (contact: IContact) => {
-    // If this is being used within a company context (companyId prop exists),
-    // maintain the drawer behavior. Otherwise, navigate to the new contact details page.
-    if (companyId) {
-      // Company context - keep existing drawer behavior
-      if (!currentUser) return;
+    if (!currentUser) return;
 
       try {
         setDocumentLoading(prev => ({
@@ -212,10 +206,6 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, companyId, preSele
           [contact.contact_name_id]: false
         }));
       }
-    } else {
-      // Main contacts list - navigate to new contact details page
-      router.push(`/msp/contacts/${contact.contact_name_id}`);
-    }
   };
 
   const handleEditContact = (contact: IContact) => {

--- a/server/src/context/DrawerContext.tsx
+++ b/server/src/context/DrawerContext.tsx
@@ -99,7 +99,7 @@ function drawerReducer(state: DrawerState, action: DrawerAction): DrawerState {
       const newEntry: DrawerHistoryEntry = {
         id: `drawer-${Date.now()}`,
         type: 'custom',
-        title: 'Drawer',
+        title: '',
         content,
         onMount,
       };
@@ -121,7 +121,7 @@ function drawerReducer(state: DrawerState, action: DrawerAction): DrawerState {
       const newEntry: DrawerHistoryEntry = {
         id: `drawer-${Date.now()}`,
         type: 'custom',
-        title: 'Drawer',
+        title: '',
         content,
         onMount,
       };
@@ -364,7 +364,9 @@ export const DrawerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                     <ChevronLeft className="h-4 w-4" />
                   </Button>
                 )}
-                <h2 className="text-xl font-semibold">{currentEntry.title}</h2>
+                {currentEntry.title && (
+                  <h2 className="text-xl font-semibold">{currentEntry.title}</h2>
+                )}
               </div>
               <div className="flex items-center">
                 {canGoForward && (

--- a/server/src/context/DrawerContext.tsx
+++ b/server/src/context/DrawerContext.tsx
@@ -345,54 +345,56 @@ export const DrawerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         isOpen={state.isOpen}
         onClose={closeDrawer}
         isInDrawer={state.history.length > 1}
-        hideCloseButton={true}
+        hideCloseButton={canGoBack || canGoForward || !!currentEntry?.title}
         drawerVariant="nested"
       >
         {currentEntry && (
           <div className="flex flex-col h-full">
-            <div className="flex items-center justify-between mb-6 border-b pb-4">
-              <div className="flex items-center">
-                {canGoBack && (
+            {(canGoBack || canGoForward || currentEntry.title) && (
+              <div className="flex items-center justify-between mb-6 border-b pb-4">
+                <div className="flex items-center">
+                  {canGoBack && (
+                    <Button
+                      id="drawer-back-button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={goBack}
+                      className="mr-2"
+                      aria-label="Go back"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                  )}
+                  {currentEntry.title && (
+                    <h2 className="text-xl font-semibold">{currentEntry.title}</h2>
+                  )}
+                </div>
+                <div className="flex items-center">
+                  {canGoForward && (
+                    <Button
+                      id="drawer-forward-button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={goForward}
+                      className="mr-2"
+                      aria-label="Go forward"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  )}
+                  {/* Always show the close button for better UX */}
                   <Button
-                    id="drawer-back-button"
+                    id="drawer-close-button"
                     variant="ghost"
                     size="sm"
-                    onClick={goBack}
-                    className="mr-2"
-                    aria-label="Go back"
+                    onClick={closeDrawer}
+                    aria-label="Close drawer"
                   >
-                    <ChevronLeft className="h-4 w-4" />
+                    <X className="h-4 w-4" />
                   </Button>
-                )}
-                {currentEntry.title && (
-                  <h2 className="text-xl font-semibold">{currentEntry.title}</h2>
-                )}
+                </div>
               </div>
-              <div className="flex items-center">
-                {canGoForward && (
-                  <Button
-                    id="drawer-forward-button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={goForward}
-                    className="mr-2"
-                    aria-label="Go forward"
-                  >
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                )}
-                {/* Always show the close button for better UX */}
-                <Button
-                  id="drawer-close-button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={closeDrawer}
-                  aria-label="Close drawer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
+            )}
             <div className="flex-1 overflow-auto">
               <DrawerContent
                 content={currentEntry.content}


### PR DESCRIPTION
## Summary
- display contact details inside the drawer regardless of context
- allow clients to pop out from drawer via button
- open client details in drawer from list/grid

## Testing
- `npm run test:local --silent` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862efcfa9f0832aafda24c8405d1958