### PR TITLE
ui: extension should take up full space in client portal

### DIFF
--- a/packages/product-extensions/ee/ExtensionIframe.tsx
+++ b/packages/product-extensions/ee/ExtensionIframe.tsx
@@ -74,7 +74,7 @@ export default function ExtensionIframe({ domain, extensionId }: Props) {
   }, [isLoading]);
 
   return (
-    <div className="relative h-full w-full" aria-busy={isLoading}>
+    <div className="absolute h-full w-full" aria-busy={isLoading}>
       {isLoading && !hasError && (
         <div className="extension-loading-overlay" role="status">
           <LoadingIndicator


### PR DESCRIPTION
## Summary
- Changed the ExtensionIframe container from `relative` to `absolute` positioning to ensure extensions take up the full available space in the client portal

## Test plan
- [ ] Open a client portal with an extension enabled
- [ ] Verify the extension iframe fills the entire available space
- [ ] Confirm no layout issues or overflow problems