### PR TITLE
Subsequent ticket comments now show automatically

### DIFF
--- a/server/src/components/tickets/ticket/TicketDetails.tsx
+++ b/server/src/components/tickets/ticket/TicketDetails.tsx
@@ -623,6 +623,16 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                     isInternal,
                     isResolution
                 );
+
+                // Refresh comments to ensure immediate UI update
+                if (ticket.ticket_id) {
+                    try {
+                        const updatedComments = await findCommentsByTicketId(ticket.ticket_id);
+                        setConversations(updatedComments);
+                    } catch (e) {
+                        console.error('Failed to refresh comments after add:', e);
+                    }
+                }
                 
                 // Reset the comment input
                 setNewCommentContent([{


### PR DESCRIPTION
Prior to this fix, only the first comment would automatically show, but now, all comments will show up on the ticket screen immediately after they are added

Before:

https://github.com/user-attachments/assets/34fabb52-55c4-43bf-be71-49fc030f730f


After:

https://github.com/user-attachments/assets/b95f2fcd-de90-4631-979c-88e35608458d

