### PR TITLE
fix: use NEXTAUTH_URL for Xero OAuth redirect URI instead of hardcoded localhost

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -466,15 +466,12 @@ spec:
           - name: XERO_CLIENT_ID
             value: "{{ .Values.xero_integration.client_id }}"
           {{- end }}
-          {{- if .Values.xero_integration.redirect_uri }}
-          - name: XERO_REDIRECT_URI
-            value: "{{ .Values.xero_integration.redirect_uri }}"
-          {{- end }}
           # XERO_CLIENT_SECRET is resolved via the secret provider chain:
           # 1. Vault (if configured in secrets_provider.readChain)
           # 2. Filesystem secrets (Docker secrets at /run/secrets/xero_client_secret)
           # 3. Environment variable XERO_CLIENT_SECRET
           # The application's secret provider will automatically resolve it.
+          # Note: XERO_REDIRECT_URI is now derived from APP_BASE_URL in the application code
           {{- end }}
 
           # ----------- STRIPE INTEGRATION ----------------

--- a/server/src/app/api/integrations/xero/callback/route.ts
+++ b/server/src/app/api/integrations/xero/callback/route.ts
@@ -13,9 +13,8 @@ import {
   XERO_TOKEN_URL
 } from 'server/src/lib/xero/xeroClientService';
 
-const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:3000';
-const XERO_REDIRECT_URI =
-  process.env.XERO_REDIRECT_URI ?? 'http://localhost:3000/api/integrations/xero/callback';
+const NEXTAUTH_URL = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+const XERO_REDIRECT_URI = `${NEXTAUTH_URL}/api/integrations/xero/callback`;
 const XERO_CONNECTIONS_URL = 'https://api.xero.com/connections';
 
 const SUCCESS_PATH = '/msp/settings?tab=integrations&xero_status=success';
@@ -28,7 +27,7 @@ type XeroStatePayload = {
 };
 
 function createRedirect(path: string, params?: Record<string, string | undefined>) {
-  const url = new URL(path, APP_BASE_URL);
+  const url = new URL(path, NEXTAUTH_URL);
   if (params) {
     for (const [key, value] of Object.entries(params)) {
       if (value !== undefined && value !== null) {

--- a/server/src/app/api/integrations/xero/connect/route.ts
+++ b/server/src/app/api/integrations/xero/connect/route.ts
@@ -10,8 +10,7 @@ import { getXeroClientId } from 'server/src/lib/xero/xeroClientService';
 
 const XERO_AUTHORIZE_URL =
   process.env.XERO_OAUTH_AUTHORIZE_URL ?? 'https://login.xero.com/identity/connect/authorize';
-const XERO_REDIRECT_URI =
-  process.env.XERO_REDIRECT_URI ?? 'http://localhost:3000/api/integrations/xero/callback';
+const XERO_REDIRECT_URI = `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/integrations/xero/callback`;
 const XERO_SCOPES =
   process.env.XERO_OAUTH_SCOPES ??
   'offline_access accounting.settings accounting.transactions accounting.contacts';


### PR DESCRIPTION
## Summary
- Remove hardcoded `XERO_REDIRECT_URI` environment variable configuration
- Use `NEXTAUTH_URL` directly for Xero OAuth redirect URI to ensure it matches the actual application URL in both development and production
- Remove `XERO_REDIRECT_URI` from Helm deployment configuration

## Changes
- **connect/route.ts**: Use `NEXTAUTH_URL` for redirect URI
- **callback/route.ts**: Use `NEXTAUTH_URL` for redirect URI and redirect destination base URL
- **deployment.yaml**: Remove `XERO_REDIRECT_URI` env var, add clarifying comment

## Test Plan
- [ ] Verify Xero OAuth flow works in development (http://localhost:3000)
- [ ] Verify Xero OAuth flow works in production with correct domain
- [ ] Confirm callback URLs match what's registered in Xero console