### PR TITLE
Add duration to available-services API response

### DIFF
--- a/server/src/app/api/public/appointment-request/available-services/route.ts
+++ b/server/src/app/api/public/appointment-request/available-services/route.ts
@@ -20,7 +20,8 @@ import logger from '@alga-psa/shared/core/logger';
  *       "service_name": "Initial Consultation",
  *       "service_description": "30-minute consultation",
  *       "service_type": "consultation",
- *       "default_rate": 150.00
+ *       "default_rate": 150.00,
+ *       "duration": 60
  *     }
  *   ]
  * }
@@ -77,7 +78,8 @@ export async function GET(req: NextRequest) {
         service_name: service.service_name,
         service_description: service.service_description,
         service_type: service.service_type,
-        default_rate: service.default_rate
+        default_rate: service.default_rate,
+        duration: service.config_json?.default_duration || null
       }))
     });
 

--- a/server/src/lib/services/availabilityService.ts
+++ b/server/src/lib/services/availabilityService.ts
@@ -702,7 +702,8 @@ export async function getServicesForPublicBooking(
         'sc.service_name',
         'sc.description as service_description',
         'sc.billing_method as service_type',
-        'sc.default_rate'
+        'sc.default_rate',
+        'avs.config_json'
       )
       .distinct();
 


### PR DESCRIPTION
  Include default_duration from availability_settings config_json in the public booking services endpoint response.

  "How long is forever?" asked Alice. "Sometimes just sixty minutes," replied the config_json, checking its default_duration with great importance. 🐰⏱️📋