### PR TITLE
Add popout button to ticket drawer for opening tickets in a new window

### DIFF
--- a/server/src/components/tickets/ticket/TicketDetails.tsx
+++ b/server/src/components/tickets/ticket/TicketDetails.tsx
@@ -48,6 +48,8 @@ import CompanyDetails from "server/src/components/companies/CompanyDetails";
 import ContactDetailsView from "server/src/components/contacts/ContactDetailsView";
 import { addTicketResource, getTicketResources, removeTicketResource } from "server/src/lib/actions/ticketResourceActions";
 import AgentScheduleDrawer from "server/src/components/tickets/ticket/AgentScheduleDrawer";
+import { Button } from "server/src/components/ui/Button";
+import { ExternalLink } from 'lucide-react';
 import { WorkItemType } from "server/src/interfaces/workItem.interfaces";
 import { ReflectionContainer } from "server/src/types/ui-reflection/ReflectionContainer";
 import TimeEntryDialog from "server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog";
@@ -937,16 +939,40 @@ const handleClose = () => {
         }
     };
 
+    // Function to open ticket in a new window
+    const openTicketInNewWindow = useCallback(() => {
+        if (ticket.ticket_id) {
+            window.open(`/msp/tickets/${ticket.ticket_id}`, '_blank');
+        }
+    }, [ticket.ticket_id]);
+
     return (
         <ReflectionContainer id={id} label={`Ticket Details - ${ticket.ticket_number}`}>
             <div className="bg-gray-100">
-                <div className="flex items-center space-x-5 mb-4">
-                    {/* Only show the Back button if NOT in a drawer, using BackNav */}
-                    {!isInDrawer && (
-                        <BackNav href="/msp/tickets">Back to Tickets</BackNav>
+                <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center space-x-5">
+                        {/* Only show the Back button if NOT in a drawer, using BackNav */}
+                        {!isInDrawer && (
+                            <BackNav href="/msp/tickets">Back to Tickets</BackNav>
+                        )}
+                        <h6 className="text-sm font-medium">#{ticket.ticket_number}</h6>
+                        <h1 className="text-xl font-bold">{ticket.title}</h1>
+                    </div>
+                    
+                    {/* Add popout button only when in drawer */}
+                    {isInDrawer && (
+                        <Button
+                            id="ticket-popout-button"
+                            variant="outline"
+                            size="sm"
+                            onClick={openTicketInNewWindow}
+                            className="flex items-center gap-2"
+                            aria-label="Open in new window"
+                        >
+                            <ExternalLink className="h-4 w-4" />
+                            <span>Open in new window</span>
+                        </Button>
                     )}
-                    <h6 className="text-sm font-medium">#{ticket.ticket_number}</h6>
-                    <h1 className="text-xl font-bold">{ticket.title}</h1>
                 </div>
 
                 <div className="flex items-center space-x-5 mb-5">


### PR DESCRIPTION
## Description
This PR adds a popout button to the ticket drawer that allows users to open the ticket in a new window to see all the details. The button is only displayed when viewing a ticket in a drawer.

## Changes
- Added an "Open in new window" button to the ticket drawer header
- Button uses the ExternalLink icon from Lucide React
- Button only appears when the ticket is viewed in a drawer
- Clicking the button opens the ticket in a new browser tab/window

## Testing
To test this feature:
1. Open a ticket from a list view (which opens in a drawer)
2. Verify the "Open in new window" button appears in the top-right corner of the drawer
3. Click the button and verify the ticket opens in a new browser tab/window with the full ticket details page

@arynshimmy can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8f188cec5e9c4a19a023e9cc86b32b83)