### PR TITLE
Enhance Microsoft calendar integration with popup support

### DIFF
--- a/server/src/app/api/auth/microsoft/calendar/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/calendar/callback/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     const state = searchParams.get('state');
     const error = searchParams.get('error');
     const errorDescription = searchParams.get('error_description');
-    const isPopup = searchParams.get('popup') === 'true';
+    let isPopup = searchParams.get('popup') === 'true';
     
     // Helper: redirect to user profile calendar tab (for non-popup flows)
     const redirectToSettings = (success: boolean, error?: string) => {
@@ -123,6 +123,10 @@ export async function GET(request: NextRequest) {
 
     // Parse state to get tenant and other info
     const decodedState = decodeCalendarState(state);
+    if (decodedState?.isPopup) {
+      isPopup = true;
+    }
+
     if (!decodedState) {
       if (isPopup) {
         return respondWithPostMessage({

--- a/server/src/components/calendar/MicrosoftCalendarProviderForm.tsx
+++ b/server/src/components/calendar/MicrosoftCalendarProviderForm.tsx
@@ -132,6 +132,7 @@ export function MicrosoftCalendarProviderForm({
       const oauthResult = await initiateCalendarOAuth({
         provider: 'microsoft',
         calendarProviderId: providerId,
+        isPopup: true,
       });
 
       if (!oauthResult.success) {

--- a/server/src/interfaces/calendar.interfaces.ts
+++ b/server/src/interfaces/calendar.interfaces.ts
@@ -203,6 +203,7 @@ export interface CalendarOAuthState {
   redirectUri?: string;
   timestamp: number;
   hosted?: boolean;
+  isPopup?: boolean;
 }
 
 export interface CalendarEventCreateRequest {

--- a/server/src/lib/actions/calendarActions.ts
+++ b/server/src/lib/actions/calendarActions.ts
@@ -22,6 +22,7 @@ export async function initiateCalendarOAuth(params: {
   provider: 'google' | 'microsoft';
   calendarProviderId?: string;
   redirectUri?: string;
+  isPopup?: boolean;
 }): Promise<{ success: true; authUrl: string; state: string } | { success: false; error: string }> {
   const user = await getCurrentUser();
   if (!user) return { success: false, error: 'Unauthorized' };
@@ -47,7 +48,7 @@ export async function initiateCalendarOAuth(params: {
       }
     }
 
-    const { provider, calendarProviderId, redirectUri: requestedRedirectUri } = params;
+    const { provider, calendarProviderId, redirectUri: requestedRedirectUri, isPopup } = params;
     const secretProvider = await getSecretProviderInstance();
     const tenant = user.tenant;
 
@@ -113,7 +114,8 @@ export async function initiateCalendarOAuth(params: {
       nonce: generateCalendarNonce(),
       redirectUri,
       timestamp: Date.now(),
-      hosted: isHostedFlow
+      hosted: isHostedFlow,
+      isPopup
     };
     const encodedState = encodeCalendarState(state);
 


### PR DESCRIPTION
## Summary

Added popup support for Microsoft calendar OAuth flow and improved the calendar provider form integration.

## Changes

**Microsoft OAuth Popup:**
- Updated callback route to support popup-based OAuth flows
- Enhanced MicrosoftCalendarProviderForm with popup support
- Added popup property to calendar provider interface
- Improved callback handling for popup-initiated flows

## Test Plan

- [ ] Test Microsoft Calendar OAuth flow in popup window
- [ ] Verify callback properly closes popup and returns to parent window
- [ ] Confirm provider is created with correct configuration after popup OAuth