### PR TITLE
Sample dual portal extension: include clientId in GUI details

### DIFF
--- a/ee/extensions/samples/client-portal-test/src/handler-impl.ts
+++ b/ee/extensions/samples/client-portal-test/src/handler-impl.ts
@@ -48,7 +48,15 @@ async function processRequest(request: ExecuteRequest, host: HostBindings): Prom
   );
 
   // Try to get user information
-  let user: { tenantId: string; clientName: string; userId: string; userEmail: string; userName: string; userType: string } | null = null;
+  let user: {
+    tenantId: string;
+    clientName: string;
+    userId: string;
+    userEmail: string;
+    userName: string;
+    userType: string;
+    clientId?: string;
+  } | null = null;
   let userError: string | null = null;
   try {
     user = await host.user.getUser();
@@ -81,6 +89,7 @@ async function processRequest(request: ExecuteRequest, host: HostBindings): Prom
       userEmail: user.userEmail,
       userType: user.userType,
       clientName: user.clientName,
+      clientId: user.clientId,
     } : null,
     userError: userError,
     version: VERSION,

--- a/ee/extensions/samples/client-portal-test/ui/main.ts
+++ b/ee/extensions/samples/client-portal-test/ui/main.ts
@@ -132,6 +132,7 @@ interface HandlerResponse {
     userName: string;
     userEmail: string;
     userType: string;
+    clientId?: string;
   };
   userError?: string;
   portalType?: string;
@@ -170,6 +171,7 @@ async function callHandler(): Promise<void> {
         ? `Error: ${data.userError}`
         : 'N/A';
     const userTypeDisplay = data.user?.userType || 'N/A';
+    const clientIdDisplay = data.user?.clientId || 'N/A';
 
     if (handlerEl) {
       handlerEl.innerHTML = `
@@ -191,6 +193,10 @@ async function callHandler(): Promise<void> {
           <div class="result-row">
             <span class="result-label">User Type</span>
             <span class="result-value"><code>${userTypeDisplay}</code></span>
+          </div>
+          <div class="result-row">
+            <span class="result-label">Client ID</span>
+            <span class="result-value"><code>${clientIdDisplay}</code></span>
           </div>
           <div class="result-row">
             <span class="result-label">Portal Type</span>


### PR DESCRIPTION
## Summary
- add clientId to the dual portal sample handler user payload
- render Client ID in the dual portal sample UI handler response details
- keep fallback as N/A when unavailable

## Files changed
- ee/extensions/samples/client-portal-test/src/handler-impl.ts
- ee/extensions/samples/client-portal-test/ui/main.ts

## Validation
- Ran npm --prefix ee/extensions/samples/client-portal-test run build
- backend/component steps succeeded
- ui build currently fails due existing package resolution issue for @alga-psa/extension-iframe-sdk (./dist/index.js missing in node_modules)
