### PR TITLE
Add gated invoice designer entry point

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -71,6 +71,19 @@ Controls access to the delegated time-entry UI (editing/viewing time sheets for 
 - When disabled: The UI only allows working with the current user’s own time periods/time sheets (delegated sheets are shown as read-only if accessed directly).
 - When enabled: Authorized users can select a subject user and edit/view that user’s time sheets via the UI.
 
+### 5. `invoice-template-gui-designer`
+Controls access to the new (experimental) invoice template visual designer.
+
+**Affected Areas:**
+- **MSP Portal:**
+  - Billing page at `/msp/billing` → **Invoice Templates** tab → Template editor view
+
+**Behavior:**
+- When disabled (default): Uses the existing AssemblyScript source editor only.
+- When enabled: Shows a **Visual** tab alongside the existing **Code** editor tab.
+  - The visual designer persists its workspace state alongside the template source (and uses local storage as a best-effort fallback).
+  - Invoice output remains driven by the AssemblyScript template (until the compilation pipeline is finalized).
+
 ## Implementation Details
 
 ### User Identification

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "@blocknote/core": "^0.22.0",
         "@blocknote/mantine": "^0.22.0",
         "@blocknote/react": "^0.22.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hocuspocus/provider": "^2.13.5",
         "@huggingface/inference": "^2.8.0",
@@ -92,6 +94,7 @@
         "ini": "^5.0.0",
         "json-as": "^1.1.19",
         "jsonwebtoken": "^9.0.2",
+        "kiwi.js": "^1.1.3",
         "knex": "^3.1.0",
         "lucide-react": "^0.428.0",
         "marked": "^14.1.3",
@@ -150,7 +153,8 @@
         "y-webrtc": "^10.3.0",
         "y-websocket": "^2.0.4",
         "yjs": "^13.6.18",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zustand": "^4.5.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -6434,6 +6438,59 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@ee/lib": {
@@ -31473,6 +31530,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kiwi.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/kiwi.js/-/kiwi.js-1.1.3.tgz",
+      "integrity": "sha512-aBA32N0LjuF0RIeV+OVhT8wnGAwdLYynKxkHbRvatI7yajOBM3OUjzTuzt3w9UnY9TYt7U65oe7U8EXlUHuTrQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "license": "MIT",
@@ -47613,7 +47676,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "0.0.1",
+      "version": "1.0.1-rc1",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@blocknote/core": "^0.22.0",
     "@blocknote/mantine": "^0.22.0",
     "@blocknote/react": "^0.22.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@hello-pangea/dnd": "^18.0.1",
     "@hocuspocus/provider": "^2.13.5",
     "@huggingface/inference": "^2.8.0",
@@ -122,6 +124,7 @@
     "ini": "^5.0.0",
     "json-as": "^1.1.19",
     "jsonwebtoken": "^9.0.2",
+    "kiwi.js": "^1.1.3",
     "knex": "^3.1.0",
     "lucide-react": "^0.428.0",
     "marked": "^14.1.3",
@@ -180,7 +183,8 @@
     "y-webrtc": "^10.3.0",
     "y-websocket": "^2.0.4",
     "yjs": "^13.6.18",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -1,0 +1,1125 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import type { Modifier } from '@dnd-kit/core';
+import {
+  DndContext,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useDndMonitor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { restrictToWindowEdges, createSnapModifier } from '@dnd-kit/modifiers';
+import { ComponentPalette } from './palette/ComponentPalette';
+import { DesignCanvas } from './canvas/DesignCanvas';
+import { DesignerToolbar } from './toolbar/DesignerToolbar';
+import type { DesignerComponentType, DesignerConstraint, DesignerNode, Point } from './state/designerStore';
+import { useInvoiceDesignerStore } from './state/designerStore';
+import { AlignmentGuide, calculateGuides, clampPositionToParent } from './utils/layout';
+import { getDefinition } from './constants/componentCatalog';
+import { getPresetById } from './constants/presets';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Input } from '@alga-psa/ui/components/Input';
+import { useDesignerShortcuts } from './hooks/useDesignerShortcuts';
+import { canNestWithinParent } from './state/hierarchy';
+
+const DROPPABLE_CANVAS_ID = 'designer-canvas';
+
+type ActiveDragState =
+  | { kind: 'component'; componentType: DesignerComponentType }
+  | { kind: 'preset'; presetId: string }
+  | { kind: 'node'; nodeId: string }
+  | null;
+
+type PaletteDragData =
+  | {
+      source: 'component';
+      componentType: DesignerComponentType;
+    }
+  | {
+      source: 'preset';
+      presetId: string;
+    };
+
+type NodeDragData = {
+  nodeId: string;
+};
+
+type DropTargetMeta = {
+  nodeId: string;
+  nodeType: DesignerComponentType;
+  allowedChildren: DesignerComponentType[];
+};
+
+const isPaletteDragData = (value: unknown): value is PaletteDragData =>
+  typeof value === 'object' &&
+  value !== null &&
+  'source' in value &&
+  ((value as { source?: unknown }).source === 'component' || (value as { source?: unknown }).source === 'preset');
+
+const isNodeDragData = (value: unknown): value is NodeDragData =>
+  typeof value === 'object' &&
+  value !== null &&
+  'nodeId' in value &&
+  typeof (value as { nodeId?: unknown }).nodeId === 'string';
+
+const createRestrictToParentBoundsModifier = (nodes: DesignerNode[]): Modifier => ({ active, transform }) => {
+  if (!active || !transform) {
+    return transform;
+  }
+  const data = active.data?.current;
+  if (!isNodeDragData(data)) {
+    return transform;
+  }
+  const node = nodes.find((candidate) => candidate.id === data.nodeId);
+  if (!node) {
+    return transform;
+  }
+  const boundedPosition = clampPositionToParent(node, nodes, {
+    x: node.position.x + transform.x,
+    y: node.position.y + transform.y,
+  });
+  return {
+    ...transform,
+    x: boundedPosition.x - node.position.x,
+    y: boundedPosition.y - node.position.y,
+  };
+};
+
+const buildDescendantPositionMap = (rootId: string, allNodes: DesignerNode[]) => {
+  const positions = new Map<string, Point>();
+  const nodesById = new Map(allNodes.map((node) => [node.id, node]));
+  const walk = (id: string) => {
+    const node = nodesById.get(id);
+    if (!node) return;
+    positions.set(id, { ...node.position });
+    node.childIds.forEach((childId) => walk(childId));
+  };
+  walk(rootId);
+  return positions;
+};
+
+export const DesignerShell: React.FC = () => {
+  const nodes = useInvoiceDesignerStore((state) => state.nodes);
+  const constraints = useInvoiceDesignerStore((state) => state.constraints);
+  const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+  const selectedNode = useMemo(() => nodes.find((node) => node.id === selectedNodeId) ?? null, [nodes, selectedNodeId]);
+  const addNode = useInvoiceDesignerStore((state) => state.addNodeFromPalette);
+  const insertPreset = useInvoiceDesignerStore((state) => state.insertPreset);
+  const setNodePosition = useInvoiceDesignerStore((state) => state.setNodePosition);
+  const updateNodeSize = useInvoiceDesignerStore((state) => state.updateNodeSize);
+  const selectNode = useInvoiceDesignerStore((state) => state.selectNode);
+  const updateNodeName = useInvoiceDesignerStore((state) => state.updateNodeName);
+  const updateNodeMetadata = useInvoiceDesignerStore((state) => state.updateNodeMetadata);
+  const toggleSnap = useInvoiceDesignerStore((state) => state.toggleSnap);
+  const snapToGrid = useInvoiceDesignerStore((state) => state.snapToGrid);
+  const toggleGuides = useInvoiceDesignerStore((state) => state.toggleGuides);
+  const showGuides = useInvoiceDesignerStore((state) => state.showGuides);
+  const toggleRulers = useInvoiceDesignerStore((state) => state.toggleRulers);
+  const showRulers = useInvoiceDesignerStore((state) => state.showRulers);
+  const setCanvasScale = useInvoiceDesignerStore((state) => state.setCanvasScale);
+  const canvasScale = useInvoiceDesignerStore((state) => state.canvasScale);
+  const gridSize = useInvoiceDesignerStore((state) => state.gridSize);
+  const setGridSize = useInvoiceDesignerStore((state) => state.setGridSize);
+  const undo = useInvoiceDesignerStore((state) => state.undo);
+  const redo = useInvoiceDesignerStore((state) => state.redo);
+  const metrics = useInvoiceDesignerStore((state) => state.metrics);
+  const recordDropResult = useInvoiceDesignerStore((state) => state.recordDropResult);
+  const toggleAspectRatioLock = useInvoiceDesignerStore((state) => state.toggleAspectRatioLock);
+  const constraintError = useInvoiceDesignerStore((state) => state.constraintError);
+  const aspectConstraint = selectedNodeId
+    ? constraints.find(
+        (constraint): constraint is Extract<DesignerConstraint, { type: 'aspect-ratio' }> =>
+          constraint.type === 'aspect-ratio' && constraint.id === `aspect-${selectedNodeId}`
+      )
+    : undefined;
+  const clearLayoutPreset = useInvoiceDesignerStore((state) => state.clearLayoutPreset);
+  const setLayoutMode = useInvoiceDesignerStore((state) => state.setLayoutMode);
+  const selectedPreset = selectedNode?.layoutPresetId ? getPresetById(selectedNode.layoutPresetId) : null;
+
+  useDesignerShortcuts();
+
+  const [activeDrag, setActiveDrag] = useState<ActiveDragState>(null);
+  const [guides, setGuides] = useState<AlignmentGuide[]>([]);
+  const [previewPositions, setPreviewPositions] = useState<Record<string, Point>>({});
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+  
+  // Fail-safe: Clear guides when no drag is active
+  React.useEffect(() => {
+    if (!activeDrag && guides.length > 0) {
+      setGuides([]);
+    }
+  }, [activeDrag, guides.length]);
+
+  const dragSessionRef = useRef<{
+    nodeId: string;
+    origin: Point;
+    originalPositions: Map<string, Point>;
+    lastDelta: Point;
+  } | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+    useSensor(KeyboardSensor)
+  );
+
+  const [propertyDraft, setPropertyDraft] = useState(() => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  }));
+
+  React.useEffect(() => {
+    if (selectedNode) {
+      setPropertyDraft({
+        x: selectedNode.position.x,
+        y: selectedNode.position.y,
+        width: selectedNode.size.width,
+        height: selectedNode.size.height,
+      });
+    }
+  }, [selectedNode]);
+
+  const updatePointerLocation = useCallback((point: { x: number; y: number } | null) => {
+    pointerRef.current = point;
+  }, []);
+
+  const snapModifier = useMemo<Modifier | null>(() => {
+    if (!snapToGrid) {
+      return null;
+    }
+    const pixelGrid = Math.max(1, gridSize * canvasScale);
+    return createSnapModifier(pixelGrid);
+  }, [snapToGrid, gridSize, canvasScale]);
+
+  const restrictToParentBoundsModifier = useMemo<Modifier>(
+    () => createRestrictToParentBoundsModifier(nodes),
+    [nodes]
+  );
+
+  const modifiers = useMemo<Modifier[]>(() => {
+    const base: Modifier[] = [restrictToParentBoundsModifier, restrictToWindowEdges];
+    return snapModifier ? [...base, snapModifier] : base;
+  }, [restrictToParentBoundsModifier, snapModifier]);
+
+  const renderedNodes = useMemo(() => {
+    if (!previewPositions || Object.keys(previewPositions).length === 0) {
+      return nodes;
+    }
+    return nodes.map((node) => {
+      const override = previewPositions[node.id];
+      return override ? { ...node, position: override } : node;
+    });
+  }, [nodes, previewPositions]);
+
+  const renderLayoutInspector = () => {
+    if (!selectedNode) return null;
+    
+    // Show layout controls for containers (sections, columns, pages)
+    const isContainer = ['section', 'column', 'page', 'container'].includes(selectedNode.type);
+    // Also show sizing controls for children of flex containers
+    const parent = nodes.find(n => n.id === selectedNode.parentId);
+    const isFlexChild = parent?.layout?.mode === 'flex';
+
+    if (!isContainer && !isFlexChild) return null;
+
+    const layout = selectedNode.layout ?? {
+      mode: 'canvas',
+      direction: 'column',
+      gap: 0,
+      padding: 0,
+      justify: 'start',
+      align: 'start',
+      sizing: 'fixed'
+    };
+
+    return (
+      <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-3">
+        <p className="text-xs font-semibold text-slate-700">Layout</p>
+        
+        {isContainer && (
+          <>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-slate-500">Mode</span>
+              <div className="flex bg-slate-100 rounded p-0.5">
+                <button
+                  className={`px-2 py-0.5 text-[10px] rounded ${layout.mode === 'canvas' ? 'bg-white shadow text-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+                  onClick={() => setLayoutMode(selectedNode.id, 'canvas')}
+                >
+                  Canvas
+                </button>
+                <button
+                  className={`px-2 py-0.5 text-[10px] rounded ${layout.mode === 'flex' ? 'bg-white shadow text-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+                  onClick={() => setLayoutMode(selectedNode.id, 'flex')}
+                >
+                  Stack
+                </button>
+              </div>
+            </div>
+
+            {layout.mode === 'flex' && (
+              <>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-[10px] text-slate-500 block mb-1">Direction</label>
+                    <select
+                      className="w-full border border-slate-300 rounded px-1 py-1 text-xs"
+                      value={layout.direction}
+                      onChange={(e) => setLayoutMode(selectedNode.id, 'flex', { direction: e.target.value as 'row' | 'column' })}
+                    >
+                      <option value="column">Vertical ↓</option>
+                      <option value="row">Horizontal →</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="text-[10px] text-slate-500 block mb-1">Gap (px)</label>
+                    <input
+                      type="number"
+                      className="w-full border border-slate-300 rounded px-1 py-1 text-xs"
+                      value={layout.gap}
+                      onChange={(e) => setLayoutMode(selectedNode.id, 'flex', { gap: Number(e.target.value) })}
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-[10px] text-slate-500 block mb-1">Padding</label>
+                    <input
+                      type="number"
+                      className="w-full border border-slate-300 rounded px-1 py-1 text-xs"
+                      value={layout.padding}
+                      onChange={(e) => setLayoutMode(selectedNode.id, 'flex', { padding: Number(e.target.value) })}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[10px] text-slate-500 block mb-1">Align Items</label>
+                    <select
+                      className="w-full border border-slate-300 rounded px-1 py-1 text-xs"
+                      value={layout.align}
+                      onChange={(e) => setLayoutMode(selectedNode.id, 'flex', { align: e.target.value as any })}
+                    >
+                      <option value="start">Start</option>
+                      <option value="center">Center</option>
+                      <option value="end">End</option>
+                      <option value="stretch">Stretch</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="text-[10px] text-slate-500 block mb-1">Justify Content</label>
+                    <select
+                      className="w-full border border-slate-300 rounded px-1 py-1 text-xs"
+                      value={layout.justify}
+                      onChange={(e) => setLayoutMode(selectedNode.id, 'flex', { justify: e.target.value as any })}
+                    >
+                      <option value="start">Start</option>
+                      <option value="center">Center</option>
+                      <option value="end">End</option>
+                      <option value="space-between">Space Between</option>
+                    </select>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        <div className="pt-2 border-t border-slate-100">
+          <label className="text-[10px] text-slate-500 block mb-1">Sizing</label>
+          <div className="flex gap-1">
+            {(['fixed', 'hug', 'fill'] as const).map((mode) => (
+              <button
+                key={mode}
+                className={`flex-1 py-1 text-[10px] border rounded ${
+                  layout.sizing === mode
+                    ? 'bg-blue-50 border-blue-200 text-blue-700 font-medium'
+                    : 'border-slate-200 text-slate-600 hover:bg-slate-50'
+                }`}
+                onClick={() => setLayoutMode(selectedNode.id, layout.mode ?? 'canvas', { sizing: mode })}
+                title={
+                  mode === 'fixed' ? 'Fixed dimensions' :
+                  mode === 'hug' ? 'Hug contents' :
+                  'Fill available space'
+                }
+              >
+                {mode.charAt(0).toUpperCase() + mode.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderMetadataInspector = () => {
+    if (!selectedNode) {
+      return null;
+    }
+    const metadata = (selectedNode.metadata ?? {}) as Record<string, any>;
+    const applyMetadata = (patch: Record<string, unknown>) => updateNodeMetadata(selectedNode.id, patch);
+
+    if (selectedNode.type === 'field') {
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Field Binding</p>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Binding key</label>
+            <Input
+              id="designer-field-binding"
+              value={metadata.bindingKey ?? ''}
+              onChange={(event) => applyMetadata({ bindingKey: event.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Format</label>
+            <select
+              className="w-full border border-slate-300 rounded-md px-2 py-1 text-sm"
+              value={metadata.format ?? 'text'}
+              onChange={(event) => applyMetadata({ format: event.target.value })}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="currency">Currency</option>
+              <option value="date">Date</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Placeholder</label>
+            <Input
+              id="designer-field-placeholder"
+              value={metadata.placeholder ?? ''}
+              onChange={(event) => applyMetadata({ placeholder: event.target.value })}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedNode.type === 'label') {
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Label Text</p>
+          <Input
+            id="designer-label-text"
+            value={metadata.text ?? selectedNode.name ?? ''}
+            onChange={(event) => applyMetadata({ text: event.target.value })}
+          />
+        </div>
+      );
+    }
+
+    if (selectedNode.type === 'table' || selectedNode.type === 'dynamic-table') {
+      const columns: Array<Record<string, any>> = Array.isArray(metadata.columns) ? metadata.columns : [];
+      const updateColumns = (next: Array<Record<string, any>>) => applyMetadata({ columns: next });
+      const updateColumn = (columnId: string, patch: Record<string, unknown>) => {
+        updateColumns(
+          columns.map((column) => (column.id === columnId ? { ...column, ...patch } : column))
+        );
+      };
+      const handleAddColumn = () => {
+        updateColumns([
+          ...columns,
+          {
+            id: createLocalId(),
+            header: 'New Column',
+            key: 'data.field',
+            type: 'text',
+            width: 120,
+          },
+        ]);
+      };
+      const handleRemoveColumn = (columnId: string) => {
+        updateColumns(columns.filter((column) => column.id !== columnId));
+      };
+
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-3">
+          <div className="flex items-center justify-between text-xs font-semibold text-slate-700">
+            <span>Table Columns</span>
+            <Button id="designer-add-column" variant="outline" size="xs" onClick={handleAddColumn}>
+              Add column
+            </Button>
+          </div>
+          {columns.length === 0 && (
+            <p className="text-xs text-slate-500">No columns defined. Add at least one column.</p>
+          )}
+          {columns.map((column) => (
+            <div key={column.id} className="border border-slate-100 rounded-md p-2 space-y-2 bg-slate-50">
+              <div className="flex items-center justify-between">
+                <Input
+                  id={`column-header-${column.id}`}
+                  value={column.header ?? ''}
+                  onChange={(event) => updateColumn(column.id, { header: event.target.value })}
+                  className="text-xs"
+                />
+                <Button
+                  id={`designer-remove-column-${column.id}`}
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemoveColumn(column.id)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-xs text-slate-600">
+                <div>
+                  <label className="block mb-1">Binding key</label>
+                  <Input
+                    id={`column-key-${column.id}`}
+                    value={column.key ?? ''}
+                    onChange={(event) => updateColumn(column.id, { key: event.target.value })}
+                    className="text-xs"
+                  />
+                </div>
+                <div>
+                  <label className="block mb-1">Type</label>
+                  <select
+                    className="w-full border border-slate-300 rounded-md px-2 py-1 text-xs"
+                    value={column.type ?? 'text'}
+                    onChange={(event) => updateColumn(column.id, { type: event.target.value })}
+                  >
+                    <option value="text">Text</option>
+                    <option value="number">Number</option>
+                    <option value="currency">Currency</option>
+                    <option value="date">Date</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block mb-1">Width (px)</label>
+                  <Input
+                    id={`column-width-${column.id}`}
+                    type="number"
+                    value={column.width ?? 120}
+                    onChange={(event) => updateColumn(column.id, { width: Number(event.target.value) })}
+                    className="text-xs"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (['subtotal', 'tax', 'discount', 'custom-total'].includes(selectedNode.type)) {
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Totals Row</p>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Label</label>
+            <Input
+              id="designer-total-label"
+              value={metadata.label ?? selectedNode.name ?? ''}
+              onChange={(event) => applyMetadata({ label: event.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Binding key</label>
+            <Input
+              id="designer-total-binding"
+              value={metadata.bindingKey ?? ''}
+              onChange={(event) => applyMetadata({ bindingKey: event.target.value })}
+            />
+          </div>
+          {selectedNode.type === 'custom-total' && (
+            <div>
+              <label className="text-xs text-slate-500 block mb-1">Computation notes</label>
+              <textarea
+                className="w-full border border-slate-300 rounded-md px-2 py-1 text-sm"
+                value={metadata.notes ?? ''}
+                onChange={(event) => applyMetadata({ notes: event.target.value })}
+              />
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    if (selectedNode.type === 'action-button') {
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Button</p>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Label</label>
+            <Input
+              id="designer-button-label"
+              value={metadata.label ?? 'Button'}
+              onChange={(event) => applyMetadata({ label: event.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Action type</label>
+            <select
+              className="w-full border border-slate-300 rounded-md px-2 py-1 text-sm"
+              value={metadata.actionType ?? 'url'}
+              onChange={(event) => applyMetadata({ actionType: event.target.value })}
+            >
+              <option value="url">URL</option>
+              <option value="mailto">Email</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Action value</label>
+            <Input
+              id="designer-button-action"
+              value={metadata.actionValue ?? ''}
+              onChange={(event) => applyMetadata({ actionValue: event.target.value })}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedNode.type === 'signature') {
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Signature Block</p>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Signer label</label>
+            <Input
+              id="designer-signature-label"
+              value={metadata.signerLabel ?? 'Authorized Signature'}
+              onChange={(event) => applyMetadata({ signerLabel: event.target.value })}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-xs text-slate-600">
+            <input
+              type="checkbox"
+              checked={Boolean(metadata.includeDate)}
+              onChange={(event) => applyMetadata({ includeDate: event.target.checked })}
+            />
+            Include signing date
+          </label>
+        </div>
+      );
+    }
+
+    if (selectedNode.type === 'attachment-list') {
+      const items: Array<Record<string, any>> = Array.isArray(metadata.items) ? metadata.items : [];
+      const updateItems = (next: Array<Record<string, any>>) => applyMetadata({ items: next });
+      const updateItem = (itemId: string, patch: Record<string, unknown>) => {
+        updateItems(items.map((item) => (item.id === itemId ? { ...item, ...patch } : item)));
+      };
+      const addItem = () => {
+        updateItems([
+          ...items,
+          {
+            id: createLocalId(),
+            label: 'Attachment',
+            url: 'https://example.com',
+          },
+        ]);
+      };
+      const removeItem = (itemId: string) => updateItems(items.filter((item) => item.id !== itemId));
+
+      return (
+        <div className="rounded border border-slate-200 bg-white px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold text-slate-700">Attachments</p>
+          <div>
+            <label className="text-xs text-slate-500 block mb-1">Title</label>
+            <Input
+              id="designer-attachments-title"
+              value={metadata.title ?? 'Attachments'}
+              onChange={(event) => applyMetadata({ title: event.target.value })}
+            />
+          </div>
+          <div className="flex items-center justify-between text-xs text-slate-600">
+            <span>Items</span>
+            <Button id="designer-attachment-add" variant="outline" size="xs" onClick={addItem}>
+              Add
+            </Button>
+          </div>
+          {items.length === 0 && <p className="text-xs text-slate-500">No attachments defined.</p>}
+          {items.map((item) => (
+            <div key={item.id} className="border border-slate-100 rounded-md p-2 space-y-2 bg-slate-50">
+              <div className="flex items-center justify-between">
+                <Input
+                  id={`attachment-label-${item.id}`}
+                  value={item.label ?? ''}
+                  onChange={(event) => updateItem(item.id, { label: event.target.value })}
+                  className="text-xs"
+                />
+                <Button
+                  id={`designer-attachment-remove-${item.id}`}
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeItem(item.id)}
+                >
+                  ✕
+                </Button>
+              </div>
+              <Input
+                id={`attachment-url-${item.id}`}
+                value={item.url ?? ''}
+                onChange={(event) => updateItem(item.id, { url: event.target.value })}
+                className="text-xs"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const data = event.active.data.current;
+    if (isPaletteDragData(data)) {
+      if (data.source === 'component') {
+        setActiveDrag({ kind: 'component', componentType: data.componentType });
+      } else if (data.source === 'preset') {
+        setActiveDrag({ kind: 'preset', presetId: data.presetId });
+      }
+      return;
+    }
+    if (isNodeDragData(data)) {
+      setActiveDrag({ kind: 'node', nodeId: data.nodeId });
+      const node = nodes.find((candidate) => candidate.id === data.nodeId);
+      if (node) {
+        dragSessionRef.current = {
+          nodeId: data.nodeId,
+          origin: { ...node.position },
+          originalPositions: buildDescendantPositionMap(data.nodeId, nodes),
+          lastDelta: { x: 0, y: 0 },
+        };
+      }
+    }
+  };
+
+  const handleDragMove = (event: DragMoveEvent) => {
+    if (!dragSessionRef.current || activeDrag?.kind !== 'node') {
+      return;
+    }
+    const session = dragSessionRef.current;
+    const { nodeId, origin } = session;
+    const nextPosition = {
+      x: origin.x + event.delta.x,
+      y: origin.y + event.delta.y,
+    };
+    const activeNode = nodes.find((node) => node.id === nodeId);
+    if (!activeNode) return;
+    const boundedPosition = clampPositionToParent(activeNode, nodes, nextPosition);
+    const delta = {
+      x: boundedPosition.x - origin.x,
+      y: boundedPosition.y - origin.y,
+    };
+    if (delta.x !== session.lastDelta.x || delta.y !== session.lastDelta.y) {
+      const nextPreview: Record<string, Point> = {};
+      session.originalPositions.forEach((point, id) => {
+        nextPreview[id] = {
+          x: point.x + delta.x,
+          y: point.y + delta.y,
+        };
+      });
+      setPreviewPositions(nextPreview);
+      session.lastDelta = delta;
+    }
+    if (showGuides) {
+      const projectedPosition = {
+        x: origin.x + session.lastDelta.x,
+        y: origin.y + session.lastDelta.y,
+      };
+      const ghostNode = {
+        ...activeNode,
+        position: projectedPosition,
+      };
+      const guideNodes = nodes.map((node) => {
+        if (session.originalPositions.has(node.id)) {
+          const original = session.originalPositions.get(node.id) ?? node.position;
+          return {
+            ...node,
+            position: {
+              x: original.x + session.lastDelta.x,
+              y: original.y + session.lastDelta.y,
+            },
+          };
+        }
+        return node;
+      });
+      setGuides(calculateGuides(ghostNode, guideNodes));
+    }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (activeDrag?.kind === 'component' || activeDrag?.kind === 'preset') {
+      const dropPoint = pointerRef.current ?? { x: 120, y: 120 };
+      const dropMeta = event.over?.data?.current as DropTargetMeta | undefined;
+      if (!dropMeta) {
+        recordDropResult(false);
+      } else if (
+        activeDrag.kind === 'component' &&
+        canNestWithinParent(activeDrag.componentType, dropMeta.nodeType)
+      ) {
+        const def = getDefinition(activeDrag.componentType);
+        const defaultMetadata = def ? buildDefaultMetadata(activeDrag.componentType, def.defaultMetadata) : undefined;
+        addNode(
+          activeDrag.componentType,
+          dropPoint,
+          def
+            ? {
+                parentId: dropMeta.nodeId,
+                defaults: { size: def.defaultSize, metadata: defaultMetadata },
+              }
+            : { parentId: dropMeta.nodeId }
+        );
+        recordDropResult(true);
+      } else if (activeDrag.kind === 'preset') {
+        const presetDef = getPresetById(activeDrag.presetId);
+        const rootTypes =
+          presetDef?.nodes.filter((node) => !node.parentKey).map((node) => node.type) ?? [];
+        const presetDropAllowed =
+          rootTypes.length > 0
+            ? rootTypes.every(
+                (type) =>
+                  type === dropMeta.nodeType || canNestWithinParent(type, dropMeta.nodeType)
+              )
+            : canNestWithinParent('section', dropMeta.nodeType);
+        if (!presetDropAllowed) {
+          recordDropResult(false);
+        } else {
+          insertPreset(activeDrag.presetId, dropPoint, dropMeta.nodeId);
+          recordDropResult(true);
+        }
+      }
+    }
+    if (activeDrag?.kind === 'node' && dragSessionRef.current) {
+      const session = dragSessionRef.current;
+      const activeNode = nodes.find((node) => node.id === session.nodeId);
+      if (activeNode) {
+        const desiredPosition = {
+          x: session.origin.x + session.lastDelta.x,
+          y: session.origin.y + session.lastDelta.y,
+        };
+        const boundedPosition = clampPositionToParent(activeNode, nodes, desiredPosition);
+        setNodePosition(session.nodeId, boundedPosition, true);
+      }
+    }
+    dragSessionRef.current = null;
+    setPreviewPositions({});
+    setGuides([]);
+    setActiveDrag(null);
+  };
+
+  const handleDragCancel = () => {
+    setActiveDrag(null);
+    setGuides([]);
+    dragSessionRef.current = null;
+    setPreviewPositions({});
+  };
+
+  const handlePropertyInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setPropertyDraft((prev) => ({ ...prev, [name]: Number(value) }));
+  };
+
+  const commitPropertyChanges = () => {
+    if (!selectedNodeId) return;
+    setNodePosition(selectedNodeId, { x: propertyDraft.x, y: propertyDraft.y }, true);
+    updateNodeSize(selectedNodeId, { width: propertyDraft.width, height: propertyDraft.height }, true);
+  };
+
+  return (
+    <div className="flex flex-col h-full border border-slate-200 rounded-lg overflow-hidden">
+      <DesignerToolbar
+        snapToGrid={snapToGrid}
+        showGuides={showGuides}
+        showRulers={showRulers}
+        canvasScale={canvasScale}
+        gridSize={gridSize}
+        metrics={metrics}
+        onToggleSnap={toggleSnap}
+        onToggleGuides={toggleGuides}
+        onToggleRulers={toggleRulers}
+        onZoomChange={setCanvasScale}
+        onUndo={undo}
+        onRedo={redo}
+        onGridSizeChange={setGridSize}
+      />
+      <DesignerBreadcrumbs nodes={nodes} selectedNodeId={selectedNodeId} onSelect={selectNode} />
+      <DndContext sensors={sensors} modifiers={modifiers}>
+        <div className="flex flex-1 min-h-[560px] bg-white">
+          <div className="w-72">
+            <ComponentPalette />
+          </div>
+          <DesignerWorkspace
+            nodes={renderedNodes}
+            selectedNodeId={selectedNodeId}
+            showGuides={showGuides}
+            showRulers={showRulers}
+            gridSize={gridSize}
+            canvasScale={canvasScale}
+            snapToGrid={snapToGrid}
+            guides={guides}
+            activeDrag={activeDrag}
+            modifiers={modifiers}
+            onPointerLocationChange={updatePointerLocation}
+            onNodeSelect={selectNode}
+            onResize={updateNodeSize}
+            onDragStart={handleDragStart}
+            onDragMove={handleDragMove}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          />
+          <aside className="w-72 border-l border-slate-200 bg-slate-50 p-4 space-y-4">
+            <h3 className="text-sm font-semibold text-slate-800 uppercase tracking-wide">Inspector</h3>
+          {selectedNode ? (
+            <div className="space-y-3">
+              {constraintError && (
+                <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                  {constraintError}
+                </div>
+              )}
+              <div>
+                <label htmlFor="selected-name" className="text-xs text-slate-500 block mb-1">Name</label>
+                <Input
+                  id="selected-name"
+                  value={selectedNode.name}
+                  onChange={(event) => updateNodeName(selectedNode.id, event.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-xs text-slate-500">
+                <div>
+                  <label htmlFor="prop-x" className="block mb-1">X</label>
+                  <Input id="prop-x" name="x" type="number" value={propertyDraft.x} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                </div>
+                <div>
+                  <label htmlFor="prop-y" className="block mb-1">Y</label>
+                  <Input id="prop-y" name="y" type="number" value={propertyDraft.y} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                </div>
+                <div>
+                  <label htmlFor="prop-width" className="block mb-1">Width</label>
+                  <Input id="prop-width" name="width" type="number" value={propertyDraft.width} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                </div>
+                <div>
+                  <label htmlFor="prop-height" className="block mb-1">Height</label>
+                  <Input id="prop-height" name="height" type="number" value={propertyDraft.height} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                </div>
+              </div>
+              {selectedPreset && (
+                <div className="rounded border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-slate-700">Layout Preset</span>
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:underline"
+                      onClick={() => clearLayoutPreset(selectedNode.id)}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                  <div className="text-slate-500 text-[11px]">{selectedPreset.label}</div>
+                  <p className="text-[11px] text-slate-500">{selectedPreset.description}</p>
+                </div>
+              )}
+              {renderLayoutInspector()}
+              <div className="pt-2 border-t border-slate-200 space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-slate-500">Lock aspect ratio</span>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300"
+                    checked={Boolean(aspectConstraint)}
+                    onChange={() => toggleAspectRatioLock(selectedNode.id)}
+                  />
+                </div>
+                {aspectConstraint && (
+                  <p className="text-[11px] text-slate-500">
+                    Preserves width/height ratio ≈ {aspectConstraint.ratio.toFixed(2)}
+                  </p>
+                )}
+              </div>
+              {renderMetadataInspector()}
+              <Button id="designer-inspector-apply" variant="outline" onClick={commitPropertyChanges}>
+                Apply
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500">Select a component to edit its properties.</p>
+          )}
+        </aside>
+        </div>
+      </DndContext>
+    </div>
+  );
+};
+
+type DesignerWorkspaceProps = {
+  nodes: DesignerNode[];
+  selectedNodeId: string | null;
+  showGuides: boolean;
+  showRulers: boolean;
+  gridSize: number;
+  canvasScale: number;
+  snapToGrid: boolean;
+  guides: AlignmentGuide[];
+  activeDrag: ActiveDragState;
+  modifiers: Modifier[];
+  onPointerLocationChange: (point: { x: number; y: number } | null) => void;
+  onNodeSelect: (nodeId: string | null) => void;
+  onResize: (nodeId: string, size: { width: number; height: number }, commit?: boolean) => void;
+  onDragStart: (event: DragStartEvent) => void;
+  onDragMove: (event: DragMoveEvent) => void;
+  onDragEnd: (event: DragEndEvent) => void;
+  onDragCancel: () => void;
+};
+
+const DesignerWorkspace: React.FC<DesignerWorkspaceProps> = ({
+  nodes,
+  selectedNodeId,
+  showGuides,
+  showRulers,
+  gridSize,
+  canvasScale,
+  snapToGrid,
+  guides,
+  activeDrag,
+  modifiers,
+  onPointerLocationChange,
+  onNodeSelect,
+  onResize,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  onDragCancel,
+}) => {
+  useDndMonitor({
+    onDragStart,
+    onDragMove,
+    onDragEnd,
+    onDragCancel,
+  });
+
+  return (
+    <div className="flex-1 flex">
+      <DesignCanvas
+        nodes={nodes}
+        selectedNodeId={selectedNodeId}
+        showGuides={showGuides}
+        showRulers={showRulers}
+        gridSize={gridSize}
+        canvasScale={canvasScale}
+        snapToGrid={snapToGrid}
+        guides={guides}
+        droppableId={DROPPABLE_CANVAS_ID}
+        onPointerLocationChange={onPointerLocationChange}
+        onNodeSelect={onNodeSelect}
+        onResize={onResize}
+      />
+      <DragOverlay modifiers={modifiers}>
+        {activeDrag && (
+          <div className="px-3 py-2 bg-white border rounded shadow-lg text-sm font-semibold">
+            {activeDrag.kind === 'component'
+              ? getDefinition(activeDrag.componentType)?.label ?? 'Component'
+              : activeDrag.kind === 'preset'
+                ? getPresetById(activeDrag.presetId)?.label ?? 'Preset'
+                : nodes.find((node) => node.id === activeDrag.nodeId)?.name ?? 'Component'}
+          </div>
+        )}
+      </DragOverlay>
+    </div>
+  );
+};
+
+type DesignerBreadcrumbsProps = {
+  nodes: DesignerNode[];
+  selectedNodeId: string | null;
+  onSelect: (nodeId: string | null) => void;
+};
+
+const DesignerBreadcrumbs: React.FC<DesignerBreadcrumbsProps> = ({ nodes, selectedNodeId, onSelect }) => {
+  const breadcrumbs = React.useMemo(() => {
+    if (!selectedNodeId) return [];
+    const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+    const path: DesignerNode[] = [];
+    let currentId: string | null = selectedNodeId;
+    while (currentId) {
+      const current = nodeMap.get(currentId);
+      if (!current) break;
+      if (current.type !== 'document') {
+        path.push(current);
+      }
+      currentId = current.parentId ?? null;
+    }
+    return path.reverse();
+  }, [nodes, selectedNodeId]);
+
+  if (breadcrumbs.length === 0) {
+    return (
+      <div className="border-t border-b border-slate-200 bg-slate-50 px-4 py-2 text-xs text-slate-500">
+        Select a component on the canvas to view its hierarchy.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-b border-slate-200 bg-slate-50 px-4 py-2 text-xs text-slate-600 flex items-center flex-wrap gap-1">
+      <span className="font-semibold text-slate-700 mr-1">Hierarchy</span>
+      {breadcrumbs.map((node, index) => {
+        const isActive = index === breadcrumbs.length - 1;
+        return (
+          <React.Fragment key={node.id}>
+            {index > 0 && <span className="text-slate-400">/</span>}
+            <button
+              type="button"
+              className={`px-1 py-0.5 rounded ${
+                isActive ? 'bg-blue-100 text-blue-700 cursor-default' : 'hover:underline text-slate-600'
+              }`}
+              onClick={() => {
+                if (!isActive) {
+                  onSelect(node.id);
+                }
+              }}
+              aria-current={isActive ? 'page' : undefined}
+              disabled={isActive}
+            >
+              {node.name}
+            </button>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+const createLocalId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2);
+
+const deepClone = <T,>(value: T): T => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const buildDefaultMetadata = (
+  componentType: DesignerComponentType,
+  metadata?: Record<string, unknown>
+): Record<string, unknown> | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+  const clone = deepClone(metadata);
+  if (componentType === 'table' && Array.isArray((clone as { columns?: unknown }).columns)) {
+    (clone as { columns: Array<Record<string, unknown>> }).columns = (
+      (clone as { columns: Array<Record<string, unknown>> }).columns ?? []
+    ).map((column) => ({
+      ...column,
+      id: column.id ? `${column.id}-${createLocalId()}` : createLocalId(),
+    }));
+  }
+  if (componentType === 'attachment-list' && Array.isArray((clone as { items?: unknown }).items)) {
+    (clone as { items: Array<Record<string, unknown>> }).items = (
+      (clone as { items: Array<Record<string, unknown>> }).items ?? []
+    ).map((item) => ({
+      ...item,
+      id: item.id ? `${item.id}-${createLocalId()}` : createLocalId(),
+    }));
+  }
+  return clone;
+};

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -1,0 +1,438 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useDroppable, useDraggable } from '@dnd-kit/core';
+import clsx from 'clsx';
+import { AlignmentGuide } from '../utils/layout';
+import { DesignerNode, Point } from '../state/designerStore';
+import { DESIGNER_CANVAS_WIDTH, DESIGNER_CANVAS_HEIGHT } from '../constants/layout';
+
+interface DesignCanvasProps {
+  nodes: DesignerNode[];
+  selectedNodeId: string | null;
+  showGuides: boolean;
+  showRulers: boolean;
+  gridSize: number;
+  canvasScale: number;
+  snapToGrid: boolean;
+  guides: AlignmentGuide[];
+  droppableId: string;
+  onPointerLocationChange: (point: { x: number; y: number } | null) => void;
+  onNodeSelect: (id: string | null) => void;
+  onResize: (id: string, size: { width: number; height: number }, commit?: boolean) => void;
+}
+
+const GRID_COLOR = 'rgba(148, 163, 184, 0.25)';
+
+interface CanvasNodeProps {
+  node: DesignerNode;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  onResize: (id: string, size: { width: number; height: number }, commit?: boolean) => void;
+  renderChildren: (parentId: string) => React.ReactNode;
+  childExtents?: { maxRight: number; maxBottom: number };
+}
+
+const getPreviewContent = (node: DesignerNode): React.ReactNode => {
+  const metadata = (node.metadata ?? {}) as Record<string, unknown>;
+  switch (node.type) {
+    case 'field': {
+      const bindingKey = typeof metadata.bindingKey === 'string' ? metadata.bindingKey : 'binding';
+      const placeholder =
+        typeof (metadata as { placeholder?: unknown }).placeholder === 'string'
+          ? (metadata as { placeholder: string }).placeholder
+          : '';
+      return placeholder ? `${bindingKey} · ${placeholder}` : `Field: ${bindingKey}`;
+    }
+    case 'label':
+      return `Label: ${metadata.text ?? node.name}`;
+    case 'text': {
+      const text = typeof metadata.text === 'string' ? metadata.text : node.name;
+      const content = text.length > 0 ? text.slice(0, 140) : node.name;
+      
+      // Check for interpolation variables {{var}}
+      const parts = content.split(/(\{\{.*?\}\})/g);
+      if (parts.length === 1) {
+        return content;
+      }
+      
+      return (
+        <span>
+          {parts.map((part, index) => {
+            if (part.startsWith('{{') && part.endsWith('}}')) {
+              return (
+                <span key={index} className="text-blue-600 bg-blue-50 px-1 rounded font-mono text-[10px] mx-0.5 border border-blue-100">
+                  {part}
+                </span>
+              );
+            }
+            return part;
+          })}
+        </span>
+      );
+    }
+    case 'subtotal':
+    case 'tax':
+    case 'discount':
+    case 'custom-total':
+      return `${metadata.label ?? node.name}: {${metadata.bindingKey ?? 'binding'}}`;
+    case 'table':
+    case 'dynamic-table': {
+      const columns = Array.isArray((metadata as { columns?: unknown }).columns)
+        ? (metadata as { columns: Array<Record<string, unknown>> }).columns
+        : [];
+      const columnLabels =
+        columns.length > 0
+          ? columns
+              .map((column) => column.header ?? column.key ?? 'column')
+              .filter(Boolean)
+              .join(' | ')
+          : 'No columns configured';
+      return `Table · ${columnLabels}`;
+    }
+    case 'action-button':
+      return metadata.label ? `Button: ${metadata.label}` : 'Button';
+    case 'signature':
+      return metadata.signerLabel ? `Signature · ${metadata.signerLabel}` : 'Signature';
+    case 'attachment-list':
+      return metadata.title ? `Attachments: ${metadata.title}` : 'Attachments';
+    case 'totals':
+      return 'Totals Summary · Subtotal / Tax / Balance';
+    case 'divider':
+      return <div className="w-full h-px bg-slate-300 my-1" />;
+    case 'spacer':
+      return <div className="w-full h-full flex items-center justify-center text-[10px] text-slate-300 bg-slate-50/50 border border-dashed border-slate-200">Spacer</div>;
+    case 'container':
+      return null; // Container renders children directly
+    default:
+      return `Placeholder content · ${node.size.width.toFixed(0)}×${node.size.height.toFixed(0)}`;
+  }
+};
+
+const CanvasNode: React.FC<CanvasNodeProps> = ({
+  node,
+  isSelected,
+  onSelect,
+  onResize,
+  renderChildren,
+  childExtents,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `node-${node.id}`,
+    data: {
+      nodeId: node.id,
+    },
+  });
+  const isContainer = node.allowedChildren.length > 0;
+  const { setNodeRef: setDropZoneRef, isOver: isNodeDropTarget } = useDroppable({
+    id: `droppable-${node.id}`,
+    disabled: !isContainer,
+    data: isContainer
+      ? {
+          nodeId: node.id,
+          nodeType: node.type,
+          allowedChildren: node.allowedChildren,
+        }
+      : undefined,
+  });
+
+  const inferredWidth =
+    isContainer && childExtents && Number.isFinite(childExtents.maxRight)
+      ? Math.max(node.size.width, childExtents.maxRight - node.position.x)
+      : node.size.width;
+  const inferredHeight =
+    isContainer && childExtents && Number.isFinite(childExtents.maxBottom)
+      ? Math.max(node.size.height, childExtents.maxBottom - node.position.y)
+      : node.size.height;
+  const localPosition = {
+    x: node.position.x,
+    y: node.position.y,
+  };
+  const nodeStyle: React.CSSProperties = {
+    width: inferredWidth,
+    height: inferredHeight,
+    top: localPosition.y,
+    left: localPosition.x,
+    position: 'absolute',
+    transform: transform && !isDragging ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+  };
+
+  const combinedRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      // dnd-kit refs are typed as HTMLElement; HTMLDivElement is compatible.
+      setNodeRef(element);
+      if (isContainer) {
+        setDropZoneRef(element);
+      }
+    },
+    [isContainer, setDropZoneRef, setNodeRef]
+  );
+
+  const draggablePointerDown = listeners?.onPointerDown;
+  const previewContent = useMemo(() => getPreviewContent(node), [node]);
+
+  const handlePointerDown: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    event.stopPropagation();
+    onSelect(node.id);
+    draggablePointerDown?.(event);
+  };
+
+  const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const { width, height } = node.size;
+    let latestSize = node.size;
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const deltaX = moveEvent.clientX - startX;
+      const deltaY = moveEvent.clientY - startY;
+      latestSize = {
+        width: Math.max(40, width + deltaX),
+        height: Math.max(32, height + deltaY),
+      };
+      onResize(node.id, latestSize, false);
+    };
+
+    const handlePointerUp = (upEvent: PointerEvent) => {
+      upEvent.preventDefault();
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      onResize(node.id, latestSize, true);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+  };
+
+  return (
+    <div
+      ref={combinedRef}
+      style={nodeStyle}
+      className={clsx(
+        'border rounded-md select-none',
+        isContainer ? 'bg-blue-50/40 border-blue-200 border-dashed' : 'bg-white shadow-sm border-slate-300',
+        isSelected ? 'ring-2 ring-blue-400' : '',
+        isNodeDropTarget && 'ring-2 ring-blue-400/60',
+        isDragging && 'opacity-80'
+      )}
+      {...listeners}
+      onPointerDown={handlePointerDown}
+      onClick={(e) => e.stopPropagation()}
+      {...attributes}
+    >
+      {isContainer ? (
+        <div className="relative w-full h-full">
+          <div className="absolute left-2 top-1 text-[10px] uppercase tracking-wide text-slate-500 pointer-events-none z-10">
+            {node.name} · {node.type}
+          </div>
+          <div className="relative w-full h-full">
+            {renderChildren(node.id)}
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="px-2 py-1 border-b bg-slate-50 text-xs font-semibold text-slate-600 flex items-center justify-between">
+            <span className="truncate">{node.name}</span>
+            <span className="text-[10px] uppercase tracking-wide text-slate-400">{node.type}</span>
+          </div>
+          <div
+            className={clsx(
+              'text-[11px] text-slate-500',
+              node.type === 'divider' ? 'p-0 flex items-center justify-center h-[14px]' : 'p-2 whitespace-pre-wrap',
+              node.type === 'spacer' && 'h-full p-0'
+            )}
+          >
+            {previewContent}
+          </div>
+        </>
+      )}
+      {node.allowResize !== false && (
+        <div
+          role="button"
+          tabIndex={0}
+          onPointerDown={startResize}
+          className="absolute -bottom-2 -right-2 h-4 w-4 rounded-full border border-blue-500 bg-white cursor-se-resize"
+        />
+      )}
+    </div>
+  );
+};
+
+export const DesignCanvas: React.FC<DesignCanvasProps> = ({
+  nodes,
+  selectedNodeId,
+  showGuides,
+  showRulers,
+  gridSize,
+  canvasScale,
+  snapToGrid,
+  guides,
+  droppableId,
+  onPointerLocationChange,
+  onNodeSelect,
+  onResize,
+}) => {
+  const artboardRef = useRef<HTMLDivElement>(null);
+  const documentNode = useMemo(() => nodes.find((node) => node.parentId === null), [nodes]);
+  const defaultPageNode = useMemo(
+    () => nodes.find((node) => node.type === 'page' && node.parentId === documentNode?.id),
+    [nodes, documentNode?.id]
+  );
+  const rootDropMeta = defaultPageNode ?? documentNode;
+  const { setNodeRef: setDroppableNodeRef, isOver } = useDroppable({
+    id: droppableId,
+    data: rootDropMeta
+      ? {
+          nodeId: rootDropMeta.id,
+          nodeType: rootDropMeta.type,
+          allowedChildren: rootDropMeta.allowedChildren,
+        }
+      : undefined,
+  });
+  const setArtboardNodeRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setDroppableNodeRef(node);
+      artboardRef.current = node;
+    },
+    [setDroppableNodeRef]
+  );
+
+  const backgroundStyle = useMemo<React.CSSProperties>(() => ({
+    backgroundSize: `${gridSize * canvasScale}px ${gridSize * canvasScale}px`,
+    backgroundImage: `linear-gradient(to right, ${GRID_COLOR} 1px, transparent 1px), linear-gradient(to bottom, ${GRID_COLOR} 1px, transparent 1px)`,
+  }), [gridSize, canvasScale]);
+
+  const childrenMap = useMemo(() => {
+    const map = new Map<string, DesignerNode[]>();
+    nodes.forEach((node) => {
+      if (!node.parentId) return;
+      if (!map.has(node.parentId)) {
+        map.set(node.parentId, []);
+      }
+      map.get(node.parentId)!.push(node);
+    });
+    map.forEach((list) => {
+      list.sort((a, b) => (a.position.y - b.position.y) || (a.position.x - b.position.x));
+    });
+    return map;
+  }, [nodes]);
+
+  const childExtentsMap = useMemo(() => {
+    const map = new Map<string, { maxRight: number; maxBottom: number }>();
+    nodes.forEach((node) => {
+      if (!node.parentId) return;
+      const existing = map.get(node.parentId) ?? { maxRight: Number.NEGATIVE_INFINITY, maxBottom: Number.NEGATIVE_INFINITY };
+      const nodeRight = node.position.x + node.size.width;
+      const nodeBottom = node.position.y + node.size.height;
+      map.set(node.parentId, {
+        maxRight: Math.max(existing.maxRight, nodeRight),
+        maxBottom: Math.max(existing.maxBottom, nodeBottom),
+      });
+    });
+    return map;
+  }, [nodes]);
+
+  const renderNodeTree = useCallback((parentId: string) => {
+    const children = childrenMap.get(parentId) ?? [];
+    return children
+      .filter((node) => node.type !== 'document' && node.type !== 'page')
+      .map((node) => (
+        <CanvasNode
+          key={`${node.id}-${(node as any)._version || 0}`}
+          node={node}
+          isSelected={selectedNodeId === node.id}
+          onSelect={onNodeSelect}
+          onResize={onResize}
+          renderChildren={renderNodeTree}
+          childExtents={childExtentsMap.get(node.id)}
+        />
+      ));
+  }, [childExtentsMap, childrenMap, onNodeSelect, onResize, selectedNodeId]);
+
+  const rootParentId = (defaultPageNode ?? documentNode)?.id;
+  const canvasWidth = defaultPageNode?.size.width ?? DESIGNER_CANVAS_WIDTH;
+  const canvasHeight = defaultPageNode?.size.height ?? DESIGNER_CANVAS_HEIGHT;
+
+  const handlePointerMove: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    if (!artboardRef.current) {
+      return;
+    }
+    const rect = artboardRef.current.getBoundingClientRect();
+    const rawX = (event.clientX - rect.left) / canvasScale;
+    const rawY = (event.clientY - rect.top) / canvasScale;
+    const x = snapToGrid ? Math.round(rawX / gridSize) * gridSize : rawX;
+    const y = snapToGrid ? Math.round(rawY / gridSize) * gridSize : rawY;
+    onPointerLocationChange({ x, y });
+  };
+
+  const handlePointerLeave = () => onPointerLocationChange(null);
+
+  useEffect(() => {
+    onPointerLocationChange(null);
+  }, [canvasScale, snapToGrid, gridSize, onPointerLocationChange]);
+
+  return (
+    <div className="relative flex-1 overflow-auto bg-slate-100" onClick={() => onNodeSelect(null)}>
+      {showRulers && (
+        <>
+          <div className="absolute top-0 left-12 right-0 h-8 bg-white border-b border-slate-200 flex items-end text-[10px] text-slate-400 px-3 gap-3 z-10">
+            {Array.from({ length: Math.ceil(canvasWidth / 50) + 2 }).map((_, index) => (
+              <span key={`hr-${index}`}>{index * 50}</span>
+            ))}
+          </div>
+          <div className="absolute top-8 bottom-0 left-0 w-12 bg-white border-r border-slate-200 flex flex-col items-end text-[10px] text-slate-400 py-4 pr-1 gap-6 z-10">
+            {Array.from({ length: Math.ceil(canvasHeight / 50) + 2 }).map((_, index) => (
+              <span key={`vr-${index}`}>{index * 50}</span>
+            ))}
+          </div>
+        </>
+      )}
+      <div className="relative flex-1" style={{ padding: showRulers ? '48px 0 0 48px' : '32px' }}>
+        <div
+          ref={setArtboardNodeRef}
+          className={clsx(
+            'relative mx-auto rounded-lg border border-slate-300 shadow-inner bg-white',
+            isOver && 'ring-2 ring-blue-400',
+            selectedNodeId === rootParentId && 'ring-2 ring-blue-400'
+          )}
+          data-designer-canvas="true"
+          style={{ 
+            width: canvasWidth, 
+            height: canvasHeight, 
+            minHeight: DESIGNER_CANVAS_HEIGHT,
+            ...backgroundStyle 
+          }}
+          onPointerMove={handlePointerMove}
+          onPointerLeave={handlePointerLeave}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (rootParentId) {
+              onNodeSelect(rootParentId);
+            }
+          }}
+        >
+          <div
+            className="absolute inset-0"
+            style={{ transform: `scale(${canvasScale})`, transformOrigin: 'top left' }}
+          >
+            {rootParentId && renderNodeTree(rootParentId)}
+            {showGuides && guides.map((guide) => (
+              <div
+                key={`${guide.type}-${guide.position}`}
+                className={clsx(
+                  'absolute pointer-events-none',
+                  guide.type === 'vertical' ? 'w-px h-full bg-blue-400/60' : 'h-px w-full bg-blue-400/60'
+                )}
+                style={guide.type === 'vertical' ? { left: guide.position } : { top: guide.position }}
+              >
+                <span className="absolute text-[10px] bg-white px-1 text-blue-500">
+                  {guide.description}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/billing/src/components/invoice-designer/constants/componentCatalog.ts
+++ b/packages/billing/src/components/invoice-designer/constants/componentCatalog.ts
@@ -1,0 +1,209 @@
+import { DesignerComponentType, Size } from '../state/designerStore';
+
+type CatalogCategory = 'Structure' | 'Content' | 'Media' | 'Dynamic';
+
+export interface ComponentDefinition {
+  type: DesignerComponentType;
+  label: string;
+  description: string;
+  category: CatalogCategory;
+  defaultSize: Size;
+  defaultMetadata?: Record<string, unknown>;
+}
+
+export const COMPONENT_CATALOG: ComponentDefinition[] = [
+  {
+    type: 'section',
+    label: 'Section',
+    description: 'Logical grouping with shared layout rules.',
+    category: 'Structure',
+    defaultSize: { width: 520, height: 200 },
+  },
+  {
+    type: 'container',
+    label: 'Box Container',
+    description: 'Styled container for grouping content (borders, backgrounds).',
+    category: 'Structure',
+    defaultSize: { width: 320, height: 120 },
+  },
+  {
+    type: 'divider',
+    label: 'Divider',
+    description: 'Horizontal line separator.',
+    category: 'Structure',
+    defaultSize: { width: 320, height: 2 },
+  },
+  {
+    type: 'spacer',
+    label: 'Spacer',
+    description: 'Empty space for layout adjustment.',
+    category: 'Structure',
+    defaultSize: { width: 320, height: 32 },
+  },
+  {
+    type: 'text',
+    label: 'Text Block',
+    description: 'Static or data-bound text content.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 60 },
+  },
+  {
+    type: 'totals',
+    label: 'Totals',
+    description: 'Subtotal/Tax/Grand total summary.',
+    category: 'Content',
+    defaultSize: { width: 360, height: 140 },
+  },
+  {
+    type: 'table',
+    label: 'Line Items Table',
+    description: 'Repeating rows for invoice line items.',
+    category: 'Dynamic',
+    defaultSize: { width: 520, height: 220 },
+    defaultMetadata: {
+      columns: [
+        { id: 'col-desc', header: 'Description', key: 'item.description', type: 'text', width: 220 },
+        { id: 'col-qty', header: 'Qty', key: 'item.quantity', type: 'number', width: 60 },
+        { id: 'col-rate', header: 'Rate', key: 'item.rate', type: 'currency', width: 100 },
+        { id: 'col-total', header: 'Amount', key: 'item.total', type: 'currency', width: 120 },
+      ],
+    },
+  },
+  {
+    type: 'dynamic-table',
+    label: 'Dynamic Table',
+    description: 'Advanced data table with column bindings.',
+    category: 'Dynamic',
+    defaultSize: { width: 520, height: 240 },
+  },
+  {
+    type: 'field',
+    label: 'Data Field',
+    description: 'Displays a bound value (invoice number, dates, totals).',
+    category: 'Content',
+    defaultSize: { width: 200, height: 48 },
+    defaultMetadata: {
+      bindingKey: 'invoice.number',
+      format: 'text',
+      placeholder: 'Invoice Number',
+    },
+  },
+  {
+    type: 'label',
+    label: 'Field Label',
+    description: 'Static label paired with data fields.',
+    category: 'Content',
+    defaultSize: { width: 160, height: 40 },
+    defaultMetadata: {
+      text: 'Label',
+    },
+  },
+  {
+    type: 'subtotal',
+    label: 'Subtotal Row',
+    description: 'Displays pre-tax subtotal.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 56 },
+    defaultMetadata: {
+      variant: 'subtotal',
+      label: 'Subtotal',
+      bindingKey: 'invoice.subtotal',
+    },
+  },
+  {
+    type: 'tax',
+    label: 'Tax Row',
+    description: 'Displays calculated tax amount.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 56 },
+    defaultMetadata: {
+      variant: 'tax',
+      label: 'Tax',
+      bindingKey: 'invoice.tax',
+    },
+  },
+  {
+    type: 'discount',
+    label: 'Discount Row',
+    description: 'Displays discount amount.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 56 },
+    defaultMetadata: {
+      variant: 'discount',
+      label: 'Discount',
+      bindingKey: 'invoice.discount',
+    },
+  },
+  {
+    type: 'custom-total',
+    label: 'Custom Total Row',
+    description: 'Configurable computed row (fees, credits, etc.).',
+    category: 'Content',
+    defaultSize: { width: 320, height: 56 },
+    defaultMetadata: {
+      variant: 'custom',
+      label: 'Custom Total',
+      bindingKey: 'invoice.custom',
+    },
+  },
+  {
+    type: 'signature',
+    label: 'Signature Block',
+    description: 'Signer name and signature line or image.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 120 },
+    defaultMetadata: {
+      signerLabel: 'Authorized Signature',
+      includeDate: true,
+    },
+  },
+  {
+    type: 'action-button',
+    label: 'Action Button',
+    description: 'Call-to-action button (e.g., Pay Now).',
+    category: 'Content',
+    defaultSize: { width: 200, height: 48 },
+    defaultMetadata: {
+      label: 'Pay Now',
+      actionType: 'url',
+      actionValue: 'https://example.com/pay',
+    },
+  },
+  {
+    type: 'attachment-list',
+    label: 'Attachment List',
+    description: 'Displays supporting documents or links.',
+    category: 'Content',
+    defaultSize: { width: 320, height: 120 },
+    defaultMetadata: {
+      title: 'Attachments',
+      items: [
+        { id: 'att-1', label: 'Contract.pdf', url: 'https://example.com/contract.pdf' },
+      ],
+    },
+  },
+  {
+    type: 'image',
+    label: 'Image',
+    description: 'Inline image element.',
+    category: 'Media',
+    defaultSize: { width: 160, height: 120 },
+  },
+  {
+    type: 'logo',
+    label: 'Logo',
+    description: 'Tenant branding asset.',
+    category: 'Media',
+    defaultSize: { width: 200, height: 120 },
+  },
+  {
+    type: 'qr',
+    label: 'QR Code',
+    description: 'Auto-generated QR for payment links.',
+    category: 'Media',
+    defaultSize: { width: 140, height: 140 },
+  },
+];
+
+export const getDefinition = (type: DesignerComponentType) =>
+  COMPONENT_CATALOG.find((component) => component.type === type);

--- a/packages/billing/src/components/invoice-designer/constants/layout.ts
+++ b/packages/billing/src/components/invoice-designer/constants/layout.ts
@@ -1,0 +1,7 @@
+export const DESIGNER_CANVAS_WIDTH = 816;
+export const DESIGNER_CANVAS_HEIGHT = 1056;
+
+export const DESIGNER_CANVAS_BOUNDS = {
+  width: DESIGNER_CANVAS_WIDTH,
+  height: DESIGNER_CANVAS_HEIGHT,
+};

--- a/packages/billing/src/components/invoice-designer/constants/presets.ts
+++ b/packages/billing/src/components/invoice-designer/constants/presets.ts
@@ -1,0 +1,611 @@
+import { DesignerComponentType, DesignerConstraint, ConstraintStrength, Point, Size, DesignerNode } from '../state/designerStore';
+
+export interface LayoutPresetNodeDefinition {
+  key: string;
+  type: DesignerComponentType;
+  offset: Point;
+  size?: Size;
+  name?: string;
+  parentKey?: string;
+  layout?: DesignerNode['layout'];
+}
+
+export type LayoutPresetConstraintDefinition =
+  | {
+      type: 'align-left' | 'align-top' | 'match-width' | 'match-height';
+      nodes: [string, string];
+      strength?: ConstraintStrength;
+    }
+  | {
+      type: 'aspect-ratio';
+      node: string;
+      ratio: number;
+      strength?: ConstraintStrength;
+    };
+
+export interface LayoutPresetDefinition {
+  id: string;
+  label: string;
+  description: string;
+  category: 'Header' | 'Body' | 'Footer';
+  nodes: LayoutPresetNodeDefinition[];
+  constraints: LayoutPresetConstraintDefinition[];
+}
+
+export const LAYOUT_PRESETS: LayoutPresetDefinition[] = [
+  {
+    id: 'header-logo-address',
+    label: 'Header: Logo + Address',
+    description: 'Two-column header with locked logo ratio and address stack.',
+    category: 'Header',
+    nodes: [
+      { 
+        key: 'section', 
+        type: 'section', 
+        offset: { x: 0, y: 0 }, 
+        size: { width: 640, height: 180 }, 
+        name: 'Header Section',
+        layout: {
+          mode: 'flex',
+          direction: 'row',
+          gap: 20,
+          padding: 20,
+          justify: 'space-between',
+          align: 'start',
+          sizing: 'hug',
+        }
+      },
+      {
+        key: 'column-left',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 260, height: 160 },
+        name: 'Logo Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'start',
+          sizing: 'fixed', // Logo column usually fixed width
+        }
+      },
+      {
+        key: 'column-right',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 320, height: 160 },
+        name: 'Address Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'end', // Align address text to right
+          sizing: 'fill',
+        }
+      },
+      {
+        key: 'logo',
+        type: 'logo',
+        parentKey: 'column-left',
+        offset: { x: 0, y: 0 },
+        size: { width: 200, height: 120 },
+        name: 'Logo',
+      },
+      {
+        key: 'address',
+        type: 'text',
+        parentKey: 'column-right',
+        offset: { x: 0, y: 0 },
+        size: { width: 260, height: 140 },
+        name: 'Billing Address',
+      },
+    ],
+    constraints: [
+      { type: 'aspect-ratio', node: 'logo', ratio: 1.5, strength: 'strong' },
+    ],
+  },
+  {
+    id: 'line-items-table',
+    label: 'Line Items Table',
+    description: 'Full-width items table with repeating rows.',
+    category: 'Body',
+    nodes: [
+      { 
+        key: 'section', 
+        type: 'section', 
+        offset: { x: 0, y: 0 }, 
+        size: { width: 520, height: 320 }, 
+        name: 'Items Section',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 0,
+          padding: 20,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'hug',
+        }
+      },
+      {
+        key: 'column',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 520, height: 320 },
+        name: 'Items Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 0,
+          padding: 0,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'fill',
+        }
+      },
+      {
+        key: 'table',
+        type: 'table',
+        parentKey: 'column',
+        offset: { x: 0, y: 0 },
+        size: { width: 520, height: 260 },
+        name: 'Line Items',
+        layout: {
+          mode: 'flex', // Tables are leaves but can use flex props for self-sizing context
+          direction: 'column',
+          gap: 0,
+          padding: 0,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'fill',
+        }
+      },
+    ],
+    constraints: [],
+  },
+  {
+    id: 'totals-stack',
+    label: 'Totals Stack',
+    description: 'Totals summary with note block.',
+    category: 'Footer',
+    nodes: [
+      { 
+        key: 'section', 
+        type: 'section', 
+        offset: { x: 0, y: 0 }, 
+        size: { width: 560, height: 200 }, 
+        name: 'Totals Section',
+        layout: {
+          mode: 'flex',
+          direction: 'row',
+          gap: 40,
+          padding: 20,
+          justify: 'space-between',
+          align: 'start',
+          sizing: 'hug',
+        }
+      },
+      {
+        key: 'column-note',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 260, height: 180 },
+        name: 'Notes Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'fill',
+        }
+      },
+      {
+        key: 'column-totals',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 180 },
+        name: 'Totals Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'end',
+          sizing: 'fixed',
+        }
+      },
+      {
+        key: 'note',
+        type: 'text',
+        parentKey: 'column-note',
+        offset: { x: 0, y: 0 },
+        size: { width: 240, height: 80 },
+        name: 'Notes',
+      },
+      {
+        key: 'totals',
+        type: 'totals',
+        parentKey: 'column-totals',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 160 },
+        name: 'Totals',
+      },
+    ],
+    constraints: [],
+  },
+  {
+    id: 'two-column-summary',
+    label: 'Two-Column Summary',
+    description: 'Equal columns for summary and contact info.',
+    category: 'Body',
+    nodes: [
+      { 
+        key: 'section', 
+        type: 'section', 
+        offset: { x: 0, y: 0 }, 
+        size: { width: 560, height: 200 }, 
+        name: 'Summary Section',
+        layout: {
+          mode: 'flex',
+          direction: 'row',
+          gap: 20,
+          padding: 20,
+          justify: 'space-between',
+          align: 'start',
+          sizing: 'hug',
+        }
+      },
+      {
+        key: 'column-left',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 260, height: 180 },
+        name: 'Summary Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'fill',
+        }
+      },
+      {
+        key: 'column-right',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 260, height: 180 },
+        name: 'Contact Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'stretch',
+          sizing: 'fill',
+        }
+      },
+      {
+        key: 'summary',
+        type: 'text',
+        parentKey: 'column-left',
+        offset: { x: 0, y: 0 },
+        size: { width: 240, height: 160 },
+        name: 'Summary',
+      },
+      {
+        key: 'contact',
+        type: 'text',
+        parentKey: 'column-right',
+        offset: { x: 0, y: 0 },
+        size: { width: 240, height: 160 },
+        name: 'Contact Info',
+      },
+    ],
+    constraints: [],
+  },
+  {
+    id: 'header-with-qr',
+    label: 'Split Header with QR',
+    description: 'Logo + address stack with QR code payment block.',
+    category: 'Header',
+    nodes: [
+      { 
+        key: 'section', 
+        type: 'section', 
+        offset: { x: 0, y: 0 }, 
+        size: { width: 640, height: 200 }, 
+        name: 'Split Header',
+        layout: {
+          mode: 'flex',
+          direction: 'row',
+          gap: 20,
+          padding: 20,
+          justify: 'space-between',
+          align: 'start',
+          sizing: 'hug',
+        }
+      },
+      {
+        key: 'column-logo',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 220, height: 180 },
+        name: 'Logo Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'start',
+          sizing: 'fixed',
+        }
+      },
+      {
+        key: 'column-address',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 220, height: 180 },
+        name: 'Address Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'start',
+          align: 'start',
+          sizing: 'fixed', // Fixed width for address middle col
+        }
+      },
+      {
+        key: 'column-qr',
+        type: 'container',
+        parentKey: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 140, height: 180 },
+        name: 'QR Column',
+        layout: {
+          mode: 'flex',
+          direction: 'column',
+          gap: 10,
+          padding: 0,
+          justify: 'center',
+          align: 'end',
+          sizing: 'fixed',
+        }
+      },
+      { key: 'logo', type: 'logo', parentKey: 'column-logo', offset: { x: 0, y: 0 }, size: { width: 200, height: 120 } },
+      { key: 'address', type: 'text', parentKey: 'column-address', offset: { x: 0, y: 0 }, size: { width: 220, height: 140 } },
+      { key: 'qr', type: 'qr', parentKey: 'column-qr', offset: { x: 0, y: 0 }, size: { width: 140, height: 140 } },
+    ],
+    constraints: [
+      { type: 'aspect-ratio', node: 'qr', ratio: 1, strength: 'strong' },
+    ],
+  },
+  {
+    id: 'modern-invoice-complete',
+    label: 'Modern Invoice Template',
+    description: 'Complete layout with Header, Billing Info, Items Table, and Footer.',
+    category: 'Body',
+    nodes: [
+      // --- Header Section ---
+      {
+        key: 'header-section',
+        type: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 750, height: 150 },
+        name: 'Header',
+        layout: { mode: 'flex', direction: 'row', gap: 20, padding: 20, justify: 'space-between', align: 'center', sizing: 'hug' }
+      },
+      {
+        key: 'header-left',
+        type: 'container',
+        parentKey: 'header-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 300, height: 100 },
+        name: 'Brand Area',
+        layout: { mode: 'flex', direction: 'column', gap: 8, padding: 0, justify: 'center', align: 'start', sizing: 'fixed' }
+      },
+      {
+        key: 'header-logo',
+        type: 'logo',
+        parentKey: 'header-left',
+        offset: { x: 0, y: 0 },
+        size: { width: 180, height: 80 },
+        name: 'Company Logo'
+      },
+      {
+        key: 'header-right',
+        type: 'container',
+        parentKey: 'header-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 300, height: 100 },
+        name: 'Invoice Details',
+        layout: { mode: 'flex', direction: 'column', gap: 4, padding: 0, justify: 'center', align: 'end', sizing: 'fixed' }
+      },
+      {
+        key: 'lbl-invoice',
+        type: 'label',
+        parentKey: 'header-right',
+        offset: { x: 0, y: 0 },
+        size: { width: 150, height: 32 },
+        name: 'INVOICE Label'
+      },
+      {
+        key: 'field-inv-num',
+        type: 'field',
+        parentKey: 'header-right',
+        offset: { x: 0, y: 0 },
+        size: { width: 150, height: 32 },
+        name: 'Invoice #'
+      },
+      
+      // --- Billing Section ---
+      {
+        key: 'billing-section',
+        type: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 750, height: 180 },
+        name: 'Billing Info',
+        layout: { mode: 'flex', direction: 'row', gap: 40, padding: 20, justify: 'start', align: 'start', sizing: 'hug' }
+      },
+      {
+        key: 'col-from',
+        type: 'container',
+        parentKey: 'billing-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 300, height: 140 },
+        name: 'From Column',
+        layout: { mode: 'flex', direction: 'column', gap: 8, padding: 0, justify: 'start', align: 'start', sizing: 'fill' }
+      },
+      {
+        key: 'lbl-from',
+        type: 'label',
+        parentKey: 'col-from',
+        offset: { x: 0, y: 0 },
+        size: { width: 100, height: 24 },
+        name: 'From Label'
+      },
+      {
+        key: 'txt-from-addr',
+        type: 'text',
+        parentKey: 'col-from',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 80 },
+        name: 'From Address'
+      },
+      {
+        key: 'col-to',
+        type: 'container',
+        parentKey: 'billing-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 300, height: 140 },
+        name: 'Bill To Column',
+        layout: { mode: 'flex', direction: 'column', gap: 8, padding: 0, justify: 'start', align: 'start', sizing: 'fill' }
+      },
+      {
+        key: 'lbl-to',
+        type: 'label',
+        parentKey: 'col-to',
+        offset: { x: 0, y: 0 },
+        size: { width: 100, height: 24 },
+        name: 'Bill To Label'
+      },
+      {
+        key: 'txt-to-addr',
+        type: 'text',
+        parentKey: 'col-to',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 80 },
+        name: 'Client Address'
+      },
+
+      // --- Items Section ---
+      {
+        key: 'items-section',
+        type: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 750, height: 300 },
+        name: 'Items Area',
+        layout: { mode: 'flex', direction: 'column', gap: 0, padding: 20, justify: 'start', align: 'stretch', sizing: 'hug' }
+      },
+      {
+        key: 'items-table',
+        type: 'table',
+        parentKey: 'items-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 710, height: 200 },
+        name: 'Line Items'
+      },
+
+      // --- Footer Section ---
+      {
+        key: 'footer-section',
+        type: 'section',
+        offset: { x: 0, y: 0 },
+        size: { width: 750, height: 200 },
+        name: 'Footer',
+        layout: { mode: 'flex', direction: 'row', gap: 20, padding: 20, justify: 'space-between', align: 'start', sizing: 'hug' }
+      },
+      {
+        key: 'footer-notes',
+        type: 'container',
+        parentKey: 'footer-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 300, height: 150 },
+        name: 'Notes Area',
+        layout: { mode: 'flex', direction: 'column', gap: 8, padding: 0, justify: 'start', align: 'start', sizing: 'fill' }
+      },
+      {
+        key: 'lbl-notes',
+        type: 'label',
+        parentKey: 'footer-notes',
+        offset: { x: 0, y: 0 },
+        size: { width: 100, height: 24 },
+        name: 'Notes Label'
+      },
+      {
+        key: 'txt-notes',
+        type: 'text',
+        parentKey: 'footer-notes',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 100 },
+        name: 'Terms Text'
+      },
+      {
+        key: 'footer-totals',
+        type: 'container',
+        parentKey: 'footer-section',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 150 },
+        name: 'Totals Area',
+        layout: { mode: 'flex', direction: 'column', gap: 8, padding: 0, justify: 'start', align: 'stretch', sizing: 'fixed' }
+      },
+      {
+        key: 'val-subtotal',
+        type: 'subtotal',
+        parentKey: 'footer-totals',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 32 },
+        name: 'Subtotal'
+      },
+      {
+        key: 'val-tax',
+        type: 'tax',
+        parentKey: 'footer-totals',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 32 },
+        name: 'Tax'
+      },
+      {
+        key: 'val-total',
+        type: 'custom-total',
+        parentKey: 'footer-totals',
+        offset: { x: 0, y: 0 },
+        size: { width: 280, height: 40 },
+        name: 'Grand Total'
+      }
+    ],
+    constraints: [],
+  },
+];
+
+export const getPresetById = (id: string) => LAYOUT_PRESETS.find((preset) => preset.id === id);

--- a/packages/billing/src/components/invoice-designer/hooks/useDesignerShortcuts.ts
+++ b/packages/billing/src/components/invoice-designer/hooks/useDesignerShortcuts.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { useInvoiceDesignerStore } from '../state/designerStore';
+
+export const useDesignerShortcuts = () => {
+  const undo = useInvoiceDesignerStore((state) => state.undo);
+  const redo = useInvoiceDesignerStore((state) => state.redo);
+  const deleteSelectedNode = useInvoiceDesignerStore((state) => state.deleteSelectedNode);
+  const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+  const moveNode = useInvoiceDesignerStore((state) => state.moveNode);
+  const snapToGrid = useInvoiceDesignerStore((state) => state.snapToGrid);
+  const gridSize = useInvoiceDesignerStore((state) => state.gridSize);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.target as HTMLElement)?.tagName === 'INPUT' || (event.target as HTMLElement)?.tagName === 'TEXTAREA') {
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'y') {
+        event.preventDefault();
+        redo();
+        return;
+      }
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (selectedNodeId) {
+          event.preventDefault();
+          deleteSelectedNode();
+        }
+        return;
+      }
+      if (selectedNodeId && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+        event.preventDefault();
+        const delta = snapToGrid ? gridSize : 4;
+        switch (event.key) {
+          case 'ArrowUp':
+            moveNode(selectedNodeId, { x: 0, y: -delta }, true);
+            break;
+          case 'ArrowDown':
+            moveNode(selectedNodeId, { x: 0, y: delta }, true);
+            break;
+          case 'ArrowLeft':
+            moveNode(selectedNodeId, { x: -delta, y: 0 }, true);
+            break;
+          case 'ArrowRight':
+            moveNode(selectedNodeId, { x: delta, y: 0 }, true);
+            break;
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [deleteSelectedNode, gridSize, moveNode, redo, selectedNodeId, snapToGrid, undo]);
+};

--- a/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
+++ b/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { COMPONENT_CATALOG, ComponentDefinition } from '../constants/componentCatalog';
+import { LAYOUT_PRESETS } from '../constants/presets';
+import { OutlineView } from './OutlineView';
+import clsx from 'clsx';
+
+interface PaletteProps {
+  onSearch?: (query: string) => void;
+}
+
+const groupByCategory = (components: ComponentDefinition[]) => {
+  return components.reduce<Record<string, ComponentDefinition[]>>((acc, component) => {
+    if (!acc[component.category]) {
+      acc[component.category] = [];
+    }
+    acc[component.category].push(component);
+    return acc;
+  }, {});
+};
+
+const paletteGroups = groupByCategory(COMPONENT_CATALOG);
+
+const ComponentCard: React.FC<{ component: ComponentDefinition }> = ({ component }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `component-${component.type}`,
+    data: {
+      source: 'component',
+      componentType: component.type,
+    },
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      className={`w-full text-left rounded-md border px-3 py-2 mb-2 transition shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
+        isDragging ? 'opacity-60 border-dashed' : 'bg-white'
+      }`}
+      data-component-type={component.type}
+      {...listeners}
+      {...attributes}
+      type="button"
+    >
+      <p className="text-sm font-semibold text-gray-900">{component.label}</p>
+      <p className="text-xs text-gray-500">{component.description}</p>
+    </button>
+  );
+};
+
+const PresetCard: React.FC<{ presetId: string; label: string; description: string }> = ({ presetId, label, description }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `preset-${presetId}`,
+    data: { source: 'preset', presetId },
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      className={`w-full text-left rounded-md border px-3 py-2 mb-2 transition shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
+        isDragging ? 'opacity-60 border-dashed' : 'bg-white'
+      }`}
+      type="button"
+      {...listeners}
+      {...attributes}
+    >
+      <p className="text-sm font-semibold text-gray-900">{label}</p>
+      <p className="text-xs text-gray-500">{description}</p>
+    </button>
+  );
+};
+
+export const ComponentPalette: React.FC<PaletteProps> = () => {
+  const [activeTab, setActiveTab] = useState<'components' | 'outline'>('components');
+
+  return (
+    <div className="flex flex-col h-full border-r border-slate-200 bg-slate-50">
+      <div className="px-4 pt-3 pb-0 border-b border-slate-200 bg-white">
+        <div className="flex space-x-4">
+          <button
+            className={clsx(
+              "pb-2 text-sm font-medium border-b-2 transition-colors",
+              activeTab === 'components' ? "border-blue-600 text-blue-600" : "border-transparent text-slate-500 hover:text-slate-700"
+            )}
+            onClick={() => setActiveTab('components')}
+          >
+            COMPONENTS
+          </button>
+          <button
+            className={clsx(
+              "pb-2 text-sm font-medium border-b-2 transition-colors",
+              activeTab === 'outline' ? "border-blue-600 text-blue-600" : "border-transparent text-slate-500 hover:text-slate-700"
+            )}
+            onClick={() => setActiveTab('outline')}
+          >
+            OUTLINE
+          </button>
+        </div>
+      </div>
+      
+      <div className="flex-1 overflow-y-auto">
+        {activeTab === 'components' ? (
+          <div className="px-4 py-3 space-y-4">
+             <p className="text-xs text-slate-500 mb-2">Drag components onto the canvas.</p>
+            <section>
+              <h4 className="text-xs font-bold text-slate-600 uppercase mb-2">Layout Presets</h4>
+              {LAYOUT_PRESETS.map((preset) => (
+                <PresetCard key={preset.id} presetId={preset.id} label={preset.label} description={preset.description} />
+              ))}
+            </section>
+            <hr className="border-slate-200" />
+            {Object.entries(paletteGroups).map(([category, components]) => (
+              <section key={category}>
+                <h4 className="text-xs font-bold text-slate-600 uppercase mb-2">{category}</h4>
+                {components.map((component) => (
+                  <ComponentCard key={component.type} component={component} />
+                ))}
+              </section>
+            ))}
+          </div>
+        ) : (
+          <OutlineView />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/billing/src/components/invoice-designer/palette/OutlineView.tsx
+++ b/packages/billing/src/components/invoice-designer/palette/OutlineView.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { useInvoiceDesignerStore, DesignerNode } from '../state/designerStore';
+import clsx from 'clsx';
+
+export const OutlineView: React.FC = () => {
+  const nodes = useInvoiceDesignerStore((state) => state.nodes);
+  const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+  const selectNode = useInvoiceDesignerStore((state) => state.selectNode);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleExpand = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  // Auto-expand logic: ensure parents of selected node are expanded
+  React.useEffect(() => {
+    if (selectedNodeId) {
+      const toExpand = new Set<string>();
+      let current = nodes.find(n => n.id === selectedNodeId);
+      while (current?.parentId) {
+        toExpand.add(current.parentId);
+        current = nodes.find(n => n.id === current?.parentId);
+      }
+      if (toExpand.size > 0) {
+        setExpanded(prev => {
+          const next = new Set(prev);
+          toExpand.forEach(id => next.add(id));
+          return next;
+        });
+      }
+    }
+  }, [selectedNodeId, nodes]);
+
+  const renderNode = (node: DesignerNode, depth: number = 0) => {
+    const children = nodes.filter((n) => n.parentId === node.id);
+    const hasChildren = children.length > 0;
+    const isExpanded = expanded.has(node.id);
+    const isSelected = node.id === selectedNodeId;
+
+    return (
+      <div key={node.id} className="select-none">
+        <div
+          className={clsx(
+            'flex items-center py-1 px-2 cursor-pointer text-xs transition-colors rounded',
+            isSelected ? 'bg-blue-600 text-white' : 'hover:bg-slate-200 text-slate-700'
+          )}
+          style={{ paddingLeft: `${depth * 12 + 8}px` }}
+          onClick={() => selectNode(node.id)}
+        >
+          <span
+            className={clsx(
+              'w-4 h-4 flex items-center justify-center mr-1 rounded hover:bg-black/10 cursor-pointer',
+              !hasChildren && 'invisible'
+            )}
+            onClick={(e) => hasChildren && toggleExpand(node.id, e)}
+          >
+            {hasChildren && (isExpanded ? '▼' : '▶')}
+          </span>
+          <span className="truncate flex-1">
+             {node.name || node.type}
+          </span>
+        </div>
+        {hasChildren && isExpanded && (
+          <div>{children.map((child) => renderNode(child, depth + 1))}</div>
+        )}
+      </div>
+    );
+  };
+
+  // Find root nodes (usually just "Document" or page)
+  const rootNodes = nodes.filter((n) => !n.parentId);
+
+  return (
+    <div className="flex-1 overflow-y-auto py-2">
+      {rootNodes.map((node) => renderNode(node))}
+    </div>
+  );
+};

--- a/packages/billing/src/components/invoice-designer/state/designerStore.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.ts
@@ -1,0 +1,1203 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+import { solveConstraints } from '../utils/constraintSolver';
+import { getDefinition } from '../constants/componentCatalog';
+import { LAYOUT_PRESETS, getPresetById, LayoutPresetConstraintDefinition } from '../constants/presets';
+import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
+import { clampPositionToParent } from '../utils/layout';
+import { canNestWithinParent, getAllowedChildrenForType, getAllowedParentsForType } from './hierarchy';
+
+export type DesignerComponentType =
+  | 'document'
+  | 'page'
+  | 'section'
+  | 'column'
+  | 'text'
+  | 'totals'
+  | 'table'
+  | 'field'
+  | 'label'
+  | 'subtotal'
+  | 'tax'
+  | 'discount'
+  | 'custom-total'
+  | 'image'
+  | 'logo'
+  | 'qr'
+  | 'dynamic-table'
+  | 'signature'
+  | 'action-button'
+  | 'attachment-list'
+  | 'divider'
+  | 'spacer'
+  | 'container';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface DesignerNode {
+  id: string;
+  type: DesignerComponentType;
+  name: string;
+  position: Point;
+  size: Size;
+  baseSize?: Size;
+  canRotate?: boolean;
+  rotation?: number;
+  allowResize?: boolean;
+  metadata?: Record<string, unknown>;
+  layoutPresetId?: string;
+  parentId: string | null;
+  childIds: string[];
+  allowedChildren: DesignerComponentType[];
+  layout?: {
+    mode: 'canvas' | 'flex';
+    direction: 'row' | 'column';
+    gap: number;
+    padding: number;
+    justify: 'start' | 'center' | 'end' | 'space-between';
+    align: 'start' | 'center' | 'end' | 'stretch';
+    sizing: 'fixed' | 'hug' | 'fill';
+  };
+}
+
+export type ConstraintStrength = 'required' | 'strong' | 'medium' | 'weak';
+
+export type DesignerConstraint =
+  | {
+      id: string;
+      type: 'align-left' | 'align-top' | 'match-width' | 'match-height';
+      nodes: [string, string];
+      strength?: ConstraintStrength;
+    }
+  | {
+      id: string;
+      type: 'aspect-ratio';
+      nodeId: string;
+      ratio: number;
+      strength?: ConstraintStrength;
+    };
+
+interface DesignerMetrics {
+  totalDrags: number;
+  completedDrops: number;
+  failedDrops: number;
+  totalSelections: number;
+}
+
+export interface DesignerWorkspaceSnapshot {
+  nodes: DesignerNode[];
+  constraints: DesignerConstraint[];
+  snapToGrid: boolean;
+  gridSize: number;
+  showGuides: boolean;
+  showRulers: boolean;
+  canvasScale: number;
+}
+
+interface DesignerState {
+  nodes: DesignerNode[];
+  constraints: DesignerConstraint[];
+  selectedNodeId: string | null;
+  hoverNodeId: string | null;
+  snapToGrid: boolean;
+  gridSize: number;
+  showGuides: boolean;
+  showRulers: boolean;
+  canvasScale: number;
+  metrics: DesignerMetrics;
+  history: DesignerNode[][];
+  historyIndex: number;
+  constraintError: string | null;
+  addNodeFromPalette: (
+    type: DesignerComponentType,
+    dropPoint: Point,
+    options?: { defaults?: Partial<DesignerNode>; parentId?: string }
+  ) => void;
+  insertPreset: (presetId: string, dropPoint?: Point, parentId?: string) => void;
+  moveNode: (id: string, delta: Point, commit?: boolean) => void;
+  setNodePosition: (id: string, position: Point, commit?: boolean) => void;
+  updateNodeSize: (id: string, size: Size, commit?: boolean) => void;
+  updateNodeName: (id: string, name: string) => void;
+  updateNodeMetadata: (id: string, metadata: Record<string, unknown>) => void;
+  selectNode: (id: string | null) => void;
+  setHoverNode: (id: string | null) => void;
+  deleteSelectedNode: () => void;
+  addConstraint: (constraint: DesignerConstraint) => void;
+  removeConstraint: (constraintId: string) => void;
+  toggleAspectRatioLock: (nodeId: string) => void;
+  clearLayoutPreset: (nodeId: string) => void;
+  toggleSnap: () => void;
+  setGridSize: (size: number) => void;
+  setCanvasScale: (scale: number) => void;
+  toggleGuides: () => void;
+  toggleRulers: () => void;
+  undo: () => void;
+  redo: () => void;
+  resetWorkspace: () => void;
+  loadNodes: (nodes: DesignerNode[]) => void;
+  loadWorkspace: (workspace: Partial<DesignerWorkspaceSnapshot> & Pick<DesignerWorkspaceSnapshot, 'nodes'>) => void;
+  exportWorkspace: () => DesignerWorkspaceSnapshot;
+  recordDropResult: (success: boolean) => void;
+  setLayoutMode: (nodeId: string, mode: 'canvas' | 'flex', options?: Partial<DesignerNode['layout']>) => void;
+}
+
+const MAX_HISTORY_LENGTH = 50;
+const DEFAULT_SIZE: Size = { width: 160, height: 64 };
+export const DOCUMENT_NODE_ID = 'designer-document-root';
+const DEFAULT_PAGE_NODE_ID = 'designer-page-default';
+const generateId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+const snapToGridValue = (value: number, gridSize: number) => Math.round(value / gridSize) * gridSize;
+
+const createDocumentNode = (): DesignerNode => ({
+  id: DOCUMENT_NODE_ID,
+  type: 'document',
+  name: 'Document',
+  position: { x: 0, y: 0 },
+  size: { width: DESIGNER_CANVAS_BOUNDS.width, height: DESIGNER_CANVAS_BOUNDS.height },
+  baseSize: { width: DESIGNER_CANVAS_BOUNDS.width, height: DESIGNER_CANVAS_BOUNDS.height },
+  canRotate: false,
+  allowResize: false,
+  rotation: 0,
+  metadata: {},
+  layoutPresetId: undefined,
+  parentId: null,
+  childIds: [],
+  allowedChildren: getAllowedChildrenForType('document'),
+  layout: {
+    mode: 'flex',
+    direction: 'column',
+    gap: 0,
+    padding: 0,
+    justify: 'start',
+    align: 'stretch',
+    sizing: 'fixed',
+  },
+});
+
+const createPageNode = (parentId: string, index = 1): DesignerNode => ({
+  id: `${DEFAULT_PAGE_NODE_ID}-${index}-${generateId()}`,
+  type: 'page',
+  name: `Page ${index}`,
+  position: { x: 0, y: 0 },
+  size: { width: DESIGNER_CANVAS_BOUNDS.width, height: DESIGNER_CANVAS_BOUNDS.height },
+  baseSize: { width: DESIGNER_CANVAS_BOUNDS.width, height: DESIGNER_CANVAS_BOUNDS.height },
+  canRotate: false,
+  allowResize: false,
+  rotation: 0,
+  metadata: {},
+  layoutPresetId: undefined,
+  parentId,
+  childIds: [],
+  allowedChildren: getAllowedChildrenForType('page'),
+  layout: {
+    mode: 'flex',
+    direction: 'column',
+    gap: 32,
+    padding: 40, // Page margins
+    justify: 'start',
+    align: 'stretch',
+    sizing: 'hug',
+  },
+});
+
+const createInitialNodes = (): DesignerNode[] => {
+  const documentNode = createDocumentNode();
+  const pageNode = createPageNode(documentNode.id);
+  documentNode.childIds = [pageNode.id];
+  return [documentNode, pageNode];
+};
+
+const attachChild = (nodes: DesignerNode[], parentId: string, childId: string) =>
+  nodes.map((node) => {
+    if (node.id !== parentId) return node;
+    if (node.childIds.includes(childId)) {
+      return node;
+    }
+    return { ...node, childIds: [...node.childIds, childId] };
+  });
+
+const detachChild = (nodes: DesignerNode[], parentId: string | null, childId: string) =>
+  parentId
+    ? nodes.map((node) =>
+        node.id === parentId ? { ...node, childIds: node.childIds.filter((id) => id !== childId) } : node
+      )
+    : nodes;
+
+const collectDescendants = (nodes: DesignerNode[], rootId: string): Set<string> => {
+  const map = new Map(nodes.map((node) => [node.id, node]));
+  const toRemove = new Set<string>();
+  const dfs = (id: string) => {
+    toRemove.add(id);
+    const node = map.get(id);
+    node?.childIds.forEach(dfs);
+  };
+  dfs(rootId);
+  return toRemove;
+};
+
+const snapshotNodes = (nodes: DesignerNode[]): DesignerNode[] =>
+  nodes.map((node) => ({
+    ...node,
+    position: { ...node.position },
+    size: { ...node.size },
+    baseSize: node.baseSize ? { ...node.baseSize } : undefined,
+    childIds: [...node.childIds],
+    allowedChildren: [...node.allowedChildren],
+    layout: node.layout ? { ...node.layout } : undefined,
+  }));
+
+const resolveWithConstraints = (nodes: DesignerNode[], constraints: DesignerConstraint[]) => {
+  try {
+    return {
+      nodes: solveConstraints(nodes, constraints),
+      constraintError: null as string | null,
+    };
+  } catch (error) {
+    console.warn('[Designer] constraint solver conflict', error);
+    return {
+      nodes,
+      constraintError:
+        error instanceof Error ? error.message : 'Constraint conflict detected. Try relaxing or removing constraints.',
+    };
+  }
+};
+
+export const getAbsolutePosition = (nodeId: string, nodes: DesignerNode[]): Point => {
+  const node = nodes.find((n) => n.id === nodeId);
+  if (!node) return { x: 0, y: 0 };
+  
+  let current = node;
+  let x = current.position.x;
+  let y = current.position.y;
+  
+  while (current.parentId) {
+    const parent = nodes.find((n) => n.id === current.parentId);
+    if (!parent) break;
+    x += parent.position.x;
+    y += parent.position.y;
+    current = parent;
+  }
+  
+  return { x, y };
+};
+
+// --- Auto-Layout Engine ---
+
+const computeLayout = (nodes: DesignerNode[]): DesignerNode[] => {
+  const nodeMap = new Map(nodes.map((n) => [n.id, { ...n }]));
+
+  // Top-down pass (recursively layout children)
+  const layoutNode = (nodeId: string) => {
+    const node = nodeMap.get(nodeId);
+    if (!node) return;
+
+    // 1. Sizing Pass (if 'hug', calculate size based on content/children)
+    // For simplicity in this iteration, we assume 'hug' relies on children's aggregated size.
+    // In a real engine, this requires a bottom-up measurement pass first.
+    // We'll stick to a simpler model: Parents dictate available space, Children fill/hug.
+
+    if (node.layout?.mode === 'flex' && node.childIds.length > 0) {
+      const {
+        direction = 'column',
+        gap = 0,
+        padding = 0,
+        align = 'stretch',
+      } = node.layout;
+
+      // We need to operate on fresh copies of children from the map
+      const children = node.childIds.map((id) => nodeMap.get(id)).filter((n): n is DesignerNode => !!n);
+
+      // 1. Measure Pass: Calculate total content size on main axis
+      let totalContentMainSize = 0;
+      let fillChildrenCount = 0;
+      
+      children.forEach((child, index) => {
+         const childLayout = child.layout ?? { sizing: 'fixed' };
+         if (childLayout.sizing === 'fill') {
+             fillChildrenCount++;
+             // Fill children contribute 0 to fixed content size initially
+         } else {
+             const childSize = child.baseSize ?? child.size;
+             const mainSize = direction === 'column' ? childSize.height : childSize.width;
+             totalContentMainSize += mainSize;
+         }
+         if (index < children.length - 1) totalContentMainSize += gap;
+      });
+
+      // 2. Calculate Justify Offsets & Fill Sizes
+      let startOffset = 0;
+      let effectiveGap = gap;
+      const { justify = 'start' } = node.layout;
+      
+      const availableMainSpace = (direction === 'column' ? node.size.height : node.size.width) - padding * 2;
+      const freeSpace = Math.max(0, availableMainSpace - totalContentMainSize);
+      
+      // Calculate size per fill child
+      const fillChildMainSize = fillChildrenCount > 0 ? freeSpace / fillChildrenCount : 0;
+
+      // Justify only applies if there are NO fill children (fill takes up all space)
+      if (fillChildrenCount === 0) {
+          if (justify === 'center') {
+            startOffset = freeSpace / 2;
+          } else if (justify === 'end') {
+            startOffset = freeSpace;
+          } else if (justify === 'space-between' && children.length > 1) {
+            effectiveGap = gap + freeSpace / (children.length - 1);
+          }
+      }
+
+      let currentX = padding + (direction === 'row' ? startOffset : 0);
+      let currentY = padding + (direction === 'column' ? startOffset : 0);
+      let maxCrossSize = 0;
+
+      children.forEach((child) => {
+        // Apply Sizing Logic
+        const childLayout = child.layout ?? { sizing: 'fixed' }; // Default if missing
+        // Use baseSize as the starting point for calculations (if available), falling back to current size
+        let newWidth = child.baseSize?.width ?? child.size.width;
+        let newHeight = child.baseSize?.height ?? child.size.height;
+
+        if (direction === 'column') {
+          // Cross axis: Width
+          if (childLayout.sizing === 'fill' || align === 'stretch') {
+            newWidth = Math.max(0, node.size.width - padding * 2);
+          }
+          // Main axis: Height
+          if (childLayout.sizing === 'fill') {
+              newHeight = fillChildMainSize;
+          }
+        } else {
+          // Row
+          // Cross axis: Height
+          if (childLayout.sizing === 'fill' || align === 'stretch') {
+            newHeight = Math.max(0, node.size.height - padding * 2);
+          }
+          // Main axis: Width
+          if (childLayout.sizing === 'fill') {
+              newWidth = fillChildMainSize;
+          }
+        }
+        
+        // Update child size in map
+        child.size = { width: newWidth, height: newHeight };
+
+        // Calculate Cross-Axis Alignment Offset
+        let crossAxisOffset = 0;
+        if (direction === 'column') {
+          // Cross Axis: X (Width)
+          const availableWidth = node.size.width - padding * 2;
+          if (align === 'center') {
+            crossAxisOffset = (availableWidth - newWidth) / 2;
+          } else if (align === 'end') {
+            crossAxisOffset = availableWidth - newWidth;
+          }
+        } else {
+          // Cross Axis: Y (Height)
+          const availableHeight = node.size.height - padding * 2;
+          if (align === 'center') {
+            crossAxisOffset = (availableHeight - newHeight) / 2;
+          } else if (align === 'end') {
+            crossAxisOffset = availableHeight - newHeight;
+          }
+        }
+
+        // 1. Set Initial Position (Relative)
+        // We must set this BEFORE recursion so children have a valid parent origin (even if relative)
+        const relativeX = direction === 'column' ? padding + crossAxisOffset : currentX;
+        const relativeY = direction === 'column' ? currentY : padding + crossAxisOffset;
+
+        child.position = {
+          x: relativeX,
+          y: relativeY,
+        };
+
+        // Recursively layout this child first (if it's also a container)
+        // This allows nested stack calculations to propagate
+        layoutNode(child.id);
+
+        // 2. Re-evaluate Alignment (if child size changed during recursion, e.g. 'hug')
+        // If the child resized, we might need to re-center it on the cross axis
+        if (child.size.width !== newWidth || child.size.height !== newHeight) {
+           let updatedCrossOffset = crossAxisOffset;
+           if (direction === 'column') {
+             const availableWidth = node.size.width - padding * 2;
+             if (align === 'center') updatedCrossOffset = (availableWidth - child.size.width) / 2;
+             else if (align === 'end') updatedCrossOffset = availableWidth - child.size.width;
+             
+             child.position.x = padding + updatedCrossOffset;
+           } else {
+             const availableHeight = node.size.height - padding * 2;
+             if (align === 'center') updatedCrossOffset = (availableHeight - child.size.height) / 2;
+             else if (align === 'end') updatedCrossOffset = availableHeight - child.size.height;
+
+             child.position.y = padding + updatedCrossOffset;
+           }
+        }
+        
+        // Advance cursor
+        if (direction === 'column') {
+          currentY += child.size.height + effectiveGap;
+          maxCrossSize = Math.max(maxCrossSize, child.size.width);
+        } else {
+          currentX += child.size.width + effectiveGap;
+          maxCrossSize = Math.max(maxCrossSize, child.size.height);
+        }
+      });
+
+      // Parent 'Hug' Logic: Resize parent to fit children
+      if (node.layout.sizing === 'hug') {
+        if (direction === 'column') {
+          node.size.height = currentY + padding - gap; 
+        } else {
+          node.size.width = currentX + padding - gap;
+        }
+        // If parent resized, we might need to re-layout siblings? 
+        // For this simple single-pass, we assume 'hug' parents are laid out *before* their parents read their size.
+        // But we are traversing Top-Down.
+        // Limitation: Top-Down is good for 'fill', Bad for 'hug'.
+        // Correct approach: Bottom-Up Measure -> Top-Down Arrange.
+        // Let's add a simple Bottom-Up size adjustment here.
+      }
+    } else {
+      // Canvas Mode: Children layout is manual, but we must enforce containment constraints
+      // and recurse.
+      node.childIds.forEach((childId) => {
+          const child = nodeMap.get(childId);
+          if (child) {
+              // Enforce Constraints: Keep child within parent bounds
+              // Unless user explicitly wants overflow (not supported yet)
+              const maxX = Math.max(0, node.size.width - child.size.width);
+              const maxY = Math.max(0, node.size.height - child.size.height);
+              
+              // Positions are relative, so we just clamp
+              const newX = Math.max(0, Math.min(child.position.x, maxX));
+              const newY = Math.max(0, Math.min(child.position.y, maxY));
+              
+              if (newX !== child.position.x || newY !== child.position.y) {
+                  child.position = { x: newX, y: newY };
+              }
+              
+              layoutNode(childId);
+          }
+      });
+    }
+  };
+
+  // Start from roots (Document)
+  const roots = Array.from(nodeMap.values()).filter((n) => !n.parentId);
+  roots.forEach((root) => layoutNode(root.id));
+
+  return Array.from(nodeMap.values());
+};
+
+// Wrapper to combine Constraint Solver + Auto Layout
+const resolveLayout = (nodes: DesignerNode[], constraints: DesignerConstraint[]) => {
+  // 1. Run Auto-Layout (Flex) to establish base positions
+  const layoutNodes = computeLayout(nodes);
+  
+  // 2. Run Constraint Solver (Cassowary) for any specific overrides or "Canvas" mode internal constraints
+  // Note: If everything is Flex, we might not need Cassowary as heavily.
+  // But let's keep it for specific alignments (e.g. "Match Width" across different sub-trees).
+  return resolveWithConstraints(layoutNodes, constraints);
+};
+
+const appendHistory = (state: DesignerState, nodes: DesignerNode[]) => {
+  const nextHistory = [...state.history.slice(0, state.historyIndex + 1), snapshotNodes(nodes)];
+  if (nextHistory.length > MAX_HISTORY_LENGTH) {
+    nextHistory.shift();
+  }
+  return {
+    history: nextHistory,
+    historyIndex: nextHistory.length - 1,
+  };
+};
+
+export const useInvoiceDesignerStore = create<DesignerState>()(
+  devtools((set, get) => ({
+    nodes: createInitialNodes(),
+    constraints: [],
+    selectedNodeId: null,
+    hoverNodeId: null,
+    snapToGrid: true,
+    gridSize: 8,
+    showGuides: true,
+    showRulers: true,
+    canvasScale: 1,
+    history: [],
+    historyIndex: -1,
+    constraintError: null,
+    metrics: {
+      totalDrags: 0,
+      completedDrops: 0,
+      failedDrops: 0,
+      totalSelections: 0,
+    },
+    addNodeFromPalette: (type, dropPoint, options = {}) => {
+      const { snapToGrid: shouldSnap, gridSize } = get();
+
+      const resolvedParentId =
+        options.parentId ??
+        (() => {
+          const allowedParents = getAllowedParentsForType(type);
+          if (!allowedParents.length) {
+            return null;
+          }
+          const fallbackParent = get()
+            .nodes.filter((node) => allowedParents.includes(node.type))
+            .at(0);
+          return fallbackParent?.id ?? null;
+        })();
+
+      if (!resolvedParentId) {
+        console.warn('[Designer] unable to resolve parent for', type);
+        return;
+      }
+
+      const parentNode = get().nodes.find((node) => node.id === resolvedParentId);
+      if (!parentNode || !canNestWithinParent(type, parentNode.type)) {
+        console.warn('[Designer] invalid parent drop target', { type, resolvedParentId });
+        return;
+      }
+
+      // Convert global dropPoint to local relative position
+      const parentAbsPos = getAbsolutePosition(resolvedParentId, get().nodes);
+      const relativeDropPoint = {
+        x: dropPoint.x - parentAbsPos.x,
+        y: dropPoint.y - parentAbsPos.y
+      };
+
+      const position = shouldSnap
+        ? {
+            x: snapToGridValue(relativeDropPoint.x, gridSize),
+            y: snapToGridValue(relativeDropPoint.y, gridSize),
+          }
+        : relativeDropPoint;
+
+      const size = options.defaults?.size ?? DEFAULT_SIZE;
+      const node: DesignerNode = {
+        id: generateId(),
+        type,
+        name: `${type} ${get().nodes.length + 1}`,
+        position,
+        size,
+        baseSize: size, // Initialize baseSize
+        rotation: 0,
+        canRotate: true,
+        allowResize: true,
+        ...options.defaults,
+        metadata: options.defaults?.metadata ?? {},
+        parentId: resolvedParentId,
+        childIds: [],
+        allowedChildren: getAllowedChildrenForType(type),
+        layout: {
+            mode: 'flex', // Default to flex for new nodes if applicable
+            direction: type === 'section' ? 'row' : 'column',
+            gap: type === 'section' || type === 'container' ? 16 : 0,
+            padding: type === 'section' || type === 'container' ? 16 : 0,
+            justify: 'start',
+            align: 'stretch',
+            sizing: type === 'section' ? 'fill' : 'fixed',
+        }
+      };
+
+      set((state) => {
+        const appendedNodes = [...state.nodes, node];
+        const withParentLink = attachChild(appendedNodes, resolvedParentId, node.id);
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(withParentLink, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          history,
+          historyIndex,
+          constraintError,
+          selectedNodeId: node.id,
+          metrics: {
+            ...state.metrics,
+            completedDrops: state.metrics.completedDrops + 1,
+          },
+        };
+      }, false, 'designer/addNodeFromPalette');
+    },
+    insertPreset: (presetId, dropPoint = { x: 120, y: 120 }, parentId) => {
+      const preset = getPresetById(presetId);
+      if (!preset) {
+        console.warn('[Designer] unknown layout preset', presetId);
+        return;
+      }
+
+      set((state) => {
+        const origin = dropPoint ?? { x: 120, y: 120 };
+        const resolvedParentId =
+          parentId ??
+          (() => {
+            const fallbackType = preset.nodes[0]?.type ?? 'section';
+            const allowedParents = getAllowedParentsForType(fallbackType);
+            const fallbackParent = state.nodes.find((node) => allowedParents.includes(node.type));
+            return fallbackParent?.id ?? null;
+          })();
+
+        if (!resolvedParentId) {
+          console.warn('[Designer] unable to resolve parent for preset', presetId);
+          return state;
+        }
+
+        const keyToId = new Map<string, string>();
+        const nodesById = new Map<string, DesignerNode>(state.nodes.map((node) => [node.id, node]));
+        const parentAssignments: Array<{ parentId: string; childId: string }> = [];
+        const createdNodes: DesignerNode[] = [];
+        const dropParentNode = nodesById.get(resolvedParentId);
+        if (!dropParentNode) {
+          return state;
+        }
+
+        const dropParentAbs = getAbsolutePosition(resolvedParentId, state.nodes);
+        const localDropOrigin = {
+            x: origin.x - dropParentAbs.x,
+            y: origin.y - dropParentAbs.y
+        };
+
+        for (let index = 0; index < preset.nodes.length; index += 1) {
+          const nodeDef = preset.nodes[index];
+          if (!nodeDef.parentKey && nodeDef.type === dropParentNode.type) {
+            keyToId.set(nodeDef.key, resolvedParentId);
+            continue;
+          }
+
+          const resolvedParentForNode: string | null = nodeDef.parentKey
+            ? keyToId.get(nodeDef.parentKey) ?? null
+            : resolvedParentId;
+          if (!resolvedParentForNode) {
+            console.warn('[Designer] preset parent resolution failed', nodeDef.key);
+            return state;
+          }
+
+          const parentNode = nodesById.get(resolvedParentForNode);
+          if (!parentNode || !canNestWithinParent(nodeDef.type, parentNode.type)) {
+            console.warn('[Designer] invalid preset parent assignment', { nodeDef, parentNode });
+            return state;
+          }
+
+          const newId = generateId();
+          keyToId.set(nodeDef.key, newId);
+
+          const catalogSize = getDefinition(nodeDef.type)?.defaultSize ?? DEFAULT_SIZE;
+          const size = nodeDef.size ?? catalogSize;
+          
+          // Calculate Position (Relative)
+          let position: Point;
+          if (resolvedParentForNode === resolvedParentId) {
+             // Direct child of drop target: Use Local Drop Origin + Offset
+             position = {
+                 x: localDropOrigin.x + nodeDef.offset.x,
+                 y: localDropOrigin.y + nodeDef.offset.y
+             };
+          } else {
+             // Nested child: Use Offset directly (relative to its new parent)
+             position = {
+                 x: nodeDef.offset.x,
+                 y: nodeDef.offset.y
+             };
+          }
+
+          const node: DesignerNode = {
+            id: newId,
+            type: nodeDef.type,
+            name: nodeDef.name ?? `${nodeDef.type} ${state.nodes.length + index + 1}`,
+            position,
+            size,
+            baseSize: size, // Initialize baseSize
+            rotation: 0,
+            canRotate: true,
+            allowResize: true,
+            layoutPresetId: preset.id,
+            metadata: {},
+            parentId: resolvedParentForNode,
+            childIds: [],
+            allowedChildren: getAllowedChildrenForType(nodeDef.type),
+            layout:
+              nodeDef.layout ?? {
+                mode: 'flex',
+                direction: nodeDef.type === 'section' ? 'row' : 'column',
+                gap: nodeDef.type === 'section' || nodeDef.type === 'container' ? 16 : 0,
+                padding: nodeDef.type === 'section' || nodeDef.type === 'container' ? 16 : 0,
+                justify: 'start',
+                align: 'stretch',
+                sizing: nodeDef.type === 'section' ? 'fill' : 'fixed',
+              },
+          };
+
+          createdNodes.push(node);
+          parentAssignments.push({ parentId: resolvedParentForNode, childId: node.id });
+          nodesById.set(node.id, node);
+        }
+
+        let nodes = [...state.nodes, ...createdNodes];
+        parentAssignments.forEach(({ parentId: assignedParent, childId }) => {
+          nodes = attachChild(nodes, assignedParent, childId);
+        });
+        const presetConstraints = preset.constraints
+          .map<DesignerConstraint | null>((constraint) => {
+            if (constraint.type === 'aspect-ratio') {
+              const nodeId = keyToId.get(constraint.node);
+              if (!nodeId) return null;
+              const aspect: DesignerConstraint = {
+                id: generateId(),
+                type: 'aspect-ratio',
+                nodeId,
+                ratio: constraint.ratio,
+              };
+              if (constraint.strength) {
+                aspect.strength = constraint.strength;
+              }
+              return aspect;
+            }
+            const first = keyToId.get(constraint.nodes[0]);
+            const second = keyToId.get(constraint.nodes[1]);
+            if (!first || !second) return null;
+            const align: DesignerConstraint = {
+              id: generateId(),
+              type: constraint.type,
+              nodes: [first, second],
+            };
+            if (constraint.strength) {
+              align.strength = constraint.strength;
+            }
+            return align;
+          })
+          .filter((constraint): constraint is DesignerConstraint => constraint !== null);
+
+        const constraints = [...state.constraints, ...presetConstraints];
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+
+        return {
+          nodes: resolvedNodes,
+          constraints,
+          history,
+          historyIndex,
+          constraintError,
+          metrics: {
+            ...state.metrics,
+            totalDrags: state.metrics.totalDrags + createdNodes.length,
+            completedDrops: state.metrics.completedDrops + createdNodes.length,
+          },
+        };
+      }, false, 'designer/insertPreset');
+    },
+    moveNode: (id, delta, commit = false) => {
+      const { snapToGrid: shouldSnap, gridSize } = get();
+      set((state) => {
+        // If in Auto-Layout, moving might mean REORDERING, not changing X/Y.
+        // For this iteration, we will stick to position updates, but the computeLayout
+        // will OVERWRITE them if the parent is flex.
+        
+        const rootNode = state.nodes.find((node) => node.id === id);
+        if (!rootNode) return state;
+
+        const rawNext = {
+          x: rootNode.position.x + delta.x,
+          y: rootNode.position.y + delta.y,
+        };
+        const snappedNext = shouldSnap
+          ? {
+              x: snapToGridValue(rawNext.x, gridSize),
+              y: snapToGridValue(rawNext.y, gridSize),
+            }
+          : rawNext;
+        
+        // Clamp works with relative bounds now (x:0, y:0) from utility update
+        const boundedNext = clampPositionToParent(rootNode, state.nodes, snappedNext);
+        
+        const appliedDelta = {
+          x: boundedNext.x - rootNode.position.x,
+          y: boundedNext.y - rootNode.position.y,
+        };
+
+        if (appliedDelta.x === 0 && appliedDelta.y === 0) {
+          return state;
+        }
+
+        // Only update the moved node. Children are relative, so they move with it.
+        const nodes = state.nodes.map((node) => {
+          if (node.id === id) {
+            return { ...node, position: boundedNext };
+          }
+          return node;
+        });
+
+        if (!commit) {
+          return { nodes };
+        }
+
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, commit ? 'designer/moveNodeCommit' : 'designer/moveNode');
+    },
+    setNodePosition: (id, position, commit = true) => {
+      const { snapToGrid: shouldSnap, gridSize } = get();
+
+      set((state) => {
+        const rootNode = state.nodes.find((node) => node.id === id);
+        if (!rootNode) return state;
+        const nextPosition = shouldSnap
+          ? {
+              x: snapToGridValue(position.x, gridSize),
+              y: snapToGridValue(position.y, gridSize),
+            }
+          : position;
+        const boundedNext = clampPositionToParent(rootNode, state.nodes, nextPosition);
+        
+        if (boundedNext.x === rootNode.position.x && boundedNext.y === rootNode.position.y) {
+          return state;
+        }
+        
+        // Only update target node.
+        const nodes = state.nodes.map((node) => {
+          if (node.id === id) {
+            return { ...node, position: boundedNext };
+          }
+          return node;
+        });
+        
+        if (!commit) {
+          return { nodes };
+        }
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/setNodePosition');
+    },
+    updateNodeSize: (id, size, commit = true) => {
+      set((state) => {
+        // Update both size and baseSize (persisting user preference)
+        const nodes = state.nodes.map((node) => (node.id === id ? { ...node, size, baseSize: size } : node));
+        if (!commit) {
+          return { nodes };
+        }
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/updateNodeSize');
+    },
+    updateNodeName: (id, name) => {
+      set((state) => {
+        const nodes = state.nodes.map((node) => (node.id === id ? { ...node, name } : node));
+        const nextHistory = [...state.history.slice(0, state.historyIndex + 1), snapshotNodes(nodes)];
+        if (nextHistory.length > MAX_HISTORY_LENGTH) {
+          nextHistory.shift();
+        }
+        return {
+          nodes,
+          history: nextHistory,
+          historyIndex: nextHistory.length - 1,
+        };
+      }, false, 'designer/updateNodeName');
+    },
+    updateNodeMetadata: (id, metadata) => {
+      set((state) => {
+        const nodes = state.nodes.map((node) =>
+          node.id === id ? { ...node, metadata: { ...(node.metadata ?? {}), ...metadata } } : node
+        );
+        const nextHistory = [...state.history.slice(0, state.historyIndex + 1), snapshotNodes(nodes)];
+        if (nextHistory.length > MAX_HISTORY_LENGTH) {
+          nextHistory.shift();
+        }
+        return {
+          nodes,
+          history: nextHistory,
+          historyIndex: nextHistory.length - 1,
+        };
+      }, false, 'designer/updateNodeMetadata');
+    },
+    selectNode: (id) => {
+      set((state) => ({
+        selectedNodeId: id,
+        metrics: {
+          ...state.metrics,
+          totalSelections: state.metrics.totalSelections + (id ? 1 : 0),
+        },
+      }), false, 'designer/selectNode');
+    },
+    setHoverNode: (id) => {
+      set(() => ({ hoverNodeId: id }), false, 'designer/hoverNode');
+    },
+    deleteSelectedNode: () => {
+      const selected = get().selectedNodeId;
+      if (!selected) return;
+      const nodeToDelete = get().nodes.find((node) => node.id === selected);
+      if (!nodeToDelete || nodeToDelete.type === 'document') {
+        return;
+      }
+      set((state) => {
+        const idsToRemove = collectDescendants(state.nodes, selected);
+        let nodes = state.nodes.filter((node) => !idsToRemove.has(node.id));
+        nodes = detachChild(nodes, nodeToDelete.parentId, nodeToDelete.id);
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          selectedNodeId: null,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/deleteNode');
+    },
+    addConstraint: (constraint) =>
+      set((state) => {
+        const constraints = [...state.constraints.filter((existing) => existing.id !== constraint.id), constraint];
+        const { nodes, constraintError } = resolveLayout(state.nodes, constraints);
+        const { history, historyIndex } = appendHistory(state, nodes);
+        return {
+          constraints,
+          nodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/addConstraint'),
+    removeConstraint: (constraintId) =>
+      set((state) => {
+        const constraints = state.constraints.filter((constraint) => constraint.id !== constraintId);
+        const { nodes, constraintError } = resolveLayout(state.nodes, constraints);
+        const { history, historyIndex } = appendHistory(state, nodes);
+        return {
+          constraints,
+          nodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/removeConstraint'),
+    toggleAspectRatioLock: (nodeId) =>
+      set((state) => {
+        const constraintId = `aspect-${nodeId}`;
+        const hasConstraint = state.constraints.some((constraint) => constraint.id === constraintId);
+        let constraints = state.constraints;
+        if (hasConstraint) {
+          constraints = state.constraints.filter((constraint) => constraint.id !== constraintId);
+        } else {
+          const node = state.nodes.find((candidate) => candidate.id === nodeId);
+          if (!node || node.size.height === 0) {
+            return state;
+          }
+          constraints = [
+            ...state.constraints,
+            {
+              id: constraintId,
+              type: 'aspect-ratio',
+              nodeId,
+              ratio: Number((node.size.width / node.size.height).toFixed(4)),
+              strength: 'strong',
+            },
+          ];
+        }
+        const { nodes, constraintError } = resolveLayout(state.nodes, constraints);
+        const { history, historyIndex } = appendHistory(state, nodes);
+        return {
+          constraints,
+          nodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/toggleAspectRatio'),
+    clearLayoutPreset: (nodeId) =>
+      set((state) => ({
+        nodes: state.nodes.map((node) => (node.id === nodeId ? { ...node, layoutPresetId: undefined } : node)),
+      }), false, 'designer/clearLayoutPreset'),
+    toggleSnap: () => set((state) => ({ snapToGrid: !state.snapToGrid }), false, 'designer/toggleSnap'),
+    setGridSize: (size) => set(() => ({ gridSize: Math.max(2, Math.min(size, 64)) }), false, 'designer/setGridSize'),
+    setCanvasScale: (scale) => set(() => ({ canvasScale: Math.min(Math.max(scale, 0.5), 3) }), false, 'designer/setCanvasScale'),
+    toggleGuides: () => set((state) => ({ showGuides: !state.showGuides }), false, 'designer/toggleGuides'),
+    toggleRulers: () => set((state) => ({ showRulers: !state.showRulers }), false, 'designer/toggleRulers'),
+    undo: () => {
+      set((state) => {
+        if (state.historyIndex <= 0) {
+          return state;
+        }
+        const previousNodes = snapshotNodes(state.history[state.historyIndex - 1]);
+        return {
+          nodes: previousNodes,
+          historyIndex: state.historyIndex - 1,
+        };
+      }, false, 'designer/undo');
+    },
+    redo: () => {
+      set((state) => {
+        if (state.historyIndex >= state.history.length - 1) {
+          return state;
+        }
+        const nextNodes = snapshotNodes(state.history[state.historyIndex + 1]);
+        return {
+          nodes: nextNodes,
+          historyIndex: state.historyIndex + 1,
+        };
+      }, false, 'designer/redo');
+    },
+    resetWorkspace: () => {
+      set(() => ({
+        nodes: createInitialNodes(),
+        constraints: [],
+        selectedNodeId: null,
+        history: [],
+        historyIndex: -1,
+        constraintError: null,
+        metrics: {
+          totalDrags: 0,
+          completedDrops: 0,
+          failedDrops: 0,
+          totalSelections: 0,
+        },
+      }), false, 'designer/resetWorkspace');
+    },
+    loadNodes: (nodes) => {
+      set(() => ({
+        nodes: snapshotNodes(nodes),
+        history: [snapshotNodes(nodes)],
+        historyIndex: 0,
+      }), false, 'designer/loadNodes');
+    },
+    loadWorkspace: (workspace) => {
+      set((state) => {
+        const nextNodes = snapshotNodes(workspace.nodes);
+        const nextConstraints = Array.isArray(workspace.constraints) ? [...workspace.constraints] : state.constraints;
+
+        return {
+          nodes: nextNodes,
+          constraints: nextConstraints,
+          snapToGrid: typeof workspace.snapToGrid === 'boolean' ? workspace.snapToGrid : state.snapToGrid,
+          gridSize: typeof workspace.gridSize === 'number' ? workspace.gridSize : state.gridSize,
+          showGuides: typeof workspace.showGuides === 'boolean' ? workspace.showGuides : state.showGuides,
+          showRulers: typeof workspace.showRulers === 'boolean' ? workspace.showRulers : state.showRulers,
+          canvasScale: typeof workspace.canvasScale === 'number' ? workspace.canvasScale : state.canvasScale,
+          selectedNodeId: null,
+          hoverNodeId: null,
+          history: [nextNodes],
+          historyIndex: 0,
+          constraintError: null,
+        };
+      }, false, 'designer/loadWorkspace');
+    },
+    exportWorkspace: () => {
+      const state = get();
+      return {
+        nodes: snapshotNodes(state.nodes),
+        constraints: [...state.constraints],
+        snapToGrid: state.snapToGrid,
+        gridSize: state.gridSize,
+        showGuides: state.showGuides,
+        showRulers: state.showRulers,
+        canvasScale: state.canvasScale,
+      };
+    },
+    recordDropResult: (success) => {
+      set((state) => ({
+        metrics: {
+          ...state.metrics,
+          totalDrags: state.metrics.totalDrags + 1,
+          completedDrops: state.metrics.completedDrops + (success ? 1 : 0),
+          failedDrops: state.metrics.failedDrops + (success ? 0 : 1),
+        },
+      }), false, 'designer/recordDropResult');
+    },
+    setLayoutMode: (nodeId, mode, options: Partial<DesignerNode['layout']> = {}) => {
+      set((state) => {
+        let nodes = state.nodes.map((node) => {
+          if (node.id !== nodeId) return node;
+          const baseLayout: NonNullable<DesignerNode['layout']> =
+            node.layout ?? {
+              mode,
+              direction: 'column',
+              gap: 0,
+              padding: 0,
+              justify: 'start',
+              align: 'stretch',
+              sizing: 'fixed',
+            };
+          const nextLayout: NonNullable<DesignerNode['layout']> = {
+            ...baseLayout,
+            ...options,
+            mode,
+          };
+          const updated = {
+            ...node,
+            layout: nextLayout,
+          };
+          return updated;
+        });
+
+        // If direction changed, reset children's size on the new main axis
+        const targetNode = nodes.find((n) => n.id === nodeId);
+        if (targetNode && targetNode.layout) {
+          const oldNode = state.nodes.find((n) => n.id === nodeId);
+          const oldDirection = oldNode?.layout?.direction;
+          const newDirection = targetNode.layout.direction;
+
+          if (oldDirection && newDirection && oldDirection !== newDirection) {
+             nodes = nodes.map(node => {
+                 if (targetNode.childIds.includes(node.id)) {
+                     const def = getDefinition(node.type);
+                     if (def) {
+                         if (newDirection === 'row') {
+                             // Reset width to default
+                             return { ...node, size: { ...node.size, width: def.defaultSize.width } };
+                         } else {
+                             // Reset height to default
+                             return { ...node, size: { ...node.size, height: def.defaultSize.height } };
+                         }
+                     }
+                 }
+                 return node;
+             });
+          }
+        }
+        
+        const { nodes: resolvedNodes, constraintError } = resolveLayout(nodes, state.constraints);
+        const { history, historyIndex } = appendHistory(state, resolvedNodes);
+        return {
+          nodes: resolvedNodes,
+          history,
+          historyIndex,
+          constraintError,
+        };
+      }, false, 'designer/setLayoutMode');
+    },
+  }))
+);
+
+export const selectNodes = (state: DesignerState) => state.nodes;
+export const selectSelectedNodeId = (state: DesignerState) => state.selectedNodeId;
+
+if (typeof window !== 'undefined') {
+  (window as typeof window & { __ALGA_INVOICE_DESIGNER_STORE__?: typeof useInvoiceDesignerStore }).__ALGA_INVOICE_DESIGNER_STORE__ =
+    useInvoiceDesignerStore;
+}

--- a/packages/billing/src/components/invoice-designer/state/hierarchy.ts
+++ b/packages/billing/src/components/invoice-designer/state/hierarchy.ts
@@ -1,0 +1,171 @@
+import type { DesignerComponentType } from './designerStore';
+
+type HierarchyConfig = {
+  allowedChildren: DesignerComponentType[];
+  allowedParents: DesignerComponentType[];
+};
+
+const HIERARCHY_RULES: Record<DesignerComponentType, HierarchyConfig> = {
+  document: {
+    allowedChildren: ['page'],
+    allowedParents: [],
+  },
+  page: {
+    allowedChildren: ['section'],
+    allowedParents: ['document'],
+  },
+  section: {
+    allowedChildren: [
+      'column', // Legacy
+      'container',
+      'text',
+      'totals',
+      'table',
+      'dynamic-table',
+      'image',
+      'logo',
+      'qr',
+      'field',
+      'label',
+      'subtotal',
+      'tax',
+      'discount',
+      'custom-total',
+      'signature',
+      'action-button',
+      'attachment-list',
+      'divider',
+      'spacer',
+    ],
+    allowedParents: ['page'],
+  },
+  column: {
+    allowedChildren: [
+      'text',
+      'totals',
+      'table',
+      'dynamic-table',
+      'image',
+      'logo',
+      'qr',
+      'field',
+      'label',
+      'subtotal',
+      'tax',
+      'discount',
+      'custom-total',
+      'signature',
+      'action-button',
+      'attachment-list',
+      'divider',
+      'spacer',
+      'container',
+    ],
+    allowedParents: ['section'],
+  },
+  text: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  totals: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  table: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  'dynamic-table': {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  field: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  label: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  subtotal: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  tax: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  discount: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  'custom-total': {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  image: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  logo: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  qr: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  signature: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  'action-button': {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  'attachment-list': {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  divider: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  spacer: {
+    allowedChildren: [],
+    allowedParents: ['column', 'container', 'section'],
+  },
+  container: {
+    allowedChildren: [
+      'text',
+      'totals',
+      'table',
+      'dynamic-table',
+      'image',
+      'logo',
+      'qr',
+      'field',
+      'label',
+      'subtotal',
+      'tax',
+      'discount',
+      'custom-total',
+      'signature',
+      'action-button',
+      'attachment-list',
+      'divider',
+      'spacer',
+      'container',
+    ],
+    allowedParents: ['column', 'container', 'section'],
+  },
+};
+
+export const getAllowedChildrenForType = (type: DesignerComponentType): DesignerComponentType[] =>
+  HIERARCHY_RULES[type]?.allowedChildren ?? [];
+
+export const getAllowedParentsForType = (type: DesignerComponentType): DesignerComponentType[] =>
+  HIERARCHY_RULES[type]?.allowedParents ?? [];
+
+export const canNestWithinParent = (childType: DesignerComponentType, parentType: DesignerComponentType): boolean =>
+  getAllowedParentsForType(childType).includes(parentType);

--- a/packages/billing/src/components/invoice-designer/toolbar/DesignerToolbar.tsx
+++ b/packages/billing/src/components/invoice-designer/toolbar/DesignerToolbar.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Switch } from '@alga-psa/ui/components/Switch';
+
+interface DesignerToolbarProps {
+  snapToGrid: boolean;
+  showGuides: boolean;
+  showRulers: boolean;
+  canvasScale: number;
+  gridSize: number;
+  metrics: {
+    totalDrags: number;
+    completedDrops: number;
+    failedDrops: number;
+  };
+  onToggleSnap: () => void;
+  onToggleGuides: () => void;
+  onToggleRulers: () => void;
+  onZoomChange: (value: number) => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onGridSizeChange: (value: number) => void;
+}
+
+export const DesignerToolbar: React.FC<DesignerToolbarProps> = ({
+  snapToGrid,
+  showGuides,
+  showRulers,
+  canvasScale,
+  gridSize,
+  metrics,
+  onToggleSnap,
+  onToggleGuides,
+  onToggleRulers,
+  onZoomChange,
+  onUndo,
+  onRedo,
+  onGridSizeChange,
+}) => {
+  return (
+    <div className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-2">
+      <div className="flex items-center gap-3">
+        <Button id="designer-toolbar-undo" variant="outline" size="sm" onClick={onUndo}>
+          Undo
+        </Button>
+        <Button id="designer-toolbar-redo" variant="outline" size="sm" onClick={onRedo}>
+          Redo
+        </Button>
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <Switch id="snap-toggle" checked={snapToGrid} onCheckedChange={onToggleSnap} />
+          <label htmlFor="snap-toggle">Snap</label>
+          <input
+            type="number"
+            min={2}
+            max={64}
+            value={gridSize}
+            onChange={(event) => onGridSizeChange(Number(event.target.value))}
+            className="w-16 border rounded px-1 py-0.5 text-xs"
+          />
+        </div>
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <Switch id="guides-toggle" checked={showGuides} onCheckedChange={onToggleGuides} />
+          <label htmlFor="guides-toggle">Guides</label>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <Switch id="rulers-toggle" checked={showRulers} onCheckedChange={onToggleRulers} />
+          <label htmlFor="rulers-toggle">Rulers</label>
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 text-sm text-slate-600 min-w-[160px]">
+          <span>Zoom</span>
+          <input
+            type="range"
+            min={50}
+            max={200}
+            step={10}
+            value={canvasScale * 100}
+            onChange={(event) => onZoomChange(Number(event.target.value) / 100)}
+            className="w-28"
+          />
+          <span>{Math.round(canvasScale * 100)}%</span>
+        </div>
+        <div className="text-xs text-slate-500 flex flex-col">
+          <span>Drags: {metrics.totalDrags}</span>
+          <span>Success: {metrics.completedDrops}</span>
+          <span>Invalid: {metrics.failedDrops}</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/billing/src/components/invoice-designer/utils/constraintSolver.test.ts
+++ b/packages/billing/src/components/invoice-designer/utils/constraintSolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
+import type { DesignerConstraint, DesignerNode } from '../state/designerStore';
+import { solveConstraints } from './constraintSolver';
+
+const createNode = (overrides: Partial<DesignerNode>): DesignerNode => {
+  const { parentId, childIds, allowedChildren, ...rest } = overrides;
+  return {
+    id: 'node-' + Math.random().toString(36).slice(2, 7),
+    type: 'text',
+    name: 'Text',
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 40 },
+    baseSize: { width: 100, height: 40 },
+    ...rest,
+    parentId: parentId ?? null,
+    childIds: childIds ?? [],
+    allowedChildren: allowedChildren ?? [],
+  };
+};
+
+describe('constraintSolver', () => {
+  it('keeps nodes within artboard bounds even without explicit constraints', () => {
+    const nodes = [
+      createNode({
+        id: 'outside',
+        position: { x: DESIGNER_CANVAS_BOUNDS.width + 50, y: DESIGNER_CANVAS_BOUNDS.height + 25 },
+        size: { width: 200, height: 200 },
+      }),
+    ];
+
+    const [solved] = solveConstraints(nodes, []);
+
+    expect(solved.position.x).toBeLessThanOrEqual(DESIGNER_CANVAS_BOUNDS.width - 1);
+    expect(solved.position.y).toBeLessThanOrEqual(DESIGNER_CANVAS_BOUNDS.height - 1);
+  });
+
+  it('honors simple alignment and dimension constraints', () => {
+    const baseNodes: DesignerNode[] = [
+      createNode({ id: 'a', position: { x: 120, y: 80 }, size: { width: 180, height: 60 } }),
+      createNode({ id: 'b', position: { x: 260, y: 200 }, size: { width: 120, height: 40 } }),
+    ];
+
+    const constraints: DesignerConstraint[] = [
+      { id: 'left-align', type: 'align-left', nodes: ['a', 'b'] },
+      { id: 'match-width', type: 'match-width', nodes: ['a', 'b'] },
+    ];
+
+    const solved = solveConstraints(baseNodes, constraints);
+
+    const nodeA = solved.find((node) => node.id === 'a');
+    const nodeB = solved.find((node) => node.id === 'b');
+
+    expect(nodeA && nodeB).toBeTruthy();
+    if (!nodeA || !nodeB) return;
+
+    expect(nodeA.position.x).toBeCloseTo(nodeB.position.x, 4);
+    expect(nodeA.size.width).toBeCloseTo(nodeB.size.width, 4);
+  });
+});

--- a/packages/billing/src/components/invoice-designer/utils/constraintSolver.ts
+++ b/packages/billing/src/components/invoice-designer/utils/constraintSolver.ts
@@ -1,0 +1,157 @@
+import * as kiwi from 'kiwi.js';
+
+import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
+import type { DesignerConstraint, DesignerNode, ConstraintStrength } from '../state/designerStore';
+
+const DEFAULT_STRENGTH = kiwi.Strength.required;
+
+const strengthMap = {
+  required: kiwi.Strength.required,
+  strong: kiwi.Strength.strong,
+  medium: kiwi.Strength.medium,
+  weak: kiwi.Strength.weak,
+} as const;
+const toKiwiStrength = (strength?: ConstraintStrength) => strengthMap[strength ?? 'required'] ?? DEFAULT_STRENGTH;
+
+type VariableBundle = {
+  x: kiwi.Variable;
+  y: kiwi.Variable;
+  width: kiwi.Variable;
+  height: kiwi.Variable;
+};
+
+export interface CanvasBounds {
+  width: number;
+  height: number;
+}
+
+export const solveConstraints = (
+  nodes: DesignerNode[],
+  constraints: DesignerConstraint[],
+  bounds: CanvasBounds = DESIGNER_CANVAS_BOUNDS
+): DesignerNode[] => {
+  if (!nodes.length) {
+    return nodes;
+  }
+
+  try {
+    const solver = new kiwi.Solver();
+    const variableMap = new Map<string, VariableBundle>();
+
+    nodes.forEach((node) => {
+      const x = new kiwi.Variable(`${node.id}-x`);
+      const y = new kiwi.Variable(`${node.id}-y`);
+      const width = new kiwi.Variable(`${node.id}-w`);
+      const height = new kiwi.Variable(`${node.id}-h`);
+
+      solver.addEditVariable(x, kiwi.Strength.strong);
+      solver.addEditVariable(y, kiwi.Strength.strong);
+      solver.addEditVariable(width, kiwi.Strength.medium);
+      solver.addEditVariable(height, kiwi.Strength.medium);
+
+      solver.suggestValue(x, node.position.x);
+      solver.suggestValue(y, node.position.y);
+      solver.suggestValue(width, node.size.width);
+      solver.suggestValue(height, node.size.height);
+
+      solver.addConstraint(new kiwi.Constraint(x, kiwi.Operator.Ge, 0, kiwi.Strength.required));
+      solver.addConstraint(new kiwi.Constraint(y, kiwi.Operator.Ge, 0, kiwi.Strength.required));
+      solver.addConstraint(new kiwi.Constraint(width, kiwi.Operator.Ge, 1, kiwi.Strength.required));
+      solver.addConstraint(new kiwi.Constraint(height, kiwi.Operator.Ge, 1, kiwi.Strength.required));
+
+      if (node.type !== 'document' && node.type !== 'page') {
+        solver.addConstraint(new kiwi.Constraint(x, kiwi.Operator.Ge, 0, kiwi.Strength.required));
+        solver.addConstraint(new kiwi.Constraint(y, kiwi.Operator.Ge, 0, kiwi.Strength.required));
+        solver.addConstraint(
+          new kiwi.Constraint(new kiwi.Expression(x).plus(width), kiwi.Operator.Le, bounds.width, kiwi.Strength.required)
+        );
+        solver.addConstraint(
+          new kiwi.Constraint(new kiwi.Expression(y).plus(height), kiwi.Operator.Le, bounds.height, kiwi.Strength.required)
+        );
+      }
+
+      variableMap.set(node.id, { x, y, width, height });
+    });
+
+    constraints.forEach((constraint) => {
+      const strength = toKiwiStrength(constraint.strength);
+
+      switch (constraint.type) {
+        case 'align-left':
+        case 'align-top':
+        case 'match-width':
+        case 'match-height': {
+          const [aId, bId] = constraint.nodes;
+          const nodeA = variableMap.get(aId);
+          const nodeB = variableMap.get(bId);
+          if (!nodeA || !nodeB) return;
+
+          const [varA, varB] =
+            constraint.type === 'align-left'
+              ? [nodeA.x, nodeB.x]
+              : constraint.type === 'align-top'
+                ? [nodeA.y, nodeB.y]
+                : constraint.type === 'match-width'
+                  ? [nodeA.width, nodeB.width]
+                  : [nodeA.height, nodeB.height];
+
+          solver.addConstraint(new kiwi.Constraint(new kiwi.Expression(varA).minus(varB), kiwi.Operator.Eq, 0, strength));
+          break;
+        }
+        case 'aspect-ratio': {
+          const nodeVars = variableMap.get(constraint.nodeId);
+          if (!nodeVars) return;
+          const expr = new kiwi.Expression(nodeVars.width).minus(
+            new kiwi.Expression([constraint.ratio, nodeVars.height])
+          );
+          solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, 0, strength));
+          break;
+        }
+        default:
+          return;
+      }
+    });
+
+    solver.updateVariables();
+
+    return nodes.map((node) => {
+      const vars = variableMap.get(node.id);
+      if (!vars) return node;
+      
+      if (node.type === 'document' || node.type === 'page') {
+        return {
+          ...node,
+          position: {
+            x: vars.x.value(),
+            y: vars.y.value(),
+          },
+          size: {
+            width: vars.width.value(),
+            height: vars.height.value(),
+          },
+        };
+      }
+
+      const width = clamp(vars.width.value(), 1, bounds.width);
+      const height = clamp(vars.height.value(), 1, bounds.height);
+      const maxX = Math.max(0, bounds.width - width);
+      const maxY = Math.max(0, bounds.height - height);
+      return {
+        ...node,
+        position: {
+          x: clamp(vars.x.value(), 0, maxX),
+          y: clamp(vars.y.value(), 0, maxY),
+        },
+        size: {
+          width,
+          height,
+        },
+      };
+    });
+  } catch (error) {
+    console.warn('[Designer] constraint solver failed, returning original layout', error);
+    return nodes;
+  }
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);

--- a/packages/billing/src/components/invoice-designer/utils/layout.ts
+++ b/packages/billing/src/components/invoice-designer/utils/layout.ts
@@ -1,0 +1,114 @@
+import type { DesignerNode, Point, Size } from '../state/designerStore';
+import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
+
+export interface AlignmentGuide {
+  type: 'vertical' | 'horizontal';
+  position: number;
+  description: string;
+}
+
+export interface ParentBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const ALIGN_THRESHOLD = 6;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export const calculateGuides = (activeNode: DesignerNode, nodes: DesignerNode[]): AlignmentGuide[] => {
+  const guides: AlignmentGuide[] = [];
+  nodes.forEach((node) => {
+    if (node.id === activeNode.id) return;
+    if (node.type === 'document' || node.type === 'page') return;
+    if (activeNode.type === 'document' || activeNode.type === 'page') return;
+
+    const nodeEdges = getEdges(node);
+    const activeEdges = getEdges(activeNode);
+
+    const verticalDiffs: Array<{ value: number; description: string }> = [
+      { value: Math.abs(nodeEdges.left - activeEdges.left), description: 'Left edges aligned' },
+      { value: Math.abs(nodeEdges.right - activeEdges.right), description: 'Right edges aligned' },
+      { value: Math.abs(nodeEdges.centerX - activeEdges.centerX), description: 'Centers aligned' },
+    ];
+
+    verticalDiffs.forEach(({ value, description }, index) => {
+      if (value <= ALIGN_THRESHOLD) {
+        const position = index === 0 ? nodeEdges.left : index === 1 ? nodeEdges.right : nodeEdges.centerX;
+        guides.push({ type: 'vertical', position, description });
+      }
+    });
+
+    const horizontalDiffs: Array<{ value: number; description: string }> = [
+      { value: Math.abs(nodeEdges.top - activeEdges.top), description: 'Top edges aligned' },
+      { value: Math.abs(nodeEdges.bottom - activeEdges.bottom), description: 'Bottom edges aligned' },
+      { value: Math.abs(nodeEdges.centerY - activeEdges.centerY), description: 'Middle lines aligned' },
+    ];
+
+    horizontalDiffs.forEach(({ value, description }, index) => {
+      if (value <= ALIGN_THRESHOLD) {
+        const position = index === 0 ? nodeEdges.top : index === 1 ? nodeEdges.bottom : nodeEdges.centerY;
+        guides.push({ type: 'horizontal', position, description });
+      }
+    });
+  });
+
+  return guides;
+};
+
+export const getEdges = (node: DesignerNode) => {
+  const { position, size } = node;
+  return {
+    left: position.x,
+    right: position.x + size.width,
+    centerX: position.x + size.width / 2,
+    top: position.y,
+    bottom: position.y + size.height,
+    centerY: position.y + size.height / 2,
+  };
+};
+
+export const clampPosition = (position: Point, canvasSize: Size): Point => ({
+  x: Math.max(0, Math.min(position.x, canvasSize.width - 10)),
+  y: Math.max(0, Math.min(position.y, canvasSize.height - 10)),
+});
+
+export const getParentBounds = (node: DesignerNode, nodes: DesignerNode[]): ParentBounds => {
+  if (!node.parentId) {
+    return {
+      x: 0,
+      y: 0,
+      width: DESIGNER_CANVAS_BOUNDS.width,
+      height: DESIGNER_CANVAS_BOUNDS.height,
+    };
+  }
+
+  const parentNode = nodes.find((candidate) => candidate.id === node.parentId);
+  if (parentNode) {
+    return {
+      x: 0, // Relative to parent
+      y: 0, // Relative to parent
+      width: parentNode.size.width,
+      height: parentNode.size.height,
+    };
+  }
+
+  return {
+    x: 0,
+    y: 0,
+    width: DESIGNER_CANVAS_BOUNDS.width,
+    height: DESIGNER_CANVAS_BOUNDS.height,
+  };
+};
+
+export const clampPositionToParent = (node: DesignerNode, nodes: DesignerNode[], desired: Point): Point => {
+  const bounds = getParentBounds(node, nodes);
+  const maxX = Math.max(bounds.x, bounds.x + bounds.width - node.size.width);
+  const maxY = Math.max(bounds.y, bounds.y + bounds.height - node.size.height);
+  return {
+    x: clamp(desired.x, bounds.x, maxX),
+    y: clamp(desired.y, bounds.y, maxY),
+  };
+};

--- a/packages/billing/src/components/invoice-designer/utils/persistence.ts
+++ b/packages/billing/src/components/invoice-designer/utils/persistence.ts
@@ -1,0 +1,70 @@
+import type { DesignerWorkspaceSnapshot } from '../state/designerStore';
+
+const MARKER = 'ALGA_INVOICE_DESIGNER_STATE_V1';
+
+type PersistedDesignerStateV1 = {
+  version: 1;
+  workspace: DesignerWorkspaceSnapshot;
+};
+
+const encodeBase64 = (value: string) => {
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    return window.btoa(unescape(encodeURIComponent(value)));
+  }
+  return Buffer.from(value, 'utf8').toString('base64');
+};
+
+const decodeBase64 = (value: string) => {
+  if (typeof window !== 'undefined' && typeof window.atob === 'function') {
+    return decodeURIComponent(escape(window.atob(value)));
+  }
+  return Buffer.from(value, 'base64').toString('utf8');
+};
+
+const commentRegex = new RegExp(`/\\\\*\\\\s*${MARKER}:([A-Za-z0-9+/=]+)\\\\s*\\\\*/`, 'm');
+
+export function extractInvoiceDesignerStateFromSource(source: string): PersistedDesignerStateV1 | null {
+  if (typeof source !== 'string' || source.length === 0) {
+    return null;
+  }
+
+  const match = source.match(commentRegex);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeBase64(match[1]);
+    const parsed = JSON.parse(decoded) as Partial<PersistedDesignerStateV1>;
+    if (parsed?.version !== 1 || !parsed.workspace || !Array.isArray(parsed.workspace.nodes)) {
+      return null;
+    }
+    return parsed as PersistedDesignerStateV1;
+  } catch {
+    return null;
+  }
+}
+
+export function upsertInvoiceDesignerStateInSource(source: string, workspace: DesignerWorkspaceSnapshot): string {
+  const payload: PersistedDesignerStateV1 = { version: 1, workspace };
+  const encoded = encodeBase64(JSON.stringify(payload));
+  const comment = `/* ${MARKER}:${encoded} */`;
+
+  if (typeof source !== 'string' || source.length === 0) {
+    // Important: do not introduce a non-empty source for brand new templates by default,
+    // because the save action will attempt to compile non-empty AssemblyScript sources.
+    return source;
+  }
+
+  if (commentRegex.test(source)) {
+    return source.replace(commentRegex, comment);
+  }
+
+  const separator = source.endsWith('\n') ? '' : '\n';
+  return `${source}${separator}${comment}\n`;
+}
+
+export function getInvoiceDesignerLocalStorageKey(templateId: string | null) {
+  return `alga.invoiceDesigner.workspace.${templateId ?? 'new'}`;
+}
+


### PR DESCRIPTION
Summary
- Introduced the invoice designer UI under `packages/billing` and gated it behind a PostHog feature flag so the legacy behavior remains the default
- Documented the new flag in `docs/features/feature-flags.md` and wired the billing dashboard to toggle between the old editor and the new designer based on the flag
- Added supporting dependencies, hooks, and utils required by the designer (palette, canvas, toolbar, persistence, etc.)

Testing
- Not run (not requested)