### PR TITLE
runner: send ALGA_AUTH_KEY as x-api-key to registry

### DIFF
--- a/ee/docs/extension-system/runner.md
+++ b/ee/docs/extension-system/runner.md
@@ -123,6 +123,8 @@ References:
 - `EXT_GATEWAY_TIMEOUT_MS`: Gateway-side invocation timeout (Runner should also have server-side timeouts).
 - `SIGNING_TRUST_BUNDLE`: Path or value for trusted publisher certificates/keys.
 - `BUNDLE_STORAGE_*`: Object storage configuration for content-addressed bundle retrieval (S3 or equivalent, if used).
+- `REGISTRY_BASE_URL`: Base URL of the EE server for registry lookups (e.g., `https://algapsa.com`).
+- `ALGA_AUTH_KEY`: Service API key used by the Runner when calling the EE registry endpoints. The Runner sends this as `x-api-key` for `/api/installs/lookup-by-host` and `/api/installs/validate`.
 
 ## Gateway → Runner flow (summary)
 

--- a/ee/runner/src/http/server.rs
+++ b/ee/runner/src/http/server.rs
@@ -244,7 +244,15 @@ async fn root_dispatch(headers: HeaderMap) -> Response {
         }
     };
 
-    let resp = match http.get(url.clone()).send().await {
+    // Attach ALGA_AUTH_KEY if present for registry auth
+    let mut rb = http.get(url.clone());
+    if let Ok(key) = std::env::var("ALGA_AUTH_KEY") {
+        if !key.is_empty() {
+            rb = rb.header("x-api-key", key);
+        }
+    }
+
+    let resp = match rb.send().await {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(host=%host, url=%url.to_string(), err=%e.to_string(), "registry request failed");

--- a/shared/package.json
+++ b/shared/package.json
@@ -28,7 +28,10 @@
     "./models/contactModel.js": "./dist/models/contactModel.js",
     "./models/tagModel.js": "./dist/models/tagModel.js",
     "./models/ticketModel.js": "./dist/models/ticketModel.js",
-    "./models/userModel.js": "./dist/models/userModel.js"
+    "./models/userModel.js": "./dist/models/userModel.js",
+    "./extensions/domain.js": "./dist/extensions/domain.js",
+    "./extensions/installs.js": "./dist/extensions/installs.js",
+    "./extensions/types.js": "./dist/extensions/types.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Runner: authenticate registry calls with ALGA_AUTH_KEY

- Attach `x-api-key` header from env `ALGA_AUTH_KEY` for:
  - Root host lookup: `GET /api/installs/lookup-by-host?host=...`
  - Strict validation client: `GET /api/installs/validate?tenant=...&extension=...&hash=...`
- Update Runner docs to include `REGISTRY_BASE_URL` and `ALGA_AUTH_KEY` in configuration.

Why:
- EE server enforces API key auth on `/api/*`. Runner’s registry calls were receiving 401.

Infra follow-up (Knative KService):
- Ensure the Runner deployment sets `ALGA_AUTH_KEY` (via Vault/Secret).
  Example (Knative Service spec):
  ```yaml
  apiVersion: serving.knative.dev/v1
  kind: Service
  metadata:
    name: runner
    namespace: <ns>
  spec:
    template:
      spec:
        containers:
          - image: <runner-image>
            env:
              - name: REGISTRY_BASE_URL
                value: https://algapsa.com
              - name: ALGA_AUTH_KEY
                valueFrom:
                  secretKeyRef:
                    name: runner-secrets
                    key: ALGA_AUTH_KEY
  ```
