### PR TITLE
fix: temporarily disable project task statuses seed

### DIFF
--- a/ee/server/seeds/onboarding/06_project_task_statuses.cjs
+++ b/ee/server/seeds/onboarding/06_project_task_statuses.cjs
@@ -1,6 +1,13 @@
 const { v4: uuidv4 } = require('uuid');
 
 exports.seed = async function (knex, tenantId) {
+    // TEMPORARILY DISABLED: This seed fails because statuses.created_by has a NOT NULL constraint,
+    // but no user exists yet during tenant creation (seeds run before user creation).
+    // TODO: Either make created_by nullable in the statuses table, or move this seed to run after user creation.
+    console.log('Skipping project task statuses seed (temporarily disabled due to created_by constraint)');
+    return;
+
+    /* COMMENTED OUT UNTIL CREATED_BY ISSUE IS RESOLVED
     // Use provided tenantId or fall back to first tenant
     if (!tenantId) {
         const tenant = await knex('tenants').select('tenant').first();
@@ -64,4 +71,5 @@ exports.seed = async function (knex, tenantId) {
     } else {
         console.log(`Project task statuses already exist for tenant ${tenantId}`);
     }
+    */
 };


### PR DESCRIPTION
## Summary

Temporarily disables the `06_project_task_statuses.cjs` onboarding seed to fix tenant creation failures.

## Root Cause

The tenant creation workflow is failing with:
```
null value in column "created_by" of relation "statuses" violates not-null constraint
```

This occurs because:
1. The seed tries to insert statuses with `created_by=null`
2. The `statuses` table has a NOT NULL constraint on `created_by` from the initial schema
3. Onboarding seeds run **before** any users exist in the workflow

## Timeline

- **Sept 2024**: `statuses` table created with `created_by uuid NOT NULL`
- **Aug 5, 2025**: Workflow refactored to run seeds before user creation (commit `59f2ad79`)
- **Sept 26, 2025**: New seed `06_project_task_statuses.cjs` added (commit `2ca1ca6a`)
  - This is the first seed file that inserts into a table with a NOT NULL `created_by` column
  - Developer correctly identified the issue and added comment, but didn't realize about the NOT NULL constraint

## Changes

- Disabled seed execution with clear early return
- Preserved original code in comments for future implementation
- Added TODO with two possible solutions:
  1. Make `created_by` nullable in the statuses table
  2. Move this seed to run after user creation in the workflow

## Impact

✅ Immediately unblocks tenant creation workflow
⚠️ New tenants won't have default project task statuses until permanent fix is implemented

## Testing

Tenant creation workflow should now complete successfully without errors.