### PR TITLE
Calendar setup: allow non-admin users to manage their own providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47198,7 +47198,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.0-rc2",
+      "version": "1.0.1-rc2",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",

--- a/packages/integrations/src/actions/integrations/googleActions.ts
+++ b/packages/integrations/src/actions/integrations/googleActions.ts
@@ -76,8 +76,9 @@ export const getGoogleIntegrationStatus = withAuth(async (
   };
 }> => {
   try {
-    const permitted = await hasPermission(user as any, 'system_settings', 'read');
-    if (!permitted) return { success: false, error: 'Forbidden' };
+    // This endpoint intentionally returns only masked/derived configuration.
+    // Any MSP user may view it so they can complete their own OAuth flows (e.g. calendar connect).
+    if ((user as any)?.user_type === 'client') return { success: false, error: 'Forbidden' };
 
     const secretProvider = await getSecretProviderInstance();
 


### PR DESCRIPTION
### What
- Remove admin-only `system_settings:*` gating from calendar provider connect/setup actions.
- Enforce ownership: actions that take a `calendarProviderId` require `calendar_providers.user_id === current user`.
- Scope mapping/status/conflict operations to the caller's providers.
- Allow MSP users to read masked Google integration status so they can complete calendar OAuth.

### Security
- Users can only create/update/delete/sync their own calendar providers; cross-user access returns Forbidden.
- Client portal users are blocked from these MSP calendar integration actions.

### Notes
- `package-lock.json` updated to reflect workspace package version (`@alga-psa/core`).
- Linted touched files (warnings only).
