### PR TITLE
fix(server-build): resolve @alga-psa/portal-shared in server webpack build

### DIFF
--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -259,6 +259,11 @@ const nextConfig = {
 	      '@alga-psa/client-portal/': '../packages/client-portal/src/',
 	      '@alga-psa/client-portal/actions': '../packages/client-portal/src/actions/index.ts',
 	      '@alga-psa/client-portal/components': '../packages/client-portal/src/components/index.ts',
+	      // Portal shared package
+	      '@alga-psa/portal-shared': '../packages/portal-shared/src',
+	      '@alga-psa/portal-shared/': '../packages/portal-shared/src/',
+	      '@alga-psa/portal-shared/actions': '../packages/portal-shared/src/actions/index.ts',
+	      '@alga-psa/portal-shared/types': '../packages/portal-shared/src/types/index.ts',
 	      // Media package
 	      '@alga-psa/media': '../packages/media/src',
 	      '@alga-psa/media/': '../packages/media/src/',
@@ -380,6 +385,7 @@ const nextConfig = {
 	    '@alga-psa/tenancy',
 	    '@alga-psa/integrations',
 	    '@alga-psa/client-portal',
+	    '@alga-psa/portal-shared',
 	    '@alga-psa/event-schemas',
 	    '@alga-psa/documents',
 	    '@alga-psa/media',
@@ -455,6 +461,7 @@ const nextConfig = {
       '@alga-psa/event-schemas': path.join(__dirname, '../packages/event-schemas/src'),
       '@alga-psa/surveys': path.join(__dirname, '../packages/surveys/src'),
       '@alga-psa/client-portal': path.join(__dirname, '../packages/client-portal/src'),
+      '@alga-psa/portal-shared': path.join(__dirname, '../packages/portal-shared/src'),
       '@alga-psa/media': path.join(__dirname, '../packages/media/src'),
       '@ee': isEE
         ? path.join(__dirname, '../ee/server/src')

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -198,6 +198,12 @@
       "@alga-psa/client-portal/*": [
         "../packages/client-portal/src/*"
       ],
+      "@alga-psa/portal-shared": [
+        "../packages/portal-shared/src"
+      ],
+      "@alga-psa/portal-shared/*": [
+        "../packages/portal-shared/src/*"
+      ],
       "@alga-psa/notifications": [
         "../packages/notifications/src"
       ],


### PR DESCRIPTION
Summary:
- add server tsconfig path aliases for @alga-psa/portal-shared and deep imports
- add server next.config aliases for @alga-psa/portal-shared (base/actions/types)
- add @alga-psa/portal-shared to server transpilePackages

Why:
CI webpack build failed with module-not-found for @alga-psa/portal-shared/actions when compiling server app routes.

Scope:
- contains only commit 5a9fc4cf1 (cherry-picked from 6525e53a6)
