### PR TITLE
fixforhoverpreviewmessageclientportalbrandpreviewbutton

### DIFF
--- a/server/src/components/settings/general/ClientPortalSettings.tsx
+++ b/server/src/components/settings/general/ClientPortalSettings.tsx
@@ -442,26 +442,40 @@ const ClientPortalSettings = () => {
                 >
                   {previewMode === 'dashboard' ? 'Hide Client Dashboard' : 'Preview Client Dashboard'}
                 </Button>
-                <Tooltip content={!hasCustomDomain ? 'Must have custom domain set up' : undefined}>
-                  <Button
-                    id="preview-signin"
-                    type="button"
-                    variant={previewMode === 'signin' ? 'default' : 'outline'}
-                    size="sm"
-                    className={!hasCustomDomain ? 'cursor-not-allowed opacity-50' : ''}
-                    onClick={(e) => {
-                      if (!hasCustomDomain) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        return;
-                      }
-                      setPreviewMode(previewMode === 'signin' ? null : 'signin');
-                    }}
-                    aria-disabled={!hasCustomDomain || undefined}
-                  >
-                    {previewMode === 'signin' ? 'Hide Sign-in Page' : 'Preview Sign-in Page'}
-                  </Button>
-                </Tooltip>
+                {(() => {
+                  const disabledMessage = 'Must have custom domain set up';
+                  const signInButton = (
+                    <Button
+                      id="preview-signin"
+                      type="button"
+                      variant={previewMode === 'signin' ? 'default' : 'outline'}
+                      size="sm"
+                      className={!hasCustomDomain ? 'cursor-not-allowed opacity-50' : ''}
+                      onClick={(e) => {
+                        if (!hasCustomDomain) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          return;
+                        }
+                        setPreviewMode(previewMode === 'signin' ? null : 'signin');
+                      }}
+                      aria-disabled={!hasCustomDomain || undefined}
+                      aria-describedby={!hasCustomDomain ? 'preview-signin-disabled-reason' : undefined}
+                    >
+                      {previewMode === 'signin' ? 'Hide Sign-in Page' : 'Preview Sign-in Page'}
+                    </Button>
+                  );
+                  return !hasCustomDomain ? (
+                    <>
+                      <Tooltip content={disabledMessage}>{signInButton}</Tooltip>
+                      <span id="preview-signin-disabled-reason" className="sr-only">
+                        {disabledMessage}
+                      </span>
+                    </>
+                  ) : (
+                    signInButton
+                  );
+                })()}
               </div>
 
               {/* Dashboard Preview */}


### PR DESCRIPTION
Settings>general>client portal>Branding & Appearance

 

If a user doesn’t have a custom domain set up, that button is greyed out. We just want to add a hover over the button, when it is greyed out for that reason, that lets them know they must have a custom domain set up. 

 Import added at line 22: import { Tooltip } from '@alga-psa/ui/components/Tooltip'
  - Tooltip wraps the disabled button (lines 445-470): Shows "Must have custom domain set up" on hover when no custom domain is configured

  The greyed out "Preview Sign-in Page" button will now show the tooltip message when users hover over it.
