### PR TITLE
Fix foreign key references in invoice_payments migration

### DIFF
--- a/ee/server/migrations/20251203120000_create_invoice_payments_table.cjs
+++ b/ee/server/migrations/20251203120000_create_invoice_payments_table.cjs
@@ -32,8 +32,8 @@ exports.up = async function up(knex) {
       table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
       table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
 
-      table.foreign('tenant').references('tenants.tenant').onDelete('CASCADE');
-      table.foreign('invoice_id').references('invoices.invoice_id').onDelete('CASCADE');
+      table.foreign('tenant').references('tenant').inTable('tenants').onDelete('CASCADE');
+      table.foreign(['tenant', 'invoice_id']).references(['tenant', 'invoice_id']).inTable('invoices').onDelete('CASCADE');
     })
   );
 


### PR DESCRIPTION
## Summary
- Fixed foreign key reference syntax in invoice_payments migration
- Updated tenant FK to use correct inTable format
- Corrected invoice_id FK to reference composite key (tenant, invoice_id)

## Test plan
- Verify migration runs without errors
- Confirm database schema matches intended foreign key structure