### PR TITLE
Fix auto-scroll during task drag operations in project views

### DIFF
--- a/server/src/components/projects/ProjectDetail.tsx
+++ b/server/src/components/projects/ProjectDetail.tsx
@@ -42,6 +42,10 @@ import { getUserAvatarUrlsBatchAction } from 'server/src/lib/actions/avatar-acti
 
 const PROJECT_VIEW_MODE_SETTING = 'project_detail_view_mode';
 
+// Auto-scroll configuration for drag operations
+const SCROLL_THRESHOLD = 100; // Pixels from edge to start scrolling
+const MAX_SCROLL_SPEED = 20; // Maximum scroll speed in pixels per frame
+
 interface ProjectDetailProps {
   project: IProject;
   phases: IProjectPhase[];
@@ -279,16 +283,22 @@ export default function ProjectDetail({
     fetchTaskCounts();
   }, [project.project_id]);
 
-  const [scrollInterval, setScrollInterval] = useState<NodeJS.Timeout | null>(null);
   const [projectTreeData, setProjectTreeData] = useState<any[]>([]);
+  const kanbanBoardRef = useRef<HTMLDivElement>(null);
+  const scrollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const scrollSpeedsRef = useRef<{ horizontal: number; vertical: number; column: HTMLElement | null }>({
+    horizontal: 0,
+    vertical: 0,
+    column: null
+  });
 
   useEffect(() => {
     return () => {
-      if (scrollInterval) {
-        clearInterval(scrollInterval);
+      if (scrollIntervalRef.current) {
+        clearInterval(scrollIntervalRef.current);
       }
     };
-  }, [scrollInterval]);
+  }, []);
 
   // Lazy load list view data when switching to list mode
   const loadListViewData = useCallback(async () => {
@@ -678,10 +688,12 @@ export default function ProjectDetail({
     document.body.classList.remove('dragging-task');
     setPhaseDropTarget(null);
     setTaskDraggingOverPhaseId(null); // Clear task dragging over phase
-    
-    if (scrollInterval) {
-      clearInterval(scrollInterval);
-      setScrollInterval(null);
+
+    // Reset scroll speeds and clear interval
+    scrollSpeedsRef.current = { horizontal: 0, vertical: 0, column: null };
+    if (scrollIntervalRef.current) {
+      clearInterval(scrollIntervalRef.current);
+      scrollIntervalRef.current = null;
     }
   };
 
@@ -772,42 +784,91 @@ export default function ProjectDetail({
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    
-    const mouseY = e.clientY;
-    const viewportHeight = window.innerHeight;
-    const topThreshold = viewportHeight * 0.3; // Start scrolling at top 30%
-    const bottomThreshold = viewportHeight * 0.7; // Start scrolling at bottom 30%
-    const edgeThreshold = 100; // Pixels from very edge for max speed
-    const maxScrollSpeed = 25;
 
-    if (scrollInterval) {
-      clearInterval(scrollInterval);
-      setScrollInterval(null);
+    // kanbanBoardRef points to .kanbanContainer which is the horizontal scroll container
+    const kanbanContainer = kanbanBoardRef.current;
+    if (!kanbanContainer) return;
+
+    const containerRect = kanbanContainer.getBoundingClientRect();
+    const mouseX = e.clientX;
+    const mouseY = e.clientY;
+
+    // Check if mouse is within the container bounds
+    if (mouseX < containerRect.left || mouseX > containerRect.right ||
+        mouseY < containerRect.top || mouseY > containerRect.bottom) {
+      // Stop scrolling if outside bounds
+      scrollSpeedsRef.current = { horizontal: 0, vertical: 0, column: null };
+      return;
     }
 
-    // Calculate scroll speed based on distance from edges
-    if (mouseY < topThreshold) {
-      const distance = Math.max(mouseY - edgeThreshold, 0);
-      const speed = Math.min(maxScrollSpeed, maxScrollSpeed * (1 - distance / (topThreshold - edgeThreshold)));
-      
-      const newInterval = setInterval(() => {
-        window.scrollBy({
-          top: -speed,
-          behavior: 'auto' // Use auto for smoother continuous scrolling
-        });
-      }, 16); // 60fps
-      setScrollInterval(newInterval);
-    } else if (mouseY > bottomThreshold) {
-      const distance = Math.max((viewportHeight - mouseY) - edgeThreshold, 0);
-      const speed = Math.min(maxScrollSpeed, maxScrollSpeed * (1 - distance / (viewportHeight - bottomThreshold - edgeThreshold)));
-      
-      const newInterval = setInterval(() => {
-        window.scrollBy({
-          top: speed,
-          behavior: 'auto' // Use auto for smoother continuous scrolling
-        });
-      }, 16); // 60fps
-      setScrollInterval(newInterval);
+    // Calculate horizontal scroll (for kanban container)
+    let horizontalScrollSpeed = 0;
+    const leftEdge = containerRect.left + SCROLL_THRESHOLD;
+    const rightEdge = containerRect.right - SCROLL_THRESHOLD;
+
+    if (mouseX < leftEdge) {
+      // Near left edge - scroll left
+      const distance = leftEdge - mouseX;
+      horizontalScrollSpeed = -Math.min(MAX_SCROLL_SPEED, (distance / SCROLL_THRESHOLD) * MAX_SCROLL_SPEED);
+    } else if (mouseX > rightEdge) {
+      // Near right edge - scroll right
+      const distance = mouseX - rightEdge;
+      horizontalScrollSpeed = Math.min(MAX_SCROLL_SPEED, (distance / SCROLL_THRESHOLD) * MAX_SCROLL_SPEED);
+    }
+
+    // Find the column being dragged over and calculate vertical scroll
+    let verticalScrollSpeed = 0;
+    let targetColumn: HTMLElement | null = null;
+
+    // Find the kanban tasks containers using data attribute (more reliable than CSS classes)
+    const columns = kanbanContainer.querySelectorAll('[data-kanban-column-tasks="true"]');
+    columns.forEach((column) => {
+      const columnRect = column.getBoundingClientRect();
+      if (mouseX >= columnRect.left && mouseX <= columnRect.right &&
+          mouseY >= columnRect.top && mouseY <= columnRect.bottom) {
+        targetColumn = column as HTMLElement;
+
+        const topEdge = columnRect.top + SCROLL_THRESHOLD;
+        const bottomEdge = columnRect.bottom - SCROLL_THRESHOLD;
+
+        if (mouseY < topEdge) {
+          // Near top edge - scroll up
+          const distance = topEdge - mouseY;
+          verticalScrollSpeed = -Math.min(MAX_SCROLL_SPEED, (distance / SCROLL_THRESHOLD) * MAX_SCROLL_SPEED);
+        } else if (mouseY > bottomEdge) {
+          // Near bottom edge - scroll down
+          const distance = mouseY - bottomEdge;
+          verticalScrollSpeed = Math.min(MAX_SCROLL_SPEED, (distance / SCROLL_THRESHOLD) * MAX_SCROLL_SPEED);
+        }
+      }
+    });
+
+    // Update scroll speeds in ref (the interval reads from this)
+    scrollSpeedsRef.current = {
+      horizontal: horizontalScrollSpeed,
+      vertical: verticalScrollSpeed,
+      column: targetColumn
+    };
+
+    // Start interval if not already running and we need to scroll
+    if (!scrollIntervalRef.current && (horizontalScrollSpeed !== 0 || verticalScrollSpeed !== 0)) {
+      scrollIntervalRef.current = setInterval(() => {
+        const { horizontal, vertical, column } = scrollSpeedsRef.current;
+        const container = kanbanBoardRef.current;
+
+        if (container && horizontal !== 0) {
+          container.scrollLeft += horizontal;
+        }
+        if (column && vertical !== 0) {
+          column.scrollTop += vertical;
+        }
+
+        // Stop interval if both speeds are 0
+        if (horizontal === 0 && vertical === 0 && scrollIntervalRef.current) {
+          clearInterval(scrollIntervalRef.current);
+          scrollIntervalRef.current = null;
+        }
+      }, 16); // ~60fps
     }
   };
 
@@ -1733,7 +1794,7 @@ export default function ProjectDetail({
             />
           </div>
           )}
-          <div className={styles.kanbanContainer}>
+          <div className={styles.kanbanContainer} ref={kanbanBoardRef} data-kanban-container="true">
             {renderContent()}
           </div>
         </div>

--- a/server/src/components/projects/StatusColumn.tsx
+++ b/server/src/components/projects/StatusColumn.tsx
@@ -335,7 +335,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
           </span>
         </div>
       </div>
-      <div className={`${styles.kanbanTasks} ${styles.taskList}`} ref={tasksRef}>
+      <div className={`${styles.kanbanTasks} ${styles.taskList}`} ref={tasksRef} data-kanban-column-tasks="true">
         {sortedTasks.map((task): React.JSX.Element => {
           const taskType = taskTypes.find(t => t.type_key === task.task_type_key);
           return (


### PR DESCRIPTION
## Summary

This PR fixes the inability to drag project tasks to columns or positions outside the visible viewport in both Kanban and List views. Previously, when dragging a task:
- **Kanban view**: Could not scroll horizontally to reach columns off-screen, or vertically within a column to reach tasks below/above the fold
- **List view**: Could not scroll vertically to reach task positions outside the visible area

Now, when dragging a task near the edge of the container (within 100px for Kanban, 80px for List), the view automatically scrolls in that direction, with scroll speed increasing as the cursor gets closer to the edge.

## Changes

### ProjectDetail.tsx
- Added `kanbanBoardRef` to reference the horizontal scroll container (`.kanbanContainer`)
- Added `scrollIntervalRef` and `scrollSpeedsRef` using refs instead of state to avoid stale closure issues
- Rewrote `handleDragOver()` to:
  - Calculate horizontal scroll speed when cursor is near left/right edges
  - Find the column under the cursor and calculate vertical scroll speed when near top/bottom edges
  - Use a single interval that reads from refs for smooth, continuous scrolling
- Added `data-kanban-container="true"` attribute for container identification

### StatusColumn.tsx
- Added `data-kanban-column-tasks="true"` attribute to the scrollable tasks container for reliable detection during drag operations (more reliable than CSS module class names)

### TaskListView.tsx
- Added `scrollContainerRef`, `scrollIntervalRef`, and `scrollSpeedRef` for scroll management
- Added auto-scroll logic to `handleDragOver()` and `handleStatusDragOver()` callbacks
- Updated `handleDragEnd()` and `handleDrop()` to properly clean up scroll state
- Added ref to the scrollable list container

## Technical Details

### Why refs instead of state?
The previous implementation used `useState` for the scroll interval, which caused stale closure issues - the `handleDragOver` callback would capture an old value of `scrollInterval` in its closure, leading to incorrect behavior when checking if an interval was already running.

### How the scroll works
1. On `dragover`, calculate scroll speeds based on cursor distance from edges
2. Store speeds in `scrollSpeedsRef` (updated on every dragover event)
3. A single `setInterval` runs at ~60fps, reading from the ref and applying scroll
4. The interval self-terminates when speeds reach 0, and is cleaned up on drag end

### Configuration
- **Kanban**: 100px threshold, 20px/frame max speed
- **List**: 80px threshold, 15px/frame max speed
- Scroll speed is proportional to distance from edge (closer = faster)

## Test plan

- [ ] **Kanban horizontal scroll**: Drag a task toward the left/right edge of the kanban board - it should auto-scroll to reveal more columns
- [ ] **Kanban vertical scroll**: In a column with many tasks, drag a task toward the top/bottom edge - the column should auto-scroll
- [ ] **List view scroll**: Drag a task toward the top/bottom of the list view - it should auto-scroll to reveal more tasks
- [ ] **Scroll stops**: When moving cursor back to center of container, scrolling should stop
- [ ] **Drop works**: After auto-scrolling, dropping the task should work correctly
- [ ] **No memory leaks**: Intervals are properly cleaned up on drag end and component unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)