### PR TITLE
Fix contract template service rates prefill and normalize seed billing methods

### DIFF
--- a/server/seeds/dev/22a_ensure_tenant_service_types.cjs
+++ b/server/seeds/dev/22a_ensure_tenant_service_types.cjs
@@ -4,6 +4,13 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
+const resolveBillingMethod = (typeName, fallbackMethod) => {
+  if (typeName === 'Hourly Time') return 'hourly';
+  if (typeName === 'Usage Based') return 'usage';
+  if (typeName === 'Fixed Price') return 'fixed';
+  return fallbackMethod || 'per_unit';
+};
+
 exports.seed = async function(knex) {
   // Fetch all tenant IDs (using the correct column name 'tenant')
   const tenants = await knex('tenants').select('tenant');
@@ -42,7 +49,7 @@ exports.seed = async function(knex) {
             name: stdType.name,
             standard_service_type_id: stdType.id,
             is_active: true,
-            billing_method: stdType.billing_method || 'per_unit', // Use the billing_method from standard type or default to 'per_unit'
+            billing_method: resolveBillingMethod(stdType.name, stdType.billing_method),
             order_number: stdType.display_order || 0,
           });
           insertedCount++;

--- a/server/seeds/dev/23_service_catalog.cjs
+++ b/server/seeds/dev/23_service_catalog.cjs
@@ -1,3 +1,10 @@
+const resolveBillingMethod = (typeName, fallbackMethod) => {
+    if (typeName === 'Hourly Time') return 'hourly';
+    if (typeName === 'Usage Based') return 'usage';
+    if (typeName === 'Fixed Price') return 'fixed';
+    return fallbackMethod || 'per_unit';
+};
+
 exports.seed = async function (knex) { // Changed to async function
     const tenantInfo = await knex('tenants').select('tenant').first();
     if (!tenantInfo) return;
@@ -9,7 +16,7 @@ exports.seed = async function (knex) { // Changed to async function
         .whereIn('name', ['Hourly Time', 'Fixed Price', 'Usage Based']) // Fetch only the types used in this seed
         .select('id', 'name');
 
-    const typeMap = serviceTypes.reduce((map, type) => {
+    let typeMap = serviceTypes.reduce((map, type) => {
         // Map standard names (like 'Hourly Time') to their tenant-specific UUIDs
         map[type.name] = type.id;
         return map;
@@ -42,7 +49,7 @@ exports.seed = async function (knex) { // Changed to async function
                 name: stdType.name,
                 standard_service_type_id: stdType.id,
                 is_active: true,
-                billing_method: stdType.billing_method || 'per_unit', // Use the billing_method from standard type or default to 'per_unit'
+                billing_method: resolveBillingMethod(stdType.name, stdType.billing_method),
             }));
 
             // Insert missing types, ignoring conflicts just in case
@@ -88,7 +95,7 @@ exports.seed = async function (knex) { // Changed to async function
             service_name: 'Rabbit Tracking',
             description: 'Locating and tracking white rabbits',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
-            billing_method: 'per_unit', // Add required billing_method
+            billing_method: 'hourly',
             default_rate: 7500,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Network Services' }).select('category_id').first()
@@ -108,7 +115,7 @@ exports.seed = async function (knex) { // Changed to async function
             service_name: 'Shrinking Potion',
             description: 'Potion to reduce size',
             custom_service_type_id: typeMap['Usage Based'], // Use fetched ID
-            billing_method: 'per_unit', // Add required billing_method
+            billing_method: 'usage',
             default_rate: 2500,
             unit_of_measure: 'Dose',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Cloud Services' }).select('category_id').first()
@@ -118,7 +125,7 @@ exports.seed = async function (knex) { // Changed to async function
             service_name: 'Yellow Brick Road Repair',
             description: 'Fixing and maintaining the yellow brick road',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
-            billing_method: 'per_unit', // Add required billing_method
+            billing_method: 'hourly',
             default_rate: 10000,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Network Services' }).select('category_id').first()
@@ -138,7 +145,7 @@ exports.seed = async function (knex) { // Changed to async function
             service_name: 'Basic Support',
             description: 'Standard support package',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
-            billing_method: 'per_unit', // Add required billing_method
+            billing_method: 'hourly',
             default_rate: 10000,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Support Services' }).select('category_id').first()
@@ -148,7 +155,7 @@ exports.seed = async function (knex) { // Changed to async function
             service_name: 'Premium Support',
             description: 'Premium support package with priority response',
             custom_service_type_id: typeMap['Hourly Time'], // Use fetched ID
-            billing_method: 'per_unit', // Add required billing_method
+            billing_method: 'hourly',
             default_rate: 15000,
             unit_of_measure: 'Hour',
             category_id: knex('service_categories').where({ tenant: tenantId, category_name: 'Support Services' }).select('category_id').first() // Corrected tenant reference in subquery


### PR DESCRIPTION
## Summary
- fix contract wizard/template snapshot hydration so hourly and usage services prefer the first positive rate from line config, custom config rate, or service catalog default rate
- avoid persisting synthetic zero custom rates in template hourly/usage config rows (store null when no positive rate exists)
- harden client contract creation to backfill hourly/usage rates from service catalog default rates when template-provided rates are zero/missing
- normalize dev seed billing method mapping so Hourly Time -> hourly and Usage Based -> usage, and update seeded catalog rows accordingly
- add regression tests for draft resume/template snapshot fallback to catalog default rates when stored rates are zero

## Validation
- npx tsc -p packages/billing/tsconfig.json --noEmit
- npx vitest packages/billing/tests/draftContractForResumeActions.test.ts