### PR TITLE
Enable bulk ticket deletion from dashboard

### DIFF
--- a/server/src/components/ui/Checkbox.tsx
+++ b/server/src/components/ui/Checkbox.tsx
@@ -1,7 +1,8 @@
-import React, { InputHTMLAttributes, useEffect } from 'react';
+import React, { InputHTMLAttributes, useEffect, useRef } from 'react';
 import { useRegisterUIComponent } from '../../types/ui-reflection/useRegisterUIComponent';
 import { FormFieldComponent, AutomationProps } from '../../types/ui-reflection/types';
 import { withDataAutomationId } from '../../types/ui-reflection/withDataAutomationId';
+import { cn } from 'server/src/lib/utils';
 
 interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'id'> {
   label?: string;
@@ -9,16 +10,22 @@ interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'typ
   id?: string;
   /** Whether the checkbox is required */
   required?: boolean;
+  /** Custom classes for the checkbox container */
+  containerClassName?: string;
+  /** Display an indeterminate state */
+  indeterminate?: boolean;
 }
 
 export const Checkbox: React.FC<CheckboxProps & AutomationProps> = ({
-  label, 
-  className, 
+  label,
+  className,
   id,
   checked,
   disabled,
   required,
-  ...props 
+  containerClassName,
+  indeterminate,
+  ...props
 }) => {
   // Register with UI reflection system if id is provided
   const updateMetadata = useRegisterUIComponent<FormFieldComponent>({
@@ -30,6 +37,8 @@ export const Checkbox: React.FC<CheckboxProps & AutomationProps> = ({
     disabled,
     required
   });
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   // Update metadata when field props change
   useEffect(() => {
@@ -43,14 +52,21 @@ export const Checkbox: React.FC<CheckboxProps & AutomationProps> = ({
     }
   }, [checked, updateMetadata, label, disabled, required]);
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = !!indeterminate && !checked;
+    }
+  }, [indeterminate, checked]);
+
   return (
-    <div className="flex items-center mb-4">
+    <div className={cn('flex items-center', containerClassName ?? 'mb-4')}>
       <input
         type="checkbox"
         className={`h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded ${className}`}
         checked={checked}
         disabled={disabled}
         required={required}
+        ref={inputRef}
         {...withDataAutomationId({ id })}
         {...props}
       />


### PR DESCRIPTION
## Summary
- add checkbox selection controls to the ticketing dashboard with bulk delete confirmation
- extend the shared checkbox component to support custom containers and indeterminate state for selection UI
- add a shared server-side helper for deleting tickets and expose a bulk deletion action

## Testing
- npm run lint *(fails: Cannot find package 'globals' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68d2ac5cf704832a97c4c8d02c032c1b