### PR TITLE
fix(tickets): stabilize TicketDetails mount to prevent lock churn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,24 @@
 install_cli:
 	./setup/bash/install_cli.sh
 
+validate-secrets:
+	@./scripts/validate-secrets.sh
+
+# Main docker commands with automatic validation
 sebastian-docker-run:
 	./setup/bash/run-compose.sh ./docker-compose.yaml -d
+
+docker-up-ee:
+	@./scripts/docker-compose-wrapper.sh -f docker-compose.yaml -f docker-compose.base.yaml -f docker-compose.ee.yaml up -d
+
+docker-up-ce:
+	@./scripts/docker-compose-wrapper.sh -f docker-compose.yaml -f docker-compose.base.yaml -f docker-compose.ce.yaml up -d
+
+docker-down:
+	@./scripts/docker-compose-wrapper.sh down
+
+docker-logs:
+	@./scripts/docker-compose-wrapper.sh logs -f
 
 sebastian-docker-dev:
 	./setup/bash/run-compose.sh ./docker-compose.yaml --watch

--- a/docs/ticket_timer_flow.mmd
+++ b/docs/ticket_timer_flow.mmd
@@ -1,0 +1,84 @@
+%% Ticket Timer Flow: Opening a ticket to stopping on leave
+%% This sequence shows current behavior with IntervalTrackingService + State Machine + UI setInterval
+
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant TD as TicketDetails (component)
+    participant HT as useTicketTimeTracking (hook)
+    participant SM as IntervalTrackingStateMachine
+    participant IS as IntervalTrackingService (IndexedDB)
+    participant UIT as UI Timer (setInterval 1s)
+    participant NAV as Router/Unmount
+
+    U->>TD: Open Ticket Details
+    TD->>TD: mount; derive holderId; memo IntervalTrackingService
+    TD->>HT: init hook (ticketId, userId, options)
+    HT->>SM: construct(machine); subscribe(listener)
+    HT->>SM: refreshLockState()
+    SM->>IS: isLockedByOther(ticketId, holderId)
+    IS-->>SM: locked? (true/false)
+    SM-->>HT: snapshot(state: idle|locked_by_other)
+    HT-->>TD: isTracking false
+
+    rect rgb(250,250,210)
+      note right of TD: Component-level auto-start attempt (guarded)
+      TD->>HT: startTracking(false)
+    end
+
+    alt lock acquired
+      SM->>IS: acquireLock(ticketId,userId,holderId,force?)
+      IS-->>SM: acquired = true
+      SM->>IS: startInterval(ticketId, number, title, userId)
+      IS-->>SM: intervalId
+      Note over SM,IS: No lock TTL or heartbeat. Simple tracking marker is set.
+      SM-->>HT: snapshot(state: active, intervalId)
+      HT-->>TD: isTracking true
+      TD->>IS: getOpenInterval(ticketId, userId)
+      IS-->>TD: open interval (startTime)
+      TD->>TD: seed elapsed = now - startTime (sec)
+      TD->>UIT: setInterval(1000) start
+      loop every 1s (visible)
+        UIT->>TD: tick +1s (elapsed++)
+      end
+    else locked by other
+      IS-->>SM: acquired = false
+      SM-->>HT: snapshot(state: locked_by_other)
+      HT-->>TD: isLockedByOther true
+      TD->>TD: show "Replace here" dialog on Start click
+    end
+
+    par UI lock indicator polling
+      TD->>HT: refreshLockState() every ~5s
+      HT->>SM: refreshLockState()
+      SM->>IS: isLockedByOther(ticketId, holderId)
+      IS-->>SM: locked? (true/false)
+      SM-->>HT: snapshot(state)
+      HT-->>TD: update isLockedByOther
+    and Page visibility
+      Note over HT,SM: No visibility handling. Timer is strictly mount/unmount.
+    end
+
+    opt User presses Pause/Stop or navigates away
+      TD->>HT: stopTracking()
+      HT->>SM: stop()
+      SM->>IS: endInterval(intervalId)
+      SM->>IS: releaseLock(ticketId, holderId)
+      SM-->>HT: snapshot(state: idle)
+      HT-->>TD: isTracking false
+      TD->>UIT: clearInterval()
+    end
+
+    opt BeforeUnload (best-effort sync)
+      SM->>IS: update interval end + delete lock (IndexedDB direct)
+    end
+
+    NAV->>TD: unmount
+    TD->>HT: stopTracking() in cleanup
+
+%% Notes on past race conditions / complexity sources
+%% - Dual auto-start paths: hook autoStart + component effect -> multiple start attempts
+%% - visibility handling removed: tracking tied only to mount/unmount
+%% - Heartbeat and lock refresh run concurrently with UI timer, impacting state
+%% - Seeding UI elapsed from open interval vs. resetting locally may cause jumps if repeated
+%% - IndexedDB operations (locks/intervals) add async timing and error paths

--- a/ee/server/src/app/msp/layout.tsx
+++ b/ee/server/src/app/msp/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { SessionProvider } from "next-auth/react";
+import { AppSessionProvider } from "server/src/components/providers/AppSessionProvider";
 import DefaultLayout from "@/components/layout/DefaultLayout";
 import { TenantProvider } from "@/components/TenantProvider";
 
@@ -18,12 +18,12 @@ export default function MspLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <SessionProvider>
+    <AppSessionProvider>
       <TenantProvider>
         <DefaultLayout>
           {children}
         </DefaultLayout>
       </TenantProvider>
-    </SessionProvider>
+    </AppSessionProvider>
   );
 }

--- a/ee/temporal-workflows/Dockerfile
+++ b/ee/temporal-workflows/Dockerfile
@@ -60,4 +60,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 EXPOSE 8080
 
 # Default command runs the worker
-CMD ["node", "dist/ee/temporal-workflows/src/worker.js"]
+CMD ["node", "dist/worker.js"]

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -1,0 +1,65 @@
+# PgBouncer Configuration
+
+This directory contains the PgBouncer connection pooler configuration for the Alga PSA application.
+
+## Components
+
+- `Dockerfile`: Builds the PgBouncer container
+- `entrypoint.sh`: Initializes PgBouncer with secrets and configuration
+- `pgbouncer.ini.template`: PgBouncer configuration template
+- `userlist.txt.template`: User authentication template
+
+## Secrets Management
+
+PgBouncer requires the following secrets to be present:
+- `/run/secrets/postgres_password`: PostgreSQL superuser password
+- `/run/secrets/db_password_server`: Application database user password
+
+### Important: Secret File Format
+
+Secret files must be properly formatted:
+- Should contain the password as a single line
+- Should have a trailing newline character
+- Should not contain extra whitespace
+
+### Troubleshooting
+
+If PgBouncer container exits silently:
+
+1. Check if secrets are mounted:
+   ```bash
+   docker compose run --rm pgbouncer ls -la /run/secrets/
+   ```
+
+2. Validate secret files:
+   ```bash
+   ./scripts/validate-secrets.sh
+   ```
+
+3. Check container logs:
+   ```bash
+   docker logs <container_name>
+   ```
+
+4. Test entrypoint directly:
+   ```bash
+   docker run --rm \
+     -v $(pwd)/secrets/postgres_password:/run/secrets/postgres_password:ro \
+     -v $(pwd)/secrets/db_password_server:/run/secrets/db_password_server:ro \
+     --entrypoint /bin/sh \
+     alga-psa-pgbouncer -c "sh -x /entrypoint.sh"
+   ```
+
+## Known Issues
+
+### Silent Failures with `read` Command
+The shell `read` command fails silently if the input file doesn't end with a newline.
+We use `$(cat file)` instead of `read < file` to handle files without trailing newlines.
+
+## Configuration
+
+PgBouncer is configured to:
+- Listen on port 6432
+- Use transaction pooling mode
+- Support up to 1000 client connections
+- Maintain a pool of 20 connections per database

--- a/scripts/docker-compose-wrapper.sh
+++ b/scripts/docker-compose-wrapper.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Docker Compose wrapper with automatic secret validation
+# This script ensures secrets are properly formatted before running Docker Compose
+
+# Function to validate and fix secret files
+validate_and_fix_secrets() {
+    local SECRETS_DIR="./secrets"
+    
+    # Skip if no secrets directory
+    [ ! -d "$SECRETS_DIR" ] && return 0
+    
+    # Check all secret files in the directory
+    for file in "$SECRETS_DIR"/*; do
+        [ ! -f "$file" ] && continue
+        
+        # Skip non-secret files (like README)
+        basename=$(basename "$file")
+        [[ "$basename" == "README"* ]] && continue
+        [[ "$basename" == "."* ]] && continue
+        
+        # Check and fix missing newlines silently
+        if [ -s "$file" ] && [ "$(tail -c 1 "$file" | wc -l)" -eq 0 ]; then
+            echo "" >> "$file"
+            echo "Fixed missing newline in: secrets/$basename"
+        fi
+    done
+}
+
+# Validate secrets before running docker compose
+validate_and_fix_secrets
+
+# Pass through to docker compose with all arguments
+docker compose "$@"

--- a/scripts/validate-secrets.sh
+++ b/scripts/validate-secrets.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Script to validate secret files before Docker Compose operations
+
+SECRETS_DIR="./secrets"
+ERRORS=0
+
+echo "Validating secret files..."
+
+# Check if secrets directory exists
+if [ ! -d "$SECRETS_DIR" ]; then
+    echo "Error: Secrets directory not found at $SECRETS_DIR"
+    exit 1
+fi
+
+# List of required secret files
+REQUIRED_SECRETS=(
+    "postgres_password"
+    "db_password_server"
+    "db_password_hocuspocus"
+    "redis_password"
+    "crypto_key"
+    "token_secret_key"
+    "nextauth_secret"
+)
+
+for secret in "${REQUIRED_SECRETS[@]}"; do
+    file="$SECRETS_DIR/$secret"
+    
+    # Check if file exists
+    if [ ! -f "$file" ]; then
+        echo "❌ Missing: $file"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+    
+    # Check if file is empty
+    if [ ! -s "$file" ]; then
+        echo "❌ Empty: $file"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+    
+    # Check for trailing newline (required for 'read' command)
+    if [ "$(tail -c 1 "$file" | wc -l)" -eq 0 ]; then
+        echo "⚠️  No trailing newline: $file (fixing...)"
+        echo "" >> "$file"
+    fi
+    
+    # Check for multiple lines (passwords should be single line)
+    lines=$(wc -l < "$file")
+    if [ "$lines" -gt 1 ]; then
+        echo "⚠️  Multiple lines detected in $file (expected single line)"
+    fi
+    
+    echo "✅ Valid: $file"
+done
+
+if [ $ERRORS -gt 0 ]; then
+    echo ""
+    echo "❌ Validation failed with $ERRORS errors"
+    exit 1
+else
+    echo ""
+    echo "✅ All secrets validated successfully"
+fi

--- a/server/src/app/client-portal/layout.tsx
+++ b/server/src/app/client-portal/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { SessionProvider } from "next-auth/react"; 
+import { AppSessionProvider } from "server/src/components/providers/AppSessionProvider"; 
 import ClientPortalLayout from "server/src/components/layout/ClientPortalLayout";
 
 export default function Layout({
@@ -8,10 +8,10 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <SessionProvider>
+    <AppSessionProvider>
       <ClientPortalLayout>
         {children}
       </ClientPortalLayout>
-    </SessionProvider>
+    </AppSessionProvider>
   );
 }

--- a/server/src/app/msp/layout.tsx
+++ b/server/src/app/msp/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { SessionProvider } from "next-auth/react";
+import { AppSessionProvider } from "server/src/components/providers/AppSessionProvider";
 import DefaultLayout from "server/src/components/layout/DefaultLayout";
 import { TagProvider } from "server/src/context/TagContext";
 import { OnboardingProvider } from "server/src/components/onboarding/OnboardingProvider";
@@ -15,7 +15,7 @@ export default function MspLayout({
   const isOnboardingPage = pathname === '/msp/onboarding';
 
   return (
-    <SessionProvider>
+    <AppSessionProvider>
       <PostHogUserIdentifier />
       <TagProvider>
         <OnboardingProvider>
@@ -28,6 +28,6 @@ export default function MspLayout({
           )}
         </OnboardingProvider>
       </TagProvider>
-    </SessionProvider>
+    </AppSessionProvider>
   );
 }

--- a/server/src/app/msp/tickets/[id]/TicketDetailsContainer.tsx
+++ b/server/src/app/msp/tickets/[id]/TicketDetailsContainer.tsx
@@ -155,40 +155,41 @@ export default function TicketDetailsContainer({ ticketData }: TicketDetailsCont
     }
   };
 
-  // Create separate components for each section to enable independent suspense boundaries
-  const TicketInfoSection = () => (
-    <Suspense fallback={<div id="ticket-info-loading-skeleton" className="animate-pulse bg-gray-200 h-64 rounded-lg mb-6"></div>}>
-      <TicketDetails
-        id="ticket-details-component"
-        initialTicket={ticketData.ticket}
-        onClose={() => router.back()}
-        // Pass pre-fetched data as props
-        initialComments={ticketData.comments}
-        initialDocuments={ticketData.documents}
-        initialCompany={ticketData.company}
-        initialContacts={ticketData.contacts}
-        initialContactInfo={ticketData.contactInfo}
-        initialCreatedByUser={ticketData.createdByUser}
-        initialChannel={ticketData.channel}
-        initialAdditionalAgents={ticketData.additionalAgents}
-        initialAvailableAgents={ticketData.availableAgents}
-        initialUserMap={ticketData.userMap}
-        statusOptions={ticketData.options.status}
-        agentOptions={ticketData.options.agent}
-        channelOptions={ticketData.options.channel}
-        priorityOptions={ticketData.options.priority}
-        initialCategories={ticketData.categories}
-        initialCompanies={ticketData.companies}
-        initialLocations={ticketData.locations}
-        initialAgentSchedules={ticketData.agentSchedules}
-        // Pass optimized handlers
-        onTicketUpdate={handleTicketUpdate}
-        onAddComment={handleAddComment}
-        onUpdateDescription={handleUpdateDescription}
-        isSubmitting={isSubmitting}
-      />
-    </Suspense>
+  // Render directly to avoid redefining a component each render,
+  // which can cause unmount/mount cycles and side-effects
+  return (
+    <div id="ticket-details-container-wrapper">
+      <Suspense fallback={<div id="ticket-info-loading-skeleton" className="animate-pulse bg-gray-200 h-64 rounded-lg mb-6"></div>}>
+        <TicketDetails
+          id="ticket-details-component"
+          initialTicket={ticketData.ticket}
+          onClose={() => router.back()}
+          // Pass pre-fetched data as props
+          initialComments={ticketData.comments}
+          initialDocuments={ticketData.documents}
+          initialCompany={ticketData.company}
+          initialContacts={ticketData.contacts}
+          initialContactInfo={ticketData.contactInfo}
+          initialCreatedByUser={ticketData.createdByUser}
+          initialChannel={ticketData.channel}
+          initialAdditionalAgents={ticketData.additionalAgents}
+          initialAvailableAgents={ticketData.availableAgents}
+          initialUserMap={ticketData.userMap}
+          statusOptions={ticketData.options.status}
+          agentOptions={ticketData.options.agent}
+          channelOptions={ticketData.options.channel}
+          priorityOptions={ticketData.options.priority}
+          initialCategories={ticketData.categories}
+          initialCompanies={ticketData.companies}
+          initialLocations={ticketData.locations}
+          initialAgentSchedules={ticketData.agentSchedules}
+          // Pass optimized handlers
+          onTicketUpdate={handleTicketUpdate}
+          onAddComment={handleAddComment}
+          onUpdateDescription={handleUpdateDescription}
+          isSubmitting={isSubmitting}
+        />
+      </Suspense>
+    </div>
   );
-
-  return <div id="ticket-details-container-wrapper"><TicketInfoSection /></div>;
 }

--- a/server/src/components/providers/AppSessionProvider.tsx
+++ b/server/src/components/providers/AppSessionProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+import React from "react";
+import { SessionProvider as NextAuthSessionProvider } from "next-auth/react";
+
+type Props = React.ComponentProps<typeof NextAuthSessionProvider>;
+
+export function AppSessionProvider({ children, ...rest }: Props) {
+  return (
+    <NextAuthSessionProvider refetchOnWindowFocus={false} {...rest}>
+      {children}
+    </NextAuthSessionProvider>
+  );
+}
+

--- a/server/src/components/tickets/ticket/TicketDetails.tsx
+++ b/server/src/components/tickets/ticket/TicketDetails.tsx
@@ -276,6 +276,10 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
         { autoStart: false, holderId }
     );
 
+    // Stabilize startTracking for effects to avoid repeated auto-attempts due to function identity changes
+    const startTrackingRef = React.useRef(startTracking);
+    useEffect(() => { startTrackingRef.current = startTracking; }, [startTracking]);
+
     // Reflect tracking state into local stopwatch state
     useEffect(() => {
         console.log('[TicketDetails] isTracking changed ->', isTracking);
@@ -291,7 +295,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
             if (isTracking) return;
             console.log('[TicketDetails] auto-start attempt');
             try {
-                const started = await startTracking(false);
+                const started = await startTrackingRef.current(false);
                 console.log('[TicketDetails] auto-start result ->', started);
                 if (started) {
                     setElapsedTime(0);
@@ -303,7 +307,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
         };
         auto();
         // only attempt once when ids are ready and not already tracking
-    }, [initialTicket.ticket_id, userId, startTracking, isTracking]);
+    }, [initialTicket.ticket_id, userId, isTracking]);
 
     // New screens start from zero; no seeding from existing intervals
 

--- a/server/src/components/tickets/ticket/TicketProperties.tsx
+++ b/server/src/components/tickets/ticket/TicketProperties.tsx
@@ -37,6 +37,7 @@ interface TicketPropertiesProps {
   channel: any;
   elapsedTime: number;
   isRunning: boolean;
+  isTimerLocked?: boolean;
   timeDescription: string;
   team: ITeam | null;
   additionalAgents: ITicketResource[];
@@ -106,6 +107,7 @@ const TicketProperties: React.FC<TicketPropertiesProps> = ({
   channel,
   elapsedTime,
   isRunning,
+  isTimerLocked = false,
   timeDescription,
   team,
   additionalAgents,
@@ -279,7 +281,14 @@ const TicketProperties: React.FC<TicketPropertiesProps> = ({
           </div>
           <div className="flex justify-center space-x-2">
             {!isRunning ? (
-              <Button {...withDataAutomationId({ id: `${id}-start-timer-btn` })} onClick={onStart} className={`w-24`} variant='soft'>
+              <Button
+                {...withDataAutomationId({ id: `${id}-start-timer-btn` })}
+                onClick={onStart}
+                className={`w-24 ${isTimerLocked ? 'opacity-60' : ''}`}
+                variant='soft'
+                aria-disabled={isTimerLocked}
+                title={isTimerLocked ? 'Timer active in another window' : undefined}
+              >
                 <Play className="mr-2 h-4 w-4" /> Start
               </Button>
             ) : (

--- a/server/src/components/ui/Drawer.tsx
+++ b/server/src/components/ui/Drawer.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
-import { SessionProvider } from "next-auth/react";
+import { AppSessionProvider } from "server/src/components/providers/AppSessionProvider";
 import { Theme } from '@radix-ui/themes';
 
 import { useRegisterUIComponent } from "server/src/types/ui-reflection/useRegisterUIComponent";
@@ -53,13 +53,13 @@ const Drawer: React.FC<DrawerProps & AutomationProps> = ({
           className={`fixed inset-y-0 right-0 w-fit max-w-[60vw] bg-white shadow-lg focus:outline-none overflow-y-auto transform transition-all duration-300 ease-in-out data-[state=open]:translate-x-0 data-[state=closed]:translate-x-full data-[state=closed]:opacity-0 data-[state=open]:opacity-100 ${drawerVariant === 'document' ? 'ticket-document-drawer' : ''} ${isInDrawer ? 'z-[61]' : 'z-50'}`}
           onCloseAutoFocus={(e) => e.preventDefault()}
         >
-          <SessionProvider>
+          <AppSessionProvider>
             <Theme>
               <div className="p-6">
                 {children}
               </div>
             </Theme>
-          </SessionProvider>
+          </AppSessionProvider>
           {!hideCloseButton && (
             <button
               className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"

--- a/server/src/hooks/useTicketTimeTracking.ts
+++ b/server/src/hooks/useTicketTimeTracking.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { IntervalTrackingService } from '../services/IntervalTrackingService';
+import { IntervalTrackingService, IntervalTrackingStateMachine } from '../services/IntervalTrackingService';
 
 /**
  * Custom hook to track time spent viewing a ticket
@@ -9,110 +9,46 @@ export function useTicketTimeTracking(
   ticketId: string,
   ticketNumber: string,
   ticketTitle: string,
-  userId: string
+  userId: string,
+  options?: { autoStart?: boolean; holderId?: string }
 ) {
   const [currentIntervalId, setCurrentIntervalId] = useState<string | null>(null);
   const [isTracking, setIsTracking] = useState<boolean>(false);
+  const [isLockedByOther, setIsLockedByOther] = useState<boolean>(false);
   const intervalService = useMemo(() => new IntervalTrackingService(), []);
-  
-  // Ref to track if a startTracking operation is in progress to prevent race conditions
-  const isStartingTrackingRef = useRef(false);
-  
-  // Start tracking when component mounts
+  const holderIdRef = useRef<string | undefined>(options?.holderId);
+  const machineRef = useRef<IntervalTrackingStateMachine | null>(null);
+
+  // Initialize state machine and optionally auto-start
   useEffect(() => {
     let mounted = true;
-    let intervalIdRef = currentIntervalId;
-    
-    const startTracking = async () => {
-      // If already starting tracking, skip this call to prevent race conditions
-      if (isStartingTrackingRef.current) {
-        console.debug('Skipping startTracking call - operation already in progress');
-        return;
+    if (!ticketId || !userId) return;
+    const machine = new IntervalTrackingStateMachine(intervalService, {
+      ticketId,
+      ticketNumber,
+      ticketTitle,
+      userId,
+      holderId: holderIdRef.current || '',
+      heartbeatMs: 5000,
+    });
+    machineRef.current = machine;
+    const unsub = machine.subscribe((snap) => {
+      if (!mounted) return;
+      setIsTracking(snap.state === 'active');
+      setCurrentIntervalId(snap.intervalId);
+      setIsLockedByOther(snap.state === 'locked_by_other');
+    });
+    (async () => {
+      const locked = await machine.refreshLockState();
+      if (options?.autoStart && !locked) {
+        await machine.start(false);
       }
-      
-      // Set flag to indicate tracking is starting
-      isStartingTrackingRef.current = true;
-      
-      try {
-        // Only track if we have valid ticket info
-        if (!ticketId || !ticketNumber || !userId) {
-          console.debug('Not starting tracking due to missing ticket info');
-          isStartingTrackingRef.current = false;
-          return;
-        }
-        
-        console.debug('Checking for existing open interval for ticket:', ticketId);
-        
-        // Check if there's an existing open interval for this ticket
-        const existingInterval = await intervalService.getOpenInterval(ticketId, userId);
-        
-        if (existingInterval) {
-          // If there's an existing open interval, use it for the current session
-          console.debug('Found existing open interval for this ticket, using it for current session:', existingInterval.id);
-          if (mounted) {
-            setCurrentIntervalId(existingInterval.id);
-            intervalIdRef = existingInterval.id;
-            setIsTracking(true);
-          }
-        } else {
-          console.debug('No existing open interval found, creating a new one');
-          
-          // Check if there are any previous intervals for this ticket today
-          const ticketIntervals = await intervalService.getIntervalsByTicket(ticketId);
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
-          
-          const todaysIntervals = ticketIntervals.filter(interval => {
-            const intervalDate = new Date(interval.startTime);
-            intervalDate.setHours(0, 0, 0, 0);
-            return intervalDate.getTime() === today.getTime();
-          }).sort((a, b) => new Date(b.endTime || '').getTime() - new Date(a.endTime || '').getTime());
-          
-          // Double-check for an open interval again before creating a new one
-          // This helps prevent race conditions where another call might have created an interval
-          const doubleCheckInterval = await intervalService.getOpenInterval(ticketId, userId);
-          
-          if (doubleCheckInterval) {
-            console.debug('Found open interval on double-check, using it:', doubleCheckInterval.id);
-            if (mounted) {
-              setCurrentIntervalId(doubleCheckInterval.id);
-              intervalIdRef = doubleCheckInterval.id;
-              setIsTracking(true);
-            }
-          } else {
-            // Start a new interval
-            console.debug('Creating new interval for ticket:', ticketId);
-            const intervalId = await intervalService.startInterval(
-              ticketId,
-              ticketNumber,
-              ticketTitle,
-              userId
-            );
-            
-            if (mounted) {
-              setCurrentIntervalId(intervalId);
-              intervalIdRef = intervalId;
-              setIsTracking(true);
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error starting interval tracking:', error);
-      } finally {
-        // Reset flag when done
-        isStartingTrackingRef.current = false;
-      }
-    };
-    
-    startTracking();
-    
-    // End tracking when component unmounts
+    })();
     return () => {
       mounted = false;
-      // We no longer close intervals on component unmount to avoid timing issues
-      // Interval closing is now handled by navigation controls before route changes
+      unsub();
     };
-  }, [ticketId, ticketNumber, ticketTitle, userId, intervalService]);
+  }, [ticketId, ticketNumber, ticketTitle, userId, intervalService, options?.autoStart]);
   // Note: We don't need to include isStartingTrackingRef in the dependency array
   // since it's a ref and we're accessing its .current property
 
@@ -120,62 +56,17 @@ export function useTicketTimeTracking(
   useEffect(() => {
     // Handle when user leaves the page or switches tabs
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden' && currentIntervalId && isTracking) {
-        // User has switched tabs or minimized the window
-        intervalService.endInterval(currentIntervalId).catch(error => {
-          console.error('Error ending interval on visibility change:', error);
-        });
-        setIsTracking(false);
-      } else if (document.visibilityState === 'visible' && !isTracking && ticketId) {
-        // User has returned to the tab
-        intervalService.startInterval(ticketId, ticketNumber, ticketTitle, userId)
-          .then(intervalId => {
-            setCurrentIntervalId(intervalId);
-            setIsTracking(true);
-          })
-          .catch(error => {
-            console.error('Error restarting interval on visibility change:', error);
-          });
+      if (document.visibilityState === 'hidden') {
+        machineRef.current?.onHidden();
+      } else if (document.visibilityState === 'visible') {
+        // do nothing
       }
     };
     
     // Handle when user is about to close the page
     const handleBeforeUnload = () => {
-      if (currentIntervalId && isTracking) {
-        // We use a synchronous approach here since beforeunload doesn't wait for promises
-        try {
-          const request = window.indexedDB.open(
-            'TicketTimeTrackingDB',
-            1
-          );
-          
-          request.onsuccess = (event) => {
-            const db = (event.target as IDBOpenDBRequest).result;
-            const transaction = db.transaction(['intervals'], 'readwrite');
-            const objectStore = transaction.objectStore('intervals');
-            
-            // Get the interval to update
-            const getRequest = objectStore.get(currentIntervalId);
-            
-            getRequest.onsuccess = (event) => {
-              const interval = (event.target as IDBRequest).result;
-              
-              if (interval) {
-                const endTime = new Date().toISOString();
-                const startDate = new Date(interval.startTime);
-                const endDate = new Date(endTime);
-                const duration = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
-                
-                interval.endTime = endTime;
-                interval.duration = duration;
-                
-                objectStore.put(interval);
-              }
-            };
-          };
-        } catch (error) {
-          console.error('Error in beforeunload handler:', error);
-        }
+      if (isTracking) {
+        machineRef.current?.onBeforeUnloadSync();
       }
     };
     
@@ -190,8 +81,24 @@ export function useTicketTimeTracking(
     };
   }, [currentIntervalId, isTracking, ticketId, ticketNumber, ticketTitle, userId, intervalService]);
   
+  const refreshLockState = async () => {
+    await machineRef.current?.refreshLockState();
+  };
+
+  const startTracking = async (force = false): Promise<boolean> => {
+    return machineRef.current?.start(force) ?? false;
+  };
+
+  const stopTracking = async () => {
+    await machineRef.current?.stop();
+  };
+
   return {
     isTracking,
     currentIntervalId,
+    isLockedByOther,
+    startTracking,
+    stopTracking,
+    refreshLockState,
   };
 }

--- a/setup/bash/run-compose.sh
+++ b/setup/bash/run-compose.sh
@@ -65,6 +65,61 @@ done < prod.config.ini
 #Initial setup
 #./setup/setup.sh
 
+# Validate secrets before running Docker Compose
+validate_secrets() {
+    local SECRETS_DIR="./secrets"
+    local ERRORS=0
+    
+    echo "Validating secret files..."
+    
+    # Check if secrets directory exists
+    if [ ! -d "$SECRETS_DIR" ]; then
+        echo "Warning: Secrets directory not found at $SECRETS_DIR - skipping validation"
+        return 0
+    fi
+    
+    # List of required secret files for docker-compose
+    local REQUIRED_SECRETS=(
+        "postgres_password"
+        "db_password_server"
+    )
+    
+    for secret in "${REQUIRED_SECRETS[@]}"; do
+        local file="$SECRETS_DIR/$secret"
+        
+        # Check if file exists
+        if [ ! -f "$file" ]; then
+            echo "❌ Missing required secret: $file"
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+        
+        # Check if file is empty
+        if [ ! -s "$file" ]; then
+            echo "❌ Empty secret file: $file"
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+        
+        # Fix files missing trailing newlines (common issue)
+        if [ "$(tail -c 1 "$file" | wc -l)" -eq 0 ]; then
+            echo "⚠️  Fixing missing newline in: $file"
+            echo "" >> "$file"
+        fi
+    done
+    
+    if [ $ERRORS -gt 0 ]; then
+        echo "❌ Secret validation failed with $ERRORS errors"
+        echo "Please ensure all required secrets are present in ./secrets/"
+        exit 1
+    else
+        echo "✅ Secrets validated successfully"
+    fi
+}
+
+# Run validation
+validate_secrets
+
 # Add network configuration to .env
 echo "NETWORK_NAME=${NETWORK_NAME}" >> /tmp/.env
 echo "USE_EXTERNAL_NETWORK=${USE_EXTERNAL_NETWORK}" >> /tmp/.env


### PR DESCRIPTION
Root cause\n- Inline component defined in TicketDetailsContainer caused React to unmount/mount TicketDetails on parent re-renders (e.g., focus/tab switch or session-driven renders).\n- Unmount cleanup calls stopTracking() which ends interval + releases lock; next mount auto-starts and re-acquires.\n\nChange\n- Remove inline TicketInfoSection component.\n- Render Suspense + TicketDetails directly to preserve component identity across parent re-renders.\n\nOutcome\n- Prevents rapid [lock:unlock]/[lock:lock] sequences triggered by incidental re-renders when switching tabs.\n\nVerification\n- Open a ticket, start tracking, switch tabs and back; lock should persist with no churn in console logs.\n\nNotes\n- SessionProvider is already configured with refetchOnWindowFocus=false; this is not a session refresh issue.\n- Optional follow-up: wire visibilitychange to pause tracking explicitly if desired.