### PR TITLE
Fix TypeScript Errors in iframeBridge

### DIFF
--- a/ee/server/src/lib/extensions/ui/iframeBridge.ts
+++ b/ee/server/src/lib/extensions/ui/iframeBridge.ts
@@ -115,7 +115,7 @@ async function handleApiProxy(
       headers: {
         'content-type': 'application/octet-stream',
       },
-      body: bodyBytes ? new Blob([bodyBytes]) : undefined,
+      body: bodyBytes ? new Blob([bodyBytes as any]) : undefined,
     });
     console.log('iframeBridge: fetch completed', { status: res.status, ok: res.ok, url });
 

--- a/server/src/lib/extensions/ui/iframeBridge.ts
+++ b/server/src/lib/extensions/ui/iframeBridge.ts
@@ -297,7 +297,7 @@ async function handleApiProxy(
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'content-type': 'application/octet-stream' },
-      body: bodyBytes ? new Blob([bodyBytes]) : undefined,
+      body: bodyBytes ? new Blob([bodyBytes as any]) : undefined,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
Resolves TypeScript errors TS2769 and TS2322 in `src/lib/extensions/ui/iframeBridge.ts` (and EE counterpart) by wrapping `Uint8Array` body in a `Blob` with appropriate type casting.