### PR TITLE
Fix checklist item alignment in TaskForm

### DIFF
--- a/packages/projects/src/components/TaskForm.tsx
+++ b/packages/projects/src/components/TaskForm.tsx
@@ -1271,6 +1271,7 @@ export default function TaskForm({
                             checked={item.completed}
                             onChange={(e) => updateChecklistItem(index, 'completed', e.target.checked)}
                             className="flex-none"
+                            containerClassName=""
                           />
                           <div className="flex-1">
                             <TextArea
@@ -1278,6 +1279,7 @@ export default function TaskForm({
                               onChange={(e) => updateChecklistItem(index, 'item_name', e.target.value)}
                               placeholder="Checklist item"
                               className="w-full"
+                              wrapperClassName="!mb-0 !px-0"
                               onBlur={() => setEditingChecklistItemId(null)} // Stop editing when focus is lost
                               autoFocus={editingChecklistItemId === item.checklist_item_id}
                               onKeyDown={handleChecklistItemKeyDown}
@@ -1297,6 +1299,7 @@ export default function TaskForm({
                             checked={item.completed}
                             onChange={(e) => updateChecklistItem(index, 'completed', e.target.checked)}
                             className="flex-none"
+                            containerClassName=""
                           />
                           <span
                             className={`flex-1 whitespace-pre-wrap ${item.completed ? 'line-through text-gray-500' : ''}`}

--- a/packages/ui/src/components/TextArea.tsx
+++ b/packages/ui/src/components/TextArea.tsx
@@ -3,6 +3,7 @@
 import React, { useLayoutEffect, useEffect, useRef, useCallback } from 'react';
 import { FormFieldComponent, AutomationProps } from '../ui-reflection/types';
 import { useAutomationIdAndRegister } from '../ui-reflection/useAutomationIdAndRegister';
+import { cn } from '../lib/utils';
 
 interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'id'> {
   label?: string;
@@ -12,6 +13,8 @@ interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaEl
   required?: boolean;
   /** Ref for the textarea element */
   ref?: React.Ref<HTMLTextAreaElement>;
+  /** Optional wrapper class overrides */
+  wrapperClassName?: string;
 }
 
 export function TextArea({
@@ -23,6 +26,7 @@ export function TextArea({
   disabled,
   required,
   ref: forwardedRef,
+  wrapperClassName,
   "data-automation-id": dataAutomationId,
   ...props
 }: TextAreaProps & AutomationProps) {
@@ -117,7 +121,7 @@ export function TextArea({
   };
 
   return (
-    <div className="mb-4 px-0.5">
+    <div className={cn('mb-4 px-0.5', wrapperClassName)}>
       {label && (
         <label className="block text-sm font-medium text-gray-700 mb-1">
           {label}


### PR DESCRIPTION
## Summary
- Fix inconsistent vertical alignment of checklist items in the task form
- Add `wrapperClassName` prop to TextArea component to allow overriding default wrapper styles
- Remove default margins from Checkbox and TextArea wrappers in checklist context

## Details
The checklist items had inconsistent vertical alignment due to default wrapper styling on the Checkbox (`mb-4`) and TextArea (`mb-4 px-0.5`) components. This caused checkboxes to appear misaligned relative to their text inputs, particularly noticeable with multi-line content.

### Changes

**TextArea component (`packages/ui/src/components/TextArea.tsx`)**
- Added optional `wrapperClassName` prop to allow overriding the default wrapper classes
- Uses `cn()` utility to merge classes, so existing usages are unaffected

**TaskForm (`packages/projects/src/components/TaskForm.tsx`)**
- Pass `containerClassName=""` to Checkbox components to remove the default `mb-4` margin
- Pass `wrapperClassName="!mb-0 !px-0"` to TextArea to remove margin and padding that caused uneven row heights

This change is backwards compatible - all existing TextArea usages without `wrapperClassName` will continue to use the default styling.