### PR TITLE
fix: fail hard when database seeds fail during setup

### DIFF
--- a/ee/setup/entrypoint.sh
+++ b/ee/setup/entrypoint.sh
@@ -175,7 +175,9 @@ main() {
     if ! check_seeds_status; then
         log "Running seeds..."
         NODE_ENV=migration npx knex seed:run --knexfile /app/server/knexfile.cjs || {
-            log "Seeds failed, but continuing since database may already be seeded"
+            local exit_code=$?
+            log "ERROR: Seeds failed with exit code $exit_code"
+            exit $exit_code
         }
         log "Seeds completed!"
     else

--- a/setup/bash/entrypoint.sh
+++ b/setup/bash/entrypoint.sh
@@ -61,7 +61,13 @@ setup_db(){
     # Run migrations
     send_log info "Running database migrations..."
     cd /app && NODE_OPTIONS="--experimental-vm-modules" npx knex --knexfile $KNEXFILE migrate:latest
-    NODE_OPTIONS="--experimental-vm-modules" npx knex --knexfile $KNEXFILE seed:run
+
+    send_log info "Running database seeds..."
+    NODE_OPTIONS="--experimental-vm-modules" npx knex --knexfile $KNEXFILE seed:run || {
+        local exit_code=$?
+        send_log error "Seeds failed with exit code $exit_code"
+        exit $exit_code
+    }
 
     send_log info " ** Database setup completed **"
 }

--- a/setup/entrypoint.sh
+++ b/setup/entrypoint.sh
@@ -240,10 +240,11 @@ EOF
         NODE_ENV=migration timeout 300 npx knex seed:run --knexfile /app/server/knexfile.cjs --verbose || {
             local exit_code=$?
             if [ $exit_code -eq 124 ]; then
-                log "WARNING: Seeds timed out after 300 seconds, but continuing since database may already be seeded"
+                log "ERROR: Seeds timed out after 300 seconds"
             else
-                log "WARNING: Seeds failed with exit code $exit_code, but continuing since database may already be seeded"
+                log "ERROR: Seeds failed with exit code $exit_code"
             fi
+            exit $exit_code
         }
         log "Seeds completed!"
     else


### PR DESCRIPTION
## Summary
- Modified setup entrypoint scripts to exit with error codes when database seeds fail
- Previously seed failures were caught and logged as warnings, allowing broken environments to start
- Now Docker Compose properly stops dependent services when setup fails

## Test plan
- [ ] Start a fresh environment and verify seeds run successfully
- [ ] Intentionally break a seed file and verify the setup container exits with an error
- [ ] Confirm the server container does not start when seeds fail