### PR TITLE
Fix SQL GROUP BY error in invoice list API endpoint

### DIFF
--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -230,8 +230,10 @@ export class InvoiceService extends BaseService<IInvoice> {
       query.orderBy(`invoices.${sortField}`, sortOrder);
       query.limit(limit).offset(offset);
 
-      // Get total count
-      const countQuery = this.buildBaseQuery(trx, context);
+      // Get total count - use a separate query without SELECT columns to avoid GROUP BY issues
+      const countQuery = trx('invoices')
+        .where('invoices.tenant', context.tenant);
+
       if (filters) {
         this.applyInvoiceFilters(countQuery, filters);
       }


### PR DESCRIPTION
## Summary
Fixed a PostgreSQL error that occurred when listing invoices via the `/api/v1/invoices` endpoint. The count query was reusing `buildBaseQuery()` which includes SELECT columns with calculated fields, causing a conflict when adding `COUNT(*)` aggregate function.

## Problem
**Error:** `column "invoices.tenant" must appear in the GROUP BY clause or be used in an aggregate function`

The `buildBaseQuery()` method returns a query with:
```typescript
.select(
  'invoices.*',
  trx.raw('COALESCE(invoices.credit_applied, 0) as credit_applied'),
  trx.raw('(invoices.total_amount - COALESCE(invoices.credit_applied, 0)) as balance_due')
)
```

When calling `.count('* as count')` on this query, PostgreSQL requires all non-aggregated columns to be in a GROUP BY clause.

## Solution
Created a separate count query that only includes the tenant filter without the additional SELECT columns:

```typescript
const countQuery = trx('invoices')
  .where('invoices.tenant', context.tenant);
```

This generates clean SQL: `SELECT count(*) as "count" FROM invoices WHERE invoices.tenant = $1`

## Testing
- ✅ Verified the old code fails with 500 error
- ✅ Verified the new code successfully returns invoices
- ✅ Tested with local API key against `http://localhost:3000`
- ✅ Returns proper paginated results (4 invoices in test)

## Changes
- **File:** `server/src/lib/api/services/InvoiceService.ts:233-239`
- **Lines changed:** 4 insertions, 2 deletions

## Impact
- Fixes broken `/api/v1/invoices` GET endpoint
- No breaking changes to API contract
- Improves query performance by using simpler count query

## Note
This is a cherry-pick of the fix already merged to main (PR #1198) to backport to release/0.12.0.