### PR TITLE
Add disabled state to MSP sign-in button during login

### DIFF
--- a/server/src/components/auth/MspLoginForm.tsx
+++ b/server/src/components/auth/MspLoginForm.tsx
@@ -24,6 +24,7 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [lookupError, setLookupError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Register the form component
   const updateForm = useRegisterUIComponent<FormComponent>({
@@ -34,6 +35,7 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setIsSubmitting(true);
 
     try {
       const result = await signIn('credentials', {
@@ -62,8 +64,7 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
         message: 'An unexpected error occurred. Please try again.' 
       });
     } finally {
-      // Re-enable form elements after submission
-      const isFormValid = email.length > 0 && password.length > 0;
+      setIsSubmitting(false);
     }
   };
 
@@ -140,6 +141,7 @@ export default function MspLoginForm({ callbackUrl, onError, onTwoFactorRequired
           type="submit"
           className="w-full"
           id="msp-sign-in-button"
+          disabled={isSubmitting}
         >
           Sign in
         </Button>


### PR DESCRIPTION
## Description
This PR adds a disabled state to the MSP sign-in button while the login process is in progress, providing visual feedback to users that their click was registered.

## Changes
- Added `isSubmitting` state to track form submission status
- Disabled sign-in button while login is in progress
- Re-enable button after login completes or fails

## Testing
- Click the sign-in button and verify it becomes disabled during the login attempt
- Verify the button re-enables if login fails
- Verify the button remains disabled during successful login (until redirect)