### PR TITLE
fix: use invoice currency code in payment success page

### DIFF
--- a/server/src/app/client-portal/billing/invoices/[invoiceId]/payment-success/PaymentSuccessContent.tsx
+++ b/server/src/app/client-portal/billing/invoices/[invoiceId]/payment-success/PaymentSuccessContent.tsx
@@ -21,6 +21,7 @@ export default function PaymentSuccessContent({
   const [status, setStatus] = useState<PaymentStatus>('verifying');
   const [invoiceNumber, setInvoiceNumber] = useState<string>('');
   const [amount, setAmount] = useState<number>(0);
+  const [currencyCode, setCurrencyCode] = useState<string>('USD');
   const [error, setError] = useState<string>('');
 
   useEffect(() => {
@@ -36,6 +37,7 @@ export default function PaymentSuccessContent({
         if (result.success && result.data) {
           setInvoiceNumber(result.data.invoiceNumber || '');
           setAmount(result.data.amount || 0);
+          setCurrencyCode(result.data.currencyCode || 'USD');
 
           if (result.data.status === 'succeeded') {
             setStatus('success');
@@ -62,7 +64,7 @@ export default function PaymentSuccessContent({
   const formatCurrency = (cents: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: 'USD',
+      currency: currencyCode,
     }).format(cents / 100);
   };
 

--- a/server/src/lib/actions/client-portal-actions/client-payment.ts
+++ b/server/src/lib/actions/client-portal-actions/client-payment.ts
@@ -151,6 +151,7 @@ export async function verifyClientPortalPayment(
   status: 'succeeded' | 'pending' | 'processing' | 'failed';
   invoiceNumber?: string;
   amount?: number;
+  currencyCode?: string;
   message?: string;
 }>> {
   try {
@@ -207,6 +208,7 @@ export async function verifyClientPortalPayment(
           status: 'succeeded',
           invoiceNumber: invoice.invoice_number,
           amount: invoice.total_amount,
+          currencyCode: invoice.currency_code || 'USD',
         },
       };
     }
@@ -262,6 +264,7 @@ export async function verifyClientPortalPayment(
           status: 'pending',
           invoiceNumber: invoice.invoice_number,
           amount: invoice.total_amount,
+          currencyCode: invoice.currency_code || 'USD',
           message: 'Payment is being processed',
         },
       };
@@ -297,6 +300,7 @@ export async function verifyClientPortalPayment(
         status,
         invoiceNumber: invoice.invoice_number,
         amount: paymentDetails.amount || invoice.total_amount,
+        currencyCode: invoice.currency_code || 'USD',
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds `currencyCode` to the payment verification response from the invoice data
- Updates `PaymentSuccessContent` to use the invoice's currency code instead of hardcoded USD for formatting

## Test plan
- [ ] Verify payment success page displays correct currency symbol for non-USD invoices
- [ ] Confirm USD invoices still display correctly