### PR TITLE
Fix dev environment startup and migration issues

### DIFF
--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -24,10 +24,10 @@ services:
       NODE_ENV: ${APP_ENV:-development}
       HOST: ${HOST}
       VERIFY_EMAIL_ENABLED: ${VERIFY_EMAIL_ENABLED:-false}
-      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_HOST: ${REDIS_HOST_DOCKER:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       DB_TYPE: ${DB_TYPE:-postgres}
-      DB_HOST: ${PGBOUNCER_HOST:-pgbouncer}
+      DB_HOST: ${PGBOUNCER_HOST_DOCKER:-pgbouncer}
       DB_PORT: ${PGBOUNCER_PORT:-6432}
       REQUIRE_HOCUSPOCUS: ${REQUIRE_HOCUSPOCUS:-false}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
@@ -95,7 +95,7 @@ services:
       NODE_ENV: ${APP_ENV:-development}
       HOST: ${HOST}
       DB_TYPE: ${DB_TYPE:-postgres}
-      DB_HOST: ${PGBOUNCER_HOST:-pgbouncer}
+      DB_HOST: ${PGBOUNCER_HOST_DOCKER:-pgbouncer}
       DB_PORT: ${PGBOUNCER_PORT:-6432}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_IS_FORMAT_JSON: ${LOG_IS_FORMAT_JSON:-false}
@@ -126,6 +126,14 @@ services:
         source: ./secrets/db_password_server
         target: /run/secrets/db_password_server
         read_only: true
+      - type: bind
+        source: /tmp/alga-migrations
+        target: /app/server/migrations
+        read_only: true
+      - type: bind
+        source: /tmp/alga-seeds
+        target: /app/server/seeds
+        read_only: true
     secrets:
       - postgres_password
       - db_password_server
@@ -154,10 +162,10 @@ services:
       APP_ENV: ${APP_ENV:-development}
       NODE_ENV: ${APP_ENV:-development}
       HOST: ${HOST}
-      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_HOST: ${REDIS_HOST_DOCKER:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       DB_TYPE: ${DB_TYPE:-postgres}
-      DB_HOST: ${PGBOUNCER_HOST:-pgbouncer}
+      DB_HOST: ${PGBOUNCER_HOST_DOCKER:-pgbouncer}
       DB_PORT: ${PGBOUNCER_PORT:-6432}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_IS_FORMAT_JSON: ${LOG_IS_FORMAT_JSON:-false}
@@ -220,10 +228,10 @@ services:
       APP_ENV: ${APP_ENV:-development}
       NODE_ENV: ${APP_ENV:-development}
       HOST: ${HOST}
-      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_HOST: ${REDIS_HOST_DOCKER:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
       DB_TYPE: ${DB_TYPE:-postgres}
-      DB_HOST: postgres
+      DB_HOST: ${DB_HOST_DOCKER:-postgres}
       DB_PORT: ${DB_PORT:-5432}
     secrets:
       - postgres_password

--- a/ee/server/migrations/20251014120000_create_stripe_integration_tables.cjs
+++ b/ee/server/migrations/20251014120000_create_stripe_integration_tables.cjs
@@ -103,10 +103,6 @@ const createStripePrices = (knex) =>
     table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
 
     table.primary(['tenant', 'stripe_price_id']);
-    table
-      .foreign(['tenant', 'stripe_product_id'])
-      .references(['tenant', 'stripe_product_id'])
-      .inTable('stripe_products')
     table.foreign('tenant').references('tenants.tenant');
     table.unique(['tenant', 'stripe_price_external_id']);
     table.unique(['stripe_price_id']);
@@ -144,14 +140,6 @@ const createStripeSubscriptions = (knex) =>
 
     table.primary(['tenant', 'stripe_subscription_id']);
     table.foreign('tenant').references('tenants.tenant');
-    table
-      .foreign(['tenant', 'stripe_customer_id'])
-      .references(['tenant', 'stripe_customer_id'])
-      .inTable('stripe_customers');
-    table
-      .foreign(['tenant', 'stripe_price_id'])
-      .references(['tenant', 'stripe_price_id'])
-      .inTable('stripe_prices');
     table.unique(['tenant', 'stripe_subscription_external_id']);
     table.index(['tenant', 'stripe_customer_id'], 'idx_stripe_subscriptions_customer');
   });

--- a/scripts/merge-migrations.sh
+++ b/scripts/merge-migrations.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Merge CE and EE migrations/seeds for dev environment
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MIGRATIONS_TARGET="/tmp/alga-migrations"
+SEEDS_TARGET="/tmp/alga-seeds"
+
+echo "Merging CE and EE migrations and seeds..."
+
+# Clean and create target directories
+rm -rf "$MIGRATIONS_TARGET" "$SEEDS_TARGET"
+mkdir -p "$MIGRATIONS_TARGET" "$SEEDS_TARGET"
+
+# Merge migrations: CE first, then EE overwrites
+if [ -d "$REPO_ROOT/server/migrations" ]; then
+    echo "Copying CE migrations..."
+    cp -r "$REPO_ROOT/server/migrations/"* "$MIGRATIONS_TARGET/" 2>/dev/null || true
+fi
+
+if [ -d "$REPO_ROOT/ee/server/migrations" ]; then
+    echo "Overlaying EE migrations..."
+    cp -r "$REPO_ROOT/ee/server/migrations/"* "$MIGRATIONS_TARGET/" 2>/dev/null || true
+fi
+
+# Merge seeds: CE first, then EE overwrites
+if [ -d "$REPO_ROOT/server/seeds" ]; then
+    echo "Copying CE seeds..."
+    cp -r "$REPO_ROOT/server/seeds/"* "$SEEDS_TARGET/" 2>/dev/null || true
+fi
+
+if [ -d "$REPO_ROOT/ee/server/seeds" ]; then
+    echo "Overlaying EE seeds..."
+    cp -r "$REPO_ROOT/ee/server/seeds/"* "$SEEDS_TARGET/" 2>/dev/null || true
+fi
+
+echo "✓ Merged $(find "$MIGRATIONS_TARGET" -type f | wc -l | tr -d ' ') migration files"
+echo "✓ Merged $(find "$SEEDS_TARGET" -type f | wc -l | tr -d ' ') seed files"
+echo "Migrations: $MIGRATIONS_TARGET"
+echo "Seeds: $SEEDS_TARGET"


### PR DESCRIPTION
## Summary
Fix critical issues preventing dev environment from starting properly, including Docker compose configuration and migration bugs.

## Changes

### 1. Docker Compose Configuration (`docker-compose.ee.yaml`)
- **Use Docker service hostnames**: Updated all services to use `*_DOCKER` environment variables (e.g., `REDIS_HOST_DOCKER`, `PGBOUNCER_HOST_DOCKER`) instead of `localhost` variants
- **Mount merged migrations**: Added volume mounts for `/tmp/alga-migrations` and `/tmp/alga-seeds` to allow hot-reloading of migrations without rebuilding containers
- This enables running the Next.js server locally while using Dockerized infrastructure

### 2. Migration Bug Fix (`20251014120000_create_stripe_integration_tables.cjs`)
- **Fixed duplicate foreign key constraints** in `stripe_prices` table:
  - Removed duplicate `stripe_prices_tenant_stripe_product_id_foreign` constraint (lines 107-109)
  - Kept only the first definition with `.onDelete('CASCADE')` (lines 91-95)
- **Fixed duplicate foreign key constraints** in `stripe_subscriptions` table:
  - Removed duplicate constraints for `stripe_customer_id` and `stripe_price_id` (lines 143-150)
  - Kept only the first definitions with `.onDelete('CASCADE')` (lines 122-131)
- These duplicates were causing migration failures with "constraint already exists" errors

### 3. Migration Merge Script (`scripts/merge-migrations.sh`)
- **Automated CE/EE migration merging**: Created script to merge server/migrations and ee/server/migrations into `/tmp/alga-migrations`
- **Handles seeds too**: Also merges server/seeds and ee/server/seeds into `/tmp/alga-seeds`
- **EE overrides CE**: EE files overwrite CE files with the same name, ensuring correct precedence
- **Integrates with dev-env.sh**: The alga-dev-env-manager skill now automatically runs this script before starting containers

## Test Plan
- [x] Start fresh dev environment with `docker compose up`
- [x] Verify setup container completes successfully
- [x] Verify all migrations run without errors
- [x] Run server locally with `PORT=3001 npm run dev`
- [x] Verify server connects to Docker infrastructure (postgres:5433, redis:6380)

## Related Issues
Fixes dev environment startup issues where:
- Setup container couldn't connect to database (was using localhost instead of service names)
- Migrations failed with duplicate constraint errors
- Local server couldn't connect to Docker infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>