### PR TITLE
Support hourly/usage bucket overlays in contract templates

### DIFF
--- a/packages/billing/src/actions/contractLineServiceActions.ts
+++ b/packages/billing/src/actions/contractLineServiceActions.ts
@@ -855,16 +855,18 @@ export const getTemplateLineServicesWithConfigurations = withAuth(async (
           .first();
       }
 
-      // Fetch bucket config details if it exists
-      let bucketConfigDetails: IContractLineServiceBucketConfig | null = null;
-      if (bucketConfigRecord) {
-        bucketConfigDetails = await trx('contract_template_line_service_bucket_config')
+      // Template bucket configs are keyed by the primary config_id in current schema.
+      // Support both models:
+      // 1) dedicated Bucket configuration row (bucketConfigRecord.config_id), and
+      // 2) bucket row attached directly to the primary Hourly/Usage config_id.
+      const bucketConfigId = bucketConfigRecord?.config_id ?? configToUse.config_id;
+      const bucketConfigDetails =
+        (await trx('contract_template_line_service_bucket_config')
           .where({
             tenant,
-            config_id: bucketConfigRecord.config_id,
+            config_id: bucketConfigId,
           })
-          .first();
-      }
+          .first()) ?? null;
 
       const configuration: IContractLineServiceConfiguration = {
         ...configToUse,

--- a/packages/billing/src/components/billing-dashboard/contracts/template-wizard/TemplateWizard.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/template-wizard/TemplateWizard.tsx
@@ -23,6 +23,13 @@ const TEMPLATE_STEPS = [
 
 const REQUIRED_TEMPLATE_STEPS = [0, 5];
 
+export interface BucketOverlayInput {
+  total_minutes?: number;
+  overage_rate?: number;
+  allow_rollover?: boolean;
+  billing_period?: 'monthly' | 'weekly';
+}
+
 export interface TemplateWizardData {
   contract_name: string;
   description?: string;
@@ -43,11 +50,13 @@ export interface TemplateWizardData {
   hourly_services: Array<{
     service_id: string;
     service_name?: string;
+    bucket_overlay?: BucketOverlayInput | null;
   }>;
   usage_services?: Array<{
     service_id: string;
     service_name?: string;
     unit_of_measure?: string;
+    bucket_overlay?: BucketOverlayInput | null;
   }>;
   minimum_billable_time?: number;
   round_up_to_nearest?: number;

--- a/packages/billing/src/components/billing-dashboard/contracts/template-wizard/steps/TemplateReviewContractStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/template-wizard/steps/TemplateReviewContractStep.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
-import { TemplateWizardData } from '../TemplateWizard';
+import { BucketOverlayInput, TemplateWizardData } from '../TemplateWizard';
 import { Badge } from '@alga-psa/ui/components/Badge';
 
 interface TemplateReviewContractStepProps {
@@ -13,6 +13,38 @@ interface TemplateReviewContractStepProps {
 export function TemplateReviewContractStep({
   data,
 }: TemplateReviewContractStepProps) {
+  const formatBucketSummary = (
+    overlay?: BucketOverlayInput | null,
+    mode: 'hours' | 'usage' = 'hours',
+    unitOfMeasure?: string
+  ): string | null => {
+    if (!overlay) return null;
+
+    const segments: string[] = [];
+    if (overlay.total_minutes != null) {
+      if (mode === 'hours') {
+        segments.push(`${(overlay.total_minutes / 60).toFixed(2)} hours included`);
+      } else {
+        segments.push(`${overlay.total_minutes} ${unitOfMeasure || 'units'} included`);
+      }
+    }
+
+    if (overlay.overage_rate != null) {
+      const unitLabel = mode === 'hours' ? 'hour' : unitOfMeasure || 'unit';
+      segments.push(`Overage $${(overlay.overage_rate / 100).toFixed(2)}/${unitLabel}`);
+    }
+
+    if (overlay.allow_rollover) {
+      segments.push('Rollover enabled');
+    }
+
+    if (overlay.billing_period) {
+      segments.push(`Period: ${overlay.billing_period}`);
+    }
+
+    return segments.length > 0 ? segments.join(' • ') : null;
+  };
+
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">Review Template</h3>
@@ -116,6 +148,11 @@ export function TemplateReviewContractStep({
                     <p className="font-medium text-gray-900">
                       {service.service_name || 'Unnamed Service'}
                     </p>
+                    {formatBucketSummary(service.bucket_overlay, 'hours') && (
+                      <div className="text-xs text-gray-600 mt-1">
+                        Bucket: {formatBucketSummary(service.bucket_overlay, 'hours')}
+                      </div>
+                    )}
                   </div>
                 ))}
               </CardContent>
@@ -139,6 +176,11 @@ export function TemplateReviewContractStep({
                     {service.unit_of_measure && (
                       <div className="text-xs text-gray-600 mt-1">
                         Unit: {service.unit_of_measure}
+                      </div>
+                    )}
+                    {formatBucketSummary(service.bucket_overlay, 'usage', service.unit_of_measure) && (
+                      <div className="text-xs text-gray-600 mt-1">
+                        Bucket: {formatBucketSummary(service.bucket_overlay, 'usage', service.unit_of_measure)}
                       </div>
                     )}
                   </div>

--- a/packages/billing/src/components/billing-dashboard/contracts/template-wizard/steps/TemplateUsageBasedServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/template-wizard/steps/TemplateUsageBasedServicesStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { TemplateWizardData } from '../TemplateWizard';
+import { BucketOverlayInput, TemplateWizardData } from '../TemplateWizard';
 import { Label } from '@alga-psa/ui/components/Label';
 import { ServiceCatalogPicker, ServiceCatalogPickerItem } from '../../ServiceCatalogPicker';
 import { Button } from '@alga-psa/ui/components/Button';
@@ -9,6 +9,8 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
 import { BarChart3, Plus, X } from 'lucide-react';
 import { TemplateServicePreviewSection } from '../TemplateServicePreviewSection';
+import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel';
+import { BucketOverlayFields } from '../../BucketOverlayFields';
 
 interface TemplateUsageBasedServicesStepProps {
   data: TemplateWizardData;
@@ -23,7 +25,7 @@ export function TemplateUsageBasedServicesStep({
     updateData({
       usage_services: [
         ...(data.usage_services ?? []),
-        { service_id: '', service_name: '', unit_of_measure: '' },
+        { service_id: '', service_name: '', unit_of_measure: '', bucket_overlay: undefined },
       ],
     });
   };
@@ -47,6 +49,39 @@ export function TemplateUsageBasedServicesStep({
   const handleUnitChange = (index: number, unit: string) => {
     const next = [...(data.usage_services ?? [])];
     next[index] = { ...next[index], unit_of_measure: unit };
+    updateData({ usage_services: next });
+  };
+
+  const defaultOverlay = (billingFrequency: string): BucketOverlayInput => ({
+    total_minutes: undefined,
+    overage_rate: undefined,
+    allow_rollover: false,
+    billing_period: billingFrequency === 'weekly' ? 'weekly' : 'monthly',
+  });
+
+  const toggleBucketOverlay = (index: number, enabled: boolean) => {
+    const next = [...(data.usage_services ?? [])];
+    if (enabled) {
+      const existing = next[index]?.bucket_overlay;
+      next[index] = {
+        ...next[index],
+        bucket_overlay: existing ? { ...existing } : defaultOverlay(data.billing_frequency),
+      };
+    } else {
+      next[index] = {
+        ...next[index],
+        bucket_overlay: undefined,
+      };
+    }
+    updateData({ usage_services: next });
+  };
+
+  const updateBucketOverlay = (index: number, overlay: BucketOverlayInput) => {
+    const next = [...(data.usage_services ?? [])];
+    next[index] = {
+      ...next[index],
+      bucket_overlay: { ...overlay },
+    };
     updateData({ usage_services: next });
   };
 
@@ -144,6 +179,24 @@ export function TemplateUsageBasedServicesStep({
                     placeholder="e.g., GB, API call, user"
                   />
                   <p className="text-xs text-gray-500">Override the default unit of measure for this service.</p>
+                </div>
+
+                <div className="space-y-3 pt-2 border-t border-dashed border-blue-100">
+                  <SwitchWithLabel
+                    label="Set bucket allocation"
+                    checked={Boolean(service.bucket_overlay)}
+                    onCheckedChange={(checked) => toggleBucketOverlay(index, Boolean(checked))}
+                  />
+                  {service.bucket_overlay && (
+                    <BucketOverlayFields
+                      mode="usage"
+                      unitLabel={service.unit_of_measure}
+                      value={service.bucket_overlay ?? defaultOverlay(data.billing_frequency)}
+                      onChange={(next) => updateBucketOverlay(index, next)}
+                      automationId={`template-usage-bucket-${index}`}
+                      billingFrequency={data.billing_frequency}
+                    />
+                  )}
                 </div>
               </div>
 

--- a/packages/billing/tests/templateWizardBucketOverlay.test.ts
+++ b/packages/billing/tests/templateWizardBucketOverlay.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const createContractTemplateFromWizard = vi.fn(async () => ({ contract_id: 'template-1' }));
+const checkTemplateNameExists = vi.fn(async () => false);
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? React.createElement('div', { 'data-testid': 'dialog' }, children) : null,
+}));
+
+vi.mock('@alga-psa/ui/components/onboarding/WizardProgress', () => ({
+  WizardProgress: ({ currentStep }: { currentStep: number }) =>
+    React.createElement('div', {
+      'data-testid': 'wizard-progress',
+      'data-current-step': String(currentStep),
+    }),
+}));
+
+vi.mock('@alga-psa/ui/components/onboarding/WizardNavigation', () => ({
+  WizardNavigation: ({
+    onNext,
+    onBack,
+    onFinish,
+  }: {
+    onNext: () => void;
+    onBack: () => void;
+    onFinish: () => void;
+  }) =>
+    React.createElement(
+      'div',
+      {},
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: onBack,
+        },
+        'Back'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: onNext,
+        },
+        'Next'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: onFinish,
+        },
+        'Finish'
+      )
+    ),
+}));
+
+vi.mock('@alga-psa/billing/actions/contractWizardActions', () => ({
+  createContractTemplateFromWizard: (...args: any[]) => createContractTemplateFromWizard(...args),
+  checkTemplateNameExists: (...args: any[]) => checkTemplateNameExists(...args),
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateContractBasicsStep', () => ({
+  TemplateContractBasicsStep: ({ updateData }: { updateData: (data: any) => void }) => {
+    React.useEffect(() => {
+      updateData({
+        contract_name: 'Bucket-Enabled Template',
+        billing_frequency: 'monthly',
+      });
+      // Intentionally initialize once per mount for test setup.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement('div', { 'data-testid': 'step-basics' });
+  },
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateFixedFeeServicesStep', () => ({
+  TemplateFixedFeeServicesStep: () => React.createElement('div', { 'data-testid': 'step-fixed' }),
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateProductsStep', () => ({
+  TemplateProductsStep: () => React.createElement('div', { 'data-testid': 'step-products' }),
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateHourlyServicesStep', () => ({
+  TemplateHourlyServicesStep: ({ updateData }: { updateData: (data: any) => void }) => {
+    React.useEffect(() => {
+      updateData({
+        hourly_services: [
+          {
+            service_id: 'svc-hourly-1',
+            service_name: 'Hourly Service',
+            bucket_overlay: {
+              total_minutes: 120,
+              overage_rate: 15000,
+              allow_rollover: true,
+              billing_period: 'monthly',
+            },
+          },
+        ],
+      });
+      // Intentionally initialize once per mount for test setup.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement('div', { 'data-testid': 'step-hourly' });
+  },
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateUsageBasedServicesStep', () => ({
+  TemplateUsageBasedServicesStep: ({ updateData }: { updateData: (data: any) => void }) => {
+    React.useEffect(() => {
+      updateData({
+        usage_services: [
+          {
+            service_id: 'svc-usage-1',
+            service_name: 'Usage Service',
+            unit_of_measure: 'seat',
+            bucket_overlay: {
+              total_minutes: 45,
+              overage_rate: 2200,
+              allow_rollover: false,
+              billing_period: 'weekly',
+            },
+          },
+        ],
+      });
+      // Intentionally initialize once per mount for test setup.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement('div', { 'data-testid': 'step-usage' });
+  },
+}));
+
+vi.mock('../src/components/billing-dashboard/contracts/template-wizard/steps/TemplateReviewContractStep', () => ({
+  TemplateReviewContractStep: () => React.createElement('div', { 'data-testid': 'step-review' }),
+}));
+
+describe('TemplateWizard bucket overlays', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createContractTemplateFromWizard.mockResolvedValue({ contract_id: 'template-1' });
+    checkTemplateNameExists.mockResolvedValue(false);
+  });
+
+  it('submits hourly and usage bucket overlays from template wizard data', async () => {
+    const { TemplateWizard } = await import(
+      '../src/components/billing-dashboard/contracts/template-wizard/TemplateWizard'
+    );
+    const user = userEvent.setup();
+
+    render(React.createElement(TemplateWizard, { open: true, onOpenChange: vi.fn(), onComplete: vi.fn() }));
+
+    await screen.findByTestId('step-basics');
+
+    await act(async () => {
+      await user.click(screen.getByText('Next'));
+    });
+    await act(async () => {
+      await user.click(screen.getByText('Next'));
+    });
+    await act(async () => {
+      await user.click(screen.getByText('Next'));
+    });
+    await screen.findByTestId('step-hourly');
+
+    await act(async () => {
+      await user.click(screen.getByText('Next'));
+    });
+    await screen.findByTestId('step-usage');
+
+    await act(async () => {
+      await user.click(screen.getByText('Next'));
+    });
+    await screen.findByTestId('step-review');
+
+    await act(async () => {
+      await user.click(screen.getByText('Finish'));
+    });
+
+    await waitFor(() => {
+      expect(createContractTemplateFromWizard).toHaveBeenCalledTimes(1);
+    });
+
+    const submitted = createContractTemplateFromWizard.mock.calls[0][0];
+    expect(submitted.hourly_services?.[0]?.bucket_overlay).toEqual({
+      total_minutes: 120,
+      overage_rate: 15000,
+      allow_rollover: true,
+      billing_period: 'monthly',
+    });
+    expect(submitted.usage_services?.[0]?.bucket_overlay).toEqual({
+      total_minutes: 45,
+      overage_rate: 2200,
+      allow_rollover: false,
+      billing_period: 'weekly',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add bucket overlay support to template wizard hourly and usage service steps
- include bucket overlay details in template review and wizard submission payloads
- fix template service retrieval to resolve bucket config when bucket rows are keyed by the primary hourly/usage config_id (no separate Bucket row)
- apply the same merged bucket handling in ContractTemplateDetail so hourly/usage template buckets display correctly
- add/extend tests to cover template wizard submission and template snapshot hydration for hourly + usage bucket overlays

## Validation
- npx tsc -p packages/billing/tsconfig.json --noEmit
- cd server && npx vitest --config vitest.config.ts run ../packages/billing/tests/templateWizardBucketOverlay.test.ts ../packages/billing/tests/draftContractForResumeActions.test.ts