### PR TITLE
docs: production persistence volumes + backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ For detailed setup instructions, please refer to our [Complete Setup Guide](docs
 - Security setup
 - Verification steps
 
+Note: For production-like persistence, both CE and EE prebuilt compose files define named volumes for the database (`postgres_data`) and uploaded documents (`files_data`). These volumes are created automatically and ensure data survives container restarts and upgrades. See the Production section in the setup guide for backup/restore examples.
+
 ## Documentation
 
 ### Setup & Configuration

--- a/docker-compose.prebuilt.ce.yaml
+++ b/docker-compose.prebuilt.ce.yaml
@@ -37,6 +37,8 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES:-86400}
     volumes:
+      # Persist user-uploaded documents and generated files
+      - files_data:/data/files
       - type: bind
         source: ./secrets/db_password_server
         target: /run/secrets/db_password_server
@@ -157,6 +159,9 @@ services:
     extends:
       file: docker-compose.base.yaml
       service: postgres
+    volumes:
+      # Persist Postgres data across restarts/upgrades
+      - postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: server
       VERSION: ${VERSION}
@@ -179,3 +184,8 @@ networks:
   app-network:
     name: ${APP_NAME:-sebastian}_app-network
     driver: bridge
+
+volumes:
+  # Named volumes for production-like persistence
+  postgres_data:
+  files_data:

--- a/docker-compose.prebuilt.ee.yaml
+++ b/docker-compose.prebuilt.ee.yaml
@@ -43,6 +43,8 @@ services:
       WORKFLOW_REDIS_STREAM_PREFIX: "workflow:events:"
       WORKFLOW_REDIS_CONSUMER_GROUP: "workflow-workers"
     volumes:
+      # Persist user-uploaded documents and generated files
+      - files_data:/data/files
       - type: bind
         source: ./secrets/db_password_server
         target: /run/secrets/db_password_server
@@ -244,6 +246,9 @@ services:
     extends:
       file: docker-compose.base.yaml
       service: postgres
+    volumes:
+      # Persist Postgres data across restarts/upgrades
+      - postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: server
       VERSION: ${VERSION}
@@ -271,3 +276,8 @@ networks:
   app-network:
     name: ${APP_NAME:-sebastian}_app-network
     driver: bridge
+ 
+volumes:
+  # Named volumes for production-like persistence
+  postgres_data:
+  files_data:


### PR DESCRIPTION
- Add Production Setup (Persistent Storage) section to setup guide\n- Add named volumes for Postgres and file storage in CE/EE prebuilt compose\n- README note pointing to volumes and guide\n\nThis guides users toward a more production-ready configuration with persistent volumes and includes backup/restore examples for DB and files.