### PR TITLE
Polish timesheet approval UI and align status badges

### DIFF
--- a/packages/scheduling/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
+++ b/packages/scheduling/src/components/time-management/approvals/ManagerApprovalDashboard.tsx
@@ -212,16 +212,15 @@ export default function ManagerApprovalDashboard({ currentUser }: ManagerApprova
             title: 'Status',
             dataIndex: 'approval_status',
             width: '20%',
-            // Badge colors match contract status badges (Contracts.tsx renderStatusBadge)
-            // and TimeSheetApproval.tsx statusConfig
+            // Badge variants align with TimeSheetApproval.tsx statusConfig
             render: (status) => {
-              const badgeMap: Record<string, { className: string; label: string }> = {
-                SUBMITTED: { className: 'bg-secondary-100 text-secondary-800', label: 'Submitted' },
-                APPROVED: { className: 'bg-green-100 text-green-800', label: 'Approved' },
-                CHANGES_REQUESTED: { className: 'bg-orange-100 text-orange-800', label: 'Changes Requested' },
+              const badgeMap: Record<string, { variant: 'secondary' | 'success' | 'warning' | 'outline'; label: string }> = {
+                SUBMITTED: { variant: 'secondary', label: 'Submitted' },
+                APPROVED: { variant: 'success', label: 'Approved' },
+                CHANGES_REQUESTED: { variant: 'warning', label: 'Changes Requested' },
               };
-              const config = badgeMap[status] ?? { className: 'bg-gray-100 text-gray-800', label: status };
-              return <Badge className={`${config.className} py-1`}>{config.label}</Badge>;
+              const config = badgeMap[status] ?? { variant: 'outline' as const, label: status };
+              return <Badge variant={config.variant} className="py-1">{config.label}</Badge>;
             }
           },
           {

--- a/packages/scheduling/src/components/time-management/approvals/TimeSheetApproval.tsx
+++ b/packages/scheduling/src/components/time-management/approvals/TimeSheetApproval.tsx
@@ -40,19 +40,15 @@ interface StatusIconProps {
   status: TimeSheetStatus;
 }
 
-// Badge color pattern matches contract status badges in:
-// - packages/billing/src/components/billing-dashboard/contracts/Contracts.tsx (renderStatusBadge)
-// - packages/billing/src/components/billing-dashboard/contracts/ContractHeader.tsx
-// - packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
-// Submitted uses secondary CSS vars to stay distinct from the primary "Current" badge in TimePeriodList.
-const statusConfig: Record<string, { icon: typeof Check; iconColor: string; label: string; badgeClassName: string }> = {
-  SUBMITTED: { icon: Send, iconColor: 'text-secondary-600', label: 'Submitted', badgeClassName: 'bg-secondary-100 text-secondary-800' },
-  APPROVED: { icon: Check, iconColor: 'text-green-800', label: 'Approved', badgeClassName: 'bg-green-100 text-green-800' },
-  CHANGES_REQUESTED: { icon: Undo, iconColor: 'text-orange-800', label: 'Changes Requested', badgeClassName: 'bg-orange-100 text-orange-800' },
+// Badge variants align with TimePeriodList, TimeSheetHeader, and ManagerApprovalDashboard
+const statusConfig: Record<string, { icon: typeof Check; iconColor: string; label: string; badgeVariant: 'secondary' | 'success' | 'warning' | 'outline' }> = {
+  SUBMITTED: { icon: Send, iconColor: 'text-secondary-600', label: 'Submitted', badgeVariant: 'secondary' },
+  APPROVED: { icon: Check, iconColor: 'text-green-800', label: 'Approved', badgeVariant: 'success' },
+  CHANGES_REQUESTED: { icon: Undo, iconColor: 'text-orange-800', label: 'Changes Requested', badgeVariant: 'warning' },
 };
 
 const getStatusConfig = (status: string) =>
-  statusConfig[status] ?? { icon: Clock, iconColor: 'text-gray-500', label: status, badgeClassName: 'bg-gray-100 text-gray-800' };
+  statusConfig[status] ?? { icon: Clock, iconColor: 'text-gray-500', label: status, badgeVariant: 'outline' as const };
 
 const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
   const config = getStatusConfig(status);
@@ -62,7 +58,7 @@ const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
 
 const StatusBadge: React.FC<StatusIconProps> = ({ status }) => {
   const config = getStatusConfig(status);
-  return <Badge className={`${config.badgeClassName} py-1`}>{config.label}</Badge>;
+  return <Badge variant={config.badgeVariant} className="py-1">{config.label}</Badge>;
 };
 
 const formatDuration = (decimalHours: number) => {

--- a/packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx
@@ -21,17 +21,16 @@ interface TimePeriodListProps {
   onSelectTimePeriod: (timePeriod: ITimePeriodWithStatusView) => void;
 }
 
-// Badge colors match contract status badges (Contracts.tsx renderStatusBadge),
-// TimeSheetApproval.tsx statusConfig, and ManagerApprovalDashboard.tsx badgeMap
-const statusBadgeConfig: Record<string, { className: string; label: string }> = {
-  DRAFT: { className: 'bg-gray-100 text-gray-800', label: 'In Progress' },
-  SUBMITTED: { className: 'bg-secondary-100 text-secondary-800', label: 'Submitted' },
-  APPROVED: { className: 'bg-green-100 text-green-800', label: 'Approved' },
-  CHANGES_REQUESTED: { className: 'bg-orange-100 text-orange-800', label: 'Changes Requested' },
+// Badge variants align with TimeSheetApproval.tsx statusConfig and ManagerApprovalDashboard.tsx badgeMap
+const statusBadgeConfig: Record<string, { variant: 'outline' | 'secondary' | 'success' | 'warning'; label: string }> = {
+  DRAFT: { variant: 'outline', label: 'In Progress' },
+  SUBMITTED: { variant: 'secondary', label: 'Submitted' },
+  APPROVED: { variant: 'success', label: 'Approved' },
+  CHANGES_REQUESTED: { variant: 'warning', label: 'Changes Requested' },
 };
 
 const getStatusBadgeConfig = (status: string) =>
-  statusBadgeConfig[status] ?? { className: 'bg-gray-100 text-gray-800', label: 'Unknown' };
+  statusBadgeConfig[status] ?? { variant: 'outline' as const, label: 'Unknown' };
 
 export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodListProps) {
   const router = useRouter();
@@ -90,9 +89,9 @@ export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodLi
               const config = getStatusBadgeConfig(status);
               return (
                 <div className="flex items-center gap-2">
-                  <Badge className={`${config.className} py-1`}>{config.label}</Badge>
+                  <Badge variant={config.variant} className="py-1">{config.label}</Badge>
                   {isCurrentPeriod(record.start_date, record.end_date) && (
-                    <Badge className="bg-[rgb(var(--color-primary-100))] text-[rgb(var(--color-primary-800))] py-1">
+                    <Badge variant="primary" className="py-1">
                       Current
                     </Badge>
                   )}

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetHeader.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetHeader.tsx
@@ -52,16 +52,15 @@ export function TimeSheetHeader({
     viewMode = 'grid',
     onViewModeChange
 }: TimeSheetHeaderProps): React.JSX.Element {
-    // Badge colors match contract status badges (Contracts.tsx renderStatusBadge),
-    // TimeSheetApproval.tsx statusConfig, and ManagerApprovalDashboard.tsx badgeMap
-    const statusBadgeConfig: Record<string, { className: string; label: string }> = {
-        DRAFT: { className: 'bg-gray-100 text-gray-800', label: 'In Progress' },
-        SUBMITTED: { className: 'bg-secondary-100 text-secondary-800', label: 'Submitted' },
-        APPROVED: { className: 'bg-green-100 text-green-800', label: 'Approved' },
-        CHANGES_REQUESTED: { className: 'bg-orange-100 text-orange-800', label: 'Changes Requested' },
+    // Badge variants align with TimeSheetApproval.tsx statusConfig and ManagerApprovalDashboard.tsx badgeMap
+    const statusBadgeConfig: Record<string, { variant: 'outline' | 'secondary' | 'success' | 'warning'; label: string }> = {
+        DRAFT: { variant: 'outline', label: 'In Progress' },
+        SUBMITTED: { variant: 'secondary', label: 'Submitted' },
+        APPROVED: { variant: 'success', label: 'Approved' },
+        CHANGES_REQUESTED: { variant: 'warning', label: 'Changes Requested' },
     };
     const getStatusBadgeConfig = (s: string) =>
-        statusBadgeConfig[s] ?? { className: 'bg-gray-100 text-gray-800', label: 'Unknown' };
+        statusBadgeConfig[s] ?? { variant: 'outline' as const, label: 'Unknown' };
 
     const statusDisplay = getStatusBadgeConfig(status);
     const showDelegationInfo = isDelegated && allowDelegatedEditing;
@@ -145,7 +144,7 @@ export function TimeSheetHeader({
                 <div className="flex flex-wrap items-center justify-end gap-x-6 gap-y-2 w-full lg:w-auto lg:ml-auto">
                     <span className="text-sm font-medium flex items-center gap-2 whitespace-nowrap">
                         Status:
-                        <Badge className={`${statusDisplay.className} py-1`}>{statusDisplay.label}</Badge>
+                        <Badge variant={statusDisplay.variant} className="py-1">{statusDisplay.label}</Badge>
                     </span>
 
                     {onToggleIntervals && (


### PR DESCRIPTION
## Summary

- **Removed obsolete "Set to Draft" button** from the approval detail panel — DRAFT is an initial state, not something an approver should set. "Request Changes" covers the intended use case.
- **Replaced hardcoded status pills with Badge component** across both approver and submitter views, using built-in Badge variants for consistent styling
- **Switched from className color overrides to Badge variants** — all status badges now use the component's built-in `outline`, `secondary`, `success`, and `warning` variants instead of hardcoded bg/text classes
- **Restyled the approval drawer** (TimeSheetApproval): stat grid summary, 2-column grid layouts, formatted work item types, clean table headers, hours-and-minutes format, conditional comments card styling
- **Aligned submitter views** (TimePeriodList, TimeSheetHeader) to use the same Badge component with matching variants and sizing

## Status Badge Variants

| Status | Badge Variant |
|---|---|
| In Progress (Draft) | `outline` |
| Submitted | `secondary` |
| Approved | `success` |
| Changes Requested | `warning` |
| Current (time period indicator) | `primary` |

## Files Changed

- `packages/scheduling/src/components/time-management/approvals/TimeSheetApproval.tsx` — approval drawer (approver view)
- `packages/scheduling/src/components/time-management/approvals/ManagerApprovalDashboard.tsx` — approval table (approver view)
- `packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx` — time period list (submitter view)
- `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetHeader.tsx` — timesheet header (submitter view)