### PR TITLE
Fix modularity module resolution and EE build

### DIFF
--- a/ee/server/src/app/msp/licenses/purchase/success/page.tsx
+++ b/ee/server/src/app/msp/licenses/purchase/success/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { CheckCircle, ArrowRight, Loader2, Calendar, Users } from 'lucide-react';
 import Link from 'next/link';
 import { getLicenseUsageAction } from 'server/src/lib/actions/license-actions';
-import { getSubscriptionInfoAction } from '@ee/lib/actions/license-actions';
+import { getSubscriptionInfoAction } from 'ee/server/src/lib/actions/license-actions';
 
 export default function LicensePurchaseSuccessPage() {
   const searchParams = useSearchParams();

--- a/ee/server/src/components/licensing/LicensePurchaseForm.tsx
+++ b/ee/server/src/components/licensing/LicensePurchaseForm.tsx
@@ -12,7 +12,7 @@ import {
   getInvoicePreviewAction,
   getPaymentMethodInfoAction,
   createCustomerPortalSessionAction,
-} from '@ee/lib/actions/license-actions';
+} from 'ee/server/src/lib/actions/license-actions';
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 import {
   EmbeddedCheckoutProvider,

--- a/ee/server/src/components/licensing/ReduceLicensesModal.tsx
+++ b/ee/server/src/components/licensing/ReduceLicensesModal.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { toast } from 'react-hot-toast';
 import { AlertTriangle, Info } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { getLicensePricingAction, reduceLicenseCountAction } from '@ee/lib/actions/license-actions';
+import { getLicensePricingAction, reduceLicenseCountAction } from 'ee/server/src/lib/actions/license-actions';
 
 interface ReduceLicensesModalProps {
   isOpen: boolean;

--- a/ee/server/src/components/settings/account/AccountManagement.tsx
+++ b/ee/server/src/components/settings/account/AccountManagement.tsx
@@ -18,7 +18,7 @@ import {
   cancelSubscriptionAction,
   getScheduledLicenseChangesAction,
   sendCancellationFeedbackAction,
-} from '@ee/lib/actions/license-actions';
+} from 'ee/server/src/lib/actions/license-actions';
 import { checkAccountManagementPermission } from 'server/src/lib/actions/permission-actions';
 import { useRouter } from 'next/navigation';
 import { ILicenseInfo, IPaymentMethod, ISubscriptionInfo, IInvoiceInfo, IScheduledLicenseChange } from 'server/src/interfaces/subscription.interfaces';

--- a/packages/auth/src/actions/apiKeyActions.ts
+++ b/packages/auth/src/actions/apiKeyActions.ts
@@ -8,11 +8,10 @@ import { withTransaction } from '@alga-psa/db';
 // Dynamic import to avoid circular dependency (auth -> users -> auth)
 // Note: Using string concatenation to prevent static analysis from detecting this dependency
 const getUserRoles = async (userId: string) => {
-  const modulePath = '@alga-psa/' + 'users/actions';
-  const { getUserRoles: getRoles } = await import(/* webpackIgnore: true */ modulePath);
+  const { getUserRoles: getRoles } = await import('@alga-psa/users/actions');
   return getRoles(userId);
 };
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 
 /**
  * Create a new API key for the current user

--- a/packages/auth/src/actions/auth-actions/passwordResetActions.ts
+++ b/packages/auth/src/actions/auth-actions/passwordResetActions.ts
@@ -11,12 +11,12 @@ import { isValidEmail } from '@alga-psa/validation';
 const getEmailModule = () => '@alga-psa/' + 'email';
 
 const getTenantEmailService = async (tenant: string) => {
-  const { TenantEmailService } = await import(/* webpackIgnore: true */ getEmailModule());
+  const { TenantEmailService } = await import('@alga-psa/email');
   return TenantEmailService.getInstance(tenant);
 };
 
 const getSystemEmailServiceAsync = async () => {
-  const { getSystemEmailService } = await import(/* webpackIgnore: true */ getEmailModule());
+  const { getSystemEmailService } = await import('@alga-psa/email');
   return getSystemEmailService();
 };
 
@@ -29,7 +29,7 @@ const sendPasswordResetEmailAsync = async (params: {
   supportEmail: string;
   clientName: string;
 }) => {
-  const { sendPasswordResetEmail } = await import(/* webpackIgnore: true */ getEmailModule());
+  const { sendPasswordResetEmail } = await import('@alga-psa/email');
   return sendPasswordResetEmail(params);
 };
 

--- a/packages/auth/src/actions/auth.tsx
+++ b/packages/auth/src/actions/auth.tsx
@@ -7,15 +7,11 @@ import logger from "@alga-psa/core/logger";
 import { IUser } from '@alga-psa/types';
 import { isValidTenantSlug } from '@alga-psa/validation';
 
-// Dynamic imports to avoid circular dependencies
-// Note: Using string concatenation to prevent static analysis from detecting these dependencies
-const getAnalyticsModule = () => '@alga-psa/' + 'analytics';
-const getTenancyModule = () => '@alga-psa/' + 'tenancy/actions';
-
-const getAnalytics = async () => (await import(/* webpackIgnore: true */ getAnalyticsModule())).analytics;
+// Dynamic imports to avoid circular dependencies (but still allow Next/Turbopack to bundle them).
+const getAnalytics = async () => (await import('@alga-psa/analytics')).analytics;
 
 const getTenantIdBySlugAsync = async (slug: string): Promise<string | null> => {
-  const { getTenantIdBySlug } = await import(/* webpackIgnore: true */ getTenancyModule());
+  const { getTenantIdBySlug } = await import('@alga-psa/tenancy/actions');
   return getTenantIdBySlug(slug);
 };
 

--- a/packages/auth/src/actions/useRegister.tsx
+++ b/packages/auth/src/actions/useRegister.tsx
@@ -17,13 +17,12 @@ import { isValidEmail } from '@alga-psa/validation';
 const getEmailModule = () => '@alga-psa/' + 'email';
 
 const getAnalytics = async () => {
-  const analyticsModule = '@alga-psa/' + 'analytics';
-  const mod = await import(/* webpackIgnore: true */ analyticsModule);
+  const mod = await import('@alga-psa/analytics');
   return { analytics: mod.analytics, AnalyticsEvents: mod.AnalyticsEvents };
 };
 
 const getSystemEmailServiceAsync = async () => {
-  const { getSystemEmailService } = await import(/* webpackIgnore: true */ getEmailModule());
+  const { getSystemEmailService } = await import('@alga-psa/email');
   return getSystemEmailService();
 };
 
@@ -36,7 +35,7 @@ const sendPasswordResetEmailAsync = async (params: {
   supportEmail: string;
   clientName: string;
 }) => {
-  const { sendPasswordResetEmail } = await import(/* webpackIgnore: true */ getEmailModule());
+  const { sendPasswordResetEmail } = await import('@alga-psa/email');
   return sendPasswordResetEmail(params);
 };
 

--- a/packages/auth/src/components/RegisterForm.tsx
+++ b/packages/auth/src/components/RegisterForm.tsx
@@ -9,15 +9,13 @@ import { validateEmailAddress, validatePassword, getPasswordRequirements } from 
 
 // Dynamic imports to avoid circular dependency (auth -> users -> auth)
 // Note: Using string concatenation to prevent static analysis from detecting this dependency
-const getUsersModule = () => '@alga-psa/' + 'users/actions';
-
 const verifyContactEmail = async (email: string) => {
-  const { verifyContactEmail: verify } = await import(/* webpackIgnore: true */ getUsersModule());
+  const { verifyContactEmail: verify } = await import('@alga-psa/users/actions');
   return verify(email);
 };
 
 const initiateRegistration = async (email: string, password: string) => {
-  const { initiateRegistration: initReg } = await import(/* webpackIgnore: true */ getUsersModule());
+  const { initiateRegistration: initReg } = await import('@alga-psa/users/actions');
   return initReg(email, password);
 };
 

--- a/packages/auth/src/lib/nextAuthOptions.ts
+++ b/packages/auth/src/lib/nextAuthOptions.ts
@@ -16,7 +16,7 @@ import {
 } from "./session";
 import { issuePortalDomainOtt } from "./PortalDomainSessionToken";
 import { buildTenantPortalSlug, isValidTenantSlug } from "@alga-psa/validation";
-import { isEnterprise } from "@alga-psa/core";
+import { isEnterprise } from "@alga-psa/core/features";
 import {
     applyOAuthAccountHints,
     decodeOAuthJwtPayload,

--- a/packages/auth/src/lib/tokenizer.tsx
+++ b/packages/auth/src/lib/tokenizer.tsx
@@ -3,7 +3,7 @@ import jwt, { TokenExpiredError, JsonWebTokenError, NotBeforeError, SignOptions,
 import type { IUserRegister, TokenResponse } from '@alga-psa/types'; 
 
 import logger from '@alga-psa/core/logger';
-import { getSecretProviderInstance } from '@alga-psa/core/server';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 
 
 async function getSecretKey(): Promise<Secret> {

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -29,8 +29,7 @@ import {
 } from '@alga-psa/billing/actions/contractActions';
 import type { IContractSummary } from '@alga-psa/billing/actions/contractActions';
 import { updateClientContractForBilling, getClientByIdForBilling } from '@alga-psa/billing/actions/billingClientsActions';
-import { getCurrentUserAsync, hasPermissionAsync, getSessionAsync, getAnalyticsAsync } from '../../../lib/authHelpers';
-import { getDocumentsByContractIdAsync } from '../../../lib/documentsHelpers';
+import { getDocumentsByContractId } from '@alga-psa/documents/actions/documentActions';
 
 import { BILLING_FREQUENCY_OPTIONS } from '@alga-psa/billing/constants/billing';
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider';
@@ -288,12 +287,11 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
     setPoAmountInputs({});
 
     try {
-      const [contractData, summaryData, assignmentData, documentsData, currentUser] = await Promise.all([
+      const [contractData, summaryData, assignmentData, documentsData] = await Promise.all([
         getContractById(contractId),
         getContractSummary(contractId),
         getContractAssignments(contractId),
-        getDocumentsByContractIdAsync(contractId),
-        getCurrentUserAsync()
+        getDocumentsByContractId(contractId)
       ]);
 
       if (!contractData) {
@@ -309,7 +307,6 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
       setSummary(summaryData);
       setAssignments(assignmentData);
       setDocuments(documentsData || []);
-      setCurrentUserId(currentUser?.user_id || '');
     } catch (err) {
       console.error('Error loading contract details:', err);
       setError('Failed to load contract');

--- a/packages/billing/src/lib/authHelpers.ts
+++ b/packages/billing/src/lib/authHelpers.ts
@@ -3,36 +3,30 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * billing -> auth -> ui -> analytics -> tenancy -> ... -> billing
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getAuthModule = () => '@alga-psa/' + 'auth';
-const getAuthCurrentUserModule = () => '@alga-psa/' + 'auth/getCurrentUser';
-const getAnalyticsModule = () => '@alga-psa/' + 'analytics';
-
 export async function getCurrentUserAsync() {
-  const { getCurrentUser } = await import(/* webpackIgnore: true */ getAuthCurrentUserModule());
+  const { getCurrentUser } = await import('@alga-psa/auth/getCurrentUser');
   return getCurrentUser();
 }
 
 export async function getSessionAsync() {
-  const { getSession } = await import(/* webpackIgnore: true */ getAuthModule());
+  const { getSession } = await import('@alga-psa/auth');
   return getSession();
 }
 
 export async function hasPermissionAsync(user: any, resource: string, action: string): Promise<boolean> {
-  const { hasPermission } = await import(/* webpackIgnore: true */ getAuthModule());
+  const { hasPermission } = await import('@alga-psa/auth');
   return hasPermission(user, resource, action);
 }
 
 // Analytics helpers
 export async function getAnalyticsAsync() {
-  const { analytics, AnalyticsEvents } = await import(/* webpackIgnore: true */ getAnalyticsModule());
+  const { analytics, AnalyticsEvents } = await import('@alga-psa/analytics');
   return { analytics, AnalyticsEvents };
 }
 
 export async function trackAnalyticsEventAsync(eventName: string, properties: Record<string, any>, userId?: string) {
-  const { analytics } = await import(/* webpackIgnore: true */ getAnalyticsModule());
+  const { analytics } = await import('@alga-psa/analytics');
   analytics.capture(eventName, properties, userId);
 }

--- a/packages/clients/src/lib/authHelpers.ts
+++ b/packages/clients/src/lib/authHelpers.ts
@@ -3,37 +3,31 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * clients -> auth -> ... -> clients
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
 import type { IRole } from '@alga-psa/types';
 
-const getAuthModule = () => '@alga-psa/' + 'auth';
-
 export async function hasPermissionAsync(user: any, resource: string, action: string, trx?: any): Promise<boolean> {
-  const module = await import(/* webpackIgnore: true */ getAuthModule());
-  return (module as any).hasPermission(user, resource, action, trx);
+  const module = await import('@alga-psa/auth');
+  return module.hasPermission(user, resource, action, trx);
 }
 
 export async function getSessionAsync() {
-  const module = await import(/* webpackIgnore: true */ getAuthModule());
-  return (module as any).getSession();
+  const module = await import('@alga-psa/auth');
+  return module.getSession();
 }
 
-const getAuthActionsModule = () => '@alga-psa/' + 'auth/actions';
-
 export async function assignRoleToUserAsync(userId: string, roleId: string) {
-  const module = await import(/* webpackIgnore: true */ getAuthActionsModule());
-  return (module as any).assignRoleToUser(userId, roleId);
+  const module = await import('@alga-psa/auth/actions');
+  return module.assignRoleToUser(userId, roleId);
 }
 
 export async function removeRoleFromUserAsync(userId: string, roleId: string) {
-  const module = await import(/* webpackIgnore: true */ getAuthActionsModule());
-  return (module as any).removeRoleFromUser(userId, roleId);
+  const module = await import('@alga-psa/auth/actions');
+  return module.removeRoleFromUser(userId, roleId);
 }
 
 export async function getRolesAsync() {
-  const module = await import(/* webpackIgnore: true */ getAuthActionsModule());
-  return (module as any).getRoles() as Promise<IRole[]>;
+  const module = await import('@alga-psa/auth/actions');
+  return module.getRoles() as Promise<IRole[]>;
 }

--- a/packages/clients/src/lib/documentsHelpers.ts
+++ b/packages/clients/src/lib/documentsHelpers.ts
@@ -3,28 +3,24 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * clients -> documents -> ... -> clients
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getDocumentsAvatarUtilsModule = () => '@alga-psa/' + 'documents/lib/avatarUtils';
-
 export async function getClientLogoUrlAsync(clientId: string, tenant: string): Promise<string | null> {
-  const module = await import(/* webpackIgnore: true */ getDocumentsAvatarUtilsModule());
-  return (module as any).getClientLogoUrl(clientId, tenant);
+  const module = await import('@alga-psa/documents/lib/avatarUtils');
+  return module.getClientLogoUrl(clientId, tenant);
 }
 
 export async function getClientLogoUrlsBatchAsync(clientIds: string[], tenant: string): Promise<Map<string, string | null>> {
-  const module = await import(/* webpackIgnore: true */ getDocumentsAvatarUtilsModule());
-  return (module as any).getClientLogoUrlsBatch(clientIds, tenant);
+  const module = await import('@alga-psa/documents/lib/avatarUtils');
+  return module.getClientLogoUrlsBatch(clientIds, tenant);
 }
 
 export async function getContactAvatarUrlAsync(contactId: string, tenant: string): Promise<string | null> {
-  const module = await import(/* webpackIgnore: true */ getDocumentsAvatarUtilsModule());
-  return (module as any).getContactAvatarUrl(contactId, tenant);
+  const module = await import('@alga-psa/documents/lib/avatarUtils');
+  return module.getContactAvatarUrl(contactId, tenant);
 }
 
 export async function getContactAvatarUrlsBatchAsync(contactIds: string[], tenant: string): Promise<Map<string, string | null>> {
-  const module = await import(/* webpackIgnore: true */ getDocumentsAvatarUtilsModule());
-  return (module as any).getContactAvatarUrlsBatch(contactIds, tenant);
+  const module = await import('@alga-psa/documents/lib/avatarUtils');
+  return module.getContactAvatarUrlsBatch(contactIds, tenant);
 }

--- a/packages/clients/src/lib/usersHelpers.ts
+++ b/packages/clients/src/lib/usersHelpers.ts
@@ -3,28 +3,24 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * clients -> users -> auth -> ui -> analytics -> tenancy -> client-portal -> clients
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getUsersActionsModule = () => '@alga-psa/' + 'users/actions';
-
 export async function getCurrentUserAsync() {
-  const module = await import(/* webpackIgnore: true */ getUsersActionsModule());
-  return (module as any).getCurrentUser();
+  const module = await import('@alga-psa/users/actions');
+  return module.getCurrentUser();
 }
 
-export async function getAllUsersBasicAsync(...args: any[]) {
-  const module = await import(/* webpackIgnore: true */ getUsersActionsModule());
-  return (module as any).getAllUsersBasic(...args);
+export async function getAllUsersBasicAsync(includeInactive?: boolean, userType?: string) {
+  const module = await import('@alga-psa/users/actions');
+  return module.getAllUsersBasic(includeInactive, userType);
 }
 
-export async function findUserByIdAsync(...args: any[]) {
-  const module = await import(/* webpackIgnore: true */ getUsersActionsModule());
-  return (module as any).findUserById(...args);
+export async function findUserByIdAsync(id: string) {
+  const module = await import('@alga-psa/users/actions');
+  return module.findUserById(id);
 }
 
-export async function getContactAvatarUrlActionAsync(...args: any[]) {
-  const module = await import(/* webpackIgnore: true */ getUsersActionsModule());
-  return (module as any).getContactAvatarUrlAction(...args);
+export async function getContactAvatarUrlActionAsync(contactId: string, tenant: string) {
+  const module = await import('@alga-psa/users/actions');
+  return module.getContactAvatarUrlAction(contactId, tenant);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
       "import": "./src/index.ts",
       "types": "./src/index.ts"
     },
+    "./features": {
+      "import": "./src/lib/features.ts",
+      "types": "./src/lib/features.ts"
+    },
     "./logger": {
       "import": "./src/lib/logger.ts",
       "types": "./src/lib/logger.ts"

--- a/packages/core/src/lib/encryption.ts
+++ b/packages/core/src/lib/encryption.ts
@@ -5,7 +5,7 @@
  * Works in both Node.js and Edge runtimes.
  */
 
-import { getSecret } from './secrets';
+import { getSecret } from './secrets/index';
 
 // Utility: encode string to Uint8Array
 const te = new TextEncoder();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -38,7 +38,7 @@ export { auditLog } from './lib/auditLog';
 export * from './lib/workDate';
 
 // DB models (tenant-scoped data access patterns)
-export * from './models';
+export * from './models/index';
 
 // Service infrastructure
 export * from './services/BaseService';
@@ -51,7 +51,7 @@ export {
 } from './lib/connection';
 
 // Transaction Helpers
-import { Knex as KnexType } from 'knex';
+import type { Knex as KnexType } from 'knex';
 import { getAdminConnection } from './lib/admin';
 
 /**

--- a/packages/db/src/lib/admin.ts
+++ b/packages/db/src/lib/admin.ts
@@ -4,9 +4,11 @@
  * Provides admin database connections for privileged operations.
  */
 
-import knex, { Knex } from 'knex';
+import knex from 'knex';
+import type { Knex } from 'knex';
 import knexfile from './knexfile';
-import { getSecret, logger } from '@alga-psa/core/server';
+import logger from '@alga-psa/core/logger';
+import { getSecret } from '@alga-psa/core/secrets';
 
 let adminConnection: Knex | null = null;
 

--- a/packages/db/src/lib/auditLog.ts
+++ b/packages/db/src/lib/auditLog.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 
 interface AuditLogParams {

--- a/packages/db/src/lib/connection.ts
+++ b/packages/db/src/lib/connection.ts
@@ -4,8 +4,9 @@
  * Database connection management utilities.
  */
 
-import Knex, { Knex as KnexType } from 'knex';
-import { getSecretProviderInstance } from '@alga-psa/core/server';
+import Knex from 'knex';
+import type { Knex as KnexType } from 'knex';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 
 // Create a map to store Knex instances
 const knexInstances: Map<string, KnexType> = new Map();

--- a/packages/db/src/lib/knex-turbopack.ts
+++ b/packages/db/src/lib/knex-turbopack.ts
@@ -90,4 +90,4 @@ if (typeof globalThis !== 'undefined' && !globalThis.__knexDialectPatched) {
 import knex from 'knex';
 
 export default knex;
-export { Knex };
+export type { Knex };

--- a/packages/db/src/lib/knexfile.ts
+++ b/packages/db/src/lib/knexfile.ts
@@ -5,10 +5,10 @@
  * Supports development, test, and production environments.
  */
 
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 import { setTypeParser } from 'pg-types';
 import { validate as uuidValidate } from 'uuid';
-import { getSecret } from '@alga-psa/core/server';
+import { getSecret } from '@alga-psa/core/secrets';
 
 type Function = (err: Error | null, connection: Knex.Client) => void;
 

--- a/packages/db/src/lib/tenant.ts
+++ b/packages/db/src/lib/tenant.ts
@@ -4,9 +4,10 @@
  * Provides tenant-aware database connections and transaction helpers.
  */
 
-import Knex, { Knex as KnexType } from './knex-turbopack';
+import Knex from './knex-turbopack';
+import type { Knex as KnexType } from './knex-turbopack';
 import { getKnexConfig } from './knexfile';
-import { logger } from '@alga-psa/core';
+import logger from '@alga-psa/core/logger';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 type PoolConfig = KnexType.PoolConfig & {

--- a/packages/db/src/lib/workDate.ts
+++ b/packages/db/src/lib/workDate.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 import { Temporal } from '@js-temporal/polyfill';
 
 export function normalizeIanaTimeZone(timeZone: string | null | undefined): string {
@@ -53,4 +53,3 @@ export async function resolveUserTimeZone(
     .first();
   return normalizeIanaTimeZone(row?.timezone ?? null);
 }
-

--- a/packages/db/src/services/BaseService.ts
+++ b/packages/db/src/services/BaseService.ts
@@ -3,7 +3,7 @@
  * Provides common database operations and patterns for API services
  */
 
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 import { createTenantKnex, withTransaction } from '../lib/tenant';
 
 // Import and re-export for services

--- a/packages/db/src/services/SystemContext.ts
+++ b/packages/db/src/services/SystemContext.ts
@@ -6,7 +6,7 @@
  */
 
 import { AsyncLocalStorage } from 'async_hooks';
-import { ServiceContext } from './BaseService';
+import type { ServiceContext } from './BaseService';
 
 // Async context storage for tracking system operations
 const systemOperationContext = new AsyncLocalStorage<{ isSystemOperation: boolean }>();

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -25,6 +25,18 @@
       "types": "./dist/handlers/index.d.ts",
       "import": "./dist/handlers/index.mjs",
       "require": "./dist/handlers/index.js"
+    },
+    "./lib/avatarUtils": {
+      "import": "./src/lib/avatarUtils.ts",
+      "types": "./src/lib/avatarUtils.ts"
+    },
+    "./lib/blocknoteUtils": {
+      "import": "./src/lib/blocknoteUtils.ts",
+      "types": "./src/lib/blocknoteUtils.ts"
+    },
+    "./lib/documentUtils": {
+      "import": "./src/lib/documentUtils.ts",
+      "types": "./src/lib/documentUtils.ts"
     }
   },
   "scripts": {

--- a/packages/documents/src/lib/authHelpers.ts
+++ b/packages/documents/src/lib/authHelpers.ts
@@ -3,19 +3,14 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * documents -> auth -> ui -> analytics -> tenancy -> ... -> documents
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getAuthModule = () => '@alga-psa/' + 'auth';
-const getAuthCurrentUserModule = () => '@alga-psa/' + 'auth/getCurrentUser';
-
 export async function getCurrentUserAsync() {
-  const { getCurrentUser } = await import(/* webpackIgnore: true */ getAuthCurrentUserModule());
+  const { getCurrentUser } = await import('@alga-psa/auth/getCurrentUser');
   return getCurrentUser();
 }
 
 export async function hasPermissionAsync(user: any, resource: string, action: string): Promise<boolean> {
-  const { hasPermission } = await import(/* webpackIgnore: true */ getAuthModule());
+  const { hasPermission } = await import('@alga-psa/auth');
   return hasPermission(user, resource, action);
 }

--- a/packages/tags/src/lib/authHelpers.ts
+++ b/packages/tags/src/lib/authHelpers.ts
@@ -3,19 +3,14 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * tags -> auth -> ui -> ... -> clients -> tags
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getAuthModule = () => '@alga-psa/' + 'auth';
-
 export async function hasPermissionAsync(user: any, resource: string, action: string, trx?: any): Promise<boolean> {
-  const module = await import(/* webpackIgnore: true */ getAuthModule());
-  return (module as any).hasPermission(user, resource, action, trx);
+  const module = await import('@alga-psa/auth');
+  return module.hasPermission(user, resource, action, trx);
 }
 
 export async function throwPermissionErrorAsync(action: string, additionalInfo?: string): Promise<never> {
-  const module = await import(/* webpackIgnore: true */ getAuthModule());
-  (module as any).throwPermissionError(action, additionalInfo);
-  throw new Error('Permission denied');
+  const module = await import('@alga-psa/auth');
+  return module.throwPermissionError(action, additionalInfo);
 }

--- a/packages/tags/src/lib/uiHelpers.ts
+++ b/packages/tags/src/lib/uiHelpers.ts
@@ -3,13 +3,10 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * tags -> ui -> ... -> clients -> tags
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getUiLibModule = () => '@alga-psa/' + 'ui/lib';
-
 export async function generateEntityColorAsync(name: string): Promise<{ backgroundColor: string; textColor: string }> {
-  const module = await import(/* webpackIgnore: true */ getUiLibModule());
-  return (module as any).generateEntityColor(name);
+  const module = await import('@alga-psa/ui/lib');
+  const result = module.generateEntityColor(name);
+  return { backgroundColor: result.background, textColor: result.text };
 }

--- a/packages/tags/src/lib/usersHelpers.ts
+++ b/packages/tags/src/lib/usersHelpers.ts
@@ -3,13 +3,9 @@
  *
  * These are dynamic import wrappers to avoid circular dependency:
  * tags -> users -> auth -> ui -> ... -> clients -> tags
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
-const getUsersActionsModule = () => '@alga-psa/' + 'users/actions';
-
 export async function getCurrentUserAsync() {
-  const module = await import(/* webpackIgnore: true */ getUsersActionsModule());
-  return (module as any).getCurrentUser();
+  const module = await import('@alga-psa/users/actions');
+  return module.getCurrentUser();
 }

--- a/packages/tenancy/src/actions/coreTenantActions.ts
+++ b/packages/tenancy/src/actions/coreTenantActions.ts
@@ -6,12 +6,8 @@ import type { Tenant, TenantCompany } from '@alga-psa/types';
 import { Knex } from 'knex';
 import { createTenantKnex } from '@alga-psa/db';
 
-// Dynamic import to avoid circular dependency (tenancy -> auth -> ui -> analytics -> tenancy)
-// Note: Using string concatenation to prevent static analysis from detecting this dependency
-const getAuthModule = () => '@alga-psa/' + 'auth';
-
 const getSessionAsync = async () => {
-  const { getSession } = await import(/* webpackIgnore: true */ getAuthModule());
+  const { getSession } = await import('@alga-psa/auth');
   return getSession();
 };
 

--- a/packages/workflows/src/components/visualization/DynamicReactFlow.tsx
+++ b/packages/workflows/src/components/visualization/DynamicReactFlow.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import ReactFlow, {
   Background,

--- a/packages/workflows/src/ee/entry.ts
+++ b/packages/workflows/src/ee/entry.ts
@@ -1,0 +1,3 @@
+export { default as DnDFlow } from '../../../../ee/server/src/components/flow/DnDFlow';
+export { default as WorkflowToggle } from '../../../../ee/server/src/components/flow/WorkflowToggle';
+

--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -2,7 +2,7 @@
 
 import { AppSessionProvider } from "@alga-psa/auth/client";
 import DefaultLayout from "@/components/layout/DefaultLayout";
-import { TagProvider } from "server/src/context/TagContext";
+import { TagProvider } from "@alga-psa/ui/context";
 import { PostHogUserIdentifier } from "@alga-psa/ui/components/analytics/PostHogUserIdentifier";
 import { ClientUIStateProvider } from "@alga-psa/ui/ui-reflection/ClientUIStateProvider";
 import { usePathname, useRouter } from "next/navigation";


### PR DESCRIPTION
Fixes post-modularity/Nx issues that prevented the app from reaching the MSP start page and broke production builds.

Key changes:
- Replace runtime webpackIgnore imports with bundler-resolved imports.
- Add missing workflows EE entry and fix client/server component boundaries.
- Fix TagProvider mismatch and tighten dynamic-import wrappers for TS.

Verification:
- npm run build:ee
