### PR TITLE
feat: Add URL routing for ticketing settings sub-sections

### DIFF
--- a/server/src/components/settings/general/TicketingSettings.tsx
+++ b/server/src/components/settings/general/TicketingSettings.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import CustomTabs from 'server/src/components/ui/CustomTabs';
 import NumberingSettings from './NumberingSettings';
 import ChannelsSettings from './ChannelsSettings';
@@ -10,6 +11,35 @@ import StatusSettings from './StatusSettings';
 import PrioritySettings from './PrioritySettings';
 
 const TicketingSettingsRefactored = (): JSX.Element => {
+  const searchParams = useSearchParams();
+  const sectionParam = searchParams?.get('section');
+  const typeParam = searchParams?.get('type');
+
+  // Map URL slugs to tab labels
+  const sectionToLabelMap: Record<string, string> = {
+    'display': 'Display',
+    'ticket-numbering': 'Ticket Numbering',
+    'boards': 'Boards',
+    'statuses': 'Statuses',
+    'priorities': 'Priorities',
+    'categories': 'Categories'
+  };
+
+  // Determine initial active tab based on URL parameter
+  const [activeTab, setActiveTab] = useState<string>(() => {
+    const initialLabel = sectionParam ? sectionToLabelMap[sectionParam.toLowerCase()] : undefined;
+    return initialLabel || 'Display'; // Default to 'Display'
+  });
+
+  // Update active tab when URL parameter changes
+  useEffect(() => {
+    const currentLabel = sectionParam ? sectionToLabelMap[sectionParam.toLowerCase()] : undefined;
+    const targetTab = currentLabel || 'Display';
+    if (targetTab !== activeTab) {
+      setActiveTab(targetTab);
+    }
+  }, [sectionParam, activeTab]);
+
   const tabs = [
     {
       label: "Display",
@@ -25,11 +55,11 @@ const TicketingSettingsRefactored = (): JSX.Element => {
     },
     {
       label: "Statuses",
-      content: <StatusSettings />
+      content: <StatusSettings initialStatusType={typeParam} />
     },
     {
       label: "Priorities",
-      content: <PrioritySettings />
+      content: <PrioritySettings initialPriorityType={typeParam} />
     },
     {
       label: "Categories",
@@ -37,10 +67,43 @@ const TicketingSettingsRefactored = (): JSX.Element => {
     }
   ];
 
+  const updateURL = (tabLabel: string) => {
+    // Map tab labels back to URL slugs
+    const labelToSlugMap: Record<string, string> = Object.entries(sectionToLabelMap).reduce((acc, [slug, label]) => {
+      acc[label] = slug;
+      return acc;
+    }, {} as Record<string, string>);
+
+    const urlSlug = labelToSlugMap[tabLabel];
+    
+    // Build new URL with tab and section parameters
+    const currentSearchParams = new URLSearchParams(window.location.search);
+    
+    if (urlSlug && urlSlug !== 'display') {
+      currentSearchParams.set('section', urlSlug);
+    } else {
+      currentSearchParams.delete('section');
+    }
+
+    // Keep existing tab parameter
+    const newUrl = currentSearchParams.toString() 
+      ? `/msp/settings?${currentSearchParams.toString()}`
+      : '/msp/settings?tab=ticketing';
+    
+    window.history.pushState({}, '', newUrl);
+  };
+
   return (
     <div className="p-6 bg-gray-100 min-h-screen">
       <h2 className="text-xl font-bold mb-4 text-gray-800">Ticket Settings</h2>
-      <CustomTabs tabs={tabs} defaultTab="Categories" />
+      <CustomTabs 
+        tabs={tabs} 
+        defaultTab={activeTab}
+        onTabChange={(tab) => {
+          setActiveTab(tab);
+          updateURL(tab);
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
• Added direct URL navigation to all ticketing sub-sections (Display, Ticket Numbering, Boards, Statuses, Priorities, Categories)
• Enabled bookmarkable URLs for nested status types (ticket, project, interaction)
• Enabled bookmarkable URLs for nested priority types (ticket, project_task)
• Implemented URL parameter support: `tab`, `section`, and `type`
• Maintains URL state when navigating between settings tabs

## Example URLs
- `/msp/settings?tab=ticketing&section=statuses&type=project` - Direct link to project statuses
- `/msp/settings?tab=ticketing&section=priorities&type=ticket` - Direct link to ticket priorities
- `/msp/settings?tab=ticketing&section=boards` - Direct link to boards section

## Changes Made
- **TicketingSettings.tsx**: Added URL parameter handling for section navigation
- **StatusSettings.tsx**: Added support for `initialStatusType` prop and URL updates
- **PrioritySettings.tsx**: Added support for `initialPriorityType` prop and URL updates

## Test Plan
- [ ] Verify direct navigation to ticketing sub-sections works
- [ ] Test bookmarking and sharing URLs for specific status/priority types
- [ ] Confirm URL updates when switching between tabs and types
- [ ] Ensure backward compatibility with existing navigation

🤖 Generated with [Claude Code](https://claude.ai/code)