### PR TITLE
Add clientId to extension user context

### DIFF
--- a/ee/runner/src/engine/host_api.rs
+++ b/ee/runner/src/engine/host_api.rs
@@ -2139,6 +2139,7 @@ impl user::HostWithStore for HasSelf<HostState> {
                         user_email: user_info.user_email.clone(),
                         user_name: user_info.user_name.clone(),
                         user_type: user_info.user_type.clone(),
+                        client_id: user_info.client_id.clone(),
                     })
                 }
                 None => {

--- a/ee/runner/src/models.rs
+++ b/ee/runner/src/models.rs
@@ -41,6 +41,9 @@ pub struct UserInfo {
     pub user_type: String,
     #[serde(default, alias = "company_name")]
     pub client_name: String,
+    /// For client portal users, the client_id they are associated with
+    #[serde(default)]
+    pub client_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/ee/runner/wit/extension-runner.wit
+++ b/ee/runner/wit/extension-runner.wit
@@ -69,6 +69,7 @@ interface types {
         user-email: string,
         user-name: string,
         user-type: string,
+        client-id: option<string>,
     }
 
     enum user-error {

--- a/sdk/extension-runtime/src/index.ts
+++ b/sdk/extension-runtime/src/index.ts
@@ -203,6 +203,8 @@ export interface UserData {
   userName: string;
   /** User type (e.g., "msp", "client") */
   userType: string;
+  /** For client portal users, the client_id they are associated with */
+  clientId?: string;
 }
 
 /** Errors that can occur when fetching user data */
@@ -363,6 +365,7 @@ export function createMockHostBindings(overrides: Partial<HostBindings> = {}): H
           userEmail: 'mock@example.com',
           userName: 'Mock User',
           userType: 'client',
+          clientId: 'client-mock',
         };
       },
     },

--- a/server/src/lib/extensions/gateway/auth.ts
+++ b/server/src/lib/extensions/gateway/auth.ts
@@ -102,6 +102,7 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
     userEmail: userInfo.user_email,
     userName: userInfo.user_name,
     userType: userInfo.user_type,
+    clientId: userInfo.client_id,
   });
 
   return userInfo;


### PR DESCRIPTION
  Expose client_id through the extension host API so client portal extensions can identify which client the current user belongs to.

  Changes:
  - Add client_id field to Rust UserInfo model and WIT user-data record
  - Map client_id through host_api.rs to extension runtime - Add clientId to TypeScript SDK UserData interface - Include clientId in gateway auth logging

  "Curiouser and curiouser!" cried Alice, for now the Client knew precisely which looking-glass it had tumbled through, and the Option<String> revealed None to those who weren't clients at all 🐇🪞✨