### PR TITLE
Fix delete entry from schedule popup

### DIFF
--- a/server/src/components/schedule/EntryPopup.tsx
+++ b/server/src/components/schedule/EntryPopup.tsx
@@ -317,6 +317,15 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [pendingUpdateData, setPendingUpdateData] = useState<Omit<IScheduleEntry, 'tenant'>>();
 
+  const handleDeleteConfirm = (selected?: string) => {
+    if (event && onDelete) {
+      const deleteType = event.is_recurring ? (selected as IEditScope) : undefined;
+      onDelete(event.entry_id, deleteType);
+    }
+    setShowDeleteDialog(false);
+    onClose();
+  };
+
   const clearErrorIfSubmitted = () => {
     if (hasAttemptedSubmit) {
       setValidationErrors([]);
@@ -438,6 +447,7 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
             <Button
               id="delete-entry-btn"
               onClick={() => setShowDeleteDialog(true)}
+              type="button"
               variant="destructive"
               size="sm"
             >
@@ -790,12 +800,7 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
       <ConfirmationDialog
         className="max-w-[450px]"
         isOpen={showDeleteDialog}
-        onConfirm={(value) => {
-          if (event && onDelete) {
-            onDelete(event.entry_id, event.is_recurring ? value as IEditScope : undefined);
-            onClose();
-          }
-        }}
+        onConfirm={handleDeleteConfirm}
         onClose={() => setShowDeleteDialog(false)}
         title="Delete Schedule Entry"
         message={event?.is_recurring 


### PR DESCRIPTION
## Summary
- ensure delete confirmation actually deletes entry
- fix delete popup callback type to match ConfirmationDialog

## Testing
- `npx dotenv -e ../.env.localtest -- vitest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_b_687fd3b988e8832abeb19d82a749bda1