### PR TITLE
RBAC: gate email OAuth using system_settings

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -380,6 +380,26 @@ spec:
           {{- end }}
           {{- end }}
 
+          # ----------- MICROSOFT INTEGRATION ----------------
+          {{- if .Values.microsoft_integration.enabled }}
+          {{- if .Values.microsoft_integration.client_id }}
+          - name: MICROSOFT_CLIENT_ID
+            value: "{{ .Values.microsoft_integration.client_id }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.client_secret }}
+          - name: MICROSOFT_CLIENT_SECRET
+            value: "{{ .Values.microsoft_integration.client_secret }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.tenant_id }}
+          - name: MICROSOFT_TENANT_ID
+            value: "{{ .Values.microsoft_integration.tenant_id }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.redirect_uri }}
+          - name: MICROSOFT_REDIRECT_URI
+            value: "{{ .Values.microsoft_integration.redirect_uri }}"
+          {{- end }}
+          {{- end }}
+
           # ----------- SECRET PROVIDER ----------------
           # Composite secret provider configuration
           - name: SECRET_READ_CHAIN

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -264,6 +264,17 @@ gmail_integration:
   project_id: ""
   redirect_uri: ""
 
+# Microsoft Graph (Microsoft 365) integration
+microsoft_integration:
+  enabled: false
+  # Azure AD App Registration (delegated) credentials
+  client_id: ""
+  client_secret: ""
+  # Use tenant GUID for single-tenant; use 'common' only for multi-tenant
+  tenant_id: ""
+  # OAuth redirect URI configured in the app registration
+  redirect_uri: ""
+
 # Secret Provider Configuration
 # Controls how secrets are read and written across different providers
 secrets:

--- a/server/src/lib/actions/email-actions/oauthActions.ts
+++ b/server/src/lib/actions/email-actions/oauthActions.ts
@@ -17,7 +17,7 @@ export async function initiateEmailOAuth(params: {
   try {
     // RBAC: validate permission based on intent (create vs update)
     const isUpdate = !!params.providerId;
-    const resource = 'emailproviders';
+    const resource = 'system_settings';
     const action = isUpdate ? 'update' : 'create';
     const permitted = await hasPermission(user as any, resource, action);
     if (!permitted) {


### PR DESCRIPTION
Switch OAuth RBAC gating from non-existent `emailproviders` to existing `system_settings`.

- Resource: `system_settings`
- Action: `create` when adding, `update` when editing (via `providerId`)
- File: `server/src/lib/actions/email-actions/oauthActions.ts`

This aligns with existing RBAC permissions in prod until a dedicated `emailproviders` resource is added.