### PR TITLE
Fix time entry validation error when contract_line_id is null

### DIFF
--- a/server/src/lib/schemas/timeSheet.schemas.ts
+++ b/server/src/lib/schemas/timeSheet.schemas.ts
@@ -88,6 +88,6 @@ export const timeEntrySchema = tenantSchema.extend({
   approval_status: timeSheetStatusSchema,
   service_id: z.string().optional(),
   tax_region: z.string().optional(),
-  contract_line_id: z.string().optional(),
+  contract_line_id: z.string().nullable().optional(),
   tax_rate_id: z.string().nullable().optional()
 });


### PR DESCRIPTION
## Summary
- Fixed Zod validation error when saving time entries without a contract line
- Changed `contract_line_id` schema from `.optional()` to `.nullable().optional()` to accept null values
- Aligns with existing patterns for `entry_id` and `tax_rate_id` in the same schema

## Test plan
- [ ] Save a time entry without selecting a contract line
- [ ] Verify no validation error occurs
- [ ] Verify time entries with contract lines still save correctly