### PR TITLE
 Fix time period job scheduling reliability

### DIFF
--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -28,6 +28,7 @@ import { getSecretProviderInstance } from '@alga-psa/shared/core/secretProvider'
 import type { ISecretProvider } from '@alga-psa/shared/core/ISecretProvider';
 import { EnvSecretProvider } from '@alga-psa/shared/core/EnvSecretProvider';
 import { validateEmailConfiguration, logEmailConfigWarnings } from './validation/emailConfigValidation';
+import { Temporal } from '@js-temporal/polyfill';
 import { JobStatus } from 'server/src/types/job';
 
 let isFunctionExecuted = false;
@@ -395,14 +396,33 @@ async function initializeJobScheduler(storageService: StorageService) {
       throw error;
     } finally {
       // Always enqueue the next run so the job continues daily even after archives are cleaned
+      // Use UTC to avoid DST drift issues
       try {
-        const nextRun = new Date(Date.now() + 24 * 60 * 60 * 1000);
-        await jobScheduler.scheduleScheduledJob(
+        const nextRunInstant = Temporal.Now.instant().add({ hours: 24 });
+        const nextRun = new Date(nextRunInstant.epochMilliseconds);
+        const singletonKey = `createNextTimePeriods:${tenantId}`;
+
+        // Use scheduleRecurringJob which has singleton deduplication built-in
+        // This prevents duplicate jobs from stacking up on retries
+        const nextJobId = await jobScheduler.scheduleRecurringJob(
           'createNextTimePeriods',
-          nextRun,
+          '24 hours',
           { tenantId }
         );
-        logger.debug('Queued next createNextTimePeriods job', { tenantId, nextRun });
+
+        if (nextJobId) {
+          logger.debug('Queued next createNextTimePeriods job', {
+            tenantId,
+            jobId: nextJobId,
+            nextRun: nextRun.toISOString(),
+            singletonKey
+          });
+        } else {
+          logger.debug('createNextTimePeriods job already queued (singleton active)', {
+            tenantId,
+            singletonKey
+          });
+        }
       } catch (scheduleError) {
         logger.error('Failed to enqueue next createNextTimePeriods job', { tenantId, scheduleError });
       }


### PR DESCRIPTION
  - Create queue before sending jobs (required in pg-boss v10+)
  - Always enqueue next createNextTimePeriods job in finally block
  - Ensures daily job continues running even after archive cleanup

  "Down the rabbit hole of scheduled jobs we tumble," said the White Rabbit, checking his pocket watch anxiously. "For what good is a Time Period if it never queues its next appointment? The Queen would have our heads if the daily intervals simply... vanished into the finally block!" 🐰⏰📅