### PR TITLE
fix(docker): build workflow worker from source

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -4,6 +4,9 @@ services:
       file: ./server/docker-compose.yaml
       service: server
     container_name: ${APP_NAME:-sebastian}_server_ce
+    # Build the CE server image from the current worktree (no GHCR dependency).
+    # This image is also reused by the `setup` one-shot container.
+    image: ${APP_NAME:-sebastian}_server_ce_local
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -75,12 +78,12 @@ services:
         condition: service_completed_successfully
 
   setup:
+    # One-shot DB bootstrap (create DB/users, run migrations/seeds).
+    # Use the locally-built CE server image so this works without GHCR access.
+    image: ${APP_NAME:-sebastian}_server_ce_local
     build:
       context: .
-      dockerfile: setup/Dockerfile
-      args:
-        SERVER_IMAGE_REPO: ${ALGA_SETUP_IMAGE_REPO:-ghcr.io/nine-minds/alga-psa-ce}
-        ALGA_IMAGE_TAG: ${ALGA_IMAGE_TAG:-latest}
+      dockerfile: Dockerfile.build
     environment:
       EDITION: community
       NODE_OPTIONS: --experimental-vm-modules
@@ -114,11 +117,11 @@ services:
     volumes:
       - type: bind
         source: ./setup/config.ini
-        target: /opt/setup/config.ini
+        target: /app/setup/config.ini
         read_only: true
       - type: bind
         source: ./setup/entrypoint.sh
-        target: /opt/setup/entrypoint.sh
+        target: /app/setup/entrypoint.sh
         read_only: true
       - type: bind
         source: ./secrets/postgres_password
@@ -138,7 +141,7 @@ services:
         condition: service_started
       pgbouncer: # Added dependency on pgbouncer
         condition: service_started
-    entrypoint: ["/opt/setup/entrypoint.sh"]
+    entrypoint: ["/app/setup/entrypoint.sh"]
 
   workflow-worker:
     # Remove extends to use a custom build

--- a/packages/event-bus/tsup.config.ts
+++ b/packages/event-bus/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'tsup';
+
+// tsup v8+ requires explicit entry points (it no longer auto-detects src/index.ts).
+// Keep output structure aligned with package.json "exports".
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/events.ts',
+    'src/publishers/index.ts',
+    'src/publishers/*.ts',
+  ],
+  format: ['esm', 'cjs'],
+  // Prefer `.mjs` for ESM to match other workspace packages, and `.js` for CJS.
+  // (This repo's packages commonly publish `.mjs` for import and `.js` for require.)
+  outExtension({ format }) {
+    return { js: format === 'esm' ? '.mjs' : '.js' };
+  },
+  dts: false,
+  bundle: true,
+  splitting: true,
+  sourcemap: false,
+  clean: true,
+  outDir: 'dist',
+  external: [
+    'redis',
+    'uuid',
+    'zod',
+  ],
+});
+

--- a/services/imap-service/Dockerfile
+++ b/services/imap-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 RUN npm install -g typescript @types/node tsc-alias
 
 COPY tsconfig.base.json ./
+COPY tsconfig.json ./
 COPY types/ ./types/
 COPY package.json package-lock.json ./
 

--- a/services/workflow-worker/Dockerfile
+++ b/services/workflow-worker/Dockerfile
@@ -14,6 +14,7 @@ RUN npm install -g typescript @types/node tsc-alias
 
 # Copy base configuration and root package files for workspace setup
 COPY tsconfig.base.json ./
+COPY tsconfig.json ./
 COPY package.json package-lock.json ./
 
 # Copy all workspace package.json files to set up the dependency tree


### PR DESCRIPTION
- Add explicit tsup entries for @alga-psa/event-bus (tsup v8 no autodetect)
- Ensure worker/imap Dockerfiles include root tsconfig.json
- Make CE setup use locally built server image to avoid GHCR dependency

Test plan:
- docker compose --env-file server/.env -f docker-compose.base.yaml -f docker-compose.ce.yaml build workflow-worker
- docker compose --env-file server/.env -f docker-compose.base.yaml -f docker-compose.ce.yaml up -d --build