### PR TITLE
helm: make Istio sidecar exclusions configurable; default exclude 8200 for Vault Agent

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -10,3 +10,13 @@ helm upgrade sebastian --kubeconfig ~/.kube/config-dev . -n msp
 ---
 
 sudo helm template sebastian helm -f values.draft.yaml > deployment.yaml         
+
+Istio/Vault networking
+- The chart sets `traffic.sidecar.istio.io/excludeOutboundPorts: "8200"` by default when you enable Vault annotations, so Vault Agent can reach Vault without Envoy during init.
+- You can fine-tune via values:
+  - `istio.sidecar.excludeOutboundPorts` (list, default ["8200"]) – bypass Envoy for these ports.
+  - `istio.sidecar.excludeOutboundIPRanges` (string CIDRs) – optionally bypass by IP ranges.
+  - `istio.sidecar.includeOutboundIPRanges` (string CIDRs) – optionally restrict Envoy egress ranges.
+
+Upgrade example
+- `helm upgrade sebastian . -n msp -f values.yaml`

--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -37,7 +37,15 @@ spec:
           {{- end -}}
           {{- end }}`}}
         # Fix for Vault + Istio compatibility - exclude Vault traffic from Istio proxy
-        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.43.191.106/32"
+        {{- with .Values.istio.sidecar.excludeOutboundPorts }}
+        traffic.sidecar.istio.io/excludeOutboundPorts: "{{ join "," . }}"
+        {{- end }}
+        {{- with .Values.istio.sidecar.excludeOutboundIPRanges }}
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ . }}"
+        {{- end }}
+        {{- with .Values.istio.sidecar.includeOutboundIPRanges }}
+        traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ . }}"
+        {{- end }}
         {{- end }}
       labels:
         {{- include "sebastian.selectorLabels" . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -35,7 +35,15 @@ spec:
           {{- end -}}
           {{- end }}`}}
         # Fix for Vault + Istio compatibility - exclude Vault traffic from Istio proxy
-        traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.43.191.106/32"
+        {{- with .Values.istio.sidecar.excludeOutboundPorts }}
+        traffic.sidecar.istio.io/excludeOutboundPorts: "{{ join "," . }}"
+        {{- end }}
+        {{- with .Values.istio.sidecar.excludeOutboundIPRanges }}
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ . }}"
+        {{- end }}
+        {{- with .Values.istio.sidecar.includeOutboundIPRanges }}
+        traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ . }}"
+        {{- end }}
         {{- end }}
       labels:
         {{- include "sebastian.selectorLabels" . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -373,3 +373,15 @@ vaultAgent:
   role: alga-psa
   secretPath: secret/data/alga-psa/server
   sharedSecretPath: secret/data/alga-psa/shared
+
+# Istio sidecar configuration (esp. for Vault agent compatibility)
+# By default, exclude Vault's port 8200 from Envoy interception so
+# init containers/sidecars can reach Vault before Envoy is ready.
+istio:
+  sidecar:
+    # List of outbound ports to bypass Envoy (comma-joined in template)
+    excludeOutboundPorts: ["8200"]
+    # Optional CIDR ranges to bypass Envoy egress (string). Leave empty to disable.
+    excludeOutboundIPRanges: ""
+    # Optional CIDR ranges to allow via Envoy only (string). Leave empty to disable.
+    includeOutboundIPRanges: ""


### PR DESCRIPTION
This PR makes Istio sidecar networking exclusions configurable in the sebastian Helm chart and defaults to excluding port 8200 so Vault Agent can authenticate without Envoy interception.

Changes:
- values.yaml: add  options; default .
- templates/deployment.yaml & deployment-dev.yaml: render  annotations from values; remove hardcoded Vault IP.
- README.md: document Istio/Vault networking knobs and upgrade example.

Context: pods in  were stuck during init due to Istio intercepting Vault traffic (8200) before sidecar readiness. Excluding 8200 allows Vault Agent to authenticate and unblock startup.

Follow-ups: optionally set include/exclude IP CIDRs in values for stricter environments.