### PR TITLE
fix: remove hardcoded OAuth scopes from NinjaOne connect endpoint

### DIFF
--- a/ee/server/src/app/api/integrations/ninjaone/connect/route.ts
+++ b/ee/server/src/app/api/integrations/ninjaone/connect/route.ts
@@ -51,8 +51,8 @@ const getRedirectUri = () => {
   return `${baseUrl}/api/integrations/ninjaone/callback`;
 };
 
-// OAuth scopes required for full RMM integration
-const NINJAONE_SCOPES = 'monitoring management control offline_access';
+// OAuth scopes - omitted to use application's configured scopes in NinjaOne dashboard
+// Available scopes: monitoring, management, control, offline_access
 
 export async function GET(request: NextRequest) {
   let tenantId: string | null = null;
@@ -112,10 +112,10 @@ export async function GET(request: NextRequest) {
     const redirectUri = getRedirectUri();
 
     // Construct the authorization URL
+    // Note: scope is omitted to use application's configured scopes in NinjaOne dashboard
     const params = new URLSearchParams({
       client_id: clientId,
       response_type: 'code',
-      scope: NINJAONE_SCOPES,
       redirect_uri: redirectUri,
       state: state,
     });


### PR DESCRIPTION
## Summary
- Remove hardcoded OAuth scopes from NinjaOne OAuth authorization request
- Allow NinjaOne to use the scopes configured for the application in their dashboard
- Fixes "Invalid scope control for client" errors when requested scopes don't match what's enabled for the API client

## Test plan
- [ ] Initiate NinjaOne OAuth connection flow
- [ ] Verify OAuth authorization succeeds without scope errors
- [ ] Confirm tokens are granted with the scopes configured in NinjaOne dashboard