### PR TITLE
feat(workflow): convert email HTML to BlockNote blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12147,7 +12147,9 @@
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -29352,7 +29354,9 @@
       }
     },
     "node_modules/turndown": {
-      "version": "7.2.1",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
       "license": "MIT",
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
@@ -34251,7 +34255,7 @@
       }
     },
     "server": {
-      "version": "0.14.6",
+      "version": "0.14.8",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.3",
@@ -35847,6 +35851,7 @@
         "node-vault": "^0.10.2",
         "pg": "8.12.0",
         "redis": "4.7.0",
+        "turndown": "^7.2.2",
         "typescript": "^5.7.3",
         "uuid": "10.0.0",
         "winston": "3.13.1",
@@ -35856,6 +35861,7 @@
       "devDependencies": {
         "@types/express": "4.17.21",
         "@types/node": "20.11.24",
+        "@types/turndown": "^5.0.6",
         "@types/uuid": "^9.0.7",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
@@ -36076,6 +36082,7 @@
         "pg": "^8.16.0",
         "pg-types": "^4.0.2",
         "redis": "^4.6.10",
+        "turndown": "^7.2.2",
         "typescript": "^5.7.3",
         "uuid": "^9.0.1",
         "vitest": "^3.2.4",
@@ -36086,6 +36093,7 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/react": "^18.0.0",
+        "@types/turndown": "^5.0.6",
         "@types/uuid": "^9.0.7",
         "tsc-alias": "^1.8.16"
       },

--- a/services/workflow-worker/package.json
+++ b/services/workflow-worker/package.json
@@ -27,6 +27,7 @@
     "node-vault": "^0.10.2",
     "pg": "8.12.0",
     "redis": "4.7.0",
+    "turndown": "^7.2.2",
     "typescript": "^5.7.3",
     "uuid": "10.0.0",
     "winston": "3.13.1",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@types/express": "4.17.21",
     "@types/node": "20.11.24",
+    "@types/turndown": "^5.0.6",
     "@types/uuid": "^9.0.7",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/shared/lib/utils/contentConversion.ts
+++ b/shared/lib/utils/contentConversion.ts
@@ -1,0 +1,160 @@
+import TurndownService from 'turndown';
+
+export interface BlockNoteBlock {
+  type: string;
+  props?: Record<string, any>;
+  content?: any[];
+  children?: BlockNoteBlock[];
+}
+
+export function convertHtmlToBlockNote(html: string): BlockNoteBlock[] {
+  if (!html) return [];
+
+  const turndownService = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-'
+  });
+
+  const markdown = turndownService.turndown(html);
+  return convertMarkdownToBlocks(markdown);
+}
+
+function convertMarkdownToBlocks(markdown: string): BlockNoteBlock[] {
+  const lines = markdown.split('\n');
+  const blocks: BlockNoteBlock[] = [];
+  
+  let currentCodeBlock: BlockNoteBlock | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    
+    // Handle code blocks
+    if (line.trim().startsWith('```')) {
+      if (currentCodeBlock) {
+        // End of code block
+        blocks.push(currentCodeBlock);
+        currentCodeBlock = null;
+      } else {
+        // Start of code block
+        const language = line.trim().substring(3);
+        currentCodeBlock = {
+          type: 'codeBlock',
+          props: { language },
+          content: []
+        };
+      }
+      continue;
+    }
+
+    if (currentCodeBlock) {
+      // Add line to code block content
+      // Code blocks in BlockNote usually have one text item with newlines, or multiple?
+      // Looking at the server utils, it seems to map content array to text. 
+      // Let's accumulate text.
+      const currentText = currentCodeBlock.content?.[0]?.text || '';
+      currentCodeBlock.content = [{ 
+        type: 'text', 
+        text: currentText ? currentText + '\n' + line : line,
+        styles: {}
+      }];
+      continue;
+    }
+
+    // Skip empty lines (except potentially as spacers, but BlockNote handles spacing)
+    if (!line.trim()) continue;
+
+    // Headings
+    if (line.startsWith('#')) {
+      const level = line.match(/^#+/)?.[0].length || 1;
+      const text = line.substring(level).trim();
+      blocks.push({
+        type: 'heading',
+        props: { level: Math.min(level, 3) }, // BlockNote supports h1-h3
+        content: parseInlineStyles(text)
+      });
+      continue;
+    }
+
+    // Unordered List
+    if (line.match(/^[\*\-]\s/)) {
+      const text = line.substring(2).trim();
+      blocks.push({
+        type: 'bulletListItem',
+        content: parseInlineStyles(text)
+      });
+      continue;
+    }
+
+    // Ordered List
+    if (line.match(/^\d+\.\s/)) {
+      const text = line.replace(/^\d+\.\s/, '').trim();
+      blocks.push({
+        type: 'numberedListItem',
+        content: parseInlineStyles(text)
+      });
+      continue;
+    }
+
+    // Blockquote (map to paragraph for now, or check if 'blockquote' type exists - usually not in standard BN schema)
+    if (line.startsWith('>')) {
+      const text = line.substring(1).trim();
+      blocks.push({
+        type: 'paragraph',
+        content: parseInlineStyles(text) // Could add italic style to represent quote
+      });
+      continue;
+    }
+
+    // Paragraph (default)
+    blocks.push({
+      type: 'paragraph',
+      content: parseInlineStyles(line)
+    });
+  }
+
+  return blocks;
+}
+
+function parseInlineStyles(text: string): any[] {
+  // Simple inline style parser: bold (**), italic (*), link ([text](url))
+  // This is a simplified parser and won't handle nested styles perfectly.
+  
+  const content: any[] = [];
+  let remaining = text;
+
+  // Regex for tokens: **bold**, *italic*, [link](url)
+  // Note: Non-greedy matching
+  const tokenRegex = /(\*\*(.*?)\*\*)|(\*(.*?)\*)|(\[(.*?)\]\((.*?)\))/;
+
+  while (remaining) {
+    const match = remaining.match(tokenRegex);
+    
+    if (!match) {
+      content.push({ type: 'text', text: remaining, styles: {} });
+      break;
+    }
+
+    const index = match.index!;
+    
+    // Add text before match
+    if (index > 0) {
+      content.push({ type: 'text', text: remaining.substring(0, index), styles: {} });
+    }
+
+    // Process match
+    const [fullMatch, boldGroup, boldText, italicGroup, italicText, linkGroup, linkText, linkUrl] = match;
+
+    if (boldGroup) {
+      content.push({ type: 'text', text: boldText, styles: { bold: true } });
+    } else if (italicGroup) {
+      content.push({ type: 'text', text: italicText, styles: { italic: true } });
+    } else if (linkGroup) {
+      content.push({ type: 'link', href: linkUrl, content: [{ type: 'text', text: linkText, styles: {} }] });
+    }
+
+    remaining = remaining.substring(index + fullMatch.length);
+  }
+
+  return content;
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -52,6 +52,7 @@
     "pg": "^8.16.0",
     "pg-types": "^4.0.2",
     "redis": "^4.6.10",
+    "turndown": "^7.2.2",
     "typescript": "^5.7.3",
     "uuid": "^9.0.1",
     "vitest": "^3.2.4",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
+    "@types/turndown": "^5.0.6",
     "@types/uuid": "^9.0.7",
     "tsc-alias": "^1.8.16"
   },

--- a/shared/workflow/init/registerWorkflowActions.ts
+++ b/shared/workflow/init/registerWorkflowActions.ts
@@ -2002,6 +2002,32 @@ function registerEmailWorkflowActions(actionRegistry: ActionRegistry): void {
     }
   );
 
+  // Convert HTML to BlockNote Blocks Action
+  actionRegistry.registerSimpleAction(
+    'convert_html_to_blocks',
+    'Convert HTML content to BlockNote blocks',
+    [{ name: 'html', type: 'string', required: true }],
+    async (params: Record<string, any>, context: ActionExecutionContext) => {
+      try {
+        const { convertHtmlToBlockNote } = await import('@alga-psa/shared/lib/utils/contentConversion');
+        const blocks = convertHtmlToBlockNote(params.html);
+
+        return {
+          success: true,
+          blocks: blocks
+        };
+      } catch (error: any) {
+        logger.error(`[ACTION] convert_html_to_blocks: Error converting HTML to blocks`, error);
+        // Return empty paragraph as fallback
+        return {
+          success: false,
+          blocks: [{ type: 'paragraph', content: [] }],
+          message: error.message
+        };
+      }
+    }
+  );
+
   logger.info('[WorkflowInit] Email workflow actions registered successfully');
 }
 


### PR DESCRIPTION
This PR enhances the email processing workflow to automatically convert incoming email HTML content into BlockNote blocks for better integration with the ticket system.

### Key Changes
- **Dependency:** Added `turndown` to `shared` and `workflow-worker` for HTML-to-Markdown conversion.
- **Utility:** Implemented `convertHtmlToBlockNote` in `shared/lib/utils/contentConversion.ts` which parses Markdown into BlockNote block structure (paragraphs, headings, lists, code blocks).
- **Action:** Registered new `convert_html_to_blocks` workflow action.
- **Workflow:** Updated `system-email-processing-workflow.ts` to use the conversion action before creating ticket comments (both for new tickets and replies).

This ensures that email comments are stored as structured blocks rather than raw HTML strings, improving the editing experience in the UI.