### PR TITLE
fix(calendar): allow unauthenticated calendar webhook requests

### DIFF
--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -93,6 +93,7 @@ const _middleware = auth((request) => {
       '/api/documents/download/',
       '/api/documents/view/',
       '/api/email/webhooks/',
+      '/api/calendar/webhooks/',
       '/api/email/oauth/',
       '/api/client-portal/domain-session',
       '/api/integrations/ninjaone/callback',


### PR DESCRIPTION
## Summary
- Allow calendar webhook endpoints to receive unauthenticated requests from Microsoft
- Fixes webhook validation requests failing with 401 Unauthorized

## Details
The middleware was blocking `/api/calendar/webhooks/` requests that lacked an API key, but calendar webhooks from Microsoft (including validation requests) arrive unauthenticated. This matches the pattern already in place for email webhooks, which are also exempt from the API key requirement.

## Test plan
- Verify that Microsoft Calendar OAuth callback successfully registers webhook subscriptions
- Confirm webhook validation requests receive 200 OK response