### PR TITLE
feat(api): NM Store API key middleware + user search refactor

### DIFF
--- a/ee/server/src/lib/middleware/withNmStoreApiKey.ts
+++ b/ee/server/src/lib/middleware/withNmStoreApiKey.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSecretProviderInstance } from '@alga-psa/shared/core/secretProvider';
+
+// Lightweight cache for the NM Store key to avoid repeated secret lookups
+let CACHED_NM_STORE_KEY: string | null = null;
+let LAST_FETCH = 0;
+const TTL_MS = 60_000;
+
+async function getNmStoreKey(): Promise<string | null> {
+  const now = Date.now();
+  if (CACHED_NM_STORE_KEY && now - LAST_FETCH < TTL_MS) return CACHED_NM_STORE_KEY;
+  try {
+    const secretProvider = await getSecretProviderInstance();
+    const key = await secretProvider.getAppSecret('nm_store_api_key');
+    CACHED_NM_STORE_KEY = key || null;
+    LAST_FETCH = now;
+    return CACHED_NM_STORE_KEY;
+  } catch {
+    return null;
+  }
+}
+
+export function withNmStoreApiKey(
+  handler: (req: NextRequest) => Promise<NextResponse>
+) {
+  return async (req: NextRequest): Promise<NextResponse> => {
+    const apiKey = req.headers.get('x-api-key');
+    if (!apiKey) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const nmKey = await getNmStoreKey();
+    if (!nmKey || apiKey !== nmKey) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return handler(req);
+  };
+}
+


### PR DESCRIPTION
This PR introduces a reusable NM Store API key auth middleware and refactors user search to use middleware+validation.\n\n- EE: add withNmStoreApiKey and wrap /api/v1/auth/verify\n- OSS: add withApiKeyAuth and refactor /api/v1/users/search with query validation\n\nBehavioral parity maintained; NM Store key requires x-tenant-id.