### PR TITLE
feat: drop tenant_settings updated_at trigger

### DIFF
--- a/server/migrations/20250709132642_drop_tenant_settings_trigger.cjs
+++ b/server/migrations/20250709132642_drop_tenant_settings_trigger.cjs
@@ -1,0 +1,20 @@
+/**
+ * Drop the tenant_settings updated_at trigger since the backend already handles
+ * updating the updated_at column explicitly in all update operations.
+ * This follows the pattern established in other migrations of moving trigger
+ * logic to application code for better control and Citus compatibility.
+ */
+exports.up = async function(knex) {
+  // Drop the trigger on tenant_settings table
+  await knex.raw('DROP TRIGGER IF EXISTS update_tenant_settings_updated_at ON tenant_settings');
+};
+
+exports.down = async function(knex) {
+  // Recreate the trigger if rolling back
+  await knex.raw(`
+    CREATE TRIGGER update_tenant_settings_updated_at
+    BEFORE UPDATE ON tenant_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+  `);
+};


### PR DESCRIPTION
Remove the database trigger for tenant_settings.updated_at since the backend already handles updating this column explicitly in all update operations. This follows the established pattern of moving trigger logic to application code for better control and Citus compatibility.

Like the Cheshire Cat's grin that fades but leaves the smile behind, this trigger vanishes but leaves the updated_at functionality perfectly intact in the application logic - we're all mad here, but at least our timestamps are sane! 🎩