### PR TITLE
fix(workflows): restore workflow event catalog access in list interface

### DIFF
--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -46,6 +46,7 @@ import WorkflowEventList from './WorkflowEventList';
 import WorkflowRunDialog from './WorkflowRunDialog';
 import WorkflowGraph from '../workflow-graph/WorkflowGraph';
 import WorkflowListV2 from '@alga-psa/workflows/components/automation-hub/WorkflowList';
+import EventsCatalogV2 from '@alga-psa/workflows/components/automation-hub/EventsCatalogV2';
 import { MappingPanel, type ActionInputField } from './mapping';
 import { ExpressionEditor, type ExpressionEditorHandle, type ExpressionContext, type JsonSchema as ExprJsonSchema } from './expression-editor';
 import { getCurrentUser, getCurrentUserPermissions } from '@alga-psa/users/actions';
@@ -1704,6 +1705,7 @@ const WorkflowDesigner: React.FC = () => {
     if (raw === 'designer') return 'Designer';
     if (raw === 'runs') return 'Runs';
     if (raw === 'events') return 'Events';
+    if (raw === 'event-catalog' || raw === 'events-catalog' || raw === 'event_catalog') return 'Event Catalog';
     if (raw === 'dead-letter' || raw === 'deadletter' || raw === 'dead_letter') return 'Dead Letter';
     return null;
   }, [tabFromQuery]);
@@ -1730,6 +1732,7 @@ const WorkflowDesigner: React.FC = () => {
         : nextTabLabel === 'Designer' ? 'designer'
           : nextTabLabel === 'Runs' ? 'runs'
             : nextTabLabel === 'Events' ? 'events'
+              : nextTabLabel === 'Event Catalog' ? 'event-catalog'
               : nextTabLabel === 'Dead Letter' ? 'dead-letter'
                 : null;
 
@@ -4327,6 +4330,13 @@ const WorkflowDesigner: React.FC = () => {
         params.set('tab', 'designer');
         router.push(`/msp/workflows?${params.toString()}`);
       }}
+      onOpenEventCatalog={() => {
+        const params = new URLSearchParams(searchParamsString);
+        params.delete('workflowId');
+        params.delete('new');
+        params.set('tab', 'event-catalog');
+        router.push(`/msp/workflows?${params.toString()}`);
+      }}
       onCreateNew={() => {
         const params = new URLSearchParams(searchParamsString);
         params.delete('search');
@@ -4339,6 +4349,8 @@ const WorkflowDesigner: React.FC = () => {
       }}
     />
   );
+
+  const eventCatalogContent = <EventsCatalogV2 />;
 
   return (
     <div className="h-full min-h-0 flex flex-col">
@@ -4439,6 +4451,7 @@ const WorkflowDesigner: React.FC = () => {
             { label: 'Designer', content: designerContent },
             { label: 'Runs', content: runListContent },
             { label: 'Events', content: eventListContent },
+            { label: 'Event Catalog', content: eventCatalogContent },
             ...(canAdmin ? [{ label: 'Dead Letter', content: deadLetterContent }] : []),
           ]}
           tabStyles={{

--- a/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
+++ b/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
@@ -797,7 +797,7 @@ export default function EventsCatalogV2() {
       const workflowId = (created as any)?.workflowId;
       toast.success('Workflow created');
       if (workflowId) {
-        router.push(`/msp/automation-hub?tab=designer&workflowId=${encodeURIComponent(workflowId)}`);
+        router.push(`/msp/workflows?tab=designer&workflowId=${encodeURIComponent(workflowId)}`);
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to create workflow');
@@ -1135,7 +1135,7 @@ export default function EventsCatalogV2() {
                         </div>
                         <div className="flex items-center gap-2 shrink-0">
                           <Button id={`workflow-event-details-open-workflow-${wf.workflow_id}`} asChild variant="outline" size="sm">
-                            <Link href={`/msp/automation-hub?tab=designer&workflowId=${encodeURIComponent(wf.workflow_id)}`}>
+                            <Link href={`/msp/workflows?tab=designer&workflowId=${encodeURIComponent(wf.workflow_id)}`}>
                               <ExternalLink className="h-4 w-4 mr-2" />
                               Open
                             </Link>
@@ -1295,7 +1295,7 @@ const MetricsDialog: React.FC<{ open: boolean; eventType: string | null; onClose
             </Button>
             {eventType && (
               <Button id="workflow-event-metrics-open-designer" asChild variant="ghost" className="ml-auto">
-                <Link href={`/msp/automation-hub?tab=designer`}>
+                <Link href={`/msp/workflows?tab=designer`}>
                   Open designer
                 </Link>
               </Button>

--- a/packages/workflows/src/components/automation-hub/WorkflowList.tsx
+++ b/packages/workflows/src/components/automation-hub/WorkflowList.tsx
@@ -111,6 +111,7 @@ type SortableColumnId = 'name' | 'status' | 'updated_at' | 'created_at';
 interface WorkflowListProps {
   onSelectWorkflow?: (workflowId: string) => void;
   onCreateNew?: () => void;
+  onOpenEventCatalog?: () => void;
 }
 
 const getStatusBadgeVariant = (status: string, isPaused?: boolean): BadgeVariant => {
@@ -169,7 +170,7 @@ const getTriggerLabel = (trigger?: Record<string, unknown> | null): string => {
   return 'Manual';
 };
 
-export default function WorkflowList({ onSelectWorkflow, onCreateNew }: WorkflowListProps) {
+export default function WorkflowList({ onSelectWorkflow, onCreateNew, onOpenEventCatalog }: WorkflowListProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const didUnmount = useRef(false);
@@ -348,6 +349,15 @@ export default function WorkflowList({ onSelectWorkflow, onCreateNew }: Workflow
     e.stopPropagation();
     // Navigate to runs tab with workflow filter
     router.push(`/msp/workflows?tab=runs&workflowId=${workflow.workflow_id}`);
+  };
+
+  const handleOpenEventCatalog = () => {
+    clearSearchDebounce();
+    if (onOpenEventCatalog) {
+      onOpenEventCatalog();
+      return;
+    }
+    router.push('/msp/workflows?tab=event-catalog');
   };
 
   // Bulk selection handlers
@@ -698,16 +708,26 @@ export default function WorkflowList({ onSelectWorkflow, onCreateNew }: Workflow
           <p className="text-sm text-[rgb(var(--color-text-500))] text-center max-w-md mb-6">
             Create your first workflow to automate tasks, respond to events, and streamline your processes.
           </p>
-          <Button
-            id="create-first-workflow-btn"
-            onClick={() => {
-              clearSearchDebounce();
-              onCreateNew?.();
-            }}
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Create Your First Workflow
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              id="open-event-catalog-empty-btn"
+              variant="outline"
+              onClick={handleOpenEventCatalog}
+            >
+              <Zap className="w-4 h-4 mr-2" />
+              Event Catalog
+            </Button>
+            <Button
+              id="create-first-workflow-btn"
+              onClick={() => {
+                clearSearchDebounce();
+                onCreateNew?.();
+              }}
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Create Your First Workflow
+            </Button>
+          </div>
         </div>
       </ReflectionContainer>
     );
@@ -737,16 +757,26 @@ export default function WorkflowList({ onSelectWorkflow, onCreateNew }: Workflow
               )}
             </div>
           </div>
-          <Button
-            id="create-workflow-btn"
-            onClick={() => {
-              clearSearchDebounce();
-              onCreateNew?.();
-            }}
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            New Workflow
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              id="workflow-list-open-event-catalog-btn"
+              variant="outline"
+              onClick={handleOpenEventCatalog}
+            >
+              <Zap className="w-4 h-4 mr-2" />
+              Event Catalog
+            </Button>
+            <Button
+              id="create-workflow-btn"
+              onClick={() => {
+                clearSearchDebounce();
+                onCreateNew?.();
+              }}
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              New Workflow
+            </Button>
+          </div>
         </div>
 
         {/* Filters */}


### PR DESCRIPTION
Summary:
- reconnect workflow list to Event Catalog from the active /msp/workflows surface
- add Event Catalog tab support in workflow tabs and URL parsing (tab=event-catalog, plus legacy aliases)
- add Event Catalog CTA buttons in WorkflowList header and empty state
- retarget Event Catalog navigation from /msp/automation-hub?tab=designer to /msp/workflows?tab=designer

Validation:
- pnpm -s tsc -p packages/workflows/tsconfig.json --noEmit
