### PR TITLE
feat: add feature-flagged email logs with outbound send logging

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -71,6 +71,18 @@ Controls access to the delegated time-entry UI (editing/viewing time sheets for 
 - When disabled: The UI only allows working with the current user’s own time periods/time sheets (delegated sheets are shown as read-only if accessed directly).
 - When enabled: Authorized users can select a subject user and edit/view that user’s time sheets via the UI.
 
+### 5. `email-logs`
+Controls access to email log UI surfaces for outbound email auditing/debugging.
+
+**Affected Areas:**
+- **MSP Portal:**
+  - System Monitor → Email Logs menu link
+  - Email Logs page at `/msp/email-logs`
+  - Ticket Details → Email Notifications section (per-ticket)
+
+**Behavior:**
+- When disabled: Email Logs page shows construction placeholder; navigation link and ticket section are hidden.
+
 ## Implementation Details
 
 ### User Identification

--- a/packages/email/src/actions/emailLogActions.ts
+++ b/packages/email/src/actions/emailLogActions.ts
@@ -1,0 +1,271 @@
+'use server';
+
+import { createTenantKnex, withTransaction } from '@alga-psa/db';
+import type { Knex } from 'knex';
+import { withAuth } from '@alga-psa/auth';
+import type { PaginatedResult } from '@alga-psa/types';
+
+export interface EmailSendingLogRecord {
+  id: number;
+  tenant: string;
+  message_id: string | null;
+  provider_id: string;
+  provider_type: string;
+  from_address: string;
+  to_addresses: string[];
+  cc_addresses: string[] | null;
+  bcc_addresses: string[] | null;
+  subject: string | null;
+  status: 'sent' | 'failed' | 'bounced' | 'delivered' | 'opened' | 'clicked';
+  error_message: string | null;
+  metadata: Record<string, any> | null;
+  sent_at: Date;
+  delivered_at: Date | null;
+  opened_at: Date | null;
+  clicked_at: Date | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  contact_id: string | null;
+  notification_subtype_id: number | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export const getEmailLogsForTicket = withAuth(
+  async (
+    _user,
+    { tenant },
+    ticketId: string,
+    options?: { limit?: number }
+  ): Promise<EmailSendingLogRecord[]> => {
+    const { knex } = await createTenantKnex();
+    const limit = Math.min(Math.max(options?.limit ?? 20, 1), 200);
+
+    return withTransaction(knex, async (trx: Knex.Transaction) => {
+      return trx<EmailSendingLogRecord>('email_sending_logs')
+        .select(
+          'id',
+          'tenant',
+          'message_id',
+          'provider_id',
+          'provider_type',
+          'from_address',
+          'to_addresses',
+          'cc_addresses',
+          'bcc_addresses',
+          'subject',
+          'status',
+          'error_message',
+          'metadata',
+          'sent_at',
+          'delivered_at',
+          'opened_at',
+          'clicked_at',
+          'entity_type',
+          'entity_id',
+          'contact_id',
+          'notification_subtype_id',
+          'created_at',
+          'updated_at'
+        )
+        .where({
+          tenant,
+          entity_type: 'ticket',
+          entity_id: ticketId
+        })
+        .orderBy('sent_at', 'desc')
+        .limit(limit);
+    });
+  }
+);
+
+export interface EmailLogFilters {
+  page?: number;
+  pageSize?: number;
+  /**
+   * Filter by sent_at >= startDate (ISO string).
+   */
+  startDate?: string;
+  /**
+   * Filter by sent_at <= endDate (ISO string).
+   */
+  endDate?: string;
+  status?: EmailSendingLogRecord['status'];
+  /**
+   * Case-insensitive substring match against recipient(s).
+   * (matches against to_addresses JSON payload)
+   */
+  recipientEmail?: string;
+  /**
+   * Case-insensitive substring match against ticket number.
+   * Only applies for entity_type='ticket'.
+   */
+  ticketNumber?: string;
+  sortBy?: 'sent_at';
+  sortDirection?: 'asc' | 'desc';
+}
+
+export type EmailSendingLogListRecord = EmailSendingLogRecord & {
+  ticket_number: string | null;
+};
+
+function parseDateFilter(input: string): Date | null {
+  const parsed = new Date(input);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseDateOnlyEndExclusive(input: string): Date | null {
+  const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateOnlyPattern.test(input)) return null;
+
+  const parsed = new Date(`${input}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  parsed.setUTCDate(parsed.getUTCDate() + 1);
+  return parsed;
+}
+
+export const getEmailLogs = withAuth(
+  async (
+    _user,
+    { tenant },
+    filters: EmailLogFilters = {}
+  ): Promise<PaginatedResult<EmailSendingLogListRecord>> => {
+    const { knex } = await createTenantKnex();
+
+    const page = Math.max(1, filters.page ?? 1);
+    const pageSize = Math.min(Math.max(filters.pageSize ?? 25, 1), 200);
+    const sortDirection = filters.sortDirection === 'asc' ? 'asc' : 'desc';
+    const offset = (page - 1) * pageSize;
+
+    return withTransaction(knex, async (trx: Knex.Transaction) => {
+      let baseQuery = trx('email_sending_logs as esl')
+        .leftJoin('tickets as t', function () {
+          this.on('esl.entity_id', '=', 't.ticket_id')
+            .andOn('t.tenant', '=', 'esl.tenant')
+            .andOn('esl.entity_type', '=', trx.raw('?', ['ticket']));
+        })
+        .where('esl.tenant', tenant);
+
+      if (filters.status) {
+        baseQuery = baseQuery.where('esl.status', filters.status);
+      }
+
+      if (filters.startDate) {
+        const parsedStartDate = parseDateFilter(filters.startDate);
+        if (parsedStartDate) {
+          baseQuery = baseQuery.where('esl.sent_at', '>=', parsedStartDate);
+        }
+      }
+
+      if (filters.endDate) {
+        const dateOnlyEndExclusive = parseDateOnlyEndExclusive(filters.endDate);
+        if (dateOnlyEndExclusive) {
+          baseQuery = baseQuery.where('esl.sent_at', '<', dateOnlyEndExclusive);
+        } else {
+          const parsedEndDate = parseDateFilter(filters.endDate);
+          if (parsedEndDate) {
+            baseQuery = baseQuery.where('esl.sent_at', '<=', parsedEndDate);
+          }
+        }
+      }
+
+      if (filters.recipientEmail) {
+        const pattern = `%${filters.recipientEmail.trim()}%`;
+        baseQuery = baseQuery.whereRaw('esl.to_addresses::text ILIKE ?', [pattern]);
+      }
+
+      if (filters.ticketNumber) {
+        const pattern = `%${filters.ticketNumber.trim()}%`;
+        baseQuery = baseQuery.whereRaw('t.ticket_number::text ILIKE ?', [pattern]);
+      }
+
+      const totalRow = await baseQuery
+        .clone()
+        .clearSelect()
+        .clearOrder()
+        .countDistinct<{ total: string }>({ total: 'esl.id' })
+        .first();
+
+      const total = parseInt(String(totalRow?.total ?? '0'), 10);
+      const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize);
+
+      const data = await baseQuery
+        .clone()
+        .select<EmailSendingLogListRecord[]>(
+          'esl.id',
+          'esl.tenant',
+          'esl.message_id',
+          'esl.provider_id',
+          'esl.provider_type',
+          'esl.from_address',
+          'esl.to_addresses',
+          'esl.cc_addresses',
+          'esl.bcc_addresses',
+          'esl.subject',
+          'esl.status',
+          'esl.error_message',
+          'esl.metadata',
+          'esl.sent_at',
+          'esl.delivered_at',
+          'esl.opened_at',
+          'esl.clicked_at',
+          'esl.entity_type',
+          'esl.entity_id',
+          'esl.contact_id',
+          'esl.notification_subtype_id',
+          'esl.created_at',
+          'esl.updated_at',
+          trx.raw('t.ticket_number as ticket_number')
+        )
+        .orderBy('esl.sent_at', sortDirection)
+        .limit(pageSize)
+        .offset(offset);
+
+      return {
+        data,
+        total,
+        page,
+        pageSize,
+        totalPages
+      };
+    });
+  }
+);
+
+export interface EmailLogMetrics {
+  total: number;
+  failed: number;
+  today: number;
+  failedRate: number;
+}
+
+export const getEmailLogMetrics = withAuth(
+  async (_user, { tenant }): Promise<EmailLogMetrics> => {
+    const { knex } = await createTenantKnex();
+
+    return withTransaction(knex, async (trx: Knex.Transaction) => {
+      const startOfToday = new Date();
+      startOfToday.setHours(0, 0, 0, 0);
+
+      const result = (await trx('email_sending_logs')
+        .where({ tenant })
+        .select(
+          trx.raw('COUNT(*)::int as total'),
+          trx.raw(`COUNT(*) FILTER (WHERE status = 'failed')::int as failed`),
+          trx.raw('COUNT(*) FILTER (WHERE sent_at >= ?)::int as today', [startOfToday])
+        )
+        .first()) as unknown as { total: number; failed: number; today: number } | undefined;
+
+      const total = Number(result?.total ?? 0);
+      const failed = Number(result?.failed ?? 0);
+      const today = Number(result?.today ?? 0);
+
+      return {
+        total,
+        failed,
+        today,
+        failedRate: total > 0 ? failed / total : 0
+      };
+    });
+  }
+);

--- a/packages/email/src/actions/index.ts
+++ b/packages/email/src/actions/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @alga-psa/email - Actions
+ *
+ * Server actions for email log operations.
+ */
+
+export * from './emailLogActions';
+

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -29,6 +29,7 @@ import { useTags } from '@alga-psa/tags/context';
 import TicketInfo from "./TicketInfo";
 import TicketProperties from "./TicketProperties";
 import TicketDocumentsSection from "./TicketDocumentsSection";
+import TicketEmailNotifications from "./TicketEmailNotifications";
 import TicketConversation from "./TicketConversation";
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-hot-toast';
@@ -51,7 +52,7 @@ import { ExternalLink } from 'lucide-react';
 import { WorkItemType } from "@alga-psa/types";
 import { ReflectionContainer } from "@alga-psa/ui/ui-reflection/ReflectionContainer";
 import { PartialBlock, StyledText } from '@blocknote/core';
-import { useTicketTimeTracking } from "@alga-psa/ui/hooks";
+import { useFeatureFlag, useTicketTimeTracking } from "@alga-psa/ui/hooks";
 import { IntervalTrackingService } from "@alga-psa/ui/services";
 import { convertBlockNoteToMarkdown } from "@alga-psa/documents/lib/blocknoteUtils";
 import BackNav from '@alga-psa/ui/components/BackNav';
@@ -178,6 +179,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     const { t } = useTranslation('clientPortal');
     const { data: session } = useSession();
     const [hasHydrated, setHasHydrated] = useState(false);
+    const { enabled: emailLogsEnabled } = useFeatureFlag('email-logs', { defaultValue: false });
 
     useEffect(() => {
         setHasHydrated(true);
@@ -1776,6 +1778,15 @@ const handleClose = () => {
                             </div>
                         </Suspense>
                         
+                        {emailLogsEnabled ? (
+                            <Suspense fallback={<div id="ticket-email-notifications-skeleton" className="animate-pulse bg-gray-200 h-40 rounded-lg mb-6"></div>}>
+                                <TicketEmailNotifications
+                                    id={`${id}-email-notifications`}
+                                    ticketId={ticket.ticket_id || ''}
+                                />
+                            </Suspense>
+                        ) : null}
+
                         <Suspense fallback={<div id="ticket-documents-skeleton" className="animate-pulse bg-gray-200 h-64 rounded-lg mb-6"></div>}>
                             <TicketDocumentsSection
                                 id={`${id}-documents-section`}

--- a/packages/tickets/src/components/ticket/TicketEmailNotifications.tsx
+++ b/packages/tickets/src/components/ticket/TicketEmailNotifications.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DataTable } from '@alga-psa/ui/components/DataTable';
+import { Button } from '@alga-psa/ui/components/Button';
+import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
+import { withDataAutomationId } from '@alga-psa/ui/ui-reflection/withDataAutomationId';
+import { getEmailLogsForTicket, type EmailSendingLogRecord } from '@alga-psa/email/actions';
+import type { ColumnDefinition } from '@alga-psa/types';
+import styles from './TicketDetails.module.css';
+
+interface TicketEmailNotificationsProps {
+  id?: string;
+  ticketId: string;
+}
+
+const INITIAL_LIMIT = 20;
+const LOAD_MORE_STEP = 20;
+
+function parseEmailList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item)).filter(Boolean);
+      }
+    } catch {
+      // ignore
+    }
+    return value ? [value] : [];
+  }
+  return [];
+}
+
+function formatSentAt(value: unknown): string {
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+const TicketEmailNotifications: React.FC<TicketEmailNotificationsProps> = ({
+  id = 'ticket-email-notifications',
+  ticketId,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [logs, setLogs] = useState<EmailSendingLogRecord[]>([]);
+  const [limit, setLimit] = useState(INITIAL_LIMIT);
+  const [hasMore, setHasMore] = useState(false);
+
+  const fetchLogs = useCallback(async () => {
+    if (!ticketId) return;
+
+    setIsLoading(true);
+    try {
+      const result = await getEmailLogsForTicket(ticketId, { limit: limit + 1 });
+      const nextHasMore = result.length > limit;
+      setHasMore(nextHasMore);
+      setLogs(nextHasMore ? result.slice(0, limit) : result);
+    } catch (error) {
+      console.error('Error fetching email logs for ticket:', error);
+      setLogs([]);
+      setHasMore(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [ticketId, limit]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void fetchLogs();
+  }, [isOpen, fetchLogs]);
+
+  const columns: ColumnDefinition<EmailSendingLogRecord>[] = useMemo(() => {
+    return [
+      {
+        title: 'Time',
+        dataIndex: 'sent_at',
+        render: (value) => formatSentAt(value),
+      },
+      {
+        title: 'Recipient',
+        dataIndex: 'to_addresses',
+        render: (value) => {
+          const list = parseEmailList(value);
+          return list[0] || '—';
+        },
+      },
+      {
+        title: 'Subject',
+        dataIndex: 'subject',
+        render: (value) => String(value || '—'),
+      },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        render: (value) => {
+          const v = String(value || '').toLowerCase();
+          const isFailed = v === 'failed';
+          const dotClass = isFailed ? 'bg-red-500' : 'bg-emerald-500';
+          const label = v ? v : '—';
+          return (
+            <span className="inline-flex items-center gap-2">
+              <span className={`h-2 w-2 rounded-full ${dotClass}`} aria-hidden="true" />
+              <span className="capitalize">{label}</span>
+            </span>
+          );
+        },
+      },
+      {
+        title: 'Error',
+        dataIndex: 'error_message',
+        render: (value, record) => {
+          if (record.status !== 'failed') return '—';
+          return String(value || 'Unknown error');
+        },
+      },
+    ];
+  }, []);
+
+  return (
+    <ReflectionContainer id={id} label="Ticket Email Notifications">
+      <div {...withDataAutomationId({ id })} className={styles['card']}>
+        <button
+          type="button"
+          className="w-full p-6 flex items-start justify-between gap-4"
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          <div className="text-left">
+            <h2 className="text-xl font-bold text-[rgb(var(--color-text-900))]">Email Notifications</h2>
+            <p className="text-sm text-[rgb(var(--color-text-500))] mt-1">
+              Outbound email notifications sent for this ticket
+            </p>
+          </div>
+          <span className="text-[rgb(var(--color-text-500))] mt-1 select-none">{isOpen ? 'Hide' : 'Show'}</span>
+        </button>
+
+        {isOpen && (
+          <div className="px-6 pb-6">
+            {isLoading ? (
+              <div className="text-sm text-[rgb(var(--color-text-500))]">Loading…</div>
+            ) : logs.length === 0 ? (
+              <div className="text-sm text-[rgb(var(--color-text-500))]">No email notifications found.</div>
+            ) : (
+              <DataTable id={`${id}-table`} data={logs} columns={columns} pagination={false} />
+            )}
+
+            {hasMore && !isLoading && (
+              <div className="mt-4 flex justify-center">
+                <Button id={`${id}-load-more`} variant="outline" onClick={() => setLimit((prev) => prev + LOAD_MORE_STEP)}>
+                  Load more
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </ReflectionContainer>
+  );
+};
+
+export default TicketEmailNotifications;
+

--- a/server/migrations/20260127153000_add_email_sending_log_entity_columns.cjs
+++ b/server/migrations/20260127153000_add_email_sending_log_entity_columns.cjs
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('email_sending_logs', (table) => {
+    table.string('entity_type', 50).nullable();
+    table.uuid('entity_id').nullable();
+    table.uuid('contact_id').nullable();
+    table.integer('notification_subtype_id').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('email_sending_logs', (table) => {
+    table.dropColumn('notification_subtype_id');
+    table.dropColumn('contact_id');
+    table.dropColumn('entity_id');
+    table.dropColumn('entity_type');
+  });
+};
+

--- a/server/migrations/20260127153100_add_email_sending_log_entity_indexes.cjs
+++ b/server/migrations/20260127153100_add_email_sending_log_entity_indexes.cjs
@@ -1,0 +1,35 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  const hasTenant = await knex.schema.hasColumn('email_sending_logs', 'tenant');
+  const hasTenantId = await knex.schema.hasColumn('email_sending_logs', 'tenant_id');
+  const tenantColumn = hasTenant ? 'tenant' : hasTenantId ? 'tenant_id' : null;
+
+  if (!tenantColumn) {
+    throw new Error('email_sending_logs is missing both tenant and tenant_id columns');
+  }
+
+  await knex.schema.raw(`
+    CREATE INDEX IF NOT EXISTS idx_email_sending_logs_tenant_entity
+    ON email_sending_logs (${tenantColumn}, entity_type, entity_id)
+  `);
+
+  await knex.schema.raw(`
+    CREATE INDEX IF NOT EXISTS idx_email_sending_logs_tenant_contact
+    ON email_sending_logs (${tenantColumn}, contact_id)
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.raw('DROP INDEX IF EXISTS idx_email_sending_logs_tenant_entity');
+  await knex.schema.raw('DROP INDEX IF EXISTS idx_email_sending_logs_tenant_contact');
+};
+
+// Disable transaction wrapper for Citus - CREATE INDEX can cause long locks on distributed tables
+exports.config = { transaction: false };

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -375,6 +375,7 @@ const nextConfig = {
 	    '@alga-psa/scheduling',
 	    '@alga-psa/users',
 	    '@alga-psa/notifications',
+	    '@alga-psa/email',
 	    '@alga-psa/teams',
 	    '@alga-psa/tenancy',
 	    '@alga-psa/integrations',

--- a/server/src/app/msp/email-logs/EmailLogsClient.tsx
+++ b/server/src/app/msp/email-logs/EmailLogsClient.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Card } from '@alga-psa/ui/components/Card';
+import { DataTable } from '@alga-psa/ui/components/DataTable';
+import { Input } from '@alga-psa/ui/components/Input';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader } from '@alga-psa/ui/components/Dialog';
+import {
+  getEmailLogMetrics,
+  getEmailLogs,
+  type EmailLogFilters,
+  type EmailLogMetrics,
+  type EmailSendingLogListRecord
+} from '@alga-psa/email/actions';
+import type { ColumnDefinition } from '@alga-psa/types';
+
+type EmailLogsClientProps = {
+  initialMetrics?: EmailLogMetrics;
+  initialLogs?: {
+    data: EmailSendingLogListRecord[];
+    total: number;
+    page: number;
+    pageSize: number;
+    totalPages: number;
+  };
+};
+
+const EMPTY_METRICS: EmailLogMetrics = {
+  total: 0,
+  failed: 0,
+  today: 0,
+  failedRate: 0,
+};
+
+const EMPTY_LOGS: NonNullable<EmailLogsClientProps['initialLogs']> = {
+  data: [],
+  total: 0,
+  page: 1,
+  pageSize: 50,
+  totalPages: 0,
+};
+
+function parseEmailList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item)).filter(Boolean);
+      }
+    } catch {
+      // ignore
+    }
+    return value ? [value] : [];
+  }
+  return [];
+}
+
+function formatSentAt(value: unknown): string {
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLogsClientProps) {
+  const seedLogs = initialLogs ?? EMPTY_LOGS;
+  const [metrics, setMetrics] = useState<EmailLogMetrics>(initialMetrics ?? EMPTY_METRICS);
+  const [logs, setLogs] = useState(seedLogs.data);
+  const [total, setTotal] = useState(seedLogs.total);
+  const [page, setPage] = useState(seedLogs.page);
+  const [pageSize, setPageSize] = useState(seedLogs.pageSize);
+  const [sortBy, setSortBy] = useState<NonNullable<EmailLogFilters['sortBy']>>('sent_at');
+  const [sortDirection, setSortDirection] = useState<NonNullable<EmailLogFilters['sortDirection']>>('desc');
+
+  const [status, setStatus] = useState<string>('');
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
+  const [recipientEmail, setRecipientEmail] = useState<string>('');
+  const [ticketNumber, setTicketNumber] = useState<string>('');
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [selected, setSelected] = useState<EmailSendingLogListRecord | null>(null);
+  const hasInitializedTextFilterEffect = useRef(false);
+  const hasInitializedDiscreteFilterEffect = useRef(false);
+
+  const fetchMetrics = useCallback(async () => {
+    const result = await getEmailLogMetrics();
+    setMetrics(result);
+  }, []);
+
+  const fetchLogs = useCallback(
+    async (next: Partial<EmailLogFilters> = {}) => {
+      setIsLoading(true);
+      try {
+        const result = await getEmailLogs({
+          page,
+          pageSize,
+          sortBy,
+          sortDirection,
+          startDate: startDate || undefined,
+          endDate: endDate || undefined,
+          status: status ? (status as any) : undefined,
+          recipientEmail: recipientEmail || undefined,
+          ticketNumber: ticketNumber || undefined,
+          ...next,
+        });
+        setLogs(result.data);
+        setTotal(result.total);
+        setPage(result.page);
+        setPageSize(result.pageSize);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [page, pageSize, sortBy, sortDirection, startDate, endDate, status, recipientEmail, ticketNumber]
+  );
+
+  // Debounce text-based filters to avoid spamming server actions
+  useEffect(() => {
+    if (!hasInitializedTextFilterEffect.current) {
+      hasInitializedTextFilterEffect.current = true;
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      void fetchLogs({ page: 1 });
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [recipientEmail, ticketNumber, fetchLogs]);
+
+  // Immediate refresh for discrete filters
+  useEffect(() => {
+    if (!hasInitializedDiscreteFilterEffect.current) {
+      hasInitializedDiscreteFilterEffect.current = true;
+      if (!initialLogs) {
+        void fetchLogs({ page: 1 });
+      }
+      return;
+    }
+
+    void fetchLogs({ page: 1 });
+  }, [status, startDate, endDate, fetchLogs, initialLogs]);
+
+  useEffect(() => {
+    if (initialMetrics) return;
+    void fetchMetrics();
+  }, [initialMetrics, fetchMetrics]);
+
+  const columns: ColumnDefinition<EmailSendingLogListRecord>[] = useMemo(() => {
+    return [
+      {
+        title: 'Time',
+        dataIndex: 'sent_at',
+        render: (value) => formatSentAt(value),
+      },
+      {
+        title: 'Ticket',
+        dataIndex: 'ticket_number',
+        render: (value) => String(value || '—'),
+      },
+      {
+        title: 'Recipient',
+        dataIndex: 'to_addresses',
+        render: (value) => {
+          const list = parseEmailList(value);
+          return list[0] || '—';
+        },
+      },
+      {
+        title: 'Subject',
+        dataIndex: 'subject',
+        render: (value) => String(value || '—'),
+      },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        render: (value) => {
+          const v = String(value || '').toLowerCase();
+          const isFailed = v === 'failed';
+          const dotClass = isFailed ? 'bg-red-500' : 'bg-emerald-500';
+          const label = v ? v : '—';
+          return (
+            <span className="inline-flex items-center gap-2">
+              <span className={`h-2 w-2 rounded-full ${dotClass}`} aria-hidden="true" />
+              <span className="capitalize">{label}</span>
+            </span>
+          );
+        },
+      },
+    ];
+  }, []);
+
+  const failedRatePct = Math.round((metrics.failedRate ?? 0) * 100);
+
+  return (
+    <div className="space-y-6">
+      {/* Metrics */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card className="p-4">
+          <div className="text-sm text-[rgb(var(--color-text-500))]">Total sent</div>
+          <div className="text-2xl font-semibold text-[rgb(var(--color-text-900))]">{metrics.total}</div>
+        </Card>
+        <Card className="p-4">
+          <div className="text-sm text-[rgb(var(--color-text-500))]">Failed rate</div>
+          <div className="text-2xl font-semibold text-[rgb(var(--color-text-900))]">{failedRatePct}%</div>
+        </Card>
+        <Card className="p-4">
+          <div className="text-sm text-[rgb(var(--color-text-500))]">Today</div>
+          <div className="text-2xl font-semibold text-[rgb(var(--color-text-900))]">{metrics.today}</div>
+        </Card>
+      </div>
+
+      {/* Filters + Table */}
+      <Card className="p-6">
+        <div className="mb-4 flex flex-col gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+            <Input
+              id="email-logs-filter-start-date"
+              type="date"
+              label="Start date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+            <Input
+              id="email-logs-filter-end-date"
+              type="date"
+              label="End date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+            <div>
+              <label className="block text-sm font-medium text-[rgb(var(--color-text-700))] mb-1">Status</label>
+              <select
+                className="w-full h-10 rounded-md border border-[rgb(var(--color-border-400))] bg-white px-3 text-sm"
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="sent">Sent</option>
+                <option value="failed">Failed</option>
+              </select>
+            </div>
+            <Input
+              id="email-logs-filter-recipient"
+              type="text"
+              label="Recipient"
+              placeholder="Search email…"
+              value={recipientEmail}
+              onChange={(e) => setRecipientEmail(e.target.value)}
+            />
+            <Input
+              id="email-logs-filter-ticket"
+              type="text"
+              label="Ticket"
+              placeholder="Ticket #…"
+              value={ticketNumber}
+              onChange={(e) => setTicketNumber(e.target.value)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-[rgb(var(--color-text-500))]">
+              {isLoading ? 'Loading…' : `${total} result${total === 1 ? '' : 's'}`}
+            </div>
+            <Button
+              id="email-logs-refresh"
+              variant="outline"
+              onClick={() => {
+                void fetchLogs({ page: 1 });
+                void fetchMetrics();
+              }}
+              disabled={isLoading}
+            >
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        <DataTable
+          id="email-logs-table"
+          data={logs}
+          columns={columns}
+          currentPage={page}
+          pageSize={pageSize}
+          totalItems={total}
+          onPageChange={(nextPage) => {
+            setPage(nextPage);
+            void fetchLogs({ page: nextPage });
+          }}
+          onItemsPerPageChange={(nextSize) => {
+            setPageSize(nextSize);
+            setPage(1);
+            void fetchLogs({ page: 1, pageSize: nextSize });
+          }}
+          manualSorting
+          sortBy={sortBy}
+          sortDirection={sortDirection}
+          onSortChange={(nextSortBy, nextDirection) => {
+            setSortBy(nextSortBy as any);
+            setSortDirection(nextDirection);
+            setPage(1);
+            void fetchLogs({ page: 1, sortBy: nextSortBy as any, sortDirection: nextDirection });
+          }}
+          onRowClick={(record) => setSelected(record)}
+        />
+      </Card>
+
+      <Dialog
+        id="email-log-detail"
+        isOpen={Boolean(selected)}
+        onClose={() => setSelected(null)}
+        title="Email Log Details"
+        draggable={false}
+      >
+        <DialogHeader>
+          <div className="text-sm text-[rgb(var(--color-text-500))]">{selected?.subject || 'No subject'}</div>
+        </DialogHeader>
+        <DialogContent>
+          {selected && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">Sent at</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))]">{formatSentAt(selected.sent_at)}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">Status</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))]">{selected.status}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">Provider</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))]">
+                    {selected.provider_type} ({selected.provider_id})
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">Message ID</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))] break-all">
+                    {selected.message_id || '—'}
+                  </div>
+                </div>
+                <div className="md:col-span-2">
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">To</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))] break-all">
+                    {parseEmailList(selected.to_addresses).join(', ') || '—'}
+                  </div>
+                </div>
+                <div className="md:col-span-2">
+                  <div className="text-xs text-[rgb(var(--color-text-500))]">From</div>
+                  <div className="text-sm text-[rgb(var(--color-text-900))] break-all">{selected.from_address}</div>
+                </div>
+                {selected.error_message && (
+                  <div className="md:col-span-2">
+                    <div className="text-xs text-[rgb(var(--color-text-500))]">Error</div>
+                    <div className="text-sm text-red-600 break-words">{selected.error_message}</div>
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <div className="text-xs text-[rgb(var(--color-text-500))] mb-1">Metadata</div>
+                <pre className="text-xs bg-gray-50 border border-gray-200 rounded-md p-3 overflow-auto max-h-72">
+                  {JSON.stringify(selected.metadata ?? {}, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+        <DialogFooter>
+          <Button id="email-log-detail-close" variant="outline" onClick={() => setSelected(null)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  );
+}

--- a/server/src/app/msp/email-logs/page.tsx
+++ b/server/src/app/msp/email-logs/page.tsx
@@ -1,0 +1,24 @@
+import SystemMonitoringWrapper from '@alga-psa/ui/components/system-monitoring/SystemMonitoringWrapper';
+import FeatureFlagPageWrapper from '@alga-psa/ui/components/feature-flags/FeatureFlagPageWrapper';
+import EmailLogsClient from './EmailLogsClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EmailLogsPage() {
+  return (
+    <SystemMonitoringWrapper>
+      <FeatureFlagPageWrapper featureFlag="email-logs">
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-3xl font-bold text-[rgb(var(--color-text-900))]">Email Logs</h1>
+            <p className="text-[rgb(var(--color-text-600))] mt-2">
+              Review outbound email activity and troubleshoot notification delivery.
+            </p>
+          </div>
+
+          <EmailLogsClient />
+        </div>
+      </FeatureFlagPageWrapper>
+    </SystemMonitoringWrapper>
+  );
+}

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -17,6 +17,8 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const navigationFlag = useFeatureFlag('ui-navigation-v2', { defaultValue: true });
   const useNavigationSections =
     typeof navigationFlag === 'boolean' ? navigationFlag : navigationFlag?.enabled ?? false;
+  const emailLogsFlag = useFeatureFlag('email-logs', { defaultValue: false });
+  const emailLogsEnabled = typeof emailLogsFlag === 'boolean' ? emailLogsFlag : emailLogsFlag?.enabled ?? false;
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
 
   useEffect(() => {
@@ -61,6 +63,12 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       ...section,
       items: section.items.map((item) => {
         if (item.name !== 'Automation Hub') {
+          if (item.name === 'System Monitor' && item.subItems && !emailLogsEnabled) {
+            return {
+              ...item,
+              subItems: item.subItems.filter((subItem) => subItem.name !== 'Email Logs'),
+            };
+          }
           return item;
         }
 
@@ -75,7 +83,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
         };
       })
     }));
-  }, [canWorkflowAdmin, useNavigationSections]);
+  }, [canWorkflowAdmin, useNavigationSections, emailLogsEnabled]);
 
   return (
     <Sidebar

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -150,7 +150,11 @@ export const navigationSections: NavigationSection[] = [
       {
         name: 'System Monitor',
         icon: LayoutDashboard,
-        href: '/msp/jobs'
+        href: '/msp/jobs',
+        subItems: [
+          { name: 'Jobs', icon: LayoutDashboard, href: '/msp/jobs' },
+          { name: 'Email Logs', icon: Mail, href: '/msp/email-logs' },
+        ]
       }
     ]
   }

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -223,7 +223,8 @@ async function sendNotificationIfEnabled(
     // Pass recipientUserId for rate limiting in TenantEmailService
     await sendEventEmail({
       ...params,
-      recipientUserId
+      recipientUserId,
+      notificationSubtypeId: subtype?.id
     });
 
     // 7. Log the notification (only for internal users with userId)
@@ -722,11 +723,19 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
       threadId: ticket.email_metadata?.threadId
     };
     const emailSubject = `New Ticket • ${ticket.title} (${priorityName})`;
+    const emailEntityContext = {
+      entityType: 'ticket',
+      entityId: ticket.ticket_id || payload.ticketId
+    };
+    const primaryContactId =
+      safeString(ticket.contact_email) && ticket.contact_name_id ? String(ticket.contact_name_id).trim() : undefined;
 
     // Send to primary recipient (contact or client) - external user, no userId
     if (isValidEmail(primaryEmail)) {
       await sendNotificationIfEnabled({
         tenantId,
+        ...emailEntityContext,
+        contactId: primaryContactId,
         to: primaryEmail,
         subject: emailSubject,
         template: 'ticket-created',
@@ -740,6 +749,7 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
     if (isValidEmail(assignedEmail) && assignedEmail !== primaryEmail) {
       await sendNotificationIfEnabled({
         tenantId,
+        ...emailEntityContext,
         to: assignedEmail,
         subject: emailSubject,
         template: 'ticket-created',
@@ -879,6 +889,12 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
     // Send to contact email if available, otherwise client email
     const primaryEmail = safeString(ticket.contact_email) || safeString(ticket.client_email);
     const assignedEmail = safeString(ticket.assigned_to_email);
+    const primaryContactId =
+      safeString(ticket.contact_email) && ticket.contact_name_id ? String(ticket.contact_name_id).trim() : undefined;
+    const emailEntityContext = {
+      entityType: 'ticket',
+      entityId: ticket.ticket_id || payload.ticketId
+    };
 
     console.log('[EmailSubscriber] Found ticket:', {
       ticketId: ticket.ticket_id,
@@ -1099,6 +1115,8 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
       if (isValidEmail(primaryEmail)) {
         await sendNotificationIfEnabled({
           tenantId,
+          ...emailEntityContext,
+          contactId: primaryContactId,
           to: primaryEmail,
           subject: `Ticket Updated: ${ticket.title}`,
           template: 'ticket-updated',
@@ -1115,6 +1133,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
       if (isValidEmail(assignedEmail) && assignedEmail !== primaryEmail) {
         await sendNotificationIfEnabled({
           tenantId,
+          ...emailEntityContext,
           to: assignedEmail,
           subject: `Ticket Updated: ${ticket.title}`,
           template: 'ticket-updated',
@@ -1144,6 +1163,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
         if (isValidEmail(resource.email)) {
           await sendNotificationIfEnabled({
             tenantId,
+            ...emailEntityContext,
             to: resource.email,
             subject: `Ticket Updated: ${ticket.title}`,
             template: 'ticket-updated',
@@ -1433,9 +1453,18 @@ export async function handleAccumulatedTicketUpdates(notification: PendingNotifi
 
     // Build subject line indicating multiple updates if applicable
     const subjectSuffix = accumulatedChanges.length > 1 ? ` (${accumulatedChanges.length} updates)` : '';
+    const normalizedRecipient = recipientEmail.trim().toLowerCase();
+    const contactEmail = safeString(ticket.contact_email);
+    const contactId =
+      !isInternal && contactEmail && contactEmail.trim().toLowerCase() === normalizedRecipient
+        ? (ticket.contact_name_id ? String(ticket.contact_name_id).trim() : undefined)
+        : undefined;
 
     await sendNotificationIfEnabled({
       tenantId,
+      entityType: 'ticket',
+      entityId: ticket.ticket_id,
+      contactId,
       to: recipientEmail,
       subject: `Ticket Updated: ${ticket.title}${subjectSuffix}`,
       template: 'ticket-updated',
@@ -1705,6 +1734,10 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
     };
 
     const ticketingFromAddress = await resolveTicketingFromAddress(db, tenantId);
+    const emailEntityContext = {
+      entityType: 'ticket',
+      entityId: ticket.ticket_id || payload.ticketId
+    };
 
     const sentEmails = new Set<string>();
     const normalizeEmail = (email: string) => email.trim().toLowerCase();
@@ -1734,6 +1767,7 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
     if (isValidEmail(ticket.assigned_to_email)) {
       await sendIfUnique({
         tenantId,
+        ...emailEntityContext,
         to: ticket.assigned_to_email,
         subject: `You have been assigned to ticket: ${ticket.title}`,
         template: 'ticket-assigned',
@@ -1744,10 +1778,14 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
 
     // Send to contact email if available, otherwise client email
     const primaryEmail = safeString(ticket.contact_email) || safeString(ticket.client_email);
+    const primaryContactId =
+      safeString(ticket.contact_email) && ticket.contact_name_id ? String(ticket.contact_name_id).trim() : undefined;
 
     if (isValidEmail(primaryEmail)) {
       await sendIfUnique({
         tenantId,
+        ...emailEntityContext,
+        contactId: primaryContactId,
         to: primaryEmail,
         subject: `Ticket Assigned: ${ticket.title}`,
         template: 'ticket-assigned',
@@ -1773,6 +1811,7 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
       if (isValidEmail(resource.email)) {
         await sendIfUnique({
           tenantId,
+          ...emailEntityContext,
           to: resource.email,
           subject: `You have been added as additional resource to ticket: ${ticket.title}`,
           template: 'ticket-assigned',
@@ -2042,6 +2081,12 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
     // Determine primary email (contact first, then client)
     const primaryEmail = safeString(ticket.contact_email) || safeString(ticket.client_email);
+    const primaryContactId =
+      safeString(ticket.contact_email) && ticket.contact_name_id ? String(ticket.contact_name_id).trim() : undefined;
+    const emailEntityContext = {
+      entityType: 'ticket',
+      entityId: ticket.ticket_id || payload.ticketId
+    };
 
     const emailMetadata = ticket.email_metadata || {};
 
@@ -2099,6 +2144,8 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       // For client portal users (contacts), pass the clientId so locale resolution respects client preferences
       const emailParams: SendEmailParams = {
         tenantId,
+        ...emailEntityContext,
+        contactId: primaryContactId,
         to: primaryEmail,
         subject: `New Comment on Ticket: ${ticket.title}`,
         template: 'ticket-comment-added',
@@ -2168,6 +2215,8 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 
           await sendIfUnique({
             tenantId,
+            entityType: 'ticket',
+            entityId: child.ticket_id,
             to: childPrimaryEmail,
             subject: `New Comment on Ticket: ${ticket.title}`,
             template: 'ticket-comment-added',
@@ -2202,6 +2251,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     if (assignedEmail && assignedEmail !== primaryEmail && !isAssignedUserTheCommentAuthor) {
       await sendIfUnique({
         tenantId,
+        ...emailEntityContext,
         to: assignedEmail,
         subject: `New Comment on Ticket: ${ticket.title}`,
         template: 'ticket-comment-added',
@@ -2222,6 +2272,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       if (!isResourceTheCommentAuthor) {
         await sendIfUnique({
           tenantId,
+          ...emailEntityContext,
           to: resource.email,
           subject: `New Comment on Ticket: ${ticket.title}`,
           template: 'ticket-comment-added',

--- a/server/src/lib/notifications/sendEventEmail.ts
+++ b/server/src/lib/notifications/sendEventEmail.ts
@@ -31,6 +31,19 @@ export interface SendEmailParams {
   subject: string;
   template: string;
   context: Record<string, unknown>;
+  /**
+   * Optional entity context for downstream logging (e.g. ticket/project association).
+   */
+  entityType?: string;
+  entityId?: string;
+  /**
+   * Optional contact association for outbound emails (when recipient is a contact).
+   */
+  contactId?: string;
+  /**
+   * Optional notification subtype association (links to notification_subtypes.id).
+   */
+  notificationSubtypeId?: number;
   replyContext?: {
     ticketId?: string;
     projectId?: string;
@@ -397,6 +410,10 @@ export async function sendEventEmail(params: SendEmailParams): Promise<void> {
     const result = await service.sendEmail({
       to: params.to,
       tenantId: params.tenantId,
+      entityType: params.entityType,
+      entityId: params.entityId,
+      contactId: params.contactId,
+      notificationSubtypeId: params.notificationSubtypeId,
       templateProcessor: processor,
       headers: params.headers,
       providerId: params.providerId,

--- a/server/src/test/integration/email/baseEmailServiceLogging.integration.test.ts
+++ b/server/src/test/integration/email/baseEmailServiceLogging.integration.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
+import type { EmailMessage, EmailSendResult, EmailProviderCapabilities, IEmailProvider } from '@alga-psa/types';
+import { BaseEmailService } from '@alga-psa/email/BaseEmailService';
+import { resetTenantConnectionPool } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../../test-utils/dbConfig';
+
+const capabilities: EmailProviderCapabilities = {
+  supportsHtml: true,
+  supportsAttachments: true,
+  supportsTemplating: false,
+  supportsBulkSending: false,
+  supportsTracking: false,
+  supportsCustomDomains: false,
+};
+
+class TestEmailService extends BaseEmailService {
+  constructor(private readonly provider: IEmailProvider) {
+    super();
+  }
+
+  protected async getEmailProvider(): Promise<IEmailProvider | null> {
+    return this.provider;
+  }
+
+  protected getFromAddress(): string {
+    return 'from@example.com';
+  }
+
+  protected getServiceName(): string {
+    return 'TestEmailService';
+  }
+}
+
+async function waitForEmailLog(knex: Knex, where: Record<string, any>, timeoutMs = 5000) {
+  const startedAt = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await knex('email_sending_logs').where(where).orderBy('id', 'desc').first();
+    if (row) return row;
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out waiting for email_sending_logs row: ${JSON.stringify(where)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+describe('BaseEmailService → email_sending_logs', () => {
+  let knex: Knex;
+  let tenantId: string;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection();
+    await resetTenantConnectionPool();
+
+    const tenant = await knex('tenants').first('tenant');
+    if (!tenant?.tenant) {
+      throw new Error('No tenant found in seeded test DB');
+    }
+    tenantId = tenant.tenant;
+  });
+
+  beforeEach(async () => {
+    await knex('email_sending_logs').del();
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+    await resetTenantConnectionPool();
+  });
+
+  it('successful send creates log entry with status sent', async () => {
+    const messageId = `msg-${uuidv4()}`;
+    const provider: IEmailProvider = {
+      providerId: 'test-provider',
+      providerType: 'test',
+      capabilities,
+      async initialize() {
+        // no-op
+      },
+      async sendEmail(_message: EmailMessage, _tenant: string): Promise<EmailSendResult> {
+        return {
+          success: true,
+          messageId,
+          providerId: 'test-provider',
+          providerType: 'test',
+          metadata: { ok: true },
+          sentAt: new Date(),
+        };
+      },
+      async healthCheck() {
+        return { healthy: true };
+      },
+    };
+
+    const service = new TestEmailService(provider);
+    const entityId = uuidv4();
+    const contactId = uuidv4();
+
+    const result = await service.sendEmail({
+      tenantId,
+      to: 'to@example.com',
+      subject: 'Hello',
+      html: '<p>Hello</p>',
+      entityType: 'ticket',
+      entityId,
+      contactId,
+      notificationSubtypeId: 42,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe(messageId);
+
+    const row = await waitForEmailLog(knex, { tenant: tenantId, message_id: messageId });
+    expect(row.status).toBe('sent');
+    expect(row.message_id).toBe(messageId);
+    expect(row.from_address).toBe('from@example.com');
+    expect(row.subject).toBe('Hello');
+    expect(row.provider_id).toBe('test-provider');
+    expect(row.provider_type).toBe('test');
+    expect(row.entity_type).toBe('ticket');
+    expect(row.entity_id).toBe(entityId);
+    expect(row.contact_id).toBe(contactId);
+    expect(row.notification_subtype_id).toBe(42);
+
+    const toAddresses = Array.isArray(row.to_addresses) ? row.to_addresses : [];
+    expect(toAddresses).toContain('to@example.com');
+  });
+
+  it('failed send creates log entry with status failed and error_message', async () => {
+    const messageId = `msg-${uuidv4()}`;
+    const provider: IEmailProvider = {
+      providerId: 'test-provider',
+      providerType: 'test',
+      capabilities,
+      async initialize() {
+        // no-op
+      },
+      async sendEmail(_message: EmailMessage, _tenant: string): Promise<EmailSendResult> {
+        return {
+          success: false,
+          messageId,
+          providerId: 'test-provider',
+          providerType: 'test',
+          error: 'Provider rejected request',
+          metadata: { ok: false },
+          sentAt: new Date(),
+        };
+      },
+      async healthCheck() {
+        return { healthy: true };
+      },
+    };
+
+    const service = new TestEmailService(provider);
+
+    const result = await service.sendEmail({
+      tenantId,
+      to: 'to@example.com',
+      subject: 'Hello',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.messageId).toBe(messageId);
+
+    const row = await waitForEmailLog(knex, { tenant: tenantId, message_id: messageId });
+    expect(row.status).toBe('failed');
+    expect(row.error_message).toBe('Provider rejected request');
+  });
+});

--- a/server/src/test/integration/email/emailLogActions.getEmailLogMetrics.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogMetrics.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Knex } from 'knex';
+import { resetTenantConnectionPool } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../../test-utils/dbConfig';
+
+let mockTenantId = 'tenant-test';
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+}));
+
+import { getEmailLogMetrics } from '@alga-psa/email/actions';
+
+describe('emailLogActions.getEmailLogMetrics', () => {
+  let knex: Knex;
+  let tenantId: string;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection();
+    await resetTenantConnectionPool();
+
+    const tenant = await knex('tenants').first('tenant');
+    if (!tenant?.tenant) {
+      throw new Error('No tenant found in seeded test DB');
+    }
+    tenantId = tenant.tenant;
+    mockTenantId = tenantId;
+  });
+
+  beforeEach(async () => {
+    await knex('email_sending_logs').del();
+
+    await knex('email_sending_logs').insert([
+      {
+        tenant: tenantId,
+        message_id: 'm1',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['a@example.com']),
+        subject: 'A1',
+        status: 'sent',
+        sent_at: new Date(),
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm2',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['b@example.com']),
+        subject: 'B1',
+        status: 'failed',
+        sent_at: new Date(),
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+    await resetTenantConnectionPool();
+  });
+
+  it('returns total, failed, today, failedRate', async () => {
+    const result = await getEmailLogMetrics();
+    expect(result.total).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.today).toBeGreaterThanOrEqual(0);
+    expect(result.failedRate).toBeCloseTo(0.5);
+  });
+});

--- a/server/src/test/integration/email/emailLogActions.getEmailLogs.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogs.integration.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
+import { resetTenantConnectionPool } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../../test-utils/dbConfig';
+
+let mockTenantId = 'tenant-test';
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+}));
+
+import { getEmailLogs } from '@alga-psa/email/actions';
+
+describe('emailLogActions.getEmailLogs', () => {
+  let knex: Knex;
+  let tenantId: string;
+  const ticketId = uuidv4();
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection();
+    await resetTenantConnectionPool();
+
+    const tenant = await knex('tenants').first('tenant');
+    if (!tenant?.tenant) {
+      throw new Error('No tenant found in seeded test DB');
+    }
+    tenantId = tenant.tenant;
+    mockTenantId = tenantId;
+  });
+
+  beforeEach(async () => {
+    await knex('email_sending_logs').del();
+
+    await knex('email_sending_logs').insert([
+      {
+        tenant: tenantId,
+        message_id: 'm1',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['alice@example.com']),
+        subject: 'A1',
+        status: 'sent',
+        sent_at: new Date('2026-01-01T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm2',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['bob@example.com']),
+        subject: 'B1',
+        status: 'failed',
+        error_message: 'boom',
+        sent_at: new Date('2026-01-02T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm3',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['alice@example.com']),
+        subject: 'A2',
+        status: 'sent',
+        sent_at: new Date('2026-01-02T12:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm4',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['carol@example.com']),
+        subject: 'C1',
+        status: 'sent',
+        sent_at: new Date('2026-01-03T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+    await resetTenantConnectionPool();
+  });
+
+  it('returns paginated results', async () => {
+    const result = await getEmailLogs({ page: 1, pageSize: 2, sortBy: 'sent_at', sortDirection: 'desc' });
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(2);
+    expect(result.total).toBe(4);
+    expect(result.data.length).toBe(2);
+    expect(result.totalPages).toBe(2);
+  });
+
+  it('filters by date range when provided', async () => {
+    const result = await getEmailLogs({
+      page: 1,
+      pageSize: 50,
+      startDate: '2026-01-02T00:00:00Z',
+      endDate: '2026-01-02T23:59:59Z',
+    });
+    const messageIds = result.data.map((r) => r.message_id);
+    expect(messageIds.sort()).toEqual(['m2', 'm3']);
+  });
+
+  it('treats date-only endDate as inclusive end of day', async () => {
+    const result = await getEmailLogs({
+      page: 1,
+      pageSize: 50,
+      startDate: '2026-01-02',
+      endDate: '2026-01-02',
+    });
+    const messageIds = result.data.map((r) => r.message_id).sort();
+    expect(messageIds).toEqual(['m2', 'm3']);
+  });
+
+  it('filters by status when provided', async () => {
+    const result = await getEmailLogs({ page: 1, pageSize: 50, status: 'failed' });
+    expect(result.total).toBe(1);
+    expect(result.data.length).toBe(1);
+    expect(result.data[0]?.message_id).toBe('m2');
+    expect(result.data[0]?.status).toBe('failed');
+  });
+
+  it('filters by recipient email when provided', async () => {
+    const result = await getEmailLogs({ page: 1, pageSize: 50, recipientEmail: 'alice@example.com' });
+    const messageIds = result.data.map((r) => r.message_id).sort();
+    expect(messageIds).toEqual(['m1', 'm3']);
+  });
+
+  it('supports sorting by sent_at ascending/descending', async () => {
+    const asc = await getEmailLogs({ page: 1, pageSize: 50, sortBy: 'sent_at', sortDirection: 'asc' });
+    expect(asc.data[0]?.message_id).toBe('m1');
+    expect(asc.data[asc.data.length - 1]?.message_id).toBe('m4');
+
+    const desc = await getEmailLogs({ page: 1, pageSize: 50, sortBy: 'sent_at', sortDirection: 'desc' });
+    expect(desc.data[0]?.message_id).toBe('m4');
+    expect(desc.data[desc.data.length - 1]?.message_id).toBe('m1');
+  });
+});

--- a/server/src/test/integration/email/emailLogActions.getEmailLogsForTicket.integration.test.ts
+++ b/server/src/test/integration/email/emailLogActions.getEmailLogsForTicket.integration.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
+import { resetTenantConnectionPool } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../../test-utils/dbConfig';
+
+let mockTenantId = 'tenant-test';
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => async (...args: any[]) =>
+    fn({ user_id: 'user-test', tenant: mockTenantId, roles: [] }, { tenant: mockTenantId }, ...args),
+}));
+
+import { getEmailLogsForTicket } from '@alga-psa/email/actions';
+
+describe('emailLogActions.getEmailLogsForTicket', () => {
+  let knex: Knex;
+  let tenantId: string;
+  const ticketId = uuidv4();
+  const otherTicketId = uuidv4();
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection();
+    await resetTenantConnectionPool();
+
+    const tenant = await knex('tenants').first('tenant');
+    if (!tenant?.tenant) {
+      throw new Error('No tenant found in seeded test DB');
+    }
+    tenantId = tenant.tenant;
+    mockTenantId = tenantId;
+  });
+
+  beforeEach(async () => {
+    await knex('email_sending_logs').del();
+
+    await knex('email_sending_logs').insert([
+      {
+        tenant: tenantId,
+        message_id: 'm1',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['a@example.com']),
+        subject: 'A1',
+        status: 'sent',
+        sent_at: new Date('2026-01-03T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm2',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['b@example.com']),
+        subject: 'B1',
+        status: 'failed',
+        sent_at: new Date('2026-01-04T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: ticketId,
+      },
+      {
+        tenant: tenantId,
+        message_id: 'm3',
+        provider_id: 'p',
+        provider_type: 'test',
+        from_address: 'from@example.com',
+        to_addresses: JSON.stringify(['c@example.com']),
+        subject: 'C1',
+        status: 'sent',
+        sent_at: new Date('2026-01-05T10:00:00Z'),
+        entity_type: 'ticket',
+        entity_id: otherTicketId,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+    await resetTenantConnectionPool();
+  });
+
+  it('returns logs for a ticket ordered by sent_at desc', async () => {
+    const result = await getEmailLogsForTicket(ticketId, { limit: 50 });
+    expect(result.map((r) => r.message_id)).toEqual(['m2', 'm1']);
+  });
+
+  it('respects limit', async () => {
+    const result = await getEmailLogsForTicket(ticketId, { limit: 1 });
+    expect(result.length).toBe(1);
+    expect(result[0]?.message_id).toBe('m2');
+  });
+});

--- a/server/src/test/integration/email/emailSendingLogsMigration.integration.test.ts
+++ b/server/src/test/integration/email/emailSendingLogsMigration.integration.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { createRequire } from 'node:module';
+import { createTestDbConnection } from '../../../../test-utils/dbConfig';
+
+const require = createRequire(import.meta.url);
+
+describe('email_sending_logs entity context migrations', () => {
+  let knex: Knex;
+
+  beforeAll(async () => {
+    knex = await createTestDbConnection();
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+  });
+
+  it('adds entity_type column', async () => {
+    await expect(knex.schema.hasColumn('email_sending_logs', 'entity_type')).resolves.toBe(true);
+  });
+
+  it('adds entity_id column', async () => {
+    await expect(knex.schema.hasColumn('email_sending_logs', 'entity_id')).resolves.toBe(true);
+  });
+
+  it('adds contact_id column', async () => {
+    await expect(knex.schema.hasColumn('email_sending_logs', 'contact_id')).resolves.toBe(true);
+  });
+
+  it('adds notification_subtype_id column', async () => {
+    await expect(knex.schema.hasColumn('email_sending_logs', 'notification_subtype_id')).resolves.toBe(true);
+  });
+
+  it('creates tenant/entity index', async () => {
+    const result = await knex.raw(
+      `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'email_sending_logs'`
+    );
+    const indexNames = (result?.rows ?? []).map((row: any) => row.indexname);
+    expect(indexNames).toContain('idx_email_sending_logs_tenant_entity');
+  });
+
+  it('creates tenant/contact index', async () => {
+    const result = await knex.raw(
+      `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'email_sending_logs'`
+    );
+    const indexNames = (result?.rows ?? []).map((row: any) => row.indexname);
+    expect(indexNames).toContain('idx_email_sending_logs_tenant_contact');
+  });
+
+  it('migration files export up/down functions', async () => {
+    const indexesMigration = require('../../../../migrations/20260127153100_add_email_sending_log_entity_indexes.cjs');
+    const columnsMigration = require('../../../../migrations/20260127153000_add_email_sending_log_entity_columns.cjs');
+
+    expect(typeof columnsMigration.up).toBe('function');
+    expect(typeof columnsMigration.down).toBe('function');
+    expect(typeof indexesMigration.up).toBe('function');
+    expect(typeof indexesMigration.down).toBe('function');
+  });
+});

--- a/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
+++ b/server/src/test/unit/email/EmailLogsClient.ui.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmailLogsClient from 'server/src/app/msp/email-logs/EmailLogsClient';
+
+vi.mock('@alga-psa/email/actions', () => ({
+  getEmailLogs: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ui/components/Card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, onClick, id, ...props }: any) => (
+    <button data-automation-id={id} onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ isOpen, children }: any) => (isOpen ? <div data-testid="dialog">{children}</div> : null),
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/DataTable', () => ({
+  DataTable: ({ data, columns, onRowClick }: any) => (
+    <table>
+      <tbody>
+        {data.map((row: any, idx: number) => (
+          <tr key={row.id ?? idx} onClick={() => onRowClick?.(row)}>
+            {columns.map((col: any, colIdx: number) => {
+              const value = row[col.dataIndex];
+              const cell = col.render ? col.render(value, row, idx) : String(value ?? '');
+              return <td key={colIdx}>{cell}</td>;
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+import { getEmailLogs } from '@alga-psa/email/actions';
+
+const getEmailLogsMock = vi.mocked(getEmailLogs);
+
+describe('EmailLogsClient', () => {
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    getEmailLogsMock.mockReset();
+    getEmailLogsMock.mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      pageSize: 50,
+      totalPages: 0,
+    } as any);
+  });
+
+  it('renders metrics cards', () => {
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 10, failed: 2, today: 3, failedRate: 0.2 }}
+        initialLogs={{ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 }}
+      />
+    );
+
+    expect(screen.getByText('Total sent')).toBeTruthy();
+    expect(screen.getByText('10')).toBeTruthy();
+    expect(screen.getByText('Failed rate')).toBeTruthy();
+    expect(screen.getByText('20%')).toBeTruthy();
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+
+  it('updates results when status filter changes', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 }}
+      />
+    );
+
+    await user.selectOptions(screen.getByRole('combobox'), 'failed');
+
+    await waitFor(() => {
+      const lastCall = getEmailLogsMock.mock.calls.at(-1)?.[0] as any;
+      expect(lastCall.status).toBe('failed');
+    });
+  });
+
+  it('updates results when date range filter changes', async () => {
+    getEmailLogsMock
+      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            sent_at: '2026-01-01T00:00:00Z',
+            ticket_number: '123',
+            to_addresses: ['to@example.com'],
+            subject: 'Filtered',
+            status: 'sent',
+            provider_type: 'test',
+            provider_id: 'p',
+            message_id: 'm1',
+            from_address: 'from@example.com',
+            metadata: {},
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 50,
+        totalPages: 1,
+      } as any);
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 }}
+      />
+    );
+
+    const start = document.querySelector('#email-logs-filter-start-date') as HTMLInputElement;
+    fireEvent.change(start, { target: { value: '2026-01-01' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Filtered')).toBeTruthy();
+    });
+
+    const lastCall = getEmailLogsMock.mock.calls.at(-1)?.[0] as any;
+    expect(lastCall.startDate).toBe('2026-01-01');
+  });
+
+  it('updates results when recipient search changes', async () => {
+    getEmailLogsMock
+      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            sent_at: '2026-01-01T00:00:00Z',
+            ticket_number: '123',
+            to_addresses: ['alice@example.com'],
+            subject: 'Recipient filtered',
+            status: 'sent',
+            provider_type: 'test',
+            provider_id: 'p',
+            message_id: 'm1',
+            from_address: 'from@example.com',
+            metadata: {},
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 50,
+        totalPages: 1,
+      } as any);
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 }}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search email…'), { target: { value: 'alice' } });
+
+    await waitFor(() => {
+      const lastCall = getEmailLogsMock.mock.calls.at(-1)?.[0] as any;
+      expect(lastCall.recipientEmail).toBe('alice');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Recipient filtered')).toBeTruthy();
+    });
+  });
+
+  it('updates results when ticket filter changes', async () => {
+    getEmailLogsMock
+      .mockResolvedValueOnce({ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 } as any)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            sent_at: '2026-01-01T00:00:00Z',
+            ticket_number: '123',
+            to_addresses: ['to@example.com'],
+            subject: 'Ticket filtered',
+            status: 'sent',
+            provider_type: 'test',
+            provider_id: 'p',
+            message_id: 'm1',
+            from_address: 'from@example.com',
+            metadata: {},
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 50,
+        totalPages: 1,
+      } as any);
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 0, failed: 0, today: 0, failedRate: 0 }}
+        initialLogs={{ data: [], total: 0, page: 1, pageSize: 50, totalPages: 0 }}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Ticket #…'), { target: { value: '123' } });
+
+    await waitFor(() => {
+      const lastCall = getEmailLogsMock.mock.calls.at(-1)?.[0] as any;
+      expect(lastCall.ticketNumber).toBe('123');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ticket filtered')).toBeTruthy();
+    });
+  });
+
+  it('opens detail dialog when a row is clicked', async () => {
+    const user = userEvent.setup();
+
+    getEmailLogsMock.mockResolvedValue({
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+      data: [
+        {
+          id: 1,
+          sent_at: '2026-01-01T00:00:00Z',
+          ticket_number: '123',
+          to_addresses: ['to@example.com'],
+          subject: 'Hello',
+          status: 'sent',
+          provider_type: 'test',
+          provider_id: 'p',
+          message_id: 'm1',
+          from_address: 'from@example.com',
+          error_message: 'Boom',
+          metadata: { ok: true },
+        },
+      ] as any,
+    } as any);
+
+    render(
+      <EmailLogsClient
+        initialMetrics={{ total: 1, failed: 0, today: 1, failedRate: 0 }}
+        initialLogs={{
+          total: 1,
+          page: 1,
+          pageSize: 50,
+          totalPages: 1,
+          data: [
+            {
+              id: 1,
+              sent_at: '2026-01-01T00:00:00Z',
+              ticket_number: '123',
+              to_addresses: ['to@example.com'],
+              subject: 'Hello',
+              status: 'sent',
+              provider_type: 'test',
+              provider_id: 'p',
+              message_id: 'm1',
+              from_address: 'from@example.com',
+              error_message: 'Boom',
+              metadata: { ok: true },
+            },
+          ] as any,
+        }}
+      />
+    );
+
+    await screen.findByText('Hello');
+    await user.click(screen.getByText('Hello'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeTruthy();
+    });
+
+    const dialog = screen.getByTestId('dialog');
+    expect(within(dialog).getByText('Sent at')).toBeTruthy();
+    expect(within(dialog).getByText('Status')).toBeTruthy();
+    expect(within(dialog).getByText('Provider')).toBeTruthy();
+    expect(within(dialog).getByText('Message ID')).toBeTruthy();
+    expect(within(dialog).getByText('To')).toBeTruthy();
+    expect(within(dialog).getByText('From')).toBeTruthy();
+    expect(within(dialog).getByText('Error')).toBeTruthy();
+    expect(within(dialog).getByText('Metadata')).toBeTruthy();
+
+    expect(within(dialog).getByText(/test \(p\)/i)).toBeTruthy();
+    expect(within(dialog).getByText('m1')).toBeTruthy();
+    expect(within(dialog).getByText('to@example.com')).toBeTruthy();
+    expect(within(dialog).getByText('from@example.com')).toBeTruthy();
+    expect(within(dialog).getByText('Boom')).toBeTruthy();
+    expect(within(dialog).getByText(/"ok": true/)).toBeTruthy();
+  });
+});

--- a/server/src/test/unit/email/EmailLogsPage.route.test.ts
+++ b/server/src/test/unit/email/EmailLogsPage.route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+describe('/msp/email-logs route', () => {
+  it('has a page.tsx entrypoint', async () => {
+    const filePath = path.resolve(process.cwd(), 'src/app/msp/email-logs/page.tsx');
+    const contents = await fs.readFile(filePath, 'utf8');
+
+    expect(contents).toContain('export default');
+    expect(contents).toContain('Email Logs');
+  });
+});

--- a/server/src/test/unit/email/baseEmailParams.types.test.ts
+++ b/server/src/test/unit/email/baseEmailParams.types.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { BaseEmailParams } from '@alga-psa/email/BaseEmailService';
+
+describe('BaseEmailParams type surface', () => {
+  it('accepts entityType', () => {
+    const params: BaseEmailParams = {
+      to: 'to@example.com',
+      entityType: 'ticket',
+    };
+    expect(params.entityType).toBe('ticket');
+  });
+
+  it('accepts entityId', () => {
+    const params: BaseEmailParams = {
+      to: 'to@example.com',
+      entityId: '00000000-0000-0000-0000-000000000000',
+    };
+    expect(params.entityId).toBe('00000000-0000-0000-0000-000000000000');
+  });
+
+  it('accepts contactId', () => {
+    const params: BaseEmailParams = {
+      to: 'to@example.com',
+      contactId: '00000000-0000-0000-0000-000000000000',
+    };
+    expect(params.contactId).toBe('00000000-0000-0000-0000-000000000000');
+  });
+
+  it('accepts notificationSubtypeId', () => {
+    const params: BaseEmailParams = {
+      to: 'to@example.com',
+      notificationSubtypeId: 123,
+    };
+    expect(params.notificationSubtypeId).toBe(123);
+  });
+});
+

--- a/server/src/test/unit/email/emailLoggingFailure.test.ts
+++ b/server/src/test/unit/email/emailLoggingFailure.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EmailMessage, EmailProviderCapabilities, EmailSendResult, IEmailProvider } from '@alga-psa/types';
+
+const { loggerWarn, loggerInfo, loggerError } = vi.hoisted(() => ({
+  loggerWarn: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    warn: loggerWarn,
+    info: loggerInfo,
+    error: loggerError,
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => {
+    throw new Error('DB unavailable');
+  }),
+}));
+
+import { BaseEmailService } from '@alga-psa/email/BaseEmailService';
+
+const capabilities: EmailProviderCapabilities = {
+  supportsHtml: true,
+  supportsAttachments: false,
+  supportsTemplating: false,
+  supportsBulkSending: false,
+  supportsTracking: false,
+  supportsCustomDomains: false,
+};
+
+class TestEmailService extends BaseEmailService {
+  constructor(private readonly provider: IEmailProvider) {
+    super();
+  }
+
+  protected async getEmailProvider(): Promise<IEmailProvider | null> {
+    return this.provider;
+  }
+
+  protected getFromAddress(): string {
+    return 'from@example.com';
+  }
+
+  protected getServiceName(): string {
+    return 'TestEmailService';
+  }
+}
+
+describe('BaseEmailService logging failure handling', () => {
+  it('does not throw or block when email_sending_logs insert fails', async () => {
+    const provider: IEmailProvider = {
+      providerId: 'test-provider',
+      providerType: 'test',
+      capabilities,
+      async initialize() {
+        // no-op
+      },
+      async sendEmail(_message: EmailMessage, _tenant: string): Promise<EmailSendResult> {
+        return {
+          success: true,
+          messageId: 'msg-1',
+          providerId: 'test-provider',
+          providerType: 'test',
+          sentAt: new Date(),
+        };
+      },
+      async healthCheck() {
+        return { healthy: true };
+      },
+    };
+
+    const service = new TestEmailService(provider);
+
+    const result = await service.sendEmail({
+      tenantId: 'tenant-test',
+      to: 'to@example.com',
+      subject: 'Hello',
+      html: '<p>Hello</p>',
+    });
+
+    expect(result.success).toBe(true);
+
+    // Allow the best-effort logging promise to run.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(loggerWarn).toHaveBeenCalled();
+    expect(String(loggerWarn.mock.calls[0]?.[0] ?? '')).toContain('Failed to write email_sending_logs record');
+  });
+});

--- a/server/src/test/unit/menuConfig.emailLogs.test.ts
+++ b/server/src/test/unit/menuConfig.emailLogs.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { navigationSections } from '../../config/menuConfig';
+
+describe('navigationSections', () => {
+  it('includes Email Logs link under System Monitor', () => {
+    const items = navigationSections.flatMap((section) => section.items);
+    const systemMonitorItem = items.find((item) => item.name === 'System Monitor');
+
+    expect(systemMonitorItem).toBeTruthy();
+    expect(systemMonitorItem?.subItems?.length).toBeTruthy();
+
+    const emailLogsItem = systemMonitorItem?.subItems?.find((item) => item.name === 'Email Logs');
+    expect(emailLogsItem).toBeTruthy();
+    expect(emailLogsItem?.href).toBe('/msp/email-logs');
+  });
+});
+

--- a/server/src/test/unit/tickets/TicketDetails.emailNotifications.integration.test.ts
+++ b/server/src/test/unit/tickets/TicketDetails.emailNotifications.integration.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+describe('TicketDetails', () => {
+  it('includes the TicketEmailNotifications section', async () => {
+    const filePath = path.resolve(process.cwd(), '../packages/tickets/src/components/ticket/TicketDetails.tsx');
+    const contents = await fs.readFile(filePath, 'utf8');
+
+    expect(contents).toContain('TicketEmailNotifications');
+    expect(contents).toContain('<TicketEmailNotifications');
+  });
+});

--- a/server/src/test/unit/tickets/TicketEmailNotifications.ui.test.tsx
+++ b/server/src/test/unit/tickets/TicketEmailNotifications.ui.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TicketEmailNotifications from '@alga-psa/tickets/components/ticket/TicketEmailNotifications';
+
+vi.mock('@alga-psa/email/actions', () => ({
+  getEmailLogsForTicket: vi.fn(),
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/ReflectionContainer', () => ({
+  ReflectionContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/ui-reflection/withDataAutomationId', () => ({
+  withDataAutomationId: ({ id }: { id: string }) => ({ 'data-automation-id': id }),
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, onClick, id, ...props }: any) => (
+    <button data-automation-id={id} onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DataTable', () => ({
+  DataTable: ({ id, data, columns }: any) => (
+    <table data-automation-id={id}>
+      <tbody>
+        {data.map((row: any, rowIndex: number) => (
+          <tr key={row.id ?? rowIndex}>
+            {columns.map((col: any, colIndex: number) => {
+              const value = row[col.dataIndex];
+              const cell = col.render ? col.render(value, row, rowIndex) : String(value ?? '');
+              return <td key={colIndex}>{cell}</td>;
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+import { getEmailLogsForTicket } from '@alga-psa/email/actions';
+
+const getEmailLogsForTicketMock = vi.mocked(getEmailLogsForTicket);
+
+describe('TicketEmailNotifications', () => {
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    getEmailLogsForTicketMock.mockReset();
+  });
+
+  it('renders without errors', () => {
+    getEmailLogsForTicketMock.mockResolvedValue([]);
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+    expect(screen.getByText('Email Notifications')).toBeTruthy();
+  });
+
+  it('is collapsed by default and expands on click', async () => {
+    const user = userEvent.setup();
+    getEmailLogsForTicketMock.mockResolvedValue([]);
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+
+    expect(screen.queryByText('No email notifications found.')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /show/i }));
+    await waitFor(() => {
+      expect(screen.getByText('No email notifications found.')).toBeTruthy();
+    });
+  });
+
+  it('shows loading state while fetching', async () => {
+    const user = userEvent.setup();
+    let resolveFetch: (value: any[]) => void;
+    const pending = new Promise<any[]>((resolve) => {
+      resolveFetch = resolve;
+    });
+    // @ts-expect-error resolveFetch is assigned synchronously above
+    getEmailLogsForTicketMock.mockReturnValue(pending);
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+
+    await user.click(screen.getByRole('button', { name: /show/i }));
+    expect(screen.getByText('Loading…')).toBeTruthy();
+
+    resolveFetch!([]);
+    await waitFor(() => {
+      expect(screen.getByText('No email notifications found.')).toBeTruthy();
+    });
+  });
+
+  it('displays timestamp, recipient, subject, and status for each log entry', async () => {
+    const user = userEvent.setup();
+    getEmailLogsForTicketMock.mockResolvedValue([
+      {
+        id: 1,
+        sent_at: '2026-01-01T12:00:00Z',
+        to_addresses: ['to@example.com'],
+        subject: 'Hello',
+        status: 'sent',
+        error_message: null,
+      } as any,
+    ]);
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+
+    await user.click(screen.getByRole('button', { name: /show/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello')).toBeTruthy();
+    });
+
+    expect(screen.getByText('to@example.com')).toBeTruthy();
+    const statusLabel = screen.getByText(/^sent$/i);
+    expect(statusLabel.parentElement?.querySelector('.bg-emerald-500')).toBeTruthy();
+    // Timestamp formatting is locale-dependent; assert we render a value that includes the year.
+    expect(screen.getByText(/2026/)).toBeTruthy();
+  });
+
+  it('shows error message for failed notifications', async () => {
+    const user = userEvent.setup();
+    getEmailLogsForTicketMock.mockResolvedValue([
+      {
+        id: 1,
+        sent_at: '2026-01-01T12:00:00Z',
+        to_addresses: ['to@example.com'],
+        subject: 'Hello',
+        status: 'failed',
+        error_message: 'Boom',
+      } as any,
+    ]);
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+    await user.click(screen.getByRole('button', { name: /show/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Boom')).toBeTruthy();
+    });
+
+    const statusLabel = screen.getByText(/^failed$/i);
+    expect(statusLabel.parentElement?.querySelector('.bg-red-500')).toBeTruthy();
+  });
+
+  it('shows maximum 20 entries initially with Load more when more exist', async () => {
+    const user = userEvent.setup();
+    const logs = Array.from({ length: 25 }, (_, idx) => ({
+      id: idx + 1,
+      sent_at: '2026-01-01T12:00:00Z',
+      to_addresses: [`user${idx}@example.com`],
+      subject: `S${idx}`,
+      status: 'sent',
+      error_message: null,
+    })) as any[];
+
+    getEmailLogsForTicketMock.mockResolvedValueOnce(logs.slice(0, 21)); // limit+1
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+    await user.click(screen.getByRole('button', { name: /show/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('S0')).toBeTruthy();
+    });
+
+    // Our DataTable mock renders one <tr> per item.
+    const rows = screen.getByRole('table').querySelectorAll('tr');
+    expect(rows.length).toBe(20);
+
+    expect(screen.getByRole('button', { name: /load more/i })).toBeTruthy();
+  });
+
+  it('Load more fetches additional entries', async () => {
+    const user = userEvent.setup();
+    const logs = Array.from({ length: 25 }, (_, idx) => ({
+      id: idx + 1,
+      sent_at: '2026-01-01T12:00:00Z',
+      to_addresses: [`user${idx}@example.com`],
+      subject: `S${idx}`,
+      status: 'sent',
+      error_message: null,
+    })) as any[];
+
+    getEmailLogsForTicketMock
+      .mockResolvedValueOnce(logs.slice(0, 21)) // initial fetch (limit+1)
+      .mockResolvedValueOnce(logs); // after load more (limit+1 big enough)
+
+    render(<TicketEmailNotifications ticketId="ticket-1" />);
+    await user.click(screen.getByRole('button', { name: /show/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('S0')).toBeTruthy();
+    });
+
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('S24')).toBeTruthy();
+    });
+
+    const rows = screen.getByRole('table').querySelectorAll('tr');
+    expect(rows.length).toBe(25);
+    expect(screen.queryByRole('button', { name: /load more/i })).toBeNull();
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
 
       { find: /^@alga-psa\/event-bus$/, replacement: path.resolve(__dirname, '../packages/event-bus/src/index.ts') },
       { find: /^@alga-psa\/email$/, replacement: path.resolve(__dirname, '../packages/email/src/index.ts') },
+      { find: /^@alga-psa\/email\/(.*)$/, replacement: path.resolve(__dirname, '../packages/email/src/$1') },
 
       { find: 'fs', replacement: 'node:fs' },
       { find: 'fs/promises', replacement: 'node:fs/promises' },


### PR DESCRIPTION
## Summary
- add outbound send-result logging in `@alga-psa/email` (`email_sending_logs`) with ticket/contact/notification subtype context
- add server actions for email log list, ticket-scoped log list, and metrics in `packages/email/src/actions`
- add `email-logs` feature-flagged UI surfaces:
  - `/msp/email-logs` page and client table/filters/details dialog
  - System Monitor sidebar entry
  - Ticket Details "Email Notifications" section
- document `email-logs` flag and behavior in docs
- include migrations for entity context columns and tenant/entity indexes
- add unit/UI/integration coverage for actions, logging behavior, migrations, and feature wiring

## Validation
- `cd server && NODE_ENV=test npx vitest --config vitest.config.ts --coverage.enabled false src/test/unit/email/EmailLogsClient.ui.test.tsx src/test/unit/email/EmailLogsPage.route.test.ts src/test/unit/email/baseEmailParams.types.test.ts src/test/unit/email/emailLoggingFailure.test.ts src/test/unit/menuConfig.emailLogs.test.ts src/test/unit/tickets/TicketEmailNotifications.ui.test.tsx src/test/unit/tickets/TicketDetails.emailNotifications.integration.test.ts`
- `cd server && DB_HOST=localhost DB_PORT=5433 DB_NAME_SERVER=test_database NODE_ENV=test npx vitest --config vitest.config.ts --coverage.enabled false src/test/integration/email/baseEmailServiceLogging.integration.test.ts src/test/integration/email/emailLogActions.getEmailLogMetrics.integration.test.ts src/test/integration/email/emailLogActions.getEmailLogs.integration.test.ts src/test/integration/email/emailLogActions.getEmailLogsForTicket.integration.test.ts src/test/integration/email/emailSendingLogsMigration.integration.test.ts`
- `cd server && npm run typecheck`
- `cd packages/email && npm run typecheck`
- `cd packages/tickets && npm run typecheck`

## Notes
- branch is synced with `origin/main` at PR creation time
- server-side email logging remains enabled regardless of the UI feature flag
