### PR TITLE
Improved schedule entry assignment logic with cascading defaults

### DIFF
--- a/server/src/components/schedule/EntryPopup.tsx
+++ b/server/src/components/schedule/EntryPopup.tsx
@@ -29,6 +29,8 @@ interface EntryPopupProps {
   slot?: {
     start: Date | string;
     end: Date | string;
+    assigned_user_ids?: string[];
+    defaultAssigneeId?: string;
   };
   onClose: () => void;
   onSave: (entryData: Omit<IScheduleEntry, 'tenant'> & { updateType?: string }) => void;
@@ -85,8 +87,8 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
         work_item_id: null,
         status: 'scheduled',
         work_item_type: 'ad_hoc',
-        // Default to focused technician if available, otherwise current user
-        assigned_user_ids: focusedTechnicianId ? [focusedTechnicianId] : [currentUserId],
+        // Use assigned_user_ids from slot if provided, otherwise default to focused technician or current user
+        assigned_user_ids: slot.assigned_user_ids || (focusedTechnicianId ? [focusedTechnicianId] : [currentUserId]),
         is_private: false,
       };
     } else {
@@ -204,7 +206,7 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
           work_item_id: null,
           status: 'scheduled',
           work_item_type: 'ad_hoc',
-          assigned_user_ids: [currentUserId],
+          assigned_user_ids: slot.assigned_user_ids || (focusedTechnicianId ? [focusedTechnicianId] : [currentUserId]),
         });
       }
     };

--- a/server/src/components/schedule/ScheduleCalendar.tsx
+++ b/server/src/components/schedule/ScheduleCalendar.tsx
@@ -300,7 +300,8 @@ const ScheduleCalendar: React.FC = (): React.ReactElement | null => {
     
     setSelectedSlot({
       ...adjustedSlotInfo,
-      defaultAssigneeId: focusedTechnicianId
+      defaultAssigneeId: focusedTechnicianId,
+      assigned_user_ids: focusedTechnicianId ? [focusedTechnicianId] : [currentUserId]
     });
     setShowEntryPopup(true);
   };

--- a/server/src/lib/actions/scheduleActions.ts
+++ b/server/src/lib/actions/scheduleActions.ts
@@ -126,12 +126,14 @@ export async function addScheduleEntry(
       };
     }
 
-    // Determine final assignedUserIds, defaulting to current user if none provided
+    // Determine final assignedUserIds, preferring entry.assigned_user_ids, then options, then defaulting to current user
     let assignedUserIds: string[];
-    if (!options?.assignedUserIds || options.assignedUserIds.length === 0) {
-      assignedUserIds = [currentUser.user_id];
-    } else {
+    if (entry.assigned_user_ids && entry.assigned_user_ids.length > 0) {
+      assignedUserIds = entry.assigned_user_ids;
+    } else if (options?.assignedUserIds && options.assignedUserIds.length > 0) {
       assignedUserIds = options.assignedUserIds;
+    } else {
+      assignedUserIds = [currentUser.user_id];
     }
 
     // --- Permission Check ---


### PR DESCRIPTION
- Added support for passing assigned_user_ids through slot props

- Implemented cascading default assignment logic:

  - Prefer slot.assigned_user_ids if provided
  - Fall back to focusedTechnicianId if available
  - Default to currentUserId as last resort

- Updated EntryPopup, ScheduleCalendar and scheduleActions to maintain consistent behavior

- Changes affect new schedule entry creation and editing

Follow the yellow brick road of user assignments, for there's no place like a properly scheduled home! 🧙‍♂️⏰