### PR TITLE
Fix duplicate ticket assignment notifications

### DIFF
--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -1252,26 +1252,13 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
       }, 'Ticket Assigned', ticket.assigned_to);
     }
 
-    const locationEmail = ticket.client_email;
-    const contactEmail = ticket.contact_email;
+    // Send to contact email if available, otherwise client email
+    const primaryEmail = safeString(ticket.contact_email) || safeString(ticket.client_email);
 
-    // Notify the client's default location email - external user, no userId
-    if (locationEmail) {
+    if (primaryEmail) {
       await sendIfUnique({
         tenantId,
-        to: locationEmail,
-        subject: `Ticket Assigned: ${ticket.title}`,
-        template: 'ticket-assigned',
-        context: buildContext(portalUrl),
-        replyContext
-      }, 'Ticket Assigned');
-    }
-
-    // Notify the ticket contact when different from the default location email - external user, no userId
-    if (contactEmail) {
-      await sendIfUnique({
-        tenantId,
-        to: contactEmail,
+        to: primaryEmail,
         subject: `Ticket Assigned: ${ticket.title}`,
         template: 'ticket-assigned',
         context: buildContext(portalUrl),


### PR DESCRIPTION
This PR fixes an issue where ticket assignment notifications were being sent to both the ticket contact and the client's default location email (billing email), even if they were different.

The fix involves updating the `handleTicketAssigned` function in `server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts` to prioritize the contact email and only fall back to the client email if the contact email is not available, matching the behavior of other ticket notification handlers.