### PR TITLE
Fix onboarding seeds not found error in temporal workflows

### DIFF
--- a/ee/temporal-workflows/package.json
+++ b/ee/temporal-workflows/package.json
@@ -5,7 +5,8 @@
   "main": "dist/worker.js",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && npm run copy-seeds",
+    "copy-seeds": "mkdir -p dist/seeds/onboarding && cp -r ../server/seeds/onboarding/*.cjs dist/seeds/onboarding/",
     "dev": "tsx watch src/worker.ts",
     "start": "node dist/worker.js",
     "start:worker": "node dist/worker.js",

--- a/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
+++ b/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
@@ -26,9 +26,20 @@ export async function runOnboardingSeeds(tenantId: string): Promise<{ success: b
       await trx.raw(`SET LOCAL app.current_tenant = '${tenantId}'`);
       
       // Get the onboarding seeds directory
-      // Path from ee/temporal-workflows/src/db to ee/server/seeds/onboarding
-      const currentDir = path.dirname(fileURLToPath(import.meta.url));
-      const seedsDir = path.resolve(currentDir, '../../../server/seeds/onboarding');
+      const currentFileUrl = import.meta.url;
+      const isRunningFromDist = currentFileUrl.includes('/dist/');
+      
+      let seedsDir: string;
+      if (isRunningFromDist) {
+        // Running from dist - seeds are copied to dist/seeds/onboarding
+        const currentDir = path.dirname(fileURLToPath(currentFileUrl));
+        // From dist/ee/temporal-workflows/src/db to dist/seeds/onboarding
+        seedsDir = path.resolve(currentDir, '../../../../seeds/onboarding');
+      } else {
+        // Running from source (development)
+        const currentDir = path.dirname(fileURLToPath(currentFileUrl));
+        seedsDir = path.resolve(currentDir, '../../../server/seeds/onboarding');
+      }
       
       // Read all files from the directory
       const files = await fs.readdir(seedsDir);


### PR DESCRIPTION
  - Add copy-seeds script to include seed files in dist directory during build
  - Update seed loading logic to use correct paths for both dev and production
  - Seeds are now copied from ee/server/seeds/onboarding to dist/seeds/onboarding