### PR TITLE
feat: add helm configuration to control database seed execution

### DIFF
--- a/helm/templates/seed-hook.yaml
+++ b/helm/templates/seed-hook.yaml
@@ -1,4 +1,4 @@
-{{- if or .Release.IsInstall .Values.devEnv.enabled }}
+{{- if and (or .Release.IsInstall .Values.devEnv.enabled) .Values.setup.runSeeds }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,7 @@ setup:
     tag: "latest"
   pullPolicy: Always
   runMigrations: true
+  runSeeds: true
 
 server:
   image: 


### PR DESCRIPTION
This commit adds a new helm configuration option `setup.runSeeds` that allows controlling whether database seeds are executed during deployment.

### Changes:
- Added `setup.runSeeds: true` to `helm/values.yaml` as default configuration
- Modified `helm/templates/seed-hook.yaml` to conditionally run seeds based on the new flag
- Seeds now only run when both installation conditions are met AND `runSeeds` is enabled

### Usage:
```yaml
setup:
  runSeeds: true   # Enable seed execution (default)
  runSeeds: false  # Disable seed execution
```

This provides better control over when database seeds are executed, allowing for scenarios where seeds should be skipped (e.g., production deployments, testing environments).