### PR TITLE
Fix N+1 priority fetches in project kanban board

### DIFF
--- a/packages/projects/src/components/KanbanBoard.tsx
+++ b/packages/projects/src/components/KanbanBoard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { IProjectTask, ProjectStatus, IProjectTicketLinkWithDetails, ITaskType, IProjectTaskDependency } from '@alga-psa/types';
 import { IUserWithRoles } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
+import { IPriority, IStandardPriority } from '@alga-psa/types';
 import { getTaskTypes } from '../actions/projectTaskActions';
 import StatusColumn from './StatusColumn';
 import styles from './ProjectDetail.module.css';
@@ -24,6 +25,7 @@ interface KanbanBoardProps {
   taskTags?: Record<string, ITag[]>;
   taskDocumentCounts?: Map<string, number>;
   allTaskTags?: ITag[];
+  priorities?: (IPriority | IStandardPriority)[];
   projectTreeData?: any[]; // Add projectTreeData prop
   animatingTasks: Set<string>;
   avatarUrls?: Record<string, string | null>;
@@ -97,6 +99,7 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
   taskTags = {},
   taskDocumentCounts = {},
   allTaskTags = [],
+  priorities = [],
   projectTreeData,
   animatingTasks,
   avatarUrls = {},
@@ -179,6 +182,7 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
             taskDependencies={taskDependencies}
             taskTags={taskTags}
             taskDocumentCounts={taskDocumentCounts instanceof Map ? Object.fromEntries(taskDocumentCounts.entries()) : {}}
+            priorities={priorities}
             statusIcon={statusIcon}
             backgroundColor={backgroundColor}
             darkBackgroundColor={darkBackgroundColor}

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -2040,6 +2040,7 @@ export default function ProjectDetail({
             taskTags={taskTags}
             taskDocumentCounts={taskDocumentCounts}
             allTaskTags={allTaskTags}
+            priorities={priorities}
             projectTreeData={projectTreeData}
             animatingTasks={animatingTasks}
             avatarUrls={avatarUrls}

--- a/packages/projects/src/components/StatusColumn.tsx
+++ b/packages/projects/src/components/StatusColumn.tsx
@@ -2,6 +2,7 @@
 
 import { IProjectTask, ProjectStatus, IProjectTicketLinkWithDetails, ITaskType, IProjectTaskDependency } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
+import { IPriority, IStandardPriority } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Circle, Plus } from 'lucide-react';
 import TaskCard from './TaskCard';
@@ -20,6 +21,7 @@ interface StatusColumnProps {
   taskDependencies?: { [taskId: string]: { predecessors: IProjectTaskDependency[]; successors: IProjectTaskDependency[] } };
   taskTags?: Record<string, ITag[]>;
   taskDocumentCounts?: Record<string, number>;
+  priorities?: (IPriority | IStandardPriority)[];
   allTaskTagTexts?: string[];
   statusIcon: React.ReactNode;
   backgroundColor: string;
@@ -59,6 +61,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
   taskDependencies = {},
   taskTags = {},
   taskDocumentCounts = {},
+  priorities = [],
   allTaskTagTexts = [],
   statusIcon,
   backgroundColor,
@@ -344,6 +347,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
       <div className={`${styles.kanbanTasks} ${styles.taskList}`} ref={tasksRef} data-kanban-column-tasks="true">
         {sortedTasks.map((task): React.JSX.Element => {
           const taskType = taskTypes.find(t => t.type_key === task.task_type_key);
+          const taskPriority = task.priority_id ? priorities.find(p => p.priority_id === task.priority_id) : undefined;
           return (
           <div key={task.task_id} data-task-id={task.task_id} className="relative">
             {/* Animated drop placeholder before task */}
@@ -359,6 +363,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
               taskDependencies={taskDependencies[task.task_id]}
               taskTags={taskTags[task.task_id] || []}
               documentCount={taskDocumentCounts[task.task_id]}
+              priority={taskPriority}
               isAnimating={animatingTasks.has(task.task_id)}
               searchQuery={searchQuery}
               searchCaseSensitive={searchCaseSensitive}

--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -8,7 +8,6 @@ import { IPriority, IStandardPriority } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
 import { CheckSquare, Square, Ticket, MoreVertical, Move, Copy, Edit, Trash2, Bug, Sparkles, TrendingUp, Flag, BookOpen, Paperclip, Ban, GitBranch, Link2 } from 'lucide-react';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
-import { findPriorityById } from '@alga-psa/reference-data/actions';
 import UserPicker from '@alga-psa/ui/components/UserPicker';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/users/actions';
 import UserAvatar from '@alga-psa/ui/components/UserAvatar';
@@ -35,6 +34,7 @@ interface TaskCardProps {
   taskDependencies?: { predecessors: IProjectTaskDependency[]; successors: IProjectTaskDependency[] };
   taskTags?: ITag[];
   documentCount?: number;
+  priority?: IPriority | IStandardPriority;
   isAnimating?: boolean;
   searchQuery?: string;
   searchCaseSensitive?: boolean;
@@ -71,6 +71,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
   taskDependencies,
   taskTags: providedTaskTags = [],
   documentCount: providedDocumentCount,
+  priority,
   isAnimating = false,
   searchQuery = '',
   searchCaseSensitive = false,
@@ -99,7 +100,6 @@ export const TaskCard: React.FC<TaskCardProps> = ({
     null
   );
   const [isDragging, setIsDragging] = useState(false);
-  const [priority, setPriority] = useState<IPriority | IStandardPriority | null>(null);
   const [documentCount, setDocumentCount] = useState<number>(providedDocumentCount ?? 0);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const { ref: descriptionRef, isTruncated: isDescriptionTruncated } = useTruncationDetection<HTMLParagraphElement>();
@@ -170,24 +170,13 @@ export const TaskCard: React.FC<TaskCardProps> = ({
           setTaskResources(resources || []); // Ensure empty array if API returns null/undefined
         }
 
-        // Fetch priority if task has priority_id
-        if (task.priority_id && !priority) {
-          const taskPriority = await findPriorityById(task.priority_id);
-          setPriority(taskPriority);
-        }
-
-        // Don't fetch document count - it should be provided from parent
-        // Documents should only be fetched when opening the task form
-
-        // Fetch tags only if not provided
-
       } catch (error) {
         console.error('Error fetching task data:', error);
       }
     };
 
     fetchData();
-  }, [task.task_id, task.ticket_links, task.resources, ticketLinks, providedTaskResources, task.priority_id, priority, providedDocumentCount]);
+  }, [task.task_id, task.ticket_links, task.resources, ticketLinks, providedTaskResources, providedDocumentCount]);
 
   // Computed values - ensure we handle the loading state
   const checklistItems = task.checklist_items || [];


### PR DESCRIPTION
  Pass priorities from parent component through KanbanBoard and StatusColumn to TaskCard instead of each card fetching individually. This eliminates 40+ server action calls when viewing a project.

  - Add priorities prop to KanbanBoard and StatusColumn
  - Remove findPriorityById call from TaskCard useEffect
  - Look up priority by ID in StatusColumn before passing to card

  "Why," said Alice, "each little TaskCard was running off to find its own Priority, making forty trips to the same tea party! Now they simply wait for the priorities to be passed down like proper props through the StatusColumn looking-glass." 🃏🫖✨