### PR TITLE
ui(assets): migrate asset screens to standard UI components

### DIFF
--- a/ee/server/src/components/assets/AssetAlertsSection.tsx
+++ b/ee/server/src/components/assets/AssetAlertsSection.tsx
@@ -148,9 +148,17 @@ export function AssetAlertsSection({ asset, className = '' }: AssetAlertsSection
   return (
     <div className={`bg-white rounded-lg border border-gray-200 ${className}`}>
       {/* Header */}
-      <button
-        className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50"
+      <div
+        role="button"
+        tabIndex={0}
+        className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 cursor-pointer"
         onClick={() => setIsExpanded(!isExpanded)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setIsExpanded(!isExpanded);
+          }
+        }}
       >
         <div className="flex items-center gap-2">
           <AlertTriangle className={`h-5 w-5 ${hasAlerts ? 'text-amber-500' : 'text-gray-400'}`} />
@@ -180,7 +188,7 @@ export function AssetAlertsSection({ asset, className = '' }: AssetAlertsSection
             <ChevronDown className="h-4 w-4 text-gray-400" />
           )}
         </div>
-      </button>
+      </div>
 
       {/* Content */}
       {isExpanded && (

--- a/ee/server/src/components/assets/RemoteAccessButton.tsx
+++ b/ee/server/src/components/assets/RemoteAccessButton.tsx
@@ -37,7 +37,7 @@ type ConnectionType = 'desktop' | 'shell';
 
 export function RemoteAccessButton({
   asset,
-  variant = 'secondary',
+  variant = 'default',
   size = 'sm',
   className = '',
 }: RemoteAccessButtonProps) {

--- a/server/src/components/assets/AssetDashboardGrid.tsx
+++ b/server/src/components/assets/AssetDashboardGrid.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { SimpleGrid, Stack } from '@mantine/core';
 import { RmmVitalsPanel } from './panels/RmmVitalsPanel';
 import { HardwareSpecsPanel } from './panels/HardwareSpecsPanel';
 import { SecurityPatchingPanel } from './panels/SecurityPatchingPanel';
@@ -27,7 +26,7 @@ export const AssetDashboardGrid: React.FC<AssetDashboardGridProps> = ({
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
       {/* Left Column (2/3 width on large screens) */}
-      <div className="lg:col-span-2 space-y-6">
+      <div className="lg:col-span-2 flex flex-col gap-6">
         <RmmVitalsPanel 
           data={rmmData} 
           isLoading={isLoading} 
@@ -47,7 +46,7 @@ export const AssetDashboardGrid: React.FC<AssetDashboardGridProps> = ({
       </div>
 
       {/* Right Column (1/3 width on large screens) */}
-      <div className="space-y-6">
+      <div className="flex flex-col gap-6">
         <AssetInfoPanel 
           asset={asset} 
           isLoading={isLoading} 

--- a/server/src/components/assets/AssetDetailDrawerClient.tsx
+++ b/server/src/components/assets/AssetDetailDrawerClient.tsx
@@ -245,13 +245,13 @@ function renderOverviewTab({ asset, maintenanceReport, history, router, statusBa
           {asset.client?.client_name && <p className="text-sm text-gray-500">Client: {asset.client.client_name}</p>}
         </div>
         <div className="flex flex-wrap gap-2">
-          <Button id="asset-drawer-open-record" variant="secondary" size="sm" className="gap-2" onClick={() => router.push(`/msp/assets/${asset.asset_id}`)}>
+          <Button id="asset-drawer-open-record" variant="default" size="sm" className="gap-2" onClick={() => router.push(`/msp/assets/${asset.asset_id}`)}>
             <FileText className="h-4 w-4" /> Open asset record
           </Button>
           {asset.rmm_provider && asset.rmm_device_id && (
-            <RemoteAccessButton asset={asset} variant="secondary" size="sm" />
+            <RemoteAccessButton asset={asset} variant="default" size="sm" />
           )}
-          <CreateTicketFromAssetButton asset={asset} defaultBoardId={defaultBoardId} variant="secondary" size="sm" />
+          <CreateTicketFromAssetButton asset={asset} defaultBoardId={defaultBoardId} variant="default" size="sm" />
           <DeleteAssetButton
             assetId={asset.asset_id}
             assetName={asset.name}

--- a/server/src/components/assets/AssetDetailHeader.tsx
+++ b/server/src/components/assets/AssetDetailHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Group, Text } from '@mantine/core';
 import { useSWRConfig } from 'swr';
 import { 
   Laptop, 
@@ -64,13 +63,13 @@ export const AssetDetailHeader: React.FC<AssetDetailHeaderProps> = ({
   return (
     <>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 p-4 bg-white border-b border-gray-200">
-        <Group align="center">
+        <div className="flex items-center gap-4">
           <Icon size={40} className="text-gray-700" />
           <div>
-            <Group gap="xs" align="center">
-              <Text size="xl" fw={700} className="leading-none text-gray-900">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl font-bold leading-none text-gray-900">
                 {asset.name}
-              </Text>
+              </h1>
               {asset.rmm_provider && (
                 <StatusBadge 
                   status={badgeStatus} 
@@ -78,19 +77,18 @@ export const AssetDetailHeader: React.FC<AssetDetailHeaderProps> = ({
                   size="md"
                 />
               )}
-            </Group>
-            <Text size="sm" c="dimmed" mt={2}>
+            </div>
+            <p className="text-sm text-gray-500 mt-1">
               Asset Tag: {asset.asset_tag}
-            </Text>
+            </p>
           </div>
-        </Group>
+        </div>
 
-        <Group>
+        <div className="flex items-center gap-3">
           {asset.rmm_provider && (
             <RemoteAccessButton
               asset={asset}
               variant="default"
-              className="bg-blue-600 hover:bg-blue-700 text-white border-0"
             />
           )}
           
@@ -115,7 +113,7 @@ export const AssetDetailHeader: React.FC<AssetDetailHeaderProps> = ({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuLabel>Actions</DropdownMenuLabel>
+              <div className="px-2 py-1.5 text-sm font-semibold text-gray-900">Actions</div>
               {asset.rmm_provider && (
                 <>
                   <DropdownMenuItem onClick={onRefresh} disabled={isRefreshing}>
@@ -140,7 +138,7 @@ export const AssetDetailHeader: React.FC<AssetDetailHeaderProps> = ({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </Group>
+        </div>
       </div>
 
       <QuickAddTicket

--- a/server/src/components/assets/AssetDetailView.tsx
+++ b/server/src/components/assets/AssetDetailView.tsx
@@ -7,7 +7,7 @@ import { AssetDashboardGrid } from './AssetDashboardGrid';
 import { AssetDetailTabs } from './AssetDetailTabs';
 import { useAssetDetail } from '../../hooks/useAssetDetail';
 import LoadingIndicator from 'server/src/components/ui/LoadingIndicator';
-import { Alert, Container } from '@mantine/core';
+import { Alert, AlertDescription, AlertTitle } from 'server/src/components/ui/Alert';
 import { AlertCircle } from 'lucide-react';
 
 interface AssetDetailViewProps {
@@ -34,11 +34,15 @@ export const AssetDetailView: React.FC<AssetDetailViewProps> = ({ assetId }) => 
 
   if (!asset) {
     return (
-      <Container size="xl" py="xl">
-        <Alert icon={<AlertCircle size={16} />} title="Error" color="red">
-          Asset not found or you do not have permission to view it.
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            Asset not found or you do not have permission to view it.
+          </AlertDescription>
         </Alert>
-      </Container>
+      </div>
     );
   }
 
@@ -50,7 +54,7 @@ export const AssetDetailView: React.FC<AssetDetailViewProps> = ({ assetId }) => 
         isRefreshing={isRefreshing}
       />
       
-      <Container size="xl" py="xl">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <AssetMetricsBanner 
           metrics={metrics} 
           isLoading={isLoading} 
@@ -66,7 +70,7 @@ export const AssetDetailView: React.FC<AssetDetailViewProps> = ({ assetId }) => 
         />
         
         <AssetDetailTabs asset={asset} />
-      </Container>
+      </div>
     </div>
   );
 };

--- a/server/src/components/assets/AssetMetricsBanner.tsx
+++ b/server/src/components/assets/AssetMetricsBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper, Text, Group, Divider } from '@mantine/core';
+import { Card } from 'server/src/components/ui/Card';
 import { 
   Check, 
   AlertTriangle, 
@@ -12,6 +12,7 @@ import {
   AlertCircle 
 } from 'lucide-react';
 import { AssetSummaryMetrics } from '../../interfaces/asset.interfaces';
+import { cn } from 'server/src/lib/utils';
 
 interface AssetMetricsBannerProps {
   metrics: AssetSummaryMetrics | undefined;
@@ -27,16 +28,18 @@ const MetricItem = ({
   value: React.ReactNode; 
   onClick?: () => void;
 }) => (
-  <Group 
-    gap="xs" 
-    className={`px-4 py-2 ${onClick ? 'cursor-pointer hover:bg-gray-50 rounded transition-colors' : ''}`}
+  <div 
+    className={cn(
+      "flex items-center gap-2 px-4 py-2 flex-1 justify-center whitespace-nowrap",
+      onClick && "cursor-pointer hover:bg-gray-50 transition-colors"
+    )}
     onClick={onClick}
   >
-    <Text size="sm" fw={700} c="dimmed">
+    <span className="text-sm font-bold text-gray-400">
       {label}:
-    </Text>
+    </span>
     {value}
-  </Group>
+  </div>
 );
 
 const StatusText = ({ 
@@ -48,18 +51,21 @@ const StatusText = ({
   color: string; 
   icon?: any;
 }) => (
-  <Group gap={4}>
-    <Text 
-      size="sm" 
-      fw={600} 
-      className={`text-${color}-600 flex items-center gap-1`}
-    >
+  <div className="flex items-center gap-1">
+    <span className={cn(
+      "text-sm font-semibold flex items-center gap-1",
+      color === 'green' && 'text-emerald-600',
+      color === 'yellow' && 'text-amber-600',
+      color === 'red' && 'text-red-600',
+      color === 'gray' && 'text-gray-500',
+      color === 'blue' && 'text-primary-600'
+    )}>
       [
       {Icon && <Icon size={12} strokeWidth={3} />}
       {text}
       ]
-    </Text>
-  </Group>
+    </span>
+  </div>
 );
 
 export const AssetMetricsBanner: React.FC<AssetMetricsBannerProps> = ({ 
@@ -68,7 +74,7 @@ export const AssetMetricsBanner: React.FC<AssetMetricsBannerProps> = ({
 }) => {
   if (isLoading || !metrics) {
     return (
-      <Paper p="md" withBorder className="h-14 animate-pulse bg-gray-50 mb-6" />
+      <div className="h-14 w-full animate-pulse bg-gray-50 border border-gray-200 rounded-lg mb-6" />
     );
   }
 
@@ -108,45 +114,35 @@ export const AssetMetricsBanner: React.FC<AssetMetricsBannerProps> = ({
   const warranty = getWarrantyConfig(metrics.warranty_status, metrics.warranty_days_remaining);
 
   return (
-    <Paper withBorder p="xs" className="mb-6 bg-white">
+    <Card className="mb-6 bg-white overflow-hidden p-0">
       <div className="flex flex-col lg:flex-row justify-between lg:items-center divide-y lg:divide-y-0 lg:divide-x divide-gray-200">
-        <div className="flex-1 flex justify-center">
-          <MetricItem 
-            label="Health Status" 
-            value={<StatusText text={health.text} color={health.color} icon={health.icon} />} 
-          />
-        </div>
+        <MetricItem 
+          label="Health Status" 
+          value={<StatusText text={health.text} color={health.color} icon={health.icon} />} 
+        />
         
-        <div className="flex-1 flex justify-center">
-          <MetricItem 
-            label="Open Tickets" 
-            value={
-              <Text size="sm" fw={600} className="text-blue-600">
-                [{metrics.open_tickets_count} Active]
-              </Text>
-            }
-            onClick={() => { /* Navigate */ }}
-          />
-        </div>
+        <MetricItem 
+          label="Open Tickets" 
+          value={
+            <span className="text-sm font-semibold text-primary-600">
+              [{metrics.open_tickets_count} Active]
+            </span>
+          }
+          onClick={() => { /* Navigate */ }}
+        />
 
-        <div className="flex-1 flex justify-center">
-          <MetricItem 
-            label="Security Status" 
-            value={<StatusText text={security.text} color={security.color} icon={security.icon} />} 
-          />
-        </div>
+        <MetricItem 
+          label="Security Status" 
+          value={<StatusText text={security.text} color={security.color} icon={security.icon} />} 
+        />
 
-        <div className="flex-1 flex justify-center">
-          <MetricItem 
-            label="Warranty" 
-            value={
-              <Text size="sm" fw={600} className={warranty.color !== 'gray' ? `text-${warranty.color}-600` : ''}>
-                [{warranty.text}]
-              </Text>
-            } 
-          />
-        </div>
+        <MetricItem 
+          label="Warranty" 
+          value={
+            <StatusText text={warranty.text} color={warranty.color} />
+          } 
+        />
       </div>
-    </Paper>
+    </Card>
   );
 };

--- a/server/src/components/assets/CreateTicketFromAssetButton.tsx
+++ b/server/src/components/assets/CreateTicketFromAssetButton.tsx
@@ -27,7 +27,7 @@ interface CreateTicketFromAssetButtonProps {
     size?: 'default' | 'sm' | 'lg' | 'icon';
 }
 
-export default function CreateTicketFromAssetButton({ asset, defaultBoardId, variant = 'secondary', size = 'sm' }: CreateTicketFromAssetButtonProps) {
+export default function CreateTicketFromAssetButton({ asset, defaultBoardId, variant = 'default', size = 'sm' }: CreateTicketFromAssetButtonProps) {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [title, setTitle] = useState(`Issue with ${asset.name}`);
     const [description, setDescription] = useState('');

--- a/server/src/components/assets/panels/AssetInfoPanel.tsx
+++ b/server/src/components/assets/panels/AssetInfoPanel.tsx
@@ -1,15 +1,63 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from 'server/src/components/ui/Card';
-import { Group, Text, ActionIcon, CopyButton, Tooltip } from '@mantine/core';
+import { Button } from 'server/src/components/ui/Button';
+import { Tooltip } from 'server/src/components/ui/Tooltip';
 import { ExternalLink, Copy, Check } from 'lucide-react';
 import { Asset } from '../../../interfaces/asset.interfaces';
 import { formatDateOnly } from '../../../lib/utils/dateTimeUtils';
 import Link from 'next/link';
+import { cn } from 'server/src/lib/utils';
 
 interface AssetInfoPanelProps {
   asset: Asset;
   isLoading: boolean;
 }
+
+const InfoRow = ({ label, value, copyable = false, link = null }: { label: string, value: React.ReactNode, copyable?: boolean, link?: string | null }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    if (typeof value === 'string') {
+      navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="flex items-start gap-2 min-h-[24px]">
+      <span className="text-sm font-bold text-gray-700 w-32 shrink-0">{label}:</span>
+      <div className="flex-1 flex items-center gap-2">
+        {link ? (
+          <Link href={link} className="text-primary-600 hover:text-primary-700 hover:underline flex items-center gap-1">
+            <span className="text-sm">{value}</span>
+            <ExternalLink size={12} />
+          </Link>
+        ) : (
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm text-gray-900">{value}</span>
+            {copyable && typeof value === 'string' && (
+              <Tooltip content={copied ? 'Copied' : 'Copy'}>
+                <Button
+                  id={`copy-${label.toLowerCase().replace(/\s+/g, '-')}`}
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    "h-5 w-5 p-0",
+                    copied ? "text-emerald-500" : "text-gray-400 hover:text-gray-600"
+                  )}
+                  onClick={handleCopy}
+                >
+                  {copied ? <Check size={12} /> : <Copy size={12} />}
+                </Button>
+              </Tooltip>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({
   asset,
@@ -18,35 +66,6 @@ export const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({
   if (isLoading) {
     return <Card className="h-64 animate-pulse bg-gray-50" />;
   }
-
-  const InfoRow = ({ label, value, copyable = false, link = null }: { label: string, value: React.ReactNode, copyable?: boolean, link?: string | null }) => (
-    <Group gap="xs" align="flex-start" className="min-h-[24px]">
-      <Text size="sm" fw={700} className="w-32 shrink-0">{label}:</Text>
-      <div className="flex-1 flex items-center gap-2">
-        {link ? (
-          <Link href={link} className="text-primary-600 hover:underline flex items-center gap-1">
-            <Text size="sm">{value}</Text>
-            <ExternalLink size={12} />
-          </Link>
-        ) : (
-          <Group gap={4}>
-            <Text size="sm">{value}</Text>
-            {copyable && typeof value === 'string' && (
-              <CopyButton value={value} timeout={2000}>
-                {({ copied, copy }) => (
-                  <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
-                    <ActionIcon color={copied ? 'teal' : 'gray'} variant="subtle" onClick={copy} size="xs">
-                      {copied ? <Check size={12} /> : <Copy size={12} />}
-                    </ActionIcon>
-                  </Tooltip>
-                )}
-              </CopyButton>
-            )}
-          </Group>
-        )}
-      </div>
-    </Group>
-  );
 
   const getModelName = () => {
     // Try to get model from system_info if available

--- a/server/src/components/assets/panels/AssetNotesPanel.tsx
+++ b/server/src/components/assets/panels/AssetNotesPanel.tsx
@@ -1,11 +1,10 @@
-'use client';
-
 import React, { useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from 'server/src/components/ui/Card';
-import { Button, Text, Group } from '@mantine/core';
+import { Button } from 'server/src/components/ui/Button';
 import { useAssetNotes } from '../../../hooks/useAssetNotes';
 import TextEditor from '../../editor/TextEditor';
 import { Save } from 'lucide-react';
+import Spinner from 'server/src/components/ui/Spinner';
 
 interface AssetNotesPanelProps {
   assetId: string;
@@ -49,12 +48,13 @@ export const AssetNotesPanel: React.FC<AssetNotesPanelProps> = ({
           <CardTitle>Notes & Quick Info</CardTitle>
           <Button 
             id="save-asset-note-btn"
-            variant="light" 
-            size="xs" 
-            leftSection={<Save size={14} />}
+            variant="ghost" 
+            size="sm" 
+            className="h-8 gap-2 text-primary-600 hover:text-primary-700 hover:bg-primary-50"
             onClick={handleSave}
-            loading={isSaving}
+            disabled={isSaving}
           >
+            {isSaving ? <Spinner size="sm" className="h-3 w-3" /> : <Save size={14} />}
             Save
           </Button>
         </div>
@@ -69,11 +69,11 @@ export const AssetNotesPanel: React.FC<AssetNotesPanelProps> = ({
         </div>
         
         {lastUpdated && (
-          <Group justify="flex-end" mt="xs">
-            <Text size="xs" c="dimmed">
+          <div className="flex justify-end mt-2">
+            <span className="text-xs text-gray-500">
               Last updated: {new Date(lastUpdated).toLocaleString()}
-            </Text>
-          </Group>
+            </span>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/server/src/components/assets/panels/HardwareSpecsPanel.tsx
+++ b/server/src/components/assets/panels/HardwareSpecsPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from 'server/src/components/ui/Card';
-import { Stack, Text, Group } from '@mantine/core';
 import { RmmCachedData, Asset } from '../../../interfaces/asset.interfaces';
 import { UtilizationBar } from '../shared/UtilizationBar';
 
@@ -26,7 +25,7 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
           <CardTitle>Hardware Specifications</CardTitle>
         </CardHeader>
         <CardContent>
-          <Text c="dimmed" ta="center" py="xl">No hardware data available</Text>
+          <p className="text-gray-400 text-center py-8">No hardware data available</p>
         </CardContent>
       </Card>
     );
@@ -40,14 +39,14 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
         <CardTitle>Hardware Specifications</CardTitle>
       </CardHeader>
       <CardContent>
-        <Stack gap="sm">
+        <div className="flex flex-col gap-4">
           {/* CPU */}
           <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-            <Text size="sm" fw={700} className="w-12 shrink-0">CPU:</Text>
+            <span className="text-sm font-bold text-gray-700 w-12 shrink-0">CPU:</span>
             <div className="flex-1 flex flex-col sm:flex-row sm:items-center gap-2">
-               <Text size="sm" className="min-w-[120px]">{cpuModel}</Text>
+               <span className="text-sm text-gray-900 min-w-[120px]">{cpuModel}</span>
                <div className="flex items-center gap-2 flex-1">
-                 <Text size="sm" c="dimmed">Utilization:</Text>
+                 <span className="text-sm text-gray-500">Utilization:</span>
                  <div className="w-32">
                    <UtilizationBar 
                      value={data.cpu_utilization_percent} 
@@ -55,20 +54,20 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                      size="sm"
                    />
                  </div>
-                 <Text size="sm">{data.cpu_utilization_percent}%</Text>
+                 <span className="text-sm text-gray-900">{data.cpu_utilization_percent}%</span>
                </div>
             </div>
           </div>
 
           {/* Memory */}
           <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-            <Text size="sm" fw={700} className="w-12 shrink-0">RAM:</Text>
+            <span className="text-sm font-bold text-gray-700 w-12 shrink-0">RAM:</span>
             <div className="flex-1 flex flex-col sm:flex-row sm:items-center gap-2">
-               <Text size="sm" className="min-w-[120px]">
+               <span className="text-sm text-gray-900 min-w-[120px]">
                  {data.memory_total_gb ? `${data.memory_total_gb}GB Unified Memory` : 'Unknown'}
-               </Text>
+               </span>
                <div className="flex items-center gap-2 flex-1">
-                 <Text size="sm" c="dimmed">Utilization:</Text>
+                 <span className="text-sm text-gray-500">Utilization:</span>
                  <div className="w-32">
                    <UtilizationBar 
                      value={data.memory_utilization_percent} 
@@ -76,10 +75,10 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                      size="sm"
                    />
                  </div>
-                 <Text size="sm">
+                 <span className="text-sm text-gray-900">
                    {data.memory_utilization_percent}% 
                    {data.memory_used_gb ? ` (${data.memory_used_gb.toFixed(1)}GB Used)` : ''}
-                 </Text>
+                 </span>
                </div>
             </div>
           </div>
@@ -88,9 +87,9 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
           <div>
              {data.storage.map((drive, index) => (
               <div key={index} className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2 last:mb-0">
-                 <Text size="sm" fw={700} className="w-16 shrink-0">Storage:</Text>
+                 <span className="text-sm font-bold text-gray-700 w-16 shrink-0">Storage:</span>
                  <div className="flex-1 flex flex-col sm:flex-row sm:items-center gap-2">
-                   <Text size="sm" className="min-w-[120px]">{drive.name}</Text>
+                   <span className="text-sm text-gray-900 min-w-[120px]">{drive.name}</span>
                    <div className="flex items-center gap-2 flex-1">
                      <div className="w-32">
                        <UtilizationBar 
@@ -99,18 +98,18 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                          size="sm"
                        />
                      </div>
-                     <Text size="sm">
+                     <span className="text-sm text-gray-900">
                        {drive.free_gb.toFixed(1)} GB Free
-                     </Text>
+                     </span>
                    </div>
                  </div>
               </div>
              ))}
              {data.storage.length === 0 && (
-               <Text size="sm" c="dimmed">No storage drives detected</Text>
+               <p className="text-sm text-gray-500">No storage drives detected</p>
              )}
           </div>
-        </Stack>
+        </div>
       </CardContent>
     </Card>
   );

--- a/server/src/components/assets/panels/RmmVitalsPanel.tsx
+++ b/server/src/components/assets/panels/RmmVitalsPanel.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from 'server/src/components/ui/Card';
-import { Group, Text, Stack, Button } from '@mantine/core';
+import { Button } from 'server/src/components/ui/Button';
 import { RefreshCw, WifiOff } from 'lucide-react';
 import Spinner from 'server/src/components/ui/Spinner';
 import { RmmCachedData } from '../../../interfaces/asset.interfaces';
 import { StatusBadge } from '../shared/StatusBadge';
 import { formatRelativeDateTime } from '../../../lib/utils/dateTimeUtils';
+import { cn } from 'server/src/lib/utils';
 
 interface RmmVitalsPanelProps {
   data: RmmCachedData | null | undefined;
@@ -15,12 +16,12 @@ interface RmmVitalsPanelProps {
 }
 
 const VitalRow = ({ label, value }: { label: string, value: React.ReactNode }) => (
-  <Group gap="xs" align="flex-start" className="min-h-[24px]">
-    <Text size="sm" fw={700} className="w-32 shrink-0">{label}:</Text>
+  <div className="flex items-start gap-2 min-h-[24px]">
+    <span className="text-sm font-bold text-gray-700 w-32 shrink-0">{label}:</span>
     <div className="flex-1">
-      {typeof value === 'string' ? <Text size="sm">{value}</Text> : value}
+      {typeof value === 'string' ? <span className="text-sm text-gray-900">{value}</span> : value}
     </div>
-  </Group>
+  </div>
 );
 
 export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
@@ -50,7 +51,7 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
         <CardContent>
           <div className="flex flex-col items-center justify-center h-48 text-gray-400">
             <WifiOff size={48} className="mb-2" />
-            <Text>Not connected to RMM</Text>
+            <span className="text-sm">Not connected to RMM</span>
           </div>
         </CardContent>
       </Card>
@@ -64,29 +65,30 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
           <CardTitle>RMM Vitals & Connectivity</CardTitle>
           <Button 
             id="refresh-rmm-vitals-btn"
-            variant="subtle" 
-            size="xs" 
-            leftSection={isRefreshing ? <Spinner size="sm" className="scale-75" /> : <RefreshCw size={12} />}
+            variant="ghost" 
+            size="sm" 
+            className="h-8 gap-2 text-primary-600 hover:text-primary-700 hover:bg-primary-50"
             onClick={onRefresh}
             disabled={isRefreshing}
           >
+            {isRefreshing ? <Spinner size="sm" className="h-3 w-3" /> : <RefreshCw size={14} />}
             Refresh
           </Button>
         </div>
       </CardHeader>
       <CardContent>
-        <Stack gap="xs">
+        <div className="flex flex-col gap-2">
           <VitalRow 
             label="Agent Status" 
             value={
-              <Group gap="xs">
-                <Text size="sm">{data.agent_status === 'online' ? 'Online' : 'Offline'}</Text>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-gray-900">{data.agent_status === 'online' ? 'Online' : 'Offline'}</span>
                 {data.last_check_in && (
-                  <Text size="sm" c="dimmed">
+                  <span className="text-sm text-gray-500">
                     (Last check-in: {formatRelativeDateTime(new Date(data.last_check_in), Intl.DateTimeFormat().resolvedOptions().timeZone)})
-                  </Text>
+                  </span>
                 )}
-              </Group>
+              </div>
             } 
           />
 
@@ -106,7 +108,7 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
             label="Network" 
             value={`LAN IP: ${data.lan_ip || 'N/A'}  |  WAN IP: ${data.wan_ip || 'N/A'}`} 
           />
-        </Stack>
+        </div>
       </CardContent>
     </Card>
   );

--- a/server/src/components/assets/panels/SecurityPatchingPanel.tsx
+++ b/server/src/components/assets/panels/SecurityPatchingPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from 'server/src/components/ui/Card';
-import { Stack, Group, Text } from '@mantine/core';
 import { AssetSummaryMetrics, Asset } from '../../../interfaces/asset.interfaces';
 
 interface SecurityPatchingPanelProps {
@@ -10,12 +9,12 @@ interface SecurityPatchingPanelProps {
 }
 
 const SecurityRow = ({ label, value }: { label: string, value: React.ReactNode }) => (
-  <Group gap="xs" align="flex-start" className="min-h-[24px]">
-    <Text size="sm" fw={700} className="w-32 shrink-0">{label}:</Text>
+  <div className="flex items-start gap-2 min-h-[24px]">
+    <span className="text-sm font-bold text-gray-700 w-32 shrink-0">{label}:</span>
     <div className="flex-1">
-      {typeof value === 'string' ? <Text size="sm">{value}</Text> : value}
+      {typeof value === 'string' ? <span className="text-sm text-gray-900">{value}</span> : value}
     </div>
-  </Group>
+  </div>
 );
 
 export const SecurityPatchingPanel: React.FC<SecurityPatchingPanelProps> = ({
@@ -40,7 +39,7 @@ export const SecurityPatchingPanel: React.FC<SecurityPatchingPanelProps> = ({
         <CardTitle>Security & Patching</CardTitle>
       </CardHeader>
       <CardContent>
-        <Stack gap="xs">
+        <div className="flex flex-col gap-2">
           <SecurityRow 
             label="OS Version" 
             value={osVersion} 
@@ -49,13 +48,13 @@ export const SecurityPatchingPanel: React.FC<SecurityPatchingPanelProps> = ({
           <SecurityRow 
             label="Antivirus" 
             value={
-              <Group gap="xs">
-                <Text size="sm">{antivirusProduct}</Text>
-                <Text size="sm" c={isAvActive ? 'green' : 'red'} fw={600}>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm text-gray-900">{antivirusProduct}</span>
+                <span className={`text-sm font-semibold ${isAvActive ? 'text-emerald-600' : 'text-red-600'}`}>
                   [{isAvActive ? '✔ Installed & Running' : 'Inactive'}]
-                </Text>
-                <Text size="sm" c="dimmed">| Last Scan: Today, 3:00 AM</Text>
-              </Group>
+                </span>
+                <span className="text-sm text-gray-400">| Last Scan: Today, 3:00 AM</span>
+              </div>
             } 
           />
 
@@ -63,14 +62,14 @@ export const SecurityPatchingPanel: React.FC<SecurityPatchingPanelProps> = ({
             label="Patch Status" 
             value={
               metrics?.security_issues && metrics.security_issues.length > 0 ? (
-                <Group gap="xs">
-                   <Text size="sm" c={metrics.security_status === 'critical' ? 'red' : 'yellow'} fw={600}>
+                <div className="flex flex-wrap items-center gap-2">
+                   <span className={`text-sm font-semibold ${metrics.security_status === 'critical' ? 'text-red-600' : 'text-amber-600'}`}>
                      [{metrics.security_status === 'critical' ? 'Critical' : 'At Risk'}]
-                   </Text>
-                   <Text size="sm">- {metrics.security_issues.length} Critical OS Patches missing.</Text>
-                </Group>
+                   </span>
+                   <span className="text-sm text-gray-700">- {metrics.security_issues.length} Critical OS Patches missing.</span>
+                </div>
               ) : (
-                <Text size="sm" c="green" fw={600}>[✔ Up to Date]</Text>
+                <span className="text-sm text-emerald-600 font-semibold">[✔ Up to Date]</span>
               )
             } 
           />
@@ -78,10 +77,10 @@ export const SecurityPatchingPanel: React.FC<SecurityPatchingPanelProps> = ({
           <SecurityRow 
             label="Firewall" 
             value={
-              <Text size="sm" c="green" fw={600}>[✔ On]</Text>
+              <span className="text-sm text-emerald-600 font-semibold">[✔ On]</span>
             } 
           />
-        </Stack>
+        </div>
       </CardContent>
     </Card>
   );

--- a/server/src/components/assets/shared/CopyableField.tsx
+++ b/server/src/components/assets/shared/CopyableField.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
-import { Text, Group, ActionIcon, CopyButton, Tooltip } from '@mantine/core';
+import React, { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
+import { Button } from 'server/src/components/ui/Button';
+import { Tooltip } from 'server/src/components/ui/Tooltip';
+import { cn } from 'server/src/lib/utils';
 
 interface CopyableFieldProps {
   label: string;
@@ -15,34 +17,52 @@ export const CopyableField: React.FC<CopyableFieldProps> = ({
   showCopyButton = true,
   truncate = false,
 }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    if (value) {
+      navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   if (!value) {
     return (
-      <div>
-        <Text size="xs" c="dimmed">{label}</Text>
-        <Text size="sm" c="dimmed">N/A</Text>
+      <div className="flex flex-col">
+        <span className="text-xs text-gray-500">{label}</span>
+        <span className="text-sm text-gray-400">N/A</span>
       </div>
     );
   }
 
   return (
-    <div>
-      <Text size="xs" c="dimmed">{label}</Text>
-      <Group gap="xs">
-        <Text size="sm" truncate={truncate ? 'end' : undefined} style={{ maxWidth: truncate ? '150px' : undefined }}>
+    <div className="flex flex-col">
+      <span className="text-xs text-gray-500">{label}</span>
+      <div className="flex items-center gap-1.5 min-h-[20px]">
+        <span className={cn(
+          "text-sm text-gray-900",
+          truncate && "truncate max-w-[150px]"
+        )}>
           {value}
-        </Text>
+        </span>
         {showCopyButton && (
-          <CopyButton value={value} timeout={2000}>
-            {({ copied, copy }) => (
-              <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
-                <ActionIcon color={copied ? 'teal' : 'gray'} variant="subtle" onClick={copy} size="xs">
-                  {copied ? <Check size={12} /> : <Copy size={12} />}
-                </ActionIcon>
-              </Tooltip>
-            )}
-          </CopyButton>
+          <Tooltip content={copied ? 'Copied' : 'Copy'}>
+            <Button
+              id={`copy-${label.toLowerCase().replace(/\s+/g, '-')}`}
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-5 w-5 p-0",
+                copied ? "text-emerald-500" : "text-gray-400 hover:text-gray-600"
+              )}
+              onClick={handleCopy}
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />}
+            </Button>
+          </Tooltip>
         )}
-      </Group>
+      </div>
     </div>
   );
 };

--- a/server/src/components/assets/shared/StatusBadge.tsx
+++ b/server/src/components/assets/shared/StatusBadge.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Badge, Tooltip } from '@mantine/core';
+import { Badge } from 'server/src/components/ui/Badge';
+import { Tooltip } from 'server/src/components/ui/Tooltip';
+import { cn } from 'server/src/lib/utils';
 import { 
   Check, 
   AlertTriangle, 
@@ -24,18 +26,18 @@ const getStatusConfig = (status: StatusBadgeStatus) => {
     case 'healthy':
     case 'secure':
     case 'active':
-      return { color: 'green', icon: Check, label: 'Healthy' };
+      return { variant: 'success' as const, icon: Check, label: 'Healthy', colorClass: 'bg-emerald-100 text-emerald-700 border-emerald-200' };
     case 'warning':
     case 'at_risk':
     case 'expiring_soon':
-      return { color: 'yellow', icon: AlertTriangle, label: 'Warning' };
+      return { variant: 'warning' as const, icon: AlertTriangle, label: 'Warning', colorClass: 'bg-amber-100 text-amber-700 border-amber-200' };
     case 'critical':
     case 'expired':
     case 'offline':
-      return { color: 'red', icon: X, label: 'Critical' };
+      return { variant: 'error' as const, icon: X, label: 'Critical', colorClass: 'bg-red-100 text-red-700 border-red-200' };
     case 'unknown':
     default:
-      return { color: 'gray', icon: HelpCircle, label: 'Unknown' };
+      return { variant: 'default' as const, icon: HelpCircle, label: 'Unknown', colorClass: 'bg-gray-100 text-gray-700 border-gray-200' };
   }
 };
 
@@ -70,19 +72,22 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
 
   const content = (
     <Badge 
-      color={config.color} 
-      size={size} 
-      variant="light"
-      className={className}
-      leftSection={showIcon && <Icon size={12} />}
+      className={cn(
+        'gap-1.5 py-1 px-3',
+        config.colorClass,
+        size === 'sm' && 'text-[10px] px-2 py-0.5',
+        size === 'lg' && 'text-sm px-4 py-1.5',
+        className
+      )}
     >
+      {showIcon && <Icon size={size === 'sm' ? 10 : size === 'lg' ? 14 : 12} />}
       {provider ? `${label} - ${provider}` : label}
     </Badge>
   );
 
   if (tooltip) {
     return (
-      <Tooltip label={tooltip}>
+      <Tooltip content={tooltip}>
         {content}
       </Tooltip>
     );

--- a/server/src/components/assets/shared/UtilizationBar.tsx
+++ b/server/src/components/assets/shared/UtilizationBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Progress, Text, Group, Tooltip } from '@mantine/core';
+import { Progress } from 'server/src/components/ui/Progress';
+import { Tooltip } from 'server/src/components/ui/Tooltip';
+import { cn } from 'server/src/lib/utils';
 
 interface UtilizationBarProps {
   value: number | null; // 0-100
@@ -19,38 +21,46 @@ export const UtilizationBar: React.FC<UtilizationBarProps> = ({
   size = 'md',
 }) => {
   if (value === null || value === undefined) {
-    return <Text size="sm" c="dimmed">N/A</Text>;
+    return <span className="text-sm text-gray-400">N/A</span>;
   }
 
-  let color = 'green';
+  let indicatorColor = 'bg-emerald-500';
   if (value >= colorThresholds.critical) {
-    color = 'red';
+    indicatorColor = 'bg-red-500';
   } else if (value >= colorThresholds.warning) {
-    color = 'yellow';
+    indicatorColor = 'bg-amber-500';
   }
+
+  const sizeClasses = {
+    xs: 'h-1',
+    sm: 'h-1.5',
+    md: 'h-2',
+    lg: 'h-3',
+    xl: 'h-4',
+  };
 
   const content = (
-    <div style={{ width: '100%' }}>
+    <div className="w-full">
       {showLabel && (
-        <Group justify="space-between" mb={4}>
-          <Text size="xs" c="dimmed">{label}</Text>
-          <Text size="xs" fw={500}>{Math.round(value)}%</Text>
-        </Group>
+        <div className="flex justify-between items-center mb-1">
+          <span className="text-xs text-gray-500">{label}</span>
+          <span className="text-xs font-medium text-gray-700">{Math.round(value)}%</span>
+        </div>
       )}
       <Progress 
         value={value} 
-        color={color} 
-        size={size} 
-        radius="xl" 
-        striped={value > 90}
-        animated={value > 90}
+        className={cn(sizeClasses[size])}
+        indicatorClassName={cn(
+          indicatorColor,
+          value > 90 && 'animate-pulse'
+        )}
       />
     </div>
   );
 
   if (tooltip) {
     return (
-      <Tooltip label={tooltip}>
+      <Tooltip content={tooltip}>
         {content}
       </Tooltip>
     );

--- a/server/src/components/assets/tabs/AuditLogTab.tsx
+++ b/server/src/components/assets/tabs/AuditLogTab.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import useSWR from 'swr';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
-import { Text, Timeline } from '@mantine/core';
 import { getAssetHistory } from '../../../lib/actions/asset-actions/assetActions';
 import { formatDateTime } from '../../../lib/utils/dateTimeUtils';
 
@@ -25,26 +24,27 @@ export const AuditLogTab: React.FC<AuditLogTabProps> = ({ assetId }) => {
         <CardTitle>Audit Log</CardTitle>
       </CardHeader>
       <CardContent>
-        <Timeline active={-1} bulletSize={12} lineWidth={2}>
+        <div className="space-y-6 relative before:absolute before:inset-0 before:left-2 before:h-full before:w-0.5 before:bg-gray-100">
           {history && history.map((record, index) => (
-            <Timeline.Item 
-              key={index} 
-              title={record.change_type.charAt(0).toUpperCase() + record.change_type.slice(1)}
-              bullet={<div className="w-2 h-2 rounded-full bg-gray-400" />}
-            >
-              <Text c="dimmed" size="sm">
-                Changed by user {record.changed_by}
-              </Text>
-              <Text size="xs" mt={4}>
-                {formatDateTime(new Date(record.changed_at), Intl.DateTimeFormat().resolvedOptions().timeZone)}
-              </Text>
-              {/* We could expand 'changes' JSON here if needed */}
-            </Timeline.Item>
+            <div key={index} className="relative pl-8">
+              <div className="absolute left-0 top-1 w-4 h-4 rounded-full border-2 border-white bg-gray-400 shadow-sm" />
+              <div className="flex flex-col">
+                <h4 className="text-sm font-semibold text-gray-900">
+                  {record.change_type.charAt(0).toUpperCase() + record.change_type.slice(1)}
+                </h4>
+                <p className="text-sm text-gray-500">
+                  Changed by user {record.changed_by}
+                </p>
+                <p className="text-xs text-gray-400 mt-1">
+                  {formatDateTime(new Date(record.changed_at), Intl.DateTimeFormat().resolvedOptions().timeZone)}
+                </p>
+              </div>
+            </div>
           ))}
           {(!history || history.length === 0) && (
-            <Text c="dimmed" ta="center">No audit history available.</Text>
+            <p className="text-sm text-gray-400 text-center py-4">No audit history available.</p>
           )}
-        </Timeline>
+        </div>
       </CardContent>
     </Card>
   );

--- a/server/src/components/assets/tabs/DocumentsPasswordsTab.tsx
+++ b/server/src/components/assets/tabs/DocumentsPasswordsTab.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import AssetDocuments from '../AssetDocuments';
 import { Asset } from '../../../interfaces/asset.interfaces';
-import { Card } from 'server/src/components/ui/Card';
-import { Text, Tabs } from '@mantine/core';
+import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 
 interface DocumentsPasswordsTabProps {
   asset: Asset;
@@ -17,10 +16,15 @@ export const DocumentsPasswordsTab: React.FC<DocumentsPasswordsTabProps> = ({ as
       />
       
       {/* Passwords Section Placeholder - could be a separate component later */}
-      <Card title="Passwords & Secrets">
-         <div className="text-center py-8 text-gray-500">
-           <Text c="dimmed">Secure password management coming soon.</Text>
-         </div>
+      <Card>
+         <CardHeader>
+           <CardTitle>Passwords & Secrets</CardTitle>
+         </CardHeader>
+         <CardContent>
+           <div className="text-center py-8">
+             <p className="text-gray-500">Secure password management coming soon.</p>
+           </div>
+         </CardContent>
       </Card>
     </div>
   );

--- a/server/src/components/assets/tabs/MaintenanceSchedulesTab.tsx
+++ b/server/src/components/assets/tabs/MaintenanceSchedulesTab.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import useSWR from 'swr';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/Table';
-import { Button, Group, Text, Stack } from '@mantine/core';
+import { Button } from '../../ui/Button';
 import { CalendarPlus } from 'lucide-react';
 import { getAssetMaintenanceReport } from '../../../lib/actions/asset-actions/assetActions';
 import { formatDateTime } from '../../../lib/utils/dateTimeUtils';
+import { cn } from 'server/src/lib/utils';
 
 interface MaintenanceSchedulesTabProps {
   assetId: string;
@@ -22,32 +23,36 @@ export const MaintenanceSchedulesTab: React.FC<MaintenanceSchedulesTabProps> = (
   }
   
   return (
-    <Stack gap="md">
-       <Group grow>
-          <Card className="p-6">
-            <Stack gap="xs">
-              <Text size="xs" c="dimmed" tt="uppercase" fw={700}>Compliance Rate</Text>
-              <Text size="xl" fw={700} c={report?.compliance_rate && report.compliance_rate >= 90 ? 'green' : 'orange'}>
+    <div className="flex flex-col gap-6">
+       <div className="flex flex-col sm:flex-row gap-4">
+          <Card className="p-6 flex-1">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-gray-400 uppercase font-bold tracking-wider">Compliance Rate</span>
+              <span className={cn(
+                "text-2xl font-bold",
+                report?.compliance_rate && report.compliance_rate >= 90 ? 'text-emerald-600' : 'text-amber-600'
+              )}>
                 {report?.compliance_rate?.toFixed(1) || 100}%
-              </Text>
-            </Stack>
+              </span>
+            </div>
           </Card>
-          <Card className="p-6">
-            <Stack gap="xs">
-              <Text size="xs" c="dimmed" tt="uppercase" fw={700}>Next Maintenance</Text>
-              <Text size="lg" fw={500}>
+          <Card className="p-6 flex-1">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-gray-400 uppercase font-bold tracking-wider">Next Maintenance</span>
+              <span className="text-xl font-medium text-gray-900">
                 {report?.next_maintenance 
                   ? formatDateTime(new Date(report.next_maintenance), Intl.DateTimeFormat().resolvedOptions().timeZone)
                   : 'None Scheduled'}
-              </Text>
-            </Stack>
+              </span>
+            </div>
           </Card>
-       </Group>
+       </div>
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <CardTitle className="text-base font-semibold">Maintenance History</CardTitle>
-          <Button id="schedule-maintenance-btn" leftSection={<CalendarPlus size={16} />} size="xs">
+          <Button id="schedule-maintenance-btn" size="xs" className="flex items-center gap-2">
+            <CalendarPlus size={16} />
             Schedule Maintenance
           </Button>
         </CardHeader>
@@ -65,16 +70,16 @@ export const MaintenanceSchedulesTab: React.FC<MaintenanceSchedulesTabProps> = (
                 {report?.maintenance_history && report.maintenance_history.length > 0 ? (
                   report.maintenance_history.map((record) => (
                     <TableRow key={record.history_id}>
-                      <TableCell>
+                      <TableCell className="text-gray-900">
                         {formatDateTime(new Date(record.performed_at), Intl.DateTimeFormat().resolvedOptions().timeZone)}
                       </TableCell>
-                      <TableCell>{record.performed_by}</TableCell>
-                      <TableCell className="text-muted-foreground">{record.notes || '-'}</TableCell>
+                      <TableCell className="text-gray-900">{record.performed_by}</TableCell>
+                      <TableCell className="text-gray-500">{record.notes || '-'}</TableCell>
                     </TableRow>
                   ))
                 ) : (
                   <TableRow>
-                    <TableCell colSpan={3} className="h-24 text-center">
+                    <TableCell colSpan={3} className="h-24 text-center text-gray-400">
                       No maintenance history recorded.
                     </TableCell>
                   </TableRow>
@@ -84,6 +89,6 @@ export const MaintenanceSchedulesTab: React.FC<MaintenanceSchedulesTabProps> = (
           </div>
         </CardContent>
       </Card>
-    </Stack>
+    </div>
   );
 };

--- a/server/src/components/assets/tabs/RelatedAssetsTab.tsx
+++ b/server/src/components/assets/tabs/RelatedAssetsTab.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/Table';
 import { Asset } from '../../../interfaces/asset.interfaces';
-import { Text, Badge, Group, Button } from '@mantine/core';
+import { Button } from '../../ui/Button';
+import { Badge } from '../../ui/Badge';
 import { Network, Link as LinkIcon } from 'lucide-react';
 import { formatDateTime } from '../../../lib/utils/dateTimeUtils';
 
@@ -17,7 +18,8 @@ export const RelatedAssetsTab: React.FC<RelatedAssetsTabProps> = ({ asset }) => 
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
         <CardTitle className="text-base font-semibold">Related Assets ({relationships.length})</CardTitle>
-        <Button id="link-asset-btn" variant="outline" size="xs" leftSection={<LinkIcon size={14} />}>
+        <Button id="link-asset-btn" variant="outline" size="xs" className="flex items-center gap-2">
+          <LinkIcon size={14} />
           Link Asset
         </Button>
       </CardHeader>
@@ -37,29 +39,31 @@ export const RelatedAssetsTab: React.FC<RelatedAssetsTabProps> = ({ asset }) => 
                 relationships.map((rel, index) => (
                   <TableRow key={`${rel.child_asset_id}-${index}`}>
                     <TableCell className="font-medium">
-                      <Group gap="xs">
-                        <Network size={16} className="text-muted-foreground" />
-                        {rel.name}
-                      </Group>
+                      <div className="flex items-center gap-2">
+                        <Network size={16} className="text-gray-400" />
+                        <span className="text-gray-900">{rel.name}</span>
+                      </div>
                     </TableCell>
                     <TableCell>
-                      <Badge variant="light" color="blue">{rel.relationship_type}</Badge>
+                      <Badge variant="secondary" className="bg-primary-50 text-primary-700 border-primary-100">
+                        {rel.relationship_type}
+                      </Badge>
                     </TableCell>
-                    <TableCell className="text-muted-foreground">
+                    <TableCell className="text-gray-500">
                       {formatDateTime(new Date(rel.created_at), Intl.DateTimeFormat().resolvedOptions().timeZone)}
                     </TableCell>
                     <TableCell>
-                      <Button id={`unlink-asset-${rel.child_asset_id}-btn`} variant="subtle" size="xs" color="red">Unlink</Button>
+                      <Button id={`unlink-asset-${rel.child_asset_id}-btn`} variant="ghost" size="xs" className="text-red-600 hover:text-red-700 hover:bg-red-50">Unlink</Button>
                     </TableCell>
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={4} className="h-32 text-center text-muted-foreground">
+                  <TableCell colSpan={4} className="h-32 text-center text-gray-500">
                     <div className="flex flex-col items-center gap-2">
                       <Network size={32} className="opacity-20" />
-                      <Text>No related assets linked.</Text>
-                      <Button id="link-asset-empty-state-btn" variant="subtle" size="xs">Link an asset</Button>
+                      <p className="text-sm">No related assets linked.</p>
+                      <Button id="link-asset-empty-state-btn" variant="ghost" size="xs">Link an asset</Button>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/server/src/components/assets/tabs/ServiceHistoryTab.tsx
+++ b/server/src/components/assets/tabs/ServiceHistoryTab.tsx
@@ -2,12 +2,14 @@ import React, { useState } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/Table';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
-import { Badge, Button } from '@mantine/core';
+import { Button } from '../../ui/Button';
+import { Badge } from '../../ui/Badge';
 import { Ticket } from 'lucide-react';
 import { getAssetLinkedTickets } from '../../../lib/actions/asset-actions/assetActions';
 import { formatDateTime } from '../../../lib/utils/dateTimeUtils';
 import { Asset } from '../../../interfaces/asset.interfaces';
 import { QuickAddTicket } from '../../tickets/QuickAddTicket';
+import { cn } from 'server/src/lib/utils';
 
 interface ServiceHistoryTabProps {
   asset: Asset;
@@ -37,10 +39,11 @@ export const ServiceHistoryTab: React.FC<ServiceHistoryTabProps> = ({ asset }) =
           <CardTitle className="text-base font-semibold">Service History</CardTitle>
           <Button 
             id="create-ticket-btn"
-            leftSection={<Ticket size={16} />} 
             size="xs"
             onClick={() => setIsTicketDialogOpen(true)}
+            className="flex items-center gap-2"
           >
+            <Ticket size={16} />
             Create Ticket
           </Button>
         </CardHeader>
@@ -63,21 +66,28 @@ export const ServiceHistoryTab: React.FC<ServiceHistoryTabProps> = ({ asset }) =
                       <TableCell className="font-medium text-primary-600">
                         #{ticket.ticket_id.substring(0, 8)}
                       </TableCell>
-                      <TableCell>{ticket.title}</TableCell>
+                      <TableCell className="text-gray-900">{ticket.title}</TableCell>
                       <TableCell>
-                        <Badge variant="light" color="gray">{ticket.status_name}</Badge>
+                        <Badge variant="secondary" className="bg-gray-100 text-gray-700 border-gray-200">
+                          {ticket.status_name}
+                        </Badge>
                       </TableCell>
                       <TableCell>
-                        {ticket.priority_name && <Badge variant="dot" color="blue">{ticket.priority_name}</Badge>}
+                        {ticket.priority_name && (
+                          <div className="flex items-center gap-1.5">
+                            <div className="w-2 h-2 rounded-full bg-primary-500" />
+                            <span className="text-xs font-medium text-gray-700">{ticket.priority_name}</span>
+                          </div>
+                        )}
                       </TableCell>
-                      <TableCell className="text-muted-foreground">
+                      <TableCell className="text-gray-500">
                         {formatDateTime(new Date(ticket.linked_at), Intl.DateTimeFormat().resolvedOptions().timeZone)}
                       </TableCell>
                     </TableRow>
                   ))
                 ) : (
                   <TableRow>
-                    <TableCell colSpan={5} className="h-24 text-center">
+                    <TableCell colSpan={5} className="h-24 text-center text-gray-400">
                       No tickets linked to this asset.
                     </TableCell>
                   </TableRow>

--- a/server/src/components/assets/tabs/SoftwareInventoryTab.tsx
+++ b/server/src/components/assets/tabs/SoftwareInventoryTab.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/Table';
-import { TextInput, Select, Group } from '@mantine/core';
+import { Input } from 'server/src/components/ui/Input';
+import CustomSelect from 'server/src/components/ui/CustomSelect';
 import { Search } from 'lucide-react';
 import { Asset } from '../../../interfaces/asset.interfaces';
 
@@ -38,21 +39,30 @@ export const SoftwareInventoryTab: React.FC<SoftwareInventoryTabProps> = ({ asse
         <CardTitle>Software Inventory</CardTitle>
       </CardHeader>
       <CardContent>
-        <Group mb="md">
-          <TextInput 
-            placeholder="Search software..." 
-            leftSection={<Search size={16} />}
-            value={search}
-            onChange={(e) => setSearch(e.currentTarget.value)}
-            className="flex-1"
-          />
-          <Select 
+        <div className="flex items-center gap-4 mb-4">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Input 
+              placeholder="Search software..." 
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <CustomSelect 
             placeholder="Category" 
-            data={['All', 'Browser', 'Security', 'Productivity', 'Development']}
-            defaultValue="All"
+            options={[
+              { value: 'All', label: 'All' },
+              { value: 'Browser', label: 'Browser' },
+              { value: 'Security', label: 'Security' },
+              { value: 'Productivity', label: 'Productivity' },
+              { value: 'Development', label: 'Development' }
+            ]}
+            value="All"
+            onValueChange={() => {}}
             className="w-48"
           />
-        </Group>
+        </div>
 
         <div className="overflow-x-auto">
           <Table>
@@ -68,17 +78,17 @@ export const SoftwareInventoryTab: React.FC<SoftwareInventoryTabProps> = ({ asse
               {filteredSoftware.length > 0 ? (
                 filteredSoftware.map((sw) => (
                   <TableRow key={sw.id}>
-                    <TableCell className="font-medium">{sw.name}</TableCell>
-                    <TableCell className="text-muted-foreground">{sw.version}</TableCell>
-                    <TableCell className="text-muted-foreground">{sw.publisher}</TableCell>
-                    <TableCell className="text-muted-foreground">
+                    <TableCell className="font-medium text-gray-900">{sw.name}</TableCell>
+                    <TableCell className="text-gray-500">{sw.version}</TableCell>
+                    <TableCell className="text-gray-500">{sw.publisher}</TableCell>
+                    <TableCell className="text-gray-500">
                       {sw.installDate ? new Date(sw.installDate).toLocaleDateString() : '-'}
                     </TableCell>
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={4} className="h-24 text-center">
+                  <TableCell colSpan={4} className="h-24 text-center text-gray-400">
                     No software found matching your search.
                   </TableCell>
                 </TableRow>

--- a/server/src/components/ui/Progress.tsx
+++ b/server/src/components/ui/Progress.tsx
@@ -6,20 +6,21 @@ interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPr
   value: number;
   max?: number;
   className?: string;
+  indicatorClassName?: string;
 }
 
 const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(
-  ({ value, max = 100, className, ...props }, ref) => {
+  ({ value, max = 100, className, indicatorClassName, ...props }, ref) => {
     const percentage = Math.min((value / max) * 100, 100);
     
     return (
       <ProgressPrimitive.Root
         ref={ref}
-        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-secondary', className)}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-secondary-100 dark:bg-secondary-900', className)}
         {...props}
       >
         <ProgressPrimitive.Indicator
-          className="h-full w-full flex-1 bg-primary transition-all"
+          className={cn('h-full w-full flex-1 bg-primary transition-all', indicatorClassName)}
           style={{ transform: `translateX(-${100 - percentage}%)` }}
         />
       </ProgressPrimitive.Root>


### PR DESCRIPTION
This PR migrates the asset management screens from Mantine to the project's custom UI kit and Tailwind CSS. It also fixes several brand styling inconsistencies and a hydration error in the alerts section.