### PR TITLE
Fix: Hardcode 'common' tenant for Microsoft OAuth multi-tenant support

### DIFF
--- a/server/src/app/api/auth/[...nextauth]/options.ts
+++ b/server/src/app/api/auth/[...nextauth]/options.ts
@@ -771,7 +771,8 @@ export async function buildAuthOptions(): Promise<NextAuthConfig> {
                 AzureADProvider({
                     clientId: secrets.microsoftClientId,
                     clientSecret: secrets.microsoftClientSecret,
-                    issuer: `https://login.microsoftonline.com/${secrets.microsoftTenantId || 'common'}/v2.0`,
+                    // Always use 'common' for multi-tenant Azure AD apps
+                    issuer: `https://login.microsoftonline.com/common/v2.0`,
                     checks: ['pkce', 'state'],
                     profile: async (profile: Record<string, any>): Promise<ExtendedUser> => {
                         const emailCandidate =
@@ -1365,7 +1366,8 @@ export const options: NextAuthConfig = {
                 AzureADProvider({
                     clientId: process.env.MICROSOFT_OAUTH_CLIENT_ID as string,
                     clientSecret: process.env.MICROSOFT_OAUTH_CLIENT_SECRET as string,
-                    issuer: `https://login.microsoftonline.com/${process.env.MICROSOFT_OAUTH_TENANT_ID || 'common'}/v2.0`,
+                    // Always use 'common' for multi-tenant Azure AD apps
+                    issuer: `https://login.microsoftonline.com/common/v2.0`,
                     profile: async (profile: Record<string, any>): Promise<ExtendedUser> => {
                         const emailCandidate =
                             profile.email ??

--- a/server/src/app/api/email/oauth/initiate/route.ts
+++ b/server/src/app/api/email/oauth/initiate/route.ts
@@ -65,14 +65,9 @@ export async function POST(request: NextRequest) {
     };
 
     // Generate authorization URL
-    // Determine Microsoft tenant authority (single-tenant support)
-    let msTenantAuthority: string | undefined;
-    if (provider === 'microsoft') {
-      msTenantAuthority = process.env.MICROSOFT_TENANT_ID
-        || (await secretProvider.getAppSecret('MICROSOFT_TENANT_ID'))
-        || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_tenant_id'))
-        || 'common';
-    }
+    // For multi-tenant Azure AD apps, always use 'common' for the authorization URL
+    // This allows users from any Azure AD tenant to authenticate
+    const msTenantAuthority = 'common';
 
     const authUrl = provider === 'microsoft'
       ? generateMicrosoftAuthUrl(

--- a/server/src/lib/actions/calendarActions.ts
+++ b/server/src/lib/actions/calendarActions.ts
@@ -116,14 +116,9 @@ export async function initiateCalendarOAuth(params: {
     };
     const encodedState = encodeCalendarState(state);
 
-    // Determine Microsoft tenant authority
-    let msTenantAuthority: string | undefined;
-    if (provider === 'microsoft') {
-      msTenantAuthority = process.env.MICROSOFT_TENANT_ID
-        || (await secretProvider.getAppSecret('MICROSOFT_TENANT_ID'))
-        || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_tenant_id'))
-        || 'common';
-    }
+    // For multi-tenant Azure AD apps, always use 'common' for the authorization URL
+    // This allows users from any Azure AD tenant to authenticate
+    const msTenantAuthority = 'common';
 
     const authUrl = provider === 'microsoft'
       ? await generateMicrosoftCalendarAuthUrl({

--- a/server/src/lib/actions/email-actions/oauthActions.ts
+++ b/server/src/lib/actions/email-actions/oauthActions.ts
@@ -79,14 +79,9 @@ export async function initiateEmailOAuth(params: {
       hosted: isHosted
     };
 
-    // Determine Microsoft tenant authority for single-tenant apps
-    let msTenantAuthority: string | undefined;
-    if (provider === 'microsoft') {
-      msTenantAuthority = process.env.MICROSOFT_TENANT_ID
-        || (await secretProvider.getAppSecret('MICROSOFT_TENANT_ID'))
-        || (await secretProvider.getTenantSecret(user.tenant, 'microsoft_tenant_id'))
-        || 'common';
-    }
+    // For multi-tenant Azure AD apps, always use 'common' for the authorization URL
+    // This allows users from any Azure AD tenant to authenticate
+    const msTenantAuthority = 'common';
 
     const authUrl = provider === 'microsoft'
       ? generateMicrosoftAuthUrl(clientId, state.redirectUri, state, undefined as any, msTenantAuthority)


### PR DESCRIPTION
## Summary
- Fixes AADSTS50020 errors for users from different Azure AD tenants authenticating via Microsoft OAuth
- Hardcodes 'common' as the tenant authority in all OAuth authorization URLs
- Affects calendar OAuth, email OAuth, and NextAuth SSO flows

## Problem
When `MICROSOFT_TENANT_ID` or `MICROSOFT_OAUTH_TENANT_ID` was configured with a specific tenant ID (e.g., the hosting organization's Azure AD tenant), users from other Azure AD tenants would get:

```
AADSTS50020: User account from identity provider does not exist in tenant
```

## Solution
For multi-tenant Azure AD apps, the authorization URL must use `common` instead of a specific tenant ID. This allows users from any Azure AD tenant to authenticate.

## Test plan
- [ ] Test Microsoft SSO login with users from different Azure AD tenants
- [ ] Test Microsoft calendar OAuth connection with users from different tenants
- [ ] Test Microsoft email OAuth connection with users from different tenants
- [ ] Verify existing single-tenant deployments continue to work (token exchange still uses configured tenant)