### PR TITLE
Fix EventBus pending stream recovery (email notifications)

### DIFF
--- a/packages/event-bus/src/index.pending.test.ts
+++ b/packages/event-bus/src/index.pending.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+type FakeRedisClient = EventEmitter & {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  quit: () => Promise<void>;
+  xGroupCreate: () => Promise<void>;
+  xReadGroup: (...args: any[]) => Promise<any>;
+  xAck: (...args: any[]) => Promise<number>;
+  xPending: (...args: any[]) => Promise<{ pending: number }>;
+  xPendingRange: (...args: any[]) => Promise<any[]>;
+  xClaim: (...args: any[]) => Promise<any>;
+  sIsMember: (...args: any[]) => Promise<boolean>;
+  sAdd: (...args: any[]) => Promise<number>;
+  expire: (...args: any[]) => Promise<number>;
+};
+
+async function flushMicrotasks(limit: number = 50) {
+  for (let i = 0; i < limit; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+describe('EventBus pending message recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('claims and processes stale pending messages (acks on success)', async () => {
+    const messageId = '1-0';
+    const tenantId = randomUUID();
+    const eventType = 'CUSTOM_EVENT';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const handler = vi.fn(async () => undefined);
+    let didAck = false;
+    const processed = new Set<string>();
+    const createdClients: FakeRedisClient[] = [];
+    const loggedErrors: any[] = [];
+
+    vi.doMock('@alga-psa/core/logger', () => {
+      return {
+        default: {
+          info: () => undefined,
+          warn: () => undefined,
+          debug: () => undefined,
+          error: (...args: any[]) => {
+            loggedErrors.push(args);
+          },
+        },
+      };
+    });
+
+    vi.doMock('redis', () => {
+      return {
+        createClient: () => {
+          const client = new EventEmitter() as FakeRedisClient;
+
+          client.connect = vi.fn(async () => {
+            client.emit('connect');
+            client.emit('ready');
+          });
+
+          client.disconnect = vi.fn(() => {
+            client.emit('end');
+          });
+
+          client.quit = vi.fn(async () => {
+            client.emit('end');
+          });
+
+          client.xGroupCreate = vi.fn(async () => undefined);
+          client.xReadGroup = vi.fn(async () => null);
+          client.xAck = vi.fn(async () => {
+            didAck = true;
+            return 1;
+          });
+
+          client.xPending = vi.fn()
+            .mockResolvedValueOnce({ pending: 1 })
+            .mockResolvedValue({ pending: 0 });
+          client.xPendingRange = vi.fn()
+            .mockResolvedValueOnce([
+              {
+                id: messageId,
+                consumer: 'consumer-old',
+                millisecondsSinceLastDelivery: 30001,
+                deliveriesCounter: 1,
+              },
+            ])
+            .mockResolvedValue([]);
+          client.xClaim = vi.fn()
+            .mockResolvedValueOnce([
+              { id: messageId, message: { event: JSON.stringify(event), channel: 'global' } },
+            ])
+            .mockResolvedValue([]);
+
+          client.sIsMember = vi.fn(async (_key: string, member: string) => processed.has(member));
+          client.sAdd = vi.fn(async (_key: string, member: string) => {
+            processed.add(member);
+            return 1;
+          });
+          client.expire = vi.fn(async () => 1);
+
+          createdClients.push(client);
+          return client;
+        },
+      };
+    });
+
+    const { getEventBus } = await import('./index');
+
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, handler);
+
+    // The event processing loop may have started before the handler was registered and scheduled
+    // a retry via setTimeout. Advance timers to let that retry run.
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 50 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(createdClients.length).toBeGreaterThanOrEqual(1);
+    expect(createdClients[0].xPending).toHaveBeenCalled();
+    expect(createdClients[0].xClaim).toHaveBeenCalled();
+
+    expect(loggedErrors).toEqual([]);
+    expect(didAck).toBe(true);
+    expect(createdClients[0].xAck).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await eventBus.close();
+  });
+});

--- a/server/src/lib/eventBus/index.pending.test.ts
+++ b/server/src/lib/eventBus/index.pending.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+type FakeRedisClient = EventEmitter & {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  quit: () => Promise<void>;
+  xGroupCreate: () => Promise<void>;
+  xReadGroup: (...args: any[]) => Promise<any>;
+  xAck: (...args: any[]) => Promise<number>;
+  xPending: (...args: any[]) => Promise<{ pending: number }>;
+  xPendingRange: (...args: any[]) => Promise<any[]>;
+  xClaim: (...args: any[]) => Promise<any>;
+  sIsMember: (...args: any[]) => Promise<boolean>;
+  sAdd: (...args: any[]) => Promise<number>;
+  expire: (...args: any[]) => Promise<number>;
+};
+
+async function flushMicrotasks(limit: number = 50) {
+  for (let i = 0; i < limit; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+describe('EventBus pending message recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('claims and processes stale pending messages (acks on success)', async () => {
+    const messageId = '1-0';
+
+    const tenantId = randomUUID();
+    const eventType = 'UNKNOWN';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const handler = vi.fn(async () => undefined);
+    let didAck = false;
+    const processed = new Set<string>();
+
+    vi.doMock('redis', () => {
+      return {
+        createClient: () => {
+          const client = new EventEmitter() as FakeRedisClient;
+
+          client.connect = vi.fn(async () => {
+            client.emit('connect');
+            client.emit('ready');
+          });
+
+          client.disconnect = vi.fn(() => {
+            client.emit('end');
+          });
+
+          client.quit = vi.fn(async () => {
+            client.emit('end');
+          });
+
+          client.xGroupCreate = vi.fn(async () => undefined);
+          client.xReadGroup = vi.fn(async () => null);
+          client.xAck = vi.fn(async () => {
+            didAck = true;
+            return 1;
+          });
+
+          client.xPending = vi.fn()
+            .mockResolvedValueOnce({ pending: 1 })
+            .mockResolvedValue({ pending: 0 });
+          client.xPendingRange = vi.fn()
+            .mockResolvedValueOnce([
+              {
+                id: messageId,
+                consumer: 'consumer-old',
+                millisecondsSinceLastDelivery: 30001,
+                deliveriesCounter: 1,
+              },
+            ])
+            .mockResolvedValue([]);
+          client.xClaim = vi.fn()
+            .mockResolvedValueOnce([
+              { id: messageId, message: { event: JSON.stringify(event), channel: 'global' } },
+            ])
+            .mockResolvedValue([]);
+
+          client.sIsMember = vi.fn(async (_key: string, member: string) => processed.has(member));
+          client.sAdd = vi.fn(async (_key: string, member: string) => {
+            processed.add(member);
+            return 1;
+          });
+          client.expire = vi.fn(async () => 1);
+
+          return client;
+        },
+      };
+    });
+
+    const { getEventBus } = await import('./index');
+
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, handler);
+
+    // The event processing loop may have started before the handler was registered and scheduled
+    // a retry via setTimeout. Advance timers to let that retry run.
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 50 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(didAck).toBe(true);
+
+    await eventBus.close();
+  });
+});

--- a/server/src/lib/eventBus/index.ts
+++ b/server/src/lib/eventBus/index.ts
@@ -403,13 +403,13 @@ export class EventBus {
           return;
         }
 
+        const subscriptionLookup = new Map(subscriptions.map((sub) => [sub.stream, sub]));
+
         if (streamEntries) {
           logger.info('[EventBus] Received stream entries:', {
             streamsWithMessages: streamEntries.length,
             totalMessages: streamEntries.reduce((sum, s) => sum + s.messages.length, 0)
           });
-
-          const subscriptionLookup = new Map(subscriptions.map((sub) => [sub.stream, sub]));
 
           for (const { name: stream, messages } of streamEntries) {
             const subscription = subscriptionLookup.get(stream);
@@ -419,77 +419,12 @@ export class EventBus {
             }
 
             for (const message of messages) {
-              try {
-                const rawEventPayload = message.message.event;
-                if (!rawEventPayload) {
-                  logger.warn('[EventBus] Missing event payload in message', {
-                    stream,
-                    messageId: message.id
-                  });
-                  await client.xAck(stream, config.eventBus.consumerGroup, message.id);
-                  continue;
-                }
-
-                const rawEvent = JSON.parse(rawEventPayload);
-                const baseEvent = BaseEventSchema.parse(rawEvent);
-                const eventSchema = EventSchemas[baseEvent.eventType];
-
-                if (!eventSchema) {
-                  logger.error('[EventBus] Unknown event type:', {
-                    eventType: baseEvent.eventType,
-                    availableTypes: Object.keys(EventSchemas)
-                  });
-                  await client.xAck(stream, config.eventBus.consumerGroup, message.id);
-                  continue;
-                }
-
-                const event = eventSchema.parse(rawEvent) as Event;
-                const handlers = subscription.handlers;
-                const handler = handlers.values().next().value as EventHandler | undefined;
-
-                if (handler) {
-                  const isProcessed = await this.isEventProcessed(event);
-                  if (!isProcessed) {
-                    try {
-                      await handler(event);
-                      await this.markEventProcessed(event);
-                    } catch (error) {
-                      logger.error('[EventBus] Error in event handler:', {
-                        error,
-                        eventType: baseEvent.eventType,
-                        handler: handler.name,
-                        channel: subscription.channel
-                      });
-                      // Don't acknowledge message on error to allow retry
-                      continue;
-                    }
-                  } else {
-                    logger.info('[EventBus] Skipping already processed event:', {
-                      eventId: event.id,
-                      eventType: event.eventType,
-                      channel: subscription.channel
-                    });
-                  }
-                } else {
-                  logger.warn('[EventBus] No handlers registered when processing message', {
-                    eventType: baseEvent.eventType,
-                    channel: subscription.channel
-                  });
-                }
-
-                await client.xAck(stream, config.eventBus.consumerGroup, message.id);
-              } catch (error) {
-                logger.error('[EventBus] Error processing message:', {
-                  error,
-                  stream,
-                  messageId: message.id
-                });
-              }
+              await this.processStreamMessage(client, config, stream, subscription, message);
             }
           }
         }
 
-        await this.claimPendingMessages();
+        await this.claimPendingMessages(subscriptionLookup);
         setImmediate(processEvents);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -517,11 +452,90 @@ export class EventBus {
     processEvents();
   }
 
-  private async claimPendingMessages() {
+  private async processStreamMessage(
+    client: Awaited<ReturnType<typeof createRedisClient>>,
+    config: ReturnType<typeof getRedisConfig>,
+    stream: string,
+    subscription: { channel: string; handlers: Set<EventHandler> },
+    message: { id: string; message: Record<string, string> }
+  ): Promise<void> {
+    try {
+      const rawEventPayload = message.message.event;
+      if (!rawEventPayload) {
+        logger.warn('[EventBus] Missing event payload in message', {
+          stream,
+          messageId: message.id
+        });
+        await client.xAck(stream, config.eventBus.consumerGroup, message.id);
+        return;
+      }
+
+      const rawEvent = JSON.parse(rawEventPayload);
+      const baseEvent = BaseEventSchema.parse(rawEvent);
+      const eventSchema = EventSchemas[baseEvent.eventType];
+
+      if (!eventSchema) {
+        logger.error('[EventBus] Unknown event type:', {
+          eventType: baseEvent.eventType,
+          availableTypes: Object.keys(EventSchemas)
+        });
+        await client.xAck(stream, config.eventBus.consumerGroup, message.id);
+        return;
+      }
+
+      const event = eventSchema.parse(rawEvent) as Event;
+      const handler = subscription.handlers.values().next().value as EventHandler | undefined;
+
+      if (handler) {
+        const isProcessed = await this.isEventProcessed(event);
+        if (!isProcessed) {
+          try {
+            await handler(event);
+            await this.markEventProcessed(event);
+          } catch (error) {
+            logger.error('[EventBus] Error in event handler:', {
+              error,
+              eventType: baseEvent.eventType,
+              handler: handler.name,
+              channel: subscription.channel
+            });
+            // Don't acknowledge message on error to allow retry
+            return;
+          }
+        } else {
+          logger.info('[EventBus] Skipping already processed event:', {
+            eventId: event.id,
+            eventType: event.eventType,
+            channel: subscription.channel
+          });
+        }
+      } else {
+        logger.warn('[EventBus] No handlers registered when processing message', {
+          eventType: baseEvent.eventType,
+          channel: subscription.channel
+        });
+      }
+
+      await client.xAck(stream, config.eventBus.consumerGroup, message.id);
+    } catch (error) {
+      logger.error('[EventBus] Error processing message:', {
+        error,
+        stream,
+        messageId: message.id
+      });
+    }
+  }
+
+  private async claimPendingMessages(
+    subscriptionLookup: Map<
+      string,
+      { eventType: EventType; channel: string; stream: string; handlers: Set<EventHandler> }
+    >
+  ) {
     try {
       const client = await getClient();
       const config = getRedisConfig();
-      const subscriptions = this.getActiveSubscriptions();
+      const subscriptions = Array.from(subscriptionLookup.values());
 
       for (const { stream } of subscriptions) {
         const pendingInfo = await client.xPending(
@@ -539,19 +553,25 @@ export class EventBus {
           );
 
           if (pendingMessages && pendingMessages.length > 0) {
-            const now = Date.now();
             const claimIds = pendingMessages
-              .filter(msg => (now - msg.millisecondsSinceLastDelivery) > config.eventBus.claimTimeout)
+              .filter(msg => msg.millisecondsSinceLastDelivery > config.eventBus.claimTimeout)
               .map(msg => msg.id);
 
             if (claimIds.length > 0) {
-              await client.xClaim(
+              const claimed = await client.xClaim(
                 stream,
                 config.eventBus.consumerGroup,
                 this.consumerName,
                 config.eventBus.claimTimeout,
                 claimIds
               );
+
+              const subscription = subscriptionLookup.get(stream);
+              if (subscription && Array.isArray(claimed) && claimed.length > 0) {
+                for (const message of claimed as Array<{ id: string; message: Record<string, string> }>) {
+                  await this.processStreamMessage(client, config, stream, subscription, message);
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Email notifications can stall when Redis stream pending entries are XCLAIMed but never processed/acked, and when pending idle age is computed incorrectly.\n\nThis change:\n- Processes + XACKs claimed pending messages\n- Uses millisecondsSinceLastDelivery correctly for claim gating\n- Adds regression tests for pending recovery\n\nObserved symptom in msp/sebastian-blue: emailservice::v7 streams accumulate high PEL delivery counts and pending never drains.