### PR TITLE
Add wildcard version support for extensions

### DIFF
--- a/ee/extensions/nineminds-reporting/manifest.json
+++ b/ee/extensions/nineminds-reporting/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "com.alga.ninemindsreporting",
   "publisher": "Nine Minds",
-  "version": "0.3.1",
+  "version": "0.3.*",
   "runtime": "wasm-js@1",
   "capabilities": ["cap:context.read", "cap:log.emit", "cap:ui.proxy"],
   "ui": {

--- a/ee/server/src/lib/extensions/README.md
+++ b/ee/server/src/lib/extensions/README.md
@@ -9,6 +9,7 @@ Key principles:
 
 Directory structure (v2):
 - /lib/extensions/
+  - /bundles/manifest.ts — Manifest parsing; supports wildcard versions (e.g., `"1.2.*"` auto-increments on install).
   - /types.ts — Core extension system types used by registry/storage/validation.
   - /registry-v2.ts — v2 registry.
   - /lib/gateway-* — Gateway helpers to communicate with Runner.

--- a/ee/server/src/lib/extensions/registry-v2-repo-knex.ts
+++ b/ee/server/src/lib/extensions/registry-v2-repo-knex.ts
@@ -131,6 +131,13 @@ export function registerRegistryV2KnexRepo(knex: Knex) {
       } as any;
     },
 
+    async listVersionStringsForExtension(extensionId: string): Promise<string[]> {
+      const rows = await knex('extension_version')
+        .where({ registry_id: extensionId })
+        .select(['version']);
+      return rows.map((r: any) => r.version as string);
+    },
+
     async create(input: Omit<ExtensionVersionRecord, 'id' | 'createdAt'>): Promise<ExtensionVersionRecord> {
       const id = uuid();
       const now = knex.fn.now();


### PR DESCRIPTION
  Enable auto-increment versions using "X.Y.*" syntax in manifest.json. On each install, the patch number increments automatically (1.2.0 → 1.2.1), ensuring fresh cache entries on the runner.

  - Add isWildcardVersion, getWildcardPrefix, resolveWildcardVersion helpers
  - Update registry-v2 to resolve wildcards before creating versions
  - Add listVersionStringsForExtension to query existing versions
  - Update nineminds-reporting manifest to use 0.3.*

  "Curiouser and curiouser!" cried Alice, watching the version numbers multiply like playing cards at the Queen's croquet match. "If 1.2.* becomes 1.2.3, and then 1.2.4, where does it end?" The Cheshire Cat grinned: "It ends when you stop installing, my dear." 🃏✨🐱