### PR TITLE
Fix payment provider migration for Citus compatibility

### DIFF
--- a/server/src/lib/actions/invoiceModification.ts
+++ b/server/src/lib/actions/invoiceModification.ts
@@ -870,7 +870,15 @@ export async function hardDeleteInvoice(invoiceId: string) {
       })
       .delete();
 
-    // 10. Delete invoice record
+    // 10. Nullify invoice_id in payment_webhook_events
+    const hasPaymentWebhookEvents = await trx.schema.hasTable('payment_webhook_events');
+    if (hasPaymentWebhookEvents) {
+      await trx('payment_webhook_events')
+        .where({ invoice_id: invoiceId, tenant })
+        .update({ invoice_id: null });
+    }
+
+    // 11. Delete invoice record
     await trx('invoices')
       .where({
         invoice_id: invoiceId,

--- a/server/src/lib/models/invoice.ts
+++ b/server/src/lib/models/invoice.ts
@@ -79,12 +79,20 @@ export default class Invoice {
 
   static async delete(knexOrTrx: Knex | Knex.Transaction, invoiceId: string): Promise<boolean> {
     const tenant = await getCurrentTenantId();
-    
+
     if (!tenant) {
       throw new Error('Tenant context is required for deleting invoice');
     }
 
     try {
+      // Nullify invoice_id in payment_webhook_events
+      const hasPaymentWebhookEvents = await knexOrTrx.schema.hasTable('payment_webhook_events');
+      if (hasPaymentWebhookEvents) {
+        await knexOrTrx('payment_webhook_events')
+          .where({ invoice_id: invoiceId, tenant })
+          .update({ invoice_id: null });
+      }
+
       const deleted = await knexOrTrx('invoices')
         .where({
           invoice_id: invoiceId,


### PR DESCRIPTION
  - Use composite primary keys with tenant for all 4 tables
  - Fix composite foreign key syntax using array notation
  - Remove ON DELETE SET NULL (incompatible with Citus)
  - Add application-level cascade logic for invoice deletion
  - Move tenant column to first position in table definitions

  "'Curiouser and curiouser!' cried Alice, as the foreign keys grew composite and the primary keys demanded their tenant companions. 'In Citus-land,' said the Cheshire Cat, 'we NULL our invoice_ids in application code, for the database cascade has gone quite mad!'" 🐱🔑🗄️