### PR TITLE
Fix Sharp installation for Alpine Linux builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,9 +19,7 @@ COPY server/package.json ./server/
 COPY tsconfig.base.json ./
 COPY server/src/invoice-templates/assemblyscript ./server/src/invoice-templates/assemblyscript
 
-RUN npm install
-# Remove existing sharp and install the correct platform-specific version
-RUN npm uninstall sharp && npm install --platform=linux --arch=x64 sharp
+RUN npm install --include=optional sharp
 
 # Builder stage for compiling the application
 FROM deps AS builder


### PR DESCRIPTION
## Summary
- Replace manual Sharp uninstall/reinstall with `--include=optional` flag
- Automatically detect correct platform binaries for Alpine musl
- Should resolve the "linuxmusl-x64 runtime" error during Docker builds

## Test plan
- [ ] Test Docker build completes without Sharp errors
- [ ] Verify image processing functionality still works
- [ ] Test document upload and thumbnail generation