### PR TITLE
fix(calendar): persist OAuth credentials and force refresh token

### DIFF
--- a/server/src/app/api/auth/google/calendar/callback/route.ts
+++ b/server/src/app/api/auth/google/calendar/callback/route.ts
@@ -277,6 +277,8 @@ export async function GET(request: NextRequest) {
             await providerService.updateProvider(stateData.calendarProviderId!, stateData.tenant, {
               calendarId: primaryCalendar.id,
               vendorConfig: {
+                client_id: clientId,
+                client_secret: clientSecret,
                 project_id: projectId || null,
                 redirect_uri: redirectUri,
                 access_token: access_token,

--- a/server/src/utils/calendar/oauthHelpers.ts
+++ b/server/src/utils/calendar/oauthHelpers.ts
@@ -21,7 +21,7 @@ export async function generateGoogleCalendarAuthUrl(params: {
     redirect_uri: params.redirectUri,
     state: params.state,
     access_type: 'offline',
-    prompt: 'select_account'
+    prompt: 'consent' // Force consent to ensure we get refresh token
   });
 
   return `https://accounts.google.com/o/oauth2/v2/auth?${queryParams.toString()}`;


### PR DESCRIPTION
## Summary
- Fixed "OAuth tokens not found in provider configuration" error after successful Google Calendar OAuth connection
- Added `client_id` and `client_secret` to the persisted vendor config so adapter can refresh tokens later
- Changed OAuth prompt from `select_account` to `consent` to ensure Google always returns a refresh token

## Root Cause
Two issues:
1. The callback route saved OAuth tokens but not the client credentials, so later adapter loads couldn't refresh tokens
2. Using `prompt=select_account` doesn't force Google to return a refresh_token on re-authorization

## Test plan
- [ ] Connect a Google Calendar provider
- [ ] Verify the connection succeeds without "OAuth tokens not found" error
- [ ] Verify calendar sync works after connection