### PR TITLE
Fix: Treat 0% tax rates as non-taxable for time entry validation

### DIFF
--- a/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -190,7 +190,10 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         return;
       }
 
-      if (selectedService.tax_rate_id != null && !entry.tax_region) {
+      const hasTaxableRate = selectedService.tax_rate_id != null &&
+        selectedService.tax_percentage != null &&
+        selectedService.tax_percentage > 0;
+      if (hasTaxableRate && !entry.tax_region) {
         toast.error('Please select a tax region for taxable services');
         return;
       }

--- a/server/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
@@ -13,7 +13,8 @@ interface Service {
   id: string;
   name: string;
   type: string;
-  tax_rate_id: string | null; // Use tax_rate_id instead
+  tax_rate_id: string | null;
+  tax_percentage: number | null;
 }
 
 interface ITimeEntryWithNew extends Omit<ITimeEntry, 'tenant'> {

--- a/server/src/components/time-management/time-entry/time-sheet/types.ts
+++ b/server/src/components/time-management/time-entry/time-sheet/types.ts
@@ -5,7 +5,8 @@ export interface Service {
   id: string;
   name: string;
   type: string;
-  tax_rate_id: string | null; // Use tax_rate_id instead
+  tax_rate_id: string | null;
+  tax_percentage: number | null;
 }
 
 export interface ITimeEntryWithNew extends Omit<ITimeEntry, 'tenant'> {

--- a/server/src/lib/actions/timeEntryServices.ts
+++ b/server/src/lib/actions/timeEntryServices.ts
@@ -204,7 +204,7 @@ export async function fetchDefaultClientTaxRateInfoForWorkItem(workItemId: strin
   }
 }
 
-export async function fetchServicesForTimeEntry(workItemType?: string): Promise<{ id: string; name: string; type: string; tax_rate_id: string | null }[]> { // Return tax_rate_id instead
+export async function fetchServicesForTimeEntry(workItemType?: string): Promise<{ id: string; name: string; type: string; tax_rate_id: string | null; tax_percentage: number | null }[]> {
   const currentUser = await getCurrentUser();
   if (!currentUser) {
     throw new Error('No authenticated user found');
@@ -222,12 +222,17 @@ export async function fetchServicesForTimeEntry(workItemType?: string): Promise<
       this.on('sc.custom_service_type_id', '=', 'st.id')
           .andOn('sc.tenant', '=', 'st.tenant');
     })
+    .leftJoin('tax_rates as tr', function() {
+      this.on('sc.tax_rate_id', '=', 'tr.tax_rate_id')
+          .andOn('sc.tenant', '=', 'tr.tenant');
+    })
     .where({ 'sc.tenant': tenant })
     .select(
       'sc.service_id as id',
       'sc.service_name as name',
-      'sc.billing_method as type', // Use billing_method as type
-      'sc.tax_rate_id' // Select tax_rate_id instead
+      'sc.billing_method as type',
+      'sc.tax_rate_id',
+      'tr.tax_percentage'
     );
 
   // For ad_hoc entries, only show Time-based services


### PR DESCRIPTION
## Summary
- Services with a 0% tax rate (e.g., "Non-taxable") were incorrectly requiring a tax region selection when creating time entries
- Updated validation to check `tax_percentage > 0` in addition to `tax_rate_id != null` before requiring a tax region
- Added `tax_percentage` to the Service interface and query to support this check