### PR TITLE
Fix empty Select.Item value crash in control panel

### DIFF
--- a/ee/extensions/nineminds-reporting/package-lock.json
+++ b/ee/extensions/nineminds-reporting/package-lock.json
@@ -29,7 +29,8 @@
       "name": "@alga-psa/ui-kit",
       "version": "0.1.0",
       "dependencies": {
-        "@radix-ui/react-select": "^2.1.2"
+        "@radix-ui/react-select": "^2.1.2",
+        "@tanstack/react-table": "^8.21.3"
       },
       "devDependencies": {
         "@types/react": "^19",

--- a/ee/extensions/nineminds-reporting/src/iframe/main.tsx
+++ b/ee/extensions/nineminds-reporting/src/iframe/main.tsx
@@ -5048,7 +5048,7 @@ function FeatureFlagsView() {
         />
         <CustomSelect
           options={[
-            { value: '', label: 'All tenants' },
+            { value: '__all__', label: 'All tenants' },
             ...(() => {
               const tenantIds = new Set<string>();
               for (const flag of flags) {
@@ -5062,8 +5062,8 @@ function FeatureFlagsView() {
                 .sort((a, b) => a.label.localeCompare(b.label));
             })(),
           ]}
-          value={tenantFilter}
-          onValueChange={(v) => setTenantFilter(v)}
+          value={tenantFilter || '__all__'}
+          onValueChange={(v) => setTenantFilter(v === '__all__' ? '' : v)}
           placeholder="Filter by tenant..."
           style={{ minWidth: '200px' }}
         />


### PR DESCRIPTION
  Replace empty string value for "All tenants" option with '__all__' sentinel. Radix UI Select.Item reserves empty string for clearing selection, causing an unhandled error that crashes the entire extension React tree on load.

  "But I don't want to go among empty strings," Alice remarked. "Oh, you can't help that," said the Select, "we're all __all__ here." 🐛🎩✨