### PR TITLE
fix: resolve CitusDB distributed table JOIN issue in company migration

### DIFF
--- a/server/migrations/20250707120000_drop_deprecated_company_fields.cjs
+++ b/server/migrations/20250707120000_drop_deprecated_company_fields.cjs
@@ -11,54 +11,64 @@ exports.up = async function(knex) {
   // Only proceed if at least one column exists
   if (hasAddress || hasPhoneNo || hasEmail) {
     // First, migrate any remaining data to company_locations
-    await knex.raw(`
-      INSERT INTO company_locations (
-        location_id,
-        company_id,
-        tenant,
-        location_name,
-        address_line1,
-        city,
-        state_province,
-        postal_code,
-        country_code,
-        country_name,
-        phone,
-        email,
-        is_default,
-        is_billing_address,
-        is_shipping_address,
-        is_active,
-        created_at,
-        updated_at
-      )
-      SELECT 
-        gen_random_uuid() as location_id,
-        c.company_id,
-        c.tenant,
-        'Main Location' as location_name,
-        COALESCE(c.address, 'N/A') as address_line1,
-        'N/A' as city,
-        NULL as state_province,
-        NULL as postal_code,
-        'XX' as country_code,
-        'Unknown' as country_name,
-        c.phone_no as phone,
-        c.email as email,
-        true as is_default,
-        true as is_billing_address,
-        true as is_shipping_address,
-        true as is_active,
-        NOW() as created_at,
-        NOW() as updated_at
-      FROM companies c
-      LEFT JOIN company_locations cl ON c.company_id = cl.company_id AND cl.is_default = true
-      WHERE cl.location_id IS NULL
+    // Loop through tenants to maintain CitusDB compatibility
+    const tenants = await knex('companies').distinct('tenant').pluck('tenant');
+    
+    for (const tenant of tenants) {
+      await knex.raw(`
+        INSERT INTO company_locations (
+          location_id,
+          company_id,
+          tenant,
+          location_name,
+          address_line1,
+          city,
+          state_province,
+          postal_code,
+          country_code,
+          country_name,
+          phone,
+          email,
+          is_default,
+          is_billing_address,
+          is_shipping_address,
+          is_active,
+          created_at,
+          updated_at
+        )
+        SELECT 
+          gen_random_uuid() as location_id,
+          c.company_id,
+          c.tenant,
+          'Main Location' as location_name,
+          COALESCE(c.address, 'N/A') as address_line1,
+          'N/A' as city,
+          NULL as state_province,
+          NULL as postal_code,
+          'XX' as country_code,
+          'Unknown' as country_name,
+          c.phone_no as phone,
+          c.email as email,
+          true as is_default,
+          true as is_billing_address,
+          true as is_shipping_address,
+          true as is_active,
+          NOW() as created_at,
+          NOW() as updated_at
+        FROM companies c
+        WHERE c.tenant = ?
+        AND NOT EXISTS (
+          SELECT 1 FROM company_locations cl 
+          WHERE cl.company_id = c.company_id 
+          AND cl.tenant = c.tenant 
+          AND cl.is_default = true
+        )
         AND ((c.address IS NOT NULL AND c.address != '') 
           OR (c.phone_no IS NOT NULL AND c.phone_no != '')
           OR (c.email IS NOT NULL AND c.email != ''))
-      ON CONFLICT DO NOTHING;
-    `);
+        ON CONFLICT DO NOTHING;
+      `, [tenant]);
+    }
     
     // Now drop the deprecated columns
     await knex.schema.alterTable('companies', function(table) {


### PR DESCRIPTION
## Summary
- Fixed CitusDB distributed table JOIN error in company migration
- Replaced problematic LEFT JOIN with tenant-based iteration
- Maintains same functionality while ensuring CitusDB compatibility

## Changes
- Loop through each tenant individually to ensure queries operate within single shards
- Use parameterized queries to prevent SQL injection  
- Avoids "complex joins are only supported when all distributed tables are co-located" error

## Test Plan
- [ ] Run migration locally to verify it completes without errors
- [ ] Verify data migration works correctly for all tenants
- [ ] Confirm deprecated columns are properly dropped after migration