### PR TITLE
Fix onboarding contacts step link

### DIFF
--- a/packages/onboarding/src/lib/stepDefinitions.ts
+++ b/packages/onboarding/src/lib/stepDefinitions.ts
@@ -42,8 +42,8 @@ export const STEP_DEFINITIONS: Record<OnboardingStepId, StepDefinition> = {
     title: 'Import Core Data',
     description: 'Add contacts so you can start working for clients and keep workflows moving.',
     icon: FileSpreadsheet,
-    ctaHref: '/msp/settings?tab=import-export',
-    ctaLabel: 'Open Import Tools',
+    ctaHref: '/msp/contacts',
+    ctaLabel: 'Create Contacts',
     analyticsTarget: 'data_import',
   },
   calendar_sync: {


### PR DESCRIPTION
## Summary
- Updated the "Create your first 5 contacts" onboarding step to link to `/msp/contacts` instead of `/msp/settings?tab=import-export`
- Changed button label from "Open Import Tools" to "Create Contacts" for better clarity

## Context
The onboarding checklist item for creating contacts was directing users to the asset import page, which was confusing. Now it properly sends them to the contacts screen where they can actually create contacts.

## Changes
- Modified `packages/onboarding/src/lib/stepDefinitions.ts` to update the `data_import` step configuration

## Test plan
- [ ] Verify the onboarding checklist displays on the dashboard
- [ ] Click the "Create Contacts" button on the "Import Core Data" step
- [ ] Confirm it navigates to `/msp/contacts`