### PR TITLE
Email ticketing from address UX + namespace bump (follow-up)

### DIFF
--- a/shared/types/email.ts
+++ b/shared/types/email.ts
@@ -30,7 +30,7 @@ export interface EmailMessage {
 
 export interface EmailProviderConfig {
   providerId: string;
-  providerType: 'smtp' | 'resend' | 'ses' | 'sendgrid';
+  providerType: 'smtp' | 'resend' | 'ses' | 'sendgrid' | 'microsoft' | 'google';
   isEnabled: boolean;
   config: Record<string, any>;
   rateLimits?: {


### PR DESCRIPTION
## Summary
- Simplify outbound ticket emails to use the configured ticketing From address
- Persist ticketing_from_email with setup-time domain validation and UI warnings (domain mismatch, not in inbound inbox, no domain configured)
- Bump email notification namespace to v5
- Align shared EmailProviderConfig types with server (adds microsoft/google)

## Testing
- manual UI: 
  - warning when From not in inbound inbox list
  - error when From domain != outbound domain
  - blocked selection when no outbound domain configured
