### PR TITLE
Fix Stripe payment flow for client portal

### DIFF
--- a/ee/server/src/lib/payments/StripePaymentProvider.ts
+++ b/ee/server/src/lib/payments/StripePaymentProvider.ts
@@ -57,10 +57,11 @@ async function getStripePaymentConfig(tenantId: string): Promise<StripePaymentCo
   if (config?.credentials_vault_path) {
     // Use tenant-specific credentials from vault
     const secretKey = await secretProvider.getTenantSecret(tenantId, 'stripe_payment_secret_key');
-    const webhookSecret = await secretProvider.getTenantSecret(tenantId, 'stripe_payment_webhook_secret');
     const publishableKey = config.configuration?.publishable_key as string;
 
-    if (secretKey && webhookSecret && publishableKey) {
+    if (secretKey && publishableKey) {
+      // Webhook secret is optional - only needed for verifying incoming webhooks
+      const webhookSecret = await secretProvider.getTenantSecret(tenantId, 'stripe_payment_webhook_secret') || '';
       return { secretKey, webhookSecret, publishableKey };
     }
   }

--- a/server/src/app/client-portal/billing/invoices/[invoiceId]/pay/PaymentRedirect.tsx
+++ b/server/src/app/client-portal/billing/invoices/[invoiceId]/pay/PaymentRedirect.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface PaymentRedirectProps {
+  url: string;
+}
+
+/**
+ * Client component to handle external redirects to payment providers.
+ * Uses window.location.href for proper handling of external URLs with fragments.
+ */
+export function PaymentRedirect({ url }: PaymentRedirectProps) {
+  useEffect(() => {
+    // Use window.location.href for external redirects
+    // This properly handles URLs with fragments (#) that Next.js redirect() may not handle correctly
+    window.location.href = url;
+  }, [url]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500 mx-auto mb-4"></div>
+        <p className="text-gray-600">Redirecting to payment...</p>
+      </div>
+    </div>
+  );
+}

--- a/server/src/app/client-portal/billing/invoices/[invoiceId]/pay/page.tsx
+++ b/server/src/app/client-portal/billing/invoices/[invoiceId]/pay/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getClientPortalInvoicePaymentLink } from 'server/src/lib/actions/client-portal-actions/client-payment';
+import { PaymentRedirect } from './PaymentRedirect';
 
 interface PayInvoicePageProps {
   params: {
@@ -23,8 +24,8 @@ export default async function PayInvoicePage({ params }: PayInvoicePageProps) {
     const result = await getClientPortalInvoicePaymentLink(invoiceId);
 
     if (result.success && result.data?.paymentUrl) {
-      // Redirect to Stripe Checkout
-      redirect(result.data.paymentUrl);
+      // Use client component for external redirect (handles URLs with fragments properly)
+      return <PaymentRedirect url={result.data.paymentUrl} />;
     }
 
     // If no payment URL, redirect back to billing with message

--- a/server/src/lib/actions/client-portal-actions/client-billing.ts
+++ b/server/src/lib/actions/client-portal-actions/client-billing.ts
@@ -93,7 +93,8 @@ export async function getClientInvoices(): Promise<InvoiceViewModel[]> {
     // Directly fetch only invoices for the current client
     const invoices = await fetchInvoicesByClient(session.user.clientId);
     // Filter out draft invoices - only finalized invoices should be visible in client portal
-    return invoices.filter(invoice => invoice.status !== 'draft');
+    // An invoice is finalized when finalized_at is set (not null)
+    return invoices.filter(invoice => invoice.finalized_at != null);
   } catch (error) {
     console.error('Error fetching client invoices:', error);
     throw new Error('Failed to fetch invoices');

--- a/server/src/lib/actions/client-portal-actions/client-payment.ts
+++ b/server/src/lib/actions/client-portal-actions/client-payment.ts
@@ -129,7 +129,13 @@ export async function getClientPortalInvoicePaymentLink(
       data: { paymentUrl: paymentLink.url },
     };
   } catch (error) {
-    logger.error('[ClientPayment] Failed to get payment link', { error, invoiceId });
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
+    logger.error('[ClientPayment] Failed to get payment link', {
+      errorMessage,
+      errorStack,
+      invoiceId
+    });
     return { success: false, error: 'Failed to get payment link' };
   }
 }


### PR DESCRIPTION
  - Fetch billing email from client_locations (is_billing_address or is_default) instead of deprecated billing_email field on clients table
  - Make webhook secret optional for payment link creation (only needed for webhook verification, not checkout sessions)
  - Add UI to manually save webhook secret when auto-config fails
  - Filter client portal invoices by finalized_at instead of status
  - Fix external redirect to Stripe using client component (handles URL fragments)
  - Improve error logging with message and stack trace

  "Pay no attention to that webhook behind the curtain!" boomed the Great and Powerful PaymentService, as the billing_location_email followed the yellow brick road from client_locations, and the vault keeper whispered, "There's no place like whsec_home." 🧙‍♂️💚🌪️