### PR TITLE
Wire SSO buttons to EE implementation via aliased entry

### DIFF
--- a/ee/server/next.config.mjs
+++ b/ee/server/next.config.mjs
@@ -23,6 +23,7 @@ const nextConfig = {
     '@product/extensions',
     '@product/extensions-pages',
     '@alga-psa/event-schemas',
+    '@alga-psa/core',
   ],
   // Turbopack-specific aliases
   turbopack: {
@@ -49,6 +50,8 @@ const nextConfig = {
       // Event schemas package
       '@alga-psa/event-schemas': '../packages/event-schemas/src',
       '@alga-psa/event-schemas/': '../packages/event-schemas/src/',
+      // SSO provider buttons - always use EE implementation in EE server
+      '@alga-psa/auth/sso/entry': './src/components/auth/SsoProviderButtons.tsx',
       // Native DB drivers not used
       'better-sqlite3': emptyShim,
       'sqlite3': emptyShim,
@@ -113,6 +116,8 @@ const nextConfig = {
           : path.join(__dirname, '../packages/product-ext-proxy/oss/handler.ts'),
         // Event schemas package
         '@alga-psa/event-schemas': path.join(__dirname, '../packages/event-schemas/src'),
+        // SSO provider buttons - always use EE implementation in EE server
+        '@alga-psa/auth/sso/entry': path.join(__dirname, 'src/components/auth/SsoProviderButtons.tsx'),
         // Stub native sharp during local dev to avoid platform build issues
         sharp: path.join(__dirname, 'src/empty/sharp.ts'),
       },

--- a/packages/auth/src/components/ClientLoginForm.tsx
+++ b/packages/auth/src/components/ClientLoginForm.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import { useRegisterUIComponent, withDataAutomationId } from '@alga-psa/ui/ui-reflection';
 import type { FormComponent, FormFieldComponent, ButtonComponent } from '@alga-psa/ui/ui-reflection';
 import { useTranslation } from '@alga-psa/ui/lib';
-import SsoProviderButtons from './SsoProviderButtons';
+import SsoProviderButtons from '@alga-psa/auth/sso/entry';
 
 interface ClientLoginFormProps {
   callbackUrl: string;

--- a/packages/auth/src/components/MspLoginForm.tsx
+++ b/packages/auth/src/components/MspLoginForm.tsx
@@ -7,7 +7,7 @@ import { Label, Input, Button, Alert, AlertDescription } from '@alga-psa/ui/comp
 import type { AlertProps } from '@alga-psa/types';
 import { useRegisterUIComponent, withDataAutomationId } from '@alga-psa/ui/ui-reflection';
 import type { FormComponent, FormFieldComponent } from '@alga-psa/ui/ui-reflection';
-import SsoProviderButtons from './SsoProviderButtons';
+import SsoProviderButtons from '@alga-psa/auth/sso/entry';
 
 interface MspLoginFormProps {
   callbackUrl: string;

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -33,7 +33,7 @@ const emptyShim = './src/empty/shims/empty.ts';
 
 const appVersion = (() => {
   try {
-    const pkgPath = path.join(__dirname, '../package.json');
+    const pkgPath = path.join(__dirname, '../packages/core/package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
     return pkg?.version || 'dev';
   } catch {
@@ -190,6 +190,10 @@ const nextConfig = {
 	      '@alga-psa/auth/nextAuthOptions': '../packages/auth/src/lib/nextAuthOptions.ts',
 	      '@alga-psa/auth/actions': '../packages/auth/src/actions/index.ts',
 	      '@alga-psa/auth/components': '../packages/auth/src/components/index.ts',
+	      // SSO provider buttons - swap between CE stub and EE implementation
+	      '@alga-psa/auth/sso/entry': isEE
+	        ? '../ee/server/src/components/auth/SsoProviderButtons.tsx'
+	        : '../packages/auth/src/components/SsoProviderButtons.tsx',
 	      // Notifications package
 	      '@alga-psa/notifications': '../packages/notifications/src',
 	      '@alga-psa/notifications/': '../packages/notifications/src/',
@@ -474,6 +478,10 @@ const nextConfig = {
         console.log(`[WEBPACK ALIAS DEBUG] @product/settings-extensions/entry -> ${selectedPath} (isEE: ${isEE})`);
         return selectedPath;
       })(),
+      // SSO provider buttons - swap between CE stub and EE implementation
+      '@alga-psa/auth/sso/entry': isEE
+        ? path.join(__dirname, '../ee/server/src/components/auth/SsoProviderButtons.tsx')
+        : path.join(__dirname, '../packages/auth/src/components/SsoProviderButtons.tsx'),
       '@alga-psa/integrations/email/providers/entry': isEE
         ? path.join(__dirname, '../packages/integrations/src/email/providers/ee/entry.tsx')
         : path.join(__dirname, '../packages/integrations/src/email/providers/oss/entry.tsx'),

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -76,6 +76,9 @@
       "@alga-psa/auth": [
         "../packages/auth/src"
       ],
+      "@alga-psa/auth/sso/entry": [
+        "../packages/auth/src/components/SsoProviderButtons.tsx"
+      ],
       "@alga-psa/auth/*": [
         "../packages/auth/src/*",
         "../packages/auth/src/lib/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,7 @@
       "@alga-psa/ui-kit": ["packages/ui-kit/src"],
       "@alga-psa/ui-kit/*": ["packages/ui-kit/src/*"],
       "@alga-psa/auth": ["packages/auth/src"],
+      "@alga-psa/auth/sso/entry": ["packages/auth/src/components/SsoProviderButtons.tsx"],
       "@alga-psa/auth/*": ["packages/auth/src/*", "packages/auth/src/lib/*"],
       "@alga-psa/analytics": ["packages/analytics/src"],
       "@alga-psa/analytics/*": ["packages/analytics/src/*"],


### PR DESCRIPTION
  Add @alga-psa/auth/sso/entry alias to swap SsoProviderButtons between CE stub and EE implementation at build time. Updates login forms to use aliased import instead of relative path.

  - Add turbopack/webpack aliases in server and ee/server configs
  - Add TypeScript path mappings in tsconfig.base.json and server
  - Update MspLoginForm and ClientLoginForm imports

  "But I don't want to go among stub people," Alice remarked. "Oh, you can't help that," said the Cat: "we're all aliased here.  I'm aliased. You're aliased." And with that, the SsoProviderButtons materialized where once there had been only null. 🐱✨🔐