### PR TITLE
Fix vault agent secret injection and related improvements

### DIFF
--- a/ee/temporal-workflows/src/config/startupValidation.ts
+++ b/ee/temporal-workflows/src/config/startupValidation.ts
@@ -13,6 +13,7 @@ const logger = createLogger({
 const REQUIRED_CONFIGS = {
   // Authentication
   ALGA_AUTH_KEY: 'Shared authentication key for internal API calls',
+  NEXTAUTH_SECRET: 'Secret used by NextAuth for session management and password hashing',
   
   // Database
   DB_HOST: 'Database host (e.g., localhost or postgres)',

--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -24,8 +24,8 @@ spec:
         {{- if .Values.vaultAgent.enabled }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "{{ .Values.vaultAgent.role }}"
-        vault.hashicorp.com/agent-inject-secret-alga-auth-key: "{{ .Values.vaultAgent.sharedSecretPath }}"
-        vault.hashicorp.com/agent-inject-template-alga-auth-key: |
+        vault.hashicorp.com/agent-inject-secret-alga_auth_key: "{{ .Values.vaultAgent.sharedSecretPath }}"
+        vault.hashicorp.com/agent-inject-template-alga_auth_key: |
           {{`{{- with secret "`}}{{ .Values.vaultAgent.sharedSecretPath }}{{`" -}}
           export ALGA_AUTH_KEY="{{ .Data.data.alga_auth_key }}"
           {{- end }}`}}
@@ -88,16 +88,6 @@ spec:
               echo "  NPM version: $(npm --version)"
               echo "  Working directory: $(pwd)"
               echo "  Source code commit: $(cd /app && git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
-              echo ""
-              {{- if .Values.vaultAgent.enabled }}
-              if [ -f /vault/secrets/alga-auth-key ]; then
-                source /vault/secrets/alga-auth-key
-                echo "Vault secrets loaded from /vault/secrets/"
-              fi
-              if [ -f /vault/secrets/server-secrets ]; then
-                source /vault/secrets/server-secrets
-              fi
-              {{- end }}
               echo "Dev pod is ready for debugging. Keeping container alive..."
               # Keep container running
               while true; do

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         vault.hashicorp.com/agent-inject-secret-alga_auth_key: "{{ .Values.vaultAgent.sharedSecretPath }}"
         vault.hashicorp.com/agent-inject-template-alga_auth_key: |
           {{`{{- with secret "`}}{{ .Values.vaultAgent.sharedSecretPath }}{{`" -}}
-          {{ .Data.data.alga_auth_key }}
+          {{- .Data.data.alga_auth_key -}}
           {{- end }}`}}        
         vault.hashicorp.com/agent-inject-secret-server-secrets: "{{ .Values.vaultAgent.secretPath }}"
         vault.hashicorp.com/agent-inject-template-server-secrets: |
@@ -66,7 +66,6 @@ spec:
           image: "{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
           {{- if .Values.vaultAgent.enabled }}
           command: ["/bin/sh", "-c"]
-          args: 
           command: ["./entrypoint.sh"]
           imagePullPolicy: {{ .Values.server.pullPolicy }}
           env:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,10 +23,6 @@ spec:
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "{{ .Values.vaultAgent.role }}"
         vault.hashicorp.com/agent-inject-secret-alga-auth-key: "{{ .Values.vaultAgent.sharedSecretPath }}"
-        vault.hashicorp.com/agent-inject-template-alga-auth-key: |
-          {{`{{- with secret "`}}{{ .Values.vaultAgent.sharedSecretPath }}{{`" -}}
-          export ALGA_AUTH_KEY="{{ .Data.data.alga_auth_key }}"
-          {{- end }}`}}
         vault.hashicorp.com/agent-inject-secret-server-secrets: "{{ .Values.vaultAgent.secretPath }}"
         vault.hashicorp.com/agent-inject-template-server-secrets: |
           {{`{{- with secret "`}}{{ .Values.vaultAgent.secretPath }}{{`" -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
         {{- if .Values.vaultAgent.enabled }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "{{ .Values.vaultAgent.role }}"
-        vault.hashicorp.com/agent-inject-secret-alga-auth-key: "{{ .Values.vaultAgent.sharedSecretPath }}"
+        vault.hashicorp.com/agent-inject-secret-alga_auth_key: "{{ .Values.vaultAgent.sharedSecretPath }}"
+        vault.hashicorp.com/agent-inject-template-alga_auth_key: |
+          {{`{{- with secret "`}}{{ .Values.vaultAgent.sharedSecretPath }}{{`" -}}
+          {{ .Data.data.alga_auth_key }}
+          {{- end }}`}}        
         vault.hashicorp.com/agent-inject-secret-server-secrets: "{{ .Values.vaultAgent.secretPath }}"
         vault.hashicorp.com/agent-inject-template-server-secrets: |
           {{`{{- with secret "`}}{{ .Values.vaultAgent.secretPath }}{{`" -}}
@@ -63,17 +67,7 @@ spec:
           {{- if .Values.vaultAgent.enabled }}
           command: ["/bin/sh", "-c"]
           args: 
-            - |
-              if [ -f /vault/secrets/alga-auth-key ]; then
-                source /vault/secrets/alga-auth-key
-              fi
-              if [ -f /vault/secrets/server-secrets ]; then
-                source /vault/secrets/server-secrets
-              fi
-              exec ./entrypoint.sh
-          {{- else }}
           command: ["./entrypoint.sh"]
-          {{- end }}
           imagePullPolicy: {{ .Values.server.pullPolicy }}
           env:
           # ----------- APP ----------------

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -64,8 +64,6 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
-          {{- if .Values.vaultAgent.enabled }}
-          command: ["/bin/sh", "-c"]
           command: ["./entrypoint.sh"]
           imagePullPolicy: {{ .Values.server.pullPolicy }}
           env:
@@ -393,3 +391,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+

--- a/server/src/middleware/authorizationMiddleware.ts
+++ b/server/src/middleware/authorizationMiddleware.ts
@@ -12,7 +12,7 @@ interface CustomToken extends JWT {
 
 export async function authorizationMiddleware(req: NextRequest) {
   const secretProvider = await getSecretProviderInstance();
-  const nextAuthSecret = await secretProvider.getAppSecret('NEXTAUTH_SECRET') || process.env.NEXTAUTH_SECRET;
+  const nextAuthSecret = await secretProvider.getAppSecret('NEXTAUTH_SECRET');
   const token = await getToken({ req, secret: nextAuthSecret }) as CustomToken;
 
   if (!token) {

--- a/shared/utils/encryption.ts
+++ b/shared/utils/encryption.ts
@@ -7,7 +7,11 @@ import { getSecret } from '../core/getSecret.js';
  * @returns A string in the format "salt:hash"
  */
 export async function hashPassword(password: string): Promise<string> {
-  const key = await getSecret('nextauth_secret', 'NEXTAUTH_SECRET', 'defaultKey');
+  const key = await getSecret('nextauth_secret', 'NEXTAUTH_SECRET');
+  if (!key) {
+    throw new Error('Failed to retrieve the encryption key from the secret provider');
+  }
+
   const saltBytes = Number(process.env.SALT_BYTES) || 12;
   const iterations = Number(process.env.ITERATIONS) || 10000;
   const keyLength = Number(process.env.KEY_LENGTH) || 64;
@@ -25,7 +29,11 @@ export async function hashPassword(password: string): Promise<string> {
  * @returns True if the password matches, false otherwise
  */
 export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
-  const key = await getSecret('nextauth_secret', 'NEXTAUTH_SECRET', 'defaultKey');
+  const key = await getSecret('nextauth_secret', 'NEXTAUTH_SECRET');
+  if (!key) {
+    throw new Error('Failed to retrieve the encryption key from the secret provider');
+  }
+    
   const iterations = Number(process.env.ITERATIONS) || 10000;
   const keyLength = Number(process.env.KEY_LENGTH) || 64;
   const digest = process.env.ALGORITHM || 'sha512';


### PR DESCRIPTION
This PR addresses several issues with vault agent secret injection:

- Remove unnecessary command override for vault agent in deployment template
- Trim whitespace in vault agent secret injection template and remove redundant args
- Update vault agent secret injection keys and remove unnecessary logging
- Remove template-style vault agent secret injection for alga_auth_key
- Include nextauth secret in temporal worker startup validation
- Remove fallback logic for missing enc keys
- Remove redundant fallback

These changes improve the reliability and security of secret injection in the vault agent setup.