### PR TITLE
feat: Switch email providers to read-only access

### DIFF
--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -189,7 +189,7 @@ export async function GET(request: NextRequest) {
         code: code,
         grant_type: 'authorization_code',
         redirect_uri: redirectUri,
-        scope: 'https://graph.microsoft.com/.default offline_access'
+        scope: 'https://graph.microsoft.com/Mail.Read offline_access'
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {

--- a/server/src/services/email/EmailProcessor.ts
+++ b/server/src/services/email/EmailProcessor.ts
@@ -40,13 +40,16 @@ export class EmailProcessor {
         emailData: emailMessage,
       });
 
-      // 4. Mark message as processed in the provider (skip for provided email data)
-      if (!job.emailData && providerConfig) {
-        const adapter = await this.createProviderAdapter(providerConfig);
-        await adapter.markMessageProcessed(job.messageId);
-      } else {
-        console.log(`📧 Skipping markMessageProcessed for ${job.providerId} (using provided email data or missing config)`);
-      }
+      // 4. Mark message as processed in database (read-only mode - no email modification)
+      // Note: markMessageProcessed is now a no-op in read-only mode
+      // Email processing status is tracked in the database via recordProcessedMessage below
+      console.log(`📧 Email ${job.messageId} processed in read-only mode (no mailbox modification)`);
+
+      // Skip calling markMessageProcessed since we're now in read-only mode
+      // if (!job.emailData && providerConfig) {
+      //   const adapter = await this.createProviderAdapter(providerConfig);
+      //   await adapter.markMessageProcessed(job.messageId);
+      // }
 
       // 5. Record successful processing in database
       await this.recordProcessedMessage(job, emailMessage, 'success');

--- a/server/src/services/email/providers/GmailAdapter.ts
+++ b/server/src/services/email/providers/GmailAdapter.ts
@@ -493,55 +493,13 @@ This indicates a problem with the OAuth token saving process.`;
   }
 
   /**
-   * Mark a message as processed
+   * Mark a message as processed (READ-ONLY MODE: No-op)
+   * Note: This system now operates in read-only mode and does not modify emails.
+   * Email processing status is tracked in the database instead.
    */
   async markMessageProcessed(messageId: string): Promise<void> {
-    try {
-      const vendorConfig = this.config.provider_config || {};
-      
-      // Add a custom label to mark as processed
-      // First, check if we have a processed label
-      let processedLabelId: string | undefined;
-      
-      if (!processedLabelId) {
-        // Try to find or create the label
-        const labels = await this.gmail.users.labels.list({ userId: 'me' });
-        const processedLabel = labels.data.labels?.find(
-          (label: any) => label.name === 'PSA/Processed'
-        );
-        
-        if (processedLabel) {
-          processedLabelId = processedLabel.id;
-        } else {
-          // Create the label
-          const newLabel = await this.gmail.users.labels.create({
-            userId: 'me',
-            requestBody: {
-              name: 'PSA/Processed',
-              messageListVisibility: 'show',
-              labelListVisibility: 'labelShow'
-            }
-          });
-          processedLabelId = newLabel.data.id;
-        }
-        
-        // Store label ID for future use
-        // Store the label ID for future use (would need to update config)
-      }
-
-      // Apply the label to the message
-      await this.gmail.users.messages.modify({
-        userId: 'me',
-        id: messageId,
-        requestBody: {
-          addLabelIds: [processedLabelId]
-        }
-      });
-
-      this.log('info', `Message ${messageId} marked as processed`);
-    } catch (error) {
-      throw this.handleError(error, 'markMessageProcessed');
-    }
+    this.log('info', `Email ${messageId} processed (read-only mode - not adding labels in mailbox)`);
+    // No API call made - operating in read-only mode
   }
 
   /**

--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -200,7 +200,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         client_secret: clientSecret,
         refresh_token: this.refreshToken,
         grant_type: 'refresh_token',
-        scope: 'https://graph.microsoft.com/.default offline_access',
+        scope: 'https://graph.microsoft.com/Mail.Read offline_access',
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {
@@ -382,19 +382,13 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   }
 
   /**
-   * Mark a message as read
+   * Mark a message as read (READ-ONLY MODE: No-op)
+   * Note: This system now operates in read-only mode and does not modify emails.
+   * Email processing status is tracked in the database instead.
    */
   async markMessageProcessed(messageId: string): Promise<void> {
-    try {
-      const mailboxBase = this.getMailboxBasePath();
-      await this.httpClient.patch(`${mailboxBase}/messages/${messageId}`, {
-        isRead: true,
-      });
-
-      this.log('info', `Marked message ${messageId} as read`);
-    } catch (error) {
-      this.log('warn', `Failed to mark message as read: ${(error as Error).message}`);
-    }
+    this.log('info', `Email ${messageId} processed (read-only mode - not marking as read in mailbox)`);
+    // No API call made - operating in read-only mode
   }
 
   /**

--- a/server/src/utils/email/oauthHelpers.ts
+++ b/server/src/utils/email/oauthHelpers.ts
@@ -16,12 +16,13 @@ export interface OAuthState {
 
 /**
  * Generate OAuth authorization URL for Microsoft
+ * Using read-only scope: Mail.Read for email access
  */
 export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
-  scopes: string[] = ['https://graph.microsoft.com/.default', 'offline_access'],
+  scopes: string[] = ['https://graph.microsoft.com/Mail.Read', 'offline_access'],
   tenantAuthority: string = 'common'
 ): string {
   const baseUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize`;
@@ -41,6 +42,7 @@ export function generateMicrosoftAuthUrl(
 
 /**
  * Generate OAuth authorization URL for Google
+ * Using read-only scopes: gmail.readonly for email access
  */
 export function generateGoogleAuthUrl(
   clientId: string,
@@ -48,8 +50,6 @@ export function generateGoogleAuthUrl(
   state: OAuthState,
   scopes: string[] = [
     'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/gmail.modify',
-    'https://www.googleapis.com/auth/gmail.labels',
     'https://www.googleapis.com/auth/pubsub'
   ]
 ): string {


### PR DESCRIPTION
Changes email processing to use read-only OAuth scopes for both
Microsoft Graph and Gmail APIs, following principle of least privilege.

Changes:
- Update Microsoft OAuth scope from .default to Mail.Read
- Update Gmail OAuth scopes to gmail.readonly only (removed gmail.modify and gmail.labels)
- Convert markMessageProcessed() to no-op in both adapters
- Remove markMessageProcessed() call from EmailProcessor
- Add documentation explaining read-only mode

Benefits:
- Minimal OAuth permissions (read-only access)
- No email modifications (marks as read, labels)
- Processing status tracked in database only
- Reduced security risk
- Better auditability

Note: Existing OAuth tokens will need re-authorization to use new read-only scopes.
Label reading still works with gmail.readonly scope.