### PR TITLE
S3 uploads: pass explicit contentLength to avoid invalid x-amz-decoded-content-length

### DIFF
--- a/ee/server/src/app/api/ext-bundles/upload-proxy/route.ts
+++ b/ee/server/src/app/api/ext-bundles/upload-proxy/route.ts
@@ -216,6 +216,7 @@ export async function POST(req: Request) {
         contentType,
         cacheControl: undefined,
         ifNoneMatch: "*",
+        contentLength: size,
       });
       eTag = out?.eTag;
     } catch (e: any) {

--- a/ee/server/src/components/settings/extensions/InstallerPanel.tsx
+++ b/ee/server/src/components/settings/extensions/InstallerPanel.tsx
@@ -74,7 +74,7 @@ export default function InstallerPanel() {
     const f = e.target.files?.[0] ?? null;
     if (f) {
       if (!f.name.endsWith('.tar.zst')) {
-        alert('File must end with ".tar.zst"');
+        alert('File must end with ".tar.zst", ' + f.name);
         e.currentTarget.value = '';
         return;
       }

--- a/ee/server/src/lib/actions/extBundleActions.ts
+++ b/ee/server/src/lib/actions/extBundleActions.ts
@@ -96,7 +96,11 @@ export async function extUploadProxy(formData: FormData): Promise<{ upload: { ke
     const webStream = (file as any).stream() as unknown as ReadableStream;
     const nodeStream = Readable.fromWeb(webStream as any);
     // contentLength is not part of our PutObjectOptions; omit to satisfy types
-    await store.putObject(key, nodeStream as unknown as NodeJS.ReadableStream, { contentType, ifNoneMatch: "*" });
+    await store.putObject(
+      key,
+      nodeStream as unknown as NodeJS.ReadableStream,
+      { contentType, ifNoneMatch: "*", contentLength: size }
+    );
   } catch (e: any) {
     try { console.log(JSON.stringify({ ts: new Date().toISOString(), event: "ext_bundles.upload_proxy.action.s3_error", message: typeof e?.message === "string" ? e.message : String(e), status: e?.httpStatusCode ?? e?.statusCode })); } catch {}
     throw new Error("Failed to store upload");

--- a/ee/server/src/lib/storage/bundles/s3-bundle-store.ts
+++ b/ee/server/src/lib/storage/bundles/s3-bundle-store.ts
@@ -120,6 +120,7 @@ export function createS3BundleStore(config?: BundleStoreConfig): IBundleStore {
       const effective: PutObjectOptions = {
         contentType: opts?.contentType,
         cacheControl: opts?.cacheControl,
+        contentLength: opts?.contentLength,
         ifNoneMatch: opts?.ifNoneMatch ?? "*",
       };
       try {

--- a/ee/server/src/lib/storage/bundles/types.ts
+++ b/ee/server/src/lib/storage/bundles/types.ts
@@ -47,6 +47,11 @@ export interface PutObjectOptions {
   contentType?: string;
   cacheControl?: string;
   /**
+   * Optional content length hint for streaming uploads. When provided, the
+   * underlying client can avoid chunked uploads and ambiguous headers.
+   */
+  contentLength?: number;
+  /**
    * Write-once protection. If unspecified, helpers will default to If-None-Match: "*".
    */
   ifNoneMatch?: string;


### PR DESCRIPTION
- Add contentLength to PutObjectOptions (bundle store types)
- Propagate contentLength through S3 bundle store to client
- Supply contentLength from ext upload server action
- Supply contentLength from API upload-proxy route

Prevents S3/compat providers from receiving undefined decoded-content-length
in streamed uploads, fixing failures like:
"Invalid value \"undefined\" for header \"x-amz-decoded-content-length\"".
