### PR TITLE
fix: use correct change object keys in email subscriber

### DIFF
--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -249,13 +249,13 @@ async function sendNotificationIfEnabled(
 async function formatChanges(db: any, changes: Record<string, unknown>, tenantId: string): Promise<string> {
   const formattedChanges = await Promise.all(
     Object.entries(changes).map(async ([field, value]): Promise<string> => {
-      // Handle different types of values
+      // Handle structured change objects with old/new values
       if (typeof value === 'object' && value !== null) {
-        const { from, to } = value as { from?: unknown; to?: unknown };
-        if (from !== undefined && to !== undefined) {
-          const fromValue = await resolveValue(db, field, from, tenantId);
-          const toValue = await resolveValue(db, field, to, tenantId);
-          return `${formatFieldName(field)}: ${fromValue} → ${toValue}`;
+        const { old: oldVal, new: newVal } = value as { old?: unknown; new?: unknown };
+        if (oldVal !== undefined && newVal !== undefined) {
+          const resolvedOldValue = await resolveValue(db, field, oldVal, tenantId);
+          const resolvedNewValue = await resolveValue(db, field, newVal, tenantId);
+          return `${formatFieldName(field)}: ${resolvedOldValue} → ${resolvedNewValue}`;
         }
       }
       const resolvedValue = await resolveValue(db, field, value, tenantId);


### PR DESCRIPTION
  The formatChanges function expected {from, to} keys but the event publishers send {old, new} keys. This mismatch caused the entire change object to be passed to resolveValue, triggering PostgreSQL 22P02 invalid UUID errors when querying the database.

  "But I don't want to go among mad objects," Alice remarked. "Oh, you can't help that," said the Cat: "we're all mad here. The old becomes new, the from becomes to, and if you don't destructure properly, the whole UUID turns to Wonderland tea!" 🐱🔄🎩