### PR TITLE
Fix time entry billable toggle UX and service requirement clarity

### DIFF
--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -177,10 +177,11 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     const isAdHoc = workItem.type === 'ad_hoc';
 
     // Skip service validation for ad_hoc items
-    if (!isAdHoc) {
-      // Validate required fields
+    const isBillable = entry.billable_duration > 0;
+    if (!isAdHoc && isBillable) {
+      // Validate required fields for billable entries
       if (!entry.service_id) {
-        toast.error('Please select a service');
+        toast.error('Please select a service for billable entries');
         return;
       }
 
@@ -237,9 +238,9 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         updated_at: formatISO(new Date()),
         notes: entry.notes || '',
         approval_status: 'DRAFT' as TimeSheetStatus,
-        // Ensure service_id and tax_region are null/undefined for ad_hoc if not selected
-        service_id: isAdHoc ? undefined : entry.service_id,
-        tax_region: isAdHoc ? undefined : entry.tax_region,
+        // Ensure service_id and tax_region are null/undefined when not applicable
+        service_id: entry.service_id || undefined,
+        tax_region: entry.tax_region || undefined,
       };
 
       console.log('Prepared time entry:', timeEntry);
@@ -266,6 +267,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
       }
   
       toast.dismiss(loadingToast);
+      toast.success('Time entry saved');
       onClose();
     } catch (error) {
       toast.dismiss(loadingToast);

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx
@@ -281,11 +281,12 @@ const updateBillableDuration = useCallback((updatedEntry: typeof entry, newDurat
 
     const isAdHoc = entry?.work_item_type === 'ad_hoc';
 
-    // Ensure we have required fields (skip for ad_hoc)
-    if (!isAdHoc && !entry?.service_id) {
+    // Ensure we have required fields (skip for ad_hoc and non-billable entries)
+    const isBillable = entry?.billable_duration > 0;
+    if (!isAdHoc && isBillable && !entry?.service_id) {
       setValidationErrors(prev => ({
         ...prev,
-        service: 'Service is required'
+        service: 'Service is required for billable entries'
       }));
       return;
     }
@@ -394,7 +395,9 @@ const updateBillableDuration = useCallback((updatedEntry: typeof entry, newDurat
       <div className="border p-4 rounded space-y-4">
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700">Service</label>
+            <label className="block text-sm font-medium text-gray-700">
+              Service {entry?.billable_duration > 0 && <span className="text-red-500">*</span>}
+            </label>
             <CustomSelect
               value={entry?.service_id || ''}
               onValueChange={(value) => {
@@ -539,9 +542,6 @@ const updateBillableDuration = useCallback((updatedEntry: typeof entry, newDurat
 
         <div className="flex items-center justify-between mt-4">
           <div className="flex items-center space-x-2">
-            <span className="text-sm font-medium text-gray-700">
-              {entry?.billable_duration > 0 ? 'Billable' : 'Non-billable'}
-            </span>
             <Switch
               id='billable-duration'
               checked={entry?.billable_duration > 0}
@@ -564,6 +564,9 @@ const updateBillableDuration = useCallback((updatedEntry: typeof entry, newDurat
               }}
               className="data-[state=checked]:bg-primary-500"
             />
+            <span className="text-sm font-medium text-gray-700">
+              Billable
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Billable toggle was confusing**: The label dynamically switched between "Billable" and "Non-billable" based on toggle state, making it unclear whether the word described the current state or what would happen on click. Replaced with a static "Billable" label positioned after the toggle switch, following standard toggle UX (switch position = on/off).

- **Service field requirement unclear and overly strict**: Service was always required for non-ad-hoc time entries with no visual indicator, and the requirement doesn't make sense for non-billable entries. Service is now only required when the entry is billable, with a red asterisk (`*`) on the label that appears/disappears based on billable state. Validation error messages updated to "Service is required for billable entries".

- **Database error on non-billable save without service**: Saving a non-billable entry without a service sent an empty string `""` for `service_id` (a UUID column), causing a Postgres `invalid input syntax for type uuid` error. Empty strings for `service_id` and `tax_region` are now coerced to `undefined` (NULL) for all entry types, not just ad_hoc.

- **No success feedback on save**: The loading toast was dismissed after a successful save but no success toast followed, leaving users with no confirmation. Added a "Time entry saved" success toast.

## Test plan

- [ ] Open a time entry form and verify the billable toggle shows a static "Billable" label (no longer changes to "Non-billable")
- [ ] Toggle billable off and verify the red `*` disappears from the Service label
- [ ] Save a non-billable time entry without selecting a service — should succeed without errors
- [ ] Toggle billable on, attempt to save without a service — should show "Service is required for billable entries" validation
- [ ] Save a valid billable time entry with a service — should show "Time entry saved" success toast
- [ ] Verify ad_hoc time entries still work as before (no service required regardless of billable state)