### PR TITLE
Remove unused comment metadata

### DIFF
--- a/shared/models/ticketModel.ts
+++ b/shared/models/ticketModel.ts
@@ -77,8 +77,7 @@ export const createCommentSchema = z.object({
   is_internal: z.boolean().optional(),
   is_resolution: z.boolean().optional(),
   author_type: z.enum(['internal', 'contact', 'system']).optional(),
-  author_id: z.string().uuid('Author ID must be a valid UUID').optional(),
-  metadata: z.record(z.unknown()).optional()
+  author_id: z.string().uuid('Author ID must be a valid UUID').optional()
 });
 
 // =============================================================================
@@ -163,7 +162,6 @@ export interface CreateCommentValidationInput {
   is_resolution?: boolean;
   author_type?: 'internal' | 'contact' | 'system';
   author_id?: string;
-  metadata?: any;
 }
 
 export interface CreateTicketOutput {
@@ -186,7 +184,6 @@ export interface CreateCommentInput {
   is_resolution?: boolean;
   author_type?: 'internal' | 'contact' | 'system';
   author_id?: string;
-  metadata?: any;
 }
 
 export interface CreateCommentOutput {
@@ -1068,7 +1065,6 @@ export class TicketModel {
       is_resolution: validatedData.is_resolution || false,
       author_type: dbAuthorType as any,
       user_id: validatedData.author_id || null,
-      metadata: validatedData.metadata ? JSON.stringify(validatedData.metadata) : null,
       created_at: now,
       updated_at: now
     };

--- a/shared/workflow/actions/emailWorkflowActions.ts
+++ b/shared/workflow/actions/emailWorkflowActions.ts
@@ -607,8 +607,7 @@ export async function createCommentFromEmail(
         is_internal: false,
         is_resolution: false,
         author_type: commentData.author_type as any || 'system',
-        author_id: commentData.author_id,
-        metadata: commentData.metadata
+        author_id: commentData.author_id
       }, tenant, trx, eventPublisher, analyticsTracker, userId);
 
       return result.comment_id;

--- a/shared/workflow/init/registerWorkflowActions.ts
+++ b/shared/workflow/init/registerWorkflowActions.ts
@@ -1955,8 +1955,7 @@ function registerEmailWorkflowActions(actionRegistry: ActionRegistry): void {
       { name: 'format', type: 'string', required: false },
       { name: 'source', type: 'string', required: false },
       { name: 'author_type', type: 'string', required: false },
-      { name: 'author_id', type: 'string', required: false },
-      { name: 'metadata', type: 'object', required: false }
+      { name: 'author_id', type: 'string', required: false }
     ],
     async (params: Record<string, any>, context: ActionExecutionContext) => {
       try {
@@ -1967,8 +1966,7 @@ function registerEmailWorkflowActions(actionRegistry: ActionRegistry): void {
           format: params.format,
           source: params.source,
           author_type: params.author_type,
-          author_id: params.author_id,
-          metadata: params.metadata
+          author_id: params.author_id
         }, context.tenant);
         
         return {


### PR DESCRIPTION
Removes unused 'metadata' from comment creation paths.

- shared/workflow/init/registerWorkflowActions.ts: drop 'metadata' param from create_comment_from_email
- shared/models/ticketModel.ts: remove metadata from validation schemas/interfaces and DB insert

This simplifies the API and avoids schema mismatches in environments where comments.metadata does not exist.