### PR TITLE
Add project task statuses seed and improve status handling

### DIFF
--- a/ee/server/seeds/onboarding/06_project_task_statuses.cjs
+++ b/ee/server/seeds/onboarding/06_project_task_statuses.cjs
@@ -1,0 +1,67 @@
+const { v4: uuidv4 } = require('uuid');
+
+exports.seed = async function (knex, tenantId) {
+    // Use provided tenantId or fall back to first tenant
+    if (!tenantId) {
+        const tenant = await knex('tenants').select('tenant').first();
+        if (!tenant) {
+            console.log('No tenant found, skipping project task statuses seed');
+            return;
+        }
+        tenantId = tenant.tenant;
+    }
+
+    // Check if project task statuses already exist for this tenant
+    const existingStatuses = await knex('statuses')
+        .where({
+            tenant: tenantId,
+            status_type: 'project_task'
+        })
+        .first();
+
+    if (!existingStatuses) {
+        const defaultStatuses = [
+            {
+                status_id: uuidv4(),
+                name: 'To Do',
+                status_type: 'project_task',
+                order_number: 1,
+                is_closed: false,
+                is_default: true,
+                item_type: 'project_task', // Add item_type for consistency
+                tenant: tenantId,
+                created_by: null, // No user exists yet during tenant creation
+                created_at: knex.fn.now()
+            },
+            {
+                status_id: uuidv4(),
+                name: 'In Progress',
+                status_type: 'project_task',
+                order_number: 2,
+                is_closed: false,
+                is_default: false,
+                item_type: 'project_task', // Add item_type for consistency
+                tenant: tenantId,
+                created_by: null, // No user exists yet during tenant creation
+                created_at: knex.fn.now()
+            },
+            {
+                status_id: uuidv4(),
+                name: 'Done',
+                status_type: 'project_task',
+                order_number: 3,
+                is_closed: true,
+                is_default: false,
+                item_type: 'project_task', // Add item_type for consistency
+                tenant: tenantId,
+                created_by: null, // No user exists yet during tenant creation
+                created_at: knex.fn.now()
+            }
+        ];
+
+        await knex('statuses').insert(defaultStatuses);
+        console.log(`Created default project task statuses in statuses table for tenant ${tenantId}`);
+    } else {
+        console.log(`Project task statuses already exist for tenant ${tenantId}`);
+    }
+};

--- a/server/src/components/tags/TagInput.tsx
+++ b/server/src/components/tags/TagInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Plus } from 'lucide-react';
 import { generateEntityColor } from 'server/src/utils/colorUtils';
@@ -36,11 +36,13 @@ export const TagInput: React.FC<TagInputProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  // Memoize current tag texts to prevent infinite loops
+  const currentTagTexts = useMemo(() => {
+    return currentTags.map(tag => tag.tag_text.toLowerCase());
+  }, [currentTags]);
+
   useEffect(() => {
     if (inputValue.trim()) {
-      // Get current tag texts (case-insensitive for comparison)
-      const currentTagTexts = currentTags.map(tag => tag.tag_text.toLowerCase());
-      
       // Filter existing tags that:
       // 1. Include the input value
       // 2. Are not already on the current entity
@@ -48,7 +50,7 @@ export const TagInput: React.FC<TagInputProps> = ({
         tag && tag.tag_text && tag.tag_text.toLowerCase().includes(inputValue.toLowerCase()) &&
         !currentTagTexts.includes(tag.tag_text.toLowerCase())
       );
-      
+
       // Remove duplicates by tag_text (case-insensitive)
       const uniqueSuggestions = filtered.reduce((acc: ITag[], current) => {
         const exists = acc.find(tag => tag.tag_text.toLowerCase() === current.tag_text.toLowerCase());
@@ -57,12 +59,12 @@ export const TagInput: React.FC<TagInputProps> = ({
         }
         return acc;
       }, []);
-      
+
       setSuggestions(uniqueSuggestions);
     } else {
       setSuggestions([]);
     }
-  }, [inputValue, existingTags, currentTags]);
+  }, [inputValue, existingTags, currentTagTexts]);
 
   // Update dropdown position when suggestions change or input is focused
   useLayoutEffect(() => {


### PR DESCRIPTION
- Add onboarding seed for default project task statuses (To Do, In Progress, Done)
- Fix TagInput infinite loop by memoizing current tag texts
- Refactor project creation to handle both standard and regular status tables
- Improve backward compatibility for project task status management

Impact: Ensures consistent project task status setup across tenants and prevents UI performance issues in tag input.

Follow the yellow brick road of statuses, for there's no place like a properly seeded database! 🧙‍♂️✨