### PR TITLE
feat: add database migration for pubsub_initialised_at field

### DIFF
--- a/server/migrations/20250719190720_add_pubsub_initialised_at_to_google_config.cjs
+++ b/server/migrations/20250719190720_add_pubsub_initialised_at_to_google_config.cjs
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('google_email_provider_config', function (table) {
+    table.timestamp('pubsub_initialised_at').nullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('google_email_provider_config', function (table) {
+    table.dropColumn('pubsub_initialised_at');
+  });
+};


### PR DESCRIPTION
## Summary
- Add database migration for `pubsub_initialised_at` field to `google_email_provider_config` table
- Required for Gmail Pub/Sub single initialization refactor idempotency protection
- Field tracks when Pub/Sub was last initialized to prevent duplicate setups within 24 hours

## Changes
- **Migration**: `20250719190720_add_pubsub_initialised_at_to_google_config.cjs`
  - Adds nullable `TIMESTAMPTZ` column to `google_email_provider_config`
  - Provides rollback capability via down migration
  - CitusDB compatible (simple column addition)

## Context
This migration supports the Gmail Pub/Sub single initialization refactor that eliminates duplicate `setupPubSub()` calls (4x → 1x) by adding idempotency protection with 24-hour cooldown tracking.

## Test plan
- [x] Migration created using proper Knex syntax
- [x] CitusDB compatibility verified (no triggers, constraints, or complex indexes)
- [ ] Run migration in development environment
- [ ] Verify `pubsub_initialised_at` column exists and accepts nullable timestamps
- [ ] Test rollback migration removes column properly