### PR TITLE
Use custom calendar component for Accounting Exports

### DIFF
--- a/server/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
+++ b/server/src/components/billing-dashboard/accounting/AccountingExportsTab.tsx
@@ -25,6 +25,8 @@ import { Alert, AlertDescription } from 'server/src/components/ui/Alert';
 import { CSVExportLockResetPanel } from 'server/src/components/integrations/csv/CSVExportLockResetPanel';
 import { UnifiedCsvTaxImportPanel } from 'server/src/components/integrations/csv/UnifiedCsvTaxImportPanel';
 import { formatCurrency, formatDate } from 'server/src/lib/utils/formatters';
+import { DatePicker } from 'server/src/components/ui/DatePicker';
+import { format as formatDateFns } from 'date-fns';
 import {
   listAccountingExportBatches,
   getAccountingExportBatch,
@@ -880,20 +882,24 @@ const AccountingExportsTab: React.FC = () => {
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
-          <input
-            type="date"
-            value={filters.startDate}
-            onChange={(e) => setFilters((prev) => ({ ...prev, startDate: e.target.value }))}
-            className="border rounded-md px-3 py-2 text-sm"
+          <DatePicker
+            id="filter-start-date"
+            value={filters.startDate ? new Date(filters.startDate + 'T00:00:00') : undefined}
+            onChange={(date) => setFilters((prev) => ({ ...prev, startDate: date ? formatDateFns(date, 'yyyy-MM-dd') : '' }))}
+            placeholder="Start date"
+            clearable
+            className="min-w-[160px]"
           />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
-          <input
-            type="date"
-            value={filters.endDate}
-            onChange={(e) => setFilters((prev) => ({ ...prev, endDate: e.target.value }))}
-            className="border rounded-md px-3 py-2 text-sm"
+          <DatePicker
+            id="filter-end-date"
+            value={filters.endDate ? new Date(filters.endDate + 'T00:00:00') : undefined}
+            onChange={(date) => setFilters((prev) => ({ ...prev, endDate: date ? formatDateFns(date, 'yyyy-MM-dd') : '' }))}
+            placeholder="End date"
+            clearable
+            className="min-w-[160px]"
           />
         </div>
         <div>
@@ -1362,20 +1368,22 @@ const AccountingExportsTab: React.FC = () => {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
-              <input
-                type="date"
-                value={createForm.startDate}
-                onChange={(e) => updateCreateFormField('startDate', e.target.value)}
-                className="border rounded-md w-full px-3 py-2 text-sm"
+              <DatePicker
+                id="create-export-start-date"
+                value={createForm.startDate ? new Date(createForm.startDate + 'T00:00:00') : undefined}
+                onChange={(date) => updateCreateFormField('startDate', date ? formatDateFns(date, 'yyyy-MM-dd') : '')}
+                placeholder="Select start date"
+                clearable
               />
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
-              <input
-                type="date"
-                value={createForm.endDate}
-                onChange={(e) => updateCreateFormField('endDate', e.target.value)}
-                className="border rounded-md w-full px-3 py-2 text-sm"
+              <DatePicker
+                id="create-export-end-date"
+                value={createForm.endDate ? new Date(createForm.endDate + 'T00:00:00') : undefined}
+                onChange={(date) => updateCreateFormField('endDate', date ? formatDateFns(date, 'yyyy-MM-dd') : '')}
+                placeholder="Select end date"
+                clearable
               />
             </div>
             <div className="md:col-span-2">

--- a/server/src/components/ui/DateRangePicker.tsx
+++ b/server/src/components/ui/DateRangePicker.tsx
@@ -27,11 +27,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps & AutomationProps> =
           value={value.from}
           onChange={(date) => onChange({ ...value, from: date })}
           placeholder="From date"
+          className="min-w-[160px]"
         />
         <DatePicker
           value={value.to}
           onChange={(date) => onChange({ ...value, to: date })}
           placeholder="To date"
+          className="min-w-[160px]"
         />
       </div>
     </div>
@@ -61,19 +63,21 @@ export const StringDateRangePicker: React.FC<StringDateRangePickerProps & Automa
       <div className="flex gap-2">
         <DatePicker
           value={value.from ? new Date(value.from) : undefined}
-          onChange={(date) => onChange({ 
-            ...value, 
-            from: date ? date.toISOString().split('T')[0] : '' 
+          onChange={(date) => onChange({
+            ...value,
+            from: date ? date.toISOString().split('T')[0] : ''
           })}
           placeholder="From date"
+          className="min-w-[160px]"
         />
         <DatePicker
           value={value.to ? new Date(value.to) : undefined}
-          onChange={(date) => onChange({ 
-            ...value, 
-            to: date ? date.toISOString().split('T')[0] : '' 
+          onChange={(date) => onChange({
+            ...value,
+            to: date ? date.toISOString().split('T')[0] : ''
           })}
           placeholder="To date"
+          className="min-w-[160px]"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace native HTML date inputs with our custom DatePicker component in the Accounting Exports tab (both filter section and create export dialog)
- Add minimum width to DateRangePicker components to prevent squished calendar icons

## Test plan
- [ ] Navigate to Billing > Accounting Exports
- [ ] Verify Start Date and End Date filters use the custom calendar picker
- [ ] Click "New Export" and verify date pickers in the dialog use the custom calendar
- [ ] Check the Import Tax from CSV section date range pickers have proper spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)