### PR TITLE
Added attempted step tracking to onboarding wizard

### DIFF
--- a/server/src/components/onboarding/OnboardingWizard.tsx
+++ b/server/src/components/onboarding/OnboardingWizard.tsx
@@ -44,6 +44,7 @@ export function OnboardingWizard({
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<Record<number, string>>({});
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [attemptedSteps, setAttemptedSteps] = useState<Set<number>>(new Set());
   const [wizardData, setWizardData] = useState<WizardData>({
     // Company Info
     firstName: '',
@@ -212,6 +213,9 @@ export function OnboardingWizard({
   };
 
   const handleNext = async () => {
+    // Mark the current step as attempted
+    setAttemptedSteps(prev => new Set([...prev, currentStep]));
+    
     if (currentStep < STEPS.length - 1) {
       const saved = await saveStepData(currentStep);
       if (saved) {
@@ -361,7 +365,7 @@ export function OnboardingWizard({
       case 3:
         return <ClientContactStep data={wizardData} updateData={updateData} />;
       case 4:
-        return <BillingSetupStep data={wizardData} updateData={updateData} />;
+        return <BillingSetupStep data={wizardData} updateData={updateData} attemptedToProceed={attemptedSteps.has(4)} />;
       case 5:
         return <TicketingConfigStep data={wizardData} updateData={updateData} />;
       default:

--- a/server/src/components/onboarding/steps/BillingSetupStep.tsx
+++ b/server/src/components/onboarding/steps/BillingSetupStep.tsx
@@ -21,7 +21,7 @@ import { Switch } from 'server/src/components/ui/Switch';
 import { Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
 
-export function BillingSetupStep({ data, updateData }: StepProps) {
+export function BillingSetupStep({ data, updateData, attemptedToProceed = false }: StepProps) {
   const { data: session } = useSession();
   const isServiceCreated = !!data.serviceId;
   const [showServiceTypes, setShowServiceTypes] = useState(false);
@@ -165,7 +165,7 @@ export function BillingSetupStep({ data, updateData }: StepProps) {
           <div className="flex items-center gap-2">
             <Package className="w-5 h-5 text-gray-500" />
             <span className="font-medium">Service Types</span>
-            {tenantTypes.length === 0 && (
+            {tenantTypes.length === 0 && attemptedToProceed && (
               <span className="text-xs bg-red-100 text-red-800 px-2 py-1 rounded">Required</span>
             )}
           </div>
@@ -346,7 +346,7 @@ export function BillingSetupStep({ data, updateData }: StepProps) {
 
                         console.log('Creating service type with order:', finalOrder, 'Existing orders:', allOrders);
 
-                        const createdType = await createServiceType({
+                        await createServiceType({
                           name: serviceTypeForm.name,
                           description: serviceTypeForm.description || null,
                           billing_method: serviceTypeForm.billingMethod,

--- a/server/src/components/onboarding/types.ts
+++ b/server/src/components/onboarding/types.ts
@@ -65,6 +65,7 @@ export interface OnboardingState {
 export interface StepProps {
   data: WizardData;
   updateData: (data: Partial<WizardData>) => void;
+  attemptedToProceed?: boolean;
 }
 
 export const STEPS = [


### PR DESCRIPTION
- Added `attemptedSteps` state to track which steps users try to proceed from
- Pass `attemptedToProceed` flag to BillingSetupStep to show required fields only after attempt
- Removed unused variable `createdType` in service type creation
- Updated StepProps interface to include new prop

Impacts:
- Better UX by only showing required field indicators after user attempts to proceed
- More accurate tracking of user navigation through wizard

Follow the yellow brick road of onboarding, but watch out for those required fields! 🧙‍♂️💫