### PR TITLE
fix: prevent infinite loops in document sync effects

### DIFF
--- a/server/src/components/tickets/ticket/TicketDocumentsSection.tsx
+++ b/server/src/components/tickets/ticket/TicketDocumentsSection.tsx
@@ -32,9 +32,16 @@ const TicketDocumentsSection: React.FC<TicketDocumentsSectionProps> = ({
   const [documents, setDocuments] = useState<IDocument[]>(initialDocuments);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Sync documents from props when they change
+  // Track previous document IDs to avoid infinite loops
+  const prevDocumentIdsRef = useRef<string>('');
+
+  // Sync documents from props when they change (by ID, not reference)
   useEffect(() => {
-    setDocuments(initialDocuments);
+    const currentIds = initialDocuments.map(d => d.document_id).sort().join(',');
+    if (currentIds !== prevDocumentIdsRef.current) {
+      prevDocumentIdsRef.current = currentIds;
+      setDocuments(initialDocuments);
+    }
   }, [initialDocuments]);
 
   // Fallback fetch function (only used if initialDocuments not provided)


### PR DESCRIPTION
  Use ID-based comparison instead of reference equality when syncing documents from props. Separates folder mode fetching from entity mode handling and fixes search clearing to properly restore the full list.

  "But I don't want to go among infinite loops," Alice remarked. "Oh, you can't help that," said the Ref. "We're all comparing IDs here. I compare IDs. You compare IDs. Even the documents compare IDs." 🔄📄🐇