### PR TITLE
Fix numbering settings edit button visibility

### DIFF
--- a/packages/notifications/src/lib/authHelpers.ts
+++ b/packages/notifications/src/lib/authHelpers.ts
@@ -1,17 +1,10 @@
 /**
  * Auth helpers for notifications package
- *
- * These are dynamic import wrappers to avoid circular dependency:
- * notifications -> auth -> ui -> analytics -> tenancy -> ... -> notifications
- *
- * Note: Using string concatenation to prevent static analysis from detecting dependencies
  */
 
 import type { Knex } from 'knex';
-
-const getAuthModule = () => '@alga-psa/' + 'auth';
+import { hasPermission } from '@alga-psa/auth';
 
 export async function hasPermissionAsync(user: any, resource: string, action: string, trx?: Knex.Transaction): Promise<boolean> {
-  const { hasPermission } = await import(/* webpackIgnore: true */ getAuthModule());
   return hasPermission(user, resource, action, trx);
 }

--- a/packages/projects/tsup.config.ts
+++ b/packages/projects/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'actions/index': 'src/actions/index.ts',
+    'components/index': 'src/components/index.ts',
+    'models/index': 'src/models/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: false,
+  bundle: false,
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  external: [
+    'react',
+    'react-dom',
+    'next',
+    'next/navigation',
+    'next/link',
+    'next-auth',
+    'next-auth/react',
+    /^@alga-psa\//,
+  ],
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+  },
+});

--- a/packages/reference-data/src/actions/number-actions/numberingActions.ts
+++ b/packages/reference-data/src/actions/number-actions/numberingActions.ts
@@ -2,7 +2,7 @@
 
 import { createTenantKnex } from '@alga-psa/db';
 import { withTransaction } from '@alga-psa/db';
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, hasPermission } from '@alga-psa/auth';
 import { Knex } from 'knex';
 import type { EntityType } from '@alga-psa/shared/services/numberingService';
 
@@ -120,6 +120,11 @@ export const updateNumberSettings = withAuth(async (
     console.error(`Error updating ${entityType} number settings:`, error);
     return { success: false, error: 'Failed to update number settings' };
   }
+});
+
+// Check if user can edit numbering settings
+export const canEditNumberingSettings = withAuth(async (user): Promise<boolean> => {
+  return hasPermission(user, 'settings', 'update');
 });
 
 // Legacy support

--- a/packages/reference-data/tsup.config.ts
+++ b/packages/reference-data/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'actions/index': 'src/actions/index.ts',
+    'components/index': 'src/components/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: false,
+  bundle: false,
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  external: [
+    'react',
+    'react-dom',
+    'next',
+    'next/navigation',
+    'next/link',
+    'next-auth',
+    'next-auth/react',
+    /^@alga-psa\//,
+  ],
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+  },
+});

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -190,6 +190,23 @@ const nextConfig = {
 	      '@alga-psa/documents': '../packages/documents/src',
 	      '@alga-psa/documents/': '../packages/documents/src/',
 	      '@alga-psa/documents/storage/StorageService': '../packages/documents/src/storage/StorageService.ts',
+	      // Reference data package
+	      '@alga-psa/reference-data': '../packages/reference-data/src',
+	      '@alga-psa/reference-data/': '../packages/reference-data/src/',
+	      '@alga-psa/reference-data/actions': '../packages/reference-data/src/actions/index.ts',
+	      '@alga-psa/reference-data/components': '../packages/reference-data/src/components/index.ts',
+	      // Billing package
+	      '@alga-psa/billing': '../packages/billing/src',
+	      '@alga-psa/billing/': '../packages/billing/src/',
+	      '@alga-psa/billing/actions': '../packages/billing/src/actions/index.ts',
+	      '@alga-psa/billing/components': '../packages/billing/src/components/index.ts',
+	      '@alga-psa/billing/models': '../packages/billing/src/models/index.ts',
+	      '@alga-psa/billing/services': '../packages/billing/src/services/index.ts',
+	      // Projects package
+	      '@alga-psa/projects': '../packages/projects/src',
+	      '@alga-psa/projects/': '../packages/projects/src/',
+	      '@alga-psa/projects/actions': '../packages/projects/src/actions/index.ts',
+	      '@alga-psa/projects/components': '../packages/projects/src/components/index.ts',
 	      // DB package (use source files for Turbopack dev/HMR)
 	      '@alga-psa/db': '../packages/db/src/index.ts',
 	      '@alga-psa/db/admin': '../packages/db/src/lib/admin.ts',
@@ -316,6 +333,9 @@ const nextConfig = {
 	    '@alga-psa/client-portal',
 	    '@alga-psa/event-schemas',
 	    '@alga-psa/documents',
+	    '@alga-psa/reference-data',
+	    '@alga-psa/billing',
+	    '@alga-psa/projects',
 	    // Product feature packages (only those needed in this app)
 	    '@product/extensions',
     '@product/settings-extensions',


### PR DESCRIPTION
  Replace session-based role check with proper hasPermission check for showing the edit button in NumberingSettings component.

  Changes:
  - Add canEditNumberingSettings action using hasPermission
  - Update NumberingSettings to use permission check instead of session roles
  - Add Turbopack aliases for reference-data, billing, projects packages
  - Add tsup configs for reference-data and projects packages
  - Simplify notifications auth helper imports

  "But I don't want to go among mad people," Alice remarked.
  "Oh, you can't help that," said the Cat: "we're all mad here.
  I'm mad. You're mad. Your hasPermission is mad."
  "How do you know my hasPermission is mad?" asked Alice.
  "It must be," said the Cat, "or it wouldn't have replaced isAdmin." 🎩✨🔐