### PR TITLE
fix: preserve client portal menu hooks

### DIFF
--- a/ee/server/src/lib/extensions/registry-v2.ts
+++ b/ee/server/src/lib/extensions/registry-v2.ts
@@ -594,7 +594,7 @@ export interface UpsertVersionFromManifestInput {
     ui?: {
       type: 'iframe';
       entry: string;
-      hooks?: { appMenu?: { label: string }; [key: string]: unknown };
+      hooks?: { appMenu?: { label: string }; clientPortalMenu?: { label: string }; [key: string]: unknown };
     };
     uiEntry?: string;
     endpoints: ManifestEndpoint[];

--- a/server/src/test/unit/extensions/uiHooks.test.ts
+++ b/server/src/test/unit/extensions/uiHooks.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { getUiHooks, type ManifestV2 } from '@ee/lib/extensions/bundles/manifest';
+
+describe('getUiHooks', () => {
+  it('returns both appMenu and clientPortalMenu when present', () => {
+    const manifest: ManifestV2 = {
+      name: 'com.acme.demo',
+      publisher: 'acme',
+      version: '1.0.0',
+      runtime: 'wasm-js@1',
+      ui: {
+        type: 'iframe',
+        entry: 'ui/index.html',
+        hooks: {
+          appMenu: { label: '  MSP App  ' },
+          clientPortalMenu: { label: '  Client App  ' },
+        },
+      },
+    };
+
+    expect(getUiHooks(manifest)).toEqual({
+      appMenu: { label: 'MSP App' },
+      clientPortalMenu: { label: 'Client App' },
+    });
+  });
+
+  it('drops empty labels and returns undefined when none remain', () => {
+    const manifest: ManifestV2 = {
+      name: 'com.acme.demo',
+      publisher: 'acme',
+      version: '1.0.0',
+      runtime: 'wasm-js@1',
+      ui: {
+        type: 'iframe',
+        entry: 'ui/index.html',
+        hooks: {
+          clientPortalMenu: { label: '   ' },
+        },
+      },
+    };
+
+    expect(getUiHooks(manifest)).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
Fixes client portal extensions not appearing in the portal menu by preserving ui.hooks.clientPortalMenu during bundle finalize/publish so extension_version.ui contains the hook used by discovery.

- Updates manifest hook parsing/validation to include clientPortalMenu
- Persists normalized hooks during finalize
- Adds a small unit test for hook normalization

Test: unable to run vitest here due to missing @testing-library/jest-dom in the current environment.