### PR TITLE
Remove board default client portal label

### DIFF
--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -386,11 +386,6 @@ const BoardsSettings: React.FC = () => {
             }}
             className="data-[state=checked]:bg-primary-500"
           />
-          {value && (
-            <span className="text-xs text-gray-500">
-              Default for client portal
-            </span>
-          )}
         </div>
       ),
     },


### PR DESCRIPTION
## Summary\n- remove the "Default for client portal" inline label from Ticket Settings > Boards default toggle\n- keep existing default toggle behavior unchanged\n\n## Testing\n- not run (UI text-only change)