### PR TITLE
Client portal user board priority consistency

### DIFF
--- a/server/src/lib/actions/ticket-actions/ticketFormActions.ts
+++ b/server/src/lib/actions/ticket-actions/ticketFormActions.ts
@@ -4,9 +4,12 @@ import { IUser, IBoard, ITicketStatus, IPriority, ICompany, IContact } from 'ser
 import { getAllUsers, getCurrentUser } from 'server/src/lib/actions/user-actions/userActions';
 import { getAllBoards } from 'server/src/lib/actions/board-actions/boardActions';
 import { getTicketStatuses } from 'server/src/lib/actions/status-actions/statusActions';
-import { getAllPriorities } from 'server/src/lib/actions/priorityActions';
+import { getAllPriorities, getPrioritiesByBoardType } from 'server/src/lib/actions/priorityActions';
 import { getAllCompanies, getCompanyById } from 'server/src/lib/actions/company-actions/companyActions';
 import { getContactsByCompany } from 'server/src/lib/actions/contact-actions/contactActions';
+import { createTenantKnex } from 'server/src/lib/db';
+import { withTransaction } from '@alga-psa/shared/db';
+import { Knex } from 'knex';
 
 export interface TicketFormData {
   users: IUser[];
@@ -103,10 +106,25 @@ export async function getClientTicketFormData(): Promise<Partial<TicketFormData>
       throw new Error('No authenticated user found');
     }
 
-    // Client portal users only need priorities for ticket creation
-    // Companies are handled automatically based on the user's associated company
-    const priorities = await getAllPriorities('ticket').catch(error => {
-      console.error('Error fetching priorities:', error);
+    const { knex: db, tenant } = await createTenantKnex();
+
+    // Get the default board for client portal tickets
+    const defaultBoard = await withTransaction(db, async (trx: Knex.Transaction) => {
+      const board = await trx('boards')
+        .select('board_id', 'priority_type')
+        .where({ tenant, is_default: true })
+        .first();
+
+      return board;
+    });
+
+    if (!defaultBoard) {
+      throw new Error('No default board found for client portal tickets');
+    }
+
+    // Get priorities filtered by the default board's priority type
+    const priorities = await getPrioritiesByBoardType(defaultBoard.board_id, 'ticket').catch((error: unknown) => {
+      console.error('Error fetching priorities for default board:', error);
       return [];
     });
 


### PR DESCRIPTION
When client portal users go to create a ticket, the only priorities they see are those that are applicable to the board the MSP has set as the default