### PR TITLE
Fix DelayedEmailQueue Redis timeouts by resetting stuck clients

### DIFF
--- a/server/src/config/redisConfig.ts
+++ b/server/src/config/redisConfig.ts
@@ -120,6 +120,16 @@ export async function getRedisClient() {
 
   const client = createClient(clientOptions);
 
+  // Prevent "Unhandled 'error' event" crashes and keep diagnostics in logs.
+  client.on('error', (error) => {
+    logger.error('[Redis] Client error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  client.on('end', () => {
+    logger.warn('[Redis] Connection ended');
+  });
+
   await client.connect();
   return client;
 }

--- a/server/src/lib/email/delayedEmailQueue.redisRecovery.test.ts
+++ b/server/src/lib/email/delayedEmailQueue.redisRecovery.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DelayedEmailQueue, type RedisClientLike } from '../../../../packages/email/src/DelayedEmailQueue';
+
+function makeRedis(overrides: Partial<RedisClientLike>): RedisClientLike {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    del: vi.fn().mockResolvedValue(0),
+    zAdd: vi.fn().mockResolvedValue(0),
+    zRem: vi.fn().mockResolvedValue(0),
+    zRangeByScore: vi.fn().mockResolvedValue([]),
+    zCard: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+describe('DelayedEmailQueue Redis recovery', () => {
+  afterEach(async () => {
+    try {
+      await DelayedEmailQueue.getInstance().shutdown();
+    } catch {
+      // ignore
+    }
+    DelayedEmailQueue.resetInstance();
+    vi.useRealTimers();
+  });
+
+  it('recreates the Redis client after a zRangeByScore timeout', async () => {
+    vi.useFakeTimers();
+
+    const hangingRedis = makeRedis({
+      zRangeByScore: vi.fn(() => new Promise<string[]>(() => {})),
+    });
+
+    const workingRedis = makeRedis({
+      zRangeByScore: vi.fn().mockResolvedValue([]),
+    });
+
+    const redisGetter = vi
+      .fn()
+      .mockResolvedValueOnce(hangingRedis)
+      .mockResolvedValueOnce(workingRedis);
+
+    const queue = DelayedEmailQueue.getInstance({
+      checkIntervalMs: 60_000,
+      redisTimeoutMs: 10,
+      batchSize: 10,
+    });
+
+    await queue.initialize(redisGetter, vi.fn().mockResolvedValue(undefined));
+
+    const resultPromise = queue.processReady();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(resultPromise).resolves.toBe(0);
+
+    expect(redisGetter).toHaveBeenCalledTimes(2);
+    expect(hangingRedis.zRangeByScore).toHaveBeenCalledTimes(1);
+    expect(workingRedis.zRangeByScore).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
In k8s (msp), DelayedEmailQueue logs showed persistent 5s zRangeByScore timeouts even when the queue ZSET is empty and fresh Redis connections from the pod respond in ~2ms.

This change makes DelayedEmailQueue self-heal by resetting/reacquiring its long-lived Redis client after zRangeByScore timeouts (safe read-only retry) and reduces error-level log spam for this failure mode. Also adds a basic Redis client error handler to avoid unhandled 'error' event crashes.

Test: npx vitest run --config server/vitest.config.ts src/lib/email/delayedEmailQueue.redisRecovery.test.ts