### PR TITLE
Allow dashboard onboarding helper cards to be dismissed per-step

### DIFF
--- a/packages/onboarding/src/actions/onboarding-actions/dashboardOnboardingActions.ts
+++ b/packages/onboarding/src/actions/onboarding-actions/dashboardOnboardingActions.ts
@@ -1,0 +1,102 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { withAuth, type AuthContext } from '@alga-psa/auth';
+import type { IUserWithRoles } from '@alga-psa/types';
+import { getTenantSettings, updateTenantSettings } from '@alga-psa/tenancy/actions';
+import type { OnboardingStepId } from '../onboarding-progress';
+import type { OnboardingActionResult } from './onboardingActions';
+import {
+  DASHBOARD_ONBOARDING_SETTINGS_KEY,
+  getDismissedStepIdsFromTenantSettings,
+  isOnboardingStepId,
+  setDismissedStepIdsInTenantSettings,
+} from '../../lib/dashboardOnboardingDismissals';
+
+export interface DashboardOnboardingDismissalResult extends OnboardingActionResult {
+  data?: {
+    dismissedStepIds: OnboardingStepId[];
+  };
+}
+
+async function getDismissedStepIds(): Promise<OnboardingStepId[]> {
+  const tenantSettings = await getTenantSettings();
+  return getDismissedStepIdsFromTenantSettings(tenantSettings?.settings);
+}
+
+async function saveDismissedStepIds(nextDismissedStepIds: OnboardingStepId[]): Promise<void> {
+  const tenantSettings = await getTenantSettings();
+  const mergedSettings = setDismissedStepIdsInTenantSettings(
+    tenantSettings?.settings,
+    nextDismissedStepIds
+  );
+
+  await updateTenantSettings({
+    [DASHBOARD_ONBOARDING_SETTINGS_KEY]: mergedSettings[DASHBOARD_ONBOARDING_SETTINGS_KEY],
+  });
+  revalidatePath('/msp/dashboard');
+}
+
+export const dismissDashboardOnboardingStep = withAuth(async (
+  _user: IUserWithRoles,
+  _context: AuthContext,
+  stepId: OnboardingStepId
+): Promise<DashboardOnboardingDismissalResult> => {
+  try {
+    if (!isOnboardingStepId(stepId)) {
+      return { success: false, error: 'Invalid onboarding step id.' };
+    }
+
+    const dismissedStepIds = await getDismissedStepIds();
+
+    if (dismissedStepIds.includes(stepId)) {
+      return { success: true, data: { dismissedStepIds } };
+    }
+
+    const nextDismissedStepIds = [...dismissedStepIds, stepId];
+    await saveDismissedStepIds(nextDismissedStepIds);
+
+    return { success: true, data: { dismissedStepIds: nextDismissedStepIds } };
+  } catch (error) {
+    console.error('Error dismissing dashboard onboarding step:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+export const restoreDashboardOnboardingStep = withAuth(async (
+  _user: IUserWithRoles,
+  _context: AuthContext,
+  stepId: OnboardingStepId
+): Promise<DashboardOnboardingDismissalResult> => {
+  try {
+    if (!isOnboardingStepId(stepId)) {
+      return { success: false, error: 'Invalid onboarding step id.' };
+    }
+
+    const dismissedStepIds = await getDismissedStepIds();
+    const nextDismissedStepIds = dismissedStepIds.filter((id) => id !== stepId);
+
+    if (nextDismissedStepIds.length === dismissedStepIds.length) {
+      return { success: true, data: { dismissedStepIds } };
+    }
+
+    await saveDismissedStepIds(nextDismissedStepIds);
+
+    return { success: true, data: { dismissedStepIds: nextDismissedStepIds } };
+  } catch (error) {
+    console.error('Error restoring dashboard onboarding step:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+export const getDismissedDashboardOnboardingSteps = withAuth(async (
+  _user: IUserWithRoles,
+  _context: AuthContext
+): Promise<OnboardingStepId[]> => {
+  try {
+    return await getDismissedStepIds();
+  } catch (error) {
+    console.error('Error loading dismissed dashboard onboarding steps:', error);
+    return [];
+  }
+});

--- a/packages/onboarding/src/actions/onboarding-actions/index.ts
+++ b/packages/onboarding/src/actions/onboarding-actions/index.ts
@@ -1,3 +1,3 @@
 export * from './onboardingActions';
 export * from './serviceTypeActions';
-
+export * from './dashboardOnboardingActions';

--- a/packages/onboarding/src/actions/onboarding-progress.ts
+++ b/packages/onboarding/src/actions/onboarding-progress.ts
@@ -30,6 +30,7 @@ export interface OnboardingStepServerState {
   progressValue?: number | null;
   meta?: Record<string, unknown>;
   substeps?: OnboardingSubstepServerState[];
+  dismissed?: boolean;
 }
 
 export interface OnboardingProgressResponse {

--- a/packages/onboarding/src/lib/dashboardOnboardingDismissals.ts
+++ b/packages/onboarding/src/lib/dashboardOnboardingDismissals.ts
@@ -1,0 +1,75 @@
+import type { OnboardingStepId } from '../actions/onboarding-progress';
+import { STEP_DEFINITIONS } from './stepDefinitions';
+
+export const DASHBOARD_ONBOARDING_SETTINGS_KEY = 'dashboardOnboarding';
+export const DASHBOARD_ONBOARDING_DISMISSED_STEP_IDS_KEY = 'dismissedStepIds';
+
+const VALID_STEP_IDS = new Set<OnboardingStepId>(
+  Object.keys(STEP_DEFINITIONS) as OnboardingStepId[]
+);
+
+function normalizeRecord(value: unknown): Record<string, unknown> {
+  if (!value) {
+    return {};
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  return typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+export function isOnboardingStepId(value: unknown): value is OnboardingStepId {
+  return typeof value === 'string' && VALID_STEP_IDS.has(value as OnboardingStepId);
+}
+
+export function normalizeDismissedStepIds(value: unknown): OnboardingStepId[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<OnboardingStepId>();
+  const normalized: OnboardingStepId[] = [];
+
+  for (const candidate of value) {
+    if (!isOnboardingStepId(candidate) || seen.has(candidate)) {
+      continue;
+    }
+
+    seen.add(candidate);
+    normalized.push(candidate);
+  }
+
+  return normalized;
+}
+
+export function getDismissedStepIdsFromTenantSettings(settingsValue: unknown): OnboardingStepId[] {
+  const settings = normalizeRecord(settingsValue);
+  const dashboardOnboardingSettings = normalizeRecord(settings[DASHBOARD_ONBOARDING_SETTINGS_KEY]);
+  return normalizeDismissedStepIds(
+    dashboardOnboardingSettings[DASHBOARD_ONBOARDING_DISMISSED_STEP_IDS_KEY]
+  );
+}
+
+export function setDismissedStepIdsInTenantSettings(
+  settingsValue: unknown,
+  dismissedStepIds: OnboardingStepId[]
+): Record<string, unknown> {
+  const settings = normalizeRecord(settingsValue);
+  const dashboardOnboardingSettings = normalizeRecord(settings[DASHBOARD_ONBOARDING_SETTINGS_KEY]);
+
+  return {
+    ...settings,
+    [DASHBOARD_ONBOARDING_SETTINGS_KEY]: {
+      ...dashboardOnboardingSettings,
+      [DASHBOARD_ONBOARDING_DISMISSED_STEP_IDS_KEY]: normalizeDismissedStepIds(dismissedStepIds),
+      updatedAt: new Date().toISOString(),
+    },
+  };
+}

--- a/packages/onboarding/src/lib/index.ts
+++ b/packages/onboarding/src/lib/index.ts
@@ -1,3 +1,3 @@
 export * from './stepDefinitions';
 export * from './deriveParentStepFromSubsteps';
-
+export * from './dashboardOnboardingDismissals';

--- a/server/src/test/unit/onboarding/dashboardOnboardingDismissals.test.ts
+++ b/server/src/test/unit/onboarding/dashboardOnboardingDismissals.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDismissedStepIdsFromTenantSettings,
+  setDismissedStepIdsInTenantSettings,
+} from '@alga-psa/onboarding/lib/dashboardOnboardingDismissals';
+
+describe('dashboard onboarding dismissal settings helpers', () => {
+  it('normalizes dismissed step ids from tenant settings', () => {
+    const dismissedStepIds = getDismissedStepIdsFromTenantSettings({
+      dashboardOnboarding: {
+        dismissedStepIds: [
+          'identity_sso',
+          'identity_sso',
+          'managed_email',
+          'unknown-step',
+          null,
+        ],
+      },
+    });
+
+    expect(dismissedStepIds).toEqual(['identity_sso', 'managed_email']);
+  });
+
+  it('handles stringified settings payloads', () => {
+    const settings = JSON.stringify({
+      dashboardOnboarding: {
+        dismissedStepIds: ['data_import'],
+      },
+    });
+
+    expect(getDismissedStepIdsFromTenantSettings(settings)).toEqual(['data_import']);
+  });
+
+  it('merges dismissal settings while preserving existing tenant settings', () => {
+    const nextSettings = setDismissedStepIdsInTenantSettings(
+      {
+        experimentalFeatures: {
+          aiAssistant: false,
+        },
+        dashboardOnboarding: {
+          someExistingSetting: true,
+        },
+      },
+      ['calendar_sync', 'managed_email']
+    );
+
+    expect(nextSettings).toMatchObject({
+      experimentalFeatures: {
+        aiAssistant: false,
+      },
+      dashboardOnboarding: {
+        someExistingSetting: true,
+        dismissedStepIds: ['calendar_sync', 'managed_email'],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tenant-scoped persistence for dismissed dashboard onboarding helper steps (`settings.dashboardOnboarding.dismissedStepIds`)
- add onboarding actions to dismiss/restore/load dismissed steps
- update dashboard onboarding slot + section so dismissed cards are hidden from active setup and treated as complete for progress
- add a hidden-cards restore panel and optimistic dismiss/restore UX
- add normalization/merge helper coverage for dismissal settings

## Validation
- `npm run -w @alga-psa/onboarding typecheck`
- `npm run -w @alga-psa/onboarding build`
- `node --import tsx -e "import { getDismissedStepIdsFromTenantSettings } from "./packages/onboarding/src/lib/dashboardOnboardingDismissals.ts"; const out = getDismissedStepIdsFromTenantSettings({ dashboardOnboarding: { dismissedStepIds: ["identity_sso","unknown"] } }); console.log(JSON.stringify(out));"`