### PR TITLE
fix(projects): remove invalid project_tasks.order_number usage

### DIFF
--- a/server/src/lib/api/services/ProjectService.ts
+++ b/server/src/lib/api/services/ProjectService.ts
@@ -563,7 +563,7 @@ export class ProjectService extends BaseService<IProject> {
         .select('project_tasks.*')
         .orderBy([
           { column: 'project_tasks.order_key', order: 'asc' },
-          { column: 'project_tasks.order_number', order: 'asc' }
+          { column: 'project_tasks.wbs_code', order: 'asc' }
         ]);
     }
 
@@ -612,7 +612,6 @@ export class ProjectService extends BaseService<IProject> {
         const taskData = {
           ...data,
           phase_id: phaseId,
-          order_number: tasks.length + 1,
           wbs_code: newWbsCode,
           order_key: orderKey,
           tenant: context.tenant,


### PR DESCRIPTION
## Summary
- stop sorting project tasks by `project_tasks.order_number` in `getTasks`
- use `project_tasks.order_key` with `project_tasks.wbs_code` fallback ordering
- stop writing `order_number` when creating project tasks

## Why
Some deployed schemas do not have `project_tasks.order_number`, which caused runtime SQL errors when loading tasks for a project.