### PR TITLE
Fix portal duplicate-user handling and remove jsondiffpatch client import

### DIFF
--- a/packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts
+++ b/packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts
@@ -62,6 +62,22 @@ export interface CreateClientPortalUserParams {
   requirePasswordChange?: boolean;
 }
 
+function normalizeCreateClientPortalUserError(error: unknown): string {
+  const dbError = error as { code?: string };
+  if (dbError?.code === '23505') {
+    return 'A portal user already exists for this contact or email address';
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (message) {
+      return message;
+    }
+  }
+
+  return 'Failed to create client portal user';
+}
+
 export const createClientPortalUser = withAuth(async (
   user: IUserWithRoles,
   { tenant }: AuthContext,
@@ -260,7 +276,7 @@ export const createClientPortalUser = withAuth(async (
     return { success: true, userId: result.user_id, message: 'Client portal user created' };
   } catch (error) {
     console.error('Error creating client portal user:', error);
-    return { success: false, error: 'Failed to create client portal user' };
+    return { success: false, error: normalizeCreateClientPortalUserError(error) };
   }
 });
 


### PR DESCRIPTION
## Summary
- fix client-portal user creation so existing-user collisions return friendly errors instead of surfacing as unhandled exceptions
- simplify create-user error handling in `UserManagement` to a single normalization/reporting path (Simplification Cascades)
- remove `jsondiffpatch` import from `UIStateContext` and replace it with a local deep-equality guard to avoid Turbopack module resolution failures

## Details
- `packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts`
  - added `normalizeCreateClientPortalUserError()` and used it in the catch block
  - maps DB unique violations (`23505`) to a user-friendly duplicate message
- `server/src/components/settings/general/UserManagement.tsx`
  - replaced branch-heavy catch handling with:
    - `extractErrorMessage()`
    - `normalizeCreateUserError()`
    - `reportCreateUserError()`
  - client-portal creation failures now go through the same normalized path instead of throw/rethrow
- `packages/ui/src/ui-reflection/UIStateContext.tsx`
  - removed `jsondiffpatch` usage
  - added `deepEqualWithCycles()` and used it to skip no-op state updates

## Validation
- `npx eslint server/src/components/settings/general/UserManagement.tsx packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts` (no errors)
- `npm -w server run typecheck` currently fails in existing code with:
  - `src/lib/extensions/bundles.ts(6,22): Cannot find module 'tar'`
