### PR TITLE
Fix timesheet approval UX and comment permissions

### DIFF
--- a/server/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
+++ b/server/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
@@ -8,6 +8,7 @@ import { Button } from 'server/src/components/ui/Button';
 import { Checkbox } from 'server/src/components/ui/Checkbox';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from 'server/src/components/ui/Card';
+import { ConfirmationDialog } from 'server/src/components/ui/ConfirmationDialog';
 import { Users } from 'lucide-react';
 import {
   fetchTimeSheetsForApproval,
@@ -32,6 +33,8 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
   const [timeSheets, setTimeSheets] = useState<ITimeSheetApprovalView[]>([]);
   const [selectedTimeSheets, setSelectedTimeSheets] = useState<string[]>([]);
   const [showApproved, setShowApproved] = useState(false);
+  const [reverseConfirmOpen, setReverseConfirmOpen] = useState(false);
+  const [timeSheetToReverse, setTimeSheetToReverse] = useState<ITimeSheetApprovalView | null>(null);
   const { isManager, managedTeams } = useTeamAuth(currentUser);
   const { openDrawer, closeDrawer } = useDrawer();
 
@@ -49,18 +52,24 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
     setTimeSheets(sheets);
   };
 
-  const handleReverseApproval = async (timeSheet: ITimeSheetApprovalView) => {
-    if (!confirm('Are you sure you want to reverse the approval of this time sheet?')) {
-      return;
-    }
+  const handleReverseApproval = (timeSheet: ITimeSheetApprovalView) => {
+    setTimeSheetToReverse(timeSheet);
+    setReverseConfirmOpen(true);
+  };
+
+  const confirmReverseApproval = async () => {
+    if (!timeSheetToReverse) return;
 
     try {
       await reverseTimeSheetApproval(
-        timeSheet.id,
+        timeSheetToReverse.id,
         currentUser.user_id,
         'Approval reversed by manager'
       );
       await loadTimeSheets();
+      setReverseConfirmOpen(false);
+      setTimeSheetToReverse(null);
+      closeDrawer();
     } catch (error) {
       console.error('Failed to reverse approval:', error);
       alert('Failed to reverse approval: ' + (error instanceof Error ? error.message : 'Unknown error'));
@@ -106,10 +115,7 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
            await loadTimeSheets();
            closeDrawer();
           }}
-          onReverseApproval={async () => {
-           await handleReverseApproval(timeSheet); // This already calls loadTimeSheets
-           closeDrawer();
-         }}
+          onReverseApproval={() => handleReverseApproval(timeSheet)}
         />
       );
     } catch (error) {
@@ -187,7 +193,7 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
           {
             title: 'Employee',
             dataIndex: 'employee_name',
-            width: '25%'
+            width: '20%'
           },
           {
             title: 'Period',
@@ -223,14 +229,17 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
           {
             title: 'Actions',
             dataIndex: 'actions',
-            width: '10%',
+            width: '15%',
             sortable: false, // Non-data column, sorting disabled
             render: (_, record) => (
               <div className="flex gap-2">
                 {/* Unique IDs for UI reflection system */}
                 <Button
                   id={`view-timesheet-${record.id}-btn`}
-                  onClick={() => handleViewTimeSheet(record)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleViewTimeSheet(record);
+                  }}
                   variant="soft"
                 >
                   View
@@ -238,7 +247,10 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
                 {record.approval_status === 'APPROVED' && (
                   <Button
                     id={`reverse-approval-${record.id}-btn`}
-                    onClick={() => handleReverseApproval(record)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleReverseApproval(record);
+                    }}
                     variant="destructive"
                   >
                     Reverse
@@ -257,6 +269,20 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
               : ''
         }
         pagination={false}
+      />
+
+      <ConfirmationDialog
+        id="reverse-approval-confirmation"
+        isOpen={reverseConfirmOpen}
+        onClose={() => {
+          setReverseConfirmOpen(false);
+          setTimeSheetToReverse(null);
+        }}
+        onConfirm={confirmReverseApproval}
+        title="Reverse Approval"
+        message={`Are you sure you want to reverse the approval of this time sheet${timeSheetToReverse?.employee_name ? ` for ${timeSheetToReverse.employee_name}` : ''}?`}
+        confirmLabel="Reverse Approval"
+        cancelLabel="Cancel"
       />
     </div>
   );

--- a/server/src/components/time-management/approvals/TimeSheetApproval.tsx
+++ b/server/src/components/time-management/approvals/TimeSheetApproval.tsx
@@ -253,7 +253,7 @@ export function TimeSheetApproval({
           <CardTitle>Time Sheet Approval for {timeSheet.employee_name}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p>Period: { timeSheet.time_period?.start_date ? timeSheet.time_period.start_date.toString() : "N/A"} - { timeSheet.time_period?.end_date ? timeSheet.time_period.end_date.toString() : "N/A"}</p>
+          <p>Period: {timeSheet.time_period?.start_date ? parseISO(timeSheet.time_period.start_date).toLocaleDateString() : "N/A"} - {timeSheet.time_period?.end_date ? parseISO(timeSheet.time_period.end_date).toLocaleDateString() : "N/A"}</p>
           <p>Status: {timeSheet.approval_status}</p>
           <p>Submitted: {timeSheet.submitted_at?.toLocaleString()}</p>
         </CardContent>


### PR DESCRIPTION
  - Replace browser confirm() with custom ConfirmationDialog for reverse approval
  - Fix comment permission to allow owners OR approvers (not just 'comment' action)
  - Standardize date format to locale format across approval views
  - Add stopPropagation to prevent row click when clicking action buttons
  - Adjust column widths to prevent button overflow in Actions column

  "Curiouser and curiouser!" cried Alice, for now the TimeSheet knew its own owner, and the Cheshire Cat's approval could be reversed without that dreadful native confirm() popping up uninvited. The dates finally agreed to speak the same locale language. 🐱📋✨