### PR TITLE
Focus client picker filter on open

### DIFF
--- a/packages/ui/src/components/ClientPicker.tsx
+++ b/packages/ui/src/components/ClientPicker.tsx
@@ -272,6 +272,7 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder="Search clients..."
+            autoFocus
             className="h-9"
           />
         </div>


### PR DESCRIPTION
When the ClientPicker dropdown opens, autofocus the search/filter input so users can start typing immediately.