### PR TITLE
feat(ninjaone): add heartbeat timeout and progress logging to sync activities

### DIFF
--- a/ee/temporal-workflows/src/workflows/ninjaone-sync-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/ninjaone-sync-workflow.ts
@@ -51,6 +51,7 @@ const activities = proxyActivities<{
 }>(
   {
     startToCloseTimeout: '1h',
+    heartbeatTimeout: '2m', // If worker dies, activity will be retried within 2 minutes
     retry: {
       maximumAttempts: 2,
       backoffCoefficient: 2.0,


### PR DESCRIPTION
## Summary
- Add 2-minute `heartbeatTimeout` to NinjaOne sync activity options so activities are retried quickly when a worker dies (instead of waiting the full 1-hour `startToCloseTimeout`)
- Add `heartbeat()` calls after each batch to keep activity alive and report progress
- Add detailed progress logging showing organization and device counts during sync

## Problem
When a Temporal worker pod was killed/restarted mid-sync, the activity would remain stuck in "Started" state for up to 1 hour before being retried on another worker.

## Solution
With the 2-minute heartbeat timeout, if a worker dies, Temporal will notice within 2 minutes and automatically retry the activity on a healthy worker.

## Test plan
- [ ] Deploy to staging and trigger a NinjaOne full sync
- [ ] Verify progress logs appear in worker output
- [ ] Kill the worker mid-sync and verify activity is retried within ~2 minutes