### PR TITLE
fix(seeds): handle missing tables and subtypes gracefully in dev seeds

### DIFF
--- a/server/seeds/dev/28_client_contract_lines.cjs
+++ b/server/seeds/dev/28_client_contract_lines.cjs
@@ -1,4 +1,9 @@
 exports.seed = async function (knex) {
+    // As of 0.15.x the legacy `client_contract_lines` table may be removed.
+    // Skip gracefully if absent.
+    const hasClientContractLines = await knex.schema.hasTable('client_contract_lines');
+    if (!hasClientContractLines) return;
+
     const tenant = await knex('tenants').select('tenant').first();
     if (!tenant) return;
     


### PR DESCRIPTION
## Summary
- Skip `client_contract_lines` seed if table doesn't exist (removed in 0.15.x schema changes)
- Warn and skip notification templates for missing subtypes instead of failing the entire seed
- Use explicit check for existing `notification_settings` to avoid `ON CONFLICT` issues on schemas without unique constraint

## Test plan
- [ ] Run `npm run seed:dev` on a fresh 0.15.x database
- [ ] Verify seeds complete without errors
- [ ] Verify warning messages appear for skipped items but don't cause failures