### PR TITLE
 fix: resolve Citus join error in task assignment emails

### DIFF
--- a/packages/event-schemas/src/schemas/domain/projectEventSchemas.ts
+++ b/packages/event-schemas/src/schemas/domain/projectEventSchemas.ts
@@ -51,6 +51,7 @@ export const projectTaskAssignedEventPayloadSchema = BaseDomainEventPayloadSchem
   assignedToId: z.string().uuid(),
   assignedToType: assignedToTypeSchema,
   assignedByUserId: userIdSchema.optional(),
+  assignedByName: z.string().optional().describe('Display name of the user who assigned the task'),
   assignedAt: z.string().datetime().optional(),
 }).describe('Payload for PROJECT_TASK_ASSIGNED');
 

--- a/packages/projects/src/actions/phaseTaskImportActions.ts
+++ b/packages/projects/src/actions/phaseTaskImportActions.ts
@@ -972,6 +972,7 @@ export const importPhasesAndTasks = withAuth(async (
                   assignedToId: newTask.assigned_to,
                   assignedToType: 'user',
                   assignedByUserId: user.user_id,
+                  assignedByName: user.first_name && user.last_name ? `${user.first_name} ${user.last_name}` : undefined,
                   assignedAt: occurredAt,
                 }),
               });

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -138,6 +138,7 @@ export const updateTaskWithChecklist = withAuth(async (
                             assignedToId: updatedTask.assigned_to,
                             assignedToType: 'user',
                             assignedByUserId: user.user_id,
+                            assignedByName: user.first_name && user.last_name ? `${user.first_name} ${user.last_name}` : undefined,
                             assignedAt: occurredAt,
                         }),
                     });
@@ -248,6 +249,7 @@ export const addTaskToPhase = withAuth(async (
                             assignedToId: newTask.assigned_to,
                             assignedToType: 'user',
                             assignedByUserId: user.user_id,
+                            assignedByName: user.first_name && user.last_name ? `${user.first_name} ${user.last_name}` : undefined,
                             assignedAt: occurredAt,
                         }),
                     });
@@ -1177,6 +1179,7 @@ export const duplicateTaskToPhase = withAuth(async (
                         assignedToId: newTask.assigned_to,
                         assignedToType: 'user',
                         assignedByUserId: user.user_id,
+                        assignedByName: user.first_name && user.last_name ? `${user.first_name} ${user.last_name}` : undefined,
                         assignedAt: occurredAt,
                     }),
                 });

--- a/shared/workflow/runtime/schemas/projectEventSchemas.ts
+++ b/shared/workflow/runtime/schemas/projectEventSchemas.ts
@@ -52,6 +52,7 @@ export const projectTaskAssignedEventPayloadSchema = BaseDomainEventPayloadSchem
   assignedToId: z.string().uuid(),
   assignedToType: assignedToTypeSchema,
   assignedByUserId: userIdSchema.optional(),
+  assignedByName: z.string().optional().describe('Display name of the user who assigned the task'),
   assignedAt: z.string().datetime().optional(),
 }).describe('Payload for PROJECT_TASK_ASSIGNED');
 

--- a/shared/workflow/streams/domainEventBuilders/__tests__/projectTaskEventBuilders.test.ts
+++ b/shared/workflow/streams/domainEventBuilders/__tests__/projectTaskEventBuilders.test.ts
@@ -63,6 +63,24 @@ describe('projectTaskEventBuilders', () => {
     expect(projectTaskAssignedEventPayloadSchema.safeParse(payload).success).toBe(true);
   });
 
+  it('builds PROJECT_TASK_ASSIGNED payloads with assignedByName compatible with schema', () => {
+    const payload = buildWorkflowPayload(
+      buildProjectTaskAssignedPayload({
+        projectId,
+        taskId,
+        assignedToId: '3b99a3a6-85b7-4c8f-bd37-4b6b5c7d0d2d',
+        assignedToType: 'user',
+        assignedByUserId: actorUserId,
+        assignedByName: 'John Doe',
+        assignedAt: occurredAt,
+      }),
+      ctx
+    );
+
+    expect(projectTaskAssignedEventPayloadSchema.safeParse(payload).success).toBe(true);
+    expect(payload.assignedByName).toBe('John Doe');
+  });
+
   it('builds PROJECT_TASK_STATUS_CHANGED payloads compatible with schema', () => {
     const payload = buildWorkflowPayload(
       buildProjectTaskStatusChangedPayload({

--- a/shared/workflow/streams/domainEventBuilders/projectTaskEventBuilders.ts
+++ b/shared/workflow/streams/domainEventBuilders/projectTaskEventBuilders.ts
@@ -30,6 +30,7 @@ export function buildProjectTaskAssignedPayload(params: {
   assignedToId: string;
   assignedToType: 'user' | 'team';
   assignedByUserId?: string;
+  assignedByName?: string;
   assignedAt?: Date | string;
 }): Record<string, unknown> {
   return {
@@ -38,6 +39,7 @@ export function buildProjectTaskAssignedPayload(params: {
     assignedToId: params.assignedToId,
     assignedToType: params.assignedToType,
     ...(params.assignedByUserId ? { assignedByUserId: params.assignedByUserId } : {}),
+    ...(params.assignedByName ? { assignedByName: params.assignedByName } : {}),
     ...(params.assignedAt ? { assignedAt: normalizeValue(params.assignedAt) } : {}),
   };
 }


### PR DESCRIPTION
  Add assignedByName to PROJECT_TASK_ASSIGNED event payload to avoid complex distributed table joins that Citus doesn't support. The subscriber now reads the assigner's name from the payload instead of joining the users table with a parameter-based condition.

  - Add assignedByName field to event schema
  - Update event builder and all 6 publish sites to include name
  - Remove problematic 'users as au' join from subscriber
  - Add resolveUserName helper for ProjectService

  "Why, sometimes I've believed as many as six impossible joins before breakfast," said the Red Queen, "but Citus believes in none at all! Best carry your assignedByName in your payload pocket, dear, lest you find yourself quite unable to send a single email." 🃏📧🐰