### PR TITLE
Fix: Use 'common' for Microsoft OAuth token exchange

### DIFF
--- a/server/src/app/api/auth/microsoft/calendar/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/calendar/callback/route.ts
@@ -220,8 +220,8 @@ export async function GET(request: NextRequest) {
 
     // Exchange authorization code for tokens
     try {
-      const authority = tenantId || 'common';
-      const tokenUrl = `https://login.microsoftonline.com/${authority}/oauth2/v2.0/token`;
+      // Always use 'common' for multi-tenant Azure AD apps
+      const tokenUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/token`;
       const params = new URLSearchParams({
         client_id: clientId,
         client_secret: clientSecret,

--- a/server/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
+++ b/server/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
@@ -132,11 +132,8 @@ export class MicrosoftCalendarAdapter extends BaseCalendarAdapter {
         throw new Error('Microsoft OAuth credentials not configured');
       }
 
-      // Determine tenant authority
-      const vendorTenantId = vendorConfig.tenantId;
-      let tenantAuthority = vendorTenantId || process.env.MICROSOFT_TENANT_ID || 'common';
-
-      const tokenUrl = `https://login.microsoftonline.com/${tenantAuthority}/oauth2/v2.0/token`;
+      // Always use 'common' for multi-tenant Azure AD apps
+      const tokenUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/token`;
 
       const params = new URLSearchParams({
         client_id: clientId,


### PR DESCRIPTION
## Summary
- Follow-up fix to #1326 for Microsoft OAuth multi-tenant support
- Token exchange endpoint must also use 'common' to match the authorization endpoint
- Without this fix, Azure AD returns AADSTS700005: "Authorization Code is intended to use against other tenant"

## Changes
- `MicrosoftCalendarAdapter.ts`: Use 'common' for token refresh
- `calendar/callback/route.ts`: Use 'common' for authorization code exchange

## Test plan
- [ ] Test Microsoft calendar OAuth connection with users from different Azure AD tenants
- [ ] Verify token refresh works correctly after initial connection