### PR TITLE
Fix Citus ext storage upsert timestamps

### DIFF
--- a/ee/server/src/lib/extensions/storage/v2/service.ts
+++ b/ee/server/src/lib/extensions/storage/v2/service.ts
@@ -218,7 +218,7 @@ export class ExtensionStorageServiceV2 {
         });
       }
 
-      const now = trx.fn.now();
+      const now = new Date();
       const revision = existing ? Number(existing.revision) + 1 : 1;
       const insertRow = {
         tenant: this.tenantId,
@@ -371,7 +371,7 @@ export class ExtensionStorageServiceV2 {
         });
       }
 
-      const now = trx.fn.now();
+      const now = new Date();
       const rows = request.items.map((item) => {
         const existing = existingMap.get(item.key);
         const ttlExpiresAt = computeTtl(item.ttlSeconds);


### PR DESCRIPTION
Citus rejects volatile functions (e.g. CURRENT_TIMESTAMP) in ON CONFLICT DO UPDATE for distributed tables.\n\n- Bind JS Date values for ext_storage_records created_at/updated_at in upserts\n\nFixes: "functions used in the DO UPDATE SET clause of INSERTs on distributed tables must be marked IMMUTABLE"