### PR TITLE
Fix client portal project view crash

### DIFF
--- a/packages/client-portal/src/components/projects/ClientKanbanBoard.tsx
+++ b/packages/client-portal/src/components/projects/ClientKanbanBoard.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// TODO: Hook return type issues with useTruncationDetection
 'use client';
 
 import React from 'react';
@@ -108,7 +106,7 @@ function TaskCard({
 }) {
   const { t } = useTranslation('clientPortal');
   const [isDescriptionExpanded, setIsDescriptionExpanded] = React.useState(false);
-  const [descriptionRef, isDescriptionTruncated] = useTruncationDetection(task.description, isDescriptionExpanded);
+  const { ref: descriptionRef, isTruncated: isDescriptionTruncated } = useTruncationDetection<HTMLParagraphElement>();
   const visibleFields = config.visible_task_fields ?? ['task_name', 'due_date', 'status'];
   const allowUploads = visibleFields.includes('document_uploads');
   const showDependencies = visibleFields.includes('dependencies');


### PR DESCRIPTION
## Summary

- Fixed "object is not iterable (cannot read property Symbol(Symbol.iterator))" error when viewing projects in the client portal kanban board
- Root cause: The `useTruncationDetection` hook in `ClientKanbanBoard.tsx` returns an object `{ ref, isTruncated }`, but the code was using array destructuring `const [descriptionRef, isDescriptionTruncated] = ...` instead of object destructuring
- Changed to correct object destructuring: `const { ref: descriptionRef, isTruncated: isDescriptionTruncated } = useTruncationDetection<HTMLParagraphElement>()`
- Removed `@ts-nocheck` directive that was suppressing TypeScript errors and hiding this bug