### PR TITLE
Prevent Redis socket close from surfacing as uncaughtException

### DIFF
--- a/packages/event-bus/src/config/redisConfig.errorHandler.test.ts
+++ b/packages/event-bus/src/config/redisConfig.errorHandler.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: vi.fn(async () => null),
+}));
+
+const mockOn = vi.fn();
+const mockConnect = vi.fn(async () => undefined);
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: mockOn,
+    connect: mockConnect,
+  })),
+}));
+
+describe('event-bus redisConfig.getRedisClient', () => {
+  it('attaches an error handler to prevent uncaughtException on socket close', async () => {
+    process.env.REDIS_HOST = 'redis.msp.svc.cluster.local';
+    process.env.REDIS_PORT = '6379';
+
+    const { getRedisClient } = await import('./redisConfig');
+    await getRedisClient();
+
+    expect(mockOn).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
This tracks down the recurring log pattern:

- `Error: Socket closed unexpectedly`
- `⨯ uncaughtException: Error: Socket closed unexpectedly`

`node-redis` emits `SocketClosedUnexpectedlyError` via the client's `error` event when the underlying TCP socket closes cleanly while the client is still considered open.

If a Redis client has no `client.on('error', ...)` handler, Node treats it as an unhandled `error` event and surfaces it as an `uncaughtException`.

Fix:
- Add `error`/`end` handlers inside `@alga-psa/event-bus`'s `getRedisClient()` (used by `packages/notifications/src/realtime/internalNotificationBroadcaster.ts`, among others).
- Avoid sending AUTH when no password is configured.

Test:
- `npx vitest run packages/event-bus/src/config/redisConfig.errorHandler.test.ts`
