### PR TITLE
fix: use monitoring, management, offline_access scopes for NinjaOne OAuth

### DIFF
--- a/ee/server/src/app/api/integrations/ninjaone/connect/route.ts
+++ b/ee/server/src/app/api/integrations/ninjaone/connect/route.ts
@@ -51,8 +51,10 @@ const getRedirectUri = () => {
   return `${baseUrl}/api/integrations/ninjaone/callback`;
 };
 
-// OAuth scopes - omitted to use application's configured scopes in NinjaOne dashboard
+// OAuth scopes for NinjaOne integration
 // Available scopes: monitoring, management, control, offline_access
+// Note: Requested scopes must be enabled for the API client in NinjaOne dashboard
+const NINJAONE_SCOPES = 'monitoring management offline_access';
 
 export async function GET(request: NextRequest) {
   let tenantId: string | null = null;
@@ -112,10 +114,10 @@ export async function GET(request: NextRequest) {
     const redirectUri = getRedirectUri();
 
     // Construct the authorization URL
-    // Note: scope is omitted to use application's configured scopes in NinjaOne dashboard
     const params = new URLSearchParams({
       client_id: clientId,
       response_type: 'code',
+      scope: NINJAONE_SCOPES,
       redirect_uri: redirectUri,
       state: state,
     });


### PR DESCRIPTION
## Summary
- Re-add OAuth scopes to NinjaOne authorization request (at least one scope is required)
- Use `monitoring management offline_access` scopes, excluding `control` which caused "Invalid scope control for client" error
- Follows up on #1398 which removed scopes entirely but resulted in "Invalid scope" error

## Test plan
- [ ] Initiate NinjaOne OAuth connection flow
- [ ] Verify OAuth authorization succeeds without scope errors
- [ ] Confirm tokens are granted with monitoring, management, and offline_access scopes