### PR TITLE
Fix service picker search closing

### DIFF
--- a/server/src/components/billing-dashboard/contracts/CreateCustomContractLineDialog.tsx
+++ b/server/src/components/billing-dashboard/contracts/CreateCustomContractLineDialog.tsx
@@ -832,7 +832,6 @@ export const CreateCustomContractLineDialog: React.FC<CreateCustomContractLineDi
       onClose={onClose}
       title="Create Custom Contract Line"
       className="max-w-3xl"
-      disableFocusTrap
     >
       <DialogContent>
         <form onSubmit={handleSubmit} className="space-y-6" noValidate>

--- a/server/src/components/billing-dashboard/contracts/ServicePicker.tsx
+++ b/server/src/components/billing-dashboard/contracts/ServicePicker.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
-import { Command } from 'cmdk';
-import { Check, ChevronsUpDown, Search } from 'lucide-react';
+import React from 'react';
 import { cn } from 'server/src/lib/utils';
-import { Button } from 'server/src/components/ui/Button';
+import SearchableSelect from 'server/src/components/ui/SearchableSelect';
 
 export interface SelectOption {
   value: string;
@@ -35,151 +32,25 @@ export function ServicePicker({
 }: ServicePickerProps): JSX.Element {
   const autoId = React.useId();
   const pickerId = id ?? `service-picker-${autoId}`;
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<{ top: number; left: number; width: number } | null>(null);
-
-  // Update position of the popover
-  const updatePosition = () => {
-    if (triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setPosition({
-        top: rect.bottom + 4,
-        left: rect.left,
-        width: rect.width,
-      });
-    }
-  };
-
-  useEffect(() => {
-    if (open) {
-      updatePosition();
-      window.addEventListener('resize', updatePosition);
-      window.addEventListener('scroll', updatePosition, true);
-      return () => {
-        window.removeEventListener('resize', updatePosition);
-        window.removeEventListener('scroll', updatePosition, true);
-      };
-    }
-  }, [open]);
-
-  // Click outside to close
-  useEffect(() => {
-    if (!open) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (
-        triggerRef.current &&
-        !triggerRef.current.contains(target) &&
-        contentRef.current &&
-        !contentRef.current.contains(target)
-      ) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
-
-  const selectedOption = options.find((option) => option.value === value);
 
   return (
-    <div className={label ? 'mb-4' : ''} id={pickerId}>
-      {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          {label}
-        </label>
+    <SearchableSelect
+      options={options}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      searchPlaceholder="Search services..."
+      dropdownMode="overlay"
+      maxListHeight="250px"
+      disabled={disabled}
+      label={label}
+      id={pickerId}
+      className={cn(
+        "bg-white border border-[rgb(var(--color-border-400))] text-[rgb(var(--color-text-700))]",
+        "hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))]",
+        className
       )}
-      
-      <Button
-        id={`${pickerId}-trigger`}
-        ref={triggerRef}
-        type="button"
-        variant="outline"
-        role="combobox"
-        aria-expanded={open}
-        className={cn(
-          "w-full justify-between bg-white border border-[rgb(var(--color-border-400))] text-[rgb(var(--color-text-700))]",
-          "hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))]",
-          disabled && "opacity-50 cursor-not-allowed",
-          className
-        )}
-        onClick={() => !disabled && setOpen(!open)}
-        disabled={disabled}
-      >
-        <span className={cn("truncate", !selectedOption && "text-gray-400")}>
-          {selectedOption ? selectedOption.label : placeholder}
-        </span>
-        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-      </Button>
-
-      {open && position && typeof document !== 'undefined' && createPortal(
-        <div
-          ref={contentRef}
-          className="fixed z-[99999] bg-white rounded-md shadow-lg border border-gray-200 overflow-hidden"
-          style={{
-            top: position.top,
-            left: position.left,
-            width: position.width,
-            maxHeight: '300px',
-          }}
-          onMouseDown={(e) => {
-            // Prevent clicks inside the dropdown from closing it
-            e.stopPropagation();
-          }}
-        >
-          <Command
-            className="w-full h-full"
-            shouldFilter={true}
-          >
-            <div className="flex items-center border-b px-3">
-              <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-              <Command.Input
-                id={`${pickerId}-search`}
-                autoFocus
-                value={search}
-                onValueChange={setSearch}
-                className="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder="Search services..."
-              />
-            </div>
-            <Command.List className="max-h-[250px] overflow-y-auto p-1">
-              <Command.Empty className="py-6 text-center text-sm text-gray-500">
-                No service found.
-              </Command.Empty>
-              {options.map((option) => (
-                <Command.Item
-                  key={option.value}
-                  value={option.label}
-                  onSelect={() => {
-                    onChange(option.value);
-                    setOpen(false);
-                    setSearch('');
-                  }}
-                  className={cn(
-                    "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
-                    "data-[selected=true]:bg-gray-100 data-[selected=true]:text-gray-900",
-                    value === option.value && "bg-gray-50 font-medium"
-                  )}
-                >
-                  <Check
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === option.value ? "opacity-100" : "opacity-0"
-                    )}
-                  />
-                  {option.label}
-                </Command.Item>
-              ))}
-            </Command.List>
-          </Command>
-        </div>,
-        document.body
-      )}
-    </div>
+      emptyMessage="No service found."
+    />
   );
 }

--- a/server/src/components/ui/SearchableSelect.tsx
+++ b/server/src/components/ui/SearchableSelect.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Command } from 'cmdk';
 import { Check, ChevronsUpDown, Search } from 'lucide-react';
 import { cn } from 'server/src/lib/utils';
@@ -27,6 +28,23 @@ interface SearchableSelectProps {
   required?: boolean;
   /** Empty message to display when no options match the search */
   emptyMessage?: string;
+  /**
+   * How the dropdown is rendered.
+   * - `inline`: renders an absolutely-positioned dropdown in-flow (may be clipped by overflow containers).
+   * - `overlay`: renders a positioned dropdown in a portal (helps avoid clipping).
+   */
+  dropdownMode?: 'inline' | 'overlay';
+  /** Placeholder text for the search input */
+  searchPlaceholder?: string;
+  /** Auto-focus the search input when opening */
+  autoFocusSearch?: boolean;
+  /** Max height for the option list */
+  maxListHeight?: string;
+  /**
+   * Optional portal container for `dropdownMode="overlay"`.
+   * If omitted, the component will portal into the nearest dialog (role="dialog") if present, otherwise document.body.
+   */
+  portalContainer?: Element | null;
 }
 
 export function SearchableSelect({
@@ -40,9 +58,17 @@ export function SearchableSelect({
   id,
   required = false,
   emptyMessage = 'No results found',
+  dropdownMode = 'inline',
+  searchPlaceholder,
+  autoFocusSearch = true,
+  maxListHeight = '15rem',
+  portalContainer,
 }: SearchableSelectProps & AutomationProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [overlayPosition, setOverlayPosition] = useState<{ top: number; left: number; width: number } | null>(null);
 
   // Memoize the mapped options to prevent recreating on every render
   const mappedOptions = useMemo(() => options.map((opt: SelectOption): { value: string; label: string } => ({
@@ -87,6 +113,140 @@ export function SearchableSelect({
   // Find the selected option label
   const selectedOption = options.find((option: SelectOption) => option.value === value);
 
+  const resolvedSearchPlaceholder =
+    searchPlaceholder ??
+    (placeholder ? `Search ${placeholder.replace(/\.\.\.$/, '').toLowerCase()}...` : 'Search...');
+
+  const getResolvedPortalContainer = useCallback((): Element | null => {
+    if (typeof document === 'undefined') return null;
+    if (portalContainer) return portalContainer;
+    const trigger = triggerRef.current;
+    const dialog = trigger?.closest?.('[role="dialog"]');
+    return dialog ?? document.body;
+  }, [portalContainer]);
+
+  const updateOverlayPosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const container = getResolvedPortalContainer();
+
+    if (!container || container === document.body) {
+      setOverlayPosition({
+        top: rect.bottom + 4,
+        left: rect.left,
+        width: rect.width,
+      });
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    setOverlayPosition({
+      top: rect.bottom - containerRect.top + 4,
+      left: rect.left - containerRect.left,
+      width: rect.width,
+    });
+  }, [getResolvedPortalContainer]);
+
+  // Positioning for overlay dropdowns
+  useEffect(() => {
+    if (!open || disabled || dropdownMode !== 'overlay') return;
+    updateOverlayPosition();
+
+    const handle = () => updateOverlayPosition();
+    window.addEventListener('resize', handle);
+    window.addEventListener('scroll', handle, true);
+
+    return () => {
+      window.removeEventListener('resize', handle);
+      window.removeEventListener('scroll', handle, true);
+    };
+  }, [open, disabled, dropdownMode, updateOverlayPosition]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!open || disabled) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        triggerRef.current &&
+        !triggerRef.current.contains(target) &&
+        contentRef.current &&
+        !contentRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open, disabled]);
+
+  // Clear search when closing
+  useEffect(() => {
+    if (!open) setSearch('');
+  }, [open]);
+
+  const dropdown = (
+    <div
+      ref={contentRef}
+      className={cn(
+        dropdownMode === 'overlay'
+          ? 'bg-white rounded-md shadow-lg border border-gray-200 overflow-hidden'
+          : 'rounded-md border border-gray-200 bg-white shadow-md overflow-hidden'
+      )}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <Command className="w-full h-full" shouldFilter={false}>
+        <div className="flex items-center border-b px-3 py-2">
+          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <Command.Input
+            autoFocus={autoFocusSearch}
+            value={search}
+            onValueChange={setSearch}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.stopPropagation();
+                setOpen(false);
+              }
+            }}
+            className="flex h-9 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-gray-500"
+            placeholder={resolvedSearchPlaceholder}
+          />
+        </div>
+        <Command.List className="overflow-y-auto p-1" style={{ maxHeight: maxListHeight }}>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((option: SelectOption) => (
+              <Command.Item
+                key={option.value}
+                value={option.value}
+                onSelect={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+                className={cn(
+                  'flex items-center px-2 py-1.5 text-sm rounded-sm cursor-pointer',
+                  'hover:bg-gray-100',
+                  'aria-selected:bg-gray-100',
+                  value === option.value && 'bg-gray-100'
+                )}
+              >
+                <span className="flex-1">{option.label}</span>
+                {value === option.value && (
+                  <Check className="w-4 h-4 text-primary-600" />
+                )}
+              </Command.Item>
+            ))
+          ) : (
+            <div className="py-6 text-center text-sm text-gray-500">
+              {emptyMessage}
+            </div>
+          )}
+        </Command.List>
+      </Command>
+    </div>
+  );
+
   return (
     <div className={label ? 'mb-4' : ''} id={id} data-automation-type="searchable-select">
       {label && (
@@ -97,6 +257,7 @@ export function SearchableSelect({
       
       <div className="relative">
         <Button
+          ref={triggerRef}
           type="button"
           variant="outline"
           role="combobox"
@@ -116,54 +277,38 @@ export function SearchableSelect({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
         
-        {open && !disabled && (
+        {open && !disabled && dropdownMode === 'inline' && (
           <div className="absolute z-50 w-full mt-1">
-            <Command
-              className="rounded-md border border-gray-200 bg-white shadow-md overflow-hidden"
-              shouldFilter={false}
-            >
-              <div className="flex items-center border-b px-3 py-2">
-                <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-                <Command.Input
-                  value={search}
-                  onValueChange={setSearch}
-                  className="flex h-9 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-gray-500"
-                  placeholder={`Search ${placeholder.toLowerCase()}...`}
-                />
-              </div>
-              <Command.List className="max-h-60 overflow-y-auto p-1">
-                {filteredOptions.length > 0 ? (
-                  filteredOptions.map((option: SelectOption) => (
-                    <Command.Item
-                      key={option.value}
-                      value={option.value}
-                      onSelect={() => {
-                        onChange(option.value);
-                        setOpen(false);
-                        setSearch('');
-                      }}
-                      className={cn(
-                        "flex items-center px-2 py-1.5 text-sm rounded-sm cursor-pointer",
-                        "hover:bg-gray-100",
-                        "aria-selected:bg-gray-100",
-                        value === option.value && "bg-gray-100"
-                      )}
-                    >
-                      <span className="flex-1">{option.label}</span>
-                      {value === option.value && (
-                        <Check className="w-4 h-4 text-primary-600" />
-                      )}
-                    </Command.Item>
-                  ))
-                ) : (
-                  <div className="py-6 text-center text-sm text-gray-500">
-                    {emptyMessage}
-                  </div>
-                )}
-              </Command.List>
-            </Command>
+            {dropdown}
           </div>
         )}
+
+        {open &&
+          !disabled &&
+          dropdownMode === 'overlay' &&
+          overlayPosition &&
+          typeof document !== 'undefined' &&
+          (() => {
+            const container = getResolvedPortalContainer();
+            if (!container) return null;
+
+            const overlayNode = (
+              <div
+                className="z-[99999]"
+                style={{
+                  position: container === document.body ? 'fixed' : 'absolute',
+                  top: overlayPosition.top,
+                  left: overlayPosition.left,
+                  width: overlayPosition.width,
+                  marginTop: 0,
+                }}
+              >
+                {dropdown}
+              </div>
+            );
+
+            return createPortal(overlayNode, container);
+          })()}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes a bug where clicking the "Search services..." input immediately closed the service picker when used inside a modal dialog.

Root cause: the picker dropdown is portaled to document.body, but the Radix Dialog runs in modal mode (pointer-events blocked outside content), so clicks landed outside and triggered the click-away close.

Changes:
- Add new cmdk-based ServicePicker component.
- Use ServicePicker in CreateCustomContractLineDialog.
- Disable dialog focus trap/modal behavior for this dialog so the portaled dropdown remains interactive.