### PR TITLE
Remove register button from client portal sign-in page

### DIFF
--- a/server/src/app/auth/signin/page.tsx
+++ b/server/src/app/auth/signin/page.tsx
@@ -229,7 +229,6 @@ export default function SignIn() {
                   callbackUrl={callbackUrl}
                   onError={handleError}
                   onTwoFactorRequired={() => setIsOpen2FA(true)}
-                  onRegister={() => setShowRegister(true)}
                 />
               )
             ) : (

--- a/server/src/components/auth/ClientLoginForm.tsx
+++ b/server/src/components/auth/ClientLoginForm.tsx
@@ -16,10 +16,9 @@ interface ClientLoginFormProps {
   callbackUrl: string;
   onError: (error: string) => void;
   onTwoFactorRequired: () => void;
-  onRegister: () => void;
 }
 
-export default function ClientLoginForm({ callbackUrl, onError, onTwoFactorRequired, onRegister }: ClientLoginFormProps) {
+export default function ClientLoginForm({ callbackUrl, onError, onTwoFactorRequired }: ClientLoginFormProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -63,14 +62,7 @@ export default function ClientLoginForm({ callbackUrl, onError, onTwoFactorRequi
     parentId: 'client-login-form'
   });
 
-  // Register register button as child of form
-  const updateRegisterButton = useRegisterUIComponent<ButtonComponent>({
-    id: 'client-register-button',
-    type: 'button',
-    label: 'Register',
-    disabled: false,
-    parentId: 'client-login-form'
-  });
+
 
   // Update field values when they change
   useEffect(() => {
@@ -170,7 +162,7 @@ export default function ClientLoginForm({ callbackUrl, onError, onTwoFactorRequi
         {isLoading ? 'Signing in...' : 'Sign In'}
       </Button>
 
-      <div className="flex justify-between text-sm">
+      <div className="text-sm">
         <Link
           href="/client-portal/auth/forgot-password"
           className="text-blue-600 hover:text-blue-800 transition-colors"
@@ -178,14 +170,6 @@ export default function ClientLoginForm({ callbackUrl, onError, onTwoFactorRequi
         >
           Forgot your password?
         </Link>
-        <button
-          type="button"
-          onClick={onRegister}
-          className="text-blue-600 hover:text-blue-800 transition-colors"
-          {...withDataAutomationId({ id: 'client-register-button' })}
-        >
-          Register
-        </button>
       </div>
     </form>
   )


### PR DESCRIPTION
## Summary

This PR removes the register button from the client portal sign-in page to prevent new user registration through the client portal interface.

## Changes Made

- **Removed Register Button**: Completely removed the "Register" button from the `ClientLoginForm` component
- **Updated Interface**: Removed the `onRegister` prop from the `ClientLoginForm` component interface
- **Simplified Layout**: Changed the layout from `flex justify-between` to a simple container for the "Forgot password" link
- **Removed UI Reflection**: Removed the register button from the UI reflection system registration
- **Updated Parent Component**: Removed the `onRegister` prop from the parent signin page component

## Files Modified

- `server/src/components/auth/ClientLoginForm.tsx` - Removed register button and related functionality
- `server/src/app/auth/signin/page.tsx` - Removed onRegister prop from ClientLoginForm usage

## Impact

- Users can no longer register new accounts through the client portal sign-in page
- The "Forgot password" functionality remains intact and accessible
- No breaking changes to existing authentication flows
- Clean removal of unused registration functionality

## Testing

The changes have been verified to:
- Remove the register button from the UI
- Maintain proper layout with only the "Forgot password" link
- Not break existing sign-in functionality
- Properly clean up all related code and props

@arynshimmy can click here to [continue refining the PR](https://app.all-hands.dev/conversations/21ac21b300234b1bb1bdda9a8e588511)