### PR TITLE
Use secret provider exclusively for Stripe webhook secrets

### DIFF
--- a/ee/server/src/lib/payments/StripePaymentProvider.ts
+++ b/ee/server/src/lib/payments/StripePaymentProvider.ts
@@ -73,15 +73,9 @@ async function getStripePaymentConfig(tenantId: string): Promise<StripePaymentCo
   }
 
   let webhookSecret = await secretProvider.getAppSecret('stripe_payment_webhook_secret');
-  if (!webhookSecret && process.env.STRIPE_PAYMENT_WEBHOOK_SECRET) {
-    webhookSecret = process.env.STRIPE_PAYMENT_WEBHOOK_SECRET;
-  }
   // Fall back to the main webhook secret if payment-specific not set
   if (!webhookSecret) {
     webhookSecret = await secretProvider.getAppSecret('stripe_webhook_secret');
-    if (!webhookSecret && process.env.STRIPE_WEBHOOK_SECRET) {
-      webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-    }
   }
 
   let publishableKey = await secretProvider.getAppSecret('stripe_publishable_key');

--- a/ee/server/src/lib/stripe/StripeService.ts
+++ b/ee/server/src/lib/stripe/StripeService.ts
@@ -30,9 +30,6 @@ async function getStripeConfig() {
   }
 
   let webhookSecret = await secretProvider.getAppSecret('stripe_webhook_secret');
-  if (!webhookSecret && process.env.STRIPE_WEBHOOK_SECRET) {
-    webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-  }
 
   let publishableKey = await secretProvider.getAppSecret('stripe_publishable_key');
   if (!publishableKey && process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) {

--- a/server/src/app/api/webhooks/stripe/payments/route.ts
+++ b/server/src/app/api/webhooks/stripe/payments/route.ts
@@ -27,7 +27,7 @@ import { getSecretProviderInstance } from '@alga-psa/shared/core';
  *    - payment_intent.succeeded
  *    - payment_intent.payment_failed
  *    - checkout.session.expired
- * 4. Copy webhook signing secret to STRIPE_PAYMENT_WEBHOOK_SECRET env var
+ * 4. Store webhook signing secret in the secret provider
  */
 
 async function getWebhookSecret(): Promise<string> {
@@ -35,16 +35,10 @@ async function getWebhookSecret(): Promise<string> {
 
   // Try payment-specific webhook secret first
   let webhookSecret = await secretProvider.getAppSecret('stripe_payment_webhook_secret');
-  if (!webhookSecret && process.env.STRIPE_PAYMENT_WEBHOOK_SECRET) {
-    webhookSecret = process.env.STRIPE_PAYMENT_WEBHOOK_SECRET;
-  }
 
   // Fall back to main webhook secret if payment-specific not set
   if (!webhookSecret) {
     webhookSecret = await secretProvider.getAppSecret('stripe_webhook_secret');
-    if (!webhookSecret && process.env.STRIPE_WEBHOOK_SECRET) {
-      webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-    }
   }
 
   if (!webhookSecret) {

--- a/server/src/app/api/webhooks/stripe/route.ts
+++ b/server/src/app/api/webhooks/stripe/route.ts
@@ -178,11 +178,22 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  let webhookSecretStatus = 'missing';
+  try {
+    const { getStripeService } = await import('@ee/lib/stripe/StripeService');
+    const stripeService = getStripeService();
+    if (stripeService.config?.webhookSecret) {
+      webhookSecretStatus = 'configured';
+    }
+  } catch {
+    webhookSecretStatus = 'missing';
+  }
+
   return NextResponse.json({
     status: 'ok',
     message: 'Stripe webhook endpoint is active',
     timestamp: new Date().toISOString(),
-    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET ? 'configured' : 'missing',
+    webhookSecret: webhookSecretStatus,
     edition: 'enterprise',
   });
 }


### PR DESCRIPTION
## Summary
Simplifies Stripe webhook secret management by removing environment variable fallbacks and using only the secret provider abstraction. This improves security by ensuring secrets are only accessed from secure vault storage.

## Changes
- Removes environment variable fallbacks (STRIPE_WEBHOOK_SECRET, STRIPE_PAYMENT_WEBHOOK_SECRET)
- Improves webhook endpoint handling: reuses existing endpoints with stored secrets, deletes and recreates when secret is missing
- Updates health check endpoints to verify secrets via secret provider instead of env vars

## Benefits
- Centralized secret management via vault
- Eliminated configuration via environment variables for sensitive data
- Better handling of webhook endpoint lifecycle