### PR TITLE
Ticket resolution notes: optionally close ticket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47198,7 +47198,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.0-rc2",
+      "version": "1.0.1-rc2",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",

--- a/packages/client-portal/src/components/tickets/TicketDetails.tsx
+++ b/packages/client-portal/src/components/tickets/TicketDetails.tsx
@@ -162,7 +162,11 @@ export function TicketDetails({
   const handleNewCommentContentChange = (content: PartialBlock[]) => {
     setNewCommentContent(content);
   };
-  const handleAddNewComment = async (isInternal: boolean, isResolution: boolean): Promise<boolean> => {
+  const handleAddNewComment = async (
+    isInternal: boolean,
+    isResolution: boolean,
+    _closeStatusId: string | null = null
+  ): Promise<boolean> => {
     const contentStr = JSON.stringify(newCommentContent);
     const hasContent = contentStr !== JSON.stringify([{
       type: "paragraph",

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -417,9 +417,11 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
     }, {} as Record<string, { user_id: string; first_name: string; last_name: string; email?: string, user_type: string, avatarUrl: string | null }>);
 
     // Format options for dropdowns
-    const statusOptions = statuses.map((status) => ({
+    // Include `is_closed` so UI can reliably derive "closed status" subsets.
+    const statusOptions = statuses.map((status: any) => ({
       value: status.status_id,
-      label: status.name || ""
+      label: status.name || "",
+      is_closed: !!status.is_closed,
     }));
 
     const agentOptions = users.map((agent) => ({

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -92,7 +92,7 @@ interface TicketDetailsProps {
     initialAdditionalAgents?: ITicketResource[];
     initialAvailableAgents?: IUserWithRoles[];
     initialUserMap?: Record<string, { user_id: string; first_name: string; last_name: string; email?: string, user_type: string, avatarUrl: string | null }>;
-    statusOptions?: { value: string; label: string }[];
+    statusOptions?: { value: string; label: string; is_closed?: boolean; className?: string }[];
     agentOptions?: { value: string; label: string }[];
     boardOptions?: { value: string; label: string }[];
     priorityOptions?: { value: string; label: string }[];
@@ -218,6 +218,14 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     const [client, setClient] = useState<IClient | null>(initialClient);
     const [contactInfo, setContactInfo] = useState<IContact | null>(initialContactInfo);
     const [createdByUser, setCreatedByUser] = useState<IUser | null>(initialCreatedByUser);
+
+    const closedStatusOptions = useMemo(
+        () =>
+            (statusOptions || [])
+                .filter((opt) => !!opt.is_closed)
+                .map(({ value, label }) => ({ value, label })),
+        [statusOptions]
+    );
     const [board, setBoard] = useState<any>(initialBoard);
     const [clients, setClients] = useState<IClient[]>(initialClients);
     const [contacts, setContacts] = useState<IContact[]>(initialContacts);
@@ -754,7 +762,11 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
 
     const [editorKey, setEditorKey] = useState(0);
 
-    const handleAddNewComment = async (isInternal: boolean, isResolution: boolean): Promise<boolean> => {
+    const handleAddNewComment = async (
+        isInternal: boolean,
+        isResolution: boolean,
+        closeStatusId: string | null = null
+    ): Promise<boolean> => {
         // Check if content is empty
         const contentStr = JSON.stringify(newCommentContent);
         const hasContent = contentStr !== JSON.stringify([{
@@ -813,6 +825,13 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                         console.error('Failed to refresh comments after add:', e);
                     }
                 }
+
+                // If this was a resolution note and a closed status was selected, close the ticket.
+                if (isResolution && closeStatusId && ticket.status_id !== closeStatusId) {
+                    // Backend clears response_state when closing; keep UI consistent.
+                    setTicket((prev: any) => ({ ...prev, response_state: null }));
+                    await handleSelectChange('status_id', closeStatusId);
+                }
                 
                 // Reset the comment input
                 setNewCommentContent([{
@@ -847,6 +866,11 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                         // Refresh comments after adding
                         const updatedComments = await findCommentsByTicketId(ticket.ticket_id);
                         setConversations(updatedComments);
+
+                        if (isResolution && closeStatusId && ticket.status_id !== closeStatusId) {
+                            setTicket((prev: any) => ({ ...prev, response_state: null }));
+                            await handleSelectChange('status_id', closeStatusId);
+                        }
                         
                         // Reset the comment input
                         setNewCommentContent([{
@@ -1798,6 +1822,7 @@ const handleClose = () => {
                                         avatarUrl: null
                                     } : session?.user}
                                     activeTab={activeTab}
+                                    closedStatusOptions={closedStatusOptions}
                                     isEditing={isEditing}
                                     currentComment={currentComment}
                                     editorKey={editorKey}

--- a/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
@@ -39,7 +39,7 @@ interface TicketDetailsContainerProps {
       }
     >;
     options: {
-      status: { value: string; label: string }[];
+      status: { value: string; label: string; is_closed?: boolean }[];
       agent: { value: string; label: string }[];
       board: { value: string; label: string }[];
       priority: { value: string; label: string }[];


### PR DESCRIPTION
Adds a close-status dropdown that appears when 'Mark as Resolution' is enabled on Ticket Details. Default is 'Do not change status'; selecting a closed status will update ticket status after the resolution note is added.\n\nNotes:\n- Status options now include is_closed in consolidated ticket data so UI can filter closed statuses.\n- Not run: full typecheck/lint (local env missing some deps).