### PR TITLE
fix(client-portal): wire extension apps menu to EE action

### DIFF
--- a/packages/client-portal/src/lib/actions/clientPortalExtActions.ts
+++ b/packages/client-portal/src/lib/actions/clientPortalExtActions.ts
@@ -1,8 +1,31 @@
+"use server";
+
 export type ClientPortalMenuItem = {
   id: string;
   label: string;
 };
 
 export async function listClientPortalMenuItemsForTenant(): Promise<ClientPortalMenuItem[]> {
-  return [];
+  try {
+    const mod = await import('@enterprise/lib/actions/clientPortalExtActions');
+    const fn = (mod as { listClientPortalMenuItemsForTenant?: () => Promise<unknown> })
+      .listClientPortalMenuItemsForTenant;
+    if (typeof fn !== 'function') {
+      return [];
+    }
+
+    const result = await fn();
+    if (!Array.isArray(result)) {
+      return [];
+    }
+
+    return result
+      .map((item) => ({
+        id: String((item as { id?: unknown }).id ?? ''),
+        label: String((item as { label?: unknown }).label ?? ''),
+      }))
+      .filter((item) => item.id.length > 0 && item.label.length > 0);
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- replace client portal extension menu action stub with an edition-aware server action wrapper
- delegate to `@enterprise/lib/actions/clientPortalExtActions` in EE builds
- preserve CE-safe fallback by returning an empty list when EE implementation is unavailable

## Why
Client Portal Apps menu was always hidden because `listClientPortalMenuItemsForTenant` in `packages/client-portal` returned `[]` unconditionally after modularity refactor.

## Validation
- npm -w server run typecheck