### PR TITLE
feat: add Assets to side menu

### DIFF
--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -58,11 +58,11 @@ export const menuItems: MenuItem[] = [
     icon: Layers,
     href: '/msp/projects'
   },
-  // {
-  //   name: 'Assets',
-  //   icon: Monitor,
-  //   href: '/msp/assets'
-  // },
+  {
+    name: 'Assets',
+    icon: Monitor,
+    href: '/msp/assets'
+  },
   {
     name: 'Clients',
     icon: Building2,


### PR DESCRIPTION
Uncomment the Assets menu item in the sidebar navigation config to make it visible in the application menu. The Assets section points to /msp/assets.