### PR TITLE
Add user_id retrieval for calendar provider callbacks

### DIFF
--- a/server/src/app/api/auth/google/calendar/callback/route.ts
+++ b/server/src/app/api/auth/google/calendar/callback/route.ts
@@ -239,10 +239,17 @@ export async function GET(request: NextRequest) {
             const { knex } = await createTenantKnex();
             const providerService = new CalendarProviderService();
 
+            // Fetch existing provider to get user_id
+            const existingProvider = await providerService.getProvider(stateData.calendarProviderId!, stateData.tenant);
+            if (!existingProvider) {
+              throw new Error('Calendar provider not found');
+            }
+
             // Get user's calendars
             const tempConfig: CalendarProviderConfig = {
               id: stateData.calendarProviderId!,
               tenant: stateData.tenant!,
+              user_id: existingProvider.user_id,
               name: 'Temp',
               provider_type: 'google' as const,
               calendar_id: 'primary',

--- a/server/src/app/api/auth/microsoft/calendar/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/calendar/callback/route.ts
@@ -282,10 +282,17 @@ export async function GET(request: NextRequest) {
             const { knex } = await createTenantKnex();
             const providerService = new CalendarProviderService();
 
+            // Fetch existing provider to get user_id
+            const existingProvider = await providerService.getProvider(stateData.calendarProviderId!, stateData.tenant);
+            if (!existingProvider) {
+              throw new Error('Calendar provider not found');
+            }
+
             // Get user's calendars
             const tempConfig: CalendarProviderConfig = {
               id: stateData.calendarProviderId!,
               tenant: stateData.tenant!,
+              user_id: existingProvider.user_id,
               name: 'Temp',
               provider_type: 'microsoft' as const,
               calendar_id: 'calendar',


### PR DESCRIPTION
## Summary

Added user_id context to Google and Microsoft calendar OAuth callbacks to ensure providers are properly associated with the authenticated user.

## Changes

**Calendar Callbacks:**
- Retrieve and pass user_id to calendar provider setup from both Google and Microsoft OAuth callbacks
- Ensures calendar providers are created with correct user association
- Maintains user-specific calendar sync functionality

## Test Plan

- [ ] Complete Google Calendar OAuth flow and verify provider is created with correct user_id
- [ ] Complete Microsoft Calendar OAuth flow and verify provider is created with correct user_id
- [ ] Verify entries sync to the correct user's calendar only