### PR TITLE
Fix tenant template matching to include language_code

### DIFF
--- a/server/src/components/settings/notifications/EmailTemplates.tsx
+++ b/server/src/components/settings/notifications/EmailTemplates.tsx
@@ -211,7 +211,7 @@ export function EmailTemplates() {
   // Group templates by category (filtered by selected languages)
   const templatesByCategory = templates.systemTemplates.reduce((acc, systemTemplate) => {
     const tenantTemplate = templates.tenantTemplates.find(
-      t => t.name === systemTemplate.name
+      t => t.name === systemTemplate.name && t.language_code === systemTemplate.language_code
     );
     const activeTemplate = tenantTemplate || systemTemplate;
 


### PR DESCRIPTION
  The find() was matching tenant templates by name only, causing a single custom template (e.g., English) to match all 6 language variants of the same system template. This resulted in duplicate rows all showing the same language.

  "Curiouser and curiouser!" cried Alice, for the templates had all become English, as if one language_code had eaten six for tea. 🐰🍵📧