### PR TITLE
refactor: consolidate OAuth configuration using Helm helpers

### DIFF
--- a/ee/setup/config.ini
+++ b/ee/setup/config.ini
@@ -134,9 +134,6 @@ NEXTAUTH_SECRET=Yih+OYr9C818n+QzdvWgKx9JTZpO9zJhklVWxYq5MYU=
 NEXTAUTH_SESSION_EXPIRES=86400
 
 
-[google_auth]
-GOOGLE_OAUTH_CLIENT_ID="get from google"
-GOOGLE_OAUTH_CLIENT_SECRET="get from google"
 [database]
 host=postgres
 port=5432

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -77,3 +77,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $suffix -}}
 {{- end -}}
 {{- end }}
+
+{{/* Render GOOGLE_OAUTH_* env vars from gmail_integration config */}}
+{{- define "sebastian.googleOAuthEnv" -}}
+{{- if and .Values.gmail_integration.enabled .Values.gmail_integration.client_id .Values.gmail_integration.client_secret }}
+- name: GOOGLE_OAUTH_CLIENT_ID
+  value: "{{ .Values.gmail_integration.client_id }}"
+- name: GOOGLE_OAUTH_CLIENT_SECRET
+  value: "{{ .Values.gmail_integration.client_secret }}"
+{{- end }}
+{{- end }}
+
+{{/*
+Render MICROSOFT_OAUTH_* env vars using the microsoft_integration config.
+*/}}
+{{- define "sebastian.microsoftOAuthEnv" -}}
+{{- if and .Values.microsoft_integration.enabled .Values.microsoft_integration.client_id }}
+- name: MICROSOFT_OAUTH_CLIENT_ID
+  value: "{{ .Values.microsoft_integration.client_id }}"
+{{- end }}
+{{- if and .Values.microsoft_integration.enabled .Values.microsoft_integration.client_secret }}
+- name: MICROSOFT_OAUTH_CLIENT_SECRET
+  value: "{{ .Values.microsoft_integration.client_secret }}"
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -406,11 +406,8 @@ spec:
           {{- end }}
 
           # ----------- GOOGLE AUTH ----------------
-          {{- if .Values.google_auth.enabled }}
-          - name: GOOGLE_OAUTH_CLIENT_ID
-            value: "{{ .Values.google_auth.client_id }}"
-          - name: GOOGLE_OAUTH_CLIENT_SECRET
-            value: "{{ .Values.google_auth.client_secret }}"
+          {{- with include "sebastian.googleOAuthEnv" . }}
+{{ . | nindent 10 }}
           {{- end }}
 
           # ----------- GMAIL INTEGRATION ----------------
@@ -444,6 +441,9 @@ spec:
           {{- if .Values.microsoft_integration.redirect_uri }}
           - name: MICROSOFT_REDIRECT_URI
             value: "{{ .Values.microsoft_integration.redirect_uri }}"
+          {{- end }}
+          {{- with include "sebastian.microsoftOAuthEnv" . }}
+{{ . | nindent 10 }}
           {{- end }}
           {{- end }}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -448,11 +448,8 @@ spec:
           {{- end }}
 
           # ----------- GOOGLE AUTH ----------------
-          {{- if .Values.google_auth.enabled }}
-          - name: GOOGLE_OAUTH_CLIENT_ID
-            value: "{{ .Values.google_auth.client_id }}"
-          - name: GOOGLE_OAUTH_CLIENT_SECRET
-            value: "{{ .Values.google_auth.client_secret }}"
+          {{- with include "sebastian.googleOAuthEnv" . }}
+{{ . | nindent 10 }}
           {{- end }}
 
           # ----------- GMAIL INTEGRATION ----------------
@@ -506,6 +503,9 @@ spec:
           {{- if .Values.microsoft_integration.redirect_uri }}
           - name: MICROSOFT_REDIRECT_URI
             value: "{{ .Values.microsoft_integration.redirect_uri }}"
+          {{- end }}
+          {{- with include "sebastian.microsoftOAuthEnv" . }}
+{{ . | nindent 10 }}
           {{- end }}
           {{- end }}
 

--- a/helm/templates/dev-env/code-server/deployment.yaml
+++ b/helm/templates/dev-env/code-server/deployment.yaml
@@ -348,11 +348,8 @@ spec:
               value: "{{ .Values.auth.nextauth_session_expires }}"
 
             # ----------- GOOGLE AUTH ----------------
-            {{- if .Values.google_auth.enabled }}
-            - name: GOOGLE_OAUTH_CLIENT_ID
-              value: "{{ .Values.google_auth.client_id }}"
-            - name: GOOGLE_OAUTH_CLIENT_SECRET
-              value: "{{ .Values.google_auth.client_secret }}"
+            {{- with include "sebastian.googleOAuthEnv" . }}
+{{ . | nindent 12 }}
             {{- end }}
 
             # ----------- EXTERNAL PORTS (DEV ENV) ----------------

--- a/helm/templates/hosted-env/code-server/deployment.yaml
+++ b/helm/templates/hosted-env/code-server/deployment.yaml
@@ -374,11 +374,8 @@ spec:
             {{- end }}
 
             # ----------- GOOGLE AUTH (OAuth for app sign-in) ----------------
-            {{- if .Values.google_auth.enabled }}
-            - name: GOOGLE_OAUTH_CLIENT_ID
-              value: "{{ .Values.google_auth.client_id }}"
-            - name: GOOGLE_OAUTH_CLIENT_SECRET
-              value: "{{ .Values.google_auth.client_secret }}"
+            {{- with include "sebastian.googleOAuthEnv" . }}
+{{ . | nindent 12 }}
             {{- end }}
 
             # ----------- MICROSOFT INTEGRATION ----------------
@@ -398,6 +395,9 @@ spec:
             {{- if .Values.microsoft_integration.redirect_uri }}
             - name: MICROSOFT_REDIRECT_URI
               value: "{{ .Values.microsoft_integration.redirect_uri }}"
+            {{- end }}
+            {{- with include "sebastian.microsoftOAuthEnv" . }}
+{{ . | nindent 12 }}
             {{- end }}
             {{- end }}
 

--- a/helm/templates/hosted-env/harbor-credentials.yaml
+++ b/helm/templates/hosted-env/harbor-credentials.yaml
@@ -63,7 +63,7 @@ metadata:
     {{- include "sebastian.labels" . | nindent 4 }}
     app.kubernetes.io/component: harbor-credentials
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-18"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
@@ -76,7 +76,7 @@ metadata:
     {{- include "sebastian.labels" . | nindent 4 }}
     app.kubernetes.io/component: harbor-credentials
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-18"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -96,7 +96,7 @@ metadata:
     {{- include "sebastian.labels" . | nindent 4 }}
     app.kubernetes.io/component: harbor-credentials
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-18"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -311,11 +311,6 @@ token:
 auth:
   nextauth_session_expires: 86400
 
-google_auth:
-  enabled: false
-  client_id: "get from google"
-  client_secret: "get from google"
-
 # Gmail Integration (Enterprise Edition)
 gmail_integration:
   enabled: false


### PR DESCRIPTION
## Summary
- Remove deprecated `google_auth` section from `values.yaml` and `config.ini`
- Create reusable Helm template helpers (`sebastian.googleOAuthEnv` and `sebastian.microsoftOAuthEnv`)
- Update all deployment templates to use new helpers instead of inline configuration
- Add `pre-upgrade` hook to harbor-credentials for proper secret management during upgrades

