### PR TITLE
fix: reconcile dollars and cents

### DIFF
--- a/server/src/lib/adapters/invoiceAdapters.ts
+++ b/server/src/lib/adapters/invoiceAdapters.ts
@@ -60,17 +60,18 @@ export function mapDbInvoiceToWasmViewModel(inputData: DbInvoiceViewModel | Wasm
         // tenantClient does not exist directly in DbInvoiceViewModel, assuming it's not needed or handled elsewhere
         tenantClient: null,
 
-        // All monetary values are stored in cents in the database, convert to dollars for display
+        // All monetary values are stored in cents in the database
+        // Keep values in cents - the WASM template's formatCurrency function handles the conversion
         items: (dbData.invoice_charges ?? []).map((item: IInvoiceCharge) => ({
           id: String(item.item_id ?? ''), // Corrected property name
           description: String(item.description ?? ''),
           quantity: Number(item.quantity ?? 0),
-          unitPrice: Number(item.unit_price ?? 0) / 100, // Convert cents to dollars
-          total: Number(item.total_price ?? 0) / 100, // Convert cents to dollars
+          unitPrice: Number(item.unit_price ?? 0), // Keep in cents for WASM template
+          total: Number(item.total_price ?? 0), // Keep in cents for WASM template
         })),
-        subtotal: Number(dbData.subtotal ?? 0) / 100, // Convert cents to dollars
-        tax: Number(dbData.tax ?? 0) / 100, // Convert cents to dollars
-        total: Number(dbData.total ?? 0) / 100, // Convert cents to dollars
+        subtotal: Number(dbData.subtotal ?? 0), // Keep in cents for WASM template
+        tax: Number(dbData.tax ?? 0), // Keep in cents for WASM template
+        total: Number(dbData.total ?? 0), // Keep in cents for WASM template
         taxSource: dbData.tax_source || 'internal',
         currencyCode: (dbData as any).currency_code || (dbData as any).currencyCode || 'USD',
         // notes: dbData.notes, // Add if needed

--- a/server/src/lib/services/invoiceService.ts
+++ b/server/src/lib/services/invoiceService.ts
@@ -349,13 +349,15 @@ async function persistFixedInvoiceCharges(
           }
           // --- End Determine Consolidated Item Tax Region & Taxability ---
 
+          console.log(`[INVOICE DEBUG] Setting fixedPlanDetailsMap for ${clientContractLineId}, charge.base_rate: ${charge.base_rate}`);
           fixedPlanDetailsMap.set(clientContractLineId, {
               consolidatedItem: {
                   invoice_id: invoiceId,
                   service_id: null,
                   description: `Fixed Plan: ${charge.serviceName}`,
                   quantity: 1,
-                  unit_price: Math.round(charge.base_rate * 100),
+                  // base_rate is already in cents from billingEngine, no conversion needed
+                  unit_price: Math.round(charge.base_rate),
                   net_amount: 0,
                   tax_amount: 0,
                   tax_region: consolidatedRegion, // Use the determined region
@@ -468,9 +470,12 @@ async function persistFixedInvoiceCharges(
     planEntry.consolidatedItem.description = `Fixed Plan: ${planInfo.contract_line_name}`;
     // Use the plan-level base rate sourced from the contract line if available.
     // Fallback to the unit_price derived from the first service charge if plan-level rate is missing (shouldn't happen ideally).
+    // contract_line_base_rate (from custom_rate) is already stored in cents, no conversion needed
+    const oldUnitPrice = planEntry.consolidatedItem.unit_price;
     planEntry.consolidatedItem.unit_price = planInfo.contract_line_base_rate !== null
-        ? Math.round(planInfo.contract_line_base_rate * 100) // Use plan base rate in cents
+        ? Math.round(planInfo.contract_line_base_rate)
         : planEntry.consolidatedItem.unit_price; // Fallback to initially set price (from first service)
+    console.log(`[INVOICE DEBUG] Updated unit_price for ${clientContractLineId}: contract_line_base_rate=${planInfo.contract_line_base_rate}, oldUnitPrice=${oldUnitPrice}, newUnitPrice=${planEntry.consolidatedItem.unit_price}`);
 
     let planNetTotal = 0;
     let planTaxTotal = 0;


### PR DESCRIPTION
## Summary
- keep monetary fields in cents through the invoice adapter and rely on WASM formatting
- treat custom_rate/service_base_rate as cents in billing engine and only convert to dollars where needed, adding debug logs
- persist fixed-plan invoice items in cents without double conversion and log consolidated updates

## Testing
- not run (not requested)
