### PR TITLE
fix(time-entry): resolve ad-hoc entry editing validation error

### DIFF
--- a/server/src/components/time-management/time-entry/time-sheet/WorkItemDrawer.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/WorkItemDrawer.tsx
@@ -229,7 +229,9 @@ export function WorkItemDrawer({
                                     scheduled_start: new Date(adHocData.scheduled_start || new Date()),
                                     scheduled_end: new Date(adHocData.scheduled_end || new Date()),
                                     status: 'SCHEDULED',
-                                    assigned_user_ids: workItem.users?.map(u => u.user_id) || [currentUser.user_id],
+                                    assigned_user_ids: workItem.users && workItem.users.length > 0
+                                        ? workItem.users.map(u => u.user_id)
+                                        : [currentUser?.user_id].filter(Boolean),
                                     created_at: new Date(),
                                     updated_at: new Date()
                                 }}


### PR DESCRIPTION
## Summary
- Fix validation error preventing ad-hoc time entries from being edited in the drawer
- Resolve "At least one assigned user" error by auto-assigning current user when workItem.users is empty
- Maintain design principle that ad-hoc entries are always owned by their creator

## Test plan
- [x] Create an ad-hoc time entry
- [x] Open the ad-hoc entry for editing in the drawer
- [x] Verify that editing and saving works without validation errors
- [x] Confirm current user is properly assigned to the ad-hoc entry

🤖 Generated with [Claude Code](https://claude.ai/code)