### PR TITLE
Fix client portal invoice display and payment bugs

### DIFF
--- a/server/public/locales/de/clientPortal.json
+++ b/server/public/locales/de/clientPortal.json
@@ -217,6 +217,7 @@
       "dueDate": "Fälligkeitsdatum",
       "dueDateText": "Fällig am {{date}}",
       "noDueDate": "Kein Fälligkeitsdatum",
+      "allPaid": "Alle Rechnungen bezahlt",
       "amount": "Betrag",
       "status": "Status",
       "paid": "Bezahlt",

--- a/server/public/locales/en/clientPortal.json
+++ b/server/public/locales/en/clientPortal.json
@@ -223,6 +223,7 @@
       "dueDate": "Due Date",
       "dueDateText": "Due {{date}}",
       "noDueDate": "No due date",
+      "allPaid": "All invoices paid",
       "amount": "Amount",
       "status": "Status",
       "paid": "Paid",

--- a/server/public/locales/es/clientPortal.json
+++ b/server/public/locales/es/clientPortal.json
@@ -217,6 +217,7 @@
       "dueDate": "Fecha de vencimiento",
       "dueDateText": "Vence el {{date}}",
       "noDueDate": "Sin fecha de vencimiento",
+      "allPaid": "Todas las facturas pagadas",
       "amount": "Importe",
       "status": "Estado",
       "paid": "Pagada",

--- a/server/public/locales/fr/clientPortal.json
+++ b/server/public/locales/fr/clientPortal.json
@@ -217,6 +217,7 @@
       "dueDate": "Date d'échéance",
       "dueDateText": "Échéance le {{date}}",
       "noDueDate": "Pas de date d'échéance",
+      "allPaid": "Toutes les factures payées",
       "amount": "Montant",
       "status": "Statut",
       "paid": "Payée",

--- a/server/public/locales/it/clientPortal.json
+++ b/server/public/locales/it/clientPortal.json
@@ -217,6 +217,7 @@
       "dueDate": "Data di scadenza",
       "dueDateText": "Scade il {{date}}",
       "noDueDate": "Nessuna data di scadenza",
+      "allPaid": "Tutte le fatture pagate",
       "amount": "Importo",
       "status": "Stato",
       "paid": "Pagata",

--- a/server/public/locales/nl/clientPortal.json
+++ b/server/public/locales/nl/clientPortal.json
@@ -217,6 +217,7 @@
       "dueDate": "Vervaldatum",
       "dueDateText": "Vervalt op {{date}}",
       "noDueDate": "Geen vervaldatum",
+      "allPaid": "Alle facturen betaald",
       "amount": "Bedrag",
       "status": "Status",
       "paid": "Betaald",

--- a/server/src/components/client-portal/account/ClientAccount.tsx
+++ b/server/src/components/client-portal/account/ClientAccount.tsx
@@ -21,10 +21,11 @@ export default function ClientAccount() {
   const [hasInvoiceAccess, setHasInvoiceAccess] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const formatCurrency = useCallback((amount: number | string | null | undefined) => {
+  // Note: Invoice amounts are stored in cents, so we divide by 100
+  const formatCurrency = useCallback((amountInCents: number | string | null | undefined) => {
     try {
-      const n = typeof amount === 'string' ? Number(amount) : (amount ?? 0);
-      return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n as number);
+      const n = typeof amountInCents === 'string' ? Number(amountInCents) : (amountInCents ?? 0);
+      return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((n as number) / 100);
     } catch {
       return '$0.00';
     }

--- a/server/src/components/client-portal/billing/BillingOverview.tsx
+++ b/server/src/components/client-portal/billing/BillingOverview.tsx
@@ -276,11 +276,12 @@ export default function BillingOverview() {
   }, [currentTab, dateRange]);
 
   // Memoize formatters to prevent unnecessary re-creation
-  const formatCurrency = useCallback((amount: number) => {
+  // Note: Invoice amounts are stored in cents, so we divide by 100
+  const formatCurrency = useCallback((amountInCents: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD'
-    }).format(amount);
+    }).format(amountInCents / 100);
   }, []);
 
   // Safe date formatter that works consistently on both server and client


### PR DESCRIPTION
  - Fix user_companies table reference (table doesn't exist) by using contacts table via contact_name_id to get client_id
  - Hide draft invoices from client portal (filter + whereNot checks)
  - Fix "Next Invoice" card to show nearest unpaid invoice by due_date instead of first invoice, and use due_date not invoice_date
  - Fix currency display by dividing cents by 100 in formatCurrency
  - Add "allPaid" translation key to all 6 language packs

  "But I don't want to go among mad invoices," Alice remarked. "Oh, you can't help that," said the Cat: "we're all paid here.  I'm paid. You're paid. Even the cents have been properly divided by one hundred, as is only proper in Wonderland." 🐱💰📜