### PR TITLE
Break circular deps with email registries

### DIFF
--- a/packages/auth/src/actions/auth-actions/passwordResetActions.ts
+++ b/packages/auth/src/actions/auth-actions/passwordResetActions.ts
@@ -6,32 +6,7 @@ import { PasswordResetService } from '@alga-psa/auth';
 import { hashPassword } from '@alga-psa/core/encryption';
 import { isValidEmail } from '@alga-psa/validation';
 
-// Dynamic imports to avoid circular dependency (auth -> email -> integrations -> users -> auth)
-// Note: Using string concatenation to prevent static analysis from detecting this dependency
-const getEmailModule = () => '@alga-psa/' + 'email';
-
-const getTenantEmailService = async (tenant: string) => {
-  const { TenantEmailService } = await import('@alga-psa/email');
-  return TenantEmailService.getInstance(tenant);
-};
-
-const getSystemEmailServiceAsync = async () => {
-  const { getSystemEmailService } = await import('@alga-psa/email');
-  return getSystemEmailService();
-};
-
-const sendPasswordResetEmailAsync = async (params: {
-  email: string;
-  userName: string;
-  resetLink: string;
-  expirationTime: string;
-  tenant: string;
-  supportEmail: string;
-  clientName: string;
-}) => {
-  const { sendPasswordResetEmail } = await import('@alga-psa/email');
-  return sendPasswordResetEmail(params);
-};
+import { getAuthEmailRegistry } from '../../lib/emailRegistry';
 
 export interface RequestResetResult {
   success: boolean;
@@ -129,13 +104,13 @@ export async function requestPasswordReset(
 
       // Ensure at least one email provider path is configured before proceeding
       console.log('[PasswordReset] Checking tenant email service configuration...');
-      const tenantEmailService = await getTenantEmailService(tenant);
+      const tenantEmailService = await getAuthEmailRegistry().getTenantEmailService(tenant);
       let emailConfigured = await tenantEmailService.isConfigured();
       console.log('[PasswordReset] Tenant email configured:', emailConfigured);
       
       if (!emailConfigured) {
         console.log('[PasswordReset] Falling back to system email configuration check');
-        const systemEmailService = await getSystemEmailServiceAsync();
+        const systemEmailService = await getAuthEmailRegistry().getSystemEmailService();
         emailConfigured = await systemEmailService.isConfigured();
         console.log('[PasswordReset] System email configured:', emailConfigured);
         if (!emailConfigured) {
@@ -216,7 +191,7 @@ export async function requestPasswordReset(
         console.log('[PasswordReset] Client name:', clientName);
         console.log('[PasswordReset] Support email:', supportEmail);
         
-        await sendPasswordResetEmailAsync({
+        await getAuthEmailRegistry().sendPasswordResetEmail({
           email: normalizedEmail,
           userName: userInfo.first_name || userInfo.username || normalizedEmail,
           resetLink: resetUrl,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -87,3 +87,7 @@ export * from './actions';
 
 // SSO/OAuth registration system (for EE to register implementations)
 export * from './lib/sso';
+
+// Email provider registration system (decouples auth from email package)
+export { registerAuthEmailProvider, getAuthEmailRegistry, resetAuthEmailRegistry } from './lib/emailRegistry';
+export type { AuthEmailProvider } from './lib/emailRegistry';

--- a/packages/auth/src/lib/emailRegistry.ts
+++ b/packages/auth/src/lib/emailRegistry.ts
@@ -1,0 +1,72 @@
+/**
+ * Email Provider Registry - Registration pattern for email functionality
+ *
+ * This allows the app to register email implementations without creating
+ * a circular dependency (auth importing from email).
+ *
+ * Default stubs throw "email not configured" errors.
+ * App startup registers real implementations.
+ */
+
+export interface AuthEmailProvider {
+  sendPasswordResetEmail(params: {
+    email: string;
+    userName: string;
+    resetLink: string;
+    expirationTime: string;
+    tenant: string;
+    supportEmail: string;
+    clientName: string;
+  }): Promise<boolean>;
+
+  getSystemEmailService(): Promise<{
+    isConfigured(): Promise<boolean>;
+    sendEmailVerification(params: {
+      email: string;
+      verificationUrl: string;
+      clientName: string;
+      expirationTime: string;
+    }): Promise<{ success: boolean; error?: string }>;
+  }>;
+
+  getTenantEmailService(tenant: string): Promise<{
+    isConfigured(): Promise<boolean>;
+  }>;
+}
+
+const defaultRegistry: AuthEmailProvider = {
+  sendPasswordResetEmail: async () => {
+    throw new Error('Email provider not configured: sendPasswordResetEmail not registered');
+  },
+
+  getSystemEmailService: async () => {
+    throw new Error('Email provider not configured: getSystemEmailService not registered');
+  },
+
+  getTenantEmailService: async () => {
+    throw new Error('Email provider not configured: getTenantEmailService not registered');
+  },
+};
+
+let registry: AuthEmailProvider = { ...defaultRegistry };
+
+/**
+ * Register email provider implementations (called at app startup)
+ */
+export function registerAuthEmailProvider(impl: Partial<AuthEmailProvider>): void {
+  registry = { ...registry, ...impl };
+}
+
+/**
+ * Get the current email registry (used by auth code)
+ */
+export function getAuthEmailRegistry(): AuthEmailProvider {
+  return registry;
+}
+
+/**
+ * Reset to default registry (for testing)
+ */
+export function resetAuthEmailRegistry(): void {
+  registry = { ...defaultRegistry };
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@alga-psa/core": "*",
     "@alga-psa/db": "*",
-    "@alga-psa/email": "*",
     "@alga-psa/event-bus": "*",
     "@alga-psa/event-schemas": "*",
     "@alga-psa/types": "*",

--- a/shared/project.json
+++ b/shared/project.json
@@ -16,7 +16,6 @@
       "dependsOn": [
         "@alga-psa/core:build",
         "@alga-psa/db:build",
-        "@alga-psa/email:build",
         "@alga-psa/types:build",
         "@alga-psa/event-schemas:build",
         "@alga-psa/event-bus:build"

--- a/shared/workflow/runtime/actions/businessOperations/email.ts
+++ b/shared/workflow/runtime/actions/businessOperations/email.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { getWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
 import { EmailProviderError } from '@alga-psa/types';
 import {
   uuidSchema,
@@ -51,7 +52,7 @@ export function registerEmailActions(): void {
       // Use the existing email permission taxonomy (email:process).
       await requirePermission(ctx, tx, { resource: 'email', action: 'process' });
 
-      const { TenantEmailService, StaticTemplateProcessor, EmailProviderManager } = await import('@alga-psa/email');
+      const { TenantEmailService, StaticTemplateProcessor, EmailProviderManager } = getWorkflowEmailProvider();
       const { StorageProviderFactory } = await import('@alga-psa/documents');
 
       const settings = await TenantEmailService.getTenantEmailSettings(tx.tenantId, tx.trx);

--- a/shared/workflow/runtime/actions/businessOperations/tickets.ts
+++ b/shared/workflow/runtime/actions/businessOperations/tickets.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { getWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
 import { TicketModel } from '../../../../models/ticketModel';
 import {
   uuidSchema,
@@ -660,7 +661,7 @@ export function registerTicketActions(): void {
           throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: 'Requester contact has no email address' });
         }
 
-        const { TenantEmailService, StaticTemplateProcessor } = await import('@alga-psa/email');
+        const { TenantEmailService, StaticTemplateProcessor } = getWorkflowEmailProvider();
         const service = TenantEmailService.getInstance(tx.tenantId);
         const subject = input.email?.subject ?? `Ticket ${ticket.ticket_number ?? ''} closed`;
         const html = input.email?.html ?? `<p>Your ticket has been closed.</p><p>Resolution: ${input.resolution.code}</p>`;

--- a/shared/workflow/runtime/index.ts
+++ b/shared/workflow/runtime/index.ts
@@ -3,6 +3,8 @@ export * from './init';
 export { SchemaRegistry, getSchemaRegistry } from './registries/schemaRegistry';
 export { ActionRegistry, getActionRegistryV2 } from './registries/actionRegistry';
 export { NodeTypeRegistry, getNodeTypeRegistry } from './registries/nodeTypeRegistry';
+export { registerWorkflowEmailProvider, getWorkflowEmailProvider, resetWorkflowEmailProvider } from './registries/workflowEmailRegistry';
+export type { WorkflowEmailProvider } from './registries/workflowEmailRegistry';
 export { WorkflowRuntimeV2 } from './runtime/workflowRuntimeV2';
 export {
   validateWorkflowDefinition,

--- a/shared/workflow/runtime/registries/workflowEmailRegistry.ts
+++ b/shared/workflow/runtime/registries/workflowEmailRegistry.ts
@@ -1,0 +1,65 @@
+/**
+ * Workflow Email Registry - Registration pattern for email functionality
+ *
+ * This decouples shared/workflow from @alga-psa/email to avoid a circular
+ * dependency (shared → email → auth → ee-stubs → shared).
+ *
+ * App startup registers real email implementations via registerWorkflowEmailProvider().
+ * Workflow actions use getWorkflowEmailProvider() at runtime.
+ */
+
+export interface WorkflowEmailProvider {
+  TenantEmailService: {
+    getInstance(tenantId: string): {
+      sendEmail(params: unknown): Promise<{ success: boolean; error?: string }>;
+    };
+    getTenantEmailSettings(tenantId: string, trx: unknown): Promise<any>;
+  };
+  StaticTemplateProcessor: new (subject: string, html: string, text?: string) => {
+    process(params: { templateData: Record<string, unknown> }): Promise<{ subject: string; html: string; text?: string }>;
+  };
+  EmailProviderManager: new () => {
+    initialize(settings: unknown): Promise<void>;
+    getAvailableProviders(tenantId: string): Promise<Array<{
+      capabilities: {
+        supportsAttachments?: boolean;
+        maxAttachmentSize?: number;
+        maxRecipientsPerMessage?: number;
+      };
+    }>>;
+    sendEmail(params: unknown, tenantId: string): Promise<{
+      success: boolean;
+      error?: string;
+      providerId?: string;
+      providerType?: string;
+      messageId?: string;
+      sentAt?: string;
+    }>;
+  };
+}
+
+let provider: WorkflowEmailProvider | null = null;
+
+/**
+ * Register email provider implementations (called at app startup)
+ */
+export function registerWorkflowEmailProvider(impl: WorkflowEmailProvider): void {
+  provider = impl;
+}
+
+/**
+ * Get the current email provider (used by workflow actions)
+ */
+export function getWorkflowEmailProvider(): WorkflowEmailProvider {
+  if (!provider) {
+    throw new Error('Workflow email provider not registered. Ensure registerWorkflowEmailProvider() is called at app startup.');
+  }
+  return provider;
+}
+
+/**
+ * Reset to default (for testing)
+ */
+export function resetWorkflowEmailProvider(): void {
+  provider = null;
+}


### PR DESCRIPTION
  Replace dynamic imports of @alga-psa/email in auth and shared packages with registry-based dependency injection. Auth and shared now define email provider interfaces; real implementationsare wired at app startup in initializeApp.ts.

  Breaks two cycles:
  - auth → email (password reset, registration emails)
  - shared → email → auth → ee-stubs → shared (workflow actions)

  "Pay no attention to the circular dependency behind the curtain!" cried the Wizard, furiously registering EmailProviders into every registry he could find, until the yellow brick road of builds finally ran in one direction only 🌪️📧🧙‍♂️