### PR TITLE
Fix task type not persisting when updating project tasks

### DIFF
--- a/server/src/lib/schemas/project.schemas.ts
+++ b/server/src/lib/schemas/project.schemas.ts
@@ -90,6 +90,7 @@ export const projectTaskSchema = tenantSchema.extend({
   due_date: z.date().nullable(),
   priority_id: z.string().uuid().nullable().optional(),
   service_id: z.string().uuid().nullable().optional(),
+  task_type_key: z.string().optional(),
   checklist_items: z.array(z.lazy(() => taskChecklistItemSchema)).optional()
 });
 


### PR DESCRIPTION
## Summary

- Fixes an issue where the `task_type_key` field was not being saved when updating project tasks
- The field was missing from the `projectTaskSchema` Zod validation schema, causing it to be stripped during validation

## Problem

When users updated project tasks and set a task type, the task type selection would not persist. This occurred because the `task_type_key` field was not included in the `projectTaskSchema` validation schema in `server/src/lib/schemas/project.schemas.ts`. As a result, Zod validation was stripping this field from the data before it reached the database update logic.

## Solution

Added `task_type_key: z.string().optional()` to the `projectTaskSchema` to allow the task type to pass through validation and be properly saved to the database.

## Test plan

- [ ] Create a new project task and assign a task type - verify it persists after save
- [ ] Edit an existing project task and change the task type - verify the change persists
- [ ] Edit a project task without changing the task type - verify it remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)