### PR TITLE
feat(email): Microsoft 365 inbound diagnostics

### DIFF
--- a/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/PRD.md
+++ b/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/PRD.md
@@ -1,0 +1,163 @@
+# PRD — Microsoft 365 Inbound Email Diagnostics
+
+- Slug: `microsoft-365-inbound-email-diagnostics`
+- Date: `2025-12-31`
+- Status: Draft
+
+## Summary
+
+Add a Microsoft 365 (Entra ID + Exchange Online) diagnostics tool inside the Admin email setup UI to help customers self-diagnose OAuth, mailbox access, folder access, and webhook subscription creation issues. The diagnostics should produce an actionable, copy/pasteable “support bundle” with Graph correlation IDs and concrete remediation steps (scopes, mailbox permissions, folder selection).
+
+## Problem
+
+Inbound email for Microsoft 365 relies on:
+
+1. User OAuth consent (delegated permissions)
+2. Selecting a mailbox (user mailbox or shared mailbox)
+3. Resolving a folder to monitor (typically Inbox)
+4. Creating a Microsoft Graph webhook subscription to the folder’s messages
+
+Customers frequently fail at steps 2–4 due to:
+
+- Insufficient OAuth scopes or missing admin consent
+- Lack of delegated access to a shared mailbox/folder
+- Mailbox is not a mailbox (group/contact) or is not provisioned/initialized
+- Folder selection/resolution mismatch (“Inbox not found”, non-English display names, custom folder, etc.)
+
+Today we surface generic errors (e.g. Graph `404 ExtensionError` “Default folder Inbox not found”) without enough context for the customer to resolve the issue independently.
+
+## Goals
+
+- Provide an in-app, Microsoft-only diagnostics workflow that:
+  - Runs deterministic Graph preflight checks.
+  - Classifies failures (401/403/404/429/etc.) with targeted recommendations.
+  - Shows the exact mailbox path decision (`/me` vs `/users/{mailbox}`) and why.
+  - Helps resolve folder issues by enumerating folders and identifying the selected folder.
+  - Produces a redacted “support bundle” including Graph `request-id` / `client-request-id`.
+- Reduce support tickets and time-to-resolution for Microsoft inbound email setup.
+
+## Non-goals
+
+- Build a standalone CLI tool (diagnostics must be in-app first).
+- Add Google/Gmail diagnostics (this plan is Microsoft-only).
+- Replace or redesign the OAuth flow itself (only add observability + diagnostics around it).
+- Persist or display raw access tokens/refresh tokens to end users.
+
+## Users and Primary Flows
+
+### Persona: Tenant Admin setting up inbound email
+
+1. Admin opens Admin → Email Settings → Inbound Email Providers.
+2. Admin selects a Microsoft provider and clicks “Run Microsoft 365 diagnostics”.
+3. The app runs checks and renders results step-by-step:
+   - Green/Yellow/Red status per check
+   - Key facts (tenant id, authorized user, target mailbox, target folder)
+   - Suggested fixes (missing scopes, mailbox permissions, choose different folder, provisioning hints)
+4. Admin copies the “support bundle” and shares it with support if needed.
+
+### Persona: Support engineer assisting customer
+
+1. Customer provides the support bundle.
+2. Support uses Graph request IDs + error classification to quickly identify likely root cause.
+
+## UX / UI Notes
+
+- Entry point: add a “Diagnostics” action for Microsoft providers in the existing admin email provider configuration UI.
+- Output format:
+  - A compact table/list of checks with status, duration, and expandable details.
+  - A single “Copy support bundle” action (JSON and/or text) with redaction applied.
+- Include warnings for actions that may create/renew subscriptions.
+- Keep diagnostics results ephemeral (in-memory response) unless explicitly saved by an admin.
+
+## Requirements
+
+### Functional Requirements
+
+Diagnostics should run a checklist of Microsoft Graph checks using the provider’s stored OAuth tokens and configuration, including:
+
+- Token validity and expiry (preflight)
+- Decoded token claims for customer visibility (scopes, tenant id, delegated vs app)
+- Graph connectivity to `/me`
+- Mailbox base path decision (`/me` vs `/users/{mailbox}`), and validation that the chosen mailbox exists/works
+- Folder reachability:
+  - Prefer Graph well-known folder endpoint (`.../mailFolders/inbox`)
+  - Enumerate available folders if Inbox/folder resolution fails
+  - Determine whether the configured folder is resolvable by id or display name
+- Message read preflight for the exact target resource we intend to subscribe to
+- Error classification with actionable suggestions
+- Correlation identifiers:
+  - Capture Graph `request-id` from response headers/errors
+  - Set and capture `client-request-id` for each request
+
+### Non-functional Requirements
+
+- Safety:
+  - Do not leak secrets (tokens, client secrets) in UI output or support bundle.
+  - Diagnostics must be restricted to authorized admin users.
+- Performance:
+  - End-to-end diagnostics should complete in ~10–20 seconds in normal conditions.
+  - Concurrency limits to prevent a tenant from triggering excessive Graph calls.
+- Reliability:
+  - Each step should fail independently and record its own error context.
+- Compatibility:
+  - Must support both personal mailbox (`/me`) and shared/delegated mailbox (`/users/{mailbox}`).
+
+## Data / API / Integrations
+
+### New server-side entrypoint
+
+Add a server action (or admin API route) like:
+
+- `runMicrosoft365Diagnostics(providerId: string, options?: DiagnosticsOptions): Promise<DiagnosticsReport>`
+
+Where `DiagnosticsReport` includes:
+
+- `summary` (overall status + key facts)
+- `steps[]` (ordered checks; each with status, timing, sanitized request/response metadata)
+- `recommendations[]` (deduplicated)
+- `supportBundle` (redacted JSON payload)
+
+### Adapter integration
+
+Implement Microsoft-specific diagnostic helpers close to existing Graph logic:
+
+- Add a diagnostics method to `shared/services/email/providers/MicrosoftGraphAdapter.ts` that:
+  - Reuses the existing authenticated HTTP client (including token refresh).
+  - Emits structured diagnostic step results.
+  - Adds `client-request-id` on every Graph request for correlation.
+
+## Security / Permissions
+
+- Diagnostics UI only visible to tenant admins (same access level as provider setup).
+- Redaction rules:
+  - Access/refresh tokens: never shown; optionally show fingerprint (first 4 + length).
+  - Client secrets: never shown.
+  - Email addresses: show fully to the tenant admin (tenant-owned), but redact in the exported “support bundle” unless the admin explicitly opts in.
+- Avoid storing diagnostics results in DB by default.
+
+## Observability
+
+- For each diagnostic step log structured events including:
+  - provider id, tenant id, mailbox, folder, step id, duration, outcome
+  - Graph `request-id` / `client-request-id`
+  - Sanitized error code/status/message
+- Ensure the UI can display the Graph `request-id` prominently when failures occur.
+
+## Rollout / Migration
+
+- Feature-gated behind “Microsoft 365 Diagnostics” flag (tenant-level or global) if available; otherwise ship as admin-only UI.
+- No DB migrations required unless we later choose to persist diagnostics runs.
+
+## Open Questions
+
+1. Should the diagnostics include an optional “subscription create/delete” live test, or remain read-only (preflight GETs only)?
+2. Should the exported support bundle include mailbox address by default, or redact unless “Include identifiers” is toggled?
+3. What exact OAuth scopes do we currently request for Microsoft inbound email, and do we want diagnostics to assert a minimum set?
+4. Do we support national cloud endpoints (GCC/DoD), or only `graph.microsoft.com` public cloud?
+
+## Acceptance Criteria (Definition of Done)
+
+- Admins can run Microsoft 365 diagnostics for a configured Microsoft inbound email provider from the UI.
+- Diagnostics provide clear pass/fail results for mailbox + folder reachability and token/scope visibility.
+- Known failure modes (401/403/404 Inbox not found/429) produce targeted recommendations.
+- A “support bundle” can be copied/exported and includes Graph correlation IDs while redacting secrets.

--- a/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/features.json
+++ b/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/features.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": "F001",
+    "description": "Add a Microsoft-only “Run Diagnostics” action in the admin inbound email provider UI.",
+    "implemented": true,
+    "prdRefs": ["PRD#Users and Primary Flows", "PRD#UX / UI Notes"]
+  },
+  {
+    "id": "F002",
+    "description": "Render diagnostics as an ordered checklist with per-step status (pass/warn/fail), duration, and expandable details.",
+    "implemented": true,
+    "prdRefs": ["PRD#UX / UI Notes", "PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F003",
+    "description": "Provide a “Copy support bundle” export (text + JSON) with redaction applied.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements", "PRD#Security / Permissions"]
+  },
+  {
+    "id": "F004",
+    "description": "Add an admin-only server entrypoint `runMicrosoft365Diagnostics(providerId, options)` returning a structured report.",
+    "implemented": true,
+    "prdRefs": ["PRD#Data / API / Integrations"]
+  },
+  {
+    "id": "F005",
+    "description": "Define a stable `DiagnosticsReport` + `DiagnosticsStepResult` schema for Microsoft diagnostics responses.",
+    "implemented": true,
+    "prdRefs": ["PRD#Data / API / Integrations"]
+  },
+  {
+    "id": "F006",
+    "description": "Gate diagnostics execution and visibility to tenant admins (or equivalent privileged role).",
+    "implemented": true,
+    "prdRefs": ["PRD#Security / Permissions"]
+  },
+  {
+    "id": "F007",
+    "description": "Implement redaction helpers for secrets and identifiers (tokens, client secrets; optional email redaction for exports).",
+    "implemented": false,
+    "prdRefs": ["PRD#Security / Permissions"]
+  },
+  {
+    "id": "F008",
+    "description": "Add a diagnostics runner method to `shared/services/email/providers/MicrosoftGraphAdapter.ts` that reuses existing auth + Graph client.",
+    "implemented": true,
+    "prdRefs": ["PRD#Adapter integration"]
+  },
+  {
+    "id": "F009",
+    "description": "Ensure each diagnostic Graph request includes a `client-request-id` and capture the Graph `request-id` from headers/errors.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements", "PRD#Observability"]
+  },
+  {
+    "id": "F010",
+    "description": "Diagnostics step: validate stored OAuth tokens exist and report token expiry state (valid/expired/unknown) without exposing tokens.",
+    "implemented": false,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F011",
+    "description": "Diagnostics step: decode access token claims and display key fields (tenant id, delegated scopes, audience, issuer, subject) in a sanitized form.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements", "PRD#Security / Permissions"]
+  },
+  {
+    "id": "F012",
+    "description": "Diagnostics step: call `GET /me` and report the authenticated user principal (used for `/me` vs `/users/{mailbox}` decision).",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F013",
+    "description": "Diagnostics step: compute and display mailbox base path decision (`/me` vs `/users/{mailbox}`) and the rationale.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F014",
+    "description": "Diagnostics step: validate mailbox directory object existence (e.g., `GET /users/{mailbox}`) and classify failures (404 vs 403).",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F015",
+    "description": "Diagnostics step: validate mailbox store/folder access using the well-known Inbox endpoint (`.../mailFolders/inbox`) before any subscription attempt.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F016",
+    "description": "Diagnostics step: enumerate top-level mail folders (`.../mailFolders?$select=id,displayName&$top=N`) when Inbox or configured folder access fails.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F017",
+    "description": "Diagnostics step: attempt to resolve the configured folder to a concrete folder id (match by well-known name and/or displayName).",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F018",
+    "description": "Diagnostics step: preflight the exact target messages resource with a read-only call (e.g., `.../messages?$top=1`) to predict subscription success.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F019",
+    "description": "Add error classification and recommendation mapping for common Graph failures (401/invalid_grant, 403, 404 mailbox, 404 Inbox/store, 429 throttling).",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F020",
+    "description": "Surface tailored remediation steps in the UI (missing scopes, admin consent required, shared mailbox delegation, folder selection guidance, provisioning hints).",
+    "implemented": true,
+    "prdRefs": ["PRD#Problem", "PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F021",
+    "description": "Add a concurrency/rate limit guard so diagnostics runs are serialized per provider and capped per tenant.",
+    "implemented": false,
+    "prdRefs": ["PRD#Requirements/Non-functional Requirements"]
+  },
+  {
+    "id": "F022",
+    "description": "Record structured logs for each step outcome (including correlation IDs) and ensure the UI displays Graph `request-id` on failures.",
+    "implemented": false,
+    "prdRefs": ["PRD#Observability"]
+  },
+  {
+    "id": "F023",
+    "description": "Expose an optional export toggle to include or redact mailbox identifiers in the support bundle.",
+    "implemented": false,
+    "prdRefs": ["PRD#Security / Permissions", "PRD#Open Questions"]
+  },
+  {
+    "id": "F024",
+    "description": "Add a read-only “/me baseline” check to distinguish ‘Graph works for me’ from ‘shared mailbox access fails’ when applicable.",
+    "implemented": true,
+    "prdRefs": ["PRD#Problem", "PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F025",
+    "description": "Add UI affordance to copy the exact mailbox + folder + resource string the system is trying to subscribe to.",
+    "implemented": false,
+    "prdRefs": ["PRD#UX / UI Notes", "PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F026",
+    "description": "Add an advanced, explicitly-confirmed ‘live subscription test’ option (create and immediately delete a short-lived subscription) if approved.",
+    "implemented": false,
+    "prdRefs": ["PRD#Open Questions", "PRD#Requirements/Functional Requirements"]
+  },
+  {
+    "id": "F027",
+    "description": "Ensure diagnostics output clearly indicates which provider config values were used (mailbox, folder, notification URL), with secrets redacted.",
+    "implemented": true,
+    "prdRefs": ["PRD#Requirements/Functional Requirements", "PRD#Security / Permissions"]
+  },
+  {
+    "id": "F028",
+    "description": "Add a short help panel linking to Microsoft 365 prerequisites (mailbox type, shared mailbox permissions, admin consent) and common fixes.",
+    "implemented": false,
+    "prdRefs": ["PRD#Problem", "PRD#UX / UI Notes"]
+  }
+]

--- a/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/tests.json
+++ b/docs/plans/2025-12-31-microsoft-365-inbound-email-diagnostics/tests.json
@@ -1,0 +1,72 @@
+[
+  { "id": "T001", "description": "Unit: `DiagnosticsReport` schema includes required fields (summary, steps, recommendations, supportBundle).", "implemented": false, "featureIds": ["F005"] },
+  { "id": "T002", "description": "Unit: diagnostics runner returns ordered steps with stable step ids.", "implemented": false, "featureIds": ["F005", "F008"] },
+  { "id": "T003", "description": "Unit: redaction hides access token content and only exposes fingerprint/length.", "implemented": false, "featureIds": ["F007", "F003"] },
+  { "id": "T004", "description": "Unit: redaction hides client secret values in all outputs and exports.", "implemented": false, "featureIds": ["F007", "F003"] },
+  { "id": "T005", "description": "Unit: support bundle export redacts mailbox identifiers by default (configurable via option).", "implemented": false, "featureIds": ["F023", "F003"] },
+  { "id": "T006", "description": "Unit: admin-only guard rejects non-admin invocation of diagnostics server entrypoint.", "implemented": false, "featureIds": ["F006", "F004"] },
+  { "id": "T007", "description": "Integration: diagnostics entrypoint returns 404/validation error when providerId does not exist or is not a Microsoft provider.", "implemented": false, "featureIds": ["F004"] },
+  { "id": "T008", "description": "Unit: each Graph request adds a unique `client-request-id` header.", "implemented": false, "featureIds": ["F009", "F008"] },
+  { "id": "T009", "description": "Unit: Graph `request-id` is captured from success responses and surfaced in step details.", "implemented": false, "featureIds": ["F009"] },
+  { "id": "T010", "description": "Unit: Graph `request-id` is captured from error responses and surfaced in step details.", "implemented": false, "featureIds": ["F009"] },
+
+  { "id": "T011", "description": "Unit: token-exists step returns fail when provider has no stored tokens.", "implemented": false, "featureIds": ["F010"] },
+  { "id": "T012", "description": "Unit: token-expiry step returns warn when expiry is unknown; pass when expiry is in the future; warn/fail when expired.", "implemented": false, "featureIds": ["F010"] },
+  { "id": "T013", "description": "Unit: token-claims step extracts `tid` and delegated `scp` claim when present.", "implemented": false, "featureIds": ["F011"] },
+  { "id": "T014", "description": "Unit: token-claims step handles missing/invalid JWT gracefully (warn + recommendation).", "implemented": false, "featureIds": ["F011", "F019"] },
+
+  { "id": "T015", "description": "Integration: `/me` step passes and records principal identifiers when Graph returns 200.", "implemented": false, "featureIds": ["F012"] },
+  { "id": "T016", "description": "Integration: `/me` step fails with 401 and produces recommendation to re-authorize when token is invalid/expired.", "implemented": false, "featureIds": ["F012", "F019", "F020"] },
+
+  { "id": "T017", "description": "Unit: mailbox base path decision chooses `/me` when configured mailbox equals authenticated user email (case-insensitive).", "implemented": false, "featureIds": ["F013"] },
+  { "id": "T018", "description": "Unit: mailbox base path decision chooses `/users/{mailbox}` when configured mailbox differs from authenticated user email.", "implemented": false, "featureIds": ["F013"] },
+  { "id": "T019", "description": "Unit: mailbox base path decision records rationale in step details for the UI.", "implemented": false, "featureIds": ["F013", "F002"] },
+
+  { "id": "T020", "description": "Integration: mailbox directory existence check passes when `GET /users/{mailbox}` returns 200.", "implemented": false, "featureIds": ["F014"] },
+  { "id": "T021", "description": "Integration: mailbox directory existence check classifies 404 as mailbox not found and recommends verifying mailbox address/tenant.", "implemented": false, "featureIds": ["F014", "F019", "F020"] },
+  { "id": "T022", "description": "Integration: mailbox directory existence check classifies 403 as insufficient directory permission and recommends verifying delegated access.", "implemented": false, "featureIds": ["F014", "F019", "F020"] },
+
+  { "id": "T023", "description": "Integration: Inbox well-known folder check uses `.../mailFolders/inbox` and passes when folder exists.", "implemented": false, "featureIds": ["F015"] },
+  { "id": "T024", "description": "Integration: Inbox check failing with 404 ‘store not found’ yields recommendation about mailbox type/provisioning.", "implemented": false, "featureIds": ["F015", "F019", "F020"] },
+  { "id": "T025", "description": "Integration: Inbox check failing with 403 yields recommendation about shared mailbox permissions.", "implemented": false, "featureIds": ["F015", "F019", "F020"] },
+
+  { "id": "T026", "description": "Integration: folder enumeration returns a non-empty list when mailbox folder access is available.", "implemented": false, "featureIds": ["F016"] },
+  { "id": "T027", "description": "Integration: folder enumeration gracefully handles large folder sets via `$top` and reports truncation.", "implemented": false, "featureIds": ["F016", "F002"] },
+  { "id": "T028", "description": "Integration: folder enumeration failing due to permission produces a targeted recommendation.", "implemented": false, "featureIds": ["F016", "F019", "F020"] },
+
+  { "id": "T029", "description": "Unit: configured folder resolution matches by well-known name mapping (Inbox, SentItems, DeletedItems, etc.).", "implemented": false, "featureIds": ["F017"] },
+  { "id": "T030", "description": "Unit: configured folder resolution matches by displayName case-insensitively when listing results include the folder.", "implemented": false, "featureIds": ["F017"] },
+  { "id": "T031", "description": "Unit: configured folder resolution reports fail + recommendation when configured folder cannot be resolved.", "implemented": false, "featureIds": ["F017", "F020"] },
+
+  { "id": "T032", "description": "Integration: message preflight GET succeeds for target resource and reports `messagesReadable=true`.", "implemented": false, "featureIds": ["F018"] },
+  { "id": "T033", "description": "Integration: message preflight 403 yields recommendation about missing `Mail.Read`/mailbox access.", "implemented": false, "featureIds": ["F018", "F019", "F020"] },
+  { "id": "T034", "description": "Integration: message preflight 404 yields recommendation about folder id/name mismatch or mailbox store not provisioned.", "implemented": false, "featureIds": ["F018", "F019", "F020"] },
+
+  { "id": "T035", "description": "Unit: error classification maps 401 to ‘re-authorize’ recommendation.", "implemented": false, "featureIds": ["F019", "F020"] },
+  { "id": "T036", "description": "Unit: error classification maps 403 to ‘insufficient permissions’ recommendation and mentions shared mailbox delegation.", "implemented": false, "featureIds": ["F019", "F020"] },
+  { "id": "T037", "description": "Unit: error classification maps 404 mailbox-not-found to ‘verify mailbox/tenant’ recommendation.", "implemented": false, "featureIds": ["F019", "F020"] },
+  { "id": "T038", "description": "Unit: error classification maps 404 inbox/store-not-found to ‘mailbox not provisioned / wrong object type’ recommendation.", "implemented": false, "featureIds": ["F019", "F020"] },
+  { "id": "T039", "description": "Unit: error classification maps 429 to throttling warning and suggests retry/backoff.", "implemented": false, "featureIds": ["F019", "F021", "F020"] },
+
+  { "id": "T040", "description": "Unit: recommendations deduplicate across multiple failing steps.", "implemented": false, "featureIds": ["F020"] },
+  { "id": "T041", "description": "Unit: support bundle includes key facts (tenant id, provider id, mailbox base path, folder, notification URL) with secrets redacted.", "implemented": false, "featureIds": ["F027", "F003"] },
+  { "id": "T042", "description": "Unit: support bundle includes step-level correlation IDs (`request-id`, `client-request-id`) where available.", "implemented": false, "featureIds": ["F022", "F009", "F003"] },
+
+  { "id": "T043", "description": "E2E/UI: diagnostics button appears only for Microsoft providers and only for admin users.", "implemented": false, "featureIds": ["F001", "F006"] },
+  { "id": "T044", "description": "E2E/UI: checklist renders with correct ordering and status icons for pass/warn/fail.", "implemented": false, "featureIds": ["F002"] },
+  { "id": "T045", "description": "E2E/UI: expandable step details shows sanitized request context (method/path) and error code/status when failing.", "implemented": false, "featureIds": ["F002", "F027"] },
+  { "id": "T046", "description": "E2E/UI: “Copy support bundle” copies a valid JSON blob and does not include raw token values.", "implemented": false, "featureIds": ["F003", "F007"] },
+  { "id": "T047", "description": "E2E/UI: mailbox+folder+resource string is shown and copyable for support.", "implemented": false, "featureIds": ["F025"] },
+  { "id": "T048", "description": "E2E/UI: help panel displays Microsoft 365 prerequisites and common fixes.", "implemented": false, "featureIds": ["F028"] },
+
+  { "id": "T049", "description": "Unit: concurrency guard prevents running two diagnostics simultaneously for the same provider.", "implemented": false, "featureIds": ["F021"] },
+  { "id": "T050", "description": "Unit: concurrency guard rate-limits repeated diagnostics runs per tenant.", "implemented": false, "featureIds": ["F021"] },
+
+  { "id": "T051", "description": "Unit: baseline `/me` check result is clearly separated from shared mailbox checks in the report.", "implemented": false, "featureIds": ["F024", "F002"] },
+  { "id": "T052", "description": "Integration: if `/me` passes but shared mailbox checks fail, recommendations explicitly point to shared mailbox permission configuration.", "implemented": false, "featureIds": ["F024", "F020"] },
+
+  { "id": "T053", "description": "Unit: step logging includes provider id, tenant id, step id, duration, and sanitized outcome fields.", "implemented": false, "featureIds": ["F022"] },
+  { "id": "T054", "description": "Unit: Graph request IDs are displayed prominently in UI for failing steps.", "implemented": false, "featureIds": ["F022", "F002"] },
+
+  { "id": "T055", "description": "Integration (optional): live subscription test create+delete succeeds when enabled and does not leave residual subscriptions.", "implemented": false, "featureIds": ["F026"] }
+]

--- a/server/src/components/EmailProviderCard.tsx
+++ b/server/src/components/EmailProviderCard.tsx
@@ -23,6 +23,7 @@ import {
   AlertCircle,
   Clock,
   Repeat,
+  Stethoscope,
 } from 'lucide-react';
 import type { EmailProvider } from './EmailProviderConfiguration';
 import { INBOUND_DEFAULTS_WARNING, providerNeedsInboundDefaults } from './emailProviderDefaults';
@@ -36,6 +37,7 @@ interface EmailProviderCardProps {
   onTestConnection: (provider: EmailProvider) => void;
   onRefreshWatchSubscription: (provider: EmailProvider) => void;
   onRetryRenewal: (provider: EmailProvider) => void;
+  onRunDiagnostics: (provider: EmailProvider) => void;
   onChangeDefaults: (provider: EmailProvider, defaultsId?: string) => void | Promise<void>;
 }
 
@@ -125,6 +127,7 @@ export function EmailProviderCard({
   onTestConnection,
   onRefreshWatchSubscription,
   onRetryRenewal,
+  onRunDiagnostics,
   onChangeDefaults,
 }: EmailProviderCardProps) {
   const expirationStatus = getExpirationStatus(provider);
@@ -170,10 +173,16 @@ export function EmailProviderCard({
                   </DropdownMenuItem>
                 )}
                 {provider.providerType === 'microsoft' && (
-                  <DropdownMenuItem onClick={() => onRetryRenewal(provider)}>
-                    <RefreshCw className="h-4 w-4 mr-2" />
-                    Retry Renewal
-                  </DropdownMenuItem>
+                  <>
+                    <DropdownMenuItem onClick={() => onRetryRenewal(provider)}>
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Retry Renewal
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => onRunDiagnostics(provider)}>
+                      <Stethoscope className="h-4 w-4 mr-2" />
+                      Run Microsoft 365 Diagnostics
+                    </DropdownMenuItem>
+                  </>
                 )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem

--- a/server/src/components/EmailProviderConfiguration.tsx
+++ b/server/src/components/EmailProviderConfiguration.tsx
@@ -14,6 +14,7 @@ import { MicrosoftProviderForm, GmailProviderForm } from '@product/email-provide
 import { EmailProviderList } from './EmailProviderList';
 import { ProviderSetupWizardDialog } from './ProviderSetupWizardDialog';
 import { InboundTicketDefaultsManager } from './admin/InboundTicketDefaultsManager';
+import { Microsoft365DiagnosticsDialog } from './admin/Microsoft365DiagnosticsDialog';
 import { DrawerProvider, useDrawer } from 'server/src/context/DrawerContext';
 import LoadingIndicator from './ui/LoadingIndicator';
 import {
@@ -101,6 +102,8 @@ function EmailProviderConfigurationContent({
   const [showDefaultsManager, setShowDefaultsManager] = useState(false);
   const [tenant, setTenant] = useState<string>('');
   const [activeSection, setActiveSection] = useState<'providers' | 'defaults'>('providers');
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const [diagnosticsProvider, setDiagnosticsProvider] = useState<EmailProvider | null>(null);
   const { openDrawer, closeDrawer } = useDrawer();
 
   // Load existing providers on component mount
@@ -224,6 +227,11 @@ function EmailProviderConfigurationContent({
     }
   };
 
+  const handleRunDiagnostics = (provider: EmailProvider) => {
+    setDiagnosticsProvider(provider);
+    setDiagnosticsOpen(true);
+  };
+
   // Inline add/setup flow removed in favor of wizard
 
   const handleEditCancel = () => {
@@ -305,6 +313,7 @@ function EmailProviderConfigurationContent({
           onRefresh={loadProviders}
           onRefreshWatchSubscription={handleRefreshWatchSubscription}
           onRetryRenewal={handleRetryRenewal}
+          onRunDiagnostics={handleRunDiagnostics}
           onAddClick={() => setWizardOpen(true)}
         />
 
@@ -391,6 +400,11 @@ function EmailProviderConfigurationContent({
               onClose={() => setWizardOpen(false)}
               onComplete={async (provider) => { onProviderAdded?.(provider); setWizardOpen(false); await loadProviders(); }}
               tenant={tenant}
+            />
+            <Microsoft365DiagnosticsDialog
+              isOpen={diagnosticsOpen}
+              onClose={() => setDiagnosticsOpen(false)}
+              provider={diagnosticsProvider}
             />
           </>
         ) : (

--- a/server/src/components/EmailProviderList.tsx
+++ b/server/src/components/EmailProviderList.tsx
@@ -21,6 +21,7 @@ interface EmailProviderListProps {
   onRefresh: () => void;
   onRefreshWatchSubscription: (provider: EmailProvider) => void;
   onRetryRenewal: (provider: EmailProvider) => void;
+  onRunDiagnostics: (provider: EmailProvider) => void;
   onAddClick?: () => void;
 }
 
@@ -32,6 +33,7 @@ export function EmailProviderList({
   onRefresh,
   onRefreshWatchSubscription,
   onRetryRenewal,
+  onRunDiagnostics,
   onAddClick
 }: EmailProviderListProps) {
   const [defaultsOptions, setDefaultsOptions] = React.useState<{ value: string; label: string }[]>([]);
@@ -98,6 +100,7 @@ export function EmailProviderList({
             onTestConnection={onTestConnection}
             onRefreshWatchSubscription={onRefreshWatchSubscription}
             onRetryRenewal={onRetryRenewal}
+            onRunDiagnostics={onRunDiagnostics}
             onChangeDefaults={handleChangeDefaults}
           />
         ))}

--- a/server/src/components/admin/Microsoft365DiagnosticsDialog.tsx
+++ b/server/src/components/admin/Microsoft365DiagnosticsDialog.tsx
@@ -1,0 +1,222 @@
+/**
+ * Microsoft 365 Inbound Email Diagnostics Dialog
+ * Runs a checklist against Microsoft Graph to help troubleshoot mailbox/folder/subscription issues.
+ */
+
+'use client';
+
+import React from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/Dialog';
+import { Button } from '../ui/Button';
+import { Alert, AlertDescription } from '../ui/Alert';
+import { Badge } from '../ui/Badge';
+import LoadingIndicator from '../ui/LoadingIndicator';
+import { CheckCircle, AlertCircle, XCircle, Clock, Copy } from 'lucide-react';
+import type { EmailProvider } from '../EmailProviderConfiguration';
+import { runMicrosoft365Diagnostics } from 'server/src/lib/actions/email-actions/emailProviderActions';
+import type { Microsoft365DiagnosticsReport, Microsoft365DiagnosticsStep } from '@alga-psa/shared/interfaces/microsoft365-diagnostics.interfaces';
+
+function statusIcon(status: Microsoft365DiagnosticsStep['status']) {
+  switch (status) {
+    case 'pass':
+      return <CheckCircle className="h-4 w-4 text-green-600" />;
+    case 'warn':
+      return <AlertCircle className="h-4 w-4 text-yellow-600" />;
+    case 'fail':
+      return <XCircle className="h-4 w-4 text-red-600" />;
+    case 'skip':
+    default:
+      return <Clock className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function statusBadge(status: Microsoft365DiagnosticsStep['status']) {
+  switch (status) {
+    case 'pass':
+      return <Badge className="bg-green-100 text-green-800">Pass</Badge>;
+    case 'warn':
+      return <Badge className="bg-yellow-100 text-yellow-800">Warn</Badge>;
+    case 'fail':
+      return <Badge variant="error">Fail</Badge>;
+    case 'skip':
+    default:
+      return <Badge variant="secondary">Skip</Badge>;
+  }
+}
+
+export function Microsoft365DiagnosticsDialog({
+  isOpen,
+  onClose,
+  provider,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  provider: EmailProvider | null;
+}) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [report, setReport] = React.useState<Microsoft365DiagnosticsReport | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      if (!isOpen || !provider) return;
+      if (provider.providerType !== 'microsoft') return;
+
+      setLoading(true);
+      setError(null);
+      setReport(null);
+      setCopied(false);
+
+      try {
+        const result = await runMicrosoft365Diagnostics(provider.id);
+        if (cancelled) return;
+        if (!result.success || !result.report) {
+          setError(result.error || 'Diagnostics failed');
+          return;
+        }
+        setReport(result.report);
+      } catch (e: any) {
+        if (cancelled) return;
+        setError(e?.message || 'Diagnostics failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, provider?.id]);
+
+  const copySupportBundle = async () => {
+    if (!report) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(report.supportBundle, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      setCopied(false);
+    }
+  };
+
+  const title = provider?.providerType === 'microsoft'
+    ? 'Microsoft 365 Diagnostics'
+    : 'Diagnostics';
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title={title} id="microsoft-365-diagnostics">
+      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Runs a live Graph check (including create+delete subscription) to diagnose mailbox, folder, and permission issues.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Alert>
+          <AlertDescription>
+            <span className="font-medium">Note:</span> Diagnostics will create a temporary Microsoft Graph subscription and then delete it.
+            If deletion fails, you may need to manually remove the subscription in Microsoft 365.
+          </AlertDescription>
+        </Alert>
+
+        {provider && (
+          <div className="text-sm text-muted-foreground mb-4">
+            Provider: <span className="font-medium text-foreground">{provider.providerName}</span> · Mailbox:{' '}
+            <span className="font-medium text-foreground">{provider.mailbox}</span>
+          </div>
+        )}
+
+        {loading && (
+          <div className="flex items-center justify-center p-6">
+            <LoadingIndicator layout="stacked" text="Running diagnostics..." spinnerProps={{ size: 'md' }} />
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {report && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-sm">
+                Overall: <span className="font-medium">{report.summary.overallStatus.toUpperCase()}</span>{' '}
+                {report.summary.targetResource && (
+                  <span className="text-muted-foreground">· Resource: {report.summary.targetResource}</span>
+                )}
+              </div>
+              <Button id="m365-diag-copy-bundle" variant="outline" size="sm" onClick={copySupportBundle}>
+                <Copy className="h-4 w-4 mr-2" />
+                {copied ? 'Copied' : 'Copy Support Bundle'}
+              </Button>
+            </div>
+
+            {report.recommendations?.length > 0 && (
+              <Alert>
+                <AlertDescription>
+                  <div className="font-medium mb-1">Recommendations</div>
+                  <ul className="list-disc pl-5 space-y-1">
+                    {report.recommendations.map((r) => (
+                      <li key={r}>{r}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="border rounded-md divide-y">
+              {report.steps.map((step) => (
+                <details key={step.id} className="p-3">
+                  <summary className="cursor-pointer select-none flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {statusIcon(step.status)}
+                      <span className="font-medium truncate">{step.title}</span>
+                      <span className="text-xs text-muted-foreground">({step.durationMs}ms)</span>
+                    </div>
+                    <div className="shrink-0">{statusBadge(step.status)}</div>
+                  </summary>
+                  <div className="mt-2 text-sm space-y-2">
+                    {step.http && (
+                      <div className="text-xs text-muted-foreground">
+                        {step.http.method} {step.http.path || step.http.url || ''}{' '}
+                        {typeof step.http.status === 'number' ? `· ${step.http.status}` : ''}
+                        {step.http.requestId ? ` · request-id: ${step.http.requestId}` : ''}
+                        {step.http.clientRequestId ? ` · client-request-id: ${step.http.clientRequestId}` : ''}
+                      </div>
+                    )}
+                    {step.error && (
+                      <div className="text-red-700 bg-red-50 border border-red-200 rounded p-2">
+                        <div className="font-medium">Error</div>
+                        <div>{step.error.message}</div>
+                        <div className="text-xs mt-1">
+                          {step.error.status ? `status: ${step.error.status}` : ''}
+                          {step.error.code ? ` · code: ${step.error.code}` : ''}
+                          {step.error.requestId ? ` · request-id: ${step.error.requestId}` : ''}
+                        </div>
+                      </div>
+                    )}
+                    {step.data && (
+                      <pre className="text-xs bg-muted rounded p-2 overflow-auto">
+                        {JSON.stringify(step.data, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button id="m365-diag-close" variant="outline" onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -84,8 +84,8 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   private async buildFolderResourcePath(desiredFolder: string): Promise<{ resource: string; resolvedFolder: string }> {
     const mailboxBase = this.getMailboxBasePath();
     const fallbackResult = {
-      resource: `${mailboxBase}/mailFolders('Inbox')/messages`,
-      resolvedFolder: 'Inbox',
+      resource: `${mailboxBase}/mailFolders/inbox/messages`,
+      resolvedFolder: 'Inbox (well-known)',
     };
 
     const requested = (desiredFolder || 'Inbox').trim();
@@ -94,26 +94,26 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
     }
 
     const wellKnownMap: Record<string, string> = {
-      inbox: 'Inbox',
-      archive: 'Archive',
-      drafts: 'Drafts',
-      deleteditems: 'DeletedItems',
-      junkemail: 'JunkEmail',
-      sentitems: 'SentItems',
-      outbox: 'Outbox',
-      conversationhistory: 'ConversationHistory',
-      clutter: 'Clutter',
-      conflicts: 'Conflicts',
-      localfailures: 'LocalFailures',
-      serverfailures: 'ServerFailures',
-      syncissues: 'SyncIssues',
+      inbox: 'inbox',
+      archive: 'archive',
+      drafts: 'drafts',
+      deleteditems: 'deleteditems',
+      junkemail: 'junkemail',
+      sentitems: 'sentitems',
+      outbox: 'outbox',
+      conversationhistory: 'conversationhistory',
+      clutter: 'clutter',
+      conflicts: 'conflicts',
+      localfailures: 'localfailures',
+      serverfailures: 'serverfailures',
+      syncissues: 'syncissues',
     };
 
     const normalizedKey = requested.toLowerCase().replace(/\s+/g, '');
     if (wellKnownMap[normalizedKey]) {
       return {
-        resource: `${mailboxBase}/mailFolders('${wellKnownMap[normalizedKey]}')/messages`,
-        resolvedFolder: requested,
+        resource: `${mailboxBase}/mailFolders/${wellKnownMap[normalizedKey]}/messages`,
+        resolvedFolder: `${requested} (well-known)`,
       };
     }
 
@@ -125,9 +125,8 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         (f: any) => (f.displayName || '').toLowerCase() === requested.toLowerCase()
       );
       if (match?.id) {
-        const folderId = String(match.id).replace(/'/g, "''");
         return {
-          resource: `${mailboxBase}/mailFolders('${folderId}')/messages`,
+          resource: `${mailboxBase}/mailFolders/${encodeURIComponent(String(match.id))}/messages`,
           resolvedFolder: match.displayName || requested,
         };
       }
@@ -263,7 +262,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         client_secret: clientSecret,
         refresh_token: this.refreshToken,
         grant_type: 'refresh_token',
-        scope: 'https://graph.microsoft.com/Mail.Read offline_access',
+        scope: 'https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.Read.Shared offline_access',
       });
 
       const response = await axios.post(tokenUrl, params.toString(), {

--- a/shared/interfaces/microsoft365-diagnostics.interfaces.ts
+++ b/shared/interfaces/microsoft365-diagnostics.interfaces.ts
@@ -1,0 +1,61 @@
+export type DiagnosticsStepStatus = 'pass' | 'warn' | 'fail' | 'skip';
+
+export interface DiagnosticsHttpMeta {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  url?: string;
+  path?: string;
+  resource?: string;
+  status?: number;
+  requestId?: string;
+  clientRequestId?: string;
+}
+
+export interface DiagnosticsErrorMeta {
+  message: string;
+  status?: number;
+  code?: string;
+  requestId?: string;
+  clientRequestId?: string;
+  responseBody?: unknown;
+}
+
+export interface Microsoft365DiagnosticsStep {
+  id: string;
+  title: string;
+  status: DiagnosticsStepStatus;
+  startedAt: string;
+  durationMs: number;
+  http?: DiagnosticsHttpMeta;
+  data?: Record<string, unknown>;
+  error?: DiagnosticsErrorMeta;
+}
+
+export interface Microsoft365DiagnosticsSummary {
+  providerId: string;
+  tenantId: string;
+  providerType: 'microsoft';
+  mailbox: string;
+  folder: string;
+  mailboxBasePath: '/me' | string;
+  notificationUrl?: string;
+  targetResource?: string;
+  authenticatedUserEmail?: string;
+  tokenExpiresAt?: string;
+  overallStatus: DiagnosticsStepStatus;
+}
+
+export interface Microsoft365DiagnosticsReport {
+  createdAt: string;
+  summary: Microsoft365DiagnosticsSummary;
+  steps: Microsoft365DiagnosticsStep[];
+  recommendations: string[];
+  supportBundle: Record<string, unknown>;
+}
+
+export interface Microsoft365DiagnosticsOptions {
+  includeIdentifiers?: boolean;
+  liveSubscriptionTest?: boolean;
+  requiredScopes?: string[];
+  folderListTop?: number;
+}
+

--- a/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
+++ b/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { MicrosoftGraphAdapter } from '../MicrosoftGraphAdapter';
+
+function makeJwt(payload: Record<string, any>) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.sig`;
+}
+
+function makeAdapter(overrides?: Partial<any>) {
+  const config: any = {
+    id: 'provider-1',
+    tenant: 'tenant-1',
+    name: 'Provider',
+    provider_type: 'microsoft',
+    mailbox: 'support@example.com',
+    folder_to_monitor: 'Inbox',
+    active: true,
+    webhook_notification_url: 'https://example.com/api/email/webhooks/microsoft',
+    connection_status: 'connected',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    provider_config: {
+      access_token: makeJwt({ tid: 'tid', scp: 'Mail.Read Mail.Read.Shared', aud: 'graph' }),
+      refresh_token: 'refresh-token',
+      token_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    },
+    ...overrides,
+  };
+
+  const adapter = new MicrosoftGraphAdapter(config);
+
+  const get = async (path: string) => {
+    if (path === '/me') {
+      return {
+        status: 200,
+        data: { id: 'me-id', userPrincipalName: 'admin@example.com', mail: 'admin@example.com' },
+        headers: { 'request-id': 'rid-me', 'client-request-id': 'cid-me' },
+      };
+    }
+    if (path.startsWith('/users/')) {
+      return {
+        status: 200,
+        data: { id: 'user-id', userPrincipalName: 'support@example.com', mail: 'support@example.com' },
+        headers: { 'request-id': 'rid-user', 'client-request-id': 'cid-user' },
+      };
+    }
+    if (path.endsWith('/mailFolders/inbox')) {
+      return {
+        status: 200,
+        data: { id: 'inbox-id', displayName: 'Inbox' },
+        headers: { 'request-id': 'rid-inbox', 'client-request-id': 'cid-inbox' },
+      };
+    }
+    if (path.endsWith('/mailFolders')) {
+      return {
+        status: 200,
+        data: { value: [{ id: 'inbox-id', displayName: 'Inbox' }] },
+        headers: { 'request-id': 'rid-folders', 'client-request-id': 'cid-folders' },
+      };
+    }
+    if (path.endsWith('/mailFolders/inbox/messages')) {
+      return {
+        status: 200,
+        data: { value: [{ id: 'm1', subject: 'Hello', receivedDateTime: new Date().toISOString() }] },
+        headers: { 'request-id': 'rid-msg', 'client-request-id': 'cid-msg' },
+      };
+    }
+    throw new Error(`Unexpected GET ${path}`);
+  };
+
+  const post = async (path: string) => {
+    if (path === '/subscriptions') {
+      return {
+        status: 201,
+        data: { id: 'sub-1', expirationDateTime: new Date(Date.now() + 10_000).toISOString() },
+        headers: { 'request-id': 'rid-sub', 'client-request-id': 'cid-sub' },
+      };
+    }
+    throw new Error(`Unexpected POST ${path}`);
+  };
+
+  const del = async (path: string) => {
+    if (path.startsWith('/subscriptions/')) {
+      return {
+        status: 204,
+        data: {},
+        headers: { 'request-id': 'rid-del', 'client-request-id': 'cid-del' },
+      };
+    }
+    throw new Error(`Unexpected DELETE ${path}`);
+  };
+
+  (adapter as any).httpClient = { get, post, delete: del };
+  return adapter;
+}
+
+describe('MicrosoftGraphAdapter.runMicrosoft365Diagnostics', () => {
+  it('returns a successful report with a live subscription test', async () => {
+    const adapter = makeAdapter();
+    const report = await adapter.runMicrosoft365Diagnostics({
+      includeIdentifiers: true,
+      liveSubscriptionTest: true,
+      requiredScopes: ['Mail.Read', 'Mail.Read.Shared'],
+    });
+
+    expect(report.summary.overallStatus).toBe('pass');
+    expect(report.summary.targetResource).toContain('/mailFolders/inbox/messages');
+
+    const tokenStep = report.steps.find((s) => s.id === 'tokens_present');
+    expect(tokenStep?.status).toBe('pass');
+    expect((tokenStep?.data as any)?.accessToken).toMatch(/^eyJ.+\.\.\.\(\d+\)$/);
+
+    const subStep = report.steps.find((s) => s.id === 'subscription_live_test');
+    expect(subStep?.status).toBe('pass');
+    expect((subStep?.data as any)?.createdSubscriptionId).toBe('sub-1');
+    expect((subStep?.data as any)?.deletedSubscriptionId).toBe('sub-1');
+  });
+
+  it('warns when delegated scopes are missing', async () => {
+    const adapter = makeAdapter({
+      provider_config: {
+        access_token: makeJwt({ tid: 'tid', scp: 'Mail.Read', aud: 'graph' }),
+        refresh_token: 'refresh-token',
+      },
+    });
+
+    const report = await adapter.runMicrosoft365Diagnostics({
+      includeIdentifiers: true,
+      liveSubscriptionTest: false,
+      requiredScopes: ['Mail.Read', 'Mail.Read.Shared'],
+    });
+
+    const claimsStep = report.steps.find((s) => s.id === 'token_claims');
+    expect(claimsStep?.status).toBe('warn');
+    expect(report.recommendations.join('\n')).toContain('Mail.Read.Shared');
+  });
+});
+


### PR DESCRIPTION
Adds Microsoft 365 inbound email diagnostics for admin self-serve troubleshooting.

Key changes:
- Admin UI action: Run Microsoft 365 Diagnostics (with note about temporary subscription create+delete)
- Server action: run diagnostics (permission-gated)
- Adapter: structured diagnostics runner w/ scope checks (Mail.Read + Mail.Read.Shared), mailbox/folder preflight, and live subscription test
- Improves folder resource to use well-known folder path (mailFolders/inbox)
- Adds plan docs + unit test

Test:
- vitest: shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
