### PR TITLE
config(helm): enable rolling updates with zero downtime

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -9,7 +9,10 @@ metadata:
 spec:
   replicas: {{ .Values.server.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       {{- include "sebastian.selectorLabels" . | nindent 6 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -55,7 +55,7 @@ server:
     tag: "4023e8f"
   verify_email: true
   pullPolicy: Always
-  replicaCount: 1
+  replicaCount: 2
   service:
     type: "ClusterIP"
     port: 3000


### PR DESCRIPTION
## Summary
- Configures deployment strategy for zero-downtime deployments using RollingUpdate
- Increases replica count to 2 for high availability
- Sets maxUnavailable: 0 and maxSurge: 1 for controlled rollouts

## Changes
- **Deployment strategy**: Changed from `Recreate` to `RollingUpdate` with:
  - `maxUnavailable: 0` - ensures at least all current pods remain running during updates
  - `maxSurge: 1` - allows one additional pod to be created at a time during rollout
- **Replica count**: Increased from 1 to 2 for high availability

## Impact
- Zero downtime during deployments
- Improved service availability with 2 replicas
- During updates, temporarily 3 pods may run (2 old + 1 new), then gracefully transitions

## Test plan
- [ ] Deploy to staging environment
- [ ] Verify 2 pods are running
- [ ] Perform a rolling update and verify zero downtime
- [ ] Confirm all pods are healthy after rollout