### PR TITLE
fix: log managed email domain workflow enqueue failures

### DIFF
--- a/ee/server/src/lib/email-domains/workflowClient.ts
+++ b/ee/server/src/lib/email-domains/workflowClient.ts
@@ -1,3 +1,5 @@
+import { observabilityLogger } from 'server/src/lib/observability/logging';
+
 export interface ManagedEmailDomainWorkflowParams {
   tenantId: string;
   domain: string;
@@ -24,12 +26,32 @@ export async function enqueueManagedEmailDomainWorkflow(
   try {
     const temporalClient = await import('@temporalio/client').catch(() => null);
     if (!temporalClient) {
+      observabilityLogger.error('Temporal client unavailable for managed email domain workflow', undefined, {
+        event_type: 'managed_email_domain_workflow_enqueue_failed',
+        tenant_id: params.tenantId,
+        domain: params.domain,
+        trigger: params.trigger,
+      });
       return { enqueued: false, error: 'temporal_client_unavailable' };
     }
 
-    const connection = await temporalClient.Connection.connect({
-      address: DEFAULT_TEMPORAL_ADDRESS,
-    });
+    let connection: any;
+    try {
+      connection = await temporalClient.Connection.connect({
+        address: DEFAULT_TEMPORAL_ADDRESS,
+      });
+    } catch (error: any) {
+      observabilityLogger.error('Failed to connect to Temporal for managed email domain workflow', error, {
+        event_type: 'managed_email_domain_workflow_enqueue_failed',
+        tenant_id: params.tenantId,
+        domain: params.domain,
+        trigger: params.trigger,
+        temporal_address: DEFAULT_TEMPORAL_ADDRESS,
+        temporal_namespace: DEFAULT_TEMPORAL_NAMESPACE,
+      });
+      return { enqueued: false, error: error?.message ?? 'temporal_connection_failed' };
+    }
+
     const client = new temporalClient.Client({
       connection,
       namespace: DEFAULT_TEMPORAL_NAMESPACE,
@@ -50,6 +72,17 @@ export async function enqueueManagedEmailDomainWorkflow(
         error?.message?.includes('WorkflowExecutionAlreadyStartedError');
 
       if (!alreadyStarted) {
+        observabilityLogger.error('Failed to start Temporal workflow for managed email domain', error, {
+          event_type: 'managed_email_domain_workflow_enqueue_failed',
+          tenant_id: params.tenantId,
+          domain: params.domain,
+          trigger: params.trigger,
+          temporal_address: DEFAULT_TEMPORAL_ADDRESS,
+          temporal_namespace: DEFAULT_TEMPORAL_NAMESPACE,
+          task_queue: DEFAULT_TASK_QUEUE,
+          workflow_name: WORKFLOW_NAME,
+          workflow_id: workflowId,
+        });
         return { enqueued: false, error: error?.message ?? 'unknown_error' };
       }
 
@@ -58,10 +91,28 @@ export async function enqueueManagedEmailDomainWorkflow(
         await handle.signal(REFRESH_SIGNAL, params);
         return { enqueued: true, alreadyRunning: true };
       } catch (signalError: any) {
+        observabilityLogger.error('Failed to signal existing Temporal workflow for managed email domain', signalError, {
+          event_type: 'managed_email_domain_workflow_enqueue_failed',
+          tenant_id: params.tenantId,
+          domain: params.domain,
+          trigger: params.trigger,
+          temporal_address: DEFAULT_TEMPORAL_ADDRESS,
+          temporal_namespace: DEFAULT_TEMPORAL_NAMESPACE,
+          task_queue: DEFAULT_TASK_QUEUE,
+          workflow_name: WORKFLOW_NAME,
+          workflow_id: workflowId,
+          signal_name: REFRESH_SIGNAL,
+        });
         return { enqueued: false, error: signalError?.message ?? 'signal_failed' };
       }
     }
   } catch (error: any) {
+    observabilityLogger.error('Unexpected error enqueueing managed email domain workflow', error, {
+      event_type: 'managed_email_domain_workflow_enqueue_failed',
+      tenant_id: params.tenantId,
+      domain: params.domain,
+      trigger: params.trigger,
+    });
     return { enqueued: false, error: error?.message ?? 'unknown_error' };
   }
 }


### PR DESCRIPTION
Adds server-side logs when managed email domain Temporal workflow fails to enqueue/start/signal (covers register, refresh/Re-check DNS, and delete paths).