### PR TITLE
fix: prevent partition key updates in schedule entries and projects

### DIFF
--- a/server/src/components/ui/UserPicker.tsx
+++ b/server/src/components/ui/UserPicker.tsx
@@ -79,15 +79,24 @@ const UserPicker: React.FC<UserPickerProps & AutomationProps> = ({
   // Create stable automation ID for the picker
   const pickerId = dataAutomationId || 'account-manager-picker';
   
-  // Filter for internal users only
-  const internalUsers = users.filter(user => user.user_type === 'internal');
+  // Find the current user first (even if inactive)
+  const currentUser = users.find(user => user.user_id === value && user.user_type === 'internal');
   
-  const currentUser = internalUsers.find(user => user.user_id === value);
+  // Filter for internal users only and exclude inactive users for the dropdown
+  const internalUsers = users.filter(user => 
+    user.user_type === 'internal' && !user.is_inactive
+  );
   
-  const filteredUsers = internalUsers.filter(user => {
-    const fullName = `${user.first_name || ''} ${user.last_name || ''}`.trim().toLowerCase();
-    return fullName.includes(searchQuery.toLowerCase());
-  });
+  const filteredUsers = internalUsers
+    .filter(user => {
+      const fullName = `${user.first_name || ''} ${user.last_name || ''}`.trim().toLowerCase();
+      return fullName.includes(searchQuery.toLowerCase());
+    })
+    .sort((a, b) => {
+      const nameA = `${a.first_name || ''} ${a.last_name || ''}`.trim().toLowerCase();
+      const nameB = `${b.first_name || ''} ${b.last_name || ''}`.trim().toLowerCase();
+      return nameA.localeCompare(nameB);
+    });
 
   // Calculate selected user name for display
   const selectedUserName = currentUser 
@@ -362,9 +371,7 @@ const UserPicker: React.FC<UserPickerProps & AutomationProps> = ({
                     id={`${pickerId}-option-${user.user_id}`}
                     label={userName}
                     onClick={(e) => handleSelectUser(user.user_id, e)}
-                    className={`relative flex items-center px-3 py-2 text-sm rounded cursor-pointer hover:bg-gray-100 focus:bg-gray-100 ${
-                      user.is_inactive ? 'text-gray-400 bg-gray-50' : 'text-gray-900'
-                    }`}
+                    className="relative flex items-center px-3 py-2 text-sm rounded cursor-pointer hover:bg-gray-100 focus:bg-gray-100 text-gray-900"
                     parentId={pickerId}
                   >
                     <div className="flex items-center gap-2">
@@ -375,9 +382,6 @@ const UserPicker: React.FC<UserPickerProps & AutomationProps> = ({
                         size={size === 'sm' ? 'sm' : 'md'}
                       />
                       <span>{userName}</span>
-                      {user.is_inactive && (
-                        <span className="ml-1 text-xs text-gray-400">(Inactive)</span>
-                      )}
                     </div>
                   </OptionButton>
                 );

--- a/server/src/lib/actions/ticket-actions/ticketFormActions.ts
+++ b/server/src/lib/actions/ticket-actions/ticketFormActions.ts
@@ -32,7 +32,7 @@ export async function getTicketFormData(prefilledCompanyId?: string): Promise<Ti
 
     // Fetch required data first
     const [users, channels, statuses, priorities, companies] = await Promise.all([
-      getAllUsers().catch(error => {
+      getAllUsers(false).catch(error => {
         console.error('Error fetching users:', error);
         return [];
       }),

--- a/server/src/lib/models/project.ts
+++ b/server/src/lib/models/project.ts
@@ -189,11 +189,13 @@ const ProjectModel = {
         assigned_to_first_name,
         assigned_to_last_name,
         contact_name,
+        tenant: _tenant, // Remove tenant from update data
         ...updateData 
       } = projectData;
       
       const [updatedProject] = await knexOrTrx<IProject>('projects')
         .where('project_id', projectId)
+        .andWhere('tenant', tenant)
         .update({
           ...updateData,
           updated_at: knexOrTrx.fn.now()

--- a/server/src/lib/models/user.tsx
+++ b/server/src/lib/models/user.tsx
@@ -22,6 +22,10 @@ const User = {
       if (!includeInactive) {
         query = query.andWhere('is_inactive', false);
       }
+      query = query.orderBy([
+        { column: 'first_name', order: 'asc' },
+        { column: 'last_name', order: 'asc' }
+      ]);
       
       const users = await query;
       return users;


### PR DESCRIPTION
  - Remove tenant field from update operations in ScheduleEntry and Project models
  - Filter out inactive users from UserPicker dropdowns across the application
  - Add alphabetical sorting to user lists for better UX
  - Update getTicketFormData to exclude inactive users by default
  - Add database-level sorting to User.getAll() method

  These changes prevent "modifying the partition value of rows is not allowed" errors
  when updating schedule entries and projects, while also improving user selection
  experience by hiding inactive users and providing consistent alphabetical ordering.

  We're all mad here, but at least our partition keys are staying put! 🎩🐰