### PR TITLE
fix: remove verbose logging from secret retrieval and update import path

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -16,10 +16,8 @@ get_secret() {
     if [ -f "$secret_path" ]; then
         cat "$secret_path"
     elif [ ! -z "${!env_var}" ]; then
-        log "Using $env_var environment variable instead of Docker secret"
         echo "${!env_var}"
     else
-        log "Neither secret file $secret_path nor $env_var environment variable found, using default value"
         echo "$default_value"
     fi
 }

--- a/server/src/app/api/auth/[...nextauth]/options.ts
+++ b/server/src/app/api/auth/[...nextauth]/options.ts
@@ -7,7 +7,7 @@ import { authenticateUser } from "server/src/lib/actions/auth";
 import { getKeycloakToken } from "server/src/utils/keycloak";
 import { decodeToken } from "server/src/utils/tokenizer";
 import User from "server/src/lib/models/user";
-import logger from '@alga-psa/shared/dist/core/logger.js';
+import logger from '@alga-psa/shared/core/logger.js';
 import "server/src/types/next-auth";
 import { analytics } from "server/src/lib/analytics/posthog";
 import { AnalyticsEvents } from "server/src/lib/analytics/events";

--- a/services/workflow-worker/entrypoint.sh
+++ b/services/workflow-worker/entrypoint.sh
@@ -16,10 +16,8 @@ get_secret() {
     if [ -f "$secret_path" ]; then
         cat "$secret_path"
     elif [ ! -z "${!env_var}" ]; then
-        log "Using $env_var environment variable instead of Docker secret"
         echo "${!env_var}"
     else
-        log "Neither secret file $secret_path nor $env_var environment variable found, using default value"
         echo "$default_value"
     fi
 }


### PR DESCRIPTION
## Summary
- Remove verbose logging from `get_secret` function in entrypoint scripts
- Update logger import path in NextAuth options

## Changes
1. **server/entrypoint.sh** and **services/workflow-worker/entrypoint.sh**:
   - Removed log messages when using environment variables instead of Docker secrets
   - Removed log messages when neither secret file nor environment variable is found
   - These messages were creating unnecessary noise in logs

2. **server/src/app/api/auth/[...nextauth]/options.ts**:
   - Updated logger import from `@alga-psa/shared/dist/core/logger.js` to `@alga-psa/shared/core/logger.js`
   - This uses the direct import path instead of the built distribution path

## Test plan
- [ ] Verify services start correctly without the verbose logging
- [ ] Confirm secrets are still properly loaded from both Docker secrets and environment variables
- [ ] Verify NextAuth functionality works with updated import path