### PR TITLE
Improve scheduled job logging and singleton handling

### DIFF
--- a/server/src/lib/jobs/initializeScheduledJobs.ts
+++ b/server/src/lib/jobs/initializeScheduledJobs.ts
@@ -15,64 +15,98 @@ export async function initializeScheduledJobs(): Promise<void> {
     // Get all tenants using root connection
     const knex = await getConnection(null);
     const tenants = await knex('tenants').select('tenant');
+    logger.info(`Preparing to schedule jobs for ${tenants.length} tenants`);
     
     // Set up expired credits job for each tenant
     for (const tenantRecord of tenants) {
       const tenantId = tenantRecord.tenant;
       
       // Schedule daily job to process expired credits (runs at 1:00 AM)
-      const expiredJobId = await scheduleExpiredCreditsJob(tenantId, undefined, '0 1 * * *');
-      
-      if (expiredJobId) {
-        logger.info(`Scheduled expired credits job for tenant ${tenantId} with job ID ${expiredJobId}`);
-      } else {
-        logger.error(`Failed to schedule expired credits job for tenant ${tenantId}`);
+      try {
+        const cron = '0 1 * * *';
+        const expiredJobId = await scheduleExpiredCreditsJob(tenantId, undefined, cron);
+        if (expiredJobId) {
+          logger.info(`Scheduled expired credits job for tenant ${tenantId} with job ID ${expiredJobId}`);
+        } else {
+          logger.info('Expired credits job already scheduled (singleton active)', {
+            tenantId,
+            cron,
+            returnedJobId: expiredJobId
+          });
+        }
+      } catch (error) {
+        logger.error(`Failed to schedule expired credits job for tenant ${tenantId}`, error);
       }
       
       // Schedule daily job to send notifications about expiring credits (runs at 9:00 AM)
-      const notificationJobId = await scheduleExpiringCreditsNotificationJob(tenantId, undefined, '0 9 * * *');
-      
-      if (notificationJobId) {
-        logger.info(`Scheduled expiring credits notification job for tenant ${tenantId} with job ID ${notificationJobId}`);
-      } else {
-        logger.error(`Failed to schedule expiring credits notification job for tenant ${tenantId}`);
+      try {
+        const cron = '0 9 * * *';
+        const notificationJobId = await scheduleExpiringCreditsNotificationJob(tenantId, undefined, cron);
+        if (notificationJobId) {
+          logger.info(`Scheduled expiring credits notification job for tenant ${tenantId} with job ID ${notificationJobId}`);
+        } else {
+          logger.info('Expiring credits notification job already scheduled (singleton active)', {
+            tenantId,
+            cron,
+            returnedJobId: notificationJobId
+          });
+        }
+      } catch (error) {
+        logger.error(`Failed to schedule expiring credits notification job for tenant ${tenantId}`, error);
       }
       
       // Schedule daily job to run credit reconciliation (runs at 2:00 AM)
-      const reconciliationJobId = await scheduleCreditReconciliationJob(tenantId, undefined, '0 2 * * *');
-      
-      if (reconciliationJobId) {
-        logger.info(`Scheduled credit reconciliation job for tenant ${tenantId} with job ID ${reconciliationJobId}`);
-      } else {
-       logger.error(`Failed to schedule credit reconciliation job for tenant ${tenantId}`);
-     }
+      try {
+        const cron = '0 2 * * *';
+        const reconciliationJobId = await scheduleCreditReconciliationJob(tenantId, undefined, cron);
+        if (reconciliationJobId) {
+          logger.info(`Scheduled credit reconciliation job for tenant ${tenantId} with job ID ${reconciliationJobId}`);
+        } else {
+          logger.info('Credit reconciliation job already scheduled (singleton active)', {
+            tenantId,
+            cron,
+            returnedJobId: reconciliationJobId
+          });
+        }
+      } catch (error) {
+        logger.error(`Failed to schedule credit reconciliation job for tenant ${tenantId}`, error);
+      }
      
      // Schedule daily job to reconcile bucket usage (runs at 3:00 AM)
-     const reconcileJobId = await scheduleReconcileBucketUsageJob(tenantId); // Uses default cron '0 3 * * *'
-     
-     if (reconcileJobId) {
-       logger.info(`Scheduled bucket usage reconciliation job for tenant ${tenantId} with job ID ${reconcileJobId}`);
-     } else {
-       logger.error(`Failed to schedule bucket usage reconciliation job for tenant ${tenantId}`);
+     try {
+       const cron = '0 3 * * *';
+       const reconcileJobId = await scheduleReconcileBucketUsageJob(tenantId); // Default cron used internally
+       if (reconcileJobId) {
+         logger.info(`Scheduled bucket usage reconciliation job for tenant ${tenantId} with job ID ${reconcileJobId}`);
+       } else {
+         logger.info('Bucket usage reconciliation job already scheduled (singleton active)', {
+           tenantId,
+           cron,
+           returnedJobId: reconcileJobId
+         });
+       }
+     } catch (error) {
+       logger.error(`Failed to schedule bucket usage reconciliation job for tenant ${tenantId}`, error);
      }
    }
    
    // Schedule temporary forms cleanup job (system-wide)
    try {
      const cleanupJobId = await scheduleCleanupTemporaryFormsJob();
-     
      if (cleanupJobId) {
        logger.info(`Scheduled temporary forms cleanup job with ID ${cleanupJobId}`);
      } else {
-       logger.error('Failed to schedule temporary forms cleanup job');
+       logger.info('Temporary forms cleanup job already scheduled (singleton active)', {
+         returnedJobId: cleanupJobId
+       });
      }
    } catch (error) {
-     logger.error('Failed to schedule temporary forms cleanup job:', error);
+     logger.error('Failed to schedule temporary forms cleanup job', error);
    }
    
    logger.info('All scheduled jobs initialized');
   } catch (error: any) {
-    logger.error('Failed to initialize scheduled jobs:', error);
+    logger.error('Failed to initialize scheduled jobs', error);
     throw error;
   }
 }


### PR DESCRIPTION
This PR improves visibility and correctness around scheduled jobs.

Changes
- initializeScheduledJobs: add contextual logs (tenantId, cron, returnedJobId) and treat null IDs as "already scheduled (singleton active)" instead of errors.
- jobScheduler: use per-tenant singletonKey (jobName:tenantId) to avoid cross-tenant collisions; add debug/info diagnostics when scheduling recurring jobs via delayed send; clarify null as singleton dedupe.
- cleanupTemporaryFormsJob: switch to shared logger; clarify already-scheduled case.

Why
- Previously, recurring helpers used a delayed send with a global singleton key (job name), causing frequent null IDs and confusing "failed to schedule" logs.
- The logs now explain when a job is already queued; null is expected in that case.

Notes / Next Steps
- Current recurring helper still schedules a single delayed job; consider migrating to persistent recurring schedules using pg-boss every/schedule with a dispatcher pattern (one global schedule that enqueues per-tenant jobs).

Testing
- Verified improved logs on startup; when a singleton already exists, logs report "already scheduled (singleton active)" with tenant and cron.