### PR TITLE
Fix: Remove hardcoded ngrok placeholder from calendar webhook configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,7 +177,8 @@ MICROSOFT_TENANT_ID=common
 MICROSOFT_REDIRECT_URI=https://yourdomain.com/api/auth/microsoft/calendar/callback
 
 # Calendar Webhook Configuration
-CALENDAR_WEBHOOK_BASE_URL=https://your-ngrok-domain.ngrok-free.app
+# Removed: Let the code use NEXTAUTH_URL as the fallback webhook base
+# CALENDAR_WEBHOOK_BASE_URL=https://your-ngrok-domain.ngrok-free.app
 
 # Enterprise Edition Gmail Configuration
 # These are only used when NEXT_PUBLIC_EDITION=enterprise


### PR DESCRIPTION
## Summary
This PR fixes the Microsoft calendar webhook registration issue by removing the hardcoded ngrok placeholder from the environment configuration.

## Root Cause
The `.env.example` file contained `CALENDAR_WEBHOOK_BASE_URL=https://your-ngrok-domain.ngrok-free.app`, which was being copied into the Docker image and took precedence over `NEXTAUTH_URL` in the OAuth callback configuration. This prevented the system from using the correct production domain (`https://algapsa.com`) for webhook URLs.

## Changes
- **Commented out** `CALENDAR_WEBHOOK_BASE_URL` in `.env.example` to allow the code to fall back to `NEXTAUTH_URL`
- **Added debug logging** to the OAuth callback to diagnose webhook URL determination during the setup process

## Test Plan
- [ ] Rebuild Docker image with updated `.env.example`
- [ ] Deploy to green environment via `build-migrate-deploy` workflow
- [ ] Delete and re-add Microsoft calendar provider in UI
- [ ] Verify webhook URL is set to `https://algapsa.com/api/calendar/webhooks/microsoft` in database
- [ ] Verify Microsoft Graph webhook validation succeeds
- [ ] Check debug logs to confirm `NEXTAUTH_URL` is being used as webhook base