### PR TITLE
Fix integration settings UI consistency

### DIFF
--- a/server/src/components/settings/integrations/QboIntegrationSettings.tsx
+++ b/server/src/components/settings/integrations/QboIntegrationSettings.tsx
@@ -285,7 +285,7 @@ const QboIntegrationSettings: React.FC = () => {
 
           {shouldShowConnectInfo ? (
             <p className="text-sm text-muted-foreground" id="qbo-connect-info-text">
-              Clicking &lsquo;Connect to QuickBooks Online&rsquo; opens Intuit authorisation in a new window. You&rsquo;ll
+              Clicking &lsquo;Connect to QuickBooks Online&rsquo; opens Intuit authorization in a new window. You&rsquo;ll
               return here once the connection completes.
             </p>
           ) : null}
@@ -336,9 +336,6 @@ const QboIntegrationSettings: React.FC = () => {
               </Button>
             )}
           </div>
-          <p className="text-xs text-muted-foreground text-center sm:text-right">
-            Need help? Review the QuickBooks onboarding guide before inviting finance to export invoices.
-          </p>
         </CardFooter>
       </Card>
 

--- a/server/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/server/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from '../../ui/Button';
 import { Alert, AlertDescription } from '../../ui/Alert';
 import LoadingIndicator from '../../ui/LoadingIndicator';
+import { Link } from 'lucide-react';
 import { XeroMappingManager } from '../../integrations/xero/XeroMappingManager';
 import {
   getXeroConnectionStatus,
@@ -248,13 +249,11 @@ const XeroIntegrationSettings: React.FC = () => {
                 onClick={handleConnect}
                 disabled={isLoading || isRefreshing}
               >
+                <Link className="mr-2 h-4 w-4" />
                 Connect to Xero
               </Button>
             )}
           </div>
-          <p className="text-xs text-muted-foreground text-center sm:text-right">
-            Need help? Review the Xero onboarding guide for connection setup steps.
-          </p>
         </CardFooter>
       </Card>
 


### PR DESCRIPTION
## Summary
- Add link icon to Xero "Connect to Xero" button to match QuickBooks Online button styling
- Remove references to nonexistent onboarding guides from both QBO and Xero integration settings
- Fix British spelling "authorisation" to American "authorization" for consistency

## Test plan
- [ ] Navigate to Settings > General > Integrations
- [ ] Verify Xero "Connect to Xero" button now has link icon
- [ ] Verify "Need help?" text is removed from both QBO and Xero sections
- [ ] Verify QuickBooks info text uses "authorization" spelling

🤖 Generated with [Claude Code](https://claude.com/claude-code)