### PR TITLE
Fix duplicate save button in time entry dialog

### DIFF
--- a/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -395,7 +395,6 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
             totalDuration={totalDurations[0] || 0}
             isEditable={isEditable}
             lastNoteInputRef={lastNoteInputRef}
-            onSave={handleSaveEntry}
             onDelete={handleDeleteEntry}
             onUpdateEntry={updateEntry}
             onUpdateTimeInputs={updateTimeInputs}


### PR DESCRIPTION
## Summary
- Removed duplicate save button that was appearing when adding a new time entry from the time sheet
- The form was rendering its own save button in addition to the dialog footer's save button

## Changes
- Removed the `onSave` prop from `SingleTimeEntryForm` in `TimeEntryDialog.tsx` when rendering new single time entries
- The form's save button is intended for multi-entry editing scenarios, not for single new entries in a dialog

## Test plan
- [ ] Open the time sheet
- [ ] Click to add a new time entry
- [ ] Verify only one save button appears at the bottom of the dialog next to the cancel button
- [ ] Verify the save button still functions correctly to save the time entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)