### PR TITLE
fix(email): add Mail.Read.Shared scope for Microsoft shared mailbox access

### DIFF
--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -204,7 +204,7 @@ export async function GET(request: NextRequest) {
         code: code,
         grant_type: 'authorization_code',
         redirect_uri: redirectUri,
-        scope: 'https://graph.microsoft.com/Mail.Read offline_access'
+        scope: 'https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.Read.Shared offline_access'
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {

--- a/server/src/utils/email/oauthHelpers.ts
+++ b/server/src/utils/email/oauthHelpers.ts
@@ -16,13 +16,13 @@ export interface OAuthState {
 
 /**
  * Generate OAuth authorization URL for Microsoft
- * Using read-only scope: Mail.Read for email access
+ * Using read-only scopes: Mail.Read for personal mailbox, Mail.Read.Shared for shared mailboxes
  */
 export function generateMicrosoftAuthUrl(
   clientId: string,
   redirectUri: string,
   state: OAuthState,
-  scopes: string[] = ['https://graph.microsoft.com/Mail.Read', 'offline_access'],
+  scopes: string[] = ['https://graph.microsoft.com/Mail.Read', 'https://graph.microsoft.com/Mail.Read.Shared', 'offline_access'],
   tenantAuthority: string = 'common'
 ): string {
   const baseUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize`;


### PR DESCRIPTION
## Summary
- Adds `Mail.Read.Shared` OAuth scope to Microsoft email integration
- Fixes 404 "Inbox not found" error when creating webhook subscriptions for shared mailboxes

## Problem
When connecting a Microsoft shared mailbox, the webhook subscription would fail with:
```
Default folder Inbox not found
```
This occurred because the OAuth token only had `Mail.Read` scope, which grants access to the authenticated user's personal mailbox only.

## Solution
Added `https://graph.microsoft.com/Mail.Read.Shared` scope to both:
- Authorization URL generation (`oauthHelpers.ts`)
- Token exchange (`callback/route.ts`)

## Test plan
- [ ] Re-authenticate a Microsoft shared mailbox connection
- [ ] Verify webhook subscription is created successfully
- [ ] Confirm email notifications work for the shared mailbox