### PR TITLE
Fix Microsoft Graph webhook validation and persistence

### DIFF
--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -308,6 +308,26 @@ spec:
             value: "{{ .Values.email.user }}"
           - name: EMAIL_PASSWORD
             value: "{{ .Values.email.password }}"
+          # Optional: Explicit provider type. If omitted, factory auto-detects 'resend' by RESEND_API_KEY
+          {{- if .Values.email.provider }}
+          - name: EMAIL_PROVIDER_TYPE
+            value: "{{ .Values.email.provider }}"
+          {{- end }}
+          # RESEND configuration (preferred for system emails). Use secret if available, else value.
+          {{- if and .Values.email.resendApiKeySecret.name .Values.email.resendApiKeySecret.key }}
+          - name: RESEND_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.email.resendApiKeySecret.name | quote }}
+                key: {{ .Values.email.resendApiKeySecret.key | quote }}
+          {{- else if .Values.email.resendApiKey }}
+          - name: RESEND_API_KEY
+            value: "{{ .Values.email.resendApiKey }}"
+          {{- end }}
+          {{- if .Values.email.resendBaseUrl }}
+          - name: RESEND_BASE_URL
+            value: "{{ .Values.email.resendBaseUrl }}"
+          {{- end }}
 
           # ----------- LLM ----------------
           - name: OPENAI_API_KEY
@@ -346,6 +366,9 @@ spec:
           # ----------- AUTH ----------------
           - name: NEXTAUTH_URL
             value: "https://{{ .Values.devPod.host | default .Values.host }}"
+          # Public base URL for links in emails and client-side code
+          - name: NEXT_PUBLIC_BASE_URL
+            value: "https://{{ .Values.devPod.host | default .Values.host }}"
           - name: NEXTAUTH_SECRET
             valueFrom:
               secretKeyRef:
@@ -360,6 +383,40 @@ spec:
             value: "{{ .Values.google_auth.client_id }}"
           - name: GOOGLE_OAUTH_CLIENT_SECRET
             value: "{{ .Values.google_auth.client_secret }}"
+          {{- end }}
+
+          # ----------- GMAIL INTEGRATION ----------------
+          {{- if .Values.gmail_integration.enabled }}
+          - name: GOOGLE_CLIENT_ID
+            value: "{{ .Values.gmail_integration.client_id }}"
+          - name: GOOGLE_CLIENT_SECRET
+            value: "{{ .Values.gmail_integration.client_secret }}"
+          - name: GOOGLE_PROJECT_ID
+            value: "{{ .Values.gmail_integration.project_id }}"
+          {{- if .Values.gmail_integration.redirect_uri }}
+          - name: GOOGLE_REDIRECT_URI
+            value: "{{ .Values.gmail_integration.redirect_uri }}"
+          {{- end }}
+          {{- end }}
+
+          # ----------- MICROSOFT INTEGRATION ----------------
+          {{- if .Values.microsoft_integration.enabled }}
+          {{- if .Values.microsoft_integration.client_id }}
+          - name: MICROSOFT_CLIENT_ID
+            value: "{{ .Values.microsoft_integration.client_id }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.client_secret }}
+          - name: MICROSOFT_CLIENT_SECRET
+            value: "{{ .Values.microsoft_integration.client_secret }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.tenant_id }}
+          - name: MICROSOFT_TENANT_ID
+            value: "{{ .Values.microsoft_integration.tenant_id }}"
+          {{- end }}
+          {{- if .Values.microsoft_integration.redirect_uri }}
+          - name: MICROSOFT_REDIRECT_URI
+            value: "{{ .Values.microsoft_integration.redirect_uri }}"
+          {{- end }}
           {{- end }}
 
           # ----------- SECRET PROVIDER ----------------

--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -36,6 +36,8 @@ spec:
           export {{ $k }}="{{ $v }}"
           {{- end -}}
           {{- end }}`}}
+        # Fix for Vault + Istio compatibility - exclude Vault traffic from Istio proxy
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.43.191.106/32"
         {{- end }}
       labels:
         {{- include "sebastian.selectorLabels" . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           export {{ $k }}="{{ $v }}"
           {{- end -}}
           {{- end }}`}}
+        # Fix for Vault + Istio compatibility - exclude Vault traffic from Istio proxy
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.43.191.106/32"
         {{- end }}
       labels:
         {{- include "sebastian.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
This PR resolves Microsoft Graph subscription validation failures and a schema mismatch during persistence.

Root Causes
- Validation failure: Microsoft Graph calls the `notificationUrl` with a `validationToken`. Our POST handler didn’t echo it and sometimes attempted to parse an empty body, causing 500s; Graph responded with `400 ValidationError` and message "OK" (we replied "OK" instead of the token).
- Persistence mismatch: After subscription creation we attempted to write `email_providers.webhook_id`, which doesn’t exist. The canonical fields are in `microsoft_email_provider_config`.

Fixes
- Webhook POST validation handling
  - Echo `validationToken` from headers or query params as plain text with 200.
  - Robust body parsing: if empty or non-JSON during validation probes, respond 200 to avoid crashes.
  - File: `server/src/app/api/email/webhooks/microsoft/route.ts`
- Subscription persistence
  - Removed write to non-existent `email_providers.webhook_id`.
  - Persist subscription fields only in `microsoft_email_provider_config` (`webhook_subscription_id`, `webhook_expires_at`, `webhook_verification_token`).
  - File: `server/src/services/email/providers/MicrosoftGraphAdapter.ts`
- Instrumentation
  - Callback route: context logs around subscription (tenant, providerId, mailbox, URL, masked token).
  - Adapter: logs subscription payload; on error, logs status/request-id/body details.
  - Base adapter: propagates status/code/requestId in thrown errors.
  - Files: callback route, MicrosoftGraphAdapter, BaseEmailAdapter

Outcome
- Graph validation succeeds and subscriptions create without 400s.
- DB warning about `email_providers.webhook_id` is eliminated.
- Logs include request-id/status for quick correlation with Microsoft logs.

Future work
- Optionally wire scheduled `renewWebhookSubscription()` before expiry.