### PR TITLE
fix: add type annotation to existingContact variable

### DIFF
--- a/server/src/lib/actions/contact-actions/contactActions.tsx
+++ b/server/src/lib/actions/contact-actions/contactActions.tsx
@@ -1060,7 +1060,7 @@ export async function importContactsFromCSV(
           }
 
           // Check for existing contact by email (primary unique constraint)
-          let existingContact = null;
+          let existingContact: IContact | null = null;
           if (contactData.email) {
             existingContact = await trx('contacts')
               .where({


### PR DESCRIPTION
Add explicit IContact | null type annotation to existingContact variable to resolve TypeScript compilation error where the type was incorrectly inferred as 'never', preventing access to the email property.