### PR TITLE
Prevent Redis socket close from surfacing as uncaughtException (rc1)

### DIFF
--- a/packages/event-bus/src/config/redisConfig.errorHandler.test.ts
+++ b/packages/event-bus/src/config/redisConfig.errorHandler.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: vi.fn(async () => null),
+}));
+
+const mockOn = vi.fn();
+const mockConnect = vi.fn(async () => undefined);
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: mockOn,
+    connect: mockConnect,
+  })),
+}));
+
+describe('event-bus redisConfig.getRedisClient', () => {
+  it('attaches an error handler to prevent uncaughtException on socket close', async () => {
+    process.env.REDIS_HOST = 'redis.msp.svc.cluster.local';
+    process.env.REDIS_PORT = '6379';
+
+    const { getRedisClient } = await import('./redisConfig');
+    await getRedisClient();
+
+    expect(mockOn).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
Fixes recurring `uncaughtException: Error: Socket closed unexpectedly` by ensuring Redis clients created via `@alga-psa/event-bus` have an `error` handler.

In node-redis, when the TCP socket closes cleanly while the client is still considered open, it emits `SocketClosedUnexpectedlyError` via the client's `error` event. If no handler is attached, Node surfaces it as an uncaught exception.

This affects code paths that call `getRedisClient()` from `@alga-psa/event-bus` (e.g. notification broadcaster).

Test: `npx vitest run packages/event-bus/src/config/redisConfig.errorHandler.test.ts`
