### PR TITLE
Fix ext storage jsonb encoding for string values

### DIFF
--- a/ee/server/src/__tests__/unit/ext-storage-jsonb-encoding.test.ts
+++ b/ee/server/src/__tests__/unit/ext-storage-jsonb-encoding.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { encodeJsonb } from '../../lib/extensions/storage/v2/json';
+
+describe('Extension storage jsonb encoding', () => {
+  it('encodes string values as a JSON string', () => {
+    expect(encodeJsonb('eyJhbGwiOlt7InRlc3QiOjF9XX0')).toBe('"eyJhbGwiOlt7InRlc3QiOjF9XX0"');
+  });
+
+  it('encodes object values as JSON object text', () => {
+    expect(encodeJsonb({ a: 1, b: true, c: null, d: ['x'] })).toBe('{"a":1,"b":true,"c":null,"d":["x"]}');
+  });
+});

--- a/ee/server/src/lib/extensions/storage/v2/json.ts
+++ b/ee/server/src/lib/extensions/storage/v2/json.ts
@@ -1,0 +1,10 @@
+import type { JsonValue } from './types';
+
+/**
+ * Knex/pg will not automatically JSON-encode plain JS strings when inserting into `jsonb`.
+ * Postgres expects valid JSON text, so scalars must be quoted (e.g. `"abc"`).
+ */
+export function encodeJsonb(value: JsonValue): string {
+  return JSON.stringify(value ?? null);
+}
+


### PR DESCRIPTION
Fixes Postgres 22P02 (invalid input syntax for type json) when extensions write scalar strings (e.g. base64/JWT-like tokens) into extension storage.

- Always JSON-encode values before inserting/updating the jsonb value column
- Add a focused unit test for encoding behavior
