### PR TITLE
Add precompile support and fix extension uiProxy routing

### DIFF
--- a/ee/extensions/nineminds-reporting/.gitignore
+++ b/ee/extensions/nineminds-reporting/.gitignore
@@ -1,0 +1,8 @@
+# Generated build artifacts
+dist/
+precompiled/
+ui/dist/
+
+# Bundle output
+*.tar.zst
+bundle.tar.zst

--- a/ee/extensions/nineminds-reporting/manifest.json
+++ b/ee/extensions/nineminds-reporting/manifest.json
@@ -4,12 +4,17 @@
   "version": "0.1.0",
   "runtime": "wasm-js@1",
   "capabilities": ["cap:context.read", "cap:log.emit", "cap:ui.proxy"],
+  "entry": "dist/main.wasm",
   "ui": {
     "type": "iframe",
     "entry": "ui/index.html",
     "hooks": {
       "appMenu": { "label": "Nine Minds Reporting" }
     }
+  },
+  "precompiled": {
+    "x86_64-linux-gnu": "precompiled/x86_64-linux-gnu.cwasm",
+    "aarch64-linux-gnu": "precompiled/aarch64-linux-gnu.cwasm"
   },
   "assets": ["ui/**/*"]
 }

--- a/ee/extensions/nineminds-reporting/package.json
+++ b/ee/extensions/nineminds-reporting/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "description": "Nine Minds Reporting Extension - Fetch and display reporting data",
   "scripts": {
-    "clean": "rm -rf dist ui/dist",
+    "clean": "rm -rf dist ui/dist precompiled",
     "build:backend": "esbuild src/index.ts --bundle --format=esm --outfile=dist/js/handler.js --platform=neutral --external:alga:extension/secrets --external:alga:extension/http --external:alga:extension/storage --external:alga:extension/logging --external:alga:extension/ui-proxy --external:alga:extension/context",
     "build:component": "npx jco componentize dist/js/handler.js --wit ./wit/extension-runner.wit --world-name runner --disable all --out dist/main.wasm",
     "build:ui": "vite build -c vite.iframe.config.ts",
+    "precompile": "mkdir -p precompiled && wasmtime compile --target x86_64-unknown-linux-gnu dist/main.wasm -o precompiled/x86_64-linux-gnu.cwasm && wasmtime compile --target aarch64-unknown-linux-gnu dist/main.wasm -o precompiled/aarch64-linux-gnu.cwasm",
     "build": "npm run clean && npm run build:backend && npm run build:component && npm run build:ui",
+    "build:full": "npm run build && npm run precompile",
     "pack": "alga pack",
     "dev": "vite",
     "type-check": "tsc --noEmit"

--- a/ee/extensions/nineminds-reporting/src/index.ts
+++ b/ee/extensions/nineminds-reporting/src/index.ts
@@ -6,18 +6,7 @@ import type {
   ContextData
 } from '@alga-psa/extension-runtime';
 
-// Raw imports from the WIT world
-// @ts-ignore
-import { get as getSecret, listKeys as listSecrets } from 'alga:extension/secrets';
-// @ts-ignore
-import { fetch as httpFetch } from 'alga:extension/http';
-// @ts-ignore
-import {
-  get as storageGet,
-  put as storagePut,
-  delete as storageDelete,
-  listEntries as storageList
-} from 'alga:extension/storage';
+// Raw imports from the WIT world - only import what we actually use
 // @ts-ignore
 import {
   logInfo,
@@ -30,24 +19,30 @@ import { callRoute as uiProxyCall } from 'alga:extension/ui-proxy';
 import { getContext } from 'alga:extension/context';
 
 // Construct the HostBindings object that the SDK expects
+// Only wire up capabilities that this extension actually uses:
+// - cap:context.read
+// - cap:log.emit
+// - cap:ui.proxy
 const host: HostBindings = {
   context: {
     get: async () => {
       return getContext() as unknown as ContextData;
     }
   },
+  // Note: secrets, http, and storage are not used by this extension
+  // and are not declared in manifest capabilities
   secrets: {
-    get: async (key: string) => getSecret(key),
-    list: async () => listSecrets()
+    get: async (_key: string) => { throw new Error('secrets not available - cap:secrets.get not granted'); },
+    list: async () => { throw new Error('secrets not available - cap:secrets.get not granted'); }
   },
   http: {
-    fetch: async (req: Parameters<HostBindings['http']['fetch']>[0]) => httpFetch(req)
+    fetch: async (_req: Parameters<HostBindings['http']['fetch']>[0]) => { throw new Error('http not available - cap:http.fetch not granted'); }
   },
   storage: {
-    get: async (ns: string, key: string) => storageGet(ns, key),
-    put: async (entry: Parameters<HostBindings['storage']['put']>[0]) => storagePut(entry),
-    delete: async (ns: string, key: string) => storageDelete(ns, key),
-    list: async (ns: string) => storageList(ns, null)
+    get: async (_ns: string, _key: string) => { throw new Error('storage not available - cap:storage.kv not granted'); },
+    put: async (_entry: Parameters<HostBindings['storage']['put']>[0]) => { throw new Error('storage not available - cap:storage.kv not granted'); },
+    delete: async (_ns: string, _key: string) => { throw new Error('storage not available - cap:storage.kv not granted'); },
+    list: async (_ns: string) => { throw new Error('storage not available - cap:storage.kv not granted'); }
   },
   logging: {
     info: async (msg: string) => logInfo(msg),

--- a/ee/server/.env.example
+++ b/ee/server/.env.example
@@ -52,7 +52,7 @@ EXT_CACHE_ROOT=/var/cache/alga-ext
 RUNNER_BASE_URL=http://alga-ext-runner.default.svc.cluster.local
 
 # Gateway timeout (ms)
-EXT_GATEWAY_TIMEOUT_MS=5000
+EXT_GATEWAY_TIMEOUT_MS=30000
 
 # Signing trust bundle (PEM) loaded by server/runner to verify bundles
 # Provide the contents via a mounted secret or file path

--- a/packages/product-ext-proxy/shared/gateway-utils.ts
+++ b/packages/product-ext-proxy/shared/gateway-utils.ts
@@ -125,6 +125,6 @@ export function filterResponseHeaders(
 
 export function getTimeoutMs(): number {
   const raw = process.env.EXT_GATEWAY_TIMEOUT_MS;
-  const parsed = raw ? Number(raw) : 5000;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+  const parsed = raw ? Number(raw) : 30000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
 }

--- a/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
+++ b/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
@@ -248,7 +248,7 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ extensionId: st
     const idempotencyKey = req.method === 'GET' ? undefined : (req.headers.get('x-idempotency-key') || requestId);
 
     const runnerUrl = process.env.RUNNER_BASE_URL || 'http://localhost:8080';
-    const timeoutMs = Number(process.env.EXT_GATEWAY_TIMEOUT_MS || '5000');
+    const timeoutMs = Number(process.env.EXT_GATEWAY_TIMEOUT_MS || '30000');
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/server/src/lib/jobs/handlers/extensionScheduledInvocationHandler.ts
+++ b/server/src/lib/jobs/handlers/extensionScheduledInvocationHandler.ts
@@ -186,7 +186,7 @@ export async function extensionScheduledInvocationHandler(
       }
 
       const runnerUrl = process.env.RUNNER_BASE_URL || 'http://localhost:8080';
-      const timeoutMs = Number(process.env.EXT_GATEWAY_TIMEOUT_MS || '5000');
+      const timeoutMs = Number(process.env.EXT_GATEWAY_TIMEOUT_MS || '30000');
       const maxResponseBytes = Number(process.env.EXT_RUNNER_MAX_RESPONSE_BYTES || '262144');
       const requestId = crypto.randomUUID();
 


### PR DESCRIPTION
  - Add precompile script for x86_64 and aarch64 targets
  - Add entry point and precompiled paths to manifest.json
  - Only import WIT bindings for capabilities actually declared in manifest
  - Add stubs that throw clear errors for undeclared capabilities
  - Fix uiProxy routing: /api/* routes go directly to platform, others prefixed
  - Increase default gateway timeout from 5s to 30s

  "Curiouser and curiouser!" cried the WASM module, as it discovered that importing capabilities one hasn't been granted is rather like asking the Cheshire Cat for directions to places that don't exist. 🐱✨ Now the precompiled artifacts shall journey through the looking-glass of aarch64 and x86_64, while the uiProxy learns the difference between platform API routes and those that need a proper extension prefix, just as Alice learned that eating from the wrong side of the mushroom has consequences. 🍄🔧