### PR TITLE
Fix CitusDB JOIN conditions to include tenant

### DIFF
--- a/ee/server/src/__tests__/utils/db-verification.ts
+++ b/ee/server/src/__tests__/utils/db-verification.ts
@@ -61,7 +61,10 @@ export async function verifyAdminUserCreation(
 
   // Verify user has admin role
   const userRole = await db('user_roles')
-    .join('roles', 'user_roles.role_id', 'roles.role_id')
+    .join('roles', function() {
+      this.on('user_roles.role_id', '=', 'roles.role_id')
+          .andOn('user_roles.tenant', '=', 'roles.tenant');
+    })
     .where('user_roles.user_id', tenantData.adminUserId)
     .where('user_roles.tenant', tenantData.tenantId)
     .where('roles.role_name', 'Admin')

--- a/packages/auth/src/actions/policyActions.ts
+++ b/packages/auth/src/actions/policyActions.ts
@@ -161,11 +161,13 @@ export async function getUserRoles(userId: string): Promise<IRole[]> {
     const { knex: db, tenant } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
         return await trx('user_roles')
-            .join('roles', 'user_roles.role_id', '=', 'roles.role_id')
-            .where({ 
+            .join('roles', function() {
+                this.on('user_roles.role_id', '=', 'roles.role_id')
+                    .andOn('user_roles.tenant', '=', 'roles.tenant');
+            })
+            .where({
                 'user_roles.user_id': userId,
-                'user_roles.tenant': tenant,
-                'roles.tenant': tenant 
+                'user_roles.tenant': tenant
             })
             .select('roles.*');
     });
@@ -274,11 +276,13 @@ export async function getRolePermissions(roleId: string): Promise<IPermission[]>
         const { knex: db, tenant } = await createTenantKnex();
         return withTransaction(db, async (trx: Knex.Transaction) => {
             return await trx('role_permissions')
-                .join('permissions', 'role_permissions.permission_id', '=', 'permissions.permission_id')
-                .where({ 
+                .join('permissions', function() {
+                    this.on('role_permissions.permission_id', '=', 'permissions.permission_id')
+                        .andOn('role_permissions.tenant', '=', 'permissions.tenant');
+                })
+                .where({
                     'role_permissions.role_id': roleId,
-                    'role_permissions.tenant': tenant,
-                    'permissions.tenant': tenant 
+                    'role_permissions.tenant': tenant
                 })
                 .select('permissions.permission_id', 'permissions.resource', 'permissions.action', 'permissions.tenant', 'permissions.msp', 'permissions.client', 'permissions.description');
         });

--- a/packages/auth/src/lib/registrationHelpers.ts
+++ b/packages/auth/src/lib/registrationHelpers.ts
@@ -70,7 +70,10 @@ export async function initiateRegistration(
 
     if (contactVerification.exists) {
       const contact = await adminDb('contacts')
-        .join('clients', 'contacts.client_id', 'clients.client_id')
+        .join('clients', function() {
+          this.on('contacts.client_id', '=', 'clients.client_id')
+              .andOn('contacts.tenant', '=', 'clients.tenant');
+        })
         .where('contacts.email', email)
         .select('clients.client_id', 'clients.tenant')
         .first();
@@ -109,7 +112,10 @@ async function registerContactUser(
   try {
     return await withTransaction(adminDb, async (trx: Knex.Transaction) => {
       const contact = await trx('contacts')
-        .join('clients', 'contacts.client_id', 'clients.client_id')
+        .join('clients', function() {
+          this.on('contacts.client_id', '=', 'clients.client_id')
+              .andOn('contacts.tenant', '=', 'clients.tenant');
+        })
         .where({ 'contacts.email': email })
         .select('contacts.contact_name_id', 'contacts.client_id', 'contacts.is_inactive', 'contacts.full_name', 'clients.tenant')
         .first();

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -928,7 +928,10 @@ export async function getTicketsForList(
           `(
             SELECT COUNT(DISTINCT x.client_id)::int
             FROM (
-              SELECT t.client_id as client_id
+              SELECT t2.client_id as client_id
+              FROM tickets as t2
+              WHERE t2.tenant = t.tenant
+                AND t2.ticket_id = t.ticket_id
               UNION ALL
               SELECT tc.client_id
               FROM tickets as tc

--- a/packages/users/src/actions/user-actions/registrationActions.ts
+++ b/packages/users/src/actions/user-actions/registrationActions.ts
@@ -45,7 +45,10 @@ export async function initiateRegistration(
     if (contactVerification.exists) {
       // Get contact's client and tenant
       const contact = await adminDb('contacts')
-        .join('clients', 'contacts.client_id', 'clients.client_id')
+        .join('clients', function() {
+          this.on('contacts.client_id', '=', 'clients.client_id')
+              .andOn('contacts.tenant', '=', 'clients.tenant');
+        })
         .where('contacts.email', email)
         .select('clients.client_id', 'clients.tenant')
         .first();
@@ -119,7 +122,10 @@ async function registerContactUser(
     return await withTransaction(adminDb, async (trx: Knex.Transaction) => {
       // Get contact details and tenant
       const contact = await trx('contacts')
-        .join('clients', 'contacts.client_id', 'clients.client_id')
+        .join('clients', function() {
+          this.on('contacts.client_id', '=', 'clients.client_id')
+              .andOn('contacts.tenant', '=', 'clients.tenant');
+        })
         .where({ 'contacts.email': email })
         .select('contacts.contact_name_id', 'contacts.client_id', 'contacts.is_inactive', 'contacts.full_name', 'clients.tenant')
         .first();

--- a/server/src/lib/models/timeSheetComment.ts
+++ b/server/src/lib/models/timeSheetComment.ts
@@ -4,7 +4,10 @@ import { ITimeSheetApproval, ITimeSheetComment } from 'server/src/interfaces/tim
 const TimeSheetComment = {
   getByTimeSheetId: async (knexOrTrx: Knex | Knex.Transaction, timeSheetId: string): Promise<ITimeSheetApproval | null> => {
     const comments = await knexOrTrx('time_sheet_comments')
-      .join('users', 'time_sheet_comments.user_id', 'users.user_id')
+      .join('users', function() {
+        this.on('time_sheet_comments.user_id', '=', 'users.user_id')
+            .andOn('time_sheet_comments.tenant', '=', 'users.tenant');
+      })
       .where({ 'time_sheet_comments.time_sheet_id': timeSheetId })
       .select(
         'time_sheet_comments.*',


### PR DESCRIPTION
  Add tenant column to JOIN conditions across multiple packages to prevent
  CitusDB repartitioning errors. Citus requires the distribution column (tenant) in JOIN conditions, not just WHERE clauses.
  Fixed JOINs in:
  - policyActions.ts: user_roles/roles, role_permissions/permissions
  - registrationHelpers.ts: contacts/clients (2 locations)
  - registrationActions.ts: contacts/clients (2 locations)
  - timeSheetComment.ts: time_sheet_comments/users
  - db-verification.ts: user_roles/roles
  - optimizedTicketActions.ts: UNION subquery with proper FROM clause "We're all mad here," said the Cheshire Cat, "but at least our JOINs now include tenant. You see, in Citus-land, a table distributed without its repartition the crumpets!" 🐱🍵🔗