### PR TITLE
Gate Workflow Automation behind experimental flag

### DIFF
--- a/packages/tenancy/src/actions/tenant-settings-actions/tenantSettingsActions.ts
+++ b/packages/tenancy/src/actions/tenant-settings-actions/tenantSettingsActions.ts
@@ -20,10 +20,12 @@ export interface TenantSettings {
 
 export interface ExperimentalFeatures {
   aiAssistant: boolean;
+  workflowAutomation: boolean;
 }
 
 const DEFAULT_EXPERIMENTAL_FEATURES: ExperimentalFeatures = {
   aiAssistant: false,
+  workflowAutomation: false,
 };
 
 function normalizeExperimentalFeatures(value: unknown): ExperimentalFeatures {
@@ -34,6 +36,7 @@ function normalizeExperimentalFeatures(value: unknown): ExperimentalFeatures {
   const record = value as Record<string, unknown>;
   return {
     aiAssistant: record.aiAssistant === true,
+    workflowAutomation: record.workflowAutomation === true,
   };
 }
 

--- a/server/src/app/msp/workflows/page.tsx
+++ b/server/src/app/msp/workflows/page.tsx
@@ -1,28 +1,87 @@
 "use client";
 
-import { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Card } from '@alga-psa/ui/components/Card';
+import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { getCurrentUser } from '@alga-psa/users/actions';
 import { DynamicWorkflowComponent } from '@alga-psa/workflows/components/WorkflowComponentLoader';
+import { isExperimentalFeatureEnabled } from '@alga-psa/tenancy/actions';
 
 export default function WorkflowsPage() {
   const router = useRouter();
+  const [workflowAutomationEnabled, setWorkflowAutomationEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {
-    const checkAuth = async () => {
+    const bootstrap = async () => {
       try {
         const user = await getCurrentUser();
         if (!user) {
           router.push('/auth/msp/signin');
+          return;
         }
       } catch (error) {
         console.error('Authentication check failed:', error);
         router.push('/auth/msp/signin');
+        return;
+      }
+
+      try {
+        const enabled = await isExperimentalFeatureEnabled('workflowAutomation');
+        setWorkflowAutomationEnabled(enabled);
+      } catch (error) {
+        console.error('[WorkflowsPage] Failed to check workflowAutomation feature flag', error);
+        setWorkflowAutomationEnabled(false);
       }
     };
 
-    checkAuth();
+    void bootstrap();
   }, [router]);
+
+  if (workflowAutomationEnabled === null) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <LoadingIndicator layout="stacked" text="Loading workflow automation..." spinnerProps={{ size: 'md' }} />
+      </div>
+    );
+  }
+
+  if (!workflowAutomationEnabled) {
+    return (
+      <div className="h-full">
+        <Card className="p-6">
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Workflow Automation</h2>
+              <p className="text-sm text-gray-600">
+                This feature is experimental and is not enabled for your tenant.
+              </p>
+            </div>
+            <Alert
+              variant="warning"
+              className="text-[rgba(255,174,0,1)] [&>svg]:text-[rgba(255,174,0,1)]"
+            >
+              <AlertTitle>Experimental</AlertTitle>
+              <AlertDescription>
+                Enable Workflow Automation in Settings to access workflow automation features.
+              </AlertDescription>
+            </Alert>
+            <div className="flex items-center gap-3">
+              <Button id="enable-workflow-automation" asChild>
+                <Link href="/msp/settings?tab=experimental-features">Go to Experimental Features</Link>
+              </Button>
+              <Link href="/msp/settings?tab=experimental-features" className="text-sm text-primary-600 hover:underline">
+                Open settings
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full">

--- a/server/src/components/settings/general/ExperimentalFeaturesSettings.tsx
+++ b/server/src/components/settings/general/ExperimentalFeaturesSettings.tsx
@@ -9,7 +9,7 @@ import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { getExperimentalFeatures, updateExperimentalFeatures } from '@alga-psa/tenancy/actions';
 
-type ExperimentalFeatureKey = 'aiAssistant';
+type ExperimentalFeatureKey = 'aiAssistant' | 'workflowAutomation';
 
 type ExperimentalFeatureDefinition = {
   key: ExperimentalFeatureKey;
@@ -23,12 +23,18 @@ const experimentalFeatureDefinitions: ExperimentalFeatureDefinition[] = [
     name: 'AI Assistant',
     description: 'Enable AI-powered Quick Ask and Chat sidebar.',
   },
+  {
+    key: 'workflowAutomation',
+    name: 'Workflow Automation',
+    description: 'Enable experimental workflow automation features in Automation Hub.',
+  },
 ];
 
 type ExperimentalFeatureState = Record<ExperimentalFeatureKey, boolean>;
 
 const defaultExperimentalFeatureState: ExperimentalFeatureState = {
   aiAssistant: false,
+  workflowAutomation: false,
 };
 
 export default function ExperimentalFeaturesSettings(): React.JSX.Element {
@@ -46,6 +52,7 @@ export default function ExperimentalFeaturesSettings(): React.JSX.Element {
       const saved = await getExperimentalFeatures();
       const loaded: ExperimentalFeatureState = {
         aiAssistant: saved.aiAssistant === true,
+        workflowAutomation: saved.workflowAutomation === true,
       };
       setFeatures(loaded);
       setSavedFeatures(loaded);
@@ -69,14 +76,14 @@ export default function ExperimentalFeaturesSettings(): React.JSX.Element {
     }));
   }, []);
 
-  const hasChanges = features.aiAssistant !== savedFeatures.aiAssistant;
+  const hasChanges = (Object.keys(features) as ExperimentalFeatureKey[]).some(
+    (key) => features[key] !== savedFeatures[key]
+  );
 
   const handleSave = useCallback(async (): Promise<void> => {
     try {
       setSaving(true);
-      await updateExperimentalFeatures({
-        aiAssistant: features.aiAssistant,
-      });
+      await updateExperimentalFeatures(features);
       setSavedFeatures(features);
       toast.success('Experimental feature settings saved. Reload the page to apply changes.');
     } catch (error) {

--- a/server/src/test/unit/components/ExperimentalFeaturesSettings.test.tsx
+++ b/server/src/test/unit/components/ExperimentalFeaturesSettings.test.tsx
@@ -12,7 +12,7 @@ import ExperimentalFeaturesSettings from '../../../components/settings/general/E
 import { getExperimentalFeatures, updateExperimentalFeatures } from '@alga-psa/tenancy/actions';
 
 vi.mock('@alga-psa/tenancy/actions', () => ({
-  getExperimentalFeatures: vi.fn().mockResolvedValue({ aiAssistant: false }),
+  getExperimentalFeatures: vi.fn().mockResolvedValue({ aiAssistant: false, workflowAutomation: false }),
   updateExperimentalFeatures: vi.fn(),
 }));
 
@@ -29,7 +29,7 @@ describe('ExperimentalFeaturesSettings', () => {
   });
 
   it("shows 'AI Assistant' name and description", async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false, workflowAutomation: false });
 
     render(
       <UIStateProvider
@@ -76,7 +76,7 @@ describe('ExperimentalFeaturesSettings', () => {
   });
 
   it('renders experimental features warning banner', async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false, workflowAutomation: false });
 
     render(
       <UIStateProvider
@@ -97,7 +97,7 @@ describe('ExperimentalFeaturesSettings', () => {
   });
 
   it('calls updateExperimentalFeatures() with current toggle states on save', async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false, workflowAutomation: false });
     vi.mocked(updateExperimentalFeatures).mockResolvedValueOnce(undefined);
 
     render(
@@ -129,12 +129,12 @@ describe('ExperimentalFeaturesSettings', () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(updateExperimentalFeatures).toHaveBeenCalledWith({ aiAssistant: true });
+      expect(updateExperimentalFeatures).toHaveBeenCalledWith({ aiAssistant: true, workflowAutomation: false });
     });
   });
 
   it('shows success feedback after saving', async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false, workflowAutomation: false });
     vi.mocked(updateExperimentalFeatures).mockResolvedValueOnce(undefined);
 
     render(
@@ -173,7 +173,7 @@ describe('ExperimentalFeaturesSettings', () => {
   });
 
   it('updates local state when toggled', async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: false, workflowAutomation: false });
 
     render(
       <UIStateProvider
@@ -201,7 +201,7 @@ describe('ExperimentalFeaturesSettings', () => {
   });
 
   it('loads current settings on mount', async () => {
-    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: true });
+    vi.mocked(getExperimentalFeatures).mockResolvedValueOnce({ aiAssistant: true, workflowAutomation: false });
 
     render(
       <UIStateProvider
@@ -247,6 +247,10 @@ describe('ExperimentalFeaturesSettings', () => {
       '[data-automation-id="experimental-feature-toggle-aiAssistant"]'
     );
     expect(toggle).toBeTruthy();
-    expect(screen.getAllByRole('switch')).toHaveLength(1);
+    const workflowAutomationToggle = document.querySelector(
+      '[data-automation-id="experimental-feature-toggle-workflowAutomation"]'
+    );
+    expect(workflowAutomationToggle).toBeTruthy();
+    expect(screen.getAllByRole('switch')).toHaveLength(2);
   });
 });

--- a/server/src/test/unit/tenantSettingsActions.experimentalFeatures.test.ts
+++ b/server/src/test/unit/tenantSettingsActions.experimentalFeatures.test.ts
@@ -89,7 +89,7 @@ describe('tenantSettingsActions.getExperimentalFeatures', () => {
       '../../../../packages/tenancy/src/actions/tenant-settings-actions/tenantSettingsActions'
     );
 
-    await expect(getExperimentalFeatures()).resolves.toEqual({ aiAssistant: false });
+    await expect(getExperimentalFeatures()).resolves.toEqual({ aiAssistant: false, workflowAutomation: false });
     expect(createTenantKnexMock).toHaveBeenCalled();
   });
 
@@ -99,6 +99,7 @@ describe('tenantSettingsActions.getExperimentalFeatures', () => {
       settings: {
         experimentalFeatures: {
           aiAssistant: true,
+          workflowAutomation: true,
         },
       },
     };
@@ -107,7 +108,7 @@ describe('tenantSettingsActions.getExperimentalFeatures', () => {
       '../../../../packages/tenancy/src/actions/tenant-settings-actions/tenantSettingsActions'
     );
 
-    await expect(getExperimentalFeatures()).resolves.toEqual({ aiAssistant: true });
+    await expect(getExperimentalFeatures()).resolves.toEqual({ aiAssistant: true, workflowAutomation: true });
     expect(knexWhereMock).toHaveBeenCalledWith({ tenant: 'tenant-test' });
   });
 });
@@ -200,6 +201,7 @@ describe('tenantSettingsActions.updateExperimentalFeatures', () => {
     expect(parsedSettings).toEqual({
       experimentalFeatures: {
         aiAssistant: true,
+        workflowAutomation: false,
       },
     });
 
@@ -239,6 +241,7 @@ describe('tenantSettingsActions.updateExperimentalFeatures', () => {
       },
       experimentalFeatures: {
         aiAssistant: true,
+        workflowAutomation: false,
       },
     });
   });


### PR DESCRIPTION
Adds an Experimental Features toggle (Workflow Automation) and gates /msp/workflows so workflow automation UI is hidden unless enabled. When disabled, users see an experimental-not-enabled screen with a link to Settings → Experimental Features to activate it.