### PR TITLE
Fix client notes not saving after first save

### DIFF
--- a/server/src/components/companies/CompanyDetails.tsx
+++ b/server/src/components/companies/CompanyDetails.tsx
@@ -466,24 +466,28 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
       // Convert blocks to JSON string
       const blockData = JSON.stringify(currentContent);
       
-      if (company.notes_document_id) {
+      if (editedCompany.notes_document_id) {
         // Update existing note document
-        await updateBlockContent(company.notes_document_id, {
+        await updateBlockContent(editedCompany.notes_document_id, {
           block_data: blockData,
           user_id: currentUser.user_id
         });
+        
+        // Refresh document metadata to show updated timestamp
+        const updatedDocument = await getDocument(editedCompany.notes_document_id);
+        setNoteDocument(updatedDocument);
       } else {
         // Create new note document
         const { document_id } = await createBlockDocument({
-          document_name: `${company.company_name} Notes`,
+          document_name: `${editedCompany.company_name} Notes`,
           user_id: currentUser.user_id,
           block_data: blockData,
-          entityId: company.company_id,
+          entityId: editedCompany.company_id,
           entityType: 'company'
         });
         
         // Update company with the new notes_document_id
-        await updateCompany(company.company_id, {
+        await updateCompany(editedCompany.company_id, {
           notes_document_id: document_id
         });
         
@@ -492,11 +496,25 @@ const CompanyDetails: React.FC<CompanyDetailsProps> = ({
           ...prev,
           notes_document_id: document_id
         }));
+        
+        // Get the newly created document metadata
+        const newDocument = await getDocument(document_id);
+        setNoteDocument(newDocument);
       }
       
       setHasUnsavedNoteChanges(false);
+      toast({
+        title: "Success",
+        description: "Note saved successfully.",
+        variant: "default"
+      });
     } catch (error) {
       console.error('Error saving note:', error);
+      toast({
+        title: "Error",
+        description: "Failed to save note. Please try again.",
+        variant: "destructive"
+      });
     }
   };
   


### PR DESCRIPTION
## Problem Description

Client notes were not working properly after the first save:
- Initial note from when the client was created worked fine
- Additional notes would not save properly
- There would be a "created by" stamp for subsequent note attempts, but no content would be saved
- Users could not add any notes after the first failed attempt

## Root Cause

The issue was in the `handleSaveNote` function in `CompanyDetails.tsx`. The function was using `company.notes_document_id` (from props) instead of `editedCompany.notes_document_id` (from state) to determine whether to create a new document or update an existing one.

**What was happening:**
1. First save: `company.notes_document_id` is null → creates new document and updates `editedCompany.notes_document_id`
2. Second save: `company.notes_document_id` is still null (props don't change), but `editedCompany.notes_document_id` has the correct document ID
3. Because the logic checked `company.notes_document_id`, it would create another new document instead of updating the existing one
4. This created duplicate documents and broke the note saving functionality

## Solution

### Changes Made
- **Fixed condition check**: Changed from `company.notes_document_id` to `editedCompany.notes_document_id` 
- **Updated all references**: Changed all other references in the function to use `editedCompany` instead of `company` for consistency
- **Added document metadata refresh**: Added calls to `getDocument()` after both create and update operations to refresh timestamps
- **Improved error handling**: Added toast notifications for success and error cases

### Specific Code Changes
- Line 469: `company.notes_document_id` → `editedCompany.notes_document_id`
- Line 471: `company.notes_document_id` → `editedCompany.notes_document_id` 
- Line 478: `company.company_name` → `editedCompany.company_name`
- Line 481: `company.company_id` → `editedCompany.company_id`
- Line 486: `company.company_id` → `editedCompany.company_id`
- Added document metadata refresh after both create and update operations
- Added success/error toast notifications

## Testing

Created and ran a comprehensive test that verified:
1. The original bug behavior (creating duplicate documents)
2. The fixed behavior (properly updating existing documents)
3. Confirmed the fix resolves the issue completely

## Impact

This fix ensures that:
- Client notes save properly on subsequent attempts
- No duplicate documents are created
- Users get proper feedback when saving notes
- Document timestamps are properly updated and displayed

## Files Changed

- `server/src/components/companies/CompanyDetails.tsx` - Fixed handleSaveNote function logic