### PR TITLE
Fix DOM reconciliation error in client contact tab

### DIFF
--- a/server/src/components/contacts/ClientContactsList.tsx
+++ b/server/src/components/contacts/ClientContactsList.tsx
@@ -30,10 +30,11 @@ type ContactWithId = IContact & { id: string };
 
 // Helper to ensure contacts have stable id for DataTable row keys
 // This prevents React DOM reconciliation errors when rows are re-rendered
+// Uses existing id if present, otherwise falls back to contact_name_id
 const addIdToContacts = (contacts: IContact[]): ContactWithId[] => {
   return contacts.map(contact => ({
     ...contact,
-    id: contact.contact_name_id
+    id: (contact as any).id ?? contact.contact_name_id
   }));
 };
 
@@ -105,7 +106,9 @@ const ClientContactsList: React.FC<ClientContactsListProps> = ({ clientId, clien
     const handleDrawerClose = () => {
       if (changesSavedInDrawer) {
         // Refresh contacts list
-        getContactsByClient(clientId, statusFilter).then(data => setContacts(addIdToContacts(data)));
+        getContactsByClient(clientId, statusFilter)
+          .then(data => setContacts(addIdToContacts(data)))
+          .catch(err => console.error('Error refreshing contacts after drawer close:', err));
         setChangesSavedInDrawer(false);
       }
     };
@@ -337,7 +340,9 @@ const ClientContactsList: React.FC<ClientContactsListProps> = ({ clientId, clien
         isOpen={isQuickAddContactOpen}
         onClose={() => setIsQuickAddContactOpen(false)}
         onContactAdded={() => {
-          getContactsByClient(clientId, statusFilter).then(data => setContacts(addIdToContacts(data)));
+          getContactsByClient(clientId, statusFilter)
+            .then(data => setContacts(addIdToContacts(data)))
+            .catch(err => console.error('Error refreshing contacts after quick add:', err));
         }}
         clients={clients}
         selectedClientId={clientId}


### PR DESCRIPTION
  Add stable id property to contacts for DataTable row keys. The contact_name_id is now mapped to id to prevent React from using unstable index-based keys during re-renders, which "removeChild" errors when combined with Radix dropdown portals.

  "But I don't want to go among mad nodes," Alice remarked. "Oh, you can't help that," said the Cat: "we're all unstable keys here. I'm mad. The DOM is mad. Only by giving each contact its proper can we prevent the Queen of Hearts from shouting 'Off with children!'" 🐱 🔑 🎭