### PR TITLE
Fix Radix UI hydration errors with client-only rendering

### DIFF
--- a/server/src/components/tags/TagGrid.tsx
+++ b/server/src/components/tags/TagGrid.tsx
@@ -40,13 +40,17 @@ export const TagGrid: React.FC<TagGridProps> = ({
             key={tagText}
             id={`tag-${index}`}
             label={tagText}
+            title={tagText}
             onClick={() => onTagSelect(tagText)}
-            className={`p-2 rounded-md text-sm text-center transition-colors ${
+            className={`p-1 rounded-md text-xs text-center transition-colors overflow-hidden min-w-0 truncate ${
               isSelected ? 'ring-2 ring-primary-500 px-1' : ''
             }`}
             style={{
               backgroundColor,
               color: textColor,
+              display: 'block',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
             }}
             variant="ghost"
           >

--- a/server/src/components/tags/TagList.tsx
+++ b/server/src/components/tags/TagList.tsx
@@ -79,6 +79,7 @@ export const TagList: React.FC<TagListProps> = ({
         return (
           <span
             key={tag.tag_id}
+            title={tag.tag_text}
             style={{
               backgroundColor: tag.background_color || colors.background,
               color: tag.text_color || colors.text,
@@ -88,7 +89,8 @@ export const TagList: React.FC<TagListProps> = ({
               fontWeight: '600',
               display: 'inline-flex',
               alignItems: 'center',
-              position: 'relative'
+              position: 'relative',
+              maxWidth: '150px',
             }}
           >
             <TagEditForm
@@ -100,7 +102,7 @@ export const TagList: React.FC<TagListProps> = ({
               trigger={
                 <button
                   type="button"
-                  className="inline-flex items-center justify-center h-full px-2 py-1 hover:opacity-70 transition-opacity"
+                  className="inline-flex items-center justify-center h-full px-2 py-1 hover:opacity-70 transition-opacity flex-shrink-0"
                   style={{
                     borderRight: `1px dotted ${tag.text_color || colors.text}`,
                     marginRight: '4px',
@@ -110,12 +112,20 @@ export const TagList: React.FC<TagListProps> = ({
                 </button>
               }
             />
-            {tag.tag_text}
+            <span
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {tag.tag_text}
+            </span>
             {onRemoveTag && (
               <button
                 type="button"
                 onClick={() => void onRemoveTag(tag.tag_id)}
-                className="ml-1 text-red-500 hover:text-red-700"
+                className="ml-1 text-red-500 hover:text-red-700 flex-shrink-0"
                 title="Remove tag"
               >
                 <X size={12} />

--- a/server/src/components/ui/Spinner.tsx
+++ b/server/src/components/ui/Spinner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface SpinnerProps {
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   className?: string;
 }
 
@@ -10,6 +10,7 @@ const Spinner: React.FC<SpinnerProps> = ({
   className = '',
 }) => {
   const sizeClasses = {
+    xs: 'h-6 w-6 border-2',
     sm: 'h-10 w-10 border-2',
     md: 'h-12 w-12 border-[6px]',
     lg: 'h-16 w-16 border-[8px]',


### PR DESCRIPTION
  - Add useIsClient hook to TreeSelect and TagFilter components to defer Radix UI rendering until after hydration, preventing aria-controls ID mismatch between server and client
  - Add xs size option to Spinner component for compact loading states
  - Improve tag display with text truncation and max-width constraints
  - Add tooltips to tags showing full text on hover

  "Curiouser and curiouser!" cried Alice, as the Spinner shrank to xs and the Tags learned to truncate themselves most politely, while the Radix components waited patiently on the client side of the looking glass, where useId worked properly at last. 🐇✨🔄