### PR TITLE
Fix contact deletion dialog to show only OK button when error occurs

### DIFF
--- a/server/src/components/contacts/Contacts.tsx
+++ b/server/src/components/contacts/Contacts.tsx
@@ -655,7 +655,7 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, companyId, preSele
             setContactToDelete(null);
             setDeleteError(null);
           }}
-          onConfirm={confirmDelete}
+          onConfirm={deleteError ? undefined : confirmDelete}
           title="Delete Contact"
           message={
             deleteError
@@ -663,7 +663,8 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, companyId, preSele
               : "Are you sure you want to delete this contact? This action cannot be undone."
           }
           confirmLabel={deleteError ? undefined : "Delete"}
-          cancelLabel={deleteError ? "Close" : "Cancel"}
+          cancelLabel={deleteError ? "OK" : "Cancel"}
+          hideConfirmButton={!!deleteError}
           isConfirming={false}
         />
       </div>


### PR DESCRIPTION
## Description
This PR fixes an issue with the contact deletion dialog where, when a user is unable to delete a contact due to dependencies or other errors, the dialog shows both "Confirm" and "Close" buttons. The "Confirm" button doesn't do anything useful in this error state and just refreshes the dialog, causing confusion.

## Changes Made
1. Updated the `ConfirmationDialog` component to support a new `hideConfirmButton` prop that allows hiding the confirm button when needed.
2. Modified the dialog to show only a single "OK" button when there's an error message, instead of showing both "Close" and "Confirm" buttons.
3. Updated the focus handling to focus on the appropriate button based on whether the confirm button is visible.
4. Made the `onConfirm` prop optional to handle cases where we don't need a confirmation action.
5. Changed the button styling to make the single "OK" button use the primary style when it's the only button.

## Testing
The changes have been tested manually to ensure:
- The normal delete confirmation dialog still shows both "Delete" and "Cancel" buttons
- When an error occurs (e.g., when a contact can't be deleted due to dependencies), only a single "OK" button is shown
- The focus handling works correctly in both cases

## Screenshots
N/A

## Related Issues
This PR addresses the issue where the "confirm" option on the contact deletion dialog doesn't do anything useful when an error occurs.

@arynshimmy can click here to [continue refining the PR](https://app.all-hands.dev/conversations/98a43c3f07cc42d29ec610c1329be71e)