### PR TITLE
Fix admin DB connection to use writable host

### DIFF
--- a/shared/db/admin.ts
+++ b/shared/db/admin.ts
@@ -28,8 +28,9 @@ export async function getAdminConnection(): Promise<Knex> {
     const base = (knexfile as any)[environment] ?? {};
     const baseConn = (base as any).connection ?? {};
 
-    const resolvedHost = process.env.DB_HOST || baseConn.host;
-    const resolvedPort = Number(process.env.DB_PORT ?? baseConn.port);
+    // Prefer direct Postgres connection vars for admin operations (avoid read-only/replica pools).
+    const resolvedHost = process.env.DB_HOST_ADMIN || process.env.DB_HOST || baseConn.host;
+    const resolvedPort = Number(process.env.DB_PORT_ADMIN ?? process.env.DB_PORT ?? baseConn.port);
     const resolvedUser = process.env.DB_USER_ADMIN || baseConn.user || 'postgres';
     const resolvedDatabase = process.env.DB_NAME_SERVER || baseConn.database || 'server';
 

--- a/shared/db/knexfile.ts
+++ b/shared/db/knexfile.ts
@@ -28,8 +28,15 @@ const getPostgresPassword = async () => await getSecret('postgres_password', 'DB
 
 // Special connection config for postgres user (needed for job scheduler)
 export const getPostgresConnection = async () => ({
-  host: (typeof process !== 'undefined' && process.env?.DB_HOST) || 'localhost',
-  port: Number((typeof process !== 'undefined' && process.env?.DB_PORT) || 5432),
+  host:
+    (typeof process !== 'undefined' &&
+      (process.env?.DB_HOST_ADMIN || process.env?.DB_HOST)) ||
+    'localhost',
+  port: Number(
+    (typeof process !== 'undefined' &&
+      (process.env?.DB_PORT_ADMIN || process.env?.DB_PORT)) ||
+      5432
+  ),
   user: (typeof process !== 'undefined' && process.env?.DB_USER_ADMIN) || 'postgres',
   password: await getPostgresPassword(),
   database: (typeof process !== 'undefined' && process.env?.DB_NAME_SERVER) || 'server'


### PR DESCRIPTION
- Prefer DB_HOST_ADMIN/DB_PORT_ADMIN for admin DB operations to avoid read-only/replica pools.\n- Updates shared admin connection + postgres connection helpers (shared/db/admin.ts, shared/db/knexfile.ts).