### PR TITLE
Replace knex.fn.now() with literal timestamps for Citus compatibility

### DIFF
--- a/server/src/lib/actions/tenant-settings-actions/tenantSettingsActions.ts
+++ b/server/src/lib/actions/tenant-settings-actions/tenantSettingsActions.ts
@@ -57,14 +57,17 @@ export async function updateTenantOnboardingStatus(
 
     const { knex } = await createTenantKnex();
     
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     const updateData: any = {
       onboarding_completed: completed,
       onboarding_skipped: skipped,
-      updated_at: knex.fn.now(),
+      updated_at: now,
     };
 
     if (completed) {
-      updateData.onboarding_completed_at = knex.fn.now();
+      updateData.onboarding_completed_at = now;
       // Clear onboarding data when completed
       updateData.onboarding_data = null;
     } else if (wizardData) {
@@ -122,6 +125,9 @@ export async function saveTenantOnboardingProgress(
 
     const { knex } = await createTenantKnex();
     
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     // Check if tenant settings already exist
     const existingRecord = await knex('tenant_settings')
       .where({ tenant })
@@ -133,7 +139,7 @@ export async function saveTenantOnboardingProgress(
         .where({ tenant })
         .update({
           onboarding_data: JSON.stringify(mergedData),
-          updated_at: knex.fn.now(),
+          updated_at: now,
         });
     } else {
       // Insert new settings
@@ -141,7 +147,7 @@ export async function saveTenantOnboardingProgress(
         .insert({
           tenant,
           onboarding_data: JSON.stringify(mergedData),
-          updated_at: knex.fn.now(),
+          updated_at: now,
         });
     }
 
@@ -166,11 +172,14 @@ export async function clearTenantOnboardingData(): Promise<void> {
 
     const { knex } = await createTenantKnex();
     
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     await knex('tenant_settings')
       .where({ tenant })
       .update({
         onboarding_data: null,
-        updated_at: knex.fn.now(),
+        updated_at: now,
       });
 
   } catch (error) {
@@ -199,16 +208,19 @@ export async function updateTenantSettings(
 
     const { knex } = await createTenantKnex();
     
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     await knex('tenant_settings')
       .insert({
         tenant,
         settings: JSON.stringify(updatedSettings),
-        updated_at: knex.fn.now(),
+        updated_at: now,
       })
       .onConflict('tenant')
       .merge({
         settings: JSON.stringify(updatedSettings),
-        updated_at: knex.fn.now(),
+        updated_at: now,
       });
 
   } catch (error) {
@@ -253,6 +265,9 @@ export async function initializeTenantSettings(tenantId: string): Promise<void> 
   try {
     const { knex } = await createTenantKnex();
     
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     // Initialize tenant settings with both onboarding flags set to false
     await knex('tenant_settings')
       .insert({
@@ -261,8 +276,8 @@ export async function initializeTenantSettings(tenantId: string): Promise<void> 
         onboarding_skipped: false,
         onboarding_data: null,
         settings: null,
-        created_at: knex.fn.now(),
-        updated_at: knex.fn.now(),
+        created_at: now,
+        updated_at: now,
       })
       .onConflict('tenant')
       .ignore(); // Don't overwrite if already exists

--- a/server/src/lib/actions/ticket-actions/ticketDisplaySettings.ts
+++ b/server/src/lib/actions/ticket-actions/ticketDisplaySettings.ts
@@ -112,10 +112,13 @@ export async function updateTicketingDisplaySettings(updated: TicketingDisplaySe
       ...updated,
     };
 
+    // Use a literal timestamp for Citus compatibility
+    const now = new Date();
+    
     await knex('tenant_settings')
-      .insert({ tenant, ticket_display_settings: JSON.stringify(merged), updated_at: knex.fn.now() })
+      .insert({ tenant, ticket_display_settings: JSON.stringify(merged), updated_at: now })
       .onConflict('tenant')
-      .merge({ ticket_display_settings: JSON.stringify(merged), updated_at: knex.fn.now() });
+      .merge({ ticket_display_settings: JSON.stringify(merged), updated_at: now });
 
     return { success: true };
   } catch (e) {

--- a/server/src/lib/models/userPreferences.tsx
+++ b/server/src/lib/models/userPreferences.tsx
@@ -230,12 +230,15 @@ const UserPreferences = {
             const trx = isTransaction ? knexOrTrx as Knex.Transaction : await knexOrTrx.transaction();
             
             try {
+                // Use a literal timestamp for Citus compatibility
+                const now = new Date();
+                
                 for (const preference of preferences) {
                     // Ensure tenant cannot be modified and is set to context tenant
                     const preferenceData = {
                         ...preference,
                         tenant,
-                        updated_at: knexOrTrx.fn.now()
+                        updated_at: now
                     };
 
                     await trx<IUserPreference>('user_preferences')
@@ -243,7 +246,7 @@ const UserPreferences = {
                         .onConflict(['tenant', 'user_id', 'setting_name'])
                         .merge({
                             setting_value: preferenceData.setting_value,
-                            updated_at: preferenceData.updated_at
+                            updated_at: now
                         });
                 }
                 


### PR DESCRIPTION
Updated tenant settings actions, ticket display settings, and user preferences models to use literal Date objects instead of knex.fn.now() for timestamp fields. This ensures compatibility with Citus distributed PostgreSQL while maintaining the same functionality. All timestamp updates now use explicit Date instances rather than database functions.

And down the rabbit hole we go, where database functions become literal tea-time dates! 🐇⏰☕️