### PR TITLE
Fix recurring event deletion issues

### DIFF
--- a/server/src/lib/actions/scheduleActions.ts
+++ b/server/src/lib/actions/scheduleActions.ts
@@ -257,10 +257,14 @@ export async function deleteScheduleEntry(entry_id: string, deleteType: IEditSco
     const userPermissions = await getCurrentUserPermissions();
     const canUpdateGlobally = userPermissions.includes('user_schedule:update');
 
+    // Parse entry ID to get master entry ID (for virtual entries)
+    const isVirtualId = entry_id.includes('_');
+    const masterEntryId = isVirtualId ? entry_id.split('_')[0] : entry_id;
+
     // Fetch the existing entry first to check permissions
     const { knex: db } = await createTenantKnex();
     const existingEntry = await withTransaction(db, async (trx: Knex.Transaction) => {
-      return await ScheduleEntry.get(trx, entry_id);
+      return await ScheduleEntry.get(trx, masterEntryId);
     });
     if (!existingEntry) {
       // If entry doesn't exist, deletion is technically successful (idempotent)


### PR DESCRIPTION
## Summary
- Fixed "Only this event" deletion incorrectly removing all instances of recurring events
- Fixed UUID parsing errors when deleting "This and future events" from recurring series
- Improved handling of master entry deletion in both SINGLE and FUTURE modes

## Issues Resolved
1. **"Only this event" was deleting entire recurring series**: Now properly adds exceptions to recurrence pattern or creates new master entry when needed
2. **UUID parsing errors**: Fixed database queries attempting to use virtual entry IDs (e.g., `uuid_timestamp`) instead of master UUIDs  
3. **Master entry deletion logic**: Added proper handling for deleting the initial/first event in a recurring series

## Technical Changes
### scheduleActions.ts
- Added parsing logic to extract master entry ID from virtual entry IDs before database queries
- Prevents `invalid input syntax for type uuid` errors

### scheduleEntry.ts  
- **SINGLE mode**: When deleting master entry, creates new master from next occurrence and adds original date to exceptions
- **FUTURE mode**: When applied to master entry, deletes entire series (logical equivalent to "All events")
- Improved recurrence pattern exception handling for virtual instances

## Test plan
- [x] Test "Only this event" on recurring series instances (virtual entries)
- [x] Test "Only this event" on initial/master recurring event 
- [x] Test "This and future events" on recurring series instances
- [x] Test "This and future events" on initial/master recurring event
- [x] Test "All events" continues to work as expected
- [x] Verify no UUID parsing errors occur with any deletion type

🤖 Generated with [Claude Code](https://claude.ai/code)