### PR TITLE
fix(billing): currency-aware PO amount display on contract edit

### DIFF
--- a/server/src/lib/utils/formatters.ts
+++ b/server/src/lib/utils/formatters.ts
@@ -23,6 +23,26 @@ export function formatCurrency(
 }
 
 /**
+ * Format an amount expressed in a currency's minor units (e.g. cents) using the
+ * currency's exponent (e.g. USD=2, JPY=0).
+ */
+export function formatCurrencyFromMinorUnits(
+  minorUnits: number,
+  locale: string = 'en-US',
+  currency: string = 'USD'
+): string {
+  const resolved = new Intl.NumberFormat(locale, { style: 'currency', currency }).resolvedOptions();
+  const fractionDigits = resolved.maximumFractionDigits;
+  const value = minorUnits / Math.pow(10, fractionDigits);
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value);
+}
+
+/**
  * Format a date as a string
  * @param date The date to format
  * @param locale The locale to use (default: 'en-US')


### PR DESCRIPTION
Fixes currency display for PO Amount on the contract edit screen.

- Uses currency-aware formatting for amounts stored in minor units (cents / lowest units).
- Removes hardcoded `$` and `/100` assumptions so non-USD and non-2-decimal currencies render correctly.

Files:
- `server/src/components/billing-dashboard/contracts/ContractDetail.tsx`
- `server/src/lib/utils/formatters.ts`