### PR TITLE
Restore auto-tracked interval display and fix duration bug

### DIFF
--- a/packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx
+++ b/packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx
@@ -7,12 +7,13 @@ import ClientDetails from '@alga-psa/clients/components/clients/ClientDetails';
 import type { IClient, IContact } from '@alga-psa/types';
 import CreateTaskFromTicketDialog from '@alga-psa/projects/components/CreateTaskFromTicketDialog';
 import LinkTicketToTaskDialog from '@alga-psa/projects/components/LinkTicketToTaskDialog';
+import { IntervalManagement } from '@alga-psa/scheduling/components/time-management/interval-tracking/IntervalManagement';
 import { TicketIntegrationProvider } from '@alga-psa/projects/context/TicketIntegrationContext';
 import { useTicketIntegrationValue } from '../projects/useTicketIntegrationValue';
 
 type MspTicketDetailsContainerClientProps = Omit<
   React.ComponentProps<typeof TicketDetailsContainer>,
-  'renderContactDetails' | 'renderClientDetails'
+  'renderContactDetails' | 'renderClientDetails' | 'renderIntervalManagement'
 >;
 
 export default function MspTicketDetailsContainerClient(props: MspTicketDetailsContainerClientProps) {
@@ -54,6 +55,13 @@ export default function MspTicketDetailsContainerClient(props: MspTicketDetailsC
     []
   );
 
+  const renderIntervalManagement = useCallback(
+    ({ ticketId, userId }: { ticketId: string; userId: string }) => (
+      <IntervalManagement ticketId={ticketId} userId={userId} />
+    ),
+    []
+  );
+
   return (
     <TicketIntegrationProvider value={ticketIntegrationValue}>
       <TicketDetailsContainer
@@ -61,6 +69,7 @@ export default function MspTicketDetailsContainerClient(props: MspTicketDetailsC
         renderContactDetails={renderContactDetails}
         renderCreateProjectTask={renderCreateProjectTask}
         renderClientDetails={renderClientDetails}
+        renderIntervalManagement={renderIntervalManagement}
       />
     </TicketIntegrationProvider>
   );

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -140,6 +140,12 @@ interface TicketDetailsProps {
         id: string;
         client: IClient;
     }) => React.ReactNode;
+
+    /**
+     * Optional injected UI for interval management (e.g. @alga-psa/scheduling IntervalManagement).
+     * Shows auto-tracked time intervals below the ticket timer.
+     */
+    renderIntervalManagement?: (args: { ticketId: string; userId: string }) => React.ReactNode;
 }
 
 const TicketDetails: React.FC<TicketDetailsProps> = ({
@@ -180,7 +186,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     associatedAssets = null,
     renderContactDetails,
     renderCreateProjectTask,
-    renderClientDetails
+    renderClientDetails,
+    renderIntervalManagement
 }) => {
     const { t } = useTranslation('clientPortal');
     const { data: session } = useSession();
@@ -1858,6 +1865,7 @@ const handleClose = () => {
                                 onTagsChange={handleTagsChange}
                                 onItilFieldChange={handleItilFieldChange}
                                 surveySummary={surveySummary}
+                                renderIntervalManagement={renderIntervalManagement}
                             />
                         </Suspense>
                         

--- a/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
@@ -54,6 +54,7 @@ interface TicketDetailsContainerProps {
   renderContactDetails?: React.ComponentProps<typeof TicketDetails>['renderContactDetails'];
   renderCreateProjectTask?: React.ComponentProps<typeof TicketDetails>['renderCreateProjectTask'];
   renderClientDetails?: React.ComponentProps<typeof TicketDetails>['renderClientDetails'];
+  renderIntervalManagement?: React.ComponentProps<typeof TicketDetails>['renderIntervalManagement'];
 }
 
 export default function TicketDetailsContainer({
@@ -63,6 +64,7 @@ export default function TicketDetailsContainer({
   renderContactDetails,
   renderCreateProjectTask,
   renderClientDetails,
+  renderIntervalManagement,
 }: TicketDetailsContainerProps) {
   const router = useRouter();
   const { data: session } = useSession();
@@ -250,6 +252,7 @@ export default function TicketDetailsContainer({
           renderContactDetails={renderContactDetails}
           renderCreateProjectTask={renderCreateProjectTask}
             renderClientDetails={renderClientDetails}
+            renderIntervalManagement={renderIntervalManagement}
         />
         </Suspense>
       </div>

--- a/packages/tickets/src/components/ticket/TicketProperties.tsx
+++ b/packages/tickets/src/components/ticket/TicketProperties.tsx
@@ -75,6 +75,7 @@ interface TicketPropertiesProps {
   onTagsChange?: (tags: ITag[]) => void;
   onItilFieldChange?: (field: string, value: any) => void;
   surveySummary?: SurveyTicketSatisfactionSummary | null;
+  renderIntervalManagement?: (args: { ticketId: string; userId: string }) => React.ReactNode;
 }
 
 // Helper function to format location display
@@ -147,6 +148,7 @@ const TicketProperties: React.FC<TicketPropertiesProps> = ({
   onTagsChange,
   onItilFieldChange,
   surveySummary = null,
+  renderIntervalManagement,
 }) => {
   const [showContactPicker, setShowContactPicker] = useState(false);
   const [showClientPicker, setShowClientPicker] = useState(false);
@@ -345,7 +347,15 @@ const TicketProperties: React.FC<TicketPropertiesProps> = ({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
             </svg>
           </Button>
-          
+
+          {/* Interval Management Section */}
+          {ticket.ticket_id && userId && renderIntervalManagement && (
+            <div className="mt-2 border-t pt-4" {...withDataAutomationId({ id: `${id}-interval-management` })}>
+              <h3 className="text-sm font-medium mb-2">Tracked Intervals</h3>
+              {renderIntervalManagement({ ticketId: ticket.ticket_id, userId })}
+            </div>
+          )}
+
         </div>
       </div>
 

--- a/packages/ui/src/services/IntervalTrackingService.ts
+++ b/packages/ui/src/services/IntervalTrackingService.ts
@@ -277,7 +277,7 @@ export class IntervalTrackingService {
 
         const endTime = new Date();
         const startTime = new Date(interval.startTime);
-        const duration = endTime.getTime() - startTime.getTime();
+        const duration = Math.floor((endTime.getTime() - startTime.getTime()) / 1000);
 
         interval.endTime = endTime.toISOString();
         interval.duration = duration;
@@ -339,7 +339,7 @@ export class IntervalTrackingService {
         const now = new Date();
         for (const interval of open) {
           const startTime = new Date(interval.startTime);
-          const duration = now.getTime() - startTime.getTime();
+          const duration = Math.floor((now.getTime() - startTime.getTime()) / 1000);
           interval.endTime = now.toISOString();
           interval.duration = duration;
           interval.autoClosed = true;


### PR DESCRIPTION
## Summary

- **Restore the IntervalManagement component** in the ticket properties sidebar, which was accidentally removed during the modularity architecture refactor. This re-adds the "Tracked Intervals" section below the ticket timer, showing auto-tracked time intervals with their durations, start/end times, active/auto-closed badges, and actions to select, merge, delete, or convert intervals into time entries.

- **Fix a unit mismatch bug in IntervalTrackingService** where `endInterval()` and `cleanupOrphanOpenIntervals()` stored interval duration in **milliseconds** while all display code (`formatDuration`, `IntervalItem`, `calculateTotalDuration`) treats the `duration` field as **seconds**. This caused intervals to display ~1000x their actual length (e.g. a 1-minute interval appeared as ~18 hours). The `autoCloseOpenIntervals()` method was already correctly dividing by 1000, confirming this was an oversight in the other two methods.

- **Use the render prop composition pattern** to inject IntervalManagement into TicketProperties, following the existing architecture used for `renderContactDetails`, `renderClientDetails`, etc. The `@alga-psa/tickets` package never imports from `@alga-psa/scheduling` directly — the wiring happens in `MspTicketDetailsContainerClient` (the composition layer).

All changes are in a single commit.

## Changes

### `packages/ui/src/services/IntervalTrackingService.ts`
- `endInterval()`: Change `endTime.getTime() - startTime.getTime()` to `Math.floor((endTime.getTime() - startTime.getTime()) / 1000)` so duration is stored in seconds
- `cleanupOrphanOpenIntervals()`: Same fix — divide by 1000 to store seconds instead of milliseconds

### `packages/tickets/src/components/ticket/TicketProperties.tsx`
- Add optional `renderIntervalManagement` render prop to interface
- Render it inside the Time Entry card below the "Add Time Entry" button, gated on `ticket.ticket_id && userId && renderIntervalManagement`

### `packages/tickets/src/components/ticket/TicketDetails.tsx`
- Add `renderIntervalManagement` to `TicketDetailsProps` interface
- Destructure and pass through to `TicketProperties`

### `packages/tickets/src/components/ticket/TicketDetailsContainer.tsx`
- Accept and forward `renderIntervalManagement` prop

### `packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx`
- Import `IntervalManagement` from `@alga-psa/scheduling`
- Create `renderIntervalManagement` callback and pass to `TicketDetailsContainer`
- Add to the `Omit` type so consumers don't need to provide it

## Note
Existing intervals stored in IndexedDB prior to this fix will still have inflated millisecond-based duration values. Users can delete those stale intervals through the UI. All new intervals going forward will have correct durations.

## Test plan
- [ ] Open a ticket and verify the "Tracked Intervals" section appears below the "Add Time Entry" button
- [ ] Stay on the ticket for a short period, navigate away, then return — verify the interval duration displays correctly (seconds, not inflated to hours)
- [ ] Test selecting intervals and using merge/delete/convert-to-time-entry actions
- [ ] Verify the ticket timer (start/pause/reset) still functions correctly alongside the interval display