### PR TITLE
shared: export extensions subpaths for ESM resolution

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -28,7 +28,10 @@
     "./models/contactModel.js": "./dist/models/contactModel.js",
     "./models/tagModel.js": "./dist/models/tagModel.js",
     "./models/ticketModel.js": "./dist/models/ticketModel.js",
-    "./models/userModel.js": "./dist/models/userModel.js"
+    "./models/userModel.js": "./dist/models/userModel.js",
+    "./extensions/domain.js": "./dist/extensions/domain.js",
+    "./extensions/installs.js": "./dist/extensions/installs.js",
+    "./extensions/types.js": "./dist/extensions/types.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Fix ESM subpath exports for shared extensions

- Add exports for `./extensions/domain.js`, `./extensions/installs.js`, and `./extensions/types.js` in `shared/package.json`.
- Resolves `ERR_PACKAGE_PATH_NOT_EXPORTED` when the Temporal worker imports `@alga-psa/shared/extensions/domain.js`.

Validation
- Build shared and temporal worker Docker image to ensure import resolution.
- Helm deploy should now start without the ESM error.

Follow-ups
- Consider a CI check that fails on unexported subpath imports from `@alga-psa/shared`.
