### PR TITLE
chore: Update @types/node to 20.19.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12965,9 +12965,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.20.tgz",
-      "integrity": "sha512-2Q7WS25j4pS1cS8yw3d6buNCVJukOTeQ39bAnwR6sOJbaxvyCGebzTMypDFN82CxBLnl+lSWVdCCWbRY6y9yZQ==",
+      "version": "20.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.21.tgz",
+      "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"


### PR DESCRIPTION
## Summary
- Update @types/node dependency from 20.19.20 to 20.19.21

## Test plan
- Verify no breaking changes in TypeScript definitions
- Ensure existing builds pass with updated types