### PR TITLE
docs: harden secret file setup for special characters

### DIFF
--- a/docs/getting-started/development_guide.md
+++ b/docs/getting-started/development_guide.md
@@ -24,8 +24,8 @@ cp .env.example .env.development
 ```bash
 mkdir -p secrets
 # Create development secrets with dummy values
-echo "dev-password" > secrets/db_password_server
-echo "dev-password" > secrets/db_password_hocuspocus
+echo 'dev-password' > secrets/db_password_server
+echo 'dev-password' > secrets/db_password_hocuspocus
 # ... create other required secrets
 chmod 600 secrets/*
 ```

--- a/docs/getting-started/setup_guide.md
+++ b/docs/getting-started/setup_guide.md
@@ -38,35 +38,43 @@ This guide provides step-by-step instructions for setting up the PSA system usin
 
 1. Create secret files in the `secrets/` directory:
 
+   Use single quotes around secret values to prevent shell expansion of special characters (for example `$`, `!`, `*`, and backticks).
+   If a secret contains a single quote (`'`), use a quoted heredoc instead:
+   ```bash
+   cat > secrets/email_password <<'EOF'
+   your-secret-value
+   EOF
+   ```
+
 Database secrets (replace placeholders with strong values):
 ```bash
-echo "your-secure-admin-password" > secrets/postgres_password
-echo "your-secure-app-password" > secrets/db_password_server
-echo "your-secure-hocuspocus-password" > secrets/db_password_hocuspocus
+echo 'your-secure-admin-password' > secrets/postgres_password
+echo 'your-secure-app-password' > secrets/db_password_server
+echo 'your-secure-hocuspocus-password' > secrets/db_password_hocuspocus
 ```
 
 Redis Secret:
 ```bash
-echo "your-secure-password" > secrets/redis_password
+echo 'your-secure-password' > secrets/redis_password
 ```
 
 Authentication secret:
 ```bash
-echo "your-32-char-min-key" > secrets/alga_auth_key
+echo 'your-32-char-min-key' > secrets/alga_auth_key
 ```
 
 Security Secrets:
 ```bash
-echo "your-32-char-min-key" > secrets/crypto_key
-echo "your-32-char-min-key" > secrets/token_secret_key
-echo "your-32-char-min-key" > secrets/nextauth_secret
+echo 'your-32-char-min-key' > secrets/crypto_key
+echo 'your-32-char-min-key' > secrets/token_secret_key
+echo 'your-32-char-min-key' > secrets/nextauth_secret
 ```
 
 Email & OAuth Secrets:
 ```bash
-echo "your-email-password" > secrets/email_password
-echo "your-client-id" > secrets/google_oauth_client_id
-echo "your-client-secret" > secrets/google_oauth_client_secret
+echo 'your-email-password' > secrets/email_password
+echo 'your-client-id' > secrets/google_oauth_client_id
+echo 'your-client-secret' > secrets/google_oauth_client_secret
 ```
 
 2. Set proper permissions:

--- a/docs/getting-started/setup_guide_windows.md
+++ b/docs/getting-started/setup_guide_windows.md
@@ -46,35 +46,43 @@ This guide provides step-by-step instructions for setting up the PSA system on W
 
 1. Create secret files in the `secrets/` directory (replace placeholders with strong values):
 
+   Use single quotes around secret values to prevent shell expansion of special characters (for example `$`, `!`, `*`, and backticks).
+   If a secret contains a single quote (`'`), use a quoted heredoc instead:
+   ```bash
+   cat > secrets/email_password <<'EOF'
+   your-secret-value
+   EOF
+   ```
+
    Database secrets:
    ```bash
-   echo "your-secure-admin-password" > secrets/postgres_password
-   echo "your-secure-app-password" > secrets/db_password_server
-   echo "your-secure-hocuspocus-password" > secrets/db_password_hocuspocus
+   echo 'your-secure-admin-password' > secrets/postgres_password
+   echo 'your-secure-app-password' > secrets/db_password_server
+   echo 'your-secure-hocuspocus-password' > secrets/db_password_hocuspocus
    ```
 
    Redis secret:
    ```bash
-   echo "your-secure-password" > secrets/redis_password
+   echo 'your-secure-password' > secrets/redis_password
    ```
 
    Authentication secret:
    ```bash
-   echo "your-32-char-min-key" > secrets/alga_auth_key
+   echo 'your-32-char-min-key' > secrets/alga_auth_key
    ```
 
    Security secrets:
    ```bash
-   echo "your-32-char-min-key" > secrets/crypto_key
-   echo "your-32-char-min-key" > secrets/token_secret_key
-   echo "your-32-char-min-key" > secrets/nextauth_secret
+   echo 'your-32-char-min-key' > secrets/crypto_key
+   echo 'your-32-char-min-key' > secrets/token_secret_key
+   echo 'your-32-char-min-key' > secrets/nextauth_secret
    ```
 
    Email & OAuth secrets:
    ```bash
-   echo "your-email-password" > secrets/email_password
-   echo "your-client-id" > secrets/google_oauth_client_id
-   echo "your-client-secret" > secrets/google_oauth_client_secret
+   echo 'your-email-password' > secrets/email_password
+   echo 'your-client-id' > secrets/google_oauth_client_id
+   echo 'your-client-secret' > secrets/google_oauth_client_secret
    ```
 
 2. Set proper permissions:

--- a/docs/security/secrets_management.md
+++ b/docs/security/secrets_management.md
@@ -115,23 +115,29 @@ The system uses a two-user database authentication model for security:
 1. Create the `secrets/` directory
 2. Create individual files for each secret:
 ```bash
+# Use single quotes to avoid shell expansion of special characters in secret values.
+# If a value contains a single quote ('), use a quoted heredoc instead:
+# cat > secrets/email_password <<'EOF'
+# your-secret-value
+# EOF
+
 # Database
-echo "your-secure-admin-password" > secrets/postgres_password
-echo "your-secure-app-password" > secrets/db_password_server
-echo "your-secure-hocuspocus-password" > secrets/db_password_hocuspocus
+echo 'your-secure-admin-password' > secrets/postgres_password
+echo 'your-secure-app-password' > secrets/db_password_server
+echo 'your-secure-hocuspocus-password' > secrets/db_password_hocuspocus
 
 # Redis
-echo "your-secure-password" > secrets/redis_password
+echo 'your-secure-password' > secrets/redis_password
 
 # Security
-echo "your-32-char-min-key" > secrets/crypto_key
-echo "your-32-char-min-key" > secrets/token_secret_key
-echo "your-32-char-min-key" > secrets/nextauth_secret
+echo 'your-32-char-min-key' > secrets/crypto_key
+echo 'your-32-char-min-key' > secrets/token_secret_key
+echo 'your-32-char-min-key' > secrets/nextauth_secret
 
 # Email & OAuth
-echo "your-email-password" > secrets/email_password
-echo "your-client-id" > secrets/google_oauth_client_id
-echo "your-client-secret" > secrets/google_oauth_client_secret
+echo 'your-email-password' > secrets/email_password
+echo 'your-client-id' > secrets/google_oauth_client_id
+echo 'your-client-secret' > secrets/google_oauth_client_secret
 ```
 
 3. Set appropriate permissions:


### PR DESCRIPTION
## Summary
- switch secret-writing examples from double-quoted echo to single-quoted echo in setup and security docs
- add explicit guidance for values that include a single quote using quoted heredoc syntax
- align related docs so setup instructions are consistent across Linux, WSL, development, and security pages

## Why
Double-quoted shell examples can expand special characters and create incorrect secret files.