### PR TITLE
docs: local EE migrations runner + env override

### DIFF
--- a/docs/AI_coding_standards.md
+++ b/docs/AI_coding_standards.md
@@ -231,6 +231,14 @@ Run migrations with the migration environment (env) flag.
 
 Every query should filter on the tenant column (including joins) to ensure compatibility with citusdb.
 
+## Local EE migrations
+- Do not physically copy EE migrations into `server/migrations/` locally.
+- Use the temp-dir overlay runner which points Knex at a merged directory via `MIGRATIONS_DIR`.
+- Commands:
+  - From repo root: `npm -w server run migrate:ee`
+  - From `server/`: `npm run migrate:ee`
+- Details and rollback guidance: see `docs/migrations/local-ee-migrations.md`.
+
 ## JSON/JSONB Column Handling with Knex
 
 When working with PostgreSQL JSON and JSONB columns in Knex.js, follow these guidelines:

--- a/docs/migrations/local-ee-migrations.md
+++ b/docs/migrations/local-ee-migrations.md
@@ -1,0 +1,56 @@
+# Running EE Migrations Locally (Without Copying Into Repo)
+
+Goal: run Community Edition (CE) and Enterprise Edition (EE) migrations together on a developer workstation without physically copying or committing merged files into the repository.
+
+Summary
+- CE migrations live in `server/migrations/`
+- EE migrations live in `ee/server/migrations/`
+- Locally, use a temp-dir overlay: copy CE first, then overlay EE, run Knex pointing at the temp dir
+- Nothing is written inside the repo, avoiding accidental commits or duplication
+
+How it works
+- `server/knexfile.cjs` now honors `MIGRATIONS_DIR` (defaults to `./migrations`)
+- New helper: `server/scripts/run-ee-migrations.js`
+  - Creates a temp directory under your OS tmp
+  - Copies `server/migrations` into it
+  - Overlays `ee/server/migrations` on top (EE overwrites on filename conflicts)
+  - Runs `npx knex migrate:latest --env migration` with `MIGRATIONS_DIR` pointing to that temp dir
+
+Prerequisites
+- Local DB reachable based on `server/.env`
+- Node 20+, repo dependencies installed
+
+Commands
+- From repo root: `npm -w server run migrate:ee`
+- Or from `server/`: `npm run migrate:ee`
+
+What the script does
+- Uses the `migration` environment from `server/knexfile.cjs` so migrations run with admin credentials
+- Leaves the temp directory in place for inspection; the script prints its path
+
+Rollback or targeted steps (optional)
+- Today, the helper runs only `migrate:latest`
+- If you need down/targeted steps, two options:
+  1) Re-run the script to produce a fresh merged temp dir, then run Knex manually against it:
+     - `NODE_ENV=migration MIGRATIONS_DIR=/path/to/temp/migrations npx knex migrate:down --knexfile server/knexfile.cjs --env migration`
+     - Or specify a particular file with `migrate:up <file>`/`migrate:down <file>`
+  2) Ask to add `migrate:ee:down`/`migrate:ee:up <file>` wrappers; we can extend the helper to support those flows
+
+Do not commit merged migrations
+- Never copy the merged/overlay results into `server/migrations/`
+- All merging happens in a temporary folder under the OS tmp
+
+CI/CD vs local
+- CI/CD images still combine/overlay migrations during build/entrypoint as before
+- Locally, use the temp-dir approach to avoid churn in version control
+
+Troubleshooting
+- Ensure `server/.env` contains correct DB host/user/password for the `migration` env
+- If you need to inspect what ran, open the printed temp path
+- If `npx knex` fails, run the command it prints with `--debug` for more detail
+
+Files involved
+- `server/knexfile.cjs` (supports `MIGRATIONS_DIR`)
+- `server/scripts/run-ee-migrations.js` (temp overlay + invoker)
+- `server/package.json` → script `migrate:ee`
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -310,6 +310,7 @@ No code has been merged yet – this section serves as an architectural note so 
   * PostgreSQL database schema defined in the `server/migrations` folder.
   * Knex.js configurations are in `server/knexfile.cjs` and `server/src/lib/db/knexfile.tsx`.
   * EE-specific migrations are located in `ee/server/migrations/`.
+  * Local EE migrations (dev workstations): use the temp-dir overlay runner documented in `docs/migrations/local-ee-migrations.md`.
 
 * **Caching:** `server/src/lib/cache` directory contains the caching implementation.
 

--- a/server/knexfile.cjs
+++ b/server/knexfile.cjs
@@ -98,7 +98,8 @@ const migrationConfig = {
     max: 20,
   },
   migrations: {
-    directory: "./migrations"
+    directory: process.env.MIGRATIONS_DIR || "./migrations",
+    loadExtensions: ['.cjs', '.js']
   },
   seeds: {
     directory: "./seeds/dev",

--- a/server/package.json
+++ b/server/package.json
@@ -48,7 +48,8 @@
     "workflow-worker:build": "tsc --project tsconfig.json --outDir dist src/bin/workflow-worker.ts",
     "workflow-worker:start": "node dist/bin/workflow-worker.js",
     "create-tenant": "tsx scripts/create-tenant.ts",
-    "rollback-tenant": "tsx scripts/rollback-tenant.ts"
+    "rollback-tenant": "tsx scripts/rollback-tenant.ts",
+    "migrate:ee": "node scripts/run-ee-migrations.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.36.3",

--- a/server/scripts/run-ee-migrations.js
+++ b/server/scripts/run-ee-migrations.js
@@ -1,0 +1,102 @@
+// Runs CE + EE migrations locally by copying into a temp directory
+// and invoking knex with MIGRATIONS_DIR pointing to that temp path.
+// Overlay rule: EE files overwrite CE files when names collide.
+
+import fs from 'fs';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function ensureDir(p) {
+  await fsp.mkdir(p, { recursive: true });
+}
+
+async function copyDir(src, dest) {
+  // Node 16+ supports fs.cp; fallback to manual copy if not available
+  if (fs.cp) {
+    await fsp.cp(src, dest, { recursive: true, force: true });
+    return;
+  }
+  const entries = await fsp.readdir(src, { withFileTypes: true });
+  await ensureDir(dest);
+  for (const e of entries) {
+    const s = path.join(src, e.name);
+    const d = path.join(dest, e.name);
+    if (e.isDirectory()) {
+      await copyDir(s, d);
+    } else if (e.isFile()) {
+      await fsp.copyFile(s, d);
+    }
+  }
+}
+
+function run(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32', ...opts });
+    child.on('close', (code) => {
+      if (code === 0) return resolve();
+      reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function main() {
+  // Resolve repo root from server/scripts/
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const ceDir = path.resolve(repoRoot, 'server', 'migrations');
+  const eeDir = path.resolve(repoRoot, 'ee', 'server', 'migrations');
+
+  // Validate inputs
+  const ceExists = fs.existsSync(ceDir);
+  const eeExists = fs.existsSync(eeDir);
+  if (!ceExists && !eeExists) {
+    console.error('No migrations found: neither server/migrations nor ee/server/migrations exist.');
+    process.exit(1);
+  }
+
+  // Create temp workspace under OS tmp
+  const tmpBase = await fsp.mkdtemp(path.join(os.tmpdir(), 'alga-ee-migrations-'));
+  const tmpMigrations = path.join(tmpBase, 'migrations');
+  await ensureDir(tmpMigrations);
+
+  // Copy CE first
+  if (ceExists) {
+    console.log(`Copying CE migrations from ${ceDir} -> ${tmpMigrations}`);
+    await copyDir(ceDir, tmpMigrations);
+  } else {
+    console.log('CE migrations folder not found; continuing with EE only.');
+  }
+
+  // Overlay EE (overwrites collisions)
+  if (eeExists) {
+    console.log(`Overlaying EE migrations from ${eeDir} -> ${tmpMigrations}`);
+    await copyDir(eeDir, tmpMigrations);
+  } else {
+    console.log('EE migrations folder not found; continuing with CE only.');
+  }
+
+  console.log(`Prepared merged migrations in: ${tmpMigrations}`);
+
+  // Run knex migrate:latest with MIGRATIONS_DIR override and migration env (uses admin connection)
+  const serverDir = path.resolve(repoRoot, 'server');
+  const knexfilePath = path.resolve(serverDir, 'knexfile.cjs');
+  const env = { ...process.env, MIGRATIONS_DIR: tmpMigrations, NODE_ENV: 'migration' };
+
+  console.log('Running migrations with Knex...');
+  await run('npx', ['knex', 'migrate:latest', '--knexfile', knexfilePath, '--env', 'migration'], { env, cwd: serverDir });
+
+  console.log('Migrations completed successfully.');
+  console.log(`Temporary migrations directory preserved at: ${tmpMigrations}`);
+  console.log('Delete it when you are done, e.g. rm -rf', tmpBase);
+}
+
+main().catch((err) => {
+  console.error('EE migration run failed:', err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR documents and enables running EE migrations locally without copying into the repo.

Changes:
- docs/migrations/local-ee-migrations.md: temp-dir overlay approach, commands, troubleshooting
- docs/AI_coding_standards.md: add "Local EE migrations" section linking to the new doc
- docs/overview.md: pointer in Database section
- server/knexfile.cjs: allow overriding migrations dir via MIGRATIONS_DIR and loadExtensions
- server/scripts/run-ee-migrations.js: helper to merge CE+EE into tmp and run Knex
- server/package.json: add script migrate:ee

Rationale:
- Avoids accidental duplication or commits of merged migrations locally
- Mirrors CI "merge then run" behavior while keeping the workspace clean

Follow-up options:
- Add migrate:ee:down or targeted up/down wrappers
- Optionally implement a custom migrationSource to avoid temp copies entirely