### PR TITLE
feat(client-portal): show edited comment immediately after save

### DIFF
--- a/server/src/components/client-portal/tickets/TicketDetails.tsx
+++ b/server/src/components/client-portal/tickets/TicketDetails.tsx
@@ -198,13 +198,13 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
         }
       }
       
-      console.log('[ClientPortal][handleSave] Attempting save', {
+      if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][handleSave] Attempting save', {
         comment_id: currentComment.comment_id,
         hasNote: !!updates.note,
         noteLen: updates.note ? updates.note.length : 0,
       });
       await updateClientTicketComment(currentComment.comment_id, updates);
-      console.log('[ClientPortal][handleSave] Save succeeded');
+      if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][handleSave] Save succeeded');
 
       // Prepare an optimistic version of the updated comment for immediate UI update and later merge
       const optimisticUpdatedAt = new Date().toISOString();
@@ -216,7 +216,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
         if (!prev) return prev;
         const updatedConversations = (prev.conversations || []).map(conv => {
           if (conv.comment_id === optimisticCommentId) {
-            console.log('[ClientPortal][optimistic] Updating local state', {
+            if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][optimistic] Updating local state', {
               comment_id: conv.comment_id,
               prevUpdatedAt: conv.updated_at,
               nextUpdatedAt: optimisticUpdatedAt,
@@ -246,11 +246,11 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
       setCurrentComment(null);
 
       // Refresh ticket details to get the authoritative updated comment
-      console.log('[ClientPortal][handleSave] Refetching ticket details');
+      if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][handleSave] Refetching ticket details');
       const details = await getClientTicketDetails(ticketId);
       const detailsWithExtras = details as TicketWithDetails;
       const fetchedConv = (detailsWithExtras.conversations || []).find(c => c.comment_id === optimisticCommentId);
-      console.log('[ClientPortal][handleSave] Refetch result for edited comment', {
+      if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][handleSave] Refetch result for edited comment', {
         comment_id: optimisticCommentId,
         fetchedUpdatedAt: fetchedConv?.updated_at,
         fetchedNoteLen: (fetchedConv?.note || '').length,
@@ -263,7 +263,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
             const fetchedTime = conv.updated_at ? new Date(conv.updated_at).getTime() : 0;
             const optimisticTime = new Date(optimisticUpdatedAt).getTime();
             if (optimisticTime > fetchedTime) {
-              console.log('[ClientPortal][merge] Keeping optimistic version', {
+              if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][merge] Keeping optimistic version', {
                 optimisticUpdatedAt,
                 fetchedUpdatedAt: conv.updated_at,
                 fetchedNoteLen: (conv.note || '').length,
@@ -275,7 +275,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
                 updated_at: optimisticUpdatedAt,
               } as IComment;
             } else {
-              console.log('[ClientPortal][merge] Keeping fetched version', {
+              if (process.env.NODE_ENV !== 'production') console.log('[ClientPortal][merge] Keeping fetched version', {
                 optimisticUpdatedAt,
                 fetchedUpdatedAt: conv.updated_at,
               });

--- a/server/src/components/client-portal/tickets/TicketDetails.tsx
+++ b/server/src/components/client-portal/tickets/TicketDetails.tsx
@@ -52,9 +52,13 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
   const [isEditing, setIsEditing] = useState(false);
   const [currentComment, setCurrentComment] = useState<IComment | null>(null);
   const [editorKey, setEditorKey] = useState(0);
+  // Force remount of TicketConversation when needed
+  const [conversationVersion, setConversationVersion] = useState(0);
+  // Local overrides for comments to ensure immediate UI reflection
+  const [commentOverrides, setCommentOverrides] = useState<Record<string, { note?: string; updated_at?: string }>>({});
   const [statusOptions, setStatusOptions] = useState<IStatus[]>([]);
   const [ticketToUpdateStatus, setTicketToUpdateStatus] = useState<{ ticketId: string; newStatusId: string; currentStatusName: string; newStatusName: string; } | null>(null);
-  const [newCommentContent, setNewCommentContent] = useState<PartialBlock[]>([{
+  const [newCommentContent, setNewCommentContent] = useState<PartialBlock[]>([{ 
     type: "paragraph",
     props: {
       textAlignment: "left",
@@ -67,6 +71,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
       styles: {}
     }]
   }]);
+  // No component-level pending state needed; we’ll keep optimistic data within the save handler scope
 
   useEffect(() => {
     const loadTicketDetails = async () => {
@@ -193,13 +198,100 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
         }
       }
       
+      console.log('[ClientPortal][handleSave] Attempting save', {
+        comment_id: currentComment.comment_id,
+        hasNote: !!updates.note,
+        noteLen: updates.note ? updates.note.length : 0,
+      });
       await updateClientTicketComment(currentComment.comment_id, updates);
+      console.log('[ClientPortal][handleSave] Save succeeded');
+
+      // Prepare an optimistic version of the updated comment for immediate UI update and later merge
+      const optimisticUpdatedAt = new Date().toISOString();
+      const optimisticCommentId = currentComment.comment_id;
+      const optimisticNote = updates.note;
+
+      // Optimistically update the local ticket state so the UI reflects changes immediately
+      setTicket(prev => {
+        if (!prev) return prev;
+        const updatedConversations = (prev.conversations || []).map(conv => {
+          if (conv.comment_id === optimisticCommentId) {
+            console.log('[ClientPortal][optimistic] Updating local state', {
+              comment_id: conv.comment_id,
+              prevUpdatedAt: conv.updated_at,
+              nextUpdatedAt: optimisticUpdatedAt,
+              prevNoteLen: (conv.note || '').length,
+              nextNoteLen: (updates.note || conv.note || '').length,
+            });
+            return {
+              ...conv,
+              ...updates,
+              updated_at: optimisticUpdatedAt,
+            } as IComment;
+          }
+          return conv;
+        });
+        return { ...prev, conversations: updatedConversations } as TicketWithDetails;
+      });
+
+      // Set override to guarantee immediate child render with latest note
+      setCommentOverrides(prev => ({
+        ...prev,
+        [optimisticCommentId]: { note: optimisticNote, updated_at: optimisticUpdatedAt }
+      }));
+
+      // Force remount of the conversation list to avoid any stale subtrees
+      setConversationVersion(v => v + 1);
       setIsEditing(false);
       setCurrentComment(null);
-      
-      // Refresh ticket details to get updated comment
+
+      // Refresh ticket details to get the authoritative updated comment
+      console.log('[ClientPortal][handleSave] Refetching ticket details');
       const details = await getClientTicketDetails(ticketId);
-      setTicket(details);
+      const detailsWithExtras = details as TicketWithDetails;
+      const fetchedConv = (detailsWithExtras.conversations || []).find(c => c.comment_id === optimisticCommentId);
+      console.log('[ClientPortal][handleSave] Refetch result for edited comment', {
+        comment_id: optimisticCommentId,
+        fetchedUpdatedAt: fetchedConv?.updated_at,
+        fetchedNoteLen: (fetchedConv?.note || '').length,
+      });
+      // Merge: prefer our optimistic update if it’s newer than fetched data
+      setTicket(() => {
+        const merged = { ...detailsWithExtras } as TicketWithDetails;
+        merged.conversations = (detailsWithExtras.conversations || []).map(conv => {
+          if (conv.comment_id === optimisticCommentId) {
+            const fetchedTime = conv.updated_at ? new Date(conv.updated_at).getTime() : 0;
+            const optimisticTime = new Date(optimisticUpdatedAt).getTime();
+            if (optimisticTime > fetchedTime) {
+              console.log('[ClientPortal][merge] Keeping optimistic version', {
+                optimisticUpdatedAt,
+                fetchedUpdatedAt: conv.updated_at,
+                fetchedNoteLen: (conv.note || '').length,
+                optimisticNoteLen: (optimisticNote || '').length,
+              });
+              return {
+                ...conv,
+                note: optimisticNote ?? conv.note,
+                updated_at: optimisticUpdatedAt,
+              } as IComment;
+            } else {
+              console.log('[ClientPortal][merge] Keeping fetched version', {
+                optimisticUpdatedAt,
+                fetchedUpdatedAt: conv.updated_at,
+              });
+            }
+          }
+          return conv;
+        });
+        return merged;
+      });
+
+      // Clear override after refetch resolution
+      setCommentOverrides(prev => {
+        const next = { ...prev };
+        delete next[optimisticCommentId];
+        return next;
+      });
     } catch (error) {
       console.error('Failed to update comment:', error);
       setError('Failed to update comment');
@@ -361,6 +453,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
 
               {ticket.conversations && (
                 <TicketConversation
+                  key={`conv-${conversationVersion}`}
                   ticket={ticket}
                   conversations={ticket.conversations}
                   documents={ticket.documents || []}
@@ -383,6 +476,7 @@ export function TicketDetails({ ticketId, isOpen, onClose }: TicketDetailsProps)
                   onClose={handleClose}
                   onDelete={handleDelete}
                   onContentChange={handleContentChange}
+                  overrides={commentOverrides}
                 />
               )}
               

--- a/server/src/components/editor/RichTextViewer.tsx
+++ b/server/src/components/editor/RichTextViewer.tsx
@@ -151,7 +151,7 @@ export default function RichTextViewer({
   const contentKey = useMemo(() => {
     try {
       const key = JSON.stringify(parsedContent);
-      console.log('[RichTextViewer] contentKey computed', {
+      if (process.env.NODE_ENV !== 'production') console.log('[RichTextViewer] contentKey computed', {
         keyHashLen: key.length,
         blocks: Array.isArray(parsedContent) ? parsedContent.length : undefined
       });

--- a/server/src/components/tickets/ticket/CommentItem.tsx
+++ b/server/src/components/tickets/ticket/CommentItem.tsx
@@ -310,7 +310,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
                   }]
                 }];
               }
-              console.log('[CommentItem] render viewer', {
+              if (process.env.NODE_ENV !== 'production') console.log('[CommentItem] render viewer', {
                 comment_id: conversation.comment_id,
                 updated_at: conversation.updated_at,
                 noteLen: (conversation.note || '').length,

--- a/server/src/components/tickets/ticket/CommentItem.tsx
+++ b/server/src/components/tickets/ticket/CommentItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { PartialBlock } from '@blocknote/core';
 import TextEditor from '../../editor/TextEditor';
 import RichTextViewer from '../../editor/RichTextViewer';
@@ -158,6 +158,36 @@ const CommentItem: React.FC<CommentItemProps> = ({
   const authorFirstName = conversation.user_id ? userMap[conversation.user_id]?.first_name || '' : '';
   const authorLastName = conversation.user_id ? userMap[conversation.user_id]?.last_name || '' : '';
 
+  // Keep editor content in sync if this comment enters edit mode with updated data
+  useEffect(() => {
+    if (isEditing && currentComment?.comment_id === conversation.comment_id) {
+      try {
+        const parsed = JSON.parse(currentComment?.note || '');
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setEditedContent(parsed);
+        }
+      } catch {
+        setEditedContent([
+          {
+            type: "paragraph",
+            props: {
+              textAlignment: "left",
+              backgroundColor: "default",
+              textColor: "default"
+            },
+            content: [
+              {
+                type: "text",
+                text: currentComment?.note || '',
+                styles: {}
+              }
+            ]
+          }
+        ]);
+      }
+    }
+  }, [isEditing, currentComment?.comment_id, currentComment?.note, conversation.comment_id]);
+
 
   return (
     <div {...withDataAutomationId({ id: commentId })} className="rounded-lg p-2 mb-2 shadow-sm border border-gray-200 hover:border-gray-300 bg-white">
@@ -260,28 +290,41 @@ const CommentItem: React.FC<CommentItemProps> = ({
           {isEditing && currentComment?.comment_id === conversation.comment_id ? (
             editorContent
           ) : (
-              <div {...withDataAutomationId({ id: `${commentId}-content` })} className="prose max-w-none mt-1">
-                <RichTextViewer content={(() => {
-                  try {
-                    return JSON.parse(conversation.note || '[]');
-                  } catch (e) {
-                    // If parsing fails, return a simple paragraph with the text
-                    return [{
-                      type: "paragraph",
-                      props: {
-                        textAlignment: "left",
-                        backgroundColor: "default",
-                        textColor: "default"
-                      },
-                      content: [{
-                        type: "text",
-                        text: conversation.note || '',
-                        styles: {}
-                      }]
-                    }];
-                  }
-                })()} />
-              </div>
+            (() => {
+              let parsed: PartialBlock[] | string;
+              try {
+                parsed = JSON.parse(conversation.note || '[]');
+                if (!Array.isArray(parsed)) parsed = [];
+              } catch {
+                parsed = [{
+                  type: "paragraph",
+                  props: {
+                    textAlignment: "left",
+                    backgroundColor: "default",
+                    textColor: "default"
+                  },
+                  content: [{
+                    type: "text",
+                    text: conversation.note || '',
+                    styles: {}
+                  }]
+                }];
+              }
+              console.log('[CommentItem] render viewer', {
+                comment_id: conversation.comment_id,
+                updated_at: conversation.updated_at,
+                noteLen: (conversation.note || '').length,
+                usingArray: Array.isArray(parsed),
+                blocks: Array.isArray(parsed) ? (parsed as PartialBlock[]).length : undefined,
+              });
+              return (
+                <div {...withDataAutomationId({ id: `${commentId}-content` })} className="prose max-w-none mt-1">
+                  <RichTextViewer 
+                    key={`${conversation.comment_id}-${conversation.updated_at || conversation.created_at}`}
+                    content={parsed as any} />
+                </div>
+              );
+            })()
           )}
         </div>
       </div>

--- a/server/src/components/tickets/ticket/TicketConversation.tsx
+++ b/server/src/components/tickets/ticket/TicketConversation.tsx
@@ -88,6 +88,8 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
   isSubmitting = false,
   overrides = {},
 }) => {
+  // Ensure we have a stable id for interactive element ids
+  const compId = id || `ticket-${ticket.ticket_id || 'unknown'}-conversation`;
   const [showEditor, setShowEditor] = useState(false);
   const [reverseOrder, setReverseOrder] = useState(false);
   const [isInternalToggle, setIsInternalToggle] = useState(false);
@@ -188,7 +190,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
   // Log when conversations prop changes
   useEffect(() => {
     try {
-      console.log('[TicketConversation] conversations changed', {
+      if (process.env.NODE_ENV !== 'production') console.log('[TicketConversation] conversations changed', {
         count: conversations.length,
         items: conversations.map(c => ({ id: c.comment_id, updated_at: c.updated_at, noteLen: (c.note || '').length }))
       });
@@ -213,7 +215,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
         ? { ...conversation, ...(override.note ? { note: override.note } : {}), ...(override.updated_at ? { updated_at: override.updated_at } : {}) }
         : conversation;
       const itemKey = `${conversation.comment_id}-${conversation.updated_at || ''}-${(conversation.note || '').length}`;
-      console.log('[TicketConversation][renderComments] Rendering', {
+      if (process.env.NODE_ENV !== 'production') console.log('[TicketConversation][renderComments] Rendering', {
         key: itemKey,
         comment_id: mergedConversation.comment_id,
         updated_at: mergedConversation.updated_at,
@@ -310,7 +312,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
           <h2 className="text-xl font-bold">Comments</h2>
           {!showEditor && (
             <Button
-              id={`${id}-show-comment-editor-btn`}
+              id={`${compId}-show-comment-editor-btn`}
               onClick={handleAddCommentClick}
             >
               Add Comment
@@ -336,7 +338,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                   {!hideInternalTab && (
                     <div className="flex items-center space-x-2">
                       <Switch
-                        id={`${id}-internal-toggle`}
+                        id={`${compId}-internal-toggle`}
                         checked={isInternalToggle}
                         onCheckedChange={setIsInternalToggle}
                       />
@@ -347,7 +349,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                   )}
                   <div className="flex items-center space-x-2">
                     <Switch
-                      id={`${id}-resolution-toggle`}
+                      id={`${compId}-resolution-toggle`}
                       checked={isResolutionToggle}
                       onCheckedChange={setIsResolutionToggle}
                     />
@@ -358,7 +360,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                 </div>
                 <Suspense fallback={<RichTextEditorSkeleton height="200px" title="Comment Editor" />}>
                   <TextEditor
-                    {...withDataAutomationId({ id: `${id}-editor` })}
+                    {...withDataAutomationId({ id: `${compId}-editor` })}
                     key={editorKey}
                     roomName={`ticket-${ticket.ticket_id}`}
                     initialContent={DEFAULT_BLOCK}
@@ -367,14 +369,14 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                 </Suspense>
                 <div className="flex justify-end space-x-2 mt-1">
                   <Button
-                    id={`${id}-add-comment-btn`}
+                    id={`${compId}-add-comment-btn`}
                     onClick={handleSubmitComment}
                     disabled={isSubmitting}
                   >
                     {isSubmitting ? 'Adding...' : 'Add Comment'}
                   </Button>
                   <Button
-                    id={`${id}-cancel-comment-btn`}
+                    id={`${compId}-cancel-comment-btn`}
                     onClick={handleCancelComment}
                     variant="outline"
                     disabled={isSubmitting}
@@ -393,6 +395,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
           onTabChange={onTabChange}
           extraContent={
             <button
+              id={`${compId}-toggle-order-btn`}
               onClick={toggleCommentOrder}
               className="flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent px-4 py-2 ml-auto"
             >

--- a/server/src/components/tickets/ticket/TicketDetails.tsx
+++ b/server/src/components/tickets/ticket/TicketDetails.tsx
@@ -642,7 +642,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                 return true;
             } else {
                 // Use the regular createComment action for MSP portal
-                if (ticket.ticket_id) {
+                if (ticket.ticket_id && userId) {
                     // Call the regular comment creation action
                     const newComment = await createComment({
                         ticket_id: ticket.ticket_id,
@@ -650,7 +650,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                         is_internal: isInternal,
                         is_resolution: isResolution,
                         user_id: userId,
-                        author_type: 'internal'
+                        author_type: 'internal' // Will be overridden based on user type in the action
                     });
                     
                     if (newComment) {


### PR DESCRIPTION

- Add optimistic update in client portal `TicketDetails.handleSave` and merge after refetch to prevent stale overwrite updated_at` for the edited comment
- Force conversation list remount via `conversationVersion` key to avoid stale subtrees post-save
- Make `RichTextViewer` remount on content changes using a keyed inner component (`ViewerCore`) and computed `contentKey`
- Key `CommentItem` and `RichTextViewer` by `comment_id` + `updated_at` (and note length in list) to ensure re-init with fresh content
- Sync `editedContent` in `CommentItem` when re-entering edit mode for an updated comment
- Add diagnostic logs across save, render, and viewer initialization to trace content/timestamps
- Fix TypeScript issue by casting refetched ticket to `TicketWithDetails` before accessing `conversations`