### PR TITLE
Add ticket list compact/spacious density control using shared UI

### DIFF
--- a/packages/projects/src/components/KanbanZoomControl.tsx
+++ b/packages/projects/src/components/KanbanZoomControl.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Minus, Plus } from 'lucide-react';
-import { Button } from '@alga-psa/ui/components/Button';
+import ViewDensityControl from '@alga-psa/ui/components/ViewDensityControl';
 
 interface KanbanZoomControlProps {
   zoomLevel: number;
@@ -23,90 +22,25 @@ export const KanbanZoomControl: React.FC<KanbanZoomControlProps> = ({
   maxZoom = 100,
   step = 10,
 }) => {
-  const handleZoomOut = () => {
-    const newLevel = Math.max(minZoom, zoomLevel - step);
-    onZoomChange(newLevel);
-  };
-
-  const handleZoomIn = () => {
-    const newLevel = Math.min(maxZoom, zoomLevel + step);
-    onZoomChange(newLevel);
-  };
-
-  const isMinZoom = zoomLevel <= minZoom;
-  const isMaxZoom = zoomLevel >= maxZoom;
-  const isDefaultZoom = zoomLevel === 50;
-
-  const handleSnapToCompact = () => {
-    onZoomChange(minZoom);
-  };
-
-  const handleSnapToSpacious = () => {
-    onZoomChange(maxZoom);
-  };
-
-  const handleResetToDefault = () => {
-    onZoomChange(50);
-  };
-
   return (
-    <div className="flex items-center gap-1.5">
-      <Button
-        id="kanban-snap-compact"
-        variant="ghost"
-        size="xs"
-        onClick={handleSnapToCompact}
-        disabled={isMinZoom}
-        title="Snap to compact view"
-        className="!h-6 !px-1 !min-w-0 text-xs text-gray-500 hover:text-gray-700 disabled:text-gray-400"
-      >
-        Compact
-      </Button>
-      <Button
-        id="kanban-zoom-out"
-        variant="outline"
-        size="xs"
-        onClick={handleZoomOut}
-        disabled={isMinZoom}
-        title="Decrease column width"
-        className="!w-6 !h-6 !p-0 !min-w-0"
-      >
-        <Minus className="w-3.5 h-3.5" />
-      </Button>
-      <Button
-        id="kanban-zoom-reset"
-        variant={isDefaultZoom ? "outline" : "ghost"}
-        size="xs"
-        onClick={handleResetToDefault}
-        disabled={isDefaultZoom}
-        title="Reset to default"
-        className="!h-6 !px-1.5 !min-w-0 text-xs"
-      >
-        Reset
-      </Button>
-      <Button
-        id="kanban-zoom-in"
-        variant="outline"
-        size="xs"
-        onClick={handleZoomIn}
-        disabled={isMaxZoom}
-        title="Increase column width"
-        className="!w-6 !h-6 !p-0 !min-w-0"
-      >
-        <Plus className="w-3.5 h-3.5" />
-      </Button>
-      <Button
-        id="kanban-snap-spacious"
-        variant="ghost"
-        size="xs"
-        onClick={handleSnapToSpacious}
-        disabled={isMaxZoom}
-        title="Snap to spacious view"
-        className="!h-6 !px-1 !min-w-0 text-xs text-gray-500 hover:text-gray-700 disabled:text-gray-400"
-      >
-        Spacious
-      </Button>
-    </div>
+    <ViewDensityControl
+      idPrefix="kanban"
+      compactId="kanban-snap-compact"
+      decreaseId="kanban-zoom-out"
+      resetId="kanban-zoom-reset"
+      increaseId="kanban-zoom-in"
+      spaciousId="kanban-snap-spacious"
+      value={zoomLevel}
+      onChange={onZoomChange}
+      minValue={minZoom}
+      maxValue={maxZoom}
+      step={step}
+      compactLabel="Compact"
+      spaciousLabel="Spacious"
+      decreaseTitle="Decrease column width"
+      increaseTitle="Increase column width"
+      resetTitle="Reset to default"
+    />
   );
 };
 

--- a/packages/ui/src/components/ViewDensityControl.tsx
+++ b/packages/ui/src/components/ViewDensityControl.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import React from 'react';
+import { Minus, Plus } from 'lucide-react';
+import { Button } from './Button';
+
+export interface ViewDensityControlProps {
+  value: number;
+  onChange: (value: number) => void;
+  minValue?: number;
+  maxValue?: number;
+  defaultValue?: number;
+  step?: number;
+  idPrefix?: string;
+  compactLabel?: string;
+  spaciousLabel?: string;
+  resetLabel?: string;
+  compactTitle?: string;
+  decreaseTitle?: string;
+  resetTitle?: string;
+  increaseTitle?: string;
+  spaciousTitle?: string;
+  className?: string;
+  compactId?: string;
+  decreaseId?: string;
+  resetId?: string;
+  increaseId?: string;
+  spaciousId?: string;
+}
+
+const ViewDensityControl: React.FC<ViewDensityControlProps> = ({
+  value,
+  onChange,
+  minValue = 0,
+  maxValue = 100,
+  defaultValue = 50,
+  step = 10,
+  idPrefix = 'view-density',
+  compactLabel = 'Compact',
+  spaciousLabel = 'Spacious',
+  resetLabel = 'Reset',
+  compactTitle = 'Snap to compact view',
+  decreaseTitle = 'Decrease spacing',
+  resetTitle = 'Reset to default',
+  increaseTitle = 'Increase spacing',
+  spaciousTitle = 'Snap to spacious view',
+  className = '',
+  compactId,
+  decreaseId,
+  resetId,
+  increaseId,
+  spaciousId,
+}) => {
+  const isAtMin = value <= minValue;
+  const isAtMax = value >= maxValue;
+  const isAtDefault = value === defaultValue;
+
+  const handleDecrease = () => {
+    onChange(Math.max(minValue, value - step));
+  };
+
+  const handleIncrease = () => {
+    onChange(Math.min(maxValue, value + step));
+  };
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`.trim()}>
+      <Button
+        id={compactId ?? `${idPrefix}-snap-compact`}
+        variant="ghost"
+        size="xs"
+        onClick={() => onChange(minValue)}
+        disabled={isAtMin}
+        title={compactTitle}
+        className="!h-6 !px-1 !min-w-0 text-xs text-gray-500 hover:text-gray-700 disabled:text-gray-400"
+      >
+        {compactLabel}
+      </Button>
+      <Button
+        id={decreaseId ?? `${idPrefix}-decrease`}
+        variant="outline"
+        size="xs"
+        onClick={handleDecrease}
+        disabled={isAtMin}
+        title={decreaseTitle}
+        className="!w-6 !h-6 !p-0 !min-w-0"
+      >
+        <Minus className="w-3.5 h-3.5" />
+      </Button>
+      <Button
+        id={resetId ?? `${idPrefix}-reset`}
+        variant={isAtDefault ? 'outline' : 'ghost'}
+        size="xs"
+        onClick={() => onChange(defaultValue)}
+        disabled={isAtDefault}
+        title={resetTitle}
+        className="!h-6 !px-1.5 !min-w-0 text-xs"
+      >
+        {resetLabel}
+      </Button>
+      <Button
+        id={increaseId ?? `${idPrefix}-increase`}
+        variant="outline"
+        size="xs"
+        onClick={handleIncrease}
+        disabled={isAtMax}
+        title={increaseTitle}
+        className="!w-6 !h-6 !p-0 !min-w-0"
+      >
+        <Plus className="w-3.5 h-3.5" />
+      </Button>
+      <Button
+        id={spaciousId ?? `${idPrefix}-snap-spacious`}
+        variant="ghost"
+        size="xs"
+        onClick={() => onChange(maxValue)}
+        disabled={isAtMax}
+        title={spaciousTitle}
+        className="!h-6 !px-1 !min-w-0 text-xs text-gray-500 hover:text-gray-700 disabled:text-gray-400"
+      >
+        {spaciousLabel}
+      </Button>
+    </div>
+  );
+};
+
+export default ViewDensityControl;

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -101,6 +101,8 @@ export * from './UserAvatar';
 export { default as UserAvatar } from './UserAvatar';
 export * from './UserPicker';
 export { default as UserPicker } from './UserPicker';
+export * from './ViewDensityControl';
+export { default as ViewDensityControl } from './ViewDensityControl';
 export * from './ViewSwitcher';
 export { default as ViewSwitcher } from './ViewSwitcher';
 export * from './providers/TenantProvider';


### PR DESCRIPTION
## Summary
- add a reusable `ViewDensityControl` component in `@alga-psa/ui`
- refactor project `KanbanZoomControl` to use the shared control (preserving existing button IDs)
- add compact/reset/spacious density controls to the ticket filter area in `TicketingDashboard`
- apply density changes to filter/header spacing, body padding, and ticket row vertical density
- persist ticket density preference in localStorage (`ticket_list_density_level`)

## Testing
- npx eslint packages/ui/src/components/ViewDensityControl.tsx packages/projects/src/components/KanbanZoomControl.tsx packages/tickets/src/components/TicketingDashboard.tsx
