### PR TITLE
Default shared Google OAuth toggle on

### DIFF
--- a/server/src/components/settings/integrations/GoogleIntegrationSettings.tsx
+++ b/server/src/components/settings/integrations/GoogleIntegrationSettings.tsx
@@ -47,7 +47,7 @@ export function GoogleIntegrationSettings() {
     } else if (res.config) {
       setProjectId(res.config.projectId || '');
       setGmailClientId(res.config.gmailClientId || '');
-      setUseSameForCalendar(res.config.usingSharedOAuthApp ?? true);
+      setUseSameForCalendar(res.config.usingSharedOAuthApp !== false);
       setCalendarClientId(res.config.calendarClientId || '');
     }
     setLoading(false);


### PR DESCRIPTION
## Summary
- default the shared Gmail+Calendar OAuth toggle to on unless explicitly disabled