### PR TITLE
EE: ensure MSP SSO entry resolves to EE buttons

### DIFF
--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -795,6 +795,10 @@ const nextConfig = {
 	        const cePackagesEeRegex = new RegExp(cePackagesEePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
 	        const eeSrcRoot = path.join(__dirname, '../ee/server/src') + path.sep;
 	        const workflowsEeEntry = path.join(__dirname, '../ee/server/src/workflows/entry.tsx');
+	        const authSsoButtonsEeEntry = path.join(
+	          __dirname,
+	          '../ee/server/src/components/auth/SsoProviderButtons.tsx',
+	        );
 	        config.plugins = config.plugins || [];
 	        config.plugins.push(new webpack.NormalModuleReplacementPlugin(/.*/, (resource) => {
 	          try {
@@ -806,6 +810,12 @@ const nextConfig = {
 	            // Force consistency by rewriting the workflows entry specifier to the canonical EE source file *before* resolution.
 	            if (req === '@alga-psa/workflows/entry') {
 	              resource.request = workflowsEeEntry;
+	              return;
+	            }
+	            // Same issue for auth SSO provider buttons: tsconfig may point `@alga-psa/auth/sso/entry`
+	            // at the CE stub. Force the EE implementation for enterprise builds.
+	            if (req === '@alga-psa/auth/sso/entry') {
+	              resource.request = authSsoButtonsEeEntry;
 	              return;
 	            }
 	            // IMPORTANT:


### PR DESCRIPTION
Fixes a production-only regression after #1720 was merged into release/1.0-rc1 (merge commit 1e92b8a8): the MSP sign-in page still bundled the CE stub for `@alga-psa/auth/sso/entry` (buttons never rendered).\n\nRoot cause: Next.js' JsConfigPathsPlugin can resolve `@alga-psa/auth/sso/entry` via tsconfig paths to the CE stub before our EE alias swap takes effect (same class of issue we already handle for `@alga-psa/workflows/entry`).\n\nChange: in EE builds, add a webpack NormalModuleReplacementPlugin rewrite forcing `@alga-psa/auth/sso/entry` to `ee/server/src/components/auth/SsoProviderButtons.tsx` before resolution.