### PR TITLE
Add async tenant export workflow with status polling

### DIFF
--- a/ee/extensions/nineminds-reporting/src/iframe/main.tsx
+++ b/ee/extensions/nineminds-reporting/src/iframe/main.tsx
@@ -2205,17 +2205,7 @@ function ExecuteReport() {
           style={{ minWidth: '150px' }}
         >
           {executing ? (
-            <span style={{ display: 'flex', alignItems: 'center', gap: '8px', justifyContent: 'center' }}>
-              <span style={{
-                width: '14px',
-                height: '14px',
-                border: '2px solid rgba(255,255,255,0.3)',
-                borderTopColor: 'white',
-                borderRadius: '50%',
-                animation: 'spin 1s linear infinite',
-              }} />
-              Executing...
-            </span>
+            <><Spinner size="button" variant="inverted" style={{ marginRight: '8px' }} /> Executing...</>
           ) : 'Execute Report'}
         </Button>
       </Card>
@@ -2228,12 +2218,6 @@ function ExecuteReport() {
           <ResultsRenderer results={results} />
         </div>
       )}
-
-      <style>{`
-        @keyframes spin {
-          to { transform: rotate(360deg); }
-        }
-      `}</style>
     </div>
   );
 }
@@ -2302,7 +2286,7 @@ function ActionMenu({ items, disabled, loading }: ActionMenuProps) {
         style={{ minWidth: '80px' }}
       >
         {loading ? (
-          <><Spinner size="xs" style={{ marginRight: '4px' }} /> Working...</>
+          <><Spinner size="button" style={{ marginRight: '4px' }} /> Working...</>
         ) : (
           <>Actions ▾</>
         )}
@@ -2507,13 +2491,17 @@ function TenantManagementView() {
   // Export dialog state
   const [showExportResultDialog, setShowExportResultDialog] = useState(false);
   const [exportResult, setExportResult] = useState<{
+    status: 'in_progress' | 'completed';
     tenantName: string;
-    downloadUrl: string;
-    urlExpiresAt: string;
-    tableCount: number;
-    recordCount: number;
-    fileSizeBytes: number;
+    workflowId?: string;
+    downloadUrl?: string;
+    urlExpiresAt?: string;
+    tableCount?: number;
+    recordCount?: number;
+    fileSizeBytes?: number;
+    message?: string;
   } | null>(null);
+  const [exportPollingInterval, setExportPollingInterval] = useState<NodeJS.Timeout | null>(null);
 
   // Fetch tenants
   const fetchTenants = useCallback(async () => {
@@ -2757,18 +2745,71 @@ function TenantManagementView() {
     }
   };
 
+  // Poll for export status
+  const pollExportStatus = async (workflowId: string, tenantName: string) => {
+    try {
+      const result = await callTenantManagementApi<{
+        status: 'pending' | 'in_progress' | 'completed' | 'failed';
+        workflowId: string;
+        downloadUrl?: string;
+        urlExpiresAt?: string;
+        tableCount?: number;
+        recordCount?: number;
+        fileSizeBytes?: number;
+        error?: string;
+      }>(`/export-status?workflowId=${encodeURIComponent(workflowId)}`);
+
+      if (result.success && result.data) {
+        if (result.data.status === 'completed') {
+          // Stop polling
+          if (exportPollingInterval) {
+            clearInterval(exportPollingInterval);
+            setExportPollingInterval(null);
+          }
+          // Update result with completed data
+          setExportResult({
+            status: 'completed',
+            tenantName,
+            workflowId,
+            downloadUrl: result.data.downloadUrl,
+            urlExpiresAt: result.data.urlExpiresAt,
+            tableCount: result.data.tableCount,
+            recordCount: result.data.recordCount,
+            fileSizeBytes: result.data.fileSizeBytes,
+          });
+          fetchAuditLogs();
+        } else if (result.data.status === 'failed') {
+          // Stop polling
+          if (exportPollingInterval) {
+            clearInterval(exportPollingInterval);
+            setExportPollingInterval(null);
+          }
+          setShowExportResultDialog(false);
+          setExportResult(null);
+          setStatusMessage({ type: 'error', text: `Export failed: ${result.data.error || 'Unknown error'}` });
+        }
+        // If still in progress, continue polling
+      }
+    } catch (err) {
+      console.error('Error polling export status:', err);
+    }
+  };
+
   // Handle export tenant data
   const handleExportTenant = async (tenant: Tenant) => {
     setActionInProgress(tenant.tenant);
     try {
       const result = await callTenantManagementApi<{
-        exportId: string;
+        status: 'in_progress' | 'completed';
+        workflowId?: string;
+        exportId?: string;
         tenantName: string;
-        downloadUrl: string;
-        urlExpiresAt: string;
-        tableCount: number;
-        recordCount: number;
-        fileSizeBytes: number;
+        downloadUrl?: string;
+        urlExpiresAt?: string;
+        tableCount?: number;
+        recordCount?: number;
+        fileSizeBytes?: number;
+        message?: string;
       }>('/export-tenant', {
         method: 'POST',
         body: JSON.stringify({
@@ -2778,16 +2819,40 @@ function TenantManagementView() {
       });
 
       if (result.success && result.data) {
-        setExportResult({
-          tenantName: result.data.tenantName || tenant.client_name,
-          downloadUrl: result.data.downloadUrl,
-          urlExpiresAt: result.data.urlExpiresAt,
-          tableCount: result.data.tableCount,
-          recordCount: result.data.recordCount,
-          fileSizeBytes: result.data.fileSizeBytes,
-        });
-        setShowExportResultDialog(true);
-        fetchAuditLogs();
+        const data = result.data;
+
+        if (data.status === 'completed') {
+          // Export completed immediately
+          setExportResult({
+            status: 'completed',
+            tenantName: data.tenantName || tenant.client_name,
+            workflowId: data.workflowId,
+            downloadUrl: data.downloadUrl,
+            urlExpiresAt: data.urlExpiresAt,
+            tableCount: data.tableCount,
+            recordCount: data.recordCount,
+            fileSizeBytes: data.fileSizeBytes,
+          });
+          setShowExportResultDialog(true);
+          fetchAuditLogs();
+        } else if (data.status === 'in_progress' && data.workflowId) {
+          // Export is in progress, show dialog and start polling
+          setExportResult({
+            status: 'in_progress',
+            tenantName: data.tenantName || tenant.client_name,
+            workflowId: data.workflowId,
+            message: data.message || 'Export in progress...',
+          });
+          setShowExportResultDialog(true);
+
+          // Start polling every 2 seconds
+          const interval = setInterval(() => {
+            pollExportStatus(data.workflowId!, data.tenantName || tenant.client_name);
+          }, 2000);
+          setExportPollingInterval(interval);
+        } else {
+          setStatusMessage({ type: 'error', text: `Unexpected response: ${JSON.stringify(data)}` });
+        }
       } else {
         setStatusMessage({ type: 'error', text: `Export failed: ${result.error}` });
       }
@@ -2797,6 +2862,15 @@ function TenantManagementView() {
       setActionInProgress(null);
     }
   };
+
+  // Cleanup polling interval on unmount
+  useEffect(() => {
+    return () => {
+      if (exportPollingInterval) {
+        clearInterval(exportPollingInterval);
+      }
+    };
+  }, [exportPollingInterval]);
 
   // Check if tenant has a pending deletion
   const hasPendingDeletion = (tenantId: string): boolean => {
@@ -2978,7 +3052,7 @@ function TenantManagementView() {
         <h2 style={{ margin: 0 }}>Tenant Management</h2>
         <div style={{ display: 'flex', gap: '8px' }}>
           <Button variant="secondary" onClick={() => { fetchTenants(); fetchAuditLogs(); fetchPendingDeletions(); }} disabled={loading}>
-            {loading ? <><Spinner size="xs" style={{ marginRight: '6px' }} /> Loading...</> : 'Refresh'}
+            {loading ? <><Spinner size="button" style={{ marginRight: '6px' }} /> Loading...</> : 'Refresh'}
           </Button>
           <Button onClick={() => setShowCreateForm(true)}>
             Create Tenant
@@ -3332,23 +3406,50 @@ function TenantManagementView() {
       {/* Export Result Dialog */}
       <ConfirmDialog
         isOpen={showExportResultDialog}
-        title="Export Complete"
-        message={exportResult ? `Successfully exported data for "${exportResult.tenantName}".` : ''}
+        title={exportResult?.status === 'in_progress' ? 'Export In Progress' : 'Export Complete'}
+        message={exportResult ? (
+          exportResult.status === 'in_progress'
+            ? `Exporting data for "${exportResult.tenantName}"...`
+            : `Successfully exported data for "${exportResult.tenantName}".`
+        ) : ''}
         onConfirm={() => {
-          if (exportResult?.downloadUrl) {
+          if (exportResult?.status === 'completed' && exportResult?.downloadUrl) {
             window.open(exportResult.downloadUrl, '_blank');
+          }
+          if (exportResult?.status === 'completed') {
+            setShowExportResultDialog(false);
+            setExportResult(null);
+          }
+        }}
+        onCancel={() => {
+          // Stop polling if in progress
+          if (exportPollingInterval) {
+            clearInterval(exportPollingInterval);
+            setExportPollingInterval(null);
           }
           setShowExportResultDialog(false);
           setExportResult(null);
         }}
-        onCancel={() => {
-          setShowExportResultDialog(false);
-          setExportResult(null);
-        }}
-        confirmText="Download"
+        confirmText={exportResult?.status === 'in_progress' ? 'Please wait...' : 'Download'}
         cancelLabel="Close"
+        confirmDisabled={exportResult?.status === 'in_progress'}
       >
-        {exportResult && (
+        {exportResult && exportResult.status === 'in_progress' && (
+          <div style={{ marginTop: '12px' }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '24px',
+            }}>
+              <Spinner size="sm" />
+            </div>
+            <Alert tone="info">
+              Large exports may take a few minutes. You can close this dialog and check the audit log for status.
+            </Alert>
+          </div>
+        )}
+        {exportResult && exportResult.status === 'completed' && (
           <div style={{ marginTop: '12px' }}>
             <div style={{
               backgroundColor: 'var(--alga-surface)',
@@ -3359,19 +3460,19 @@ function TenantManagementView() {
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px', fontSize: '0.875rem' }}>
                 <div>
                   <Text tone="muted">Tables:</Text>
-                  <Text style={{ fontWeight: 500 }}>{exportResult.tableCount}</Text>
+                  <Text style={{ fontWeight: 500 }}>{exportResult.tableCount ?? '-'}</Text>
                 </div>
                 <div>
                   <Text tone="muted">Records:</Text>
-                  <Text style={{ fontWeight: 500 }}>{exportResult.recordCount.toLocaleString()}</Text>
+                  <Text style={{ fontWeight: 500 }}>{exportResult.recordCount?.toLocaleString() ?? '-'}</Text>
                 </div>
                 <div>
                   <Text tone="muted">File Size:</Text>
-                  <Text style={{ fontWeight: 500 }}>{(exportResult.fileSizeBytes / 1024 / 1024).toFixed(2)} MB</Text>
+                  <Text style={{ fontWeight: 500 }}>{exportResult.fileSizeBytes ? ((exportResult.fileSizeBytes / 1024 / 1024).toFixed(2) + ' MB') : '-'}</Text>
                 </div>
                 <div>
                   <Text tone="muted">Expires:</Text>
-                  <Text style={{ fontWeight: 500 }}>{new Date(exportResult.urlExpiresAt).toLocaleTimeString()}</Text>
+                  <Text style={{ fontWeight: 500 }}>{exportResult.urlExpiresAt ? new Date(exportResult.urlExpiresAt).toLocaleTimeString() : '-'}</Text>
                 </div>
               </div>
             </div>
@@ -3564,7 +3665,7 @@ function AuditLogs() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
         <h2 style={{ margin: 0 }}>Audit Logs</h2>
         <Button variant="secondary" onClick={fetchLogs} disabled={loading}>
-          {loading ? <><Spinner size="xs" style={{ marginRight: '6px' }} /> Loading...</> : 'Refresh'}
+          {loading ? <><Spinner size="button" style={{ marginRight: '6px' }} /> Loading...</> : 'Refresh'}
         </Button>
       </div>
 

--- a/ee/server/src/app/api/v1/tenant-management/export-status/route.ts
+++ b/ee/server/src/app/api/v1/tenant-management/export-status/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/getSession';
+import { ApiKeyServiceForApi } from '@/lib/services/apiKeyServiceForApi';
+import { TenantWorkflowClient } from '@ee/temporal-workflows/client';
+
+const MASTER_BILLING_TENANT_ID = process.env.MASTER_BILLING_TENANT_ID;
+
+/**
+ * Check if this is an internal request from ext-proxy with trusted user info.
+ */
+function getInternalUserInfo(request: NextRequest): { user_id: string; tenant: string; email?: string } | null {
+  const internalRequest = request.headers.get('x-internal-request');
+  if (internalRequest !== 'ext-proxy-prefetch') {
+    return null;
+  }
+
+  const userId = request.headers.get('x-internal-user-id');
+  const tenant = request.headers.get('x-internal-user-tenant');
+  const email = request.headers.get('x-internal-user-email') || undefined;
+
+  if (!userId || !tenant) {
+    return null;
+  }
+
+  return { user_id: userId, tenant, email };
+}
+
+/**
+ * GET /api/v1/tenant-management/export-status?workflowId=xxx
+ *
+ * Get the status of a tenant export workflow.
+ * Requires master tenant authorization.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    if (!MASTER_BILLING_TENANT_ID) {
+      return NextResponse.json({ success: false, error: 'MASTER_BILLING_TENANT_ID not configured' }, { status: 500 });
+    }
+
+    // Check for internal ext-proxy request first
+    const internalUser = getInternalUserInfo(req);
+    let userTenant: string;
+
+    if (internalUser) {
+      userTenant = internalUser.tenant;
+    } else {
+      // Check for API key auth (used by extension uiProxy)
+      const apiKey = req.headers.get('x-api-key');
+      if (apiKey) {
+        const keyRecord = await ApiKeyServiceForApi.validateApiKeyAnyTenant(apiKey);
+        if (keyRecord) {
+          if (keyRecord.tenant === MASTER_BILLING_TENANT_ID) {
+            userTenant = MASTER_BILLING_TENANT_ID;
+          } else {
+            return NextResponse.json({ success: false, error: 'API key not authorized for tenant management' }, { status: 403 });
+          }
+        } else {
+          return NextResponse.json({ success: false, error: 'Invalid API key' }, { status: 401 });
+        }
+      } else {
+        // Fall back to session auth
+        const session = await getSession();
+
+        if (!session?.user) {
+          return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const user = session.user as any;
+        userTenant = user.tenant;
+      }
+    }
+
+    // Verify user is from master tenant
+    if (userTenant !== MASTER_BILLING_TENANT_ID) {
+      return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const workflowId = searchParams.get('workflowId');
+
+    if (!workflowId) {
+      return NextResponse.json({ success: false, error: 'workflowId is required' }, { status: 400 });
+    }
+
+    // Query the workflow state
+    const client = await TenantWorkflowClient.create();
+
+    try {
+      const state = await client.getTenantExportState(workflowId);
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          workflowId,
+          status: state.status,
+          step: state.step,
+          exportId: state.exportId,
+          tenantId: state.tenantId,
+          tenantName: state.tenantName,
+          progress: state.progress,
+          currentTable: state.currentTable,
+          s3Key: state.s3Key,
+          downloadUrl: state.downloadUrl,
+          urlExpiresAt: state.urlExpiresAt,
+          fileSizeBytes: state.fileSizeBytes,
+          tableCount: state.tableCount,
+          recordCount: state.recordCount,
+          error: state.error,
+          startedAt: state.startedAt,
+          completedAt: state.completedAt,
+        },
+      });
+    } catch (error) {
+      // Check if workflow doesn't exist or completed
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // If the workflow is not found, it might have completed - try to get the result
+      if (errorMessage.includes('not found') || errorMessage.includes('workflow not found')) {
+        return NextResponse.json({
+          success: false,
+          error: 'Workflow not found. It may have completed or never existed.',
+        }, { status: 404 });
+      }
+
+      throw error;
+    } finally {
+      await client.close();
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    return NextResponse.json({
+      success: false,
+      error: errorMessage,
+    }, { status: 500 });
+  }
+}

--- a/ee/server/src/app/api/v1/tenant-management/export-tenant/route.ts
+++ b/ee/server/src/app/api/v1/tenant-management/export-tenant/route.ts
@@ -3,7 +3,7 @@ import { getSession } from '@/lib/auth/getSession';
 import { getAdminConnection } from '@alga-psa/shared/db/admin';
 import { observabilityLogger } from '@/lib/observability/logging';
 import { ApiKeyServiceForApi } from '@/lib/services/apiKeyServiceForApi';
-import { exportTenantData } from '@ee/lib/tenant-management/tenant-export';
+import { TenantWorkflowClient } from '@ee/temporal-workflows/client';
 
 const MASTER_BILLING_TENANT_ID = process.env.MASTER_BILLING_TENANT_ID;
 
@@ -30,8 +30,8 @@ function getInternalUserInfo(request: NextRequest): { user_id: string; tenant: s
 /**
  * POST /api/v1/tenant-management/export-tenant
  *
- * Export all data for a tenant to JSON and upload to S3.
- * Returns a presigned download URL.
+ * Start a tenant data export workflow.
+ * Returns a workflowId for polling status, or waits for completion if quick.
  * Requires master tenant authorization.
  */
 export async function POST(req: NextRequest) {
@@ -108,7 +108,7 @@ export async function POST(req: NextRequest) {
     }
 
     // LOG: Action initiated
-    observabilityLogger.info('Export tenant data initiated', {
+    observabilityLogger.info('Export tenant data initiated via Temporal workflow', {
       event_type: 'tenant_management_action',
       action: 'export_tenant_data',
       tenant_id: tenantId,
@@ -132,65 +132,125 @@ export async function POST(req: NextRequest) {
       })
       .returning('log_id');
 
-    // Execute export (this runs synchronously - could be moved to Temporal for large tenants)
-    const exportResult = await exportTenantData({
-      tenantId,
-      requestedBy: userId,
-      reason,
-    });
+    // Start the Temporal workflow
+    const client = await TenantWorkflowClient.create();
 
-    if (!exportResult.success) {
-      // Update audit record with failure
+    try {
+      const { workflowId, result } = await client.startTenantExport({
+        tenantId,
+        requestedBy: userId,
+        reason,
+      });
+
+      observabilityLogger.info('Export workflow started', {
+        event_type: 'tenant_management_workflow_started',
+        action: 'export_tenant_data',
+        tenant_id: tenantId,
+        workflow_id: workflowId,
+      });
+
+      // Wait for the workflow to complete (with timeout)
+      // Most exports complete in seconds, so we wait up to 2 minutes
+      const WAIT_TIMEOUT_MS = 120000;
+
+      const timeoutPromise = new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), WAIT_TIMEOUT_MS);
+      });
+
+      const exportResult = await Promise.race([result, timeoutPromise]);
+
+      if (exportResult === null) {
+        // Workflow is still running, return workflowId for polling
+        observabilityLogger.info('Export workflow still in progress, returning workflowId for polling', {
+          workflow_id: workflowId,
+          tenant_id: tenantId,
+        });
+
+        // Update audit record to show workflow is in progress
+        await knex('extension_audit_logs')
+          .where({ tenant: MASTER_BILLING_TENANT_ID, log_id: auditRecord.log_id })
+          .update({
+            status: 'in_progress',
+            details: JSON.stringify({
+              source: 'ninemindsreporting_extension',
+              reason,
+              workflowId,
+            }),
+          });
+
+        return NextResponse.json({
+          success: true,
+          data: {
+            status: 'in_progress',
+            workflowId,
+            tenantName: targetTenant.client_name,
+            message: 'Export started. Poll /export-status for progress.',
+          },
+        });
+      }
+
+      // Workflow completed
+      if (!exportResult.success) {
+        // Update audit record with failure
+        await knex('extension_audit_logs')
+          .where({ tenant: MASTER_BILLING_TENANT_ID, log_id: auditRecord.log_id })
+          .update({
+            status: 'failed',
+            error_message: exportResult.error || 'Export failed',
+          });
+
+        return NextResponse.json({
+          success: false,
+          error: exportResult.error || 'Export failed',
+        }, { status: 500 });
+      }
+
+      // Update audit record with success
       await knex('extension_audit_logs')
         .where({ tenant: MASTER_BILLING_TENANT_ID, log_id: auditRecord.log_id })
         .update({
-          status: 'failed',
-          error_message: exportResult.error || 'Export failed',
+          status: 'completed',
+          details: JSON.stringify({
+            source: 'ninemindsreporting_extension',
+            reason,
+            workflowId,
+            exportId: exportResult.exportId,
+            tableCount: exportResult.tableCount,
+            recordCount: exportResult.recordCount,
+            fileSizeBytes: exportResult.fileSizeBytes,
+            duration_ms: Date.now() - startTime,
+          }),
         });
 
-      return NextResponse.json({
-        success: false,
-        error: exportResult.error || 'Export failed',
-      }, { status: 500 });
-    }
+      // LOG: Action completed
+      observabilityLogger.info('Export tenant data completed', {
+        event_type: 'tenant_management_action_completed',
+        action: 'export_tenant_data',
+        tenant_id: tenantId,
+        workflow_id: workflowId,
+        export_id: exportResult.exportId,
+        table_count: exportResult.tableCount,
+        record_count: exportResult.recordCount,
+        duration_ms: Date.now() - startTime,
+      });
 
-    // Update audit record with success
-    await knex('extension_audit_logs')
-      .where({ tenant: MASTER_BILLING_TENANT_ID, log_id: auditRecord.log_id })
-      .update({
-        status: 'completed',
-        details: JSON.stringify({
-          source: 'ninemindsreporting_extension',
-          reason,
+      return NextResponse.json({
+        success: true,
+        data: {
+          status: 'completed',
+          workflowId,
           exportId: exportResult.exportId,
+          tenantName: targetTenant.client_name,
+          downloadUrl: exportResult.downloadUrl,
+          urlExpiresAt: exportResult.urlExpiresAt,
           tableCount: exportResult.tableCount,
           recordCount: exportResult.recordCount,
           fileSizeBytes: exportResult.fileSizeBytes,
-          duration_ms: Date.now() - startTime,
-        }),
+        },
       });
-
-    // LOG: Action completed
-    observabilityLogger.info('Export tenant data completed', {
-      event_type: 'tenant_management_action_completed',
-      action: 'export_tenant_data',
-      tenant_id: tenantId,
-      export_id: exportResult.exportId,
-      table_count: exportResult.tableCount,
-      record_count: exportResult.recordCount,
-      duration_ms: Date.now() - startTime,
-    });
-
-    return NextResponse.json({
-      success: true,
-      exportId: exportResult.exportId,
-      tenantName: targetTenant.client_name,
-      downloadUrl: exportResult.downloadUrl,
-      urlExpiresAt: exportResult.urlExpiresAt,
-      tableCount: exportResult.tableCount,
-      recordCount: exportResult.recordCount,
-      fileSizeBytes: exportResult.fileSizeBytes,
-    });
+    } finally {
+      await client.close();
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 

--- a/ee/temporal-workflows/src/activities/tenant-export-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-export-activities.ts
@@ -141,8 +141,9 @@ export async function exportTenantData(
   input: ExportTenantDataInput
 ): Promise<ExportTenantDataResult> {
   const log = logger();
-  const { tenantId, requestedBy, reason, urlExpiresIn = 3600 } = input; // 1 hour default for initial URL
-  const exportId = crypto.randomUUID();
+  const { tenantId, requestedBy, reason, urlExpiresIn = 3600, exportId: providedExportId } = input; // 1 hour default for initial URL
+  // Use provided exportId (from workflow) or generate a new one
+  const exportId = providedExportId || crypto.randomUUID();
 
   log.info('Starting tenant data export', {
     tenantId,

--- a/ee/temporal-workflows/src/types/tenant-export-types.ts
+++ b/ee/temporal-workflows/src/types/tenant-export-types.ts
@@ -13,6 +13,8 @@ export interface ExportTenantDataInput {
   reason?: string;
   /** URL expiration in seconds (default: 1 hour = 3600) */
   urlExpiresIn?: number;
+  /** Optional export ID - if not provided, one will be generated */
+  exportId?: string;
 }
 
 export interface ExportTenantDataResult {
@@ -64,5 +66,75 @@ export interface TenantExportRecord {
 export interface ListTenantExportsResult {
   success: boolean;
   exports?: TenantExportRecord[];
+  error?: string;
+}
+
+// Workflow-specific types
+
+export type TenantExportStep =
+  | 'initializing'
+  | 'validating_tenant'
+  | 'collecting_data'
+  | 'uploading_to_s3'
+  | 'generating_url'
+  | 'completed'
+  | 'failed';
+
+export type TenantExportStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'failed';
+
+export interface TenantExportWorkflowInput {
+  tenantId: string;
+  requestedBy: string;
+  reason?: string;
+  /** URL expiration in seconds (default: 1 hour = 3600) */
+  urlExpiresIn?: number;
+}
+
+export interface TenantExportWorkflowState {
+  step: TenantExportStep;
+  status: TenantExportStatus;
+  exportId: string;
+  tenantId: string;
+  tenantName?: string;
+  /** Progress percentage (0-100) */
+  progress?: number;
+  /** Current table being exported */
+  currentTable?: string;
+  /** S3 key where export is stored */
+  s3Key?: string;
+  /** Presigned download URL */
+  downloadUrl?: string;
+  /** When download URL expires */
+  urlExpiresAt?: ISO8601String;
+  /** File size in bytes */
+  fileSizeBytes?: number;
+  /** Number of tables exported */
+  tableCount?: number;
+  /** Total records exported */
+  recordCount?: number;
+  /** Error message if failed */
+  error?: string;
+  /** When export started */
+  startedAt?: ISO8601String;
+  /** When export completed */
+  completedAt?: ISO8601String;
+}
+
+export interface TenantExportWorkflowResult {
+  success: boolean;
+  exportId: string;
+  tenantId: string;
+  tenantName?: string;
+  status: TenantExportStatus;
+  s3Key?: string;
+  downloadUrl?: string;
+  urlExpiresAt?: ISO8601String;
+  fileSizeBytes?: number;
+  tableCount?: number;
+  recordCount?: number;
   error?: string;
 }

--- a/ee/temporal-workflows/src/workflows/index.ts
+++ b/ee/temporal-workflows/src/workflows/index.ts
@@ -9,3 +9,4 @@ export * from './calendar-webhook-maintenance-workflow.js';
 export * from './ninjaone-sync-workflow.js';
 export * from './resend-welcome-email-workflow.js';
 export * from './tenant-deletion-workflow.js';
+export * from './tenant-export-workflow.js';

--- a/ee/temporal-workflows/src/workflows/tenant-deletion-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/tenant-deletion-workflow.ts
@@ -7,6 +7,7 @@ import {
   condition,
   sleep,
   workflowInfo,
+  uuid4,
 } from '@temporalio/workflow';
 import type * as activities from '../activities/tenant-deletion-activities';
 import type {
@@ -69,8 +70,8 @@ const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
 export async function tenantDeletionWorkflow(
   input: TenantDeletionInput
 ): Promise<TenantDeletionResult> {
-  // Generate unique deletion ID
-  const deletionId = crypto.randomUUID();
+  // Generate unique deletion ID using Temporal's deterministic UUID
+  const deletionId = uuid4();
   const { workflowId, firstExecutionRunId } = workflowInfo();
 
   // Initialize workflow state

--- a/ee/temporal-workflows/src/workflows/tenant-export-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/tenant-export-workflow.ts
@@ -1,0 +1,162 @@
+import {
+  proxyActivities,
+  defineQuery,
+  setHandler,
+  log,
+  workflowInfo,
+  uuid4,
+} from '@temporalio/workflow';
+import type * as activities from '../activities/tenant-export-activities';
+import type {
+  TenantExportWorkflowInput,
+  TenantExportWorkflowResult,
+  TenantExportWorkflowState,
+} from '../types/tenant-export-types.js';
+
+// Activity proxies with appropriate timeouts
+// Export can take a while for large tenants
+const { exportTenantData } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '30 minutes',
+  heartbeatTimeout: '5 minutes',
+  retry: {
+    maximumAttempts: 3,
+    backoffCoefficient: 2.0,
+    initialInterval: '5 seconds',
+    maximumInterval: '1 minute',
+    nonRetryableErrorTypes: ['ValidationError', 'TenantNotFoundError'],
+  },
+});
+
+// Query to get current workflow state
+export const getExportWorkflowStateQuery = defineQuery<TenantExportWorkflowState>('getExportState');
+
+/**
+ * Tenant Export Workflow
+ *
+ * This workflow handles exporting all tenant data:
+ * 1. Validates the tenant exists
+ * 2. Collects data from all tenant tables
+ * 3. Uploads to S3 storage
+ * 4. Generates a presigned download URL
+ *
+ * The workflow returns immediately with a workflow ID, allowing
+ * the caller to poll for status via the query handler.
+ */
+export async function tenantExportWorkflow(
+  input: TenantExportWorkflowInput
+): Promise<TenantExportWorkflowResult> {
+  // Generate unique export ID using Temporal's deterministic UUID
+  const exportId = uuid4();
+  const { workflowId } = workflowInfo();
+
+  // Initialize workflow state
+  let state: TenantExportWorkflowState = {
+    step: 'initializing',
+    status: 'pending',
+    exportId,
+    tenantId: input.tenantId,
+    startedAt: new Date().toISOString(),
+  };
+
+  // Set up query handler for status polling
+  setHandler(getExportWorkflowStateQuery, () => state);
+
+  try {
+    log.info('Starting tenant export workflow', {
+      tenantId: input.tenantId,
+      exportId,
+      workflowId,
+      requestedBy: input.requestedBy,
+      reason: input.reason,
+    });
+
+    // Update state to in_progress
+    state.status = 'in_progress';
+    state.step = 'collecting_data';
+
+    // Execute the export activity
+    // This handles: validation, data collection, S3 upload, and URL generation
+    // Pass the workflow-generated exportId to ensure consistency
+    const exportResult = await exportTenantData({
+      tenantId: input.tenantId,
+      requestedBy: input.requestedBy,
+      reason: input.reason,
+      urlExpiresIn: input.urlExpiresIn,
+      exportId,
+    });
+
+    if (!exportResult.success) {
+      state.step = 'failed';
+      state.status = 'failed';
+      state.error = exportResult.error || 'Export failed';
+      state.completedAt = new Date().toISOString();
+
+      log.error('Tenant export failed', {
+        tenantId: input.tenantId,
+        exportId,
+        error: state.error,
+      });
+
+      return {
+        success: false,
+        exportId,
+        tenantId: input.tenantId,
+        status: 'failed',
+        error: state.error,
+      };
+    }
+
+    // Update state with results
+    state.step = 'completed';
+    state.status = 'completed';
+    state.s3Key = exportResult.s3Key;
+    state.downloadUrl = exportResult.downloadUrl;
+    state.urlExpiresAt = exportResult.urlExpiresAt;
+    state.fileSizeBytes = exportResult.fileSizeBytes;
+    state.tableCount = exportResult.tableCount;
+    state.recordCount = exportResult.recordCount;
+    state.completedAt = new Date().toISOString();
+
+    log.info('Tenant export completed successfully', {
+      tenantId: input.tenantId,
+      exportId,
+      tableCount: exportResult.tableCount,
+      recordCount: exportResult.recordCount,
+      fileSizeBytes: exportResult.fileSizeBytes,
+    });
+
+    return {
+      success: true,
+      exportId,
+      tenantId: input.tenantId,
+      tenantName: state.tenantName,
+      status: 'completed',
+      s3Key: exportResult.s3Key,
+      downloadUrl: exportResult.downloadUrl,
+      urlExpiresAt: exportResult.urlExpiresAt,
+      fileSizeBytes: exportResult.fileSizeBytes,
+      tableCount: exportResult.tableCount,
+      recordCount: exportResult.recordCount,
+    };
+
+  } catch (error) {
+    state.step = 'failed';
+    state.status = 'failed';
+    state.error = error instanceof Error ? error.message : 'Unknown error';
+    state.completedAt = new Date().toISOString();
+
+    log.error('Tenant export workflow failed with exception', {
+      tenantId: input.tenantId,
+      exportId,
+      error: state.error,
+    });
+
+    return {
+      success: false,
+      exportId,
+      tenantId: input.tenantId,
+      status: 'failed',
+      error: state.error,
+    };
+  }
+}

--- a/packages/ui-kit/src/components/Spinner.tsx
+++ b/packages/ui-kit/src/components/Spinner.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 
 export interface SpinnerProps {
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: 'button' | 'xs' | 'sm' | 'md' | 'lg';
+  /** Use 'inverted' for spinners on colored backgrounds (e.g., primary buttons) */
+  variant?: 'default' | 'inverted';
   className?: string;
   style?: React.CSSProperties;
 }
 
+// Match main app spinner sizes from server/src/components/ui/Spinner.tsx
 const sizeMap = {
-  xs: { size: 16, border: 2 },  // For inline/button use
-  sm: { size: 24, border: 2 },
-  md: { size: 40, border: 4 },
-  lg: { size: 48, border: 6 },
+  button: { size: 16, border: 2 },  // For inline button use - prevents wrapping
+  xs: { size: 24, border: 2 },      // h-6 w-6 border-2
+  sm: { size: 40, border: 2 },      // h-10 w-10 border-2
+  md: { size: 48, border: 6 },      // h-12 w-12 border-[6px]
+  lg: { size: 64, border: 8 },      // h-16 w-16 border-[8px]
 };
 
 const keyframesId = 'alga-spinner-keyframes';
@@ -30,12 +34,13 @@ function ensureKeyframes() {
   document.head.appendChild(style);
 }
 
-export function Spinner({ size = 'md', className, style }: SpinnerProps) {
+export function Spinner({ size = 'md', variant = 'default', className, style }: SpinnerProps) {
   React.useEffect(() => {
     ensureKeyframes();
   }, []);
 
   const dims = sizeMap[size];
+  const isInverted = variant === 'inverted';
 
   const containerStyle: React.CSSProperties = {
     display: 'flex',
@@ -54,25 +59,16 @@ export function Spinner({ size = 'md', className, style }: SpinnerProps) {
     borderStyle: 'solid',
     borderWidth: dims.border,
     borderRadius: '9999px',
-    borderColor: 'var(--alga-primary, #9855ee)',
-    borderTopColor: 'var(--alga-secondary, #53d7fa)',
+    borderColor: isInverted ? 'rgba(255, 255, 255, 0.3)' : 'var(--alga-primary, #9855ee)',
+    borderTopColor: isInverted ? 'white' : 'var(--alga-secondary, #53d7fa)',
     animation: 'alga-spinner-spin 0.9s linear infinite',
     backgroundColor: 'transparent',
     boxSizing: 'border-box',
   };
 
-  const innerStyle: React.CSSProperties = {
-    position: 'absolute',
-    inset: '28%',
-    borderRadius: 'inherit',
-    backgroundColor: 'var(--alga-primary, #9855ee)',
-    opacity: 0.2,
-  };
-
   return (
     <div style={containerStyle} className={className}>
       <div style={spinnerStyle} role="status" aria-label="Loading">
-        <div style={innerStyle} />
         <span style={{
           position: 'absolute',
           width: 1,
@@ -100,6 +96,7 @@ export interface LoadingIndicatorProps {
 }
 
 const gapMap = {
+  button: { inline: 4, stacked: 4 },
   xs: { inline: 4, stacked: 4 },
   sm: { inline: 6, stacked: 6 },
   md: { inline: 8, stacked: 8 },
@@ -122,7 +119,7 @@ export function LoadingIndicator({
     ...style,
   };
 
-  const fontSizeMap = { xs: '0.75rem', sm: '0.8125rem', md: '0.875rem', lg: '1rem' };
+  const fontSizeMap = { button: '0.75rem', xs: '0.75rem', sm: '0.8125rem', md: '0.875rem', lg: '1rem' };
   const textStyle: React.CSSProperties = {
     color: 'var(--alga-muted-fg, #4b5563)',
     fontSize: fontSizeMap[size],


### PR DESCRIPTION
  - Implement Temporal workflow for tenant data export with query-based status polling (2s interval) instead of synchronous blocking
  - Add /export-status API endpoint for workflow state queries
  - Fix Spinner component: remove gray inner dot, match main app sizes, add 'button' size (16px) and 'inverted' variant for primary buttons
  - Fix non-deterministic UUID in tenant-deletion-workflow (crypto → uuid4)
  - Update nineminds-reporting extension to use consistent UI kit spinners

  🎪 "But I don't want to wait synchronously," said Alice. "Then you shall poll every two seconds," replied the Temporal Cat, its workflow state fading slowly until nothing was left but the exportId, hovering in the air. "We're all async here." 🐱✨⏳