### PR TITLE
runner/sdk: restore user v1 shape and extend user-v2 metadata

### DIFF
--- a/ee/runner/src/engine/host_api.rs
+++ b/ee/runner/src/engine/host_api.rs
@@ -2165,7 +2165,6 @@ impl user::HostWithStore for HasSelf<HostState> {
                     );
                     Ok(UserData {
                         tenant_id: tenant,
-                        client_id: user_info.client_id.clone(),
                         client_name: user_info.client_name.clone(),
                         user_id: user_info.user_id.clone(),
                         user_email: user_info.user_email.clone(),
@@ -2211,6 +2210,13 @@ impl user_v2::HostWithStore for HasSelf<HostState> {
 
             match &ctx.user {
                 Some(user_info) => {
+                    let mut additional_fields: Vec<(String, String)> = user_info
+                        .additional_fields
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.clone()))
+                        .collect();
+                    additional_fields.sort_by(|a, b| a.0.cmp(&b.0));
+
                     tracing::info!(
                         tenant=%tenant,
                         extension=%extension,
@@ -2225,6 +2231,7 @@ impl user_v2::HostWithStore for HasSelf<HostState> {
                         user_name: user_info.user_name.clone(),
                         user_type: user_info.user_type.clone(),
                         client_id: user_info.client_id.clone(),
+                        additional_fields,
                     })
                 }
                 None => {

--- a/ee/runner/src/models.rs
+++ b/ee/runner/src/models.rs
@@ -44,6 +44,9 @@ pub struct UserInfo {
     /// For client portal users, the client_id they are associated with
     #[serde(default)]
     pub client_id: Option<String>,
+    /// Additional user attributes forwarded by the gateway/proxy.
+    #[serde(default)]
+    pub additional_fields: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/ee/runner/wit/extension-runner.wit
+++ b/ee/runner/wit/extension-runner.wit
@@ -64,7 +64,6 @@ interface types {
 
     record user-data {
         tenant-id: string,
-        client-id: option<string>,
         client-name: string,
         user-id: string,
         user-email: string,
@@ -80,6 +79,7 @@ interface types {
         user-name: string,
         user-type: string,
         client-id: option<string>,
+        additional-fields: list<tuple<string, string>>,
     }
 
     enum user-error {

--- a/packages/product-ext-proxy/ee/handler.ts
+++ b/packages/product-ext-proxy/ee/handler.ts
@@ -213,6 +213,8 @@ async function handle(
         user_name: userInfo.user_name,
         user_type: userInfo.user_type,
         client_name: userInfo.client_name,
+        client_id: userInfo.client_id,
+        additional_fields: userInfo.additional_fields,
       } : undefined,
     };
 

--- a/sdk/alga-client-sdk/templates/component-basic/README.md
+++ b/sdk/alga-client-sdk/templates/component-basic/README.md
@@ -54,7 +54,7 @@ Create `src/index.ts`:
 
 ```typescript
 import { handler as userHandler } from './handler-impl.js';
-import { ExecuteRequest, ExecuteResponse, HostBindings } from '@alga-psa/extension-runtime';
+import { ExecuteRequest, ExecuteResponse, HostBindings, normalizeUserData } from '@alga-psa/extension-runtime';
 
 // @ts-ignore - WIT imports resolved at runtime
 import { getUser } from 'alga:extension/user-v2';
@@ -70,7 +70,7 @@ const host: HostBindings = {
     warn: async (msg) => logWarn(msg),
     error: async (msg) => logError(msg),
   },
-  user: { getUser: async () => getUser() },
+  user: { getUser: async () => normalizeUserData(await getUser()) },
   // Add other bindings as needed
 };
 

--- a/sdk/alga-client-sdk/templates/component-basic/package.json
+++ b/sdk/alga-client-sdk/templates/component-basic/package.json
@@ -10,7 +10,7 @@
     "pack": "alga pack"
   },
   "dependencies": {
-    "@alga-psa/extension-runtime": "^0.2.0"
+    "@alga-psa/extension-runtime": "^0.3.0"
   },
   "devDependencies": {
     "@alga-psa/cli": "^0.2.0",

--- a/sdk/alga-client-sdk/templates/component-basic/wit/extension-runner.wit
+++ b/sdk/alga-client-sdk/templates/component-basic/wit/extension-runner.wit
@@ -84,6 +84,7 @@ record user-data-v2 {
     user-name: string,
     user-type: string,
     client-id: option<string>,
+    additional-fields: list<tuple<string, string>>,
 }
 
 enum user-error {
@@ -141,7 +142,7 @@ interface user {
     get-user: func() -> result<user-data, user-error>;
 }
 
-/// Access current user information (v2 adds client-id).
+/// Access current user information (v2 adds client-id and additional-fields).
 /// @requires(cap:user.read)
 interface user-v2 {
     get-user: func() -> result<user-data-v2, user-error>;

--- a/sdk/docs/guides/user-host-api.md
+++ b/sdk/docs/guides/user-host-api.md
@@ -47,6 +47,10 @@ interface UserData {
   userName: string;
   /** User type: "internal" (MSP staff) or "client" (client portal user) */
   userType: string;
+  /** For client portal users, the client_id they are associated with */
+  clientId?: string;
+  /** Optional additional attributes provided by the host */
+  additionalFields?: Record<string, string>;
 }
 
 type UserError = 'not-available' | 'not-allowed';
@@ -117,7 +121,7 @@ To use the User API (or any host capability), your extension needs a wrapper tha
 ```typescript
 // src/index.ts
 import { handler as userHandler } from './handler-impl.js';
-import { ExecuteRequest, ExecuteResponse, HostBindings } from '@alga-psa/extension-runtime';
+import { ExecuteRequest, ExecuteResponse, HostBindings, normalizeUserData } from '@alga-psa/extension-runtime';
 
 // Import WIT functions (these are resolved at runtime by jco)
 // @ts-ignore
@@ -139,7 +143,7 @@ const host: HostBindings = {
     error: async (msg: string) => logError(msg),
   },
   user: {
-    getUser: async () => getUser(),
+    getUser: async () => normalizeUserData(await getUser()),
   },
   // ... other bindings
 };
@@ -181,6 +185,7 @@ record user-data-v2 {
     user-name: string,
     user-type: string,
     client-id: option<string>,
+    additional-fields: list<tuple<string, string>>,
 }
 
 enum user-error {

--- a/sdk/extension-runtime/README.md
+++ b/sdk/extension-runtime/README.md
@@ -82,6 +82,8 @@ interface UserData {
   userEmail: string;
   userName: string;
   userType: string;  // "internal" or "client"
+  clientId?: string;
+  additionalFields?: Record<string, string>;
 }
 ```
 
@@ -127,6 +129,7 @@ Create mock host bindings for testing.
 When building with jco componentize, host capabilities are imported from WIT modules. Create a wrapper `index.ts`:
 
 ```typescript
+import { normalizeUserData } from '@alga-psa/extension-runtime';
 // Import WIT functions
 // @ts-ignore
 import { getUser } from 'alga:extension/user-v2';
@@ -135,7 +138,7 @@ import { logInfo } from 'alga:extension/logging';
 
 // Build HostBindings
 const host: HostBindings = {
-  user: { getUser: async () => getUser() },
+  user: { getUser: async () => normalizeUserData(await getUser()) },
   logging: { info: async (msg) => logInfo(msg), /* ... */ },
   // ... other bindings
 };


### PR DESCRIPTION
## Summary
- restore alga:extension/user v1 contract to 6 fields in runner WIT for compatibility
- extend alga:extension/user-v2 with client-id plus additional-fields (list<tuple<string,string>>)
- update runner host mapping and request model to populate additional_fields
- forward client_id and additional_fields from ext-proxy user context
- add normalizeUserData to @alga-psa/extension-runtime so extensions consume a stable shape
- update SDK template/docs to use user-v2 + normalizeUserData

## Validation
- cargo check (in ee/runner)
- npm -w sdk/extension-runtime run build
- npm -w sdk/alga-client-sdk run build
