### PR TITLE
Make logo in sidebar link to home/dashboard page

### DIFF
--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -104,18 +104,23 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }): JSX.E
       <aside 
         className={`bg-[#1e1f25] text-white h-screen flex flex-col relative transition-all duration-300 ease-in-out ${sidebarOpen ? 'w-64' : 'w-16'}`}
       >
-      <div className="p-4 flex items-center space-x-2">
+      <a 
+        href="/msp/dashboard" 
+        className="p-4 flex items-center space-x-2 hover:bg-[#2a2b32] cursor-pointer"
+        aria-label="Go to dashboard"
+        id="logo-home-link"
+      >
         <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
           <Image
             src="/images/avatar-purple-background.png"
-            alt="404"
+            alt="AlgaPSA Logo"
             width={200}
             height={200}
             className="w-full h-full object-cover"
           />
         </div>
         {sidebarOpen && <span className="text-xl font-semibold truncate">AlgaPSA</span>}
-      </div>
+      </a>
 
       {/* Temporarily hide the search bar since it is non-functional */}
       {/*


### PR DESCRIPTION
## Description
This PR adds functionality to make the logo in the side navigation bar clickable, linking back to the home (dashboard) page when clicked.

## Changes Made
- Wrapped the logo and text in the sidebar with an anchor tag that links to `/msp/dashboard`
- Added hover effect to improve user experience
- Added `aria-label` for better accessibility
- Added an ID to the element for easier testing and selection

## Testing
The changes have been tested locally to ensure the logo is properly clickable and navigates to the dashboard page.

## Screenshots
N/A

## Additional Notes
This is a simple UI enhancement that improves navigation by allowing users to quickly return to the dashboard by clicking on the logo, which is a common pattern in web applications.

@arynshimmy can click here to [continue refining the PR](https://app.all-hands.dev/conversations/eae29761bf04423a9581baad494ed8fc)