### PR TITLE
sample client-portal-test: switch user call to GET-style bridge API

### DIFF
--- a/ee/extensions/samples/client-portal-test/README.md
+++ b/ee/extensions/samples/client-portal-test/README.md
@@ -63,7 +63,17 @@ This pattern ensures:
 - Authentication is handled by the host
 - Secrets never reach the browser
 
-See `ui/main.js` for the implementation.
+In the UI, use the SDK helper style:
+
+```ts
+const user = await callHandlerJson(bridge, '/user', { method: 'GET' });
+const result = await callHandlerJson(bridge, '/', {
+  method: 'POST',
+  body: { portalType: 'client' },
+});
+```
+
+See `ui/main.ts` for the implementation.
 
 ## Structure
 
@@ -76,7 +86,8 @@ client-portal-test/
 │   └── handler.ts     # WASM handler implementation
 ├── ui/
 │   ├── index.html     # Extension UI with portal-aware styling
-│   └── main.js        # UI JavaScript (context detection + proxy pattern)
+│   ├── main.ts        # UI TypeScript (context detection + SDK proxy calls)
+│   └── call-handler-json.ts # Temporary compatibility shim until SDK export is widely available
 └── wit/
     └── ext.wit        # WIT interface definition
 ```

--- a/ee/extensions/samples/client-portal-test/ui/call-handler-json.ts
+++ b/ee/extensions/samples/client-portal-test/ui/call-handler-json.ts
@@ -1,0 +1,80 @@
+import type { IframeBridge } from '@alga-psa/extension-iframe-sdk';
+import * as IframeSdk from '@alga-psa/extension-iframe-sdk';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+type HandlerMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+interface CallHandlerJsonOptions<TBody = unknown> {
+  method?: HandlerMethod;
+  body?: TBody;
+}
+
+type CallHandlerJsonFn = <TResponse = unknown, TBody = unknown>(
+  bridge: IframeBridge,
+  path: string,
+  options?: CallHandlerJsonOptions<TBody>,
+) => Promise<TResponse | null>;
+
+function parseMethod(method?: string): HandlerMethod {
+  const normalized = (method ?? 'GET').toUpperCase();
+  if (
+    normalized === 'GET' ||
+    normalized === 'POST' ||
+    normalized === 'PUT' ||
+    normalized === 'PATCH' ||
+    normalized === 'DELETE'
+  ) {
+    return normalized;
+  }
+  throw new Error(`Unsupported method: ${method}`);
+}
+
+function appendMethodOverride(path: string, method: Exclude<HandlerMethod, 'POST'>): string {
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}__method=${encodeURIComponent(method)}`;
+}
+
+function applyBodyMethodOverride<TBody>(
+  method: Exclude<HandlerMethod, 'POST'>,
+  body: TBody | undefined,
+): unknown {
+  if (body === undefined) return { __method: method };
+  if (body && typeof body === 'object' && !Array.isArray(body)) {
+    return { __method: method, ...(body as Record<string, unknown>) };
+  }
+  return body;
+}
+
+// Prefer SDK-native helper when available (future releases),
+// with a transport-compatible shim for currently published builds.
+const sdkExports = IframeSdk as unknown as Record<string, unknown>;
+const sdkCallHandlerJson = sdkExports['callHandlerJson'] as CallHandlerJsonFn | undefined;
+
+const fallbackCallHandlerJson: CallHandlerJsonFn = async <TResponse = unknown, TBody = unknown>(
+  bridge: IframeBridge,
+  path: string,
+  options: CallHandlerJsonOptions<TBody> = {},
+) => {
+  const method = parseMethod(options.method);
+  if (method === 'GET' && typeof options.body !== 'undefined') {
+    throw new Error('GET requests cannot include a body');
+  }
+
+  let route = path;
+  let body: unknown = options.body;
+
+  if (method !== 'POST') {
+    route = appendMethodOverride(path, method);
+    body = applyBodyMethodOverride(method, options.body);
+  }
+
+  const payload =
+    typeof body === 'undefined' ? undefined : encoder.encode(JSON.stringify(body));
+  const responseBytes = await bridge.uiProxy.callRoute(route, payload ?? undefined);
+  const text = decoder.decode(responseBytes);
+  return text.length ? (JSON.parse(text) as TResponse) : null;
+};
+
+export const callHandlerJson: CallHandlerJsonFn = sdkCallHandlerJson ?? fallbackCallHandlerJson;


### PR DESCRIPTION
## Summary
- update the `client-portal-test` sample UI to use `callHandlerJson(..., { method })` style calls
- use GET for `/user` and POST for `/`
- add a local compatibility wrapper so sample code stays ergonomic while supporting current bridge transport behavior

## Why
This keeps the sample extension aligned with the SDK-bridge style extension authors should use, while the platform proxy fix lands separately.

## Testing
- sample extension bundle builds pass for UI and handler entrypoints
