### PR TITLE
fix(msp): avoid tenant-context miss in assets page loaders

### DIFF
--- a/server/src/app/msp/assets/[asset_id]/page.tsx
+++ b/server/src/app/msp/assets/[asset_id]/page.tsx
@@ -1,9 +1,7 @@
 import { getAssetDetailBundle } from '@alga-psa/assets/actions/assetActions';
-import User from '@alga-psa/db/models/user';
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@alga-psa/users/actions';
 import { AssetDetailView } from '@alga-psa/assets/components/AssetDetailView';
-import { getConnection } from 'server/src/lib/db/db';
 import { getSession } from 'server/src/lib/auth/getSession';
 
 interface Props {
@@ -19,8 +17,8 @@ export default async function AssetPage({ params }: Props) {
     redirect('/auth/msp/signin');
   }
 
-  const userEmail = await getCurrentUser();
-  const userId = userEmail?.user_id;
+  const currentUser = await getCurrentUser();
+  const userId = currentUser?.user_id;
   
   if (!userId) {
     console.error('User ID is missing from the session');
@@ -28,13 +26,6 @@ export default async function AssetPage({ params }: Props) {
   }
 
   try {
-    const knex = await getConnection();
-    const user = await User.get(knex, userId);
-    if (!user) {
-      console.error(`User not found for ID: ${userId}`);
-      redirect('/auth/msp/signin');
-    }
-
     const bundle = await getAssetDetailBundle(resolvedParams.asset_id);
     if (!bundle.asset) {
       return <div>Asset not found</div>;

--- a/server/src/app/msp/assets/page.tsx
+++ b/server/src/app/msp/assets/page.tsx
@@ -1,10 +1,8 @@
 import { listAssets } from '@alga-psa/assets/actions/assetActions';
-import User from '@alga-psa/db/models/user';
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@alga-psa/users/actions';
 import type { AssetListResponse } from '@alga-psa/types';
 import AssetDashboard from '@alga-psa/assets/components/AssetDashboard';
-import { getConnection } from 'server/src/lib/db/db';
 import { getSession } from 'server/src/lib/auth/getSession';
 
 export default async function AssetsPage() {
@@ -13,8 +11,8 @@ export default async function AssetsPage() {
     redirect('/auth/msp/signin');
   }
 
-  const userEmail = await getCurrentUser();
-  const userId = userEmail?.user_id;
+  const currentUser = await getCurrentUser();
+  const userId = currentUser?.user_id;
   
   if (!userId) {
     console.error('User ID is missing from the session');
@@ -22,13 +20,6 @@ export default async function AssetsPage() {
   }
 
   try {
-    const knex = await getConnection();
-    const user = await User.get(knex, userId);
-    if (!user) {
-      console.error(`User not found for ID: ${userId}`);
-      redirect('/auth/msp/signin');
-    }
-
     const assets: AssetListResponse = await listAssets({});
     return <AssetDashboard initialAssets={assets} />;
   } catch (error) {


### PR DESCRIPTION
## Summary
- remove direct `@alga-psa/db/models/user` lookups from MSP assets page loaders
- remove direct `getConnection()` usage in these pages
- keep session + `getCurrentUser()` auth gate, then rely on action-layer access/tenant handling

## Why
After tenant-context hardening, direct model calls from app routes can fail with `tenant context not found` when AsyncLocalStorage context is not established.

## Validation
- npm -w server run typecheck
