### PR TITLE
Fix agent mapping to show only MSP agents with UserPicker

### DIFF
--- a/server/src/components/projects/PhaseTaskImportDialog.tsx
+++ b/server/src/components/projects/PhaseTaskImportDialog.tsx
@@ -5,6 +5,8 @@ import { Dialog, DialogContent, DialogFooter } from 'server/src/components/ui/Di
 import { Button } from 'server/src/components/ui/Button';
 import { Input } from 'server/src/components/ui/Input';
 import CustomSelect from 'server/src/components/ui/CustomSelect';
+import UserPicker from 'server/src/components/ui/UserPicker';
+import { IUser } from '@shared/interfaces/user.interfaces';
 import { DataTable } from 'server/src/components/ui/DataTable';
 import { Switch } from 'server/src/components/ui/Switch';
 import { ColumnDefinition } from 'server/src/interfaces/dataTable.interfaces';
@@ -996,17 +998,19 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                           />
                           <span className="text-sm">Map to existing user:</span>
                         </label>
-                        <CustomSelect
-                          options={availableUsers.map(user => ({
-                            value: user.user_id,
-                            label: `${user.first_name} ${user.last_name}`.trim() || 'Unnamed User',
-                          }))}
+                        <UserPicker
+                          id={`agent-mapping-${agentInfo.agentName}`}
+                          users={availableUsers as IUser[]}
                           value={resolution?.mappedUserId || ''}
                           onValueChange={(value) =>
                             handleAgentResolutionChange(agentInfo.agentName, 'map_to_existing', value)
                           }
                           disabled={resolution?.action !== 'map_to_existing'}
-                          className="w-48"
+                          placeholder="Select user..."
+                          labelStyle="none"
+                          buttonWidth="fit"
+                          size="sm"
+                          className="min-w-[200px]"
                         />
                       </div>
                     </div>

--- a/server/src/interfaces/phaseTaskImport.interfaces.ts
+++ b/server/src/interfaces/phaseTaskImport.interfaces.ts
@@ -6,6 +6,7 @@
  */
 
 import { TenantEntity } from './index';
+import { IUser } from '@shared/interfaces/user.interfaces';
 
 /**
  * All mappable fields in the CSV import
@@ -143,9 +144,14 @@ export interface IPhaseTaskValidationResponse {
  * Contains both full objects (for dropdowns) and lookup maps (for validation).
  * Fetched in a single transaction to reduce DB connection usage.
  */
+/**
+ * Subset of IUser fields needed for the import user picker
+ */
+export type IImportUser = Pick<IUser, 'user_id' | 'username' | 'first_name' | 'last_name' | 'email' | 'user_type' | 'is_inactive' | 'tenant'>;
+
 export interface IImportReferenceData {
   // Full objects for dropdowns
-  users: Array<{ user_id: string; first_name: string; last_name: string }>;
+  users: IImportUser[];
   priorities: Array<{ priority_id: string; priority_name: string }>;
   services: Array<{ service_id: string; service_name: string }>;
   statusMappings: Array<{ project_status_mapping_id: string; status_name: string; name: string; custom_name?: string; is_closed?: boolean }>;

--- a/server/src/lib/actions/project-actions/phaseTaskImportActions.ts
+++ b/server/src/lib/actions/project-actions/phaseTaskImportActions.ts
@@ -292,11 +292,12 @@ export async function getImportReferenceData(
 
     // Fetch all reference data in parallel within the same transaction
     const [users, priorities, services, statusMappings] = await Promise.all([
-      // Users (exclude inactive - only show active users for assignment)
+      // Users (only active internal/MSP agents - exclude client portal users)
       trx('users')
-        .select('user_id', 'first_name', 'last_name')
+        .select('user_id', 'username', 'first_name', 'last_name', 'email', 'user_type', 'is_inactive', 'tenant')
         .where('tenant', tenant)
         .where('is_inactive', false)
+        .where('user_type', 'internal')
         .orderBy(['first_name', 'last_name']),
 
       // Priorities for project_task
@@ -526,7 +527,7 @@ export async function validatePhaseTaskImportData(
 
   // Fetch lookup data
   const [users, priorities, servicesResponse] = await Promise.all([
-    getAllUsersBasic(true),
+    getAllUsersBasic(true, 'internal'), // Only fetch active internal/MSP agents
     getAllPriorities('project_task'),
     getServices(1, 999, { is_active: true }),
   ]);


### PR DESCRIPTION
## Summary
- Fixes agent mapping dropdown in phase/task import to only show active MSP/internal agents (excludes client portal users and contacts)
- Replaces CustomSelect with UserPicker component for better UX (shows avatars and has search)
- Adds proper type safety with `IImportUser` type using `Pick<IUser, ...>`

## Test plan
- [ ] Open phase/task import dialog on a project
- [ ] Upload a CSV with agent names that don't match existing users
- [ ] Verify the agent mapping step only shows internal/MSP agents (no client portal users or contacts)
- [ ] Verify user avatars are displayed in the picker
- [ ] Verify search functionality works in the picker
- [ ] Complete the import and verify agents are mapped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)