### PR TITLE
Microsoft inbound email parity, single-tenant OAuth, and UI server-action refactor

### DIFF
--- a/docs/AI_coding_standards.md
+++ b/docs/AI_coding_standards.md
@@ -9,20 +9,6 @@
 
 Prefer radix components over other libraries
 
-## Import Paths
-
-- **Always use full relative paths** instead of `@` aliases
-- Example:
-  ```tsx
-  // Good
-  import { Button } from 'server/src/components/ui/Button';
-  import { createUser } from 'server/src/lib/actions/user-actions/userActions';
-  
-  // Bad - Don't use @ imports
-  import { Button } from '@/components/ui/Button';
-  import { createUser } from '@/lib/actions/user-actions/userActions';
-  ```
-
 ## UI Components
 
 **IMPORTANT: All interactive elements (buttons, inputs, selects, etc.) MUST have unique `id` attributes for the reflection UI system. See Component ID Guidelines section for naming conventions.**

--- a/ee/docs/plans/microsoft-inbound-email-parity.md
+++ b/ee/docs/plans/microsoft-inbound-email-parity.md
@@ -1,0 +1,102 @@
+# Microsoft Graph Inbound Email Parity Plan
+
+Status: In Progress
+Owner: Email Platform
+Last updated: 2025-08-16
+
+## Goals
+- Achieve functional parity between Microsoft (Graph) and Gmail inbound email providers.
+- Use consistent token storage, webhook setup/renewal, and message retrieval flows.
+- Ensure webhook routes can publish enriched INBOUND_EMAIL_RECEIVED events reliably.
+
+## Current State (Summary)
+- Gmail: Production-ready with OAuth lifecycle, Pub/Sub watch, DB persistence, webhook handler publishing enriched events.
+- Microsoft: Basic OAuth refresh and webhook subscription exist; tokens stored in tenant secrets; limited DB persistence; webhook route publishes minimal events only; header/body fetch and connection checks are lighter than Gmail.
+
+## Scope of Work
+
+1) Credentials: Load + Persist in DB (not tenant secrets)
+- Update `MicrosoftGraphAdapter.loadCredentials()` to read `access_token`, `refresh_token`, `token_expires_at` from `microsoft_email_provider_config` via `config.provider_config` (matches Gmail pattern).
+- Update `MicrosoftGraphAdapter.refreshAccessToken()` to persist refreshed tokens and expiry back to `microsoft_email_provider_config` (use admin/tenant DB access akin to Gmail adapter) instead of `email_provider_credentials` secret.
+- Keep `client_id`/`client_secret` lookup via env first, then tenant secrets as fallback.
+
+2) Webhook Subscription: Persist + Validate
+- On subscription create/renew in `MicrosoftGraphAdapter`:
+  - Set `email_providers.webhook_id = subscription.id` (route uses this for lookup).
+  - Persist `webhook_subscription_id` and `webhook_expires_at` into `microsoft_email_provider_config`.
+- Use `clientState` for validation:
+  - Source: `config.webhook_verification_token` (reuse main provider field) to avoid schema changes.
+  - Ensure the Microsoft webhook route validates `notification.clientState` against `email_providers.webhook_verification_token`; keep backward compatibility by also accepting `provider.provider_config.clientState` if present.
+
+3) Webhook Route Behavior: Enriched events (parity with Gmail)
+- In `app/api/email/webhooks/microsoft/route.ts`, after provider lookup and validation:
+  - Instantiate `MicrosoftGraphAdapter` with the resolved provider config.
+  - Fetch full message details (`getMessageDetails(id)`).
+  - Publish `INBOUND_EMAIL_RECEIVED` with `emailData` payload, mirroring Gmail flow.
+- Keep minimal event publish as fallback if fetch fails (warn and continue to ack webhook).
+
+4) Message Retrieval Parity
+- Enhance `getMessageDetails` to request/select the needed fields:
+  - Use `$select=internetMessageHeaders,receivedDateTime,subject,body,bodyPreview,from,toRecipients,ccRecipients,conversationId` and `$expand=attachments`.
+  - Map `headers`, `references`, `inReplyTo`, `threadId`, attachments metadata the same way Gmail does.
+  - Consider `Prefer: outlook.body-content-type="text"` for consistent `body.text` extraction.
+
+5) Connection Test Parity
+- Update `testConnection()` to verify the mailbox:
+  - Compare `/me` (use `mail` or `userPrincipalName`) to `config.mailbox`, returning a mismatch error like Gmail.
+
+6) Processed Semantics (Optional but recommended)
+- Current: `isRead=true`. Improve by adding a category (e.g., `PSA/Processed`) or moving to a folder, mirroring Gmail’s label approach.
+
+## Acceptance Criteria
+- Tokens for Microsoft are loaded from and persisted to `microsoft_email_provider_config` (DB), not tenant secrets.
+- Webhook subscription creation/renewal writes:
+  - `email_providers.webhook_id` set to Graph subscription ID.
+  - `microsoft_email_provider_config.webhook_subscription_id` and `webhook_expires_at` updated.
+- Webhook route validates `clientState` against `email_providers.webhook_verification_token` (and optionally against historical `provider_config.clientState`).
+- Microsoft webhook route publishes enriched `INBOUND_EMAIL_RECEIVED` events containing `emailData` (subject, body, headers, attachments, participants).
+- `testConnection()` reports mailbox mismatch explicitly.
+- Gmail inbound flow remains unaffected.
+
+## Implementation Plan (Tasks)
+- [x] Adapter: Credentials
+  - [x] Refactor credential load/refresh to use DB; add DB update helper mirroring Gmail’s `updateStoredCredentials()`.
+- [x] Adapter: Webhooks
+  - [x] Create/renew watch writes to `email_providers` and `microsoft_email_provider_config`; use `config.webhook_verification_token` as `clientState`.
+- [x] Adapter: Message Retrieval
+  - [x] Expand `getMessageDetails()` to include headers, correct body handling, and attachments using `$select`/`$expand` and Prefer text body.
+- [x] Adapter: Connection Test
+  - [x] Compare `/me` mailbox vs `config.mailbox` and report mismatch, using `mail` or `userPrincipalName`.
+- [x] Route: Microsoft Webhook
+  - [x] Lookup provider by `webhook_id`, validate `clientState`, fetch details via adapter, publish enriched event.
+  - [x] Log + continue on per-message fetch failures (fallback minimal publish).
+- [x] Route: Validation
+  - [x] Update validation to prioritize `webhook_verification_token`; maintain backward compatibility (warn if absent).
+
+## Data/Schema Considerations
+- No new columns required if we reuse `email_providers.webhook_id` and `email_providers.webhook_verification_token`.
+- Assumes `microsoft_email_provider_config` has `webhook_subscription_id` and `webhook_expires_at` (EmailProviderService mapping already supports these fields).
+
+## Testing Strategy
+- Unit: Adapter methods for credential load/refresh (mock axios), message fetch with `$select/$expand` mapping.
+- Integration: Webhook route end-to-end using mocked Graph API responses.
+- E2E: Simulate Microsoft webhook payload and verify enriched `INBOUND_EMAIL_RECEIVED` published; verify DB persistence of subscription and tokens.
+
+## Rollout & Migration
+- For existing Microsoft providers:
+  - Backfill `email_providers.webhook_id` on next renewal or during a one-time maintenance script that reads current subscription and stores it.
+  - First refresh post-deploy moves tokens into `microsoft_email_provider_config`.
+- Monitor webhook processing logs for clientState mismatches.
+
+## Risks & Mitigations
+- Risk: Token source switch (secrets → DB) can desync.
+  - Mitigation: Keep a temporary fallback to secrets for reads; write always to DB.
+- Risk: Graph throttling.
+  - Mitigation: Guard retries and log; backoff on message fetch.
+- Risk: Different mailbox principal vs SMTP address.
+  - Mitigation: Use both `mail` and `userPrincipalName` for match.
+
+## Timeline (Rough)
+- Day 1–2: Adapter refactor (credentials, webhooks persistence, connection test).
+- Day 2–3: Message retrieval enhancements; webhook route enrichment.
+- Day 4: Tests and verification; rollout plan preparation.

--- a/ee/server/src/components/GmailProviderForm.tsx
+++ b/ee/server/src/components/GmailProviderForm.tsx
@@ -13,7 +13,8 @@ import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Shield } from 'lucide-react';
 import type { EmailProvider } from '@/components/EmailProviderConfiguration';
-import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedGmailConfig, initiateOAuth } from '@/lib/actions/email-actions/emailProviderActions';
+import { createEmailProvider, updateEmailProvider, upsertEmailProvider, getHostedGmailConfig } from '@/lib/actions/email-actions/emailProviderActions';
+import { initiateEmailOAuth } from '@/lib/actions/email-actions/oauthActions';
 import { useOAuthPopup } from '@/components/providers/gmail/useOAuthPopup';
 import { BasicConfigCard } from '@/components/providers/gmail/BasicConfigCard';
 import { ProcessingSettingsCard } from '@/components/providers/gmail/ProcessingSettingsCard';
@@ -185,10 +186,9 @@ export function GmailProviderForm({
       }
 
       // Get OAuth URL from server action (hosted OAuth configuration)
-      const oauthResult = await initiateOAuth({
+      const oauthResult = await initiateEmailOAuth({
         provider: 'google',
         providerId,
-        hosted: true,
       });
       if (!oauthResult.success || !oauthResult.authUrl) {
         throw new Error(oauthResult.error || 'Failed to initiate OAuth');

--- a/ee/server/src/components/GmailProviderForm.tsx
+++ b/ee/server/src/components/GmailProviderForm.tsx
@@ -190,11 +190,12 @@ export function GmailProviderForm({
         provider: 'google',
         providerId,
       });
-      if (!oauthResult.success || !oauthResult.authUrl) {
+      if (!oauthResult.success) {
         throw new Error(oauthResult.error || 'Failed to initiate OAuth');
       }
+      const { authUrl } = oauthResult;
 
-      openOAuthPopup(oauthResult.authUrl, {
+      openOAuthPopup(authUrl, {
         onAfterSuccess: () => {},
         onAutoSubmit: (oauthDataForSubmit) => {
           form.handleSubmit((data) => onSubmit(data, oauthDataForSubmit))();

--- a/scripts/ms-graph-list-subscriptions.cjs
+++ b/scripts/ms-graph-list-subscriptions.cjs
@@ -72,7 +72,12 @@ async function main() {
     try {
       token = await getAppOnlyToken();
     } catch (err) {
+      const status = err.response?.status;
+      const body = err.response?.data;
       console.error('Failed to obtain app-only token:', err.message || err);
+      if (status || body) {
+        console.error('Token endpoint response:', { status, body });
+      }
       process.exit(1);
     }
   }
@@ -114,4 +119,3 @@ async function main() {
 }
 
 main();
-

--- a/scripts/ms-graph-list-subscriptions.js
+++ b/scripts/ms-graph-list-subscriptions.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * List Microsoft Graph subscriptions (webhooks) via REST
+ *
+ * Supports two auth modes:
+ * 1) Delegated: provide ACCESS_TOKEN env (e.g., from OAuth callback) — best for /me mail subscriptions
+ * 2) App-only (client credentials): MICROSOFT_TENANT_ID, MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET
+ *
+ * Falls back to reading secrets from ./secrets/ files if env vars are missing:
+ * - secrets/MICROSOFT_TENANT_ID
+ * - secrets/MICROSOFT_CLIENT_ID
+ * - secrets/MICROSOFT_CLIENT_SECRET
+ *
+ * Usage:
+ *   node scripts/ms-graph-list-subscriptions.js
+ *   node scripts/ms-graph-list-subscriptions.js --id <subscriptionId>
+ *   ACCESS_TOKEN=... node scripts/ms-graph-list-subscriptions.js
+ */
+
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+
+function readSecretFile(name) {
+  try {
+    const p = path.resolve(process.cwd(), 'secrets', name);
+    if (fs.existsSync(p)) {
+      return fs.readFileSync(p, 'utf8').trim();
+    }
+  } catch (_) {}
+  return null;
+}
+
+function getArg(flag) {
+  const idx = process.argv.indexOf(flag);
+  if (idx !== -1 && idx + 1 < process.argv.length) return process.argv[idx + 1];
+  return null;
+}
+
+async function getAppOnlyToken() {
+  const tenantId = process.env.MICROSOFT_TENANT_ID || readSecretFile('MICROSOFT_TENANT_ID') || 'common';
+  const clientId = process.env.MICROSOFT_CLIENT_ID || readSecretFile('MICROSOFT_CLIENT_ID');
+  const clientSecret = process.env.MICROSOFT_CLIENT_SECRET || readSecretFile('MICROSOFT_CLIENT_SECRET');
+
+  if (!clientId || !clientSecret) {
+    throw new Error('Missing MICROSOFT_CLIENT_ID or MICROSOFT_CLIENT_SECRET (env or secrets/)');
+  }
+
+  const tokenUrl = `https://login.microsoftonline.com/${encodeURIComponent(tenantId)}/oauth2/v2.0/token`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'client_credentials',
+    scope: 'https://graph.microsoft.com/.default',
+  });
+  const resp = await axios.post(tokenUrl, params.toString(), {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    timeout: 30000,
+  });
+  return resp.data.access_token;
+}
+
+async function main() {
+  const subId = getArg('--id');
+  const verbose = process.argv.includes('--verbose');
+  const accessToken = process.env.ACCESS_TOKEN || null;
+
+  let token = accessToken;
+  if (!token) {
+    if (verbose) console.log('ACCESS_TOKEN not provided; attempting app-only token via client credentials...');
+    try {
+      token = await getAppOnlyToken();
+    } catch (err) {
+      console.error('Failed to obtain app-only token:', err.message || err);
+      process.exit(1);
+    }
+  }
+
+  const http = axios.create({
+    baseURL: 'https://graph.microsoft.com/v1.0',
+    headers: { Authorization: `Bearer ${token}` },
+    timeout: 30000,
+  });
+
+  try {
+    let data;
+    if (subId) {
+      if (verbose) console.log(`Fetching subscription ${subId}...`);
+      const resp = await http.get(`/subscriptions/${encodeURIComponent(subId)}`);
+      data = resp.data;
+    } else {
+      if (verbose) console.log('Listing subscriptions...');
+      const resp = await http.get('/subscriptions');
+      data = resp.data;
+    }
+
+    console.log(JSON.stringify(data, null, 2));
+    if (!subId && Array.isArray(data.value)) {
+      console.log(`\nTotal: ${data.value.length}`);
+      for (const s of data.value) {
+        console.log(`- ${s.id} | ${s.resource} | expires: ${s.expirationDateTime}`);
+      }
+    }
+  } catch (err) {
+    const status = err.response?.status;
+    const body = err.response?.data;
+    console.error('Graph request failed:', status, JSON.stringify(body || err.message));
+    if (status === 401) {
+      console.error('Unauthorized. If subscriptions were created with delegated user tokens, set ACCESS_TOKEN to a user token.');
+    }
+    process.exit(2);
+  }
+}
+
+main();
+

--- a/server/src/app/api/email/oauth/initiate/route.ts
+++ b/server/src/app/api/email/oauth/initiate/route.ts
@@ -65,11 +65,22 @@ export async function POST(request: NextRequest) {
     };
 
     // Generate authorization URL
+    // Determine Microsoft tenant authority (single-tenant support)
+    let msTenantAuthority: string | undefined;
+    if (provider === 'microsoft') {
+      msTenantAuthority = process.env.MICROSOFT_TENANT_ID
+        || (await secretProvider.getAppSecret('MICROSOFT_TENANT_ID'))
+        || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_tenant_id'))
+        || 'common';
+    }
+
     const authUrl = provider === 'microsoft'
       ? generateMicrosoftAuthUrl(
           clientId,
           state.redirectUri,
-          state
+          state,
+          undefined as any,
+          msTenantAuthority
         )
       : generateGoogleAuthUrl(
           clientId,

--- a/server/src/app/api/email/webhooks/microsoft/route.ts
+++ b/server/src/app/api/email/webhooks/microsoft/route.ts
@@ -88,6 +88,7 @@ export async function POST(request: NextRequest) {
           // Build provider config to fetch full email details
           const msConfig = await trx('microsoft_email_provider_config')
             .where('email_provider_id', provider.id)
+            .andWhere('tenant', provider.tenant)
             .first();
 
           const providerConfig: EmailProviderConfig = {

--- a/server/src/app/api/email/webhooks/microsoft/route.ts
+++ b/server/src/app/api/email/webhooks/microsoft/route.ts
@@ -3,6 +3,8 @@ import { getAdminConnection } from '@alga-psa/shared/db/admin.js';
 import { withTransaction } from '@alga-psa/shared/db';
 import { publishEvent } from '@alga-psa/shared/events/publisher.js';
 import { randomBytes } from 'crypto';
+import { MicrosoftGraphAdapter } from '@/services/email/providers/MicrosoftGraphAdapter';
+import type { EmailProviderConfig } from '@/interfaces/email.interfaces';
 
 interface MicrosoftNotification {
   changeType: string;
@@ -69,12 +71,9 @@ export async function POST(request: NextRequest) {
             return;
           }
 
-          // Validate client state
-          const vendorConfig = typeof provider.vendor_config === 'string' 
-            ? JSON.parse(provider.vendor_config) 
-            : provider.vendor_config;
-
-          if (notification.clientState !== vendorConfig.clientState) {
+          // Validate clientState against primary source (email_providers.webhook_verification_token)
+          const webhookToken = provider.webhook_verification_token;
+          if (webhookToken && notification.clientState !== webhookToken) {
             console.error(`Invalid client state for provider ${provider.id}`);
             return;
           }
@@ -86,29 +85,77 @@ export async function POST(request: NextRequest) {
             return;
           }
 
-          // Publish INBOUND_EMAIL_RECEIVED event
-          await publishEvent({
-            eventType: 'INBOUND_EMAIL_RECEIVED',
-            tenant: provider.tenant,
-            payload: {
-              tenantId: provider.tenant,
-              tenant: provider.tenant,
-              providerId: provider.id,
-              providerType: 'microsoft',
-              mailbox: provider.mailbox,
-              messageId: messageId,
-              changeType: notification.changeType,
-              webhookData: {
-                subscriptionId: notification.subscriptionId,
-                resource: notification.resource,
-                resourceData: notification.resourceData,
-                timestamp: new Date().toISOString()
-              }
-            }
-          });
+          // Build provider config to fetch full email details
+          const msConfig = await trx('microsoft_email_provider_config')
+            .where('email_provider_id', provider.id)
+            .first();
 
-          processedNotifications.push(messageId);
-          console.log(`Published event for Microsoft email: ${messageId} from ${provider.mailbox}`);
+          const providerConfig: EmailProviderConfig = {
+            id: provider.id,
+            tenant: provider.tenant,
+            name: provider.provider_name || provider.mailbox,
+            provider_type: 'microsoft',
+            mailbox: provider.mailbox,
+            folder_to_monitor: 'Inbox',
+            active: provider.is_active,
+            webhook_notification_url: provider.webhook_notification_url,
+            webhook_subscription_id: provider.webhook_subscription_id,
+            webhook_verification_token: provider.webhook_verification_token,
+            webhook_expires_at: provider.webhook_expires_at,
+            connection_status: provider.connection_status || provider.status || 'connected',
+            created_at: provider.created_at,
+            updated_at: provider.updated_at,
+            provider_config: msConfig ? {
+              client_id: msConfig.client_id,
+              client_secret: msConfig.client_secret,
+              tenant_id: msConfig.tenant_id,
+              access_token: msConfig.access_token,
+              refresh_token: msConfig.refresh_token,
+              token_expires_at: msConfig.token_expires_at,
+            } : {},
+          } as any;
+
+          try {
+            const adapter = new MicrosoftGraphAdapter(providerConfig);
+            await adapter.connect();
+            const details = await adapter.getMessageDetails(messageId);
+            await publishEvent({
+              eventType: 'INBOUND_EMAIL_RECEIVED',
+              tenant: provider.tenant,
+              payload: {
+                tenantId: provider.tenant,
+                tenant: provider.tenant,
+                providerId: provider.id,
+                emailData: details,
+              },
+            });
+            processedNotifications.push(messageId);
+            console.log(`Published enriched event for Microsoft email: ${messageId} from ${provider.mailbox}`);
+          } catch (detailErr: any) {
+            console.warn(`Failed to fetch/publish Microsoft message ${messageId}: ${detailErr?.message || detailErr}`);
+            // Fallback: publish minimal event to acknowledge
+            await publishEvent({
+              eventType: 'INBOUND_EMAIL_RECEIVED',
+              tenant: provider.tenant,
+              payload: {
+                tenantId: provider.tenant,
+                tenant: provider.tenant,
+                providerId: provider.id,
+                emailData: {
+                  id: messageId,
+                  provider: 'microsoft',
+                  providerId: provider.id,
+                  tenant: provider.tenant,
+                  receivedAt: new Date().toISOString(),
+                  from: { email: '', name: undefined },
+                  to: [],
+                  subject: notification.resourceData?.subject || '',
+                  body: { text: '', html: undefined },
+                } as any,
+              },
+            });
+            processedNotifications.push(messageId);
+          }
         });
       } catch (error) {
         console.error('Error processing Microsoft notification:', error);

--- a/server/src/components/GmailProviderForm.tsx
+++ b/server/src/components/GmailProviderForm.tsx
@@ -15,7 +15,8 @@ import { Alert, AlertDescription } from './ui/Alert';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/Card';
 import { ExternalLink, Eye, EyeOff } from 'lucide-react';
 import type { EmailProvider } from './EmailProviderConfiguration';
-import { createEmailProvider, updateEmailProvider, upsertEmailProvider, initiateOAuth } from '../lib/actions/email-actions/emailProviderActions';
+import { createEmailProvider, updateEmailProvider, upsertEmailProvider } from '../lib/actions/email-actions/emailProviderActions';
+import { initiateEmailOAuth } from 'server/src/lib/actions/email-actions/oauthActions';
 import { useOAuthPopup } from './providers/gmail/useOAuthPopup';
 import { BasicConfigCard } from './providers/gmail/BasicConfigCard';
 import { ProcessingSettingsCard } from './providers/gmail/ProcessingSettingsCard';
@@ -198,11 +199,10 @@ export function GmailProviderForm({
       }
 
       // Get OAuth URL from server action
-      const oauthResult = await initiateOAuth({
+      const oauthResult = await initiateEmailOAuth({
         provider: 'google',
         redirectUri: formData.redirectUri,
         providerId: providerId,
-        hosted: process.env.NEXT_PUBLIC_EDITION === 'enterprise'
       });
 
       if (!oauthResult.success || !oauthResult.authUrl) {

--- a/server/src/components/GmailProviderForm.tsx
+++ b/server/src/components/GmailProviderForm.tsx
@@ -205,12 +205,13 @@ export function GmailProviderForm({
         providerId: providerId,
       });
 
-      if (!oauthResult.success || !oauthResult.authUrl) {
+      if (!oauthResult.success) {
         throw new Error(oauthResult.error || 'Failed to initiate OAuth');
       }
+      const { authUrl } = oauthResult;
 
       // Open popup and handle callback + auto-submit
-      openOAuthPopup(oauthResult.authUrl, {
+      openOAuthPopup(authUrl, {
         onAfterSuccess: () => {},
         onAutoSubmit: (oauthDataForSubmit) => {
           form.handleSubmit((data) => onSubmit(data, oauthDataForSubmit))();

--- a/server/src/lib/actions/email-actions/oauthActions.ts
+++ b/server/src/lib/actions/email-actions/oauthActions.ts
@@ -47,10 +47,10 @@ export async function initiateEmailOAuth(params: {
 
     if (isHosted) {
       if (provider === 'google') {
-        clientId = await secretProvider.getAppSecret('GOOGLE_CLIENT_ID');
+        clientId = (await secretProvider.getAppSecret('GOOGLE_CLIENT_ID')) || null;
         effectiveRedirectUri = effectiveRedirectUri || (await secretProvider.getAppSecret('GOOGLE_REDIRECT_URI')) || 'https://api.algapsa.com/api/auth/google/callback';
       } else {
-        clientId = await secretProvider.getAppSecret('MICROSOFT_CLIENT_ID');
+        clientId = (await secretProvider.getAppSecret('MICROSOFT_CLIENT_ID')) || null;
         effectiveRedirectUri = effectiveRedirectUri || (await secretProvider.getAppSecret('MICROSOFT_REDIRECT_URI')) || 'https://api.algapsa.com/api/auth/microsoft/callback';
       }
     } else {

--- a/server/src/lib/actions/email-actions/oauthActions.ts
+++ b/server/src/lib/actions/email-actions/oauthActions.ts
@@ -1,0 +1,69 @@
+'use server'
+
+import { getCurrentUser } from '../user-actions/userActions';
+import { getSecretProviderInstance } from '@alga-psa/shared/core';
+import { generateMicrosoftAuthUrl, generateGoogleAuthUrl, generateNonce, type OAuthState } from '@/utils/email/oauthHelpers';
+
+export async function initiateEmailOAuth(params: {
+  provider: 'microsoft' | 'google';
+  providerId?: string;
+  redirectUri?: string;
+}): Promise<{ success: true; authUrl: string; state: string } | { success: false; error: string } > {
+  const user = await getCurrentUser();
+  if (!user) return { success: false, error: 'Unauthorized' };
+
+  try {
+    const { provider, providerId, redirectUri } = params;
+    const secretProvider = await getSecretProviderInstance();
+
+    // Hosted detection via NEXTAUTH_URL
+    const nextauthUrl = process.env.NEXTAUTH_URL || (await secretProvider.getAppSecret('NEXTAUTH_URL')) || '';
+    const isHosted = nextauthUrl.startsWith('https://algapsa.com');
+
+    let clientId: string | null = null;
+    let effectiveRedirectUri = redirectUri || '';
+
+    if (isHosted) {
+      if (provider === 'google') {
+        clientId = await secretProvider.getAppSecret('GOOGLE_CLIENT_ID');
+        effectiveRedirectUri = effectiveRedirectUri || (await secretProvider.getAppSecret('GOOGLE_REDIRECT_URI')) || 'https://api.algapsa.com/api/auth/google/callback';
+      } else {
+        clientId = await secretProvider.getAppSecret('MICROSOFT_CLIENT_ID');
+        effectiveRedirectUri = effectiveRedirectUri || (await secretProvider.getAppSecret('MICROSOFT_REDIRECT_URI')) || 'https://api.algapsa.com/api/auth/microsoft/callback';
+      }
+    } else {
+      if (provider === 'google') {
+        clientId = process.env.GOOGLE_CLIENT_ID || (await secretProvider.getTenantSecret(user.tenant, 'google_client_id')) || null;
+      } else {
+        clientId = process.env.MICROSOFT_CLIENT_ID || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_client_id')) || null;
+      }
+      if (!effectiveRedirectUri) {
+        const base = process.env.NEXT_PUBLIC_BASE_URL || (await secretProvider.getAppSecret('NEXT_PUBLIC_BASE_URL')) || 'http://localhost:3000';
+        effectiveRedirectUri = `${base}/api/auth/${provider}/callback`;
+      }
+    }
+
+    if (!clientId) {
+      return { success: false, error: `${provider} OAuth client ID not configured` };
+    }
+
+    const state: OAuthState = {
+      tenant: user.tenant,
+      userId: user.user_id,
+      providerId,
+      redirectUri: effectiveRedirectUri,
+      timestamp: Date.now(),
+      nonce: generateNonce(),
+      hosted: isHosted
+    };
+
+    const authUrl = provider === 'microsoft'
+      ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state)
+      : generateGoogleAuthUrl(clientId, state.redirectUri, state);
+
+    return { success: true, authUrl, state: Buffer.from(JSON.stringify(state)).toString('base64') };
+  } catch (err: any) {
+    return { success: false, error: err?.message || 'Failed to initiate OAuth' };
+  }
+}
+

--- a/server/src/lib/actions/email-actions/oauthActions.ts
+++ b/server/src/lib/actions/email-actions/oauthActions.ts
@@ -57,8 +57,17 @@ export async function initiateEmailOAuth(params: {
       hosted: isHosted
     };
 
+    // Determine Microsoft tenant authority for single-tenant apps
+    let msTenantAuthority: string | undefined;
+    if (provider === 'microsoft') {
+      msTenantAuthority = process.env.MICROSOFT_TENANT_ID
+        || (await secretProvider.getAppSecret('MICROSOFT_TENANT_ID'))
+        || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_tenant_id'))
+        || 'common';
+    }
+
     const authUrl = provider === 'microsoft'
-      ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state)
+      ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state, undefined as any, msTenantAuthority)
       : generateGoogleAuthUrl(clientId, state.redirectUri, state);
 
     return { success: true, authUrl, state: Buffer.from(JSON.stringify(state)).toString('base64') };
@@ -66,4 +75,3 @@ export async function initiateEmailOAuth(params: {
     return { success: false, error: err?.message || 'Failed to initiate OAuth' };
   }
 }
-

--- a/server/src/middleware/express/authMiddleware.ts
+++ b/server/src/middleware/express/authMiddleware.ts
@@ -102,6 +102,12 @@ export async function apiKeyAuthMiddleware(
     return next();
   }
 
+  // Skip API key requirement for OAuth initiation when user is authenticated via session
+  // The route itself checks session via getCurrentUser and returns 401 if not logged in
+  if (req.path === '/api/email/oauth/initiate' || req.path === '/api/email/oauth/initiate/') {
+    return next();
+  }
+
   const apiKey = req.headers['x-api-key'] as string;
   
   if (!apiKey) {

--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -108,7 +108,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       }
 
       // Determine tenant authority for single-tenant apps
-      const vendorTenantId = this.config.provider_config?.tenant_id;
+      const vendorTenantId = (this.config.provider_config as any)?.tenant_id || this.config.provider_config?.tenantId;
       let tenantAuthority = vendorTenantId || process.env.MICROSOFT_TENANT_ID;
       if (!tenantAuthority) {
         try {

--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -170,6 +170,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         const knex = await getAdminConnection();
         await knex('microsoft_email_provider_config')
           .where('email_provider_id', this.config.id)
+          .andWhere('tenant', this.config.tenant)
           .update({
             access_token: this.accessToken,
             refresh_token: this.refreshToken,
@@ -229,11 +230,13 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         // email_providers: set webhook_id for lookup by route
         await knex('email_providers')
           .where('id', this.config.id)
+          .andWhere('tenant', this.config.tenant)
           .update({ webhook_id: response.data.id, updated_at: new Date().toISOString() });
 
         // microsoft_email_provider_config: track subscription specific fields
         await knex('microsoft_email_provider_config')
           .where('email_provider_id', this.config.id)
+          .andWhere('tenant', this.config.tenant)
           .update({
             webhook_subscription_id: response.data.id,
             webhook_expires_at: response.data.expirationDateTime,
@@ -272,6 +275,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         const knex = await getAdminConnection();
         await knex('microsoft_email_provider_config')
           .where('email_provider_id', this.config.id)
+          .andWhere('tenant', this.config.tenant)
           .update({ webhook_expires_at: newExpiry, updated_at: new Date().toISOString() });
       } catch (dbErr: any) {
         this.log('warn', `Failed to persist webhook renewal: ${dbErr?.message}`);

--- a/server/src/utils/email/oauthHelpers.ts
+++ b/server/src/utils/email/oauthHelpers.ts
@@ -21,9 +21,10 @@ export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
-  scopes: string[] = ['https://graph.microsoft.com/.default', 'offline_access']
+  scopes: string[] = ['https://graph.microsoft.com/.default', 'offline_access'],
+  tenantAuthority: string = 'common'
 ): string {
-  const baseUrl = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
+  const baseUrl = `https://login.microsoftonline.com/${encodeURIComponent(tenantAuthority)}/oauth2/v2.0/authorize`;
   
   const params = new URLSearchParams({
     client_id: clientId,


### PR DESCRIPTION
Summary:
- Microsoft vs Gmail inbound parity
  - DB-backed token load/refresh for Microsoft
  - Webhook persistence in email_providers and microsoft_email_provider_config
  - Enriched INBOUND_EMAIL_RECEIVED events with full emailData
- Single-tenant Microsoft OAuth
  - Tenant-specific authority for authorize, token exchange, and refresh (fixes AADSTS50194)
- UI refactor
  - CE/EE Microsoft and Gmail forms call server actions (no x-api-key in UI)
  - Exempt /api/email/oauth/initiate from API-key middleware for authenticated UI
- Tooling: adds scripts/ms-graph-list-subscriptions.cjs; improved error logging
- Docs: updates EE plan to mark completed tasks

Testing:
- Microsoft: set MICROSOFT_TENANT_ID to tenant GUID; OAuth popup works; enriched events published
- Gmail: OAuth via server action; no API key needed
- Script: delegated ACCESS_TOKEN mode; app-only requires CA and admin consent

Notes:
- Minimal delegated perms: User.Read, Mail.Read, offline_access (Mail.ReadWrite optional for mark/move)
- Single-tenant supported; multi-tenant still possible when needed
