### PR TITLE
Fix invoice preview/rendering after billing model modularization

### DIFF
--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-// TODO: Invoice model missing getFullInvoiceById method
 'use server'
 
 import { withTransaction } from '@alga-psa/db';
@@ -742,7 +741,7 @@ export const generateInvoice = withAuth(async (
     }
 
 console.log(`[generateInvoice] Zero-dollar invoice created (${createdInvoice.invoice_id}). Fetching full ViewModel before returning.`);
-    return await Invoice.getFullInvoiceById(knex, createdInvoice.invoice_id);
+    return await Invoice.getFullInvoiceById(knex, tenant, createdInvoice.invoice_id);
   }
 
   if (billingResult.charges.length === 0) {
@@ -775,7 +774,7 @@ console.log(`[generateInvoice] Zero-dollar invoice created (${createdInvoice.inv
   await billingEngine.rolloverUnapprovedTime(client_id, cycleEnd, nextBillingTimestamp);
 
 console.log(`[generateInvoice] Regular invoice created (${createdInvoice.invoice_id}). Fetching full ViewModel before returning.`);
-  let invoiceView = await Invoice.getFullInvoiceById(knex, createdInvoice.invoice_id);
+  let invoiceView = await Invoice.getFullInvoiceById(knex, tenant, createdInvoice.invoice_id);
 
   return invoiceView;
 });

--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-// TODO: Invoice model missing getFullInvoiceById method
 'use server'
 
 import { withTransaction } from '@alga-psa/db';
@@ -14,7 +13,7 @@ import { applyCreditToInvoice } from './creditActions';
 import { IInvoiceCharge, InvoiceViewModel, DiscountType } from '@alga-psa/types';
 import { BillingEngine } from '../lib/billing/billingEngine';
 import { persistInvoiceCharges, persistManualInvoiceCharges } from '../services/invoiceService'; // Import persistManualInvoiceCharges
-import Invoice from '@alga-psa/billing/models/invoice'; // Needed for getFullInvoiceById
+import Invoice from '@alga-psa/billing/models/invoice';
 import { v4 as uuidv4 } from 'uuid';
 import { getWorkflowRuntime } from '@alga-psa/shared/workflow/core'; // Import runtime getter via package export
 // import { getRedisStreamClient } from '@alga-psa/shared/workflow/streams/redisStreamClient'; // No longer directly used here
@@ -409,7 +408,7 @@ export const updateInvoiceManualItems = withAuth(async (
   const currentDate = Temporal.Now.plainDateISO().toString();
 
   await updateManualInvoiceItemsInternal(invoiceId, changes, session!, tenant); // Renamed internal call
-  return await Invoice.getFullInvoiceById(knex, invoiceId);
+  return await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
 });
 
 // Internal helper function to avoid recursive export/import loop
@@ -643,7 +642,7 @@ export const addManualItemsToInvoice = withAuth(async (
   }
 
   await addManualInvoiceItemsInternal(invoiceId, items, session!, tenant); // Renamed internal call
-  return await Invoice.getFullInvoiceById(knex, invoiceId);
+  return await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
 });
 
 // Internal helper function

--- a/packages/billing/src/actions/invoiceQueries.ts
+++ b/packages/billing/src/actions/invoiceQueries.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-// TODO: Invoice model missing getFullInvoiceById method, argument count issues
 'use server';
 
 import { withTransaction } from '@alga-psa/db';
@@ -421,7 +420,7 @@ export const getInvoiceForRendering = withAuth(async (
 
     const { knex } = await createTenantKnex();
 
-    return Invoice.getFullInvoiceById(knex, invoiceId);
+    return Invoice.getFullInvoiceById(knex, tenant, invoiceId);
   } catch (error) {
     console.error('Error fetching invoice for rendering:', error);
     throw new Error('Error fetching invoice for rendering');
@@ -493,7 +492,7 @@ export const getInvoiceLineItems = withAuth(async (
   try {
     const { knex } = await createTenantKnex();
     console.log('Fetching line items for invoice:', invoiceId);
-    const items = await Invoice.getInvoiceItems(knex, invoiceId);
+    const items = await Invoice.getInvoiceItems(knex, tenant, invoiceId);
     console.log(`Got ${items.length} line items`);
     return items;
   } catch (error) {

--- a/packages/billing/src/actions/invoiceTemplates.ts
+++ b/packages/billing/src/actions/invoiceTemplates.ts
@@ -273,7 +273,7 @@ export const saveInvoiceTemplate = withAuth(async (
         console.log('No compilation needed, saving template metadata directly...');
         try {
             // Pass the template to saveTemplate
-            const savedTemplate = await Invoice.saveTemplate(knex, templateToSaveWithoutFlags);
+            const savedTemplate = await Invoice.saveTemplate(knex, tenant, templateToSaveWithoutFlags);
 
             console.log('Template metadata saved successfully (no compilation):', {
                 id: savedTemplate.template_id,


### PR DESCRIPTION
## Summary
- restore `Invoice.getFullInvoiceById` in `packages/billing` with tenant-explicit signature and view-model hydration
- update invoice action call sites to pass `tenant` for `getFullInvoiceById` and `getInvoiceItems`
- fix template save call to pass `tenant` into `Invoice.saveTemplate`
- align invoice contact mapping with actual contacts schema (`full_name`)

## Validation
- `pnpm --filter @alga-psa/billing typecheck`

## Issue addressed
Fixes runtime failures during invoice preview/rendering caused by stale model method signatures after modularity changes.
