### PR TITLE
Fix survey response route + ticket event schema/db mismatches

### DIFF
--- a/packages/surveys/src/actions/surveyActions.ts
+++ b/packages/surveys/src/actions/surveyActions.ts
@@ -498,8 +498,8 @@ const getProjectStatusesForSurveys = withAuth(async (user, { tenant }): Promise<
     }
 
     return (await trx('statuses')
-      .where({ tenant, item_type: 'project' })
-      .orderBy('display_order', 'asc')
+      .where({ tenant, status_type: 'project' })
+      .orderBy('order_number', 'asc')
       .orderBy('name', 'asc')) as unknown as IStatus[];
   });
 });

--- a/packages/tickets/src/lib/workflowTicketCommunicationEvents.ts
+++ b/packages/tickets/src/lib/workflowTicketCommunicationEvents.ts
@@ -12,7 +12,7 @@ export type TicketCommunicationMessageInput = {
   visibility: TicketMessageVisibility;
   author: TicketCommunicationAuthor;
   channel: TicketMessageChannel;
-  createdAt?: string;
+  createdAt?: string | Date;
   attachmentsCount?: number;
 };
 
@@ -54,6 +54,7 @@ export function buildTicketCommunicationWorkflowEvents(
   input: TicketCommunicationMessageInput
 ): TicketCommunicationWorkflowEvent[] {
   const events: TicketCommunicationWorkflowEvent[] = [];
+  const createdAt = normalizeOptionalTimestamp(input.createdAt);
 
   events.push({
     eventType: 'TICKET_MESSAGE_ADDED',
@@ -64,7 +65,7 @@ export function buildTicketCommunicationWorkflowEvents(
       authorId: input.author.authorId,
       authorType: input.author.authorType,
       channel: input.channel,
-      createdAt: input.createdAt,
+      createdAt,
       attachmentsCount: input.attachmentsCount,
     },
   });
@@ -75,7 +76,7 @@ export function buildTicketCommunicationWorkflowEvents(
       payload: {
         ticketId: input.ticketId,
         noteId: input.messageId,
-        createdAt: input.createdAt,
+        createdAt,
       },
     });
   }
@@ -88,7 +89,7 @@ export function buildTicketCommunicationWorkflowEvents(
         messageId: input.messageId,
         contactId: input.author.contactId,
         channel: input.channel,
-        receivedAt: input.createdAt,
+        receivedAt: createdAt,
         attachmentsCount: input.attachmentsCount,
       },
     });
@@ -97,3 +98,9 @@ export function buildTicketCommunicationWorkflowEvents(
   return events;
 }
 
+function normalizeOptionalTimestamp(value?: string | Date): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/server/src/app/surveys/respond/[token]/page.tsx
+++ b/server/src/app/surveys/respond/[token]/page.tsx
@@ -5,8 +5,8 @@ import { getSurveyInvitationForToken } from '@alga-psa/surveys/actions/surveyRes
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
 type PageParams = {
-  params: { token: string };
-  searchParams?: Record<string, string | string[] | undefined>;
+  params: Promise<{ token: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -35,8 +35,10 @@ function parseInitialRating(
 }
 
 export default async function Page({ params, searchParams }: PageParams) {
-  const { token } = params;
-  const initialRating = parseInitialRating(searchParams);
+  const resolvedParams = await params;
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const { token } = resolvedParams;
+  const initialRating = parseInitialRating(resolvedSearchParams);
   const { t } = await getServerTranslation();
 
   try {

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -1939,7 +1939,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       const commentAuthor = await db('comments as cm')
         .select(
           'cm.user_id as comment_user_id',
-          'cm.contact_id as comment_contact_id',
+          'cu.contact_id as comment_contact_id',
           'cu.email as comment_user_email',
           'cc.email as comment_contact_email'
         )
@@ -1948,8 +1948,8 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
             .andOn('cm.tenant', '=', 'cu.tenant');
         })
         .leftJoin('contacts as cc', function() {
-          this.on('cm.contact_id', '=', 'cc.contact_name_id')
-            .andOn('cm.tenant', '=', 'cc.tenant');
+          this.on('cu.contact_id', '=', 'cc.contact_name_id')
+            .andOn('cu.tenant', '=', 'cc.tenant');
         })
         .where({
           'cm.tenant': tenantId,


### PR DESCRIPTION
## Summary
- fix survey response page route params/searchParams handling to align with async Next.js route props (params/searchParams now awaited)
- fix survey trigger project status lookup to use real statuses schema columns (status_type + order_number)
- normalize ticket communication event timestamps so TICKET_MESSAGE_ADDED.createdAt is always a string
- fix ticket email subscriber comment author lookup to join via users.contact_id instead of missing comments.contact_id

## Why
- users reported survey links resolving to invalid state despite valid tokens
- survey trigger settings errored with column "display_order" does not exist
- event bus rejected TICKET_MESSAGE_ADDED payloads when createdAt was a Date
- email subscriber failed on TICKET_COMMENT_ADDED due to cm.contact_id missing

## Validation
- npm -w @alga-psa/surveys run typecheck
- npm -w @alga-psa/tickets run typecheck
- npm -w server run typecheck
- verified SQL shape compatibility for updated comment author join against local DB
