### PR TITLE
Fix: Use absolute URLs with NEXTAUTH_URL for ticket email notifications

### DIFF
--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -18,6 +18,14 @@ import { formatBlockNoteContent } from '../../utils/blocknoteUtils';
 import { getEmailEventChannel } from '@/lib/notifications/emailChannel';
 
 /**
+ * Get the base URL from NEXTAUTH_URL environment variable
+ */
+function getBaseUrl(): string {
+  const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+/**
  * Wrapper function that checks notification preferences before sending email
  * @param params - Same params as sendEventEmail
  * @param subtypeName - Name of the notification subtype (e.g., "Ticket Created")
@@ -513,7 +521,7 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
         locationSummary,
         clientName,
         metaLine,
-        url: `/tickets/${ticket.ticket_number}`
+        url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
       }
     };
 
@@ -653,7 +661,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
         status: ticket.status_name || 'Unknown',
         changes: formattedChanges,
         updatedBy: updater ? `${updater.first_name} ${updater.last_name}` : payload.userId,
-        url: `/tickets/${ticket.ticket_number}`
+        url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
       }
     };
 
@@ -793,7 +801,7 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
         priority: ticket.priority_name || 'Unknown',
         status: ticket.status_name || 'Unknown',
         assignedBy: assignerName,
-        url: `/tickets/${ticket.ticket_number}`
+        url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
       }
     };
 
@@ -957,7 +965,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
           ticket: {
             id: ticket.ticket_number,
             title: ticket.title,
-            url: `/tickets/${ticket.ticket_number}`
+            url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
           },
           comment: commentContext
         },
@@ -980,7 +988,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
           ticket: {
             id: ticket.ticket_number,
             title: ticket.title,
-            url: `/tickets/${ticket.ticket_number}`
+            url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
           },
           comment: commentContext
         },
@@ -1004,7 +1012,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
           ticket: {
             id: ticket.ticket_number,
             title: ticket.title,
-            url: `/tickets/${ticket.ticket_number}`
+            url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
           },
           comment: commentContext
         },
@@ -1080,7 +1088,7 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
         changes: await formatChanges(db, payload.changes || {}, tenantId),
         closedBy: payload.userId,
         resolution: ticket.resolution || '',
-        url: `/tickets/${ticket.ticket_number}`
+        url: `${getBaseUrl()}/msp/tickets/${ticket.ticket_id}`
       }
     };
 


### PR DESCRIPTION
## Summary
Fixes ticket notification email URLs to use absolute URLs based on the `NEXTAUTH_URL` environment variable instead of relative paths.

## Problem
Email notifications for tickets were using relative URLs like `/tickets/{number}`, which don't work when clicking links from external email clients.

## Solution
- Added `getBaseUrl()` helper function to retrieve and format `NEXTAUTH_URL` from environment
- Updated all ticket event handlers to generate full URLs in the format: `{NEXTAUTH_URL}/msp/tickets/{ticket_id}`
- Changed from using `ticket_number` to `ticket_id` for consistency with the routing structure

## Changes
Updated email context URLs in all ticket notification handlers:
- ✅ Ticket Created
- ✅ Ticket Updated  
- ✅ Ticket Assigned
- ✅ Ticket Closed
- ✅ Ticket Comment Added

## Example
**Before:** `/tickets/12345`  
**After:** `https://algapsa.com/msp/tickets/cb9bd8c7-2235-4de0-b480-a18621795ddc`

## Test plan
- [ ] Send test ticket notification emails
- [ ] Verify "View Ticket" links work correctly
- [ ] Confirm URLs use the configured NEXTAUTH_URL