### PR TITLE
feat: Add support for configurable secrets in Helm values

### DIFF
--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -10,6 +10,24 @@ metadata:
     "helm.sh/hook-weight": "-5"
 type: Opaque
 data:
+  {{- if .Values.secrets }}
+  {{- if .Values.secrets.NEXTAUTH_SECRET }}
+  NEXTAUTH_SECRET: {{ .Values.secrets.NEXTAUTH_SECRET | b64enc | quote }}
+  {{- else }}
+  NEXTAUTH_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.CRYPTR_KEY }}
+  CRYPTR_KEY: {{ .Values.secrets.CRYPTR_KEY | b64enc | quote }}
+  {{- else }}
+  CRYPTR_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.TOKEN_SECRET_KEY }}
+  TOKEN_SECRET_KEY: {{ .Values.secrets.TOKEN_SECRET_KEY | b64enc | quote }}
+  {{- else }}
+  TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+  {{- else }}
   NEXTAUTH_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
   CRYPTR_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
## Summary
- Modified `helm/templates/secret.yaml` to support user-defined secret values
- Allows configuration of `NEXTAUTH_SECRET`, `CRYPTR_KEY`, and `TOKEN_SECRET_KEY` via values.yaml
- Falls back to generating random values if secrets are not specified

## Changes
This PR modifies the Helm secret template to check for secret values in `.Values.secrets` before generating random values. This enhancement allows users to:

1. Specify their own secret values in their values.yaml file
2. Maintain consistent secrets across deployments
3. Use existing secrets when migrating or upgrading

The template logic:
- First checks if `.Values.secrets` exists
- For each secret, uses the provided value if available
- Falls back to generating random 32-character alphanumeric values if not specified
- Base64 encodes all values as required by Kubernetes secrets

## Example Usage
Users can now add the following to their values.yaml:
```yaml
secrets:
  NEXTAUTH_SECRET: "your-custom-secret"
  CRYPTR_KEY: "your-custom-key"
  TOKEN_SECRET_KEY: "your-custom-token-key"
```

## Test Plan
- [ ] Deploy with no secrets section in values.yaml - should generate random values
- [ ] Deploy with partial secrets in values.yaml - should use provided values and generate missing ones
- [ ] Deploy with all secrets specified - should use all provided values
- [ ] Verify all secrets are properly base64 encoded in the resulting Kubernetes secret