### PR TITLE
When on settings/billing page, clicking "Back to Main" now shows the …

### DIFF
--- a/server/src/components/layout/DefaultLayout.tsx
+++ b/server/src/components/layout/DefaultLayout.tsx
@@ -25,8 +25,24 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
   const isOnSettingsPage = pathname?.startsWith('/msp/settings') ?? false;
   const isOnBillingPage = pathname?.startsWith('/msp/billing') ?? false;
 
-  // Determine sidebar mode based on current route
-  const sidebarMode = isOnSettingsPage ? 'settings' : isOnBillingPage ? 'billing' : 'main';
+  // Determine default sidebar mode based on current route
+  const defaultSidebarMode = isOnSettingsPage ? 'settings' : isOnBillingPage ? 'billing' : 'main';
+
+  // Allow overriding the mode (e.g., show main menu while on settings page)
+  const [modeOverride, setModeOverride] = useState<'main' | null>(null);
+
+  // Reset mode override when navigating to a different page type
+  useEffect(() => {
+    setModeOverride(null);
+  }, [defaultSidebarMode]);
+
+  // Use override if set, otherwise use route-based mode
+  const sidebarMode = modeOverride ?? defaultSidebarMode;
+
+  // Callback for "Back to Main" - just switches to main menu without navigation
+  const handleBackToMain = () => {
+    setModeOverride('main');
+  };
 
   // Sidebar collapsed state
   const [sidebarCollapsed, setSidebarCollapsedState] = useState<boolean>(initialSidebarCollapsed);
@@ -140,6 +156,7 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
             setSidebarOpen={setSidebarOpen}
             disableTransition={disableTransition}
             mode={sidebarMode}
+            onBackToMain={handleBackToMain}
           />
           <div className="flex-1 flex flex-col overflow-hidden">
             <Header

--- a/server/src/components/layout/Sidebar.tsx
+++ b/server/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ interface SidebarProps {
   menuSections?: NavigationSection[];
   disableTransition?: boolean;
   mode?: NavMode;
+  onBackToMain?: () => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -39,7 +40,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   bottomMenuItems = defaultBottomMenuItems,
   menuSections,
   disableTransition = false,
-  mode = 'main'
+  mode = 'main',
+  onBackToMain
 }): JSX.Element => {
   const appVersion = getAppVersion();
   const pathname = usePathname();
@@ -118,7 +120,12 @@ const Sidebar: React.FC<SidebarProps> = ({
   };
 
   const handleBackToMain = () => {
-    router.push('/msp/dashboard');
+    if (onBackToMain) {
+      onBackToMain();
+    } else {
+      // Fallback to navigation if no callback provided
+      router.push('/msp/dashboard');
+    }
   };
 
   const renderMenuItem = (item: MenuItem) => {

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -19,6 +19,7 @@ interface SidebarWithFeatureFlagsProps {
   setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
   disableTransition?: boolean;
   mode?: NavMode;
+  onBackToMain?: () => void;
 }
 
 export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsProps) {
@@ -67,6 +68,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       bottomMenuItems={bottomMenuItems}
       disableTransition={props.disableTransition}
       mode={props.mode}
+      onBackToMain={props.onBackToMain}
     />
   );
 }


### PR DESCRIPTION
…main menu while staying on the current page

"But I don't want to go to the Dashboard," said Alice. "Then don't," said the Sidebar, overriding its mode with a mischievous grin. "You can stay precisely where you are and still see the main menu—it's all a matter of state management, you know." 🐇✨🧭