### PR TITLE
fix(samples): use user-v2 host import with v1 fallback

### DIFF
--- a/ee/extensions/samples/client-portal-test/package.json
+++ b/ee/extensions/samples/client-portal-test/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist",
-    "build:backend": "esbuild src/index.ts --bundle --format=esm --platform=neutral --outfile=dist/js/index.js --external:alga:extension/secrets --external:alga:extension/http --external:alga:extension/storage --external:alga:extension/logging --external:alga:extension/ui-proxy --external:alga:extension/context --external:alga:extension/user",
+    "build:backend": "esbuild src/index.ts --bundle --format=esm --platform=neutral --outfile=dist/js/index.js --external:alga:extension/secrets --external:alga:extension/http --external:alga:extension/storage --external:alga:extension/logging --external:alga:extension/ui-proxy --external:alga:extension/context --external:alga:extension/user --external:alga:extension/user-v2",
     "build:component": "jco componentize dist/js/index.js --wit ./wit/extension-runner.wit --world-name runner --disable all --out dist/main.wasm",
     "build:ui": "mkdir -p dist/ui && cp ui/index.html dist/ui/ && esbuild ui/main.ts --bundle --outfile=dist/ui/main.js --format=esm --platform=browser --target=es2020 --minify",
     "build": "npm run clean && npm run build:backend && npm run build:component && npm run build:ui",

--- a/ee/extensions/samples/client-portal-test/src/index.ts
+++ b/ee/extensions/samples/client-portal-test/src/index.ts
@@ -3,7 +3,8 @@ import {
   ExecuteRequest,
   ExecuteResponse,
   HostBindings,
-  ContextData
+  ContextData,
+  normalizeUserData,
 } from '@alga-psa/extension-runtime';
 
 // Raw imports from the WIT world
@@ -29,7 +30,9 @@ import { callRoute as uiProxyCall } from 'alga:extension/ui-proxy';
 // @ts-ignore
 import { getContext } from 'alga:extension/context';
 // @ts-ignore
-import { getUser } from 'alga:extension/user';
+import { getUser as getUserV1 } from 'alga:extension/user';
+// @ts-ignore
+import { getUser as getUserV2 } from 'alga:extension/user-v2';
 
 // Construct the HostBindings object that the SDK expects
 const host: HostBindings = {
@@ -60,7 +63,13 @@ const host: HostBindings = {
     callRoute: async (route: string, payload: any) => uiProxyCall(route, payload)
   },
   user: {
-    getUser: async () => getUser()
+    getUser: async () => {
+      try {
+        return normalizeUserData(await getUserV2() as any);
+      } catch {
+        return normalizeUserData(await getUserV1() as any);
+      }
+    }
   },
   // Scheduler not used in this extension, but required by HostBindings
   scheduler: {

--- a/ee/extensions/samples/client-portal-test/wit/extension-runner.wit
+++ b/ee/extensions/samples/client-portal-test/wit/extension-runner.wit
@@ -71,6 +71,17 @@ interface types {
         user-type: string,
     }
 
+    record user-data-v2 {
+        tenant-id: string,
+        client-name: string,
+        user-id: string,
+        user-email: string,
+        user-name: string,
+        user-type: string,
+        client-id: option<string>,
+        additional-fields: list<tuple<string, string>>,
+    }
+
     enum user-error {
         not-available,
         not-allowed,
@@ -128,6 +139,11 @@ interface user {
     get-user: func() -> result<user-data, user-error>;
 }
 
+interface user-v2 {
+    use types.{user-data-v2, user-error};
+    get-user: func() -> result<user-data-v2, user-error>;
+}
+
 world runner {
     use types.{execute-request, execute-response};
 
@@ -138,6 +154,7 @@ world runner {
     import logging;
     import ui-proxy;
     import user;
+    import user-v2;
 
     export handler: func(request: execute-request) -> execute-response;
 }


### PR DESCRIPTION
## Summary
- update dual portal sample WIT to import both user and user-v2
- update wrapper to call alga:extension/user-v2 first and fall back to alga:extension/user
- normalize host payload through normalizeUserData so extension code receives a stable shape
- include alga:extension/user-v2 in backend esbuild externals

## Why
The sample was bound to the v1 user host interface only, so clientId was always missing even when runner provided user-v2.

## Validation
- npm run build in ee/extensions/samples/client-portal-test
- packed bundle successfully via node node_modules/@alga-psa/cli/dist/cli.js pack
