### PR TITLE
Move email feature flag to inbound email only

### DIFF
--- a/server/src/components/admin/EmailSettings.tsx
+++ b/server/src/components/admin/EmailSettings.tsx
@@ -30,6 +30,8 @@ import {
 } from '../../lib/actions/email-actions/emailDomainActions';
 import { EmailProviderConfiguration } from '../EmailProviderConfiguration';
 import { useTenant } from '../TenantProvider';
+import { useFeatureFlag } from 'server/src/hooks/useFeatureFlag';
+import { FeaturePlaceholder } from 'server/src/components/FeaturePlaceholder';
 
 interface EmailSettingsProps {
   // Remove tenantId prop since we'll use the tenant context
@@ -51,6 +53,8 @@ interface DomainStatus {
 
 export const EmailSettings: React.FC<EmailSettingsProps> = () => {
   const tenantId = useTenant();
+  const inboundFlag = useFeatureFlag('email-configuration');
+  const isInboundEnabled = typeof inboundFlag === 'boolean' ? inboundFlag : inboundFlag?.enabled;
   const [settings, setSettings] = useState<TenantEmailSettings | null>(null);
   const [domains, setDomains] = useState<DomainStatus[]>([]);
   const [loading, setLoading] = useState(true);
@@ -509,24 +513,29 @@ export const EmailSettings: React.FC<EmailSettingsProps> = () => {
       </TabsContent>
 
       <TabsContent value="inbound" className="space-y-6">
-        <div className="text-sm text-muted-foreground mb-4">
-          Configure email providers to receive and process emails as tickets
-        </div>
-        
-        <EmailProviderConfiguration 
-          onProviderAdded={(provider) => {
-            // Optional: Handle provider added event
-            console.log('Provider added:', provider);
-          }}
-          onProviderUpdated={(provider) => {
-            // Optional: Handle provider updated event
-            console.log('Provider updated:', provider);
-          }}
-          onProviderDeleted={(providerId) => {
-            // Optional: Handle provider deleted event
-            console.log('Provider deleted:', providerId);
-          }}
-        />
+        {isInboundEnabled ? (
+          <>
+            <div className="text-sm text-muted-foreground mb-4">
+              Configure email providers to receive and process emails as tickets
+            </div>
+            <EmailProviderConfiguration 
+              onProviderAdded={(provider) => {
+                // Optional: Handle provider added event
+                console.log('Provider added:', provider);
+              }}
+              onProviderUpdated={(provider) => {
+                // Optional: Handle provider updated event
+                console.log('Provider updated:', provider);
+              }}
+              onProviderDeleted={(providerId) => {
+                // Optional: Handle provider deleted event
+                console.log('Provider deleted:', providerId);
+              }}
+            />
+          </>
+        ) : (
+          <FeaturePlaceholder />
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/server/src/components/settings/general/SettingsPage.tsx
+++ b/server/src/components/settings/general/SettingsPage.tsx
@@ -47,8 +47,6 @@ const SettingsPage = (): JSX.Element =>  {
   const isBillingEnabled = typeof billingFeatureFlag === 'boolean' ? billingFeatureFlag : billingFeatureFlag?.enabled;
   const advancedFeatureFlag = useFeatureFlag('advanced-features-enabled');
   const isAdvancedFeaturesEnabled = typeof advancedFeatureFlag === 'boolean' ? advancedFeatureFlag : advancedFeatureFlag?.enabled;
-  const emailConfigFlag = useFeatureFlag('email-configuration');
-  const isEmailConfigEnabled = typeof emailConfigFlag === 'boolean' ? emailConfigFlag : emailConfigFlag?.enabled;
   // Extensions are conditionally available based on edition
   // The webpack alias will resolve to either the EE component or empty component
   const isEEAvailable = process.env.NEXT_PUBLIC_EDITION === 'enterprise';
@@ -201,7 +199,7 @@ const SettingsPage = (): JSX.Element =>  {
     },
     {
       label: "Email",
-      content: isEmailConfigEnabled ? (
+      content: (
         <Card>
           <CardHeader>
             <CardTitle>Email Configuration</CardTitle>
@@ -211,8 +209,6 @@ const SettingsPage = (): JSX.Element =>  {
             <EmailSettings />
           </CardContent>
         </Card>
-      ) : (
-        <FeaturePlaceholder />
       ),
     },
     { // Add the new Integrations tab definition


### PR DESCRIPTION
Summary\n- Remove email-configuration flag from Settings page so Email tab is always visible.\n- In EmailSettings, always show the Inbound tab; gate only its contents behind the email-configuration feature flag.\n- When disabled, show FeaturePlaceholder (under construction) in the Inbound tab.\n- Outbound tab remains fully accessible.\n\nFiles changed\n- server/src/components/settings/general/SettingsPage.tsx\n- server/src/components/admin/EmailSettings.tsx\n\nVerification\n- Email tab appears regardless of flag.\n- Inbound tab content shows placeholder when flag disabled; shows EmailProviderConfiguration when enabled.\n- Outbound unaffected.