### PR TITLE
Fix user identity cross-contamination in onboarding wizard

### DIFF
--- a/server/src/app/msp/onboarding/page.tsx
+++ b/server/src/app/msp/onboarding/page.tsx
@@ -39,10 +39,14 @@ export default function OnboardingPage() {
         const initialDataResult = await getOnboardingInitialData();
 
         if (initialDataResult.success && initialDataResult.data) {
-          // Merge with any existing saved data (saved data takes precedence)
+          // Merge saved progress with current user data
+          // IMPORTANT: User-specific fields (firstName, lastName, email) must always come from
+          // the current user's session, NOT from saved tenant-wide data which could contain
+          // another user's info if they previously used the wizard
+          const { firstName: _f, lastName: _l, email: _e, ...savedNonUserData } = data;
           data = {
-            ...initialDataResult.data,
-            ...data
+            ...savedNonUserData,        // Saved progress (client info, team members, etc.)
+            ...initialDataResult.data,  // Current user's identity always takes precedence
           };
         }
       } else {

--- a/server/src/lib/actions/onboarding-actions/onboardingActions.ts
+++ b/server/src/lib/actions/onboarding-actions/onboardingActions.ts
@@ -128,13 +128,12 @@ export async function saveClientInfo(data: ClientInfoData): Promise<OnboardingAc
       }
 
       // Save progress to tenant settings
+      // IMPORTANT: Do NOT save user-specific fields (firstName, lastName, email) to tenant-wide storage
+      // These fields are specific to the current user and should not be shared across users in the tenant
+      // Only save tenant-level data like clientName
       const progressData: any = {
         clientName: data.clientName
       };
-
-      if (data.firstName) progressData.firstName = data.firstName;
-      if (data.lastName) progressData.lastName = data.lastName;
-      if (data.email) progressData.email = data.email;
 
       await saveTenantOnboardingProgress(progressData);
     });


### PR DESCRIPTION
The Cheshire progressData grinned wickedly from atop the tenant_settings table, having swapped everyone's firstName like teacups at a very rude party. "We shall decrapitate your identity at once!" declared the Queen of Sessions, wielding her mighty spreadOperator. "Off with their savedNonUserData!" 🎩👤🔀🫖