### PR TITLE
back to tickets filter fix

### DIFF
--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -349,7 +349,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       params.set('responseState', selectedResponseState);
     }
     if (selectedTags.length > 0) {
-      params.set('tags', selectedTags.map(tag => encodeURIComponent(String(tag))).join(','));
+      params.set('tags', selectedTags.join(','));
     }
     if (sortBy && sortBy !== 'entered_at') {
       params.set('sortBy', sortBy);


### PR DESCRIPTION
1. Encode: getCurrentFiltersQuery() → handleTicketClick wraps in encodeURIComponent → ticket URL
  2. Decode: BackNav reads returnFilters, decodeURIComponent → router.push('/msp/tickets?...')
  3. Parse: page.tsx extracts all params → passes to TicketingDashboardContainer
  4. Initialize: Container sets currentPage = initialPage, activeFilters = {...defaults, ...initialFilters}

  - Filter change resets page: handleFiltersChanged calls setCurrentPage(1) before re-render, so getCurrentFiltersQuery() will omit page (since 1 > 1 is false). Correct.
  - Sort change resets page: Same — handleSortChange resets to page 1. Correct.
  - Page size preference sync: If stored preference matches URL value, no reset occurs. If they differ, it resets to page 1 (pre-existing behavior, unaffected by this change).
