### PR TITLE
fix(ee): stabilize build + runtime (aliases, deps, Chromium, tsconfig, workflow)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,9 @@ COPY .env.example /app/server/.env
 COPY ./shared/dist/ ./shared/dist/
 COPY ./shared/package.json ./shared/package.json
 
-# Copy pre-built artifacts (must exist locally)
-# These should be built by Argo workflow or separate build step
+# Copy pre-built Next.js artifacts (must exist locally)
+# server/dist is no longer required here; workflow-worker is built/deployed separately
 COPY ./server/.next ./server/.next
-COPY ./server/dist ./server/dist
 
 # Copy runtime files
 COPY ./server/public ./server/public

--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -46,10 +46,9 @@ COPY .env.example /app/server/.env
 COPY ./shared/dist/ ./shared/dist/
 COPY ./shared/package.json ./shared/package.json
 
-# Copy pre-built artifacts (must exist locally with EE features)
-# These should be built by Argo workflow with build-enterprise.sh
+# Copy pre-built Next.js artifacts (must exist locally with EE features)
+# server/dist is no longer required here; workflow-worker is built/deployed separately
 COPY ./server/.next ./server/.next
-COPY ./server/dist ./server/dist
 
 # Copy runtime files
 COPY ./server/public ./server/public

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -99,6 +99,7 @@ COPY --from=builder /app/shared ./shared
 COPY --from=builder /app/server/.next ./server/.next
 COPY --from=builder /app/server/public ./server/public
 COPY --from=builder /app/server/next.config.mjs ./server/
+COPY --from=builder /app/server/tsconfig.json ./server/
 COPY --from=builder /app/server/package.json ./server/
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json ./

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -77,7 +77,14 @@ RUN apk add --no-cache bash \
     imagemagick \
     ghostscript \
     curl \
-    nano
+    nano \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
 
 WORKDIR /app
 COPY tsconfig.base.json ./
@@ -122,6 +129,10 @@ EXPOSE 3000
 # Environment configuration
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_EDITION=enterprise
+
+# Puppeteer chromium configuration
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Secret provider configuration
 # Default configuration for composite secret system

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -94,6 +94,7 @@ COPY --from=builder /app/server/package.json ./server/
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/server/knexfile.cjs ./server/
+COPY --from=builder /app/server/index.ts ./server/
 COPY --from=builder /app/server/migrations/ ./server/migrations/
 COPY --from=builder /app/server/seeds/ ./server/seeds/
 COPY --from=builder /app/server/src/ ./server/src/

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -21,6 +21,8 @@ COPY tsconfig.base.json ./
 COPY server/src/invoice-templates/assemblyscript ./server/src/invoice-templates/assemblyscript
 
 RUN npm install
+## Ensure workspace installs for server and shared so node_modules exist per workspace
+RUN npm install --workspace=server --workspace=shared
 
 # Builder stage for compiling the application
 FROM deps AS builder
@@ -100,12 +102,16 @@ COPY --from=builder /app/server/seeds/ ./server/seeds/
 COPY --from=builder /app/server/src/ ./server/src/
 COPY --from=builder /app/secrets ./secrets
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/server/node_modules ./server/node_modules
 
 # Copy EE migrations (they get merged during build-enterprise.sh)
 COPY --from=builder /app/ee/server/migrations/ ./server/migrations/
 
 COPY server/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+# Ensure tsx is available on PATH at runtime for `npm start`
+RUN npm install -g tsx
 
 # Create build timestamp for verification
 RUN echo "BUILD_TIME=$(date)" > /app/build-info.txt && \

--- a/ee/server/src/__tests__/unit/debug-user-auth.test.ts
+++ b/ee/server/src/__tests__/unit/debug-user-auth.test.ts
@@ -6,8 +6,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestDbConnection } from '../../lib/testing/db-test-utils';
 import { createTestTenant, cleanupTestTenant } from '../../lib/testing/tenant-test-factory';
-import { authenticateUser } from '../../../../../server/src/lib/actions/auth';
-import { verifyPassword } from '../../../../../server/src/utils/encryption/encryption';
+import { authenticateUser } from '@/lib/actions/auth';
+import { verifyPassword } from '@/utils/encryption/encryption';
 import type { Knex } from 'knex';
 
 describe('Debug User Authentication', () => {

--- a/ee/server/src/app/api/provisioning/tenants/route.ts
+++ b/ee/server/src/app/api/provisioning/tenants/route.ts
@@ -3,8 +3,8 @@ import { TenantService, TenantProvisioningError } from '../../../../services/pro
 import { CreateTenantSchema } from '../../../../services/provisioning/types/tenant.schema';
 import { ZodError } from 'zod';
 import { getServerSession } from 'next-auth';
-import { hasPermission } from '../../../../../../../server/src/lib/auth/rbac';
-import { getCurrentUser } from '../../../../../../../server/src/lib/actions/user-actions/userActions';
+import { hasPermission } from '@/lib/auth/rbac';
+import { getCurrentUser } from '@/lib/actions/user-actions/userActions';
 
 export async function POST(req: NextRequest) {
   try {

--- a/ee/server/src/app/api/v1/auth/verify/route.ts
+++ b/ee/server/src/app/api/v1/auth/verify/route.ts
@@ -3,9 +3,9 @@ import {
   checkAuthVerificationLimit, 
   formatRateLimitError,
   logSecurityEvent 
-} from 'server/src/lib/security/rateLimiting';
-import { observability, observabilityLogger, observabilityMetrics } from 'server/src/lib/observability';
-import { verifyPassword } from 'server/src/utils/encryption/encryption';
+} from '@/lib/security/rateLimiting';
+import { observability, observabilityLogger, observabilityMetrics } from '@/lib/observability';
+import { verifyPassword } from '@/utils/encryption/encryption';
 import { withAdminTransaction } from '@alga-psa/shared/db';
 import { getSecretProviderInstance } from '@alga-psa/shared/core/secretProvider.js';
 

--- a/ee/server/src/app/msp/layout.tsx
+++ b/ee/server/src/app/msp/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { SessionProvider } from "next-auth/react";
-import DefaultLayout from "server/src/components/layout/DefaultLayout";
-import { TenantProvider } from "server/src/components/TenantProvider";
+import DefaultLayout from "@/components/layout/DefaultLayout";
+import { TenantProvider } from "@/components/TenantProvider";
 
 /**
  * MSP Layout for Enterprise Edition

--- a/ee/server/src/components/GmailProviderForm.tsx
+++ b/ee/server/src/components/GmailProviderForm.tsx
@@ -8,19 +8,19 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button } from 'server/src/components/ui/Button';
-import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'server/src/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Shield } from 'lucide-react';
-import type { EmailProvider } from 'server/src/components/EmailProviderConfiguration';
-import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedGmailConfig, initiateOAuth } from 'server/src/lib/actions/email-actions/emailProviderActions';
-import { useOAuthPopup } from 'server/src/components/providers/gmail/useOAuthPopup';
-import { BasicConfigCard } from 'server/src/components/providers/gmail/BasicConfigCard';
-import { ProcessingSettingsCard } from 'server/src/components/providers/gmail/ProcessingSettingsCard';
-import { OAuthSection } from 'server/src/components/providers/gmail/OAuthSection';
-import { baseGmailProviderSchema } from 'server/src/components/providers/gmail/schemas';
-import CustomSelect from 'server/src/components/ui/CustomSelect';
-import { getInboundTicketDefaults } from 'server/src/lib/actions/email-actions/inboundTicketDefaultsActions';
+import type { EmailProvider } from '@/components/EmailProviderConfiguration';
+import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedGmailConfig, initiateOAuth } from '@/lib/actions/email-actions/emailProviderActions';
+import { useOAuthPopup } from '@/components/providers/gmail/useOAuthPopup';
+import { BasicConfigCard } from '@/components/providers/gmail/BasicConfigCard';
+import { ProcessingSettingsCard } from '@/components/providers/gmail/ProcessingSettingsCard';
+import { OAuthSection } from '@/components/providers/gmail/OAuthSection';
+import { baseGmailProviderSchema } from '@/components/providers/gmail/schemas';
+import CustomSelect from '@/components/ui/CustomSelect';
+import { getInboundTicketDefaults } from '@/lib/actions/email-actions/inboundTicketDefaultsActions';
 
 type EEGmailProviderFormData = import('server/src/components/providers/gmail/schemas').BaseGmailProviderFormData;
 

--- a/ee/server/src/components/MicrosoftProviderForm.tsx
+++ b/ee/server/src/components/MicrosoftProviderForm.tsx
@@ -9,17 +9,17 @@ import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { Button } from 'server/src/components/ui/Button';
-import { Input } from 'server/src/components/ui/Input';
-import { Label } from 'server/src/components/ui/Label';
-import { Switch } from 'server/src/components/ui/Switch';
-import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'server/src/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Switch } from '@/components/ui/Switch';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { CheckCircle, Clock, Shield } from 'lucide-react';
-import type { EmailProvider } from 'server/src/components/EmailProviderConfiguration';
-import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedMicrosoftConfig } from 'server/src/lib/actions/email-actions/emailProviderActions';
-import CustomSelect from 'server/src/components/ui/CustomSelect';
-import { getInboundTicketDefaults } from 'server/src/lib/actions/email-actions/inboundTicketDefaultsActions';
+import type { EmailProvider } from '@/components/EmailProviderConfiguration';
+import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedMicrosoftConfig } from '@/lib/actions/email-actions/emailProviderActions';
+import CustomSelect from '@/components/ui/CustomSelect';
+import { getInboundTicketDefaults } from '@/lib/actions/email-actions/inboundTicketDefaultsActions';
 
 const eeMicrosoftProviderSchema = z.object({
   providerName: z.string().min(1, 'Provider name is required'),

--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { Message } from "../../components/message/Message";
 import { IChat } from "../../interfaces/chat.interface";
 import { createNewChatAction, addMessageToChatAction } from '../../lib/chat-actions/chatActions';
-import { getCurrentUser } from '../../../../../server/src/lib/actions/user-actions/userActions';
+import { getCurrentUser } from '@/lib/actions/user-actions/userActions';
 import { ChatModelInterface, ChatMessage } from '../../interfaces/ChatModelInterface';
 import { HfInference } from '@huggingface/inference';
 

--- a/ee/server/src/components/flow/ComboBoxFieldSelector.tsx
+++ b/ee/server/src/components/flow/ComboBoxFieldSelector.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Popup from './Popup';
 import { Template } from '../../services/flow/types/workflowTypes';
-import { Input } from 'server/src/components/ui/Input';
+import { Input } from '@/components/ui/Input';
 
 interface ComboBoxFieldSelectorProps {
   value?: Template;

--- a/ee/server/src/components/flow/DeleteWorkflowButton.tsx
+++ b/ee/server/src/components/flow/DeleteWorkflowButton.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import styles from '../../../../../server/src/app/msp/workflows/Workflows.module.css';
+import styles from '@/app/msp/workflows/Workflows.module.css';
 import Popup from './Popup';
 import { useRouter } from 'next/navigation';
 

--- a/ee/server/src/components/flow/InputFieldSelector.tsx
+++ b/ee/server/src/components/flow/InputFieldSelector.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Popup from './Popup';
 import { Template } from '../../services/flow/types/workflowTypes';
-import { Input } from 'server/src/components/ui/Input';
+import { Input } from '@/components/ui/Input';
 
 interface InputFieldSelectorProps {
   value: Template;

--- a/ee/server/src/components/flow/Picker.tsx
+++ b/ee/server/src/components/flow/Picker.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { PickerProps, PickerOption } from '../../services/flow/types/nodes';
 import styles from './Picker.module.css';
-import { Input } from 'server/src/components/ui/Input';
+import { Input } from '@/components/ui/Input';
 
 const Picker: React.FC<PickerProps> = ({ label, value, options, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/ee/server/src/components/settings/extensions/ExtensionDetails.tsx
+++ b/ee/server/src/components/settings/extensions/ExtensionDetails.tsx
@@ -8,12 +8,12 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ReflectionContainer } from '../../../../../server/src/lib/ui-reflection/ReflectionContainer';
-import { useAutomationIdAndRegister } from '../../../../../server/src/lib/ui-reflection/useAutomationIdAndRegister';
-import { ContainerComponent } from '../../../../../server/src/lib/ui-reflection/types';
+import { ReflectionContainer } from '@/lib/ui-reflection/ReflectionContainer';
+import { useAutomationIdAndRegister } from '@/lib/ui-reflection/useAutomationIdAndRegister';
+import { ContainerComponent } from '@/lib/ui-reflection/types';
 import { Extension } from '../../../lib/extensions/types';
 import { ChevronLeftIcon, InfoIcon, SettingsIcon, PackageIcon, ShieldIcon, AlertCircleIcon, CheckCircleIcon, XCircleIcon } from 'lucide-react';
-import { logger } from '../../../../../server/src/utils/logger';
+import { logger } from '@/utils/logger';
 import { fetchExtensionById, toggleExtension, uninstallExtension } from '../../../lib/actions/extensionActions';
 import { ExtensionPermissions } from './ExtensionPermissions';
 

--- a/ee/server/src/components/settings/extensions/Extensions.tsx
+++ b/ee/server/src/components/settings/extensions/Extensions.tsx
@@ -7,12 +7,12 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { ReflectionContainer } from 'server/src/types/ui-reflection/ReflectionContainer';
-import { useAutomationIdAndRegister } from 'server/src/types/ui-reflection/useAutomationIdAndRegister';
-import { ContainerComponent } from 'server/src/types/ui-reflection/types';
+import { ReflectionContainer } from '@/lib/ui-reflection/ReflectionContainer';
+import { useAutomationIdAndRegister } from '@/lib/ui-reflection/useAutomationIdAndRegister';
+import { ContainerComponent } from '@/lib/ui-reflection/types';
 import { Extension } from '../../../lib/extensions/types';
 import { PlusIcon, AlertCircleIcon, CheckCircleIcon, XCircleIcon, Settings, EyeIcon } from 'lucide-react';
-import logger from 'server/src/utils/logger';
+import logger from '@/utils/logger';
 import { fetchExtensions, toggleExtension, uninstallExtension } from '../../../lib/actions/extensionActions';
 
 /**

--- a/ee/server/src/components/settings/extensions/InstallerPanel.tsx
+++ b/ee/server/src/components/settings/extensions/InstallerPanel.tsx
@@ -3,11 +3,11 @@
 import React, { useCallback, useRef, useState } from 'react';
 
 // Server UI components
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'server/src/components/ui/Card';
-import { Button } from 'server/src/components/ui/Button';
-import { Input } from 'server/src/components/ui/Input';
-import { Label } from 'server/src/components/ui/Label';
-import { TextArea } from 'server/src/components/ui/TextArea';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { TextArea } from '@/components/ui/TextArea';
 import Link from 'next/link';
 
 // EE server actions

--- a/ee/server/src/components/settings/policy/PolicyManagement.tsx
+++ b/ee/server/src/components/settings/policy/PolicyManagement.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect } from 'react';
 import { Flex, Text, TextArea } from '@radix-ui/themes';
-import { createPolicy, updatePolicy, deletePolicy, getPolicies } from '/home/coder/alga-psa/server/src/lib/actions/policyActions';
-import { IPolicy } from '/home/coder/alga-psa/server/src/interfaces/auth.interfaces';
-import { parsePolicy } from '/home/coder/alga-psa/ee/server/src/lib/auth/policyParser';
-import { DataTable } from '/home/coder/alga-psa/server/src/components/ui/DataTable';
-import { ColumnDefinition } from '/home/coder/alga-psa/server/src/interfaces/dataTable.interfaces';
-import { Button } from '/home/coder/alga-psa/server/src/components/ui/Button';
+import { createPolicy, updatePolicy, deletePolicy, getPolicies } from '@/lib/actions/policyActions';
+import { IPolicy } from '@/interfaces/auth.interfaces';
+import { parsePolicy } from '@ee/lib/auth/policyParser';
+import { DataTable } from '@/components/ui/DataTable';
+import { ColumnDefinition } from '@/interfaces/dataTable.interfaces';
+import { Button } from '@/components/ui/Button';
 
 export default function PolicyManagement() {
   const [policies, setPolicies] = useState<IPolicy[]>([]);

--- a/ee/server/src/interfaces/chat.interface.tsx
+++ b/ee/server/src/interfaces/chat.interface.tsx
@@ -1,4 +1,4 @@
-import { TenantEntity } from '../../../../server/src/interfaces';
+import { TenantEntity } from '@/interfaces';
 
 export interface IChat extends TenantEntity {
   id?: string;

--- a/ee/server/src/interfaces/message.interface.ts
+++ b/ee/server/src/interfaces/message.interface.ts
@@ -1,4 +1,4 @@
-import { TenantEntity } from '../../../../server/src/interfaces';
+import { TenantEntity } from '@/interfaces';
 
 export interface IMessage extends TenantEntity {
   id?: string;

--- a/ee/server/src/lib/actions/extensionActions.ts
+++ b/ee/server/src/lib/actions/extensionActions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { createTenantKnex } from 'server/src/lib/db'
+import { createTenantKnex } from '@/lib/db'
 import { withTransaction } from '@alga-psa/shared/db'
 import { ExtensionRegistry } from '../extensions/registry'
 import { ExtensionStorageService } from '../extensions/storage/storageService'

--- a/ee/server/src/lib/actions/workflow.ts
+++ b/ee/server/src/lib/actions/workflow.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { createTenantKnex } from '../../../../../server/src/lib/db'
+import { createTenantKnex } from '@/lib/db'
 import { WorkflowVersionResponse } from '../../services/flow/types'
 
 export async function fetchWorkflowVersion(

--- a/ee/server/src/lib/auth/abac.ts
+++ b/ee/server/src/lib/auth/abac.ts
@@ -1,5 +1,5 @@
-import { IUser, IResource, IPolicy, ICondition, IRole, IUserWithRoles } from '../../../../../server/src/interfaces/auth.interfaces';
-import { USER_ATTRIBUTES, TICKET_ATTRIBUTES, UserAttributeKey, TicketAttributeKey } from '../../../../../server/src/lib/attributes/EntityAttributes';
+import { IUser, IResource, IPolicy, ICondition, IRole, IUserWithRoles } from '@/interfaces/auth.interfaces';
+import { USER_ATTRIBUTES, TICKET_ATTRIBUTES, UserAttributeKey, TicketAttributeKey } from '@/lib/attributes/EntityAttributes';
 
 export class Resource implements IResource {
   type: string;

--- a/ee/server/src/lib/auth/policyEngine.ts
+++ b/ee/server/src/lib/auth/policyEngine.ts
@@ -1,6 +1,6 @@
-import { IResource, IPolicy, ICondition, IRole, IUserWithRoles } from '../../../../../server/src/interfaces/auth.interfaces';
-import { USER_ATTRIBUTES, UserAttributeKey } from '../../../../../server/src/lib/attributes/EntityAttributes';
-import { hasPermission } from '../../../../../server/src/lib/auth/rbac';
+import { IResource, IPolicy, ICondition, IRole, IUserWithRoles } from '@/interfaces/auth.interfaces';
+import { USER_ATTRIBUTES, UserAttributeKey } from '@/lib/attributes/EntityAttributes';
+import { hasPermission } from '@/lib/auth/rbac';
 import { Policy } from './abac';
 
 export class PolicyEngine {

--- a/ee/server/src/lib/auth/policyParser.ts
+++ b/ee/server/src/lib/auth/policyParser.ts
@@ -1,8 +1,8 @@
 /* eslint-disable custom-rules/map-return-type */
 import * as P from 'parsimmon';
 import { Policy } from './abac';
-import { ICondition } from '../../../../../server/src/interfaces/auth.interfaces';
-import { UserAttributeKey, TicketAttributeKey } from '../../../../../server/src/lib/attributes/EntityAttributes';
+import { ICondition } from '@/interfaces/auth.interfaces';
+import { UserAttributeKey, TicketAttributeKey } from '@/lib/attributes/EntityAttributes';
 
 const policyParser = P.createLanguage({
   // Basic parsers

--- a/ee/server/src/lib/extensions/context/ExtensionContext.tsx
+++ b/ee/server/src/lib/extensions/context/ExtensionContext.tsx
@@ -9,7 +9,7 @@ import type {
   StorageService,
   UIService,
   UserInfo
-} from '../descriptors/types';
+} from '../types';
 
 interface ExtensionContextProviderProps {
   extensionId: string;

--- a/ee/server/src/lib/extensions/context/ExtensionContext.tsx
+++ b/ee/server/src/lib/extensions/context/ExtensionContext.tsx
@@ -2,8 +2,8 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { useToast } from '@/hooks/use-toast';
 import { ExtensionStorageService } from '../storage/ExtensionStorageService';
-import type { 
-  ExtensionContext as IExtensionContext,
+import type {
+  UiExtensionContext as IExtensionContext,
   NavigationService,
   ApiService,
   StorageService,

--- a/ee/server/src/lib/extensions/context/ExtensionContext.tsx
+++ b/ee/server/src/lib/extensions/context/ExtensionContext.tsx
@@ -149,6 +149,7 @@ export function ExtensionContextProvider({
       toast: (message: string, type = 'info') => {
         toast({
           title: message,
+          description: '',
           variant: type === 'error' ? 'destructive' : 'default'
         });
       },

--- a/ee/server/src/lib/extensions/registry.ts
+++ b/ee/server/src/lib/extensions/registry.ts
@@ -3,8 +3,8 @@
  * 
  * This service manages extension registration, initialization, and lifecycle.
  */
-import { createTenantKnex } from '../../../../../server/src/lib/db';
-import logger from '../../../../../shared/core/logger';
+import { createTenantKnex } from '@/lib/db';
+import logger from '@alga-psa/shared/core/logger';
 import { ExtensionStorageService } from './storage/storageService';
 import {
   Extension,

--- a/ee/server/src/lib/extensions/storage/storageService.ts
+++ b/ee/server/src/lib/extensions/storage/storageService.ts
@@ -3,9 +3,9 @@
  * 
  * Provides extension data storage with tenant isolation
  */
-import { createTenantKnex } from '../../../../../../server/src/lib/db';
-import logger from '../../../../../../shared/core/logger';
-import { getRedisClient } from '../../../../../../server/src/config/redisConfig';
+import { createTenantKnex } from '@/lib/db';
+import logger from '@alga-psa/shared/core/logger';
+import { getRedisClient } from '@/config/redisConfig';
 import { 
   ExtensionStorageService as IExtensionStorageService,
   StorageOptions

--- a/ee/server/src/lib/extensions/types.ts
+++ b/ee/server/src/lib/extensions/types.ts
@@ -289,3 +289,52 @@ export interface ExtensionRegistry {
   getComponentsByType(type: ExtensionComponentType, options: ExtensionInitOptions): Promise<ExtensionComponentDefinition[]>;
   getComponentsBySlot(slot: string, options: ExtensionInitOptions): Promise<ExtensionComponentDefinition[]>;
 }
+
+/**
+ * UI helper types used by the client-side ExtensionContext provider
+ */
+export interface NavigationService {
+  navigate(path: string): void;
+  getCurrentRoute(): string;
+  onNavigate(callback: (path: string) => void): () => void;
+}
+
+export interface ApiService {
+  get(path: string, options?: any): Promise<any>;
+  post(path: string, data?: any, options?: any): Promise<any>;
+  put(path: string, data?: any, options?: any): Promise<any>;
+  delete(path: string, options?: any): Promise<any>;
+}
+
+export interface UIService {
+  toast(message: string, type?: 'info' | 'error' | 'success' | 'warning'): void;
+  confirm(message: string, title?: string): Promise<boolean>;
+  modal(content: any, options?: any): Promise<void>;
+}
+
+export interface StorageService {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T): Promise<void>;
+  remove(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export interface UserInfo {
+  id: string;
+  email?: string;
+  name?: string;
+  roles?: string[];
+  [key: string]: any;
+}
+
+/**
+ * UI Extension Context exposed to client-side components
+ */
+export interface UiExtensionContext {
+  navigation: NavigationService;
+  api: ApiService;
+  storage: StorageService;
+  ui: UIService;
+  tenantId: string;
+  user: UserInfo;
+}

--- a/ee/server/src/lib/extensions/ui/iframeBridge.ts
+++ b/ee/server/src/lib/extensions/ui/iframeBridge.ts
@@ -13,7 +13,7 @@
  * - Never uses targetOrigin="*" except in dev explicitly guarded via NODE_ENV !== 'production' or global __ALGA_DEV__ flag
  */
 
-import { buildExtUiSrc as buildExtUiSrcShared } from '../../assets/url.shared';
+import { buildExtUiSrc as buildExtUiSrcShared } from '@/lib/extensions/assets/url.shared';
 
 const ENVELOPE_VERSION = '1' as const;
 const HASH_REGEX = /^sha256:[0-9a-f]{64}$/i;

--- a/ee/server/src/lib/licensing/EnterpriseLicenseChecker.ts
+++ b/ee/server/src/lib/licensing/EnterpriseLicenseChecker.ts
@@ -1,4 +1,4 @@
-import { ILicenseChecker, LicenseCheckResult } from '../../../../../server/src/lib/licensing/LicenseChecker';
+import { ILicenseChecker, LicenseCheckResult } from '@/lib/licensing/LicenseChecker';
 
 export class EnterpriseLicenseChecker implements ILicenseChecker {
   private readonly DEFAULT_USER_LIMIT = 50;

--- a/ee/server/src/lib/storage/providers/S3StorageProvider.ts
+++ b/ee/server/src/lib/storage/providers/S3StorageProvider.ts
@@ -8,8 +8,8 @@ import {
     S3
 } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
-import { BaseStorageProvider, UploadResult, StorageError, RangeOptions } from 'server/src/lib/storage/providers/StorageProvider';
-import { S3ProviderConfig, StorageCapabilities } from 'server/src/types/storage';
+import { BaseStorageProvider, UploadResult, StorageError, RangeOptions } from '@/lib/storage/providers/StorageProvider';
+import { S3ProviderConfig, StorageCapabilities } from '@/types/storage';
 
 export class S3StorageProvider extends BaseStorageProvider {
     private readonly client: S3Client;

--- a/ee/server/src/lib/testing/tenant-creation.ts
+++ b/ee/server/src/lib/testing/tenant-creation.ts
@@ -5,7 +5,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { Knex } from 'knex';
-import { hashPassword, generateSecurePassword } from '../../../../../server/src/utils/encryption/encryption';
+import { hashPassword, generateSecurePassword } from '@/utils/encryption/encryption';
 
 export interface TenantCreationInput {
   tenantName: string;

--- a/ee/server/src/services/chatStreamService.ts
+++ b/ee/server/src/services/chatStreamService.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { HuggingFaceChatModel } from '../models/HuggingFaceChatModel';
 import { AnthropicChatModel } from '../models/AnthropicChatModel';
-import { getSecretProviderInstance } from '../../../../shared/core/secretProvider.js';
+import { getSecretProviderInstance } from '@alga-psa/shared/core/secretProvider.js';
 
 interface StreamRequestBody {
   inputs: any[];

--- a/ee/server/src/services/provisioning/tenantService.ts
+++ b/ee/server/src/services/provisioning/tenantService.ts
@@ -1,4 +1,4 @@
-import { createTenantKnex } from 'server/src/lib/db';
+import { createTenantKnex } from '@/lib/db';
 import { CreateTenantInput, TenantResponse } from './types/tenant.schema';
 import { Knex } from 'knex';
 

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -153,11 +153,12 @@ const nextConfig = {
 
     // In CE builds, replace any deep import of the EE S3 provider with the CE stub.
     // This also catches relative paths like ../../../ee/server/src/lib/storage/providers/S3StorageProvider
+    // and @ee alias imports like @ee/lib/storage/providers/S3StorageProvider
     if (process.env.NEXT_PUBLIC_EDITION !== 'enterprise') {
       config.plugins = config.plugins || [];
       config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(
-          /(.*)ee[\\\/]server[\\\/]src[\\\/]lib[\\\/]storage[\\\/]providers[\\\/]S3StorageProvider(\.[jt]s)?$/,
+          /(.*)(ee[\\\/]server[\\\/]src[\\\/]|@ee[\\\/])lib[\\\/]storage[\\\/]providers[\\\/]S3StorageProvider(\.[jt]s)?$/,
           path.join(__dirname, 'src/empty/lib/storage/providers/S3StorageProvider')
         )
       );


### PR DESCRIPTION
Summary:
- Replace deep relative EE imports with path aliases (`@`, `@alga-psa/shared`, `@ee`) for build stability.
- Remove workflow-worker build from CI workflow; use Dockerfile.build for CE/EE; fix artifact verification paths.
- Add npm installs in Argo setup for repo root and `server/`.
- EE Dockerfile.build changes:
  - Copy `server/index.ts` and `server/tsconfig.json` into runtime.
  - Copy `server/node_modules` and `node_modules` into runtime; install global `tsx`.
  - Install `chromium` + fonts; set `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` and `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser`.
- Fix iframe URL import in EE (`iframeBridge.ts`) to use server alias.
- Add UI extension context types; adjust imports in EE UI code.

Why:
- Fixes Next build failures in EE due to missing types/imports and incorrect relative paths.
- Prevents runtime “module not found” for `@alga-psa/shared` by including tsconfig and workspace deps.
- Restores BlockNote preview rendering by including Chromium and Puppeteer env in the runtime image.

Paths touched (highlights):
- `ee/server/src/lib/...` (aliases, types, iframeBridge)
- `ee/server/Dockerfile.build` (runtime changes)
- `Dockerfile.build` (CE build hardening)
- `nm-kube-config/alga-psa/workflows/build/alga-psa-ci-cd-workflow.yaml` (setup step, Dockerfile usage, build verifications)

Commits included:
- 05205b66: include server/tsconfig.json in runtime image
- 3f9b22ac: install chromium + fonts + Puppeteer env
- f5a3ea44: install server workspace deps and copy server/node_modules; install global tsx
- 72468800: include server/index.ts in runtime
- 156109df: fix iframeBridge import to use server alias
- 9dbbc23c / 3820b13b / 9d167cff / db6e112a: EE alias and type fixes