### PR TITLE
Microsoft Graph: fix subscription 400s (validation + expiration window)

### DIFF
--- a/server/src/app/api/email/webhooks/microsoft/route.ts
+++ b/server/src/app/api/email/webhooks/microsoft/route.ts
@@ -25,12 +25,33 @@ interface MicrosoftWebhookPayload {
   value: MicrosoftNotification[];
 }
 
+// Handle GET for Microsoft validation handshake
+export async function GET(request: NextRequest) {
+  try {
+    const url = request.nextUrl;
+    const validationToken = url.searchParams.get('validationtoken') || url.searchParams.get('validationToken');
+    if (validationToken) {
+      console.log('Microsoft webhook validation (GET) received');
+      return new NextResponse(validationToken, {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      });
+    }
+    // If no token, just acknowledge
+    return new NextResponse('OK', { status: 200 });
+  } catch (error) {
+    console.error('Microsoft webhook GET handler error:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Handle subscription validation
-    const validationToken = request.headers.get('validationtoken');
+    // Microsoft may send validation either via querystring (GET) or header on POST in some flows/tests
+    const validationToken = request.headers.get('validationtoken') || request.headers.get('ValidationToken');
     if (validationToken) {
-      console.log('Microsoft webhook validation request received');
+      console.log('Microsoft webhook validation (POST) received');
       return new NextResponse(validationToken, {
         status: 200,
         headers: {

--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -210,11 +210,14 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         throw new Error('Webhook notification URL not configured');
       }
 
+      // Microsoft Graph limit for Outlook message subscriptions is 4230 minutes (~70.5 hours)
+      // Use a safe window (e.g., 60 hours) to avoid 400 due to out-of-range expiration
+      const expirationMs = 60 * 60 * 1000 * 60; // 60 hours in ms
       const subscription = {
         changeType: 'created',
         notificationUrl: webhookUrl,
         resource: `/me/mailFolders('${this.config.folder_to_monitor}')/messages`,
-        expirationDateTime: new Date(Date.now() + (3 * 24 * 60 * 60 * 1000)).toISOString(), // 3 days
+        expirationDateTime: new Date(Date.now() + expirationMs).toISOString(),
         clientState: this.config.webhook_verification_token || 'email-webhook-verification',
       };
 


### PR DESCRIPTION
Fixes subscription creation failing with 400 and webhook validation parsing errors.

Key changes:
- Add GET handler for Microsoft webhook to echo validationToken query param as plain text (required by Graph validation handshake)
- Accept ValidationToken via POST header as a fallback and short-circuit before JSON parsing
- Keep subscription expiration inside Graph limits (~60 hours) to avoid out-of-range 400s

Why:
- Logs showed 400 from POST /v1.0/subscriptions and SyntaxError: Unexpected end of JSON input in webhook handler. These are consistent with (a) invalid expirationDateTime and (b) attempting to JSON-parse validation requests with no payload.

Testing/QA:
- Re-run Microsoft OAuth callback; subscription should be created successfully
- Send a GET request to /api/email/webhooks/microsoft?validationtoken=foo and verify the response body echoes  with Content-Type: text/plain
- Send a POST with header ValidationToken and empty body; verify echo response without JSON parse errors
