### PR TITLE
Boards: default ticket priority

### DIFF
--- a/packages/types/src/interfaces/board.interface.ts
+++ b/packages/types/src/interfaces/board.interface.ts
@@ -10,6 +10,7 @@ export interface IBoard extends TenantEntity {
   is_default?: boolean;
   description?: string;
   display_order?: number;
+  default_priority_id?: string | null;
 
   // Category type configuration
   category_type?: CategoryType;

--- a/server/migrations/20260212090000_add_default_priority_to_boards.cjs
+++ b/server/migrations/20260212090000_add_default_priority_to_boards.cjs
@@ -1,0 +1,102 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  // 1) Add the column first (nullable).
+  const hasDefaultPriorityColumn = await knex.schema.hasColumn('boards', 'default_priority_id');
+  if (!hasDefaultPriorityColumn) {
+    await knex.schema.alterTable('boards', (table) => {
+      table.uuid('default_priority_id').nullable();
+    });
+  }
+
+  // 2) Backfill existing boards so Quick Add can pick a per-board default immediately.
+  // - ITIL boards: prefer ITIL level 3 (medium) if present, otherwise lowest order ITIL priority.
+  // - Custom boards: prefer lowest order custom priority (non-ITIL).
+  // Falls back to any ticket priority if the preferred subset is empty.
+  await knex.raw(`
+    UPDATE boards b
+    SET default_priority_id = (
+      SELECT c.priority_id
+      FROM (
+        -- Preferred subset first.
+        SELECT
+          p.priority_id,
+          0 AS pref,
+          p.order_number,
+          p.priority_name,
+          p.itil_priority_level
+        FROM priorities p
+        WHERE p.tenant = b.tenant
+          AND p.item_type = 'ticket'
+          AND (
+            (COALESCE(b.priority_type, 'custom') = 'itil' AND p.is_from_itil_standard = TRUE)
+            OR
+            (COALESCE(b.priority_type, 'custom') <> 'itil' AND (p.is_from_itil_standard IS NULL OR p.is_from_itil_standard = FALSE))
+          )
+
+        UNION ALL
+
+        -- Fallback to any ticket priority if the preferred subset is empty.
+        SELECT
+          p.priority_id,
+          1 AS pref,
+          p.order_number,
+          p.priority_name,
+          p.itil_priority_level
+        FROM priorities p
+        WHERE p.tenant = b.tenant
+          AND p.item_type = 'ticket'
+      ) c
+      ORDER BY
+        c.pref ASC,
+        -- Prefer ITIL medium when board is ITIL.
+        CASE
+          WHEN COALESCE(b.priority_type, 'custom') = 'itil' AND c.itil_priority_level = 3 THEN 0
+          ELSE 1
+        END,
+        c.order_number ASC,
+        c.priority_name ASC
+      LIMIT 1
+    )
+    WHERE b.default_priority_id IS NULL
+  `);
+
+  // 3) Add foreign key constraint (separate statement for Citus compatibility)
+  // Note: ON DELETE SET NULL is not supported in CitusDB; priority deletion should be blocked if referenced.
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'boards_default_priority_fk'
+      ) THEN
+        ALTER TABLE boards
+        ADD CONSTRAINT boards_default_priority_fk
+        FOREIGN KEY (tenant, default_priority_id)
+        REFERENCES priorities (tenant, priority_id);
+      END IF;
+    END
+    $$;
+  `);
+
+  // 4) Add index for efficient lookups / joins.
+  await knex.raw('CREATE INDEX IF NOT EXISTS boards_default_priority_idx ON boards (tenant, default_priority_id)');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  await knex.schema.alterTable('boards', (table) => {
+    table.dropIndex(['tenant', 'default_priority_id'], 'boards_default_priority_idx');
+    table.dropForeign(['tenant', 'default_priority_id']);
+    table.dropColumn('default_priority_id');
+  });
+};
+
+// Citus requires ALTER TABLE with foreign key constraints to run outside a transaction block
+exports.config = { transaction: false };

--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Plus, MoreVertical, HelpCircle } from "lucide-react";
-import { IBoard, CategoryType, PriorityType } from '@alga-psa/types';
+import { IBoard, CategoryType, PriorityType, IPriority, IUser, ColumnDefinition } from '@alga-psa/types';
 import {
   getAllBoards,
   createBoard,
@@ -12,19 +12,19 @@ import {
   deleteBoard
 } from '@alga-psa/tickets/actions';
 import { getAvailableReferenceData, importReferenceData, checkImportConflicts, ImportConflict } from '@alga-psa/reference-data/actions';
+import { getAllPriorities } from '@alga-psa/reference-data/actions';
 import { getAllUsers, getUserAvatarUrlsBatchAction } from '@alga-psa/users/actions';
 import UserPicker from '@alga-psa/ui/components/UserPicker';
-import { IUser } from '@alga-psa/types';
 import { toast } from 'react-hot-toast';
 import { Dialog, DialogContent, DialogFooter } from '@alga-psa/ui/components/Dialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Label } from '@alga-psa/ui/components/Label';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
-import { ColumnDefinition } from '@alga-psa/types';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Switch } from '@alga-psa/ui/components/Switch';
+import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -35,6 +35,7 @@ import {
 const BoardsSettings: React.FC = () => {
   const [boards, setBoards] = useState<IBoard[]>([]);
   const [users, setUsers] = useState<IUser[]>([]);
+  const [priorities, setPriorities] = useState<IPriority[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [deleteDialog, setDeleteDialog] = useState<{
     isOpen: boolean;
@@ -75,7 +76,8 @@ const BoardsSettings: React.FC = () => {
     category_type: 'custom' as CategoryType,
     priority_type: 'custom' as PriorityType,
     is_itil_compliant: false,
-    default_assigned_to: ''
+    default_assigned_to: '',
+    default_priority_id: ''
   });
   
   // State for Import Dialog
@@ -92,7 +94,25 @@ const BoardsSettings: React.FC = () => {
   useEffect(() => {
     fetchBoards();
     fetchUsers();
+    fetchPriorities();
   }, []);
+
+  // Prevent saving a mismatched default priority when toggling ITIL compliance on new boards.
+  useEffect(() => {
+    if (editingBoard) return;
+    if (!formData.default_priority_id) return;
+    const match = priorities.find(p => p.priority_id === formData.default_priority_id);
+    if (!match) {
+      setFormData(prev => ({ ...prev, default_priority_id: '' }));
+      return;
+    }
+
+    const effectivePriorityType: PriorityType = formData.is_itil_compliant ? 'itil' : 'custom';
+    const isItil = !!match.is_from_itil_standard;
+    if ((effectivePriorityType === 'itil' && !isItil) || (effectivePriorityType !== 'itil' && isItil)) {
+      setFormData(prev => ({ ...prev, default_priority_id: '' }));
+    }
+  }, [editingBoard, formData.default_priority_id, formData.is_itil_compliant, priorities]);
 
   const fetchBoards = async () => {
     try {
@@ -114,6 +134,16 @@ const BoardsSettings: React.FC = () => {
     }
   };
 
+  const fetchPriorities = async () => {
+    try {
+      const allPriorities = await getAllPriorities('ticket');
+      setPriorities(allPriorities || []);
+    } catch (error) {
+      console.error('Error fetching priorities:', error);
+      setPriorities([]);
+    }
+  };
+
   const startEditing = (board: IBoard) => {
     setEditingBoard(board);
     setFormData({
@@ -124,7 +154,8 @@ const BoardsSettings: React.FC = () => {
       category_type: board.category_type || 'custom',
       priority_type: board.priority_type || 'custom',
       is_itil_compliant: board.category_type === 'itil' && board.priority_type === 'itil',
-      default_assigned_to: board.default_assigned_to || ''
+      default_assigned_to: board.default_assigned_to || '',
+      default_priority_id: board.default_priority_id || ''
     });
     setShowAddEditDialog(true);
     setError(null);
@@ -210,7 +241,8 @@ const BoardsSettings: React.FC = () => {
           is_inactive: formData.is_inactive,
           category_type: categoryType,
           priority_type: priorityType,
-          default_assigned_to: formData.default_assigned_to || null
+          default_assigned_to: formData.default_assigned_to || null,
+          default_priority_id: formData.default_priority_id || null
         });
         toast.success('Board updated successfully');
       } else {
@@ -221,14 +253,15 @@ const BoardsSettings: React.FC = () => {
           is_inactive: formData.is_inactive,
           category_type: categoryType,
           priority_type: priorityType,
-          default_assigned_to: formData.default_assigned_to || null
+          default_assigned_to: formData.default_assigned_to || null,
+          default_priority_id: formData.default_priority_id || null
         });
         toast.success('Board created successfully');
       }
 
       setShowAddEditDialog(false);
       setEditingBoard(null);
-      setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '' });
+      setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '', default_priority_id: '' });
       await fetchBoards();
     } catch (error) {
       console.error('Error saving board:', error);
@@ -403,6 +436,18 @@ const BoardsSettings: React.FC = () => {
       },
     },
     {
+      title: 'Default Priority',
+      dataIndex: 'default_priority_id',
+      render: (value: string | null) => {
+        if (!value) return <span className="text-gray-400">-</span>;
+        const pr = priorities.find(p => p.priority_id === value);
+        if (!pr) return <span className="text-gray-400 italic">Unknown</span>;
+        return (
+          <span className="text-gray-700">{pr.priority_name}</span>
+        );
+      },
+    },
+    {
       title: 'Order',
       dataIndex: 'display_order',
       render: (value: number) => (
@@ -486,7 +531,7 @@ const BoardsSettings: React.FC = () => {
             id="add-board-button"
             onClick={() => {
               setEditingBoard(null);
-              setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '' });
+              setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '', default_priority_id: '' });
               setShowAddEditDialog(true);
             }} 
             className="bg-primary-500 text-white hover:bg-primary-600"
@@ -591,7 +636,7 @@ const BoardsSettings: React.FC = () => {
         onClose={() => {
           setShowAddEditDialog(false);
           setEditingBoard(null);
-          setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '' });
+          setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '', default_priority_id: '' });
           setError(null);
         }}
         title={editingBoard ? "Edit Board" : "Add Board"}
@@ -660,6 +705,40 @@ const BoardsSettings: React.FC = () => {
               </p>
             </div>
 
+            <div>
+              <Label htmlFor="default-priority-select">Default Priority</Label>
+              <CustomSelect
+                id="default-priority-select"
+                label=""
+                value={formData.default_priority_id}
+                onValueChange={(value) => setFormData({ ...formData, default_priority_id: value })}
+                options={((): SelectOption[] => {
+                  const effectivePriorityType: PriorityType = editingBoard
+                    ? formData.priority_type
+                    : (formData.is_itil_compliant ? 'itil' : 'custom');
+
+                  const allowed = priorities.filter(p => {
+                    if (p.item_type !== 'ticket') return false;
+                    const isItil = !!p.is_from_itil_standard;
+                    return effectivePriorityType === 'itil' ? isItil : !isItil;
+                  });
+
+                  return [
+                    { value: '', label: 'None (use system default)' },
+                    ...allowed
+                      .slice()
+                      .sort((a, b) => (a.order_number - b.order_number) || a.priority_name.localeCompare(b.priority_name))
+                      .map(p => ({ value: p.priority_id, label: p.priority_name }))
+                  ];
+                })()}
+                placeholder="Select default priority"
+                data-automation-id="board-default-priority-select"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Used to preselect the Priority field when adding a ticket for this board (for example in Quick Add).
+              </p>
+            </div>
+
             {/* ITIL Configuration - Only show for new boards */}
             {!editingBoard && (
               <div className="border-t pt-4 space-y-4">
@@ -695,7 +774,7 @@ const BoardsSettings: React.FC = () => {
             onClick={() => {
               setShowAddEditDialog(false);
               setEditingBoard(null);
-              setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '' });
+              setFormData({ board_name: '', description: '', display_order: 0, is_inactive: false, category_type: 'custom', priority_type: 'custom', is_itil_compliant: false, default_assigned_to: '', default_priority_id: '' });
               setError(null);
             }}
           >

--- a/server/src/interfaces/board.interface.ts
+++ b/server/src/interfaces/board.interface.ts
@@ -10,6 +10,7 @@ export interface IBoard extends TenantEntity {
   is_default?: boolean;
   description?: string;
   display_order?: number;
+  default_priority_id?: string | null;
 
   // Category type configuration
   category_type?: CategoryType;


### PR DESCRIPTION
Adds board-level default ticket priority (boards.default_priority_id) and uses it in Quick Add.\n\n- Migration adds nullable boards.default_priority_id with FK/index and backfills existing boards\n- Boards Settings UI lets you pick a per-board default priority\n- Quick Add uses the selected board’s default_priority_id (with type guard + fallback)\n