### PR TITLE
Rename Dashboard to Home and swap icons 🔄

### DIFF
--- a/server/src/components/dashboard/Dashboard.tsx
+++ b/server/src/components/dashboard/Dashboard.tsx
@@ -116,7 +116,7 @@ const WelcomeDashboard = () => {
       {/* Welcome Banner */}
       <div className="rounded-lg mb-6 p-6" 
            style={{ background: 'linear-gradient(to right, rgb(var(--color-primary-500)), rgb(var(--color-secondary-500)))' }}>
-        <div className="max-w-3xl">
+        <div className="max-w-6xl">
           <h1 className="text-3xl font-bold mb-2 text-white">Welcome to Your MSP Command Center</h1>
           <p className="text-lg text-white opacity-90">
             Your all-in-one platform for managing IT services, tracking assets, 

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -28,6 +28,7 @@ import {
   Code,
   Bell,
   Monitor,
+  Home,
   Settings,
   UserCircle,
   Shield,
@@ -44,13 +45,13 @@ export interface MenuItem {
 
 export const menuItems: MenuItem[] = [
   {
-    name: 'Dashboard',
-    icon: BarChart3,
+    name: 'Home',
+    icon: Home,
     href: '/msp/dashboard'  // Updated to point to our new dashboard page
   },
   {
     name: 'User Activities',
-    icon: Activity,
+    icon: BarChart3,
     href: '/msp/user-activities'
   },
   {


### PR DESCRIPTION
  - Changed "Dashboard" menu item to "Home" with Home icon 🏠
  - Moved BarChart3 icon to "User Activities" menu item 📊
  - Kept dashboard URL unchanged to preserve login flow 🔒
  - Also adjusted welcome banner max-width for better layout 📐

  "But I don't want to go among mad dashboards," Alice remarked. 🎩
  "Oh, you can't help that," said the Cat: "we're all Home here." 🐱