### PR TITLE
Fix prod Docker install failure from npm peer resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ COPY shared/package.json ./shared/
 COPY ee/server/package.json ./ee/server/
 COPY services/workflow-worker/package.json ./services/workflow-worker/
 
-# Install only production dependencies
-RUN npm install --omit=dev
+# Install only production dependencies.
+# npm@11 enforces peer dependency resolution more strictly; this image only
+# needs runtime deps and should not fail on dev-only peer conflicts.
+RUN npm install --omit=dev --legacy-peer-deps
 
 # Copy base files
 COPY tsconfig.base.json ./

--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -34,8 +34,10 @@ COPY shared/package.json ./shared/
 COPY ee/server/package.json ./ee/server/
 COPY services/workflow-worker/package.json ./services/workflow-worker/
 
-# Install only production dependencies
-RUN npm install --omit=dev
+# Install only production dependencies.
+# npm@11 enforces peer dependency resolution more strictly; this image only
+# needs runtime deps and should not fail on dev-only peer conflicts.
+RUN npm install --omit=dev --legacy-peer-deps
 
 # Copy base files
 COPY tsconfig.base.json ./


### PR DESCRIPTION
## Summary
- update production dependency install commands in server image Dockerfiles to use legacy peer resolution under npm 11
- prevents CI image builds from failing on dev-only peer conflicts (eslint/eslint-config-next) during npm install --omit=dev

## Changes
- Dockerfile
- ee/server/Dockerfile

## Validation
- reproduced failure in clean node:alpine container with npm install --omit=dev (ERESOLVE)
- verified npm install --omit=dev --legacy-peer-deps succeeds in same environment
