### PR TITLE
Add Assets tab to client screen

### DIFF
--- a/packages/clients/src/components/clients/ClientDetails.tsx
+++ b/packages/clients/src/components/clients/ClientDetails.tsx
@@ -955,12 +955,12 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
         </div>
       )
     },
-    // {
-    //   label: "Assets",
-    //   content: (
-    //     <ClientAssets clientId={client.client_id} />
-    //   )
-    // },
+    {
+      label: "Assets",
+      content: (
+        <ClientAssets clientId={client.client_id} />
+      )
+    },
     {
       label: "Billing",
       content: (


### PR DESCRIPTION
## Summary
- Enables the Assets tab on the client details screen
- When clicking an asset row, opens asset details in a drawer instead of navigating away
- Uses the existing `AssetDetailDrawerClient` component with full tab support (Overview, Maintenance, Tickets, Configuration, Documents)

## Test plan
- [ ] Open a client from the clients list
- [ ] Navigate to the new "Assets" tab
- [ ] Verify assets load with server-side pagination
- [ ] Click on an asset row and verify the drawer opens with asset details
- [ ] Switch between tabs in the drawer and verify data loads correctly
- [ ] Close the drawer and verify state resets properly
- [ ] Test the "Quick Add Asset" button still works