### PR TITLE
Sidebar: contain scroll to menu when focused

### DIFF
--- a/server/src/app/globals.css
+++ b/server/src/app/globals.css
@@ -53,6 +53,7 @@
 
   /* Sidebar scrollbar styles */
   .sidebar-nav {
+    overscroll-behavior: contain;
     scrollbar-width: thin;
     scrollbar-color: rgb(var(--color-border-300)) var(--color-sidebar-bg);
   }

--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -151,7 +151,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       </div>
       */}
 
-      <nav className="mt-4 flex-grow overflow-y-auto sidebar-nav">
+      <nav className="mt-4 flex-grow min-h-0 overflow-y-auto overscroll-contain sidebar-nav">
         <ul className="space-y-1">
           {menuItems.map(renderMenuItem)}
         </ul>


### PR DESCRIPTION
Prevents scroll chaining from the sidebar to the page by adding overscroll containment to the sidebar nav and ensuring proper flex sizing with min-h-0.\n\nChanges:\n- Sidebar.tsx: Add `overscroll-contain` and `min-h-0` to the scroll container.\n- globals.css: Set `.sidebar-nav { overscroll-behavior: contain; }`.\n\nBehavior: When the sidebar has focus, mouse wheel scroll affects only the menu and not the entire application. Content area scrolling remains unchanged.