### PR TITLE
Auto-check comment toggles based on active tab

### DIFF
--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -99,7 +99,15 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
   const [isResolutionToggle, setIsResolutionToggle] = useState(false);
   const [contactAvatarUrls, setContactAvatarUrls] = useState<Record<string, string | null>>({});
 
+  const internalLabel = t('tickets.conversation.internal', 'Internal');
+  const resolutionLabel = t('tickets.conversation.resolution', 'Resolution');
+
   const handleAddCommentClick = () => {
+    // Auto-check toggles based on which tab is active
+    if (!hideInternalTab) {
+      setIsInternalToggle(activeTab === internalLabel);
+    }
+    setIsResolutionToggle(activeTab === resolutionLabel);
     setShowEditor(true);
   };
   const handleSubmitComment = async () => {
@@ -146,6 +154,16 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
       await onAddNewComment(isInternalToggle, isResolutionToggle);
     }
   };
+
+  // Sync toggles when active tab changes while editor is open
+  useEffect(() => {
+    if (showEditor) {
+      if (!hideInternalTab) {
+        setIsInternalToggle(activeTab === internalLabel);
+      }
+      setIsResolutionToggle(activeTab === resolutionLabel);
+    }
+  }, [activeTab, showEditor, hideInternalTab, internalLabel, resolutionLabel]);
 
   // Fetch contact avatar URLs for client users
   useEffect(() => {


### PR DESCRIPTION
  When opening the comment editor or switching tabs while it's open, automatically set the internal/resolution toggles to match the current tab view.

  "But I don't want to toggle among mad toggles," Alice remarked. "Oh, you can't help that," said the Tab, "we're all checked here. If you're in Internal, you're internally checked. If you're in Resolution, you're resolutely checked. It's only when you wander to All Comments that nothing is checked at all." 🎩🔀✅