### PR TITLE
fix(msp): await timesheet route params

### DIFF
--- a/server/src/app/msp/time-entry/timesheet/[id]/page.tsx
+++ b/server/src/app/msp/time-entry/timesheet/[id]/page.tsx
@@ -6,8 +6,8 @@ import { createTenantKnex } from '@alga-psa/db';
 import { hasPermission } from '@alga-psa/auth';
 import { assertCanActOnBehalf, isManagerOfSubject } from '@alga-psa/scheduling/actions/timeEntryDelegationAuth';
 
-export default async function TimeSheetPage({ params }: { params: { id?: string } }) {
-  const id = params?.id;
+export default async function TimeSheetPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   if (!id) {
     return notFound();
   }


### PR DESCRIPTION
Fixes Next.js App Router route params handling for the timesheet page. In some runtimes params are a Promise; we now await params before reading id, preventing erroneous 404s in the blue deployment.