### PR TITLE
fix(time-entry): disable bundled child tickets in work item picker

### DIFF
--- a/packages/scheduling/src/actions/workItemActions.ts
+++ b/packages/scheduling/src/actions/workItemActions.ts
@@ -301,6 +301,10 @@ export const searchPickerWorkItems = withAuth(async (
         this.on('t.status_id', '=', 's.status_id')
             .andOn('t.tenant', '=', 's.tenant');
       })
+      .leftJoin('tickets as mt', function() {
+        this.on('t.master_ticket_id', '=', 'mt.ticket_id')
+            .andOn('t.tenant', '=', 'mt.tenant');
+      })
       .leftJoin(
         db('ticket_resources')
           .where('tenant', tenant)
@@ -364,6 +368,8 @@ export const searchPickerWorkItems = withAuth(async (
          db.raw("t.attributes ->> 'description' as description"),
          db.raw("'ticket' as type"),
          't.ticket_number',
+         't.master_ticket_id as master_ticket_id',
+         'mt.ticket_number as master_ticket_number',
          't.title',
          db.raw('NULL::text as project_name'),
          db.raw('NULL::text as phase_name'),
@@ -493,6 +499,8 @@ export const searchPickerWorkItems = withAuth(async (
          'pt.description',
          db.raw("'project_task' as type"),
          db.raw('NULL::text as ticket_number'),
+         db.raw('NULL::uuid as master_ticket_id'),
+         db.raw('NULL::text as master_ticket_number'),
          db.raw('NULL::text as title'),
          'p.project_name',
          'pp.phase_name',
@@ -559,6 +567,8 @@ export const searchPickerWorkItems = withAuth(async (
           'se.notes as description',
           db.raw("'ad_hoc' as type"),
           db.raw('NULL::text as ticket_number'),
+          db.raw('NULL::uuid as master_ticket_id'),
+          db.raw('NULL::text as master_ticket_number'),
           'se.title',
           db.raw('NULL::text as project_name'),
           db.raw('NULL::text as phase_name'),
@@ -600,6 +610,8 @@ export const searchPickerWorkItems = withAuth(async (
           db.raw("'' as description"), // Don't copy interaction notes to time entry
           db.raw("'interaction' as type"),
           db.raw('NULL::text as ticket_number'),
+          db.raw('NULL::uuid as master_ticket_id'),
+          db.raw('NULL::text as master_ticket_number'),
           'i.title',
           db.raw('NULL::text as project_name'),
           db.raw('NULL::text as phase_name'),
@@ -713,6 +725,8 @@ export const searchPickerWorkItems = withAuth(async (
         description: item.description,
         is_billable: true,
         ticket_number: item.ticket_number,
+        master_ticket_id: item.master_ticket_id,
+        master_ticket_number: item.master_ticket_number,
         title: item.title,
         project_name: item.project_name,
         phase_name: item.phase_name,

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
@@ -106,6 +106,7 @@ export function WorkItemList({
 
   const renderItemContent = (item: WorkItemWithStatus) => {
     if (item.type === 'ticket') {
+      const isBundledTicket = !!item.master_ticket_id;
       return (
         <>
           <div className="font-medium text-[rgb(var(--color-text-900))] text-lg mb-1">
@@ -129,6 +130,12 @@ export function WorkItemList({
               </span>
             )}
           </div>
+          {isBundledTicket && (
+            <div className="text-sm text-[rgb(var(--color-text-600))] mt-2 italic">
+              Bundled ticket — log time on the master ticket
+              {item.master_ticket_number ? ` #${item.master_ticket_number}` : ''}.
+            </div>
+          )}
         </>
       );
     } else if (item.type === 'project_task') {
@@ -228,20 +235,30 @@ export function WorkItemList({
           {items.length > 0 ? (
             <div>
               <ul className="divide-y divide-[rgb(var(--color-border-200))]">
-                {items.map((item) => (
-                  <li
-                    key={item.work_item_id}
-                    className="bg-[rgb(var(--color-border-50))] hover:bg-[rgb(var(--color-border-100))] cursor-pointer transition-colors duration-150"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSelect(item);
-                    }}
-                  >
-                    <div className="px-4 py-3">
-                      {renderItemContent(item)}
-                    </div>
-                  </li>
-                ))}
+                {items.map((item) => {
+                  const isDisabled = item.type === 'ticket' && !!item.master_ticket_id;
+                  return (
+                    <li
+                      key={item.work_item_id}
+                      aria-disabled={isDisabled}
+                      className={[
+                        'bg-[rgb(var(--color-border-50))] transition-colors duration-150',
+                        isDisabled
+                          ? 'opacity-50 cursor-not-allowed'
+                          : 'hover:bg-[rgb(var(--color-border-100))] cursor-pointer',
+                      ].join(' ')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (isDisabled) return;
+                        onSelect(item);
+                      }}
+                    >
+                      <div className="px-4 py-3">
+                        {renderItemContent(item)}
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
               <div className="px-6 py-4 border-t border-gray-100 bg-white">
                 <div className="flex items-center justify-between">

--- a/packages/types/src/interfaces/workItem.interfaces.ts
+++ b/packages/types/src/interfaces/workItem.interfaces.ts
@@ -27,6 +27,8 @@ export interface IExtendedWorkItem extends IWorkItem {
   title?: string;
   client_id?: string;
   client_name?: string | null;
+  master_ticket_id?: string | null;
+  master_ticket_number?: string | null;
   status_name?: string;
   board_name?: string;
   assigned_to_name?: string;

--- a/server/src/interfaces/workItem.interfaces.ts
+++ b/server/src/interfaces/workItem.interfaces.ts
@@ -27,6 +27,8 @@ export interface IExtendedWorkItem extends IWorkItem {
   title?: string;
   client_id?: string;
   client_name?: string | null;
+  master_ticket_id?: string | null;
+  master_ticket_number?: string | null;
   status_name?: string;
   board_name?: string;
   assigned_to_name?: string;

--- a/server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts
+++ b/server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePathFromRepoRoot: string): string {
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  return readFileSync(path.join(repoRoot, relativePathFromRepoRoot), 'utf8');
+}
+
+describe('bundled ticket selection (static)', () => {
+  it('exposes bundle metadata on picker results', () => {
+    const src = readRepoFile('packages/scheduling/src/actions/workItemActions.ts');
+    expect(src).toContain('export const searchPickerWorkItems');
+    const pickerStart = src.indexOf('export const searchPickerWorkItems');
+    expect(pickerStart).toBeGreaterThan(0);
+    const pickerSrc = src.slice(pickerStart);
+
+    expect(pickerSrc).toMatch(/master_ticket_id\s+as\s+master_ticket_id/);
+    expect(pickerSrc).toMatch(/master_ticket_number/);
+  });
+
+  it('disables bundled tickets in the work item picker list with an explanation', () => {
+    const src = readRepoFile(
+      'packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx'
+    );
+    expect(src).toMatch(/item\.type\s*===\s*'ticket'\s*&&\s*!!item\.master_ticket_id/);
+    expect(src).toContain('Bundled ticket — log time on the master ticket');
+  });
+});


### PR DESCRIPTION
Summary
- Bundled child tickets (tickets with master_ticket_id) cannot accept time entries, so show them as disabled in the Time Entry work item picker with a clear explanation.

Key changes
- Work item picker query returns master_ticket_id + master_ticket_number for ticket rows and aligns UNION types.
- Work item picker list disables bundled child tickets and shows messaging.

Test
- server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts
