### PR TITLE
Fix task type not saving when updating project tasks

### DIFF
--- a/packages/projects/src/schemas/project.schemas.ts
+++ b/packages/projects/src/schemas/project.schemas.ts
@@ -90,7 +90,9 @@ export const projectTaskSchema = tenantSchema.extend({
   due_date: z.date().nullable(),
   priority_id: z.string().uuid().nullable().optional(),
   service_id: z.string().uuid().nullable().optional(),
-  checklist_items: z.array(z.lazy(() => taskChecklistItemSchema)).optional()
+  checklist_items: z.array(z.lazy(() => taskChecklistItemSchema)).optional(),
+  task_type_key: z.string().optional(),
+  order_key: z.string().nullable().optional()
 });
 
 export const projectTicketLinkSchema = tenantSchema.extend({


### PR DESCRIPTION
## Summary
- The `projectTaskSchema` Zod validation schema was missing `task_type_key` and `order_key` fields
- When `updateTaskWithChecklist` validates incoming task data through `validateData(updateTaskSchema, taskUpdateData)`, Zod strips out any fields not defined in the schema
- This caused task type changes made in the TaskForm to be silently discarded before reaching the database update query
- Added both fields to the schema so they pass through validation and get persisted correctly