### PR TITLE
fix: ensure templateDescription is always a string in TriggerForm

### DIFF
--- a/server/src/components/surveys/triggers/TriggerForm.tsx
+++ b/server/src/components/surveys/triggers/TriggerForm.tsx
@@ -387,7 +387,7 @@ export function TriggerForm({ templates, trigger, onSuccess, onDeleteSuccess, on
       ? triggerConditions
       : {};
     const selectedTemplateName = templateOptions.find((option) => option.value === formState.templateId)?.label;
-    const templateDescription = typeof selectedTemplateName === 'string' ? selectedTemplateName : undefined;
+    const templateDescription = typeof selectedTemplateName === 'string' ? selectedTemplateName : '';
 
     setIsSubmitting(true);
     try {


### PR DESCRIPTION
## Summary

Fix TypeScript compilation error where `templateDescription` could be undefined, but the `toast()` function requires a string type for the description property.

## Changes

- Changed the fallback value from `undefined` to an empty string `''` in `TriggerForm.tsx:390`
- This ensures the type system is satisfied while maintaining the same runtime behavior

## Test Plan

- [x] TypeScript compilation passes with no errors
- [x] No behavioral changes to the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>