### PR TITLE
Remove NinjaOne OAuth connect API route

### DIFF
--- a/server/src/app/api/integrations/ninjaone/connect/route.ts
+++ b/server/src/app/api/integrations/ninjaone/connect/route.ts
@@ -1,7 +1,0 @@
-/**
- * NinjaOne OAuth Connect Endpoint
- *
- * Re-exports the EE implementation for NinjaOne OAuth connection.
- */
-
-export { GET, dynamic } from '@ee/app/api/integrations/ninjaone/connect/route';


### PR DESCRIPTION
## Summary\n- remove the legacy NinjaOne OAuth connect API route now that the UI uses a server action to build the authorization URL\n\n## Testing\n- not run (routing change only)