### PR TITLE
Restore recurring schedule entry support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47125,7 +47125,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.7-rc1",
+      "version": "1.0.10-rc1",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -47543,6 +47543,7 @@
         "@alga-psa/db": "*",
         "@alga-psa/types": "*",
         "@alga-psa/validation": "*",
+        "rrule": "^2.7.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -41,6 +41,7 @@
     "@alga-psa/db": "*",
     "@alga-psa/types": "*",
     "@alga-psa/validation": "*",
+    "rrule": "^2.7.2",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/scheduling/src/actions/scheduleActions.ts
+++ b/packages/scheduling/src/actions/scheduleActions.ts
@@ -388,7 +388,7 @@ export const updateScheduleEntry = withAuth(async (
     };
 
     const updatedEntry = await withTransaction(db, async (trx: Knex.Transaction) => {
-      return await ScheduleEntry.update(trx, tenant, masterEntryId, updateData);
+      return await ScheduleEntry.update(trx, tenant, entry_id, updateData, entry.updateType);
     });
 
     if (updatedEntry) {
@@ -682,16 +682,8 @@ export const deleteScheduleEntry = withAuth(async (
     }
     // --- End Permission Check ---
 
-    if (isVirtualId && deleteType === IEditScope.SINGLE) {
-      return {
-        success: false,
-        error: 'Deleting a single occurrence of a recurring entry is not supported yet.',
-      };
-    }
-
-    const entryIdToDelete = deleteType === IEditScope.SINGLE ? masterEntryId : masterEntryId;
     const success = await withTransaction(db, async (trx: Knex.Transaction) => {
-      return ScheduleEntry.delete(trx, tenant, entryIdToDelete);
+      return ScheduleEntry.delete(trx, tenant, entry_id, deleteType);
     });
 
     if (success) {

--- a/packages/scheduling/src/components/schedule/EntryPopup.tsx
+++ b/packages/scheduling/src/components/schedule/EntryPopup.tsx
@@ -1002,16 +1002,14 @@ const EntryPopup: React.FC<EntryPopupProps> = ({
                 <label htmlFor="endDate" className="block text-sm font-medium text-gray-700">
                   End Date
                 </label>
-                <Input
-                  type="date"
+                <DatePicker
                   id="endDate"
-                  value={recurrencePattern.endDate ? format(recurrencePattern.endDate, 'yyyy-MM-dd') : ''}
-                  onChange={(e) => setRecurrencePattern(prev => {
+                  value={recurrencePattern.endDate instanceof Date ? recurrencePattern.endDate : new Date(recurrencePattern.endDate)}
+                  onChange={(date: Date) => setRecurrencePattern(prev => {
                     if (prev === null) return null;
-                    return { ...prev, endDate: new Date(e.target.value) };
+                    return { ...prev, endDate: date };
                   })}
-                  className=""
-                  disabled={!canEditFields} // Disable based on permissions
+                  disabled={!canEditFields}
                 />
               </div>
             )}

--- a/packages/scheduling/src/index.ts
+++ b/packages/scheduling/src/index.ts
@@ -28,6 +28,7 @@ export { IEditScope, Views } from '@alga-psa/types';
 
 // Utils
 export { generateICS, type ICSEventData } from './utils/icsGenerator';
+export { generateOccurrences, applyTimeToDate } from './utils/recurrenceUtils';
 
 // Note: This module contains:
 // - Schedule Entry management (migrated)

--- a/packages/scheduling/src/utils/recurrenceUtils.ts
+++ b/packages/scheduling/src/utils/recurrenceUtils.ts
@@ -1,0 +1,135 @@
+import type { IScheduleEntry } from '@alga-psa/types';
+import { Frequency, RRule, Weekday } from 'rrule';
+
+export function generateOccurrences(entry: IScheduleEntry, start: Date, end: Date): Date[] {
+  try {
+    if (!entry.recurrence_pattern) {
+      return [new Date(entry.scheduled_start)];
+    }
+    const pattern = entry.recurrence_pattern;
+
+    // Validate and normalize start date
+    const dtstart = new Date(pattern.startDate);
+    if (isNaN(dtstart.getTime())) {
+      console.error('[generateOccurrences] Invalid start date:', pattern.startDate);
+      return [new Date(entry.scheduled_start)];
+    }
+    dtstart.setHours(0, 0, 0, 0);
+
+    // If end date exists, validate and normalize it
+    let until: Date | undefined;
+    if (pattern.endDate) {
+      until = new Date(pattern.endDate);
+      if (isNaN(until.getTime())) {
+        console.error('[generateOccurrences] Invalid end date:', pattern.endDate);
+        return [new Date(entry.scheduled_start)];
+      }
+      until.setHours(23, 59, 59, 999);
+    }
+
+    // Create RRule with error handling for frequency
+    const freqKey = pattern.frequency.toUpperCase() as keyof typeof RRule;
+    if (!(freqKey in RRule)) {
+      console.error('[generateOccurrences] Invalid frequency:', pattern.frequency);
+      return [new Date(entry.scheduled_start)];
+    }
+    const rrule = new RRule({
+      freq: RRule[freqKey] as Frequency,
+      interval: pattern.interval,
+      dtstart,
+      until,
+      byweekday: pattern.daysOfWeek?.map((day): Weekday => {
+        const days = 'MO TU WE TH FR SA SU'.split(' ');
+        if (day < 0 || day >= days.length) {
+          console.error('[generateOccurrences] Invalid day of week:', day);
+          return RRule.MO;
+        }
+        return RRule[days[day] as keyof typeof RRule] as Weekday;
+      }),
+      bymonthday: pattern.dayOfMonth,
+      bymonth: pattern.monthOfYear,
+      count: pattern.count
+    });
+
+    // Normalize and validate range dates
+    const rangeStart = new Date(start);
+    if (isNaN(rangeStart.getTime())) {
+      console.error('[generateOccurrences] Invalid range start date:', start);
+      return [new Date(entry.scheduled_start)];
+    }
+    rangeStart.setHours(0, 0, 0, 0);
+    rangeStart.setSeconds(rangeStart.getSeconds() - 1);
+
+    const rangeEnd = new Date(end);
+    if (isNaN(rangeEnd.getTime())) {
+      console.error('[generateOccurrences] Invalid range end date:', end);
+      return [new Date(entry.scheduled_start)];
+    }
+    rangeEnd.setHours(23, 59, 59, 999);
+
+    // Get the base occurrences using normalized dates
+    const baseOccurrences = rrule.between(rangeStart, rangeEnd);
+
+    // Validate and get the original time
+    const originalTime = new Date(entry.scheduled_start);
+    if (isNaN(originalTime.getTime())) {
+      console.error('[generateOccurrences] Invalid scheduled start time:', entry.scheduled_start);
+      return baseOccurrences;
+    }
+
+    // Filter out the master entry's start date and apply the original time to each occurrence
+    const masterStartDate = new Date(entry.scheduled_start);
+    const occurrencesWithTime = baseOccurrences
+      .filter((date): boolean => {
+        const dateStr = date.toISOString().split('T')[0];
+        const masterStr = masterStartDate.toISOString().split('T')[0];
+        return dateStr !== masterStr;
+      })
+      .map((date): Date => applyTimeToDate(date, originalTime));
+
+    // Apply exceptions with validation
+    if (pattern.exceptions && Array.isArray(pattern.exceptions)) {
+      try {
+        const validExceptions = pattern.exceptions
+          .map((d): Date | null => {
+            try {
+              const date = d instanceof Date ? d : new Date(d);
+              if (isNaN(date.getTime())) {
+                return null;
+              }
+              return date;
+            } catch {
+              return null;
+            }
+          })
+          .filter((d): d is Date => d !== null);
+
+        const exceptionDates = validExceptions.map((d): string => d.toISOString().split('T')[0]);
+
+        return occurrencesWithTime.filter((date: Date): boolean => {
+          const dateStr = date.toISOString().split('T')[0];
+          return !exceptionDates.includes(dateStr);
+        });
+      } catch (error) {
+        console.error('[generateOccurrences] Error processing exceptions:', error);
+        return occurrencesWithTime;
+      }
+    }
+
+    return occurrencesWithTime;
+  } catch (error) {
+    console.error('[generateOccurrences] Unexpected error:', error);
+    return [new Date(entry.scheduled_start)];
+  }
+}
+
+export function applyTimeToDate(date: Date, time: Date): Date {
+  try {
+    const result = new Date(date);
+    result.setHours(time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+    return result;
+  } catch (error) {
+    console.error('[applyTimeToDate] Error applying time:', error);
+    return date;
+  }
+}

--- a/packages/scheduling/tests/recurrenceUtils.test.ts
+++ b/packages/scheduling/tests/recurrenceUtils.test.ts
@@ -1,0 +1,455 @@
+/**
+ * @alga-psa/scheduling - Recurrence Utils Tests
+ *
+ * Tests for generateOccurrences() and applyTimeToDate() utility functions.
+ * These are pure functions that can be tested without database mocking.
+ *
+ * Note: generateOccurrences() normalizes range boundaries using setHours() in local
+ * time, which means exact boundary behavior varies by timezone. Tests use wide ranges
+ * and check for known interior dates rather than exact boundary inclusion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateOccurrences, applyTimeToDate } from '../src/utils/recurrenceUtils';
+import type { IScheduleEntry, IRecurrencePattern } from '@alga-psa/types';
+
+/**
+ * Helper to create a minimal IScheduleEntry for testing.
+ */
+function makeEntry(overrides: Partial<IScheduleEntry> = {}): IScheduleEntry {
+  return {
+    entry_id: 'entry-1',
+    title: 'Test Entry',
+    scheduled_start: new Date('2024-01-15T09:00:00Z'),
+    scheduled_end: new Date('2024-01-15T10:00:00Z'),
+    status: 'scheduled',
+    work_item_id: null,
+    work_item_type: 'ad_hoc',
+    assigned_user_ids: [],
+    is_recurring: false,
+    tenant: 'test-tenant',
+    ...overrides,
+  } as IScheduleEntry;
+}
+
+function makePattern(overrides: Partial<IRecurrencePattern> = {}): IRecurrencePattern {
+  return {
+    frequency: 'daily',
+    interval: 1,
+    startDate: new Date('2024-01-15'),
+    ...overrides,
+  };
+}
+
+describe('applyTimeToDate', () => {
+  it('should apply hours/minutes/seconds from time to date', () => {
+    const date = new Date('2024-03-20T00:00:00');
+    const time = new Date('2024-01-01T14:30:45.123');
+
+    const result = applyTimeToDate(date, time);
+
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+    expect(result.getSeconds()).toBe(45);
+    expect(result.getMilliseconds()).toBe(123);
+    // Date portion should be preserved
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(2); // March = 2
+    expect(result.getDate()).toBe(20);
+  });
+
+  it('should not mutate the original date', () => {
+    const date = new Date('2024-03-20T00:00:00');
+    const originalTime = date.getTime();
+    const time = new Date('2024-01-01T14:30:00');
+
+    applyTimeToDate(date, time);
+
+    expect(date.getTime()).toBe(originalTime);
+  });
+});
+
+describe('generateOccurrences', () => {
+  describe('without recurrence pattern', () => {
+    it('should return the entry scheduled_start when no recurrence_pattern', () => {
+      const entry = makeEntry({ recurrence_pattern: undefined });
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-01-31');
+
+      const result = generateOccurrences(entry, start, end);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].toISOString()).toBe(new Date('2024-01-15T09:00:00Z').toISOString());
+    });
+  });
+
+  describe('daily recurrence', () => {
+    it('should generate daily occurrences excluding master date', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      // Use a wide range to avoid boundary issues
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-20');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      // Should include several days after master
+      expect(dates).toContain('2024-01-16');
+      expect(dates).toContain('2024-01-17');
+      expect(dates).toContain('2024-01-18');
+      expect(dates).toContain('2024-01-19');
+      // Master date should be excluded
+      expect(dates).not.toContain('2024-01-15');
+    });
+
+    it('should apply the original entry time to each occurrence', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T14:30:00'),
+        scheduled_end: new Date('2024-01-15T15:30:00'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-15');
+      const end = new Date('2024-01-20');
+
+      const result = generateOccurrences(entry, start, end);
+
+      expect(result.length).toBeGreaterThan(0);
+      for (const occ of result) {
+        // Time should match the master entry's scheduled_start time (local)
+        expect(occ.getHours()).toBe(14);
+        expect(occ.getMinutes()).toBe(30);
+      }
+    });
+
+    it('should respect interval > 1', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 2, // every other day
+        startDate: new Date('2024-01-15'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-30');
+
+      const result = generateOccurrences(entry, start, end);
+
+      // With interval=2, each consecutive occurrence should be exactly 2 days apart
+      expect(result.length).toBeGreaterThanOrEqual(3);
+      for (let i = 1; i < result.length; i++) {
+        const diffMs = result[i].getTime() - result[i - 1].getTime();
+        const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+        expect(diffDays).toBe(2);
+      }
+    });
+  });
+
+  describe('weekly recurrence', () => {
+    it('should generate weekly occurrences', () => {
+      const pattern = makePattern({
+        frequency: 'weekly',
+        interval: 1,
+        startDate: new Date('2024-01-15'), // Monday
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-02-28');
+
+      const result = generateOccurrences(entry, start, end);
+
+      // Should generate multiple weekly occurrences (master excluded)
+      expect(result.length).toBeGreaterThanOrEqual(3);
+
+      // Each consecutive occurrence should be exactly 7 days apart
+      for (let i = 1; i < result.length; i++) {
+        const diffMs = result[i].getTime() - result[i - 1].getTime();
+        const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+        expect(diffDays).toBe(7);
+      }
+
+      // Master date should not be in the result
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+      expect(dates).not.toContain('2024-01-15');
+    });
+
+    it('should support daysOfWeek for weekly recurrence', () => {
+      const pattern = makePattern({
+        frequency: 'weekly',
+        interval: 1,
+        startDate: new Date('2024-01-15'), // Monday
+        daysOfWeek: [0, 2, 4], // Mon, Wed, Fri
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-28');
+
+      const result = generateOccurrences(entry, start, end);
+
+      // All occurrences should fall on Mon(1), Wed(3), or Fri(5) UTC day-of-week
+      for (const occ of result) {
+        expect([1, 3, 5]).toContain(occ.getUTCDay());
+      }
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('monthly recurrence', () => {
+    it('should generate monthly occurrences', () => {
+      const pattern = makePattern({
+        frequency: 'monthly',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-06-01');
+
+      const result = generateOccurrences(entry, start, end);
+
+      // Should generate multiple monthly occurrences (master excluded)
+      expect(result.length).toBeGreaterThanOrEqual(3);
+
+      // Each consecutive occurrence should be roughly 28-31 days apart (monthly)
+      for (let i = 1; i < result.length; i++) {
+        const diffMs = result[i].getTime() - result[i - 1].getTime();
+        const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+        expect(diffDays).toBeGreaterThanOrEqual(28);
+        expect(diffDays).toBeLessThanOrEqual(31);
+      }
+
+      // Master date should not be in the result
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+      expect(dates).not.toContain('2024-01-15');
+    });
+  });
+
+  describe('endDate handling', () => {
+    it('should not generate occurrences after endDate', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        endDate: new Date('2024-01-18'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-31');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      // Should have Jan 16, 17 at minimum (limited by endDate of Jan 18)
+      expect(dates).toContain('2024-01-16');
+      expect(dates).toContain('2024-01-17');
+      // Should NOT have dates clearly after the endDate
+      expect(dates).not.toContain('2024-01-20');
+      expect(dates).not.toContain('2024-01-25');
+    });
+  });
+
+  describe('count handling', () => {
+    it('should limit occurrences by count', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        count: 5, // Only 5 total occurrences (including master)
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-31');
+
+      const result = generateOccurrences(entry, start, end);
+
+      // Count=5 means 5 total. Master (Jan 15) is excluded from result.
+      // So we should get at most 4 virtual instances: Jan 16, 17, 18, 19
+      expect(result.length).toBeLessThanOrEqual(4);
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('exception dates', () => {
+    it('should exclude exception dates from occurrences', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        exceptions: [new Date('2024-01-17'), new Date('2024-01-19')],
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-22');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      // Jan 16, 18, 20, 21 should be present
+      expect(dates).toContain('2024-01-16');
+      expect(dates).toContain('2024-01-18');
+      expect(dates).toContain('2024-01-20');
+      // Exception dates should be excluded
+      expect(dates).not.toContain('2024-01-17');
+      expect(dates).not.toContain('2024-01-19');
+    });
+
+    it('should handle exception dates as strings', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        exceptions: ['2024-01-17T00:00:00.000Z' as any],
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-20');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      expect(dates).not.toContain('2024-01-17'); // exception
+      expect(dates).toContain('2024-01-16');
+      expect(dates).toContain('2024-01-18');
+    });
+
+    it('should silently skip invalid exception dates', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        exceptions: ['not-a-date' as any, new Date('2024-01-17')],
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const start = new Date('2024-01-14');
+      const end = new Date('2024-01-20');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      // Jan 17 should still be excluded (valid exception)
+      expect(dates).not.toContain('2024-01-17');
+      // Other dates should be present
+      expect(dates).toContain('2024-01-16');
+      expect(dates).toContain('2024-01-18');
+    });
+  });
+
+  describe('range filtering', () => {
+    it('should only return occurrences within the range', () => {
+      const pattern = makePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-01'),
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-01T09:00:00Z'),
+        scheduled_end: new Date('2024-01-01T10:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      // Small window well inside the series
+      const start = new Date('2024-01-09');
+      const end = new Date('2024-01-13');
+
+      const result = generateOccurrences(entry, start, end);
+      const dates = result.map((d) => d.toISOString().split('T')[0]);
+
+      // Should include interior dates
+      expect(dates).toContain('2024-01-10');
+      expect(dates).toContain('2024-01-11');
+      expect(dates).toContain('2024-01-12');
+      // Should not include dates well outside the window
+      expect(dates).not.toContain('2024-01-07');
+      expect(dates).not.toContain('2024-01-15');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return scheduled_start as fallback for invalid pattern startDate', () => {
+      const pattern = makePattern({
+        startDate: new Date('invalid') as any,
+      });
+      const entry = makeEntry({
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        is_recurring: true,
+        recurrence_pattern: pattern,
+      });
+
+      const result = generateOccurrences(entry, new Date('2024-01-01'), new Date('2024-01-31'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].toISOString()).toBe(new Date('2024-01-15T09:00:00Z').toISOString());
+    });
+  });
+});

--- a/packages/scheduling/tests/scheduleEntryRecurrence.test.ts
+++ b/packages/scheduling/tests/scheduleEntryRecurrence.test.ts
@@ -1,0 +1,886 @@
+/**
+ * @alga-psa/scheduling - Schedule Entry Recurrence Tests
+ *
+ * Tests for recurrence-aware update/delete operations in the ScheduleEntry model.
+ * Uses a mock Knex builder to verify the correct DB operations are performed
+ * for SINGLE/FUTURE/ALL edit scopes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ScheduleEntry from '../src/models/scheduleEntry';
+import type { IScheduleEntry, IRecurrencePattern } from '@alga-psa/types';
+
+// ---------- Mock Knex Builder ----------
+
+/**
+ * Creates a deeply chainable mock Knex object that records calls.
+ * Every method returns the chainable object so query builder chaining works.
+ * Terminal methods (first, del, returning) can be configured to resolve with values.
+ */
+function createMockKnex() {
+  const calls: { table: string; method: string; args: any[] }[] = [];
+  let currentTable = '';
+
+  // Storage for configuring mock return values
+  const firstResults: Map<string, any> = new Map();
+  const selectResults: any[] = [];
+  let insertCalled = false;
+  let insertArgs: any = null;
+  let updateCalled = false;
+  let updateArgs: any = null;
+  let deleteCalled = false;
+  let returningResult: any[] = [];
+
+  const chainable: Record<string, any> = {};
+
+  const chainMethods = [
+    'where',
+    'andWhere',
+    'whereIn',
+    'whereNull',
+    'whereNotNull',
+    'whereBetween',
+    'orWhereBetween',
+    'orWhere',
+    'orWhereRaw',
+    'andWhereRaw',
+    'whereRaw',
+    'select',
+    'orderBy',
+    'join',
+  ];
+
+  for (const method of chainMethods) {
+    chainable[method] = vi.fn((...args: any[]) => {
+      calls.push({ table: currentTable, method, args });
+      return chainable;
+    });
+  }
+
+  chainable.first = vi.fn(async () => {
+    calls.push({ table: currentTable, method: 'first', args: [] });
+    return firstResults.get(currentTable) ?? undefined;
+  });
+
+  chainable.del = vi.fn(async () => {
+    calls.push({ table: currentTable, method: 'del', args: [] });
+    deleteCalled = true;
+    return 1;
+  });
+
+  chainable.insert = vi.fn(async (data: any) => {
+    calls.push({ table: currentTable, method: 'insert', args: [data] });
+    insertCalled = true;
+    insertArgs = data;
+    return chainable;
+  });
+
+  chainable.update = vi.fn((data: any) => {
+    calls.push({ table: currentTable, method: 'update', args: [data] });
+    updateCalled = true;
+    updateArgs = data;
+    return chainable;
+  });
+
+  chainable.returning = vi.fn(async () => {
+    calls.push({ table: currentTable, method: 'returning', args: [] });
+    return returningResult;
+  });
+
+  const mockKnex = vi.fn((tableName: string) => {
+    currentTable = tableName;
+    return chainable;
+  }) as any;
+
+  return {
+    knex: mockKnex,
+    chainable,
+    calls,
+    // Helpers to configure mock behavior
+    setFirstResult: (table: string, result: any) => firstResults.set(table, result),
+    setReturningResult: (result: any[]) => {
+      returningResult = result;
+    },
+    getInsertArgs: () => insertArgs,
+    getUpdateArgs: () => updateArgs,
+    wasInsertCalled: () => insertCalled,
+    wasUpdateCalled: () => updateCalled,
+    wasDeleteCalled: () => deleteCalled,
+    reset: () => {
+      calls.length = 0;
+      firstResults.clear();
+      selectResults.length = 0;
+      insertCalled = false;
+      insertArgs = null;
+      updateCalled = false;
+      updateArgs = null;
+      deleteCalled = false;
+      returningResult = [];
+    },
+  };
+}
+
+// ---------- Test Fixtures ----------
+
+const TENANT = 'test-tenant';
+
+function makeRecurrencePattern(overrides: Partial<IRecurrencePattern> = {}): IRecurrencePattern {
+  return {
+    frequency: 'daily',
+    interval: 1,
+    startDate: new Date('2024-01-15'),
+    ...overrides,
+  };
+}
+
+function makeMasterEntry(overrides: Partial<any> = {}) {
+  return {
+    entry_id: 'master-1',
+    title: 'Daily Standup',
+    scheduled_start: new Date('2024-01-15T09:00:00Z'),
+    scheduled_end: new Date('2024-01-15T09:30:00Z'),
+    notes: 'Team standup',
+    status: 'scheduled',
+    work_item_id: null,
+    work_item_type: 'ad_hoc',
+    tenant: TENANT,
+    is_recurring: true,
+    recurrence_pattern: JSON.stringify(makeRecurrencePattern()),
+    is_private: false,
+    original_entry_id: null,
+    ...overrides,
+  };
+}
+
+// ---------- Tests ----------
+
+describe('ScheduleEntry - Recurrence Operations', () => {
+  describe('update() with IEditScope', () => {
+    describe('SINGLE scope', () => {
+      it('should create a standalone entry and add exception to master', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        // Stub getAssignedUserIds to avoid DB calls
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+
+        // Stub updateAssignees to avoid DB calls
+        const origUpdateAssignees = ScheduleEntry.updateAssignees;
+        ScheduleEntry.updateAssignees = vi.fn(async () => {});
+
+        try {
+          const result = await ScheduleEntry.update(
+            mock.knex,
+            TENANT,
+            'master-1_1705485600000', // virtual ID: master-1 at Jan 17 2024 09:00 UTC
+            {
+              title: 'Updated Standup',
+              scheduled_start: new Date('2024-01-17T10:00:00Z'),
+              scheduled_end: new Date('2024-01-17T10:30:00Z'),
+            },
+            'single' as any
+          );
+
+          expect(result).toBeDefined();
+          // The returned entry should be non-recurring (standalone)
+          expect(result!.is_recurring).toBe(false);
+          expect(result!.original_entry_id).toBeNull();
+          expect(result!.title).toBe('Updated Standup');
+          expect(result!.assigned_user_ids).toEqual(['user-1']);
+
+          // Should have inserted a new standalone entry
+          expect(mock.wasInsertCalled()).toBe(true);
+          const insertArgs = mock.getInsertArgs();
+          expect(insertArgs.is_recurring).toBe(false);
+          expect(insertArgs.recurrence_pattern).toBeNull();
+          expect(insertArgs.title).toBe('Updated Standup');
+
+          // Should have updated master pattern with exception
+          expect(mock.wasUpdateCalled()).toBe(true);
+          const updateArgs = mock.getUpdateArgs();
+          expect(updateArgs.recurrence_pattern).toBeDefined();
+          const updatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+          expect(updatedPattern.exceptions).toBeDefined();
+          expect(updatedPattern.exceptions.length).toBeGreaterThan(0);
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+          ScheduleEntry.updateAssignees = origUpdateAssignees;
+        }
+      });
+    });
+
+    describe('FUTURE scope', () => {
+      it('should truncate original master and create new master for future', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+
+        const origUpdateAssignees = ScheduleEntry.updateAssignees;
+        ScheduleEntry.updateAssignees = vi.fn(async () => {});
+
+        try {
+          // Virtual ID for Jan 20, 2024 09:00 UTC
+          const virtualTimestamp = new Date('2024-01-20T09:00:00Z').getTime();
+          const result = await ScheduleEntry.update(
+            mock.knex,
+            TENANT,
+            `master-1_${virtualTimestamp}`,
+            {
+              title: 'Renamed Standup',
+            },
+            'future' as any
+          );
+
+          expect(result).toBeDefined();
+          // The new master should be recurring
+          expect(result!.is_recurring).toBe(true);
+          expect(result!.title).toBe('Renamed Standup');
+
+          // Should have updated original master (truncating its endDate)
+          expect(mock.wasUpdateCalled()).toBe(true);
+          const updateArgs = mock.getUpdateArgs();
+          const truncatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+          // endDate should be the day before the virtual timestamp
+          const expectedEnd = new Date('2024-01-19T23:59:59.999');
+          expect(new Date(truncatedPattern.endDate).getDate()).toBe(expectedEnd.getDate());
+
+          // Should have inserted a new master entry
+          expect(mock.wasInsertCalled()).toBe(true);
+          const insertArgs = mock.getInsertArgs();
+          expect(insertArgs.is_recurring).toBe(true);
+          expect(insertArgs.recurrence_pattern).toBeDefined();
+          const newPattern = JSON.parse(insertArgs.recurrence_pattern);
+          expect(new Date(newPattern.startDate).getTime()).toBe(
+            new Date('2024-01-20T09:00:00Z').getTime()
+          );
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+          ScheduleEntry.updateAssignees = origUpdateAssignees;
+        }
+      });
+
+      it('should throw when virtualTimestamp is missing for FUTURE scope', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        await expect(
+          ScheduleEntry.update(
+            mock.knex,
+            TENANT,
+            'master-1', // NOT a virtual ID — no timestamp
+            { title: 'Updated' },
+            'future' as any
+          )
+        ).rejects.toThrow('Virtual timestamp is required for future updates');
+      });
+    });
+
+    describe('ALL scope', () => {
+      it('should update the master entry directly, preserving exceptions', async () => {
+        const patternWithExceptions = makeRecurrencePattern({
+          exceptions: [new Date('2024-01-17')],
+        });
+        const masterEntry = makeMasterEntry({
+          recurrence_pattern: JSON.stringify(patternWithExceptions),
+        });
+
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', masterEntry);
+        mock.setReturningResult([
+          {
+            ...masterEntry,
+            title: 'All Updated',
+            recurrence_pattern: JSON.stringify(patternWithExceptions),
+          },
+        ]);
+
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+
+        try {
+          const result = await ScheduleEntry.update(
+            mock.knex,
+            TENANT,
+            'master-1',
+            { title: 'All Updated' },
+            'all' as any
+          );
+
+          expect(result).toBeDefined();
+          expect(result!.is_recurring).toBe(true);
+          expect(result!.assigned_user_ids).toEqual(['user-1']);
+
+          // Should have updated the master entry
+          expect(mock.wasUpdateCalled()).toBe(true);
+          const updateArgs = mock.getUpdateArgs();
+          expect(updateArgs.title).toBe('All Updated');
+          expect(updateArgs.is_recurring).toBe(true);
+
+          // Exceptions should be preserved
+          const updatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+          expect(updatedPattern.exceptions).toBeDefined();
+          expect(updatedPattern.exceptions.length).toBe(1);
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+        }
+      });
+    });
+
+    describe('non-recurring update (no scope)', () => {
+      it('should perform a simple field update when entry has no recurrence_pattern', async () => {
+        const nonRecurringEntry = makeMasterEntry({
+          is_recurring: false,
+          recurrence_pattern: null,
+        });
+
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', nonRecurringEntry);
+        mock.setReturningResult([{ ...nonRecurringEntry, title: 'Updated Title' }]);
+
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+
+        try {
+          const result = await ScheduleEntry.update(mock.knex, TENANT, 'master-1', {
+            title: 'Updated Title',
+          });
+
+          expect(result).toBeDefined();
+          expect(result!.title).toBe('Updated Title');
+
+          // Should have done a regular update (not insert)
+          expect(mock.wasUpdateCalled()).toBe(true);
+          expect(mock.wasInsertCalled()).toBe(false);
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+        }
+      });
+
+      it('should return undefined when entry does not exist', async () => {
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', undefined);
+
+        const result = await ScheduleEntry.update(mock.knex, TENANT, 'nonexistent', {
+          title: 'test',
+        });
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('removing recurrence', () => {
+      it('should clear recurrence when pattern is set to empty object', async () => {
+        const masterEntry = makeMasterEntry();
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', masterEntry);
+        mock.setReturningResult([
+          {
+            ...masterEntry,
+            is_recurring: false,
+            recurrence_pattern: null,
+          },
+        ]);
+
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+
+        try {
+          // Pass empty recurrence_pattern and no updateType — triggers removal path
+          const result = await ScheduleEntry.update(mock.knex, TENANT, 'master-1', {
+            recurrence_pattern: {} as any,
+          });
+
+          expect(result).toBeDefined();
+          expect(mock.wasUpdateCalled()).toBe(true);
+          const updateArgs = mock.getUpdateArgs();
+          expect(updateArgs.recurrence_pattern).toBeNull();
+          expect(updateArgs.is_recurring).toBe(false);
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+        }
+      });
+    });
+  });
+
+  describe('delete() with IEditScope', () => {
+    describe('SINGLE scope — virtual instance', () => {
+      it('should add exception date to master pattern', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        // Virtual ID for Jan 17, 2024 09:00 UTC
+        const virtualTimestamp = new Date('2024-01-17T09:00:00Z').getTime();
+        const result = await ScheduleEntry.delete(
+          mock.knex,
+          TENANT,
+          `master-1_${virtualTimestamp}`,
+          'single' as any
+        );
+
+        expect(result).toBe(true);
+
+        // Should have updated (not deleted) the master with an exception
+        expect(mock.wasUpdateCalled()).toBe(true);
+        const updateArgs = mock.getUpdateArgs();
+        const updatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+        expect(updatedPattern.exceptions).toBeDefined();
+        expect(updatedPattern.exceptions.length).toBe(1);
+
+        // The exception should be midnight UTC on Jan 17
+        const exceptionDate = new Date(updatedPattern.exceptions[0]);
+        expect(exceptionDate.getUTCFullYear()).toBe(2024);
+        expect(exceptionDate.getUTCMonth()).toBe(0); // January
+        expect(exceptionDate.getUTCDate()).toBe(17);
+        expect(exceptionDate.getUTCHours()).toBe(0);
+      });
+    });
+
+    describe('SINGLE scope — master entry', () => {
+      it('should delete the original master', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        // Stub getAssignedUserIds + updateAssignees for the new master creation
+        const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+        ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+          'master-1': ['user-1'],
+        }));
+        const origUpdateAssignees = ScheduleEntry.updateAssignees;
+        ScheduleEntry.updateAssignees = vi.fn(async () => {});
+
+        try {
+          const result = await ScheduleEntry.delete(
+            mock.knex,
+            TENANT,
+            'master-1', // NOT a virtual ID
+            'single' as any
+          );
+
+          expect(result).toBe(true);
+          // Should have deleted the master entry
+          expect(mock.wasDeleteCalled()).toBe(true);
+        } finally {
+          ScheduleEntry.getAssignedUserIds = origGetAssigned;
+          ScheduleEntry.updateAssignees = origUpdateAssignees;
+        }
+      });
+    });
+
+    describe('FUTURE scope — virtual instance', () => {
+      it('should truncate master series endDate to before this instance', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        // Virtual ID for Jan 20, 2024 09:00 UTC
+        const virtualTimestamp = new Date('2024-01-20T09:00:00Z').getTime();
+        const result = await ScheduleEntry.delete(
+          mock.knex,
+          TENANT,
+          `master-1_${virtualTimestamp}`,
+          'future' as any
+        );
+
+        expect(result).toBe(true);
+
+        // Should have updated master with truncated endDate
+        expect(mock.wasUpdateCalled()).toBe(true);
+        const updateArgs = mock.getUpdateArgs();
+        const updatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+
+        // endDate should be Jan 19 end of day
+        const endDate = new Date(updatedPattern.endDate);
+        expect(endDate.getDate()).toBe(19);
+        expect(endDate.getHours()).toBe(23);
+        expect(endDate.getMinutes()).toBe(59);
+      });
+
+      it('should filter out exceptions after the truncation point', () => {
+        // This is an indirect test — the update method filters exceptions.
+        // We verify by checking the pattern stored.
+        const mock = createMockKnex();
+        const patternWithExceptions = makeRecurrencePattern({
+          exceptions: [
+            new Date('2024-01-17T00:00:00Z'), // before truncation
+            new Date('2024-01-22T00:00:00Z'), // after truncation
+          ],
+        });
+        const masterEntry = makeMasterEntry({
+          recurrence_pattern: JSON.stringify(patternWithExceptions),
+        });
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        const virtualTimestamp = new Date('2024-01-20T09:00:00Z').getTime();
+
+        return ScheduleEntry.delete(
+          mock.knex,
+          TENANT,
+          `master-1_${virtualTimestamp}`,
+          'future' as any
+        ).then((result) => {
+          expect(result).toBe(true);
+          const updateArgs = mock.getUpdateArgs();
+          const updatedPattern = JSON.parse(updateArgs.recurrence_pattern);
+          // Only the exception before the truncation point should remain
+          expect(updatedPattern.exceptions.length).toBe(1);
+          expect(new Date(updatedPattern.exceptions[0]).getUTCDate()).toBe(17);
+        });
+      });
+    });
+
+    describe('FUTURE scope — master entry', () => {
+      it('should delete the entire series', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        const result = await ScheduleEntry.delete(
+          mock.knex,
+          TENANT,
+          'master-1',
+          'future' as any
+        );
+
+        expect(result).toBe(true);
+        expect(mock.wasDeleteCalled()).toBe(true);
+      });
+    });
+
+    describe('ALL scope', () => {
+      it('should delete the master entry entirely', async () => {
+        const mock = createMockKnex();
+        const masterEntry = makeMasterEntry();
+        mock.setFirstResult('schedule_entries', masterEntry);
+
+        const result = await ScheduleEntry.delete(
+          mock.knex,
+          TENANT,
+          'master-1',
+          'all' as any
+        );
+
+        expect(result).toBe(true);
+        expect(mock.wasDeleteCalled()).toBe(true);
+      });
+    });
+
+    describe('non-recurring delete', () => {
+      it('should perform a simple delete for non-recurring entries', async () => {
+        const nonRecurringEntry = makeMasterEntry({
+          is_recurring: false,
+          recurrence_pattern: null,
+        });
+
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', nonRecurringEntry);
+
+        const result = await ScheduleEntry.delete(mock.knex, TENANT, 'master-1');
+
+        expect(result).toBe(true);
+        expect(mock.wasDeleteCalled()).toBe(true);
+      });
+
+      it('should return false when entry does not exist', async () => {
+        const mock = createMockKnex();
+        mock.setFirstResult('schedule_entries', undefined);
+
+        const result = await ScheduleEntry.delete(mock.knex, TENANT, 'nonexistent');
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('Virtual ID parsing', () => {
+    it('should correctly parse virtual entry IDs in update()', async () => {
+      const mock = createMockKnex();
+      const masterEntry = makeMasterEntry();
+      mock.setFirstResult('schedule_entries', masterEntry);
+
+      const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+      ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+        'master-1': ['user-1'],
+      }));
+      const origUpdateAssignees = ScheduleEntry.updateAssignees;
+      ScheduleEntry.updateAssignees = vi.fn(async () => {});
+
+      try {
+        // The virtual ID should be parsed into master-1 + timestamp
+        await ScheduleEntry.update(
+          mock.knex,
+          TENANT,
+          'master-1_1705485600000',
+          { title: 'Updated' },
+          'single' as any
+        );
+
+        // Verify the master entry was fetched using master-1 (not the full virtual ID)
+        const firstCall = mock.calls.find(
+          (c) => c.table === 'schedule_entries' && c.method === 'first'
+        );
+        expect(firstCall).toBeDefined();
+      } finally {
+        ScheduleEntry.getAssignedUserIds = origGetAssigned;
+        ScheduleEntry.updateAssignees = origUpdateAssignees;
+      }
+    });
+
+    it('should correctly parse virtual entry IDs in delete()', async () => {
+      const mock = createMockKnex();
+      const masterEntry = makeMasterEntry();
+      mock.setFirstResult('schedule_entries', masterEntry);
+
+      await ScheduleEntry.delete(
+        mock.knex,
+        TENANT,
+        'master-1_1705485600000',
+        'single' as any
+      );
+
+      // The exception should have been added based on the parsed timestamp
+      expect(mock.wasUpdateCalled()).toBe(true);
+      const updateArgs = mock.getUpdateArgs();
+      const pattern = JSON.parse(updateArgs.recurrence_pattern);
+      expect(pattern.exceptions).toHaveLength(1);
+    });
+  });
+
+  describe('getRecurringEntriesInRange()', () => {
+    it('should throw when tenant is not provided', async () => {
+      const mock = createMockKnex();
+      await expect(
+        ScheduleEntry.getRecurringEntriesInRange(
+          mock.knex,
+          '',
+          new Date('2024-01-01'),
+          new Date('2024-01-31')
+        )
+      ).rejects.toThrow('Tenant context is required');
+    });
+  });
+
+  describe('getRecurringEntriesWithAssignments()', () => {
+    it('should generate virtual entries with composite IDs and assignments', async () => {
+      const pattern = makeRecurrencePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+      });
+
+      const masterEntry: IScheduleEntry = {
+        entry_id: 'master-1',
+        title: 'Daily Standup',
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T09:30:00Z'),
+        notes: 'Team standup',
+        status: 'scheduled',
+        work_item_id: null,
+        work_item_type: 'ad_hoc',
+        tenant: TENANT,
+        is_recurring: true,
+        recurrence_pattern: pattern,
+        is_private: false,
+        original_entry_id: null,
+        assigned_user_ids: [],
+      } as IScheduleEntry;
+
+      // Stub getAssignedUserIds
+      const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+      ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+        'master-1': ['user-1', 'user-2'],
+      }));
+
+      try {
+        const mock = createMockKnex();
+        const start = new Date('2024-01-16');
+        const end = new Date('2024-01-18');
+
+        const result = await ScheduleEntry.getRecurringEntriesWithAssignments(
+          mock.knex,
+          TENANT,
+          [masterEntry],
+          start,
+          end
+        );
+
+        // Should have generated virtual entries for Jan 16, 17, 18
+        expect(result.length).toBeGreaterThanOrEqual(2);
+
+        for (const entry of result) {
+          // Each virtual entry should have a composite ID
+          expect(entry.entry_id).toContain('master-1_');
+          // Should reference the master
+          expect(entry.original_entry_id).toBe('master-1');
+          // Should be marked as recurring
+          expect(entry.is_recurring).toBe(true);
+          // Should inherit assignments
+          expect(entry.assigned_user_ids).toEqual(['user-1', 'user-2']);
+          // Duration should be preserved (30 min)
+          const duration =
+            new Date(entry.scheduled_end).getTime() -
+            new Date(entry.scheduled_start).getTime();
+          expect(duration).toBe(30 * 60 * 1000); // 30 minutes in ms
+        }
+      } finally {
+        ScheduleEntry.getAssignedUserIds = origGetAssigned;
+      }
+    });
+
+    it('should skip entries with empty recurrence patterns', async () => {
+      const entryWithoutPattern: IScheduleEntry = {
+        entry_id: 'entry-no-pattern',
+        title: 'No Pattern',
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T09:30:00Z'),
+        notes: '',
+        status: 'scheduled',
+        work_item_id: null,
+        work_item_type: 'ad_hoc',
+        tenant: TENANT,
+        is_recurring: true,
+        recurrence_pattern: null as any,
+        is_private: false,
+        original_entry_id: null,
+        assigned_user_ids: [],
+      } as IScheduleEntry;
+
+      const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+      ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({}));
+
+      try {
+        const mock = createMockKnex();
+        const result = await ScheduleEntry.getRecurringEntriesWithAssignments(
+          mock.knex,
+          TENANT,
+          [entryWithoutPattern],
+          new Date('2024-01-16'),
+          new Date('2024-01-18')
+        );
+
+        expect(result).toEqual([]);
+      } finally {
+        ScheduleEntry.getAssignedUserIds = origGetAssigned;
+      }
+    });
+
+    it('should parse JSON string recurrence patterns from DB', async () => {
+      const patternObj = makeRecurrencePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+      });
+
+      // Simulate what the DB returns — pattern as a JSON string
+      const masterEntry: IScheduleEntry = {
+        entry_id: 'master-1',
+        title: 'Daily Standup',
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T09:30:00Z'),
+        notes: '',
+        status: 'scheduled',
+        work_item_id: null,
+        work_item_type: 'ad_hoc',
+        tenant: TENANT,
+        is_recurring: true,
+        recurrence_pattern: JSON.stringify(patternObj) as any,
+        is_private: false,
+        original_entry_id: null,
+        assigned_user_ids: [],
+      } as IScheduleEntry;
+
+      const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+      ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+        'master-1': ['user-1'],
+      }));
+
+      try {
+        const mock = createMockKnex();
+        const result = await ScheduleEntry.getRecurringEntriesWithAssignments(
+          mock.knex,
+          TENANT,
+          [masterEntry],
+          new Date('2024-01-16'),
+          new Date('2024-01-17')
+        );
+
+        expect(result.length).toBeGreaterThan(0);
+        for (const entry of result) {
+          expect(entry.entry_id).toContain('master-1_');
+        }
+      } finally {
+        ScheduleEntry.getAssignedUserIds = origGetAssigned;
+      }
+    });
+
+    it('should filter out exception dates from virtual entries', async () => {
+      const pattern = makeRecurrencePattern({
+        frequency: 'daily',
+        interval: 1,
+        startDate: new Date('2024-01-15'),
+        exceptions: [new Date('2024-01-17')],
+      });
+
+      const masterEntry: IScheduleEntry = {
+        entry_id: 'master-1',
+        title: 'Daily Standup',
+        scheduled_start: new Date('2024-01-15T09:00:00Z'),
+        scheduled_end: new Date('2024-01-15T09:30:00Z'),
+        notes: '',
+        status: 'scheduled',
+        work_item_id: null,
+        work_item_type: 'ad_hoc',
+        tenant: TENANT,
+        is_recurring: true,
+        recurrence_pattern: pattern,
+        is_private: false,
+        original_entry_id: null,
+        assigned_user_ids: [],
+      } as IScheduleEntry;
+
+      const origGetAssigned = ScheduleEntry.getAssignedUserIds;
+      ScheduleEntry.getAssignedUserIds = vi.fn(async () => ({
+        'master-1': ['user-1'],
+      }));
+
+      try {
+        const mock = createMockKnex();
+        // Use a wide range to avoid boundary issues
+        const result = await ScheduleEntry.getRecurringEntriesWithAssignments(
+          mock.knex,
+          TENANT,
+          [masterEntry],
+          new Date('2024-01-14'),
+          new Date('2024-01-20')
+        );
+
+        const dates = result.map(
+          (e) => new Date(e.scheduled_start).toISOString().split('T')[0]
+        );
+
+        expect(dates).toContain('2024-01-16');
+        expect(dates).not.toContain('2024-01-17'); // exception
+        expect(dates).toContain('2024-01-18');
+      } finally {
+        ScheduleEntry.getAssignedUserIds = origGetAssigned;
+      }
+    });
+  });
+});

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -345,7 +345,7 @@ export function Dialog({
           aria-modal="true"
           aria-label={title || 'Dialog'}
           tabIndex={-1}
-          className={`relative bg-background rounded-lg shadow-lg w-full ${className || 'max-w-3xl'} max-h-[90%] flex flex-col focus:outline-none focus-within:ring-2 focus-within:ring-primary-100 focus-within:ring-offset-2`}
+          className={`relative bg-background rounded-lg shadow-lg w-full ${className || 'max-w-3xl'} max-h-[90%] flex flex-col outline-none focus-within:ring-2 focus-within:ring-primary-100 focus-within:ring-offset-2`}
         >
           {/* Title bar */}
           {title ? (
@@ -409,7 +409,7 @@ export function Dialog({
           ref={dialogRef}
           {...withDataAutomationId(updateDialog)}
           {...(!hasDescription ? { 'aria-describedby': undefined } : {})}
-          className={`fixed top-1/2 left-1/2 bg-background rounded-lg shadow-lg w-full ${className || 'max-w-3xl'} z-50 focus-within:ring-2 focus-within:ring-primary-100 focus-within:ring-offset-2 max-h-[90vh] flex flex-col`}
+          className={`fixed top-1/2 left-1/2 bg-background rounded-lg shadow-lg w-full ${className || 'max-w-3xl'} z-50 max-h-[90vh] flex flex-col outline-none focus-within:ring-2 focus-within:ring-primary-100 focus-within:ring-offset-2`}
           style={dialogStyle}
           onKeyDown={(e) => {
             // Handle Escape key manually when focus trap is disabled

--- a/server/src/test/integration/scheduling/scheduleEntryRecurrence.integration.test.ts
+++ b/server/src/test/integration/scheduling/scheduleEntryRecurrence.integration.test.ts
@@ -1,0 +1,786 @@
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+
+import { TestContext } from '../../../../test-utils/testContext';
+import { ScheduleEntry } from '@alga-psa/scheduling';
+import { IEditScope } from '@alga-psa/types';
+
+const helpers = TestContext.createHelpers();
+const HOOK_TIMEOUT = 240_000;
+
+/** JSONB columns are already parsed by PostgreSQL; plain JSON columns are strings. */
+function parsePattern(val: unknown): Record<string, unknown> {
+  if (typeof val === 'string') return JSON.parse(val);
+  return val as Record<string, unknown>;
+}
+
+describe('Schedule entry recurrence integration', () => {
+  let ctx: TestContext;
+
+  beforeAll(async () => {
+    ctx = await helpers.beforeAll({
+      cleanupTables: [
+        'schedule_entry_assignees',
+        'schedule_entries',
+      ],
+    });
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    await helpers.afterAll();
+  }, HOOK_TIMEOUT);
+
+  beforeEach(async () => {
+    ctx = await helpers.beforeEach();
+    await ctx.db('schedule_entry_assignees').where({ tenant: ctx.tenantId }).del();
+    await ctx.db('schedule_entries').where({ tenant: ctx.tenantId }).del();
+  }, HOOK_TIMEOUT);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await helpers.afterEach();
+  }, HOOK_TIMEOUT);
+
+  // ── Helper ───────────────────────────────────────────────────────────────
+
+  async function createRecurringEntry(overrides: Record<string, unknown> = {}) {
+    const entryId = uuidv4();
+    const defaults = {
+      entry_id: entryId,
+      tenant: ctx.tenantId,
+      title: 'Daily standup',
+      scheduled_start: new Date('2024-06-01T09:00:00Z'),
+      scheduled_end: new Date('2024-06-01T09:30:00Z'),
+      status: 'scheduled',
+      work_item_type: 'ad_hoc',
+      is_recurring: true,
+      is_private: false,
+      recurrence_pattern: JSON.stringify({
+        frequency: 'daily',
+        interval: 1,
+        startDate: '2024-06-01T00:00:00.000Z',
+        endDate: '2024-06-14T23:59:59.000Z',
+        exceptions: [],
+      }),
+    };
+
+    const data = { ...defaults, ...overrides, entry_id: overrides.entry_id || entryId };
+    await ctx.db('schedule_entries').insert(data);
+
+    // Add assignee
+    await ctx.db('schedule_entry_assignees').insert({
+      tenant: ctx.tenantId,
+      entry_id: data.entry_id,
+      user_id: ctx.userId,
+    });
+
+    return data;
+  }
+
+  // ── getAll: virtual recurring instances ──────────────────────────────────
+
+  describe('getAll() with recurring entries', () => {
+    it('returns virtual instances for a daily recurring entry within the date range', async () => {
+      await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-07T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+
+      // Recurring masters are excluded from getAll — only virtual instances appear.
+      // One virtual instance per day from June 1–7 (7 days).
+      const virtualEntries = entries.filter(e => e.entry_id.includes('_'));
+
+      expect(entries.length).toBe(virtualEntries.length); // no master entry in results
+      expect(virtualEntries.length).toBeGreaterThanOrEqual(6);
+
+      // Virtual entries should have composite IDs
+      for (const ve of virtualEntries) {
+        expect(ve.entry_id).toMatch(/^[0-9a-f-]+_\d+$/);
+        expect(ve.is_recurring).toBe(true);
+        expect(ve.original_entry_id).toBeDefined();
+      }
+    });
+
+    it('respects recurrence end date and does not generate instances beyond it', async () => {
+      await createRecurringEntry({
+        recurrence_pattern: JSON.stringify({
+          frequency: 'daily',
+          interval: 1,
+          startDate: '2024-06-01T00:00:00.000Z',
+          endDate: '2024-06-03T23:59:59.000Z',
+          exceptions: [],
+        }),
+      });
+
+      // Query a wider range than the recurrence end date
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-10T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualEntries = entries.filter(e => e.entry_id.includes('_'));
+
+      // Should only have instances up to June 3
+      for (const ve of virtualEntries) {
+        const scheduledStart = new Date(ve.scheduled_start);
+        expect(scheduledStart.getTime()).toBeLessThanOrEqual(new Date('2024-06-03T23:59:59Z').getTime());
+      }
+    });
+
+    it('carries user assignments to virtual instances', async () => {
+      await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-03T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualEntries = entries.filter(e => e.entry_id.includes('_'));
+
+      expect(virtualEntries.length).toBeGreaterThan(0);
+      for (const ve of virtualEntries) {
+        expect(ve.assigned_user_ids).toContain(ctx.userId);
+      }
+    });
+
+    it('includes non-recurring entries alongside virtual instances', async () => {
+      // Create a regular (non-recurring) entry
+      const regularId = uuidv4();
+      await ctx.db('schedule_entries').insert({
+        entry_id: regularId,
+        tenant: ctx.tenantId,
+        title: 'One-off meeting',
+        scheduled_start: new Date('2024-06-02T14:00:00Z'),
+        scheduled_end: new Date('2024-06-02T15:00:00Z'),
+        status: 'scheduled',
+        work_item_type: 'ad_hoc',
+        is_recurring: false,
+        is_private: false,
+      });
+      await ctx.db('schedule_entry_assignees').insert({
+        tenant: ctx.tenantId,
+        entry_id: regularId,
+        user_id: ctx.userId,
+      });
+
+      // Create a recurring entry
+      await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-03T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+
+      const regularEntries = entries.filter(e => e.title === 'One-off meeting');
+      const recurringEntries = entries.filter(e => e.title === 'Daily standup');
+
+      expect(regularEntries.length).toBe(1);
+      expect(regularEntries[0].entry_id).toBe(regularId);
+      expect(recurringEntries.length).toBeGreaterThan(0); // virtual instances only (no master)
+    });
+
+    it('does not include virtual instances for entries outside the date range', async () => {
+      await createRecurringEntry();
+
+      // Query a range entirely after the recurrence end date
+      const start = new Date('2024-07-01T00:00:00Z');
+      const end = new Date('2024-07-31T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      expect(entries.length).toBe(0);
+    });
+  });
+
+  // ── Weekly recurrence ───────────────────────────────────────────────────
+
+  describe('weekly recurrence', () => {
+    it('generates instances only on specified days of the week', async () => {
+      await createRecurringEntry({
+        recurrence_pattern: JSON.stringify({
+          frequency: 'weekly',
+          interval: 1,
+          startDate: '2024-06-03T00:00:00.000Z', // Monday
+          endDate: '2024-06-21T23:59:59.000Z',
+          daysOfWeek: [1, 3, 5], // Mon, Wed, Fri
+          exceptions: [],
+        }),
+        scheduled_start: new Date('2024-06-03T09:00:00Z'),
+        scheduled_end: new Date('2024-06-03T09:30:00Z'),
+      });
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-22T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualEntries = entries.filter(e => e.entry_id.includes('_'));
+
+      // Verify instances are generated on consistent days (RRule uses local time internally,
+      // so we check local day-of-week rather than UTC)
+      const daysSet = new Set<number>();
+      for (const ve of virtualEntries) {
+        daysSet.add(new Date(ve.scheduled_start).getDay());
+      }
+      // Should land on exactly 3 distinct weekdays
+      expect(daysSet.size).toBe(3);
+
+      // Should have approximately 9 instances (3 weeks × 3 days)
+      expect(virtualEntries.length).toBeGreaterThanOrEqual(8);
+    });
+  });
+
+  // ── delete with SINGLE scope (virtual instance) ─────────────────────────
+
+  describe('delete() with SINGLE scope on a virtual instance', () => {
+    it('adds exception date to master and excludes that occurrence from getAll', async () => {
+      const entry = await createRecurringEntry();
+
+      // First, get all entries to find a virtual instance ID
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-07T23:59:59Z');
+
+      const entriesBefore = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsBefore = entriesBefore.filter(e => e.entry_id.includes('_'));
+      expect(virtualsBefore.length).toBeGreaterThan(0);
+
+      // Pick the second virtual instance to delete
+      const targetVirtual = virtualsBefore[1];
+      const targetDate = new Date(targetVirtual.scheduled_start);
+
+      // Delete the single virtual instance
+      const result = await ScheduleEntry.delete(ctx.db, ctx.tenantId, targetVirtual.entry_id, IEditScope.SINGLE);
+      expect(result).toBe(true);
+
+      // Verify the exception was added to the master's recurrence_pattern
+      const masterAfter = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+
+      expect(masterAfter).toBeDefined();
+      const pattern = parsePattern(masterAfter.recurrence_pattern);
+      expect(pattern.exceptions.length).toBe(1);
+
+      // Verify getAll no longer returns that occurrence
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsAfter = entriesAfter.filter(e => e.entry_id.includes('_'));
+
+      expect(virtualsAfter.length).toBe(virtualsBefore.length - 1);
+
+      // The deleted occurrence's date should not appear
+      const afterDates = virtualsAfter.map(e => new Date(e.scheduled_start).toISOString().slice(0, 10));
+      const targetDateStr = targetDate.toISOString().slice(0, 10);
+      expect(afterDates).not.toContain(targetDateStr);
+    });
+  });
+
+  // ── delete with SINGLE scope (master entry) ─────────────────────────────
+
+  describe('delete() with SINGLE scope on a master entry', () => {
+    it('creates a new master from the next occurrence and deletes the original', async () => {
+      const entry = await createRecurringEntry();
+      const originalEntryId = entry.entry_id as string;
+
+      // Delete the master with SINGLE scope (removes the first occurrence, shifts master)
+      const result = await ScheduleEntry.delete(ctx.db, ctx.tenantId, originalEntryId, IEditScope.SINGLE);
+      expect(result).toBe(true);
+
+      // Original master should be gone
+      const originalMaster = await ctx.db('schedule_entries')
+        .where({ entry_id: originalEntryId, tenant: ctx.tenantId })
+        .first();
+      expect(originalMaster).toBeUndefined();
+
+      // A new master should have been created
+      const newMasters = await ctx.db('schedule_entries')
+        .where({ tenant: ctx.tenantId, is_recurring: true })
+        .select('*');
+
+      expect(newMasters.length).toBe(1);
+      const newMaster = newMasters[0];
+      expect(newMaster.entry_id).not.toBe(originalEntryId);
+      expect(newMaster.title).toBe('Daily standup');
+
+      // New master's start should be after the original
+      expect(new Date(newMaster.scheduled_start).getTime()).toBeGreaterThan(
+        new Date(entry.scheduled_start as Date).getTime()
+      );
+
+      // New master should have the original's first date as an exception
+      const newPattern = parsePattern(newMaster.recurrence_pattern);
+      expect(newPattern.exceptions.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ── delete with FUTURE scope (virtual instance) ─────────────────────────
+
+  describe('delete() with FUTURE scope on a virtual instance', () => {
+    it('truncates the series end date to before the target instance', async () => {
+      const entry = await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-14T23:59:59Z');
+
+      const entriesBefore = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsBefore = entriesBefore.filter(e => e.entry_id.includes('_'));
+
+      // Pick a virtual instance in the middle of the series (e.g. around June 7)
+      const midIndex = Math.floor(virtualsBefore.length / 2);
+      const targetVirtual = virtualsBefore[midIndex];
+      const targetDate = new Date(targetVirtual.scheduled_start);
+
+      // Delete FUTURE from that point
+      const result = await ScheduleEntry.delete(ctx.db, ctx.tenantId, targetVirtual.entry_id, IEditScope.FUTURE);
+      expect(result).toBe(true);
+
+      // Verify the master's pattern now has an endDate before the target
+      const masterAfter = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+
+      const pattern = parsePattern(masterAfter.recurrence_pattern);
+      const newEndDate = new Date(pattern.endDate);
+      expect(newEndDate.getTime()).toBeLessThan(targetDate.getTime());
+
+      // Verify getAll no longer returns instances at or after the target date
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsAfter = entriesAfter.filter(e => e.entry_id.includes('_'));
+
+      for (const ve of virtualsAfter) {
+        expect(new Date(ve.scheduled_start).getTime()).toBeLessThan(targetDate.getTime());
+      }
+
+      expect(virtualsAfter.length).toBeLessThan(virtualsBefore.length);
+    });
+  });
+
+  // ── delete with ALL scope ───────────────────────────────────────────────
+
+  describe('delete() with ALL scope', () => {
+    it('deletes the master entry and all virtual instances disappear', async () => {
+      const entry = await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-14T23:59:59Z');
+
+      // Verify entries exist before
+      const entriesBefore = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      expect(entriesBefore.length).toBeGreaterThan(0);
+
+      // Delete ALL
+      const result = await ScheduleEntry.delete(ctx.db, ctx.tenantId, entry.entry_id as string, IEditScope.ALL);
+      expect(result).toBe(true);
+
+      // Master should be gone from DB
+      const masterAfter = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+      expect(masterAfter).toBeUndefined();
+
+      // Assignees should be gone
+      const assigneesAfter = await ctx.db('schedule_entry_assignees')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .select('*');
+      expect(assigneesAfter.length).toBe(0);
+
+      // getAll should return nothing
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      expect(entriesAfter.length).toBe(0);
+    });
+  });
+
+  // ── update with SINGLE scope ──────────────────────────────────────────
+
+  describe('update() with SINGLE scope', () => {
+    it('creates a standalone entry and adds exception to master', async () => {
+      const entry = await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-07T23:59:59Z');
+
+      const entriesBefore = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsBefore = entriesBefore.filter(e => e.entry_id.includes('_'));
+      expect(virtualsBefore.length).toBeGreaterThan(0);
+
+      const targetVirtual = virtualsBefore[1];
+      const targetDate = new Date(targetVirtual.scheduled_start);
+
+      // Update single instance with new title
+      const updated = await ScheduleEntry.update(
+        ctx.db,
+        ctx.tenantId,
+        targetVirtual.entry_id,
+        {
+          title: 'Special standup',
+          scheduled_start: targetDate,
+          scheduled_end: new Date(targetDate.getTime() + 30 * 60 * 1000),
+        },
+        IEditScope.SINGLE
+      );
+
+      expect(updated).toBeDefined();
+      expect(updated!.title).toBe('Special standup');
+      expect(updated!.is_recurring).toBe(false);
+
+      // Verify a standalone entry was created in the DB
+      const standaloneEntry = await ctx.db('schedule_entries')
+        .where({ entry_id: updated!.entry_id, tenant: ctx.tenantId })
+        .first();
+      expect(standaloneEntry).toBeDefined();
+      expect(standaloneEntry.title).toBe('Special standup');
+      expect(standaloneEntry.is_recurring).toBe(false);
+
+      // Verify exception was added to master
+      const masterAfter = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+      const pattern = parsePattern(masterAfter.recurrence_pattern);
+      expect(pattern.exceptions.length).toBe(1);
+
+      // getAll should include the standalone entry and exclude the old virtual instance
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const standalone = entriesAfter.find(e => e.entry_id === updated!.entry_id);
+      expect(standalone).toBeDefined();
+      expect(standalone!.title).toBe('Special standup');
+
+      // The virtual instance for that date should no longer appear
+      const virtualsAfter = entriesAfter.filter(e => e.entry_id.includes('_'));
+      const virtualDates = virtualsAfter.map(e => new Date(e.scheduled_start).toISOString().slice(0, 10));
+      const targetDateStr = targetDate.toISOString().slice(0, 10);
+      expect(virtualDates).not.toContain(targetDateStr);
+    });
+
+    it('copies assignments from master to standalone entry', async () => {
+      await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-05T23:59:59Z');
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtuals = entries.filter(e => e.entry_id.includes('_'));
+      const target = virtuals[0];
+
+      const updated = await ScheduleEntry.update(
+        ctx.db,
+        ctx.tenantId,
+        target.entry_id,
+        { title: 'Modified' },
+        IEditScope.SINGLE
+      );
+
+      // Check the assignee was copied
+      const assignees = await ctx.db('schedule_entry_assignees')
+        .where({ entry_id: updated!.entry_id, tenant: ctx.tenantId })
+        .select('user_id');
+      expect(assignees.length).toBe(1);
+      expect(assignees[0].user_id).toBe(ctx.userId);
+    });
+  });
+
+  // ── update with FUTURE scope ──────────────────────────────────────────
+
+  describe('update() with FUTURE scope', () => {
+    it('splits the series into two: original truncated, new master created', async () => {
+      const entry = await createRecurringEntry();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-14T23:59:59Z');
+
+      const entriesBefore = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsBefore = entriesBefore.filter(e => e.entry_id.includes('_'));
+
+      // Pick a virtual instance in the middle
+      const midIndex = Math.floor(virtualsBefore.length / 2);
+      const targetVirtual = virtualsBefore[midIndex];
+
+      // Update FUTURE with new title
+      const updated = await ScheduleEntry.update(
+        ctx.db,
+        ctx.tenantId,
+        targetVirtual.entry_id,
+        { title: 'Renamed standup' },
+        IEditScope.FUTURE
+      );
+
+      expect(updated).toBeDefined();
+      expect(updated!.title).toBe('Renamed standup');
+      expect(updated!.is_recurring).toBe(true);
+
+      // Verify original master was truncated
+      const originalMaster = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+      const originalPattern = parsePattern(originalMaster.recurrence_pattern);
+      const originalEnd = new Date(originalPattern.endDate);
+      const targetDate = new Date(targetVirtual.scheduled_start);
+      expect(originalEnd.getTime()).toBeLessThan(targetDate.getTime());
+
+      // Verify new master was created
+      const newMaster = await ctx.db('schedule_entries')
+        .where({ entry_id: updated!.entry_id, tenant: ctx.tenantId })
+        .first();
+      expect(newMaster).toBeDefined();
+      expect(newMaster.title).toBe('Renamed standup');
+      expect(newMaster.is_recurring).toBe(true);
+
+      // We now have 2 recurring masters in the DB
+      const allMasters = await ctx.db('schedule_entries')
+        .where({ tenant: ctx.tenantId, is_recurring: true })
+        .select('*');
+      expect(allMasters.length).toBe(2);
+
+      // getAll should show entries from both series
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const oldTitle = entriesAfter.filter(e => e.title === 'Daily standup');
+      const newTitle = entriesAfter.filter(e => e.title === 'Renamed standup');
+
+      expect(oldTitle.length).toBeGreaterThan(0);
+      expect(newTitle.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── update with ALL scope ─────────────────────────────────────────────
+
+  describe('update() with ALL scope', () => {
+    it('updates the master entry and preserves existing exceptions', async () => {
+      const entry = await createRecurringEntry();
+
+      // First, add an exception by deleting a single instance
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-07T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtuals = entries.filter(e => e.entry_id.includes('_'));
+      const target = virtuals[0];
+
+      await ScheduleEntry.delete(ctx.db, ctx.tenantId, target.entry_id, IEditScope.SINGLE);
+
+      // Verify exception exists
+      const masterMid = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+      const midPattern = parsePattern(masterMid.recurrence_pattern);
+      expect(midPattern.exceptions.length).toBe(1);
+
+      // Now update ALL with a new title
+      const updated = await ScheduleEntry.update(
+        ctx.db,
+        ctx.tenantId,
+        entry.entry_id as string,
+        { title: 'Updated daily standup' },
+        IEditScope.ALL
+      );
+
+      expect(updated).toBeDefined();
+      expect(updated!.title).toBe('Updated daily standup');
+      expect(updated!.is_recurring).toBe(true);
+
+      // Verify DB was updated
+      const masterAfter = await ctx.db('schedule_entries')
+        .where({ entry_id: entry.entry_id, tenant: ctx.tenantId })
+        .first();
+      expect(masterAfter.title).toBe('Updated daily standup');
+
+      // Exceptions should be preserved
+      const afterPattern = parsePattern(masterAfter.recurrence_pattern);
+      expect(afterPattern.exceptions.length).toBe(1);
+
+      // getAll should reflect the new title on all virtual instances
+      const entriesAfter = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualsAfter = entriesAfter.filter(e => e.entry_id.includes('_'));
+      for (const ve of virtualsAfter) {
+        expect(ve.title).toBe('Updated daily standup');
+      }
+    });
+  });
+
+  // ── Exception dates filtering ────────────────────────────────────────
+
+  describe('exception dates', () => {
+    it('entries with pre-existing exceptions skip those dates', async () => {
+      const exceptionDate = '2024-06-05T00:00:00.000Z'; // June 5
+
+      await createRecurringEntry({
+        recurrence_pattern: JSON.stringify({
+          frequency: 'daily',
+          interval: 1,
+          startDate: '2024-06-01T00:00:00.000Z',
+          endDate: '2024-06-10T23:59:59.000Z',
+          exceptions: [exceptionDate],
+        }),
+      });
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-10T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualEntries = entries.filter(e => e.entry_id.includes('_'));
+
+      // June 5 should NOT appear in virtual instances
+      const virtualDates = virtualEntries.map(e =>
+        new Date(e.scheduled_start).toISOString().slice(0, 10)
+      );
+      expect(virtualDates).not.toContain('2024-06-05');
+    });
+
+    it('multiple exception dates are all respected', async () => {
+      await createRecurringEntry({
+        recurrence_pattern: JSON.stringify({
+          frequency: 'daily',
+          interval: 1,
+          startDate: '2024-06-01T00:00:00.000Z',
+          endDate: '2024-06-10T23:59:59.000Z',
+          exceptions: [
+            '2024-06-03T00:00:00.000Z',
+            '2024-06-05T00:00:00.000Z',
+            '2024-06-07T00:00:00.000Z',
+          ],
+        }),
+      });
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-10T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtualDates = entries
+        .filter(e => e.entry_id.includes('_'))
+        .map(e => new Date(e.scheduled_start).toISOString().slice(0, 10));
+
+      expect(virtualDates).not.toContain('2024-06-03');
+      expect(virtualDates).not.toContain('2024-06-05');
+      expect(virtualDates).not.toContain('2024-06-07');
+    });
+  });
+
+  // ── Non-recurring entries: simple update/delete ──────────────────────
+
+  describe('non-recurring entry operations', () => {
+    it('update() on a non-recurring entry performs a simple update', async () => {
+      const entryId = uuidv4();
+      await ctx.db('schedule_entries').insert({
+        entry_id: entryId,
+        tenant: ctx.tenantId,
+        title: 'Regular meeting',
+        scheduled_start: new Date('2024-06-05T10:00:00Z'),
+        scheduled_end: new Date('2024-06-05T11:00:00Z'),
+        status: 'scheduled',
+        work_item_type: 'ad_hoc',
+        is_recurring: false,
+        is_private: false,
+      });
+      await ctx.db('schedule_entry_assignees').insert({
+        tenant: ctx.tenantId,
+        entry_id: entryId,
+        user_id: ctx.userId,
+      });
+
+      const updated = await ScheduleEntry.update(
+        ctx.db,
+        ctx.tenantId,
+        entryId,
+        { title: 'Renamed meeting' }
+      );
+
+      expect(updated).toBeDefined();
+      expect(updated!.title).toBe('Renamed meeting');
+
+      // Verify in DB
+      const dbEntry = await ctx.db('schedule_entries')
+        .where({ entry_id: entryId, tenant: ctx.tenantId })
+        .first();
+      expect(dbEntry.title).toBe('Renamed meeting');
+    });
+
+    it('delete() on a non-recurring entry removes it completely', async () => {
+      const entryId = uuidv4();
+      await ctx.db('schedule_entries').insert({
+        entry_id: entryId,
+        tenant: ctx.tenantId,
+        title: 'To be deleted',
+        scheduled_start: new Date('2024-06-05T10:00:00Z'),
+        scheduled_end: new Date('2024-06-05T11:00:00Z'),
+        status: 'scheduled',
+        work_item_type: 'ad_hoc',
+        is_recurring: false,
+        is_private: false,
+      });
+      await ctx.db('schedule_entry_assignees').insert({
+        tenant: ctx.tenantId,
+        entry_id: entryId,
+        user_id: ctx.userId,
+      });
+
+      const result = await ScheduleEntry.delete(ctx.db, ctx.tenantId, entryId);
+      expect(result).toBe(true);
+
+      // Should be gone from DB
+      const dbEntry = await ctx.db('schedule_entries')
+        .where({ entry_id: entryId, tenant: ctx.tenantId })
+        .first();
+      expect(dbEntry).toBeUndefined();
+
+      // Assignees should be gone too
+      const assignees = await ctx.db('schedule_entry_assignees')
+        .where({ entry_id: entryId, tenant: ctx.tenantId })
+        .select('*');
+      expect(assignees.length).toBe(0);
+    });
+  });
+
+  // ── Create with recurrence ──────────────────────────────────────────
+
+  describe('create() with recurrence pattern', () => {
+    it('creates a recurring master entry and getAll returns virtual instances', async () => {
+      const created = await ScheduleEntry.create(
+        ctx.db,
+        ctx.tenantId,
+        {
+          title: 'New recurring',
+          scheduled_start: new Date('2024-06-01T10:00:00Z'),
+          scheduled_end: new Date('2024-06-01T11:00:00Z'),
+          status: 'scheduled',
+          work_item_type: 'ad_hoc',
+          is_private: false,
+          recurrence_pattern: {
+            frequency: 'daily',
+            interval: 1,
+            startDate: new Date('2024-06-01T00:00:00Z'),
+            endDate: new Date('2024-06-05T23:59:59Z'),
+          } as any,
+        },
+        { assignedUserIds: [ctx.userId] }
+      );
+
+      expect(created).toBeDefined();
+      expect(created.is_recurring).toBe(true);
+
+      // Verify in DB
+      const dbEntry = await ctx.db('schedule_entries')
+        .where({ entry_id: created.entry_id, tenant: ctx.tenantId })
+        .first();
+      expect(dbEntry.is_recurring).toBe(true);
+      expect(dbEntry.recurrence_pattern).toBeTruthy();
+
+      // getAll should return virtual instances
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-05T23:59:59Z');
+      const entries = await ScheduleEntry.getAll(ctx.db, ctx.tenantId, start, end);
+      const virtuals = entries.filter(e => e.entry_id.includes('_'));
+
+      expect(virtuals.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  // ── Tenant isolation ────────────────────────────────────────────────
+
+  describe('tenant isolation', () => {
+    it('recurring entries from one tenant are not visible to another', async () => {
+      await createRecurringEntry();
+
+      const fakeTenant = uuidv4();
+
+      const start = new Date('2024-06-01T00:00:00Z');
+      const end = new Date('2024-06-14T23:59:59Z');
+
+      const entries = await ScheduleEntry.getAll(ctx.db, fakeTenant, start, end);
+      expect(entries.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
  Port recurrence expansion from legacy server model into the scheduling package: virtual instance generation via RRule,SINGLE/FUTURE/ALL scope handling for update and delete, exception date tracking, and series splitting.

  - Add recurrenceUtils.ts with generateOccurrences/applyTimeToDate
  - Add getRecurringEntriesInRange and virtual instance generation
  - Implement scoped update/delete (SINGLE/FUTURE/ALL) on model
  - Wire updateType/deleteType through schedule actions
  - Fix duplicate first-day instance (exclude masters from getAll)
  - Replace native date input with DatePicker for recurrence end date
  - Suppress browser focus outline on Dialog, keep pale purple ring
  - Add integration tests (20) against real DB and unit tests (38)

  "But I don't want to go among mad recurring entries," Alice remarked. "Oh, you can't help that," said the Cat: "we're all virtual instances here. I'm virtual. You're virtual. Even the exceptions are just dates who couldn't attend." 🐱📅✨