### PR TITLE
Time sheet approval sorting doesn't work

### DIFF
--- a/server/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
+++ b/server/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
@@ -189,7 +189,7 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
           },
           {
             title: 'Period',
-            dataIndex: 'time_period',
+            dataIndex: ['time_period', 'start_date'],
             width: '25%',
             render: (_, record) => (
               <>


### PR DESCRIPTION
## Summary
- Fixed Period column sorting in the Time Sheet Approvals dashboard
- The column was using `dataIndex: 'time_period'` which points to an object, causing DataTable's sorting to fail (all rows compared as equal)
- Changed to `dataIndex: ['time_period', 'start_date']` to access the nested date string for proper date-based sorting

## Test plan
- [ ] Navigate to Time Management > Approvals as a team manager
- [ ] Click the Period column header to sort
- [ ] Verify rows sort correctly by period start date (ascending/descending)