### PR TITLE
Fix Next.js async params in ext storage routes

### DIFF
--- a/ee/server/src/app/api/ext-storage/install/[installId]/[namespace]/records/[key]/route.ts
+++ b/ee/server/src/app/api/ext-storage/install/[installId]/[namespace]/records/[key]/route.ts
@@ -120,17 +120,18 @@ async function ensureExtensionPermission(requiredAction: 'read' | 'write', tenan
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { installId: string; namespace: string; key: string } },
+  ctx: { params: Promise<{ installId: string; namespace: string; key: string }> },
 ) {
   try {
     const ifRevisionHeader = req.headers.get('if-revision-match');
-    const { service, tenantId, knex } = await getStorageServiceForInstall(params.installId);
+    const { installId, namespace, key } = await ctx.params;
+    const { service, tenantId, knex } = await getStorageServiceForInstall(installId);
     await ensureTenantAccess(req, tenantId);
     await ensureExtensionPermission('read', tenantId, knex);
 
     const request: StorageGetRequest = {
-      namespace: params.namespace,
-      key: params.key,
+      namespace,
+      key,
       ifRevision: ifRevisionHeader ? Number(ifRevisionHeader) : undefined,
     };
 
@@ -143,17 +144,18 @@ export async function GET(
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { installId: string; namespace: string; key: string } },
+  ctx: { params: Promise<{ installId: string; namespace: string; key: string }> },
 ) {
   try {
     const body = putSchema.parse(await req.json());
-    const { service, tenantId, knex } = await getStorageServiceForInstall(params.installId);
+    const { installId, namespace, key } = await ctx.params;
+    const { service, tenantId, knex } = await getStorageServiceForInstall(installId);
     await ensureTenantAccess(req, tenantId);
     await ensureExtensionPermission('write', tenantId, knex);
 
     const request: StoragePutRequest = {
-      namespace: params.namespace,
-      key: params.key,
+      namespace,
+      key,
       value: body.value,
       metadata: body.metadata,
       ttlSeconds: body.ttlSeconds,
@@ -170,19 +172,20 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { installId: string; namespace: string; key: string } },
+  ctx: { params: Promise<{ installId: string; namespace: string; key: string }> },
 ) {
   try {
     const search = deleteQuerySchema.parse(
       Object.fromEntries(new URL(req.url).searchParams.entries()),
     );
-    const { service, tenantId, knex } = await getStorageServiceForInstall(params.installId);
+    const { installId, namespace, key } = await ctx.params;
+    const { service, tenantId, knex } = await getStorageServiceForInstall(installId);
     await ensureTenantAccess(req, tenantId);
     await ensureExtensionPermission('write', tenantId, knex);
 
     const request: StorageDeleteRequest = {
-      namespace: params.namespace,
-      key: params.key,
+      namespace,
+      key,
       ifRevision: search.ifRevision,
     };
 

--- a/ee/server/src/app/api/ext-storage/install/[installId]/[namespace]/records/route.ts
+++ b/ee/server/src/app/api/ext-storage/install/[installId]/[namespace]/records/route.ts
@@ -127,16 +127,17 @@ async function ensureExtensionPermission(requiredAction: 'read' | 'write', tenan
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { installId: string; namespace: string } },
+  ctx: { params: Promise<{ installId: string; namespace: string }> },
 ) {
   try {
+    const { installId, namespace } = await ctx.params;
     const search = listQuerySchema.parse(Object.fromEntries(new URL(req.url).searchParams.entries()));
-    const { service, tenantId, knex } = await getStorageServiceForInstall(params.installId);
+    const { service, tenantId, knex } = await getStorageServiceForInstall(installId);
     await ensureTenantAccess(req, tenantId);
     await ensureExtensionPermission('read', tenantId, knex);
 
     const request: StorageListRequest = {
-      namespace: params.namespace,
+      namespace,
       limit: search.limit,
       cursor: search.cursor,
       keyPrefix: search.keyPrefix,
@@ -153,16 +154,17 @@ export async function GET(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { installId: string; namespace: string } },
+  ctx: { params: Promise<{ installId: string; namespace: string }> },
 ) {
   try {
+    const { installId, namespace } = await ctx.params;
     const body = bulkPutSchema.parse(await req.json());
-    const { service, tenantId, knex } = await getStorageServiceForInstall(params.installId);
+    const { service, tenantId, knex } = await getStorageServiceForInstall(installId);
     await ensureTenantAccess(req, tenantId);
     await ensureExtensionPermission('write', tenantId, knex);
 
     const request: StorageBulkPutRequest = {
-      namespace: params.namespace,
+      namespace,
       items: body.items,
     };
 

--- a/ee/server/src/app/api/internal/ext-scheduler/install/[installId]/route.ts
+++ b/ee/server/src/app/api/internal/ext-scheduler/install/[installId]/route.ts
@@ -166,20 +166,21 @@ async function getInstallContext(installId: string): Promise<InstallContext> {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { installId: string } }
+  ctx: { params: Promise<{ installId: string }> }
 ) {
   try {
     ensureRunnerAuth(req);
+    const { installId } = await ctx.params;
 
     const raw = await req.json();
     const base = baseSchema.parse(raw);
 
     // Apply rate limiting for mutating operations
-    if (!checkRateLimit(params.installId, base.operation)) {
+    if (!checkRateLimit(installId, base.operation)) {
       throw new SchedulerApiError('RATE_LIMITED', 'Too many requests, please try again later');
     }
 
-    const ctx = await getInstallContext(params.installId);
+    const ctx = await getInstallContext(installId);
 
     switch (base.operation) {
       case 'list': {

--- a/ee/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
+++ b/ee/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
@@ -110,14 +110,15 @@ function ensureRunnerAuth(req: NextRequest): void {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { installId: string } }
+  ctx: { params: Promise<{ installId: string }> }
 ) {
   try {
     ensureRunnerAuth(req);
 
+    const { installId } = await ctx.params;
     const raw = await req.json();
     const base = baseSchema.parse(raw);
-    const { service } = await getStorageServiceForInstall(params.installId);
+    const { service } = await getStorageServiceForInstall(installId);
 
     switch (base.operation) {
       case 'put': {

--- a/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
+++ b/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
@@ -8,7 +8,7 @@ const isEnterpriseEdition =
   (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
 
 type EeRouteModule = {
-  POST: (req: NextRequest, ctx: { params: { installId: string } }) => Promise<Response> | Response;
+  POST: (req: NextRequest, ctx: { params: Promise<{ installId: string }> }) => Promise<Response> | Response;
 };
 
 let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
@@ -45,7 +45,7 @@ function eeUnavailable(): Response {
 
 export async function POST(
   request: NextRequest,
-  ctx: { params: { installId: string } }
+  ctx: { params: Promise<{ installId: string }> }
 ): Promise<Response> {
   const eeRoute = await loadEeRoute();
   if (!eeRoute?.POST) {


### PR DESCRIPTION
Next.js now provides route params as a Promise for dynamic routes. Accessing params.installId synchronously caused installId to be undefined and triggered "installId is required" failures for the internal ext-storage API.

This PR awaits ctx.params in the internal ext-storage + ext-scheduler routes, plus the public ext-storage routes, and aligns the non-EE shim signature to match.