### PR TITLE
feat: preserve ticket filters when navigating back from ticket details

### DIFF
--- a/server/src/components/tickets/TicketingDashboard.tsx
+++ b/server/src/components/tickets/TicketingDashboard.tsx
@@ -173,6 +173,24 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
 
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
 
+  // Helper function to generate URL with current filter state
+  const getCurrentFiltersQuery = useCallback(() => {
+    const params = new URLSearchParams();
+    
+    // Only add non-default/non-empty values to URL
+    if (selectedChannel) params.set('channelId', selectedChannel);
+    if (selectedCompany) params.set('companyId', selectedCompany);
+    if (selectedStatus && selectedStatus !== 'open') params.set('statusId', selectedStatus);
+    if (selectedPriority && selectedPriority !== 'all') params.set('priorityId', selectedPriority);
+    if (selectedCategories.length > 0) params.set('categoryId', selectedCategories[0]);
+    if (debouncedSearchQuery) params.set('searchQuery', debouncedSearchQuery);
+    if (channelFilterState && channelFilterState !== 'active') {
+      params.set('channelFilterState', channelFilterState);
+    }
+
+    return params.toString();
+  }, [selectedChannel, selectedCompany, selectedStatus, selectedPriority, selectedCategories, debouncedSearchQuery, channelFilterState]);
+
   useEffect(() => {
     const currentFilters: Partial<ITicketListFilters> = {
       channelId: selectedChannel === null ? undefined : selectedChannel,
@@ -266,14 +284,21 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       title: 'Ticket Number',
       dataIndex: 'ticket_number',
       width: '9%',
-      render: (value: string, record: ITicketListItem) => (
-        <Link
-          href={`/msp/tickets/${record.ticket_id}`}
-          className="text-blue-500 hover:underline"
-        >
-          {value}
-        </Link>
-      ),
+      render: (value: string, record: ITicketListItem) => {
+        const filterQuery = getCurrentFiltersQuery();
+        const href = filterQuery 
+          ? `/msp/tickets/${record.ticket_id}?returnFilters=${encodeURIComponent(filterQuery)}`
+          : `/msp/tickets/${record.ticket_id}`;
+        
+        return (
+          <Link
+            href={href}
+            className="text-blue-500 hover:underline"
+          >
+            {value}
+          </Link>
+        );
+      },
     },
     {
       title: 'Title',
@@ -397,7 +422,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         </DropdownMenu>
       ),
     }
-  ], [ticketTagsRef, allUniqueTags]);
+  ], [ticketTagsRef, allUniqueTags, getCurrentFiltersQuery]);
 
   // Create columns with categories data
   const columns = useMemo(() => createTicketColumns(categories), [categories, createTicketColumns]);

--- a/server/src/components/tickets/TicketingDashboardContainer.tsx
+++ b/server/src/components/tickets/TicketingDashboardContainer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import TicketingDashboard from './TicketingDashboard';
 import { loadMoreTickets } from 'server/src/lib/actions/ticket-actions/optimizedTicketActions';
 import { toast } from 'react-hot-toast';
@@ -25,17 +26,23 @@ interface TicketingDashboardContainerProps {
     nextCursor: string | null;
   };
   currentUser: IUser;
+  initialFilters?: Partial<ITicketListFilters>;
 }
 
 export default function TicketingDashboardContainer({ 
   consolidatedData,
-  currentUser
+  currentUser,
+  initialFilters
 }: TicketingDashboardContainerProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [tickets, setTickets] = useState<ITicketListItem[]>(consolidatedData.tickets);
   const [nextCursor, setNextCursor] = useState<string | null>(consolidatedData.nextCursor);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [activeFilters, setActiveFilters] = useState<Partial<ITicketListFilters>>(() => {
-    return {
+    // Use initialFilters if provided, otherwise use defaults
+    return initialFilters || {
       statusId: 'open',
       priorityId: 'all',
       searchQuery: '',
@@ -46,6 +53,26 @@ export default function TicketingDashboardContainer({
       companyId: undefined,
     };
   });
+
+  // Function to sync filter state to URL
+  const updateURLWithFilters = useCallback((filters: Partial<ITicketListFilters>) => {
+    const params = new URLSearchParams();
+    
+    // Only add non-default/non-empty values to URL
+    if (filters.channelId) params.set('channelId', filters.channelId);
+    if (filters.companyId) params.set('companyId', filters.companyId);
+    if (filters.statusId && filters.statusId !== 'open') params.set('statusId', filters.statusId);
+    if (filters.priorityId && filters.priorityId !== 'all') params.set('priorityId', filters.priorityId);
+    if (filters.categoryId) params.set('categoryId', filters.categoryId);
+    if (filters.searchQuery) params.set('searchQuery', filters.searchQuery);
+    if (filters.channelFilterState && filters.channelFilterState !== 'active') {
+      params.set('channelFilterState', filters.channelFilterState);
+    }
+
+    // Update URL without causing a page refresh
+    const newURL = params.toString() ? `/msp/tickets?${params.toString()}` : '/msp/tickets';
+    router.replace(newURL, { scroll: false });
+  }, [router]);
 
   const fetchTickets = useCallback(async (filters: Partial<ITicketListFilters>, cursor?: string | null) => {
     if (!currentUser) {
@@ -98,8 +125,11 @@ export default function TicketingDashboardContainer({
   }, [fetchTickets, activeFilters, nextCursor]);
 
   const handleFiltersChanged = useCallback(async (newFilters: Partial<ITicketListFilters>) => {
+    // Update URL to persist filter state
+    updateURLWithFilters(newFilters);
+    // Fetch new tickets with updated filters
     await fetchTickets(newFilters, null); // Fetch page 1
-  }, [fetchTickets]);
+  }, [fetchTickets, updateURLWithFilters]);
 
   const mappedAndFilteredChannels = consolidatedData.options.channelOptions.map(channel => ({
     ...channel,

--- a/server/src/components/ui/BackNav.tsx
+++ b/server/src/components/ui/BackNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { AutomationProps } from '../../types/ui-reflection/types';
 
 interface BackNavProps extends AutomationProps {
@@ -10,6 +10,7 @@ interface BackNavProps extends AutomationProps {
 
 export default function BackNav({ children, href }: BackNavProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   
   return (
     <button
@@ -17,7 +18,17 @@ export default function BackNav({ children, href }: BackNavProps) {
       className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
       onClick={() => {
         if (href) {
-          router.push(href);
+          // Check if there are returnFilters in the current URL
+          const returnFilters = searchParams.get('returnFilters');
+          
+          if (returnFilters && href === '/msp/tickets') {
+            // Decode the filters and append them to the tickets URL
+            const filtersQuery = decodeURIComponent(returnFilters);
+            const urlWithFilters = filtersQuery ? `${href}?${filtersQuery}` : href;
+            router.push(urlWithFilters);
+          } else {
+            router.push(href);
+          }
         } else {
           router.back();
         }


### PR DESCRIPTION
## Summary
- Add URL persistence for ticket list filters (channel, company, status, priority, category, search query)
- Preserve filter state when navigating from ticket list to ticket details and back
- Update ticket links to include current filter state as return parameters
- Modify BackNav component to restore filters when returning to ticket list

## Test plan
- [ ] Navigate to ticket list and apply various filters
- [ ] Click on a ticket to view details
- [ ] Use back navigation to return to ticket list
- [ ] Verify all previously applied filters are restored
- [ ] Test with different combinations of filters
- [ ] Verify URL updates correctly when filters change

🤖 Generated with [Claude Code](https://claude.ai/code)