### PR TITLE
Fix tenant deletion workflow and standardize on clients table

### DIFF
--- a/ee/extensions/nineminds-reporting/src/iframe/main.tsx
+++ b/ee/extensions/nineminds-reporting/src/iframe/main.tsx
@@ -2684,7 +2684,7 @@ function TenantManagementView() {
         method: 'POST',
         body: JSON.stringify({
           workflowId: selectedPendingDeletion.workflow_id,
-          confirmationType: confirmationType,
+          type: confirmationType,
         }),
       });
 

--- a/ee/server/src/lib/extensions/bundles/manifest.ts
+++ b/ee/server/src/lib/extensions/bundles/manifest.ts
@@ -118,7 +118,8 @@ export function resolveWildcardVersion(wildcardVersion: string, existingVersions
   }
 
   // Filter versions that match the prefix (e.g., "1.2.0", "1.2.1", etc.)
-  const prefixPattern = new RegExp(`^${prefix.replace('.', '\\.')}\\.(\\d+)$`);
+  // Note: Only stable versions are matched; pre-release (e.g., "1.2.4-beta") are intentionally skipped
+  const prefixPattern = new RegExp(`^${prefix.replace(/\./g, '\\.')}\\.(\\d+)$`);
   let maxPatch = -1;
 
   for (const v of existingVersions) {

--- a/ee/temporal-workflows/src/activities/tenant-export-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-export-activities.ts
@@ -30,7 +30,6 @@ const TENANT_TABLES_EXPORT_ORDER: string[] = [
   // Core business data
   'users',
   'contacts',
-  'companies',
   'clients',
 
   // Tickets and support
@@ -165,7 +164,7 @@ export async function exportTenantData(
       _metadata: {
         exportId,
         tenantId,
-        tenantName: tenant.company_name || tenant.client_name,
+        tenantName: tenant.client_name,
         exportedAt: new Date().toISOString(),
         requestedBy,
         reason,

--- a/ee/temporal-workflows/src/types/tenant-deletion-types.ts
+++ b/ee/temporal-workflows/src/types/tenant-deletion-types.ts
@@ -79,7 +79,7 @@ export interface TenantStats {
   invoiceCount: number;
   projectCount: number;
   documentCount: number;
-  companyCount: number;
+  clientCount: number;
   contactCount: number;
   collectedAt: ISO8601String;
 }

--- a/server/migrations/202409071803_initial_schema.cjs
+++ b/server/migrations/202409071803_initial_schema.cjs
@@ -1,3 +1,13 @@
+/**
+ * ⚠️ SCHEMA RENAME NOTICE: Many tables in this file have been renamed.
+ * DO NOT use names from this file directly - check the rename migrations:
+ *
+ * - companies → clients (see 20251003000001_company_to_client_migration.cjs)
+ * - channels → boards (see 20250930000001_rename_channels_to_boards.cjs)
+ * - billing_plans → contract_lines (see 20251008000001_rename_billing_to_contracts.cjs)
+ * - service_categories → ticket_categories (see 20250327144330_rename_service_categories_to_ticket_categories.cjs)
+ */
+
 exports.up = async function(knex) {
     await knex.schema.createTable('tenants', (table) => {
         table.uuid('tenant').primary().defaultTo(knex.raw('gen_random_uuid()'));

--- a/server/migrations/20250323194900_create_plan_bundles_tables.cjs
+++ b/server/migrations/20250323194900_create_plan_bundles_tables.cjs
@@ -1,6 +1,9 @@
 /**
- * Migration to create Plan Bundles feature tables
- * This implements the schema for plan bundles, bundle contract lines, and company plan bundles
+ * ⚠️ RENAMED: Tables in this file have been renamed.
+ * See 20251008000001_rename_billing_to_contracts.cjs for current names:
+ * - plan_bundles → contracts
+ * - company_plan_bundles → client_contracts
+ * - bundle_billing_plans → contract_line_mappings
  */
 exports.up = function(knex) {
   return knex.schema


### PR DESCRIPTION
  "Curiouser and curiouser!" cried Alice, as the companies transformed into clients before her very eyes. "In this wonderland, one must never confuse a company_id with a client_id, lest the Cheshire Cat's deletion workflow vanish entirely—leaving only its ValidationError behind!" 🐱✨🗑️