### PR TITLE
fix: delete external entity mappings when assets are deleted

### DIFF
--- a/server/src/lib/actions/asset-actions/assetActions.ts
+++ b/server/src/lib/actions/asset-actions/assetActions.ts
@@ -651,6 +651,9 @@ export async function deleteAsset(asset_id: string): Promise<void> {
             await trx('document_associations')
                 .where({ tenant, entity_type: 'asset', entity_id: asset_id })
                 .delete();
+            await trx('tenant_external_entity_mappings')
+                .where({ tenant, alga_entity_type: 'asset', alga_entity_id: asset_id })
+                .delete();
 
             await trx('assets')
                 .where({ tenant, asset_id })

--- a/server/src/lib/api/services/AssetService.ts
+++ b/server/src/lib/api/services/AssetService.ts
@@ -289,8 +289,14 @@ export class AssetService extends BaseService<any> {
     // Delete extension data
     await this.deleteExtensionData(id, asset.asset_type, context);
 
-    // Delete main asset record (cascade will handle relationships, documents, etc.)
     const knex = await this.getDbForContext(context);
+
+    // Delete external entity mapping (e.g., NinjaOne device mapping)
+    await knex('tenant_external_entity_mappings')
+      .where({ tenant: context.tenant, alga_entity_type: 'asset', alga_entity_id: id })
+      .del();
+
+    // Delete main asset record (cascade will handle relationships, documents, etc.)
     await knex(this.tableName)
       .where({ [this.primaryKey]: id, tenant: context.tenant })
       .del();


### PR DESCRIPTION
## Summary
- When an asset is deleted in Alga, now also removes its entry from `tenant_external_entity_mappings`
- Prevents orphaned mappings that cause NinjaOne sync to skip devices that were previously deleted in Alga
- Updated both deletion paths: `deleteAsset()` server action and `AssetService.delete()` API method

## Context
When a device synced from NinjaOne was deleted in Alga, the external entity mapping remained in the database. On subsequent syncs, this orphaned mapping caused the device to be skipped instead of being re-created.

## Test plan
- [ ] Delete a NinjaOne-synced asset in Alga
- [ ] Verify the `tenant_external_entity_mappings` entry is also deleted
- [ ] Run NinjaOne device sync
- [ ] Verify the device is recreated from NinjaOne