### PR TITLE
Rename System Monitor to Job Monitoring and remove submenu

### DIFF
--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -17,8 +17,6 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const navigationFlag = useFeatureFlag('ui-navigation-v2', { defaultValue: true });
   const useNavigationSections =
     typeof navigationFlag === 'boolean' ? navigationFlag : navigationFlag?.enabled ?? false;
-  const emailLogsFlag = useFeatureFlag('email-logs', { defaultValue: false });
-  const emailLogsEnabled = typeof emailLogsFlag === 'boolean' ? emailLogsFlag : emailLogsFlag?.enabled ?? false;
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
 
   useEffect(() => {
@@ -63,12 +61,6 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       ...section,
       items: section.items.map((item) => {
         if (item.name !== 'Automation Hub') {
-          if (item.name === 'System Monitor' && item.subItems && !emailLogsEnabled) {
-            return {
-              ...item,
-              subItems: item.subItems.filter((subItem) => subItem.name !== 'Email Logs'),
-            };
-          }
           return item;
         }
 
@@ -83,7 +75,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
         };
       })
     }));
-  }, [canWorkflowAdmin, useNavigationSections, emailLogsEnabled]);
+  }, [canWorkflowAdmin, useNavigationSections]);
 
   return (
     <Sidebar

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -148,13 +148,9 @@ export const navigationSections: NavigationSection[] = [
         ]
       },
       {
-        name: 'System Monitor',
+        name: 'Job Monitoring',
         icon: LayoutDashboard,
-        href: '/msp/jobs',
-        subItems: [
-          { name: 'Jobs', icon: LayoutDashboard, href: '/msp/jobs' },
-          { name: 'Email Logs', icon: Mail, href: '/msp/email-logs' },
-        ]
+        href: '/msp/jobs'
       },
       {
         name: 'Extensions',

--- a/server/src/test/unit/menuConfig.emailLogs.test.ts
+++ b/server/src/test/unit/menuConfig.emailLogs.test.ts
@@ -3,16 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { navigationSections } from '../../config/menuConfig';
 
 describe('navigationSections', () => {
-  it('includes Email Logs link under System Monitor', () => {
+  it('includes Job Monitoring as a direct link without submenu', () => {
     const items = navigationSections.flatMap((section) => section.items);
-    const systemMonitorItem = items.find((item) => item.name === 'System Monitor');
+    const jobMonitoringItem = items.find((item) => item.name === 'Job Monitoring');
 
-    expect(systemMonitorItem).toBeTruthy();
-    expect(systemMonitorItem?.subItems?.length).toBeTruthy();
-
-    const emailLogsItem = systemMonitorItem?.subItems?.find((item) => item.name === 'Email Logs');
-    expect(emailLogsItem).toBeTruthy();
-    expect(emailLogsItem?.href).toBe('/msp/email-logs');
+    expect(jobMonitoringItem).toBeTruthy();
+    expect(jobMonitoringItem?.href).toBe('/msp/jobs');
+    expect(jobMonitoringItem?.subItems).toBeUndefined();
   });
 });
-


### PR DESCRIPTION
## Summary\n- rename the main navigation item from `System Monitor` to `Job Monitoring`\n- remove the System Monitor submenu so it routes directly to `/msp/jobs`\n- remove obsolete email-logs submenu filtering in `SidebarWithFeatureFlags`\n- update the unit test to assert the direct-link menu shape\n\n## Testing\n- not run locally (vitest binary unavailable in this environment)