### PR TITLE
docs: surface initial login credentials earlier

### DIFF
--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -118,6 +118,26 @@ docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.c
 
 > Note: The `-d` flag runs containers in detached/background mode. Remove the `-d` flag if you want to monitor the server output directly in the terminal.
 
+### Initial Login Credentials
+
+The first successful boot seeds a sample workspace admin account and prints its credentials to the server logs. Tail the logs right after the stack starts so you can copy the values for your first login:
+
+```bash
+docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+  --env-file server/.env --env-file .env.image logs -f
+```
+
+Look for a banner similar to the following (password redacted here for safety—yours will show the real value):
+
+```
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *******************************************************
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ******** User Email is -> [ glinda@emeraldcity.oz ]  ********
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********       Password is -> [ ****REDACTED**** ]   ********
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *******************************************************
+```
+
+> Copy the credentials before stopping the logs. After you sign in, update the password for production use.
+
 The CE stack now includes the `workflow-worker` service by default, giving you a production-like asynchronous processing setup without additional compose overrides. The `ALGA_IMAGE_TAG` value determines which prebuilt image is retrieved; compose does not fall back to `latest` unless you leave the variable unset.
 
 ## Production Setup (Persistent Storage)
@@ -222,15 +242,6 @@ docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.c
     --env-file server/.env --env-file .env.image up -d
   ```
 - After credentials are in sync, the `setup` container will finish running and migrations plus seed data will be applied automatically.
-
-## Initial Login Credentials
-
-After successful initialization, the server logs will display a sample username and password that can be used for initial access:
-
-```bash
-docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
-  --env-file server/.env --env-file .env.image logs -f
-```
 
 ## Verification
 

--- a/docs/setup_guide_windows.md
+++ b/docs/setup_guide_windows.md
@@ -1,171 +1,263 @@
 # Complete Setup Guide - Windows
 
-This guide provides step-by-step instructions for setting up the PSA system using Docker and Windows Subsystem for Linux.
+This guide provides step-by-step instructions for setting up the PSA system on Windows using Docker Compose from within Windows Subsystem for Linux (WSL).
+
+> Note: The instructions below focus on the CE prebuilt images. Full EE setup guidance, including any edition-specific overrides, is being prepared and will be added soon.
 
 ## Prerequisites
 
-Install components in order:
-- [WSL](https://learn.microsoft.com/en-us/windows/wsl/install?WT.mc_id=310915)
-- [Docker for Windows](https://docs.docker.com/desktop/setup/install/windows-install/)
+- Windows 10/11 with [WSL](https://learn.microsoft.com/en-us/windows/wsl/install?WT.mc_id=310915) enabled (Ubuntu is recommended)
+- [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/) with the WSL 2 based engine
+- Docker Compose v2.20.0 or later (bundled with Docker Desktop)
+- Git (available inside your WSL distribution)
+- Text editor for configuration files (e.g., `nano`, `vim`, VS Code Remote)
 
- Restart your system before continuing.
+> Windows-specific: After installing Docker Desktop, open **Settings → General** and enable **Use the WSL 2 based engine**. Then go to **Settings → Resources → WSL Integration**, enable your Ubuntu distro, apply, and restart Docker Desktop. Restart Windows after the initial installations if prompted.
 
-## Docker Configuration
+## Choose a Release
 
-1. Open Docker and go to Settings --> General --> Toggle `Use the WSL 2 based engine` to ON
-2. Go to Resources --> WSL integration --> Toggle `Ubuntu` to ON
-3. Apply and restart
+> Windows/WSL: Launch Windows Terminal, open your Ubuntu (WSL) shell, and ensure Docker Desktop is running before executing the commands below.
 
-## Server Setup
+1. Visit the [GitHub releases](https://github.com/nine-minds/alga-psa/releases) page and note the exact release you want to run (example below uses `release/0.11.0`).
+2. Clone and check out that release:
+   ```bash
+   git clone https://github.com/nine-minds/alga-psa.git
+   cd alga-psa
+   git checkout release/0.11.0
+   ```
+3. Pin the container image to the same release by running the helper script:
+   ```bash
+   ./scripts/set-image-tag.sh
+   ```
 
-1. Open Windows Terminal, select the dropdown at the top, and start a new Ubuntu console (the round logo)
-2. Set the username/password until you are presented with ``USERNAME@COMPUTERNAME:~$`` in the console
-3. Create an AlgaPSA Directory:
-``mkdir algapsa``
-4. Change to the new directory: ``cd algapsa``
-5. Clone the repository:
-```bash
-git clone https://github.com/nine-minds/alga-psa.git
-```
-5. Change your console location to the cloned directory:
-```bash
-cd alga-psa
-```
-6. Make the secrets directory:
-```bash
-mkdir -p secrets
-```
-7. Create your secrets by pasting the entire codeblock into the console:
+## Initial Setup
 
-> [!WARNING]
-> The provided strings are examples only! It is highly recommended you change them for your own deployment!
-```bash
-echo pEVhcMWeq5RTL2US > secrets/postgres_password
-echo brCKSMZW798eGcLt > secrets/db_password_server
-echo XKrQauZTVRfFH87j > secrets/db_password_hocuspocus
-echo H59BszmU8wFYnKQx > secrets/redis_password
-echo n3h8uCc6yNm9SrHBeD2JVdYKfxtpkZv3 > secrets/alga_auth_key
-echo KGn4swfUBS6jxt9Rhdkp8qeX73TEQNbR > secrets/crypto_key
-echo ENZrjMqJXsUPYKfxh6uBkDCv4np3ma9S > secrets/token_secret_key
-echo yWVM6ANsD42Pv79GxpECHkZKzXh8mrSr > secrets/nextauth_secret
-echo dmfxBhp9NAQG4zF8SPLJ7UMWR5rCbtjh > secrets/email_password
-echo ZkX6aHPK2nsJtLdMSxzUgvmcV9Qu5yBw > secrets/google_oauth_client_id
-echo yYtgSsfVPXTcRM5GDnaKvAuzF3N4pbHj > secrets/google_oauth_client_secret
-```
-7. Set permissions on the secrets folder
-```bash
-chmod 600 secrets/*
-```
+1. Clone the repository (skip if already done above):
+   ```bash
+   git clone https://github.com/nine-minds/alga-psa.git
+   cd alga-psa
+   ```
+2. Create the secrets directory:
+   ```bash
+   mkdir -p secrets
+   ```
+
+## Secrets Configuration
+
+1. Create secret files in the `secrets/` directory (replace placeholders with strong values):
+
+   Database secrets:
+   ```bash
+   echo "your-secure-admin-password" > secrets/postgres_password
+   echo "your-secure-app-password" > secrets/db_password_server
+   echo "your-secure-hocuspocus-password" > secrets/db_password_hocuspocus
+   ```
+
+   Redis secret:
+   ```bash
+   echo "your-secure-password" > secrets/redis_password
+   ```
+
+   Authentication secret:
+   ```bash
+   echo "your-32-char-min-key" > secrets/alga_auth_key
+   ```
+
+   Security secrets:
+   ```bash
+   echo "your-32-char-min-key" > secrets/crypto_key
+   echo "your-32-char-min-key" > secrets/token_secret_key
+   echo "your-32-char-min-key" > secrets/nextauth_secret
+   ```
+
+   Email & OAuth secrets:
+   ```bash
+   echo "your-email-password" > secrets/email_password
+   echo "your-client-id" > secrets/google_oauth_client_id
+   echo "your-client-secret" > secrets/google_oauth_client_secret
+   ```
+
+2. Set proper permissions:
+   ```bash
+   chmod 600 secrets/*
+   ```
 
 ## Environment Configuration
 
-1. Copy the appropriate environment template:
+1. Copy the environment template:
+   ```bash
+   cp .env.example server/.env
+   ```
+2. Open `server/.env` in your editor and confirm these core settings (adjust as needed):
+   - `DB_TYPE=postgres` (required)
+   - `DB_USER_ADMIN=postgres`
+   - `HOST=http://localhost:3000` (use your public domain in production)
+   - `LOG_LEVEL=INFO`
+   - `LOG_IS_FORMAT_JSON=false`
+   - `LOG_IS_FULL_DETAILS=false`
+   - `EMAIL_ENABLE=false` (set to `true` when you are ready to send mail)
+   - `EMAIL_FROM=noreply@example.com`
+   - `EMAIL_HOST=smtp.gmail.com`
+   - `EMAIL_PORT=587`
+   - `EMAIL_USERNAME=noreply@example.com`
+   - `NEXTAUTH_URL=http://localhost:3000`
+   - `NEXTAUTH_SESSION_EXPIRES=86400`
 
-```bash
-cp .env.example server/.env
-```
+   Optional: enable collaborative editing by setting `REQUIRE_HOCUSPOCUS=true`.
 
-2. Edit the environment file and configure required values:
-
-> [!NOTE]
-> The default config file you just copied will work as-is, change the below values if you need to.
-
-To edit file, enter the below into console:
-```bash
-nano server/.env
-```
-
-Required Variables:
-```bash
-# Database Configuration
-DB_TYPE=postgres  # Must be "postgres"
-DB_USER_ADMIN=postgres  # Admin user for database operations
-
-# Logging Configuration
-LOG_LEVEL=INFO  # One of: SYSTEM, TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL
-LOG_IS_FORMAT_JSON=false
-LOG_IS_FULL_DETAILS=false
-
-# Email Configuration
-EMAIL_ENABLE=false  # Set to "true" to enable email notifications
-EMAIL_FROM=noreply@example.com  # Must be valid email
-EMAIL_HOST=smtp.gmail.com  # SMTP server hostname
-EMAIL_PORT=587  # SMTP port (587 for TLS, 465 for SSL)
-EMAIL_USERNAME=noreply@example.com  # SMTP username
-
-# Authentication Configuration
-NEXTAUTH_URL=http://localhost:3000  # Must be valid URL - for production, use your public domain (e.g., https://your-domain.com)
-NEXTAUTH_SESSION_EXPIRES=86400  # Must be > 0
-```
-
-Optional Variables:
-```bash
-# Hocuspocus Configuration
-REQUIRE_HOCUSPOCUS=false  # Set to "true" to require hocuspocus service
-```
-
-Note: The system performs validation of these environment variables at startup. Missing or invalid values will prevent the system from starting.
+> Note: The system performs validation of these environment variables at startup. Missing or invalid values will prevent the system from starting.
 
 ## Docker Compose Configuration
 
-```bash
-docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env up -d
-```
-This will build, deploy, and start the server which you can get to at http://localhost:3000
-
-## Initial Login Credentials
-
-After successful initialization, the server logs will display a sample username and password that can be used for initial access:
+> All commands in this section assume you have run `./scripts/set-image-tag.sh` and that `.env.image` sits alongside `server/.env`. Always pass both env files so Compose pulls the correct prebuilt image.
 
 ```bash
-docker compose logs -f
+docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+  --env-file server/.env --env-file .env.image up -d
 ```
 
 > Note: The `-d` flag runs containers in detached/background mode. Remove the `-d` flag if you want to monitor the server output directly in the terminal.
 
-Look for:
+### Initial Login Credentials
+
+The first successful boot seeds a sample workspace admin account and prints its credentials to the server logs. Tail the logs right after the stack starts so you can copy the values for your first login:
 
 ```bash
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *************************************************************
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********                                             ********
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ******** User Email is -> [ glinda@emeraldcity.oz ]  ********
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********                                             ********
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********       Password is -> [ ****REDACTED**** ]   ********
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********                                             ********
-sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *************************************************************
+docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+  --env-file server/.env --env-file .env.image logs -f
 ```
 
-## Service Initialization
+Look for a banner similar to the following (password redacted here for safety—yours will show the real value):
 
-The entrypoint scripts will automatically:
-1. Validate environment variables
-2. Check dependencies
-3. Initialize database with both users
-4. Set up RLS policies
-5. Run database migrations
-6. Seed initial data (in development)
-7. Start services
+```
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *******************************************************
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ******** User Email is -> [ glinda@emeraldcity.oz ]  ********
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: ********       Password is -> [ ****REDACTED**** ]   ********
+sebastian_server_ce  | 2025-02-10 15:12:23 [INFO   ]: *******************************************************
+```
+
+> Copy the credentials before stopping the logs. After you sign in, update the password for production use.
+
+The CE stack now includes the `workflow-worker` service by default, giving you a production-like asynchronous processing setup without additional compose overrides. The `ALGA_IMAGE_TAG` value determines which prebuilt image is retrieved; compose does not fall back to `latest` unless you leave the variable unset.
+
+## Production Setup (Persistent Storage)
+
+For production-like deployments, persist both your database and uploaded documents to named Docker volumes. This keeps data safe across container restarts and image updates.
+
+- Database volume: `postgres_data` (mounted at `/var/lib/postgresql/data`)
+- Documents/files volume: `files_data` (mounted at `/data/files`)
+
+The CE prebuilt compose now includes these volumes by default. When you run the compose command above, Docker will automatically create and attach them.
+
+Recommended environment config for storage (add to `server/.env`):
+```bash
+STORAGE_DEFAULT_PROVIDER=local
+STORAGE_LOCAL_BASE_PATH=/data/files
+```
+
+Verify volumes:
+```bash
+docker volume ls | grep -E "postgres_data|files_data"
+```
+
+### Network Exposure
+
+The shared base compose file exposes Postgres, PgBouncer, Redis, and the application ports to the host for local convenience. For hardened environments, either remove or override the `ports:` entries with a compose override file, bind them to `127.0.0.1` behind a reverse proxy/firewall, or enforce host-level firewall rules that only allow trusted networks. Restart the stack after applying your chosen approach.
+
+### Backups
+
+- Postgres (logical backup using pg_dump — recommended). Replace the container name if you customized it.
+  ```bash
+  PGPASSWORD=$(cat secrets/postgres_password) \
+  docker exec -e PGPASSWORD=${PGPASSWORD} $(docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image ps -q postgres) \
+    pg_dump -U postgres -d server -Fc -f /tmp/pg_backup.dump
+  docker cp $(docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image ps -q postgres):/tmp/pg_backup.dump ./pg_backup_$(date +%F).dump
+  ```
+
+- Postgres (quick snapshot of the data volume — use when DB is stopped):
+  ```bash
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image stop server pgbouncer postgres
+  docker run --rm -v <project>_postgres_data:/var/lib/postgresql/data -v "$PWD":/backup alpine \
+    tar czf /backup/postgres_volume_$(date +%F).tar.gz -C /var/lib/postgresql/data .
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image start postgres pgbouncer server
+  ```
+
+- Files/documents volume:
+  ```bash
+  docker run --rm -v <project>_files_data:/data/files -v "$PWD":/backup alpine \
+    tar czf /backup/files_volume_$(date +%F).tar.gz -C /data/files .
+  ```
+
+Note: Volume names are prefixed by your Compose project (e.g., `<project>_postgres_data`). If you customized `APP_NAME` or use `-p` with compose, check with `docker volume ls` and substitute accordingly.
+
+### Restores (brief)
+
+- Postgres (pg_restore). Create an empty database first if needed.
+  ```bash
+  PGPASSWORD=$(cat secrets/postgres_password) \
+  docker cp ./pg_backup.dump $(docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image ps -q postgres):/tmp/pg_backup.dump
+  docker exec -e PGPASSWORD=${PGPASSWORD} $(docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image ps -q postgres) \
+    pg_restore -U postgres -d server --clean --if-exists /tmp/pg_backup.dump
+  ```
+
+- Files/documents volume:
+  ```bash
+  docker run --rm -v <project>_files_data:/data/files -v "$PWD":/backup alpine \
+    sh -c "rm -rf /data/files/* && tar xzf /backup/files_volume.tgz -C /data/files"
+  ```
+
+### Notes
+
+- The application’s local storage provider writes to `/data/files` inside the server container. Using the named volume `files_data` keeps those assets across restarts without host-permission tweaks.
+- `docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml --env-file server/.env --env-file .env.image down` followed by `... up -d` is safe for restarts. Avoid adding `-v` unless you explicitly intend to wipe Postgres/files volumes.
+- To inspect the volume contents from the host, use `docker run --rm -v <project>_postgres_data:/var/lib/postgresql/data busybox ls /var/lib/postgresql/data` (replace the volume name if you changed `APP_NAME` or pass `-p`).
+
+## Monitoring
 
 You can monitor the initialization process through Docker logs:
 ```bash
-docker compose logs -f
+docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+  --env-file server/.env --env-file .env.image logs -f
 ```
+
+## Troubleshooting
+
+### Postgres authentication loop
+- Continuous `password authentication failed for user "postgres"` or `role "hocuspocus_user" does not exist` messages mean the secrets on disk no longer match the credentials stored inside the `postgres_data` volume.
+- If you need to keep existing data, sync the passwords and recreate the missing role:
+  ```bash
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+    --env-file server/.env --env-file .env.image exec postgres \
+    psql -U postgres -c "ALTER ROLE postgres WITH PASSWORD '$(cat secrets/postgres_password)';"
+
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+    --env-file server/.env --env-file .env.image exec postgres \
+    psql -U postgres -c "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'hocuspocus_user') THEN CREATE ROLE hocuspocus_user LOGIN PASSWORD '$(cat secrets/db_password_hocuspocus)'; ELSE ALTER ROLE hocuspocus_user WITH PASSWORD '$(cat secrets/db_password_hocuspocus)'; END IF; END $$;" 
+  ```
+- To start fresh (wipes the database), stop the stack and remove the named volumes before bringing it back up:
+  ```bash
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+    --env-file server/.env --env-file .env.image down -v
+  docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+    --env-file server/.env --env-file .env.image up -d
+  ```
+- After credentials are in sync, the `setup` container will finish running and migrations plus seed data will be applied automatically.
 
 ## Verification
 
 1. Check service health:
-```bash
-docker compose ps
-```
-
+   ```bash
+   docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+     --env-file server/.env --env-file .env.image ps
+   ```
 2. Access the application:
-- Development: http://localhost:3000
-- Production: https://your-domain.com
-
+   - Development: http://localhost:3000
+   - Production: https://your-domain.com
 3. Verify logs for any errors:
-```bash
-docker compose logs [service-name]
-```
+   ```bash
+   docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+     --env-file server/.env --env-file .env.image logs [service-name]
+   ```
 
 ## Common Issues & Solutions
 
@@ -228,12 +320,15 @@ When deploying for public access (not localhost), additional configuration is re
 ### Authentication URL Configuration
 The `NEXTAUTH_URL` environment variable must match your public domain:
 
+For local development:
 ```bash
-# For local development
 NEXTAUTH_URL=http://localhost:3000
+```
 
-# For production deployment
+For production deployment:
+```bash
 NEXTAUTH_URL=https://your-domain.com
+HOST=https://your-domain.com
 ```
 
 ### SSL/TLS Configuration
@@ -247,7 +342,7 @@ For production deployments:
 Update email settings for production notifications:
 ```bash
 EMAIL_ENABLE=true
-EMAIL_FROM=noreply@your-domain.com  # Use your domain
+EMAIL_FROM=noreply@your-domain.com
 EMAIL_HOST=your-smtp-server.com
 EMAIL_USERNAME=noreply@your-domain.com
 ```
@@ -259,30 +354,34 @@ EMAIL_USERNAME=noreply@your-domain.com
 - Regular backup procedures
 - Monitor access logs
 
-## Next Steps
+## Upgrading
 
-1. Configure email notifications:
-   - Set environment variables:
-     ```bash
-     EMAIL_ENABLE=true
-     EMAIL_HOST=smtp.example.com
-     EMAIL_PORT=587  # or 465 for SSL
-     EMAIL_USERNAME=noreply@example.com
-     EMAIL_PASSWORD=your-secure-password
-     EMAIL_FROM=noreply@example.com
-     ```
-   - Features available after setup:
-     * System-wide default templates
-     * Tenant-specific template customization
-     * User notification preferences
-     * Rate limiting and audit logging
-     * Categories: Tickets, Invoices, Projects, Time Entries
-2. Set up OAuth if using Google authentication
-3. Configure SSL/TLS for production
-4. Set up backup procedures
-5. Configure monitoring and logging
-6. Review security settings
-7. Review and test RLS policies
+When upgrading from a previous version:
+
+1. Backup all data:
+   ```bash
+   docker compose --env-file server/.env --env-file .env.image exec postgres \
+     pg_dump -U postgres server > backup.sql
+   ```
+2. Update your checkout to the target release (e.g., `git fetch && git checkout release/0.11.0`).
+3. Run `./scripts/set-image-tag.sh` again so `.env.image` updates to the new release tag or short commit.
+4. Pull the new images and restart the stack:
+   ```bash
+   docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+     --env-file server/.env --env-file .env.image pull
+   docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+     --env-file server/.env --env-file .env.image down
+   docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.ce.yaml \
+     --env-file server/.env --env-file .env.image up -d
+   ```
+5. Review changes in:
+   - Docker Compose files
+   - Environment variables
+   - Secret requirements
+   - Database schema
+   - RLS policies
+   - Protocol Buffer definitions (EE only)
+6. Update configurations as needed and verify the application starts cleanly before removing the old backups.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- surface the initial login credential instructions immediately after the compose startup command
- sync the Windows setup guide with the primary guide, keeping Windows-specific notes
- document storage, monitoring, troubleshooting, and upgrade guidance for Windows users to match main docs

## Testing
- not applicable