### PR TITLE
Ensure portal domains update base VirtualService

### DIFF
--- a/ee/temporal-workflows/src/config/startupValidation.ts
+++ b/ee/temporal-workflows/src/config/startupValidation.ts
@@ -63,6 +63,7 @@ const REQUIRED_CONFIGS = {
   TEMPORAL_ADDRESS: 'Temporal server address (e.g., temporal-frontend:7233)',
   TEMPORAL_NAMESPACE: 'Temporal namespace (e.g., default)',
   TEMPORAL_TASK_QUEUE: 'Temporal task queue name',
+  PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE: 'Existing VirtualService name that anchors portal routing',
 } as const;
 
 /**
@@ -161,6 +162,8 @@ export async function validateRequiredConfiguration(): Promise<void> {
     TEMPORAL_ADDRESS: validatedConfigs.TEMPORAL_ADDRESS,
     TEMPORAL_NAMESPACE: validatedConfigs.TEMPORAL_NAMESPACE,
     TEMPORAL_TASK_QUEUE: validatedConfigs.TEMPORAL_TASK_QUEUE,
+    PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE:
+      validatedConfigs.PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE,
   });
 }
 
@@ -326,6 +329,8 @@ export function logConfiguration(): void {
     TEMPORAL_ADDRESS: process.env.TEMPORAL_ADDRESS,
     TEMPORAL_NAMESPACE: process.env.TEMPORAL_NAMESPACE,
     TEMPORAL_TASK_QUEUE: process.env.TEMPORAL_TASK_QUEUE,
+    PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE:
+      process.env.PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE,
     
     // Email
     EMAIL_PROVIDER: process.env.EMAIL_PROVIDER,


### PR DESCRIPTION
## Summary
- require the portal worker to define `PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE`
- merge each tenant VirtualService host and gateway into the shared base VS during reconciliation
- extend test coverage for TLS routing and base VirtualService updates
