### PR TITLE
test(workflow): add robustness tests for content conversion

### DIFF
--- a/shared/lib/utils/contentConversion.test.ts
+++ b/shared/lib/utils/contentConversion.test.ts
@@ -118,4 +118,29 @@ describe('convertHtmlToBlockNote', () => {
     expect(link?.content?.[0]?.text).toContain('🖼️');
     expect(link?.content?.[0]?.text).toContain('icon');
   });
+
+  it('should handle images with mid-string parentheses in URL', () => {
+    const html = '<p><img src="https://example.com/folder(1)/image.png" alt="Complex Image" /></p>';
+    const result = convertHtmlToBlockNote(html);
+    
+    const imageBlock = result.find(b => b.type === 'image');
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock?.props?.url).toBe('https://example.com/folder(1)/image.png');
+  });
+
+  it('should handle complex nested styles', () => {
+    // **bold *and italic*** -> Bold + (Bold & Italic)
+    const html = '<p><strong>bold <em>and italic</em></strong></p>';
+    const result = convertHtmlToBlockNote(html);
+    
+    const paragraph = result[0];
+    const content = paragraph.content || [];
+    
+    const boldSegment = content.find(c => c.text === 'bold ');
+    expect(boldSegment?.styles).toMatchObject({ bold: true });
+    expect(boldSegment?.styles?.italic).toBeUndefined();
+
+    const mixedSegment = content.find(c => c.text === 'and italic');
+    expect(mixedSegment?.styles).toMatchObject({ bold: true, italic: true });
+  });
 });


### PR DESCRIPTION
This PR adds additional unit tests to verify the robustness of the email content conversion utility, specifically targeting:

- **URL Parsing:** Verifies that images with parentheses in their URLs (e.g., `image(1).png`) are correctly parsed.
- **Nested Styles:** Verifies correct handling of complex nested markdown styles (e.g., `**bold *and italic***`).

These tests ensure the regex parsers are functioning correctly for edge cases.