### PR TITLE
Added priority color display to ticket details

### DIFF
--- a/server/src/components/client-portal/tickets/TicketDetails.tsx
+++ b/server/src/components/client-portal/tickets/TicketDetails.tsx
@@ -37,6 +37,7 @@ interface TicketDetailsProps {
 interface TicketWithDetails extends ITicket {
   status_name?: string;
   priority_name?: string;
+  priority_color?: string;
   conversations?: IComment[];
   documents?: IDocument[];
   userMap?: Record<string, { first_name: string; last_name: string; user_id: string; email?: string; user_type: string; avatarUrl: string | null }>;
@@ -313,7 +314,13 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
                       </DropdownMenu.Content>
                     </DropdownMenu.Root>
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                      {ticket.priority_name || 'Unknown Priority'}
+                      <div className="flex items-center gap-2">
+                        <div 
+                          className="w-3 h-3 rounded-full border border-gray-300" 
+                          style={{ backgroundColor: ticket.priority_color || '#6B7280' }}
+                        />
+                        <span>{ticket.priority_name || 'Unknown Priority'}</span>
+                      </div>
                     </span>
                   </div>
                   <p className="text-sm text-gray-500">

--- a/server/src/lib/actions/client-portal-actions/client-tickets.ts
+++ b/server/src/lib/actions/client-portal-actions/client-tickets.ts
@@ -81,6 +81,7 @@ export async function getClientTickets(status: string): Promise<ITicketListItem[
         't.tenant',
         's.name as status_name',
         'p.priority_name',
+        'p.color as priority_color',
         'c.channel_name',
         'cat.category_name',
         db.raw("CONCAT(u.first_name, ' ', u.last_name) as entered_by_name"),
@@ -186,7 +187,8 @@ export async function getClientTicketDetails(ticketId: string): Promise<ITicket>
         .select(
           't.*',
           's.name as status_name',
-          'p.priority_name'
+          'p.priority_name',
+          'p.color as priority_color'
         )
         .leftJoin('statuses as s', function() {
           this.on('t.status_id', '=', 's.status_id')


### PR DESCRIPTION
- Extended TicketWithDetails interface to include priority_color
- Updated ticket details UI to show colored priority indicator
- Modified client-tickets actions to include priority color in queries
- Added styling for priority color display in badge component

These changes affect both frontend display and backend data fetching, ensuring consistent priority color representation throughout the client portal.

"Now the tickets shall wear their priorities like the Cheshire Cat wears its grin - with colorful flair and disappearing logic!" 🎩🐇🌈