### PR TITLE
Fix QuickAddTicket dialog width

### DIFF
--- a/server/src/components/tickets/QuickAddTicket.tsx
+++ b/server/src/components/tickets/QuickAddTicket.tsx
@@ -533,7 +533,7 @@ export function QuickAddTicket({
         id={`${id}-dialog`}
         isOpen={open}
         onClose={handleClose}
-        className="max-w-2xl max-h-[90vh] overflow-y-auto"
+        className="w-full max-w-2xl max-h-[90vh] overflow-y-auto"
         title="Add Ticket"
       >
         <DialogContent>


### PR DESCRIPTION
## Summary
- Fix QuickAddTicket dialog appearing narrower than intended
- Add `w-full` class back to the dialog className

## Problem
After commit 2fa607fd (Oct 17, 2025), the Dialog component was refactored and `w-full` was moved inside the default className fallback. When QuickAddTicket passes a custom className (`max-w-2xl max-h-[90vh] overflow-y-auto`), it completely replaces the default, causing the dialog to lose the `w-full` property. Without `w-full`, the dialog doesn't expand to fill the available space up to its max-width, making it appear significantly narrower.

## Solution
Add `w-full` to QuickAddTicket's custom className: `w-full max-w-2xl max-h-[90vh] overflow-y-auto`

This ensures the dialog properly expands to its intended width of 672px (max-w-2xl).

## Test plan
- [ ] Open the Quick Add Ticket dialog
- [ ] Verify the dialog is wider and properly fills the space up to max-w-2xl
- [ ] Test that the dialog still scrolls properly with overflow-y-auto
- [ ] Verify the dialog remains responsive at different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)