### PR TITLE
Adding work item to time sheet: ability to clear fields without having to reset all filters

### DIFF
--- a/server/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
+++ b/server/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
@@ -501,6 +501,7 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
                   }}
                   placeholder="Start date"
                   className="w-full"
+                  clearable
                 />
               </div>
               <div className="flex items-center">
@@ -514,6 +515,7 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
                   }}
                   placeholder="End date"
                   className="w-full"
+                  clearable
                 />
               </div>
             </div>

--- a/server/src/components/ui/Calendar.tsx
+++ b/server/src/components/ui/Calendar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronDown } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronDown, X } from 'lucide-react';
 import { DayPicker } from 'react-day-picker';
 import { cn } from 'server/src/lib/utils';
 import { format } from 'date-fns';
@@ -11,6 +11,8 @@ interface CalendarProps extends Omit<React.ComponentProps<typeof DayPicker>, 'mo
   mode?: 'single';
   selected?: Date;
   onSelect?: (date: Date | undefined) => void;
+  /** Callback when clear button is clicked. If provided, shows a Clear button. */
+  onClear?: () => void;
 }
 
 interface MonthYearSelectProps {
@@ -90,6 +92,7 @@ function Calendar({
   showOutsideDays = true,
   selected,
   onSelect,
+  onClear,
   mode = 'single',
   ...props
 }: CalendarProps) {
@@ -154,7 +157,18 @@ function Calendar({
         modifiers={{ today: new Date() }}
         hideNavigation
         footer={
-          <div className="flex justify-center">
+          <div className="flex justify-center gap-2">
+            {onClear && (
+              <button
+                onClick={onClear}
+                className="calendar-today-button"
+                aria-label="Clear date"
+                type="button"
+              >
+                <X className="w-4 h-4" />
+                Clear
+              </button>
+            )}
             <button
               onClick={handleTodayClick}
               className="calendar-today-button"

--- a/server/src/components/ui/DatePicker.tsx
+++ b/server/src/components/ui/DatePicker.tsx
@@ -39,6 +39,18 @@ export function DatePicker({
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
 
+  const handleClear = React.useCallback(() => {
+    onChange(undefined);
+    setOpen(false);
+  }, [onChange]);
+
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    if ((e.key === 'Backspace' || e.key === 'Delete') && value && !disabled) {
+      e.preventDefault();
+      onChange(undefined);
+    }
+  }, [value, disabled, onChange]);
+
   // Register with UI reflection system if id is provided
   const { automationIdProps, updateMetadata } = useAutomationIdAndRegister<DatePickerComponent>({
     type: 'datePicker',
@@ -67,6 +79,7 @@ export function DatePicker({
           {...automationIdProps}
           disabled={disabled}
           aria-label={label || placeholder}
+          onKeyDown={handleKeyDown}
           className={`
             flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm
             file:border-0 file:bg-transparent file:text-sm file:font-medium
@@ -114,6 +127,7 @@ export function DatePicker({
                     onChange(undefined);
                   }
                 }}
+                onClear={clearable ? handleClear : undefined}
                 defaultMonth={value}
                 fromDate={new Date(new Date().getFullYear(), new Date().getMonth(), 1)}
               />


### PR DESCRIPTION
## Summary
- Added Clear button to Calendar component next to the Today button (only shown when `clearable` prop is enabled)
- Added keyboard support: pressing Backspace or Delete while the date input is focused clears the value
- Enabled `clearable` on Start/End date pickers in the Add Work Item dialog's filter section

## Test plan
- [ ] Open Time Management > Time Sheet
- [ ] Click "Add Work Item" to open the dialog
- [ ] Expand the Filters section
- [ ] Select a start date - verify:
  - [ ] Clear button appears in the calendar popup next to Today
  - [ ] Clicking Clear removes the date and closes the popup
  - [ ] With the date input focused, pressing Backspace or Delete clears it
  - [ ] The inline X button also clears the date
- [ ] Repeat for end date
- [ ] Verify clearing one date doesn't affect other filter values