### PR TITLE
fix(clients): route contact portal invitation calls through server action bridge

### DIFF
--- a/packages/clients/src/actions/contact-actions/index.ts
+++ b/packages/clients/src/actions/contact-actions/index.ts
@@ -1,3 +1,3 @@
 export * from './contactActions';
 export * from './contactNoteActions';
-
+export * from './portalInvitationBridgeActions';

--- a/packages/clients/src/actions/contact-actions/portalInvitationBridgeActions.ts
+++ b/packages/clients/src/actions/contact-actions/portalInvitationBridgeActions.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import {
+  sendPortalInvitation as sendPortalInvitationAction,
+  getPortalInvitations as getPortalInvitationsAction,
+  revokePortalInvitation as revokePortalInvitationAction,
+  updateClientUser as updateClientUserAction
+} from '@alga-psa/portal-shared/actions';
+import type { IUser } from '@alga-psa/types';
+import type {
+  SendInvitationResult,
+  InvitationHistoryItem
+} from '@alga-psa/portal-shared/types';
+
+export async function sendPortalInvitation(contactId: string): Promise<SendInvitationResult> {
+  return sendPortalInvitationAction(contactId);
+}
+
+export async function getPortalInvitations(contactId: string): Promise<InvitationHistoryItem[]> {
+  return getPortalInvitationsAction(contactId);
+}
+
+export async function revokePortalInvitation(invitationId: string): Promise<{ success: boolean; error?: string }> {
+  return revokePortalInvitationAction(invitationId);
+}
+
+export async function updateClientUser(userId: string, data: { is_inactive?: boolean }): Promise<IUser | null> {
+  return updateClientUserAction(userId, data);
+}

--- a/packages/clients/src/components/contacts/ContactPortalTab.tsx
+++ b/packages/clients/src/components/contacts/ContactPortalTab.tsx
@@ -18,39 +18,13 @@ import {
   removeRoleFromUser,
   getRoles
 } from '@alga-psa/auth/actions';
-
-// Dynamic imports to avoid circular dependency (clients -> client-portal -> clients)
-// TODO: Consolidate after circular dependency is resolved
-type InvitationHistoryItem = {
-  invitation_id: string;
-  email: string;
-  created_at: string | Date;
-  expires_at: string | Date;
-  status: 'pending' | 'accepted' | 'expired' | 'revoked';
-  used_at?: string | Date | null;
-};
-
-const getClientPortalModule = () => '@alga-psa/' + 'client-portal/actions';
-
-const sendPortalInvitation = async (contactId: string): Promise<{ success: boolean; message?: string; invitation?: any }> => {
-  const mod = await import(/* webpackIgnore: true */ getClientPortalModule());
-  return mod.sendPortalInvitation(contactId);
-};
-
-const getPortalInvitations = async (contactId: string): Promise<InvitationHistoryItem[]> => {
-  const mod = await import(/* webpackIgnore: true */ getClientPortalModule());
-  return mod.getPortalInvitations(contactId);
-};
-
-const revokePortalInvitation = async (invitationId: string): Promise<{ success: boolean; message?: string }> => {
-  const mod = await import(/* webpackIgnore: true */ getClientPortalModule());
-  return mod.revokePortalInvitation(invitationId);
-};
-
-const updateClientUser = async (userId: string, data: { is_inactive?: boolean }): Promise<{ success: boolean; message?: string }> => {
-  const mod = await import(/* webpackIgnore: true */ getClientPortalModule());
-  return mod.updateClientUser(userId, data);
-};
+import {
+  sendPortalInvitation,
+  getPortalInvitations,
+  revokePortalInvitation,
+  updateClientUser
+} from '../../actions/contact-actions/portalInvitationBridgeActions';
+import type { InvitationHistoryItem } from '@alga-psa/portal-shared/types';
 import { useToast } from '@alga-psa/ui';
 import SettingsTabSkeleton from '@alga-psa/ui/components/skeletons/SettingsTabSkeleton';
 
@@ -147,7 +121,7 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
       } else {
         toast({
           title: "Error",
-          description: result.message || "Failed to send invitation",
+          description: result.error || result.message || "Failed to send invitation",
           variant: "destructive"
         });
       }
@@ -178,7 +152,7 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
       } else {
         toast({
           title: "Error",
-          description: result.message || "Failed to revoke invitation",
+          description: result.error || "Failed to revoke invitation",
           variant: "destructive"
         });
       }
@@ -217,7 +191,7 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
       } else {
         toast({
           title: "Error",
-          description: result.message || "Failed to resend invitation",
+          description: result.error || result.message || "Failed to resend invitation",
           variant: "destructive"
         });
       }
@@ -637,4 +611,3 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
     </div>
   );
 }
-


### PR DESCRIPTION
Summary:
- Remove client-side dynamic module import from ContactPortalTab
- Add portalInvitationBridgeActions in clients contact actions as the server-action boundary
- Route invite/get/revoke/update calls via portal-shared from the bridge
- Import InvitationHistoryItem from portal-shared types to avoid action-manifest runtime export errors

Why:
Next 16/Turbopack was throwing runtime module resolution errors for client-portal actions from browser code and an action-manifest error from exporting a type in a use server module.

Validation:
- npm -w @alga-psa/clients run typecheck
- npm -w @alga-psa/portal-shared run typecheck
- eslint on changed clients files (warnings only, no errors)
