### PR TITLE
extension iframe bridge: forward explicit HTTP methods

### DIFF
--- a/sdk/extension-iframe-sdk/README.md
+++ b/sdk/extension-iframe-sdk/README.md
@@ -89,7 +89,7 @@ const created = await callHandlerJson(bridge, '/api/items', {
 await callHandlerJson(bridge, '/api/items/123', { method: 'DELETE' });
 ```
 
-For non-`POST` methods (`GET`, `PUT`, `PATCH`, `DELETE`), the helper applies method override transport (`__method`) so calls work consistently over the proxy channel.
+`callHandlerJson` forwards the requested HTTP method through the iframe bridge transport, so handlers can receive the intended method without embedding transport-specific override fields in route/body data.
 
 ## Protocol
 - Parent → Child: `bootstrap` with `{ session, theme_tokens, navigation }`

--- a/sdk/extension-iframe-sdk/src/types.ts
+++ b/sdk/extension-iframe-sdk/src/types.ts
@@ -37,7 +37,12 @@ export type HostToClientMessage =
  */
 export interface ResizePayload { height: number }
 export interface NavigatePayload { path: string }
-export interface ApiProxyPayload { route: string; body?: string } // body is base64 encoded bytes
+export type ProxyHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export interface ApiProxyPayload {
+  route: string;
+  body?: string; // body is base64 encoded bytes
+  method?: ProxyHttpMethod;
+}
 
 export type ClientToHostType = 'ready' | 'resize' | 'navigate' | 'apiproxy';
 export type ClientToHostMessage =

--- a/sdk/extension-iframe-sdk/src/ui-proxy.ts
+++ b/sdk/extension-iframe-sdk/src/ui-proxy.ts
@@ -1,13 +1,18 @@
 import type { IframeBridge } from './bridge';
+import type { ProxyHttpMethod } from './types';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-export type HandlerMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export type HandlerMethod = ProxyHttpMethod;
+
+export interface UiProxyCallOptions {
+  method?: HandlerMethod;
+}
 
 export interface UiProxyHostLike {
-  callRoute(route: string, payload?: Uint8Array | null): Promise<Uint8Array>;
-  call?(route: string, payload?: Uint8Array | null): Promise<Uint8Array>;
+  callRoute(route: string, payload?: Uint8Array | null, options?: UiProxyCallOptions): Promise<Uint8Array>;
+  call?(route: string, payload?: Uint8Array | null, options?: UiProxyCallOptions): Promise<Uint8Array>;
 }
 
 export interface CallHandlerJsonOptions<TBody = unknown> {
@@ -21,19 +26,6 @@ function resolveUiProxy(target: BridgeOrProxy): UiProxyHostLike {
   const maybeBridge = target as Pick<IframeBridge, 'uiProxy'>;
   if (maybeBridge.uiProxy) return maybeBridge.uiProxy;
   return target as UiProxyHostLike;
-}
-
-function appendMethodOverride(path: string, method: Exclude<HandlerMethod, 'POST'>): string {
-  const separator = path.includes('?') ? '&' : '?';
-  return `${path}${separator}__method=${encodeURIComponent(method)}`;
-}
-
-function applyBodyMethodOverride<TBody>(method: Exclude<HandlerMethod, 'POST'>, body: TBody | undefined): unknown {
-  if (body === undefined) return { __method: method };
-  if (body && typeof body === 'object' && !Array.isArray(body)) {
-    return { __method: method, ...(body as Record<string, unknown>) };
-  }
-  return body;
 }
 
 function parseMethod(method?: string): HandlerMethod {
@@ -55,8 +47,7 @@ function parseMethod(method?: string): HandlerMethod {
  *
  * Notes:
  * - Uses JSON request/response payloads.
- * - Non-POST methods are transported via POST-compatible override:
- *   route query `?__method=...` and JSON body `{"__method":"..."}`.
+ * - Methods are forwarded to the host bridge via uiProxy call options.
  */
 export async function callHandlerJson<TResponse = unknown, TBody = unknown>(
   bridgeOrProxy: BridgeOrProxy,
@@ -74,18 +65,11 @@ export async function callHandlerJson<TResponse = unknown, TBody = unknown>(
     throw new Error('GET requests cannot include a body');
   }
 
-  let route = path;
-  let body: unknown = options.body;
-
-  if (method !== 'POST') {
-    route = appendMethodOverride(path, method);
-    body = applyBodyMethodOverride(method, options.body);
-  }
-
+  const body: unknown = options.body;
   const payload =
     typeof body === 'undefined' ? undefined : encoder.encode(JSON.stringify(body));
 
-  const responseBytes = await call.call(uiProxy, route, payload ?? undefined);
+  const responseBytes = await call.call(uiProxy, path, payload ?? undefined, { method });
   const text = decoder.decode(responseBytes);
   return text.length ? (JSON.parse(text) as TResponse) : null;
 }


### PR DESCRIPTION
## Summary
- add explicit HTTP method support to iframe UI proxy transport (`apiproxy.payload.method`)
- update SDK `IframeBridge`/`callHandlerJson` to forward the requested method to host transport
- keep backward compatibility by defaulting to `POST` when method is absent
- update host iframe bridges (CE + EE) to honor explicit method and avoid sending body for `GET`
- add integration coverage for explicit method forwarding in extension proxy flow tests

## Why
Extension UI calls were historically normalized through POST-style transport semantics. This change makes method intent explicit and native through the bridge path so handler routing aligns with extension author expectations.

## Validation
- `npm -w sdk/extension-iframe-sdk run test`
- `npm -w sdk/extension-iframe-sdk run build`
- `npm -w server run typecheck`
- host bridge integration flow test updated with explicit method case
