### PR TITLE
fix(typescript): remove duplicate contentLength properties

### DIFF
--- a/ee/server/src/lib/storage/bundles/s3-bundle-store.ts
+++ b/ee/server/src/lib/storage/bundles/s3-bundle-store.ts
@@ -124,7 +124,6 @@ export function createS3BundleStore(config?: BundleStoreConfig): IBundleStore {
         cacheControl: opts?.cacheControl,
         contentLength: opts?.contentLength,
         ifNoneMatch: opts?.ifNoneMatch ?? "*",
-        contentLength: opts?.contentLength,
       };
       try {
         return await s3PutObject(key, body as any, effective, bundleBucket);

--- a/ee/server/src/lib/storage/bundles/types.ts
+++ b/ee/server/src/lib/storage/bundles/types.ts
@@ -46,8 +46,6 @@ export interface BundleStoreConfig {
 export interface PutObjectOptions {
   contentType?: string;
   cacheControl?: string;
-  /** Known content length in bytes (used by some providers). */
-  contentLength?: number;
   /**
    * Optional content length hint for streaming uploads. When provided, the
    * underlying client can avoid chunked uploads and ambiguous headers.


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation errors by removing duplicate `contentLength` property declarations
- Cleaned up redundant property assignments in S3 bundle store

## Changes
- Removed duplicate `contentLength` property declaration in `PutObjectOptions` interface (types.ts)
- Removed duplicate `contentLength` assignment in s3-bundle-store.ts effective options object
- Resolves TypeScript errors TS2300 (duplicate identifier) and TS1117 (duplicate property in object literal)

## Test plan
- [x] Run `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` - builds successfully without errors
- [ ] Verify S3 bundle store functionality remains intact
- [ ] Confirm content length is properly passed through to S3 operations

🤖 Generated with [Claude Code](https://claude.ai/code)