### PR TITLE
fix: correct import path for getSecretProviderInstance in database setup

### DIFF
--- a/server/setup/create_database.js
+++ b/server/setup/create_database.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import fs from 'fs';
 import path from 'path';
-import { getSecretProviderInstance } from '../../shared/dist/core/index.js';
+import { getSecretProviderInstance } from '../../shared/core/index.js';
 
 // Enable long stack traces for async operations
 Error.stackTraceLimit = 50;


### PR DESCRIPTION
## Summary
• Fixed import path for `getSecretProviderInstance` in `server/setup/create_database.js`
• Changed from `../../shared/dist/core/index.js` to `../../shared/core/index.js`

## Test plan
- [ ] Verify database setup script runs without import errors
- [ ] Confirm the secret provider functionality still works correctly