### PR TITLE
fix(auth): ensure database user ID is used in OAuth session

### DIFF
--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -15,15 +15,6 @@ try {
 // Determine if this is an EE build
 const isEE = process.env.EDITION === 'ee' || process.env.NEXT_PUBLIC_EDITION === 'enterprise';
 
-// DEBUG LOGGING - Remove after troubleshooting
-console.log('=== BUILD DEBUG ===');
-console.log('process.env.EDITION:', process.env.EDITION);
-console.log('process.env.NEXT_PUBLIC_EDITION:', process.env.NEXT_PUBLIC_EDITION);
-console.log('isEE result:', isEE);
-console.log('Current working directory:', process.cwd());
-console.log('__dirname:', __dirname);
-console.log('=== END DEBUG ===');
-
 // Reusable path to an empty shim for optional/native modules (used by Turbopack aliases)
 const emptyShim = './src/empty/shims/empty.ts';
 
@@ -156,6 +147,10 @@ const nextConfig = {
       // Base app alias
       '@': './src',
       'server/src': './src', // Add explicit alias for server/src imports
+      '@/empty': isEE ? '../ee/server/src' : './src/empty',
+      '@/empty/': isEE ? '../ee/server/src/' : './src/empty/',
+      './src/empty': isEE ? '../ee/server/src' : './src/empty',
+      './src/empty/': isEE ? '../ee/server/src/' : './src/empty/',
       '@ee': isEE ? '../ee/server/src' : './src/empty',
       '@ee/': isEE ? '../ee/server/src/' : './src/empty/',
       'ee/server/src': isEE ? '../ee/server/src' : './src/empty',

--- a/server/src/app/api/auth/[...nextauth]/options.ts
+++ b/server/src/app/api/auth/[...nextauth]/options.ts
@@ -640,16 +640,6 @@ async function ensureOAuthAccountLink(
         metadata.linkNonceIssuedAt,
         toOptionalString(metadata.linkNonceSignature),
     );
-    console.log('[oauth] account metadata for link', {
-        providerId,
-        userId: user.id,
-        linkUserId,
-        linkMode,
-        hasNonce: Boolean(linkNonce),
-        nonceIssuedAt: metadata.linkNonceIssuedAt,
-        hasSignature: Boolean(metadata.linkNonceSignature),
-        linkingAuthorized,
-    });
 
     const existingLink = await findOAuthAccountLink(normalizedProvider, providerAccountId);
     let autoLinkAuthorized = false;
@@ -773,7 +763,7 @@ export async function buildAuthOptions(): Promise<NextAuthConfig> {
                             typeof googleProfile.vanity_host === 'string'
                                 ? googleProfile.vanity_host
                                 : undefined;
-                        return mapOAuthProfileToExtendedUser({
+                        return await mapOAuthProfileToExtendedUser({
                             provider: 'google',
                             email: profile.email,
                             image: profile.picture,
@@ -781,7 +771,7 @@ export async function buildAuthOptions(): Promise<NextAuthConfig> {
                             tenantHint,
                             vanityHostHint,
                             userTypeHint,
-                        }) as Promise<ExtendedUser>;
+                        }) as ExtendedUser;
                     },
                 }),
             ]
@@ -1166,6 +1156,13 @@ export async function buildAuthOptions(): Promise<NextAuthConfig> {
             const request = (context as any).request; // NextAuth v5 runtime provides request
 
             if (extendedUser && providerId && providerId !== 'credentials') {
+                // NextAuth v5 can sometimes override the user.id with a random UUID.
+                // Since we return the DB user_id as the 'id' in our profile callbacks,
+                // the account.providerAccountId will contain the correct DB ID.
+                if (account?.providerAccountId) {
+                    extendedUser.id = account.providerAccountId;
+                }
+
                 const accountRecord = account as unknown as Record<string, unknown> | null;
                 try {
                     const enrichedUser = await applyOAuthAccountHints(
@@ -1530,7 +1527,7 @@ export const options: NextAuthConfig = {
                             typeof googleProfile.vanity_host === 'string'
                                 ? googleProfile.vanity_host
                                 : undefined;
-                        return mapOAuthProfileToExtendedUser({
+                        return await mapOAuthProfileToExtendedUser({
                             provider: 'google',
                             email: profile.email,
                             image: (profile as any).picture,
@@ -1538,7 +1535,7 @@ export const options: NextAuthConfig = {
                             tenantHint,
                             vanityHostHint,
                             userTypeHint,
-                        }) as Promise<ExtendedUser>;
+                        }) as ExtendedUser;
                     },
                 }),
             ]
@@ -1928,35 +1925,10 @@ export const options: NextAuthConfig = {
             const extendedUser = user as ExtendedUser | undefined;
 
             if (extendedUser && providerId && providerId !== 'credentials') {
-                try {
-                    const enrichedUser = await applyOAuthAccountHints(
-                        toOAuthProfileMappingResult(extendedUser),
-                        account as unknown as Record<string, unknown>,
-                    );
-                    Object.assign(extendedUser, enrichedUser);
-                } catch (error) {
-                    console.warn('[signIn] failed to apply OAuth tenant hints', {
-                        providerId,
-                        error,
-                    });
+                if (account?.providerAccountId) {
+                    extendedUser.id = account.providerAccountId;
                 }
-            }
 
-            // Track last login
-            if (extendedUser?.id && extendedUser?.tenant && providerId) {
-                try {
-                    const User = (await import('server/src/lib/models/user')).default;
-                    await User.updateLastLogin(
-                        extendedUser.id,
-                        extendedUser.tenant,
-                        providerId
-                    );
-                } catch (error) {
-                    console.warn('[signIn] failed to update last login', error);
-                }
-            }
-
-            if (extendedUser && providerId && providerId !== 'credentials') {
                 const accountRecord = account as unknown as Record<string, unknown> | null;
                 try {
                     const enrichedUser = await applyOAuthAccountHints(
@@ -1974,13 +1946,26 @@ export const options: NextAuthConfig = {
                 await ensureOAuthAccountLink(extendedUser, accountRecord, providerId);
             }
 
+            // Track last login
+            if (extendedUser?.id && extendedUser?.tenant && providerId) {
+                try {
+                    const User = (await import('server/src/lib/models/user')).default;
+                    await User.updateLastLogin(
+                        extendedUser.id,
+                        extendedUser.tenant,
+                        providerId
+                    );
+                } catch (error) {
+                    console.warn('[signIn] failed to update last login', error);
+                }
+            }
+
             if (providerId === 'credentials') {
                 const callbackUrl = typeof credentials?.callbackUrl === 'string' ? credentials.callbackUrl : undefined;
                 const canonicalBaseUrl = process.env.NEXTAUTH_URL;
 
                 if (extendedUser?.user_type === 'client' && callbackUrl && canonicalBaseUrl) {
                     try {
-                        console.log('[signIn] computing vanity redirect');
                         const vanityRedirect = await computeVanityRedirect({
                             url: callbackUrl,
                             baseUrl: canonicalBaseUrl,


### PR DESCRIPTION
This PR fixes an issue where NextAuth v5 would occasionally override the database user ID with a random internal UUID during OAuth login. 

Key changes:
- Synchronize `user.id` with `account.providerAccountId` in `signIn` callbacks (both async and sync options).
- Add Turbopack aliases for `@/empty` and `src/empty` to support enterprise component swapping in dev mode.
- Remove debug logging from the investigation.