### PR TITLE
feat(extensions): expose user_type to extension user API

### DIFF
--- a/ee/runner/src/engine/host_api.rs
+++ b/ee/runner/src/engine/host_api.rs
@@ -1191,6 +1191,7 @@ impl user::HostWithStore for HasSelf<HostState> {
                         user_id: user_info.user_id.clone(),
                         user_email: user_info.user_email.clone(),
                         user_name: user_info.user_name.clone(),
+                        user_type: user_info.user_type.clone(),
                     })
                 }
                 None => {

--- a/ee/runner/src/models.rs
+++ b/ee/runner/src/models.rs
@@ -39,6 +39,7 @@ pub struct UserInfo {
     pub user_email: String,
     pub user_name: String,
     pub company_name: String,
+    pub user_type: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/ee/runner/wit/extension-runner.wit
+++ b/ee/runner/wit/extension-runner.wit
@@ -68,6 +68,7 @@ interface types {
         user-id: string,
         user-email: string,
         user-name: string,
+        user-type: string,
     }
 
     enum user-error {

--- a/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
+++ b/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
@@ -96,6 +96,7 @@ interface UserInfo {
   user_email: string;
   user_name: string;
   company_name: string;
+  user_type: string;
 }
 
 async function getUserInfo(tenantId: string): Promise<UserInfo | null> {
@@ -125,6 +126,7 @@ async function getUserInfo(tenantId: string): Promise<UserInfo | null> {
       user_email: currentUser.email || '',
       user_name: `${currentUser.first_name || ''} ${currentUser.last_name || ''}`.trim(),
       company_name: companyName,
+      user_type: currentUser.user_type,
     };
     console.log('[api/ext] getUserInfo completed', { elapsed: Date.now() - start });
     return info;


### PR DESCRIPTION
## Summary
- Adds `user_type` field to the extension user API, allowing extensions to distinguish between MSP users (`internal`) and portal users (`client`)
- Threads the field through all layers: WIT interface → Rust models → host implementation → gateway route

## Test plan
- [ ] Deploy runner with changes and verify extensions can call `get-user()` and receive `user_type` field
- [ ] Verify internal users return `user_type: "internal"`
- [ ] Verify portal users return `user_type: "client"`