### PR TITLE
Fix feature flag UI and PostHog API issues

### DIFF
--- a/ee/server/src/app/api/v1/platform-feature-flags/[flagId]/route.ts
+++ b/ee/server/src/app/api/v1/platform-feature-flags/[flagId]/route.ts
@@ -69,7 +69,8 @@ function errorResponse(error: unknown, context: string): NextResponse {
     }
   }
 
-  return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  const detail = error instanceof Error ? error.message : String(error);
+  return NextResponse.json({ success: false, error: 'Internal server error', detail }, { status: 500 });
 }
 
 /**


### PR DESCRIPTION
  - Fix tenant property key mismatch: use 'tenant' instead of 'tenant_id' to match PostHog person properties
  - Fix flag deletion: use PATCH soft-delete instead of HTTP DELETE (PostHog returns 405 on DELETE)
  - Add search and tenant filter to feature flags table
  - Add expandable rows showing per-flag tenant list
  - Default to Feature Flags tab on extension open
  - Improve error detail in delete handler and API error responses

  "But I don't want to go among mad tenants," Alice remarked. "Oh, you can't help that," said the Cat: "we're all filtered here. I'm filtered. You're filtered. Even the soft-deleted ones still linger like Cheshire grins—PATCH by PATCH they fade away, but their tenant properties remain, expanded for all to see." 🐱🏳️✨