### PR TITLE
  1. Removed the npm copy-seeds script that was failing

### DIFF
--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -32,6 +32,9 @@ COPY ee/temporal-workflows/ ./
 WORKDIR /app/ee/temporal-workflows
 RUN npm run build
 
+# Copy onboarding seeds after build
+COPY ee/server/seeds/onboarding /app/ee/temporal-workflows/dist/seeds/onboarding
+
 # Production stage
 FROM base AS production
 

--- a/ee/temporal-workflows/package.json
+++ b/ee/temporal-workflows/package.json
@@ -5,8 +5,7 @@
   "main": "dist/worker.js",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && npm run copy-seeds",
-    "copy-seeds": "mkdir -p dist/seeds/onboarding && cp -r ../server/seeds/onboarding/*.cjs dist/seeds/onboarding/",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "tsx watch src/worker.ts",
     "start": "node dist/worker.js",
     "start:worker": "node dist/worker.js",

--- a/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
+++ b/ee/temporal-workflows/src/db/onboarding-seeds-operations.ts
@@ -31,10 +31,9 @@ export async function runOnboardingSeeds(tenantId: string): Promise<{ success: b
       
       let seedsDir: string;
       if (isRunningFromDist) {
-        // Running from dist - seeds are copied to dist/seeds/onboarding
-        const currentDir = path.dirname(fileURLToPath(currentFileUrl));
-        // From dist/ee/temporal-workflows/src/db to dist/seeds/onboarding
-        seedsDir = path.resolve(currentDir, '../../../../seeds/onboarding');
+        // Running from dist - seeds are copied to dist/seeds/onboarding by Docker
+        // This assumes we're running in the container where working directory is /app/ee/temporal-workflows
+        seedsDir = path.resolve(process.cwd(), 'dist/seeds/onboarding');
       } else {
         // Running from source (development)
         const currentDir = path.dirname(fileURLToPath(currentFileUrl));


### PR DESCRIPTION
  2. Added a COPY command in the Dockerfile to copy the onboarding seeds after the build
  3. Simplified the path resolution in the code to use process.cwd() which will be /app/ee/temporal-workflows in the container