### PR TITLE
fix(email): use NEXTAUTH_URL for Google webhook JWT audience verification

### DIFF
--- a/server/src/app/api/email/webhooks/google/route.ts
+++ b/server/src/app/api/email/webhooks/google/route.ts
@@ -135,7 +135,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify JWT token (audience + issuer), now that we know which tenant/provider this webhook maps to
-    const webhookUrl = `${request.nextUrl.origin}${request.nextUrl.pathname}`;
+    // Use NEXTAUTH_URL or NEXT_PUBLIC_BASE_URL for the expected audience since request.nextUrl.origin
+    // returns the container's internal URL (e.g., https://localhost:3000) instead of the public URL
+    const baseUrl = (process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || '').replace(/\/$/, '');
+    const webhookUrl = baseUrl ? `${baseUrl}${request.nextUrl.pathname}` : `${request.nextUrl.origin}${request.nextUrl.pathname}`;
     console.log('🔐 Verifying JWT token from Pub/Sub', {
       webhookUrl,
       providerId: provider.id,


### PR DESCRIPTION
## Summary
- Fixed "Wrong recipient, payload audience != requiredAudience" error in Google Pub/Sub webhook verification
- The issue was that `request.nextUrl.origin` returns the container's internal URL (`https://localhost:3000`) instead of the public URL (`https://algapsa.com`)
- Now uses `NEXTAUTH_URL` or `NEXT_PUBLIC_BASE_URL` for the expected audience

## Root Cause
When running behind a proxy/in a container, `request.nextUrl.origin` returns the internal origin, not the public-facing URL. The JWT token from Google Pub/Sub has the correct production audience, but verification failed because we were comparing against the wrong URL.

## Test plan
- [ ] Verify Gmail webhook notifications are processed successfully on production
- [ ] Confirm JWT verification passes with correct audience matching