### PR TITLE
Fix dark theme leaking onto auth pages

### DIFF
--- a/packages/ui/src/hooks/useAppTheme.tsx
+++ b/packages/ui/src/hooks/useAppTheme.tsx
@@ -59,6 +59,9 @@ export function useAppTheme() {
         const preference = await actions.getPreference();
         if (isThemePreference(preference) && preference !== theme) {
           setTheme(preference);
+        } else if (preference === null && theme !== 'system') {
+          // No saved preference — default to system detection when themes are enabled
+          setTheme('system');
         }
       } catch (error) {
         console.error('Failed to load theme preference:', error);

--- a/server/src/app/auth/client-portal/layout.tsx
+++ b/server/src/app/auth/client-portal/layout.tsx
@@ -4,7 +4,7 @@ import { ThemeBridge } from '@/components/providers/ThemeBridge';
 
 export default function ClientPortalAuthLayout({ children }: { children: ReactNode }) {
   return (
-    <AppThemeProvider>
+    <AppThemeProvider forcedTheme="light">
       <ThemeBridge>
         {children}
       </ThemeBridge>

--- a/server/src/components/providers/AppThemeProvider.tsx
+++ b/server/src/components/providers/AppThemeProvider.tsx
@@ -12,7 +12,7 @@ type AppThemeProviderProps = {
   forcedTheme?: string;
 };
 
-export function AppThemeProvider({ children, defaultTheme = 'system', forcedTheme }: AppThemeProviderProps) {
+export function AppThemeProvider({ children, defaultTheme = 'light', forcedTheme }: AppThemeProviderProps) {
   const actions = useMemo(() => ({
     getPreference: getThemePreferenceAction,
     savePreference: async (theme: 'light' | 'dark' | 'system') => {


### PR DESCRIPTION
  Default AppThemeProvider to light instead of system so  next-themes' blocking script doesn't apply .dark class before the feature flag can gate it. Force light theme on client portal auth layout and upgrade to system detection only when themes-enabled flag is active with no saved pref.

  "You don't know the power of the dark side," whispered the AppThemeProvider. But Master Yoda shook his head: "Default to light, you must. Only when the feature flag is enabled, to the dark side may you turn." 🌑⚔️ ✨