### PR TITLE
fix: prevent syncing skipped devices when they are deleted in Alga

### DIFF
--- a/ee/server/src/lib/integrations/ninjaone/sync/syncEngine.ts
+++ b/ee/server/src/lib/integrations/ninjaone/sync/syncEngine.ts
@@ -950,7 +950,10 @@ export class NinjaOneSyncEngine {
     external_entity_id: string;
   } | null> {
     const mapping = await this.knex!('tenant_external_entity_mappings')
-      .join('assets', 'tenant_external_entity_mappings.alga_entity_id', 'assets.asset_id')
+      .join('assets', function () {
+        this.on('tenant_external_entity_mappings.alga_entity_id', '=', 'assets.asset_id')
+            .andOn('tenant_external_entity_mappings.tenant', '=', 'assets.tenant');
+      })
       .where({
         'tenant_external_entity_mappings.tenant': this.tenantId,
         'tenant_external_entity_mappings.integration_type': 'ninjaone',
@@ -958,6 +961,7 @@ export class NinjaOneSyncEngine {
         'tenant_external_entity_mappings.external_entity_id': String(deviceId),
         'assets.status': 'active',
       })
+      .where('assets.tenant', this.tenantId)
       .select('tenant_external_entity_mappings.alga_entity_id', 'tenant_external_entity_mappings.external_entity_id')
       .first();
 


### PR DESCRIPTION
## Summary
- Fixes issue where deleted devices in Alga were being skipped during NinjaOne sync instead of being recreated
- Modified `findAssetByDeviceId()` to only return mappings for active assets
- Deleted devices will now be treated as new and properly re-synced if they still exist in NinjaOne

## Test plan
- [ ] Delete a device in Alga
- [ ] Run NinjaOne device sync
- [ ] Verify the deleted device is recreated from NinjaOne instead of being skipped