### PR TITLE
feat(helm): Istio Gateway/VirtualService for 0.9.0 (dash hostnames)

### DIFF
--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -8,7 +8,7 @@ services:
     container_name: ${APP_NAME:-sebastian}_server_ee
     build:
       context: .
-      dockerfile: ee/server/Dockerfile
+      dockerfile: ee/server/Dockerfile.build
     environment:
       EDITION: enterprise
       DB_NAME: server

--- a/helm/README.md
+++ b/helm/README.md
@@ -20,3 +20,32 @@ Istio/Vault networking
 
 Upgrade example
 - `helm upgrade sebastian . -n msp -f values.yaml`
+
+## Istio Gateway + VirtualService (optional)
+
+Enable Istio-managed ingress when you terminate TLS upstream (e.g., Cloudflare) and send HTTP to the cluster.
+
+1) Label the namespace for injection:
+   - kubectl label ns msp istio-injection=enabled --overwrite
+   - or: kubectl label ns msp istio.io/rev=default --overwrite
+
+2) Enable the templates and set hosts:
+
+   helm upgrade --install sebastian . -n msp \
+     --set istio.enabled=true \
+     --set istio.gateway.selector.istio=ingress \
+     --set istio.hosts={sebastian.9minds.ai,green-sebastian.9minds.ai,blue-sebastian.9minds.ai,istio.9minds.ai} \
+     --set istio.routes.default.service=sebastian-green \
+     --set istio.routes.default.port=3000 \
+     --set istio.routes.green.host=green-sebastian.9minds.ai \
+     --set istio.routes.green.service=sebastian-green \
+     --set istio.routes.green.port=3000 \
+     --set istio.routes.blue.host=blue-sebastian.9minds.ai \
+     --set istio.routes.blue.service=sebastian-blue \
+     --set istio.routes.blue.port=3000
+
+Notes:
+- Only HTTP (port 80) is exposed by the Gateway. Terminate TLS at your reverse
+  proxy (e.g., Cloudflare) and target the origin URL:
+  http://istio-ingress.istio-system.svc.cluster.local:80
+- The default apex host routes to green. Adjust to your needs.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -54,3 +54,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Resolve the correct namespace for the resource.
      Returns a trimmed single-line string to avoid newline emission in include sites. */}}
 {{- define "sebastian.namespace" -}}{{- if .Values.devEnv.enabled -}}{{- .Values.devEnv.namespace -}}{{- else if .Values.hostedEnv.enabled -}}{{- .Values.hostedEnv.namespace -}}{{- else -}}{{- .Values.namespace -}}{{- end -}}{{- end }}
+
+{{/* Derive deployment color from release name */}}
+{{- define "sebastian.color" -}}
+{{- $rn := .Release.Name -}}
+{{- if hasSuffix "-blue" $rn -}}blue{{- else if hasSuffix "-green" $rn -}}green{{- else -}}{{- "" -}}{{- end -}}
+{{- end }}
+
+{{/* Resolve host for app:
+     - If release is colored (-blue/-green) and .Values.domainSuffix is set -> <color>.<domainSuffix>
+     - Else if .Values.host is set -> .Values.host
+     - Else fallback to .Values.domainSuffix (may be empty) */}}
+{{- define "sebastian.resolveHost" -}}
+{{- $host := default "" .Values.host -}}
+{{- $suffix := default "" .Values.domainSuffix -}}
+{{- $color := include "sebastian.color" . -}}
+{{- if and $color (ne $color "") (ne $suffix "") -}}
+{{- printf "%s.%s" $color $suffix -}}
+{{- else if ne $host "" -}}
+{{- $host -}}
+{{- else -}}
+{{- $suffix -}}
+{{- end -}}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           - name: NODE_ENV
             value: "{{ .Values.env }}"
           - name: HOST
-            value: "{{ .Values.host }}"
+            value: "{{ include "sebastian.resolveHost" . }}"
           - name: VERIFY_EMAIL_ENABLED
             value: "{{ .Values.server.verify_email}}"
 
@@ -171,22 +171,20 @@ spec:
           - name: DB_NAME_SERVER
             value: "{{ .Values.config.db.server_database }}"
           - name: DB_PASSWORD_ADMIN
-            {{- if and .Values.config.db.server_password_admin_secret.name .Values.config.db.server_password_admin_secret.key }}
+            {{- with .Values.config.db.server_password_admin_secret }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.config.db.server_password_admin_secret.name | quote }}
-                key: {{ .Values.config.db.server_password_admin_secret.key | quote }}
-                namespace: {{ .Values.config.db.server_password_admin_secret.namespace | quote }}
+                name: {{ .name | quote }}
+                key: {{ .key | quote }}
             {{- else }}
             value: {{ .Values.config.db.server_admin_password | quote }}
             {{- end }}
           - name: DB_PASSWORD_SERVER
-            {{- if and .Values.config.db.server_password_secret.name .Values.config.db.server_password_secret.key }}
+            {{- with .Values.config.db.server_password_secret }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.config.db.server_password_secret.name | quote }}
-                key: {{ .Values.config.db.server_password_secret.key | quote }}
-                namespace: {{ .Values.config.db.server_password_admin_secret.namespace | quote }}
+                name: {{ .name | quote }}
+                key: {{ .key | quote }}
             {{- else }}
             value: {{ .Values.config.db.server_password | quote }}
             {{- end }}

--- a/helm/templates/istio/gateway.yaml
+++ b/helm/templates/istio/gateway.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.istio.enabled }}
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "sebastian.fullname" . }}-gw
+  namespace: {{ include "sebastian.namespace" . }}
+  labels:
+    {{- include "sebastian.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- toYaml .Values.istio.gateway.selector | nindent 4 }}
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    {{- range .Values.istio.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/istio/virtualservice.yaml
+++ b/helm/templates/istio/virtualservice.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.istio.enabled }}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ include "sebastian.fullname" . }}-vs
+  namespace: {{ include "sebastian.namespace" . }}
+  labels:
+    {{- include "sebastian.labels" . | nindent 4 }}
+spec:
+  gateways:
+  - {{ include "sebastian.namespace" . }}/{{ include "sebastian.fullname" . }}-gw
+  hosts:
+  {{- range .Values.istio.hosts }}
+  - {{ . | quote }}
+  {{- end }}
+  http:
+  # Route: explicit green host
+  - name: green-direct
+    match:
+    - authority:
+        exact: {{ .Values.istio.routes.green.host | quote }}
+      uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: {{ printf "%s.%s.svc.cluster.local" .Values.istio.routes.green.service (include "sebastian.namespace" .) | quote }}
+        port:
+          number: {{ .Values.istio.routes.green.port }}
+  # Route: explicit blue host (optional)
+  - name: blue-direct
+    match:
+    - authority:
+        exact: {{ .Values.istio.routes.blue.host | quote }}
+      uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: {{ printf "%s.%s.svc.cluster.local" .Values.istio.routes.blue.service (include "sebastian.namespace" .) | quote }}
+        port:
+          number: {{ .Values.istio.routes.blue.port }}
+  # Route: default apex host to green by default
+  - name: default-colored
+    match:
+    - headers:
+        :authority:
+          exact: {{ .Values.istio.routes.default.host | quote }}
+      uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: {{ printf "%s.%s.svc.cluster.local" .Values.istio.routes.default.service (include "sebastian.namespace" .) | quote }}
+        port:
+          number: {{ .Values.istio.routes.default.port }}
+  # Optional extra route for an ops/debug host
+  - name: istio-host
+    match:
+    - headers:
+        :authority:
+          exact: {{ .Values.istio.routes.istio.host | quote }}
+      uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: {{ printf "%s.%s.svc.cluster.local" .Values.istio.routes.istio.service (include "sebastian.namespace" .) | quote }}
+        port:
+          number: {{ .Values.istio.routes.istio.port }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,35 @@ namespace: msp
 nameOverride: ""
 fullnameOverride: ""
 host: "localhost"
+
+# Istio ingress configuration
+istio:
+  enabled: false
+  gateway:
+    selector:
+      istio: ingress
+  hosts:
+    - sebastian.9minds.ai
+    - green-sebastian.9minds.ai
+    - blue-sebastian.9minds.ai
+    - istio.9minds.ai
+  routes:
+    green:
+      host: green-sebastian.9minds.ai
+      service: sebastian-green
+      port: 3000
+    blue:
+      host: blue-sebastian.9minds.ai
+      service: sebastian-blue
+      port: 3000
+    default:
+      host: sebastian.9minds.ai
+      service: sebastian-green
+      port: 3000
+    istio:
+      host: istio.9minds.ai
+      service: sebastian-green
+      port: 3000
 #env: "development"
 
 #FIXME: In image change nineminds to public when we we make image public 

--- a/shared/package.json
+++ b/shared/package.json
@@ -31,7 +31,8 @@
     "./models/userModel.js": "./dist/models/userModel.js",
     "./extensions/domain.js": "./dist/extensions/domain.js",
     "./extensions/installs.js": "./dist/extensions/installs.js",
-    "./extensions/types.js": "./dist/extensions/types.js"
+    "./extensions/types.js": "./dist/extensions/types.js",
+    "./*": "./dist/*"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Backports Istio ingress support to the 0.9.0 release branch.

What’s included
- New templates under helm/templates/istio/
  - Gateway (HTTP :80) with configurable hosts
  - VirtualService with routes for green/blue and apex default
- New values under `istio.*` (disabled by default)
- Default hosts updated to dash form (green-sebastian / blue-sebastian)
- README guidance to enable and use with Cloudflare Tunnel (HTTP origin)

Why
- Aligns Istio ingress with current environment using Cloudflare termination and HTTP to origin.
- Supports single-level hostnames compatible with Universal SSL.

Base: release/0.9.0
Cherry-picked from: fb1a3cea (squash of changes since d8082e9d)
