### PR TITLE
Fix webhook health migration: correct column reference and formatting

### DIFF
--- a/server/migrations/20251118000000_add_webhook_health_columns.cjs
+++ b/server/migrations/20251118000000_add_webhook_health_columns.cjs
@@ -2,8 +2,8 @@
  * Add webhook health tracking columns to email_provider_health
  */
 
-exports.up = async function(knex) {
-  await knex.schema.table('email_provider_health', function(table) {
+exports.up = async function (knex) {
+  await knex.schema.table('email_provider_health', function (table) {
     table.string('subscription_status'); // enum: healthy, renewing, error
     table.timestamp('subscription_expires_at');
     table.timestamp('last_renewal_attempt_at');
@@ -11,16 +11,16 @@ exports.up = async function(knex) {
     table.text('failure_reason');
     table.timestamp('last_notification_received_at');
   });
-  
+
   // Add index for monitoring, using the standardized 'tenant' column
   await knex.schema.raw(`
     CREATE INDEX idx_email_provider_health_subscription_status 
-    ON email_provider_health (tenant_id, subscription_status)
+    ON email_provider_health (tenant, subscription_status)
   `);
 };
 
-exports.down = async function(knex) {
-  await knex.schema.table('email_provider_health', function(table) {
+exports.down = async function (knex) {
+  await knex.schema.table('email_provider_health', function (table) {
     table.dropColumn('subscription_status');
     table.dropColumn('subscription_expires_at');
     table.dropColumn('last_renewal_attempt_at');


### PR DESCRIPTION
## Summary
- **Fix**: Change `tenant_id` to `tenant` in the index creation (matches the standardized column name used in the table)
- **Format**: Add space before parentheses in function declarations (code style consistency)
- **Clean**: Remove trailing whitespace

## Test Plan
- [ ] Verify migration runs without errors
- [ ] Confirm the index is created on the correct columns