### PR TITLE
Harden IMAP inbound webhook flow and deployment secret wiring

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -45,6 +45,7 @@ services:
       WORKFLOW_DISTRIBUTED_MODE: "true"
       WORKFLOW_REDIS_STREAM_PREFIX: "workflow:events:"
       WORKFLOW_REDIS_CONSUMER_GROUP: "workflow-workers"
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       - type: bind
         source: ./secrets/db_password_server
@@ -252,6 +253,10 @@ services:
       IMAP_FETCH_DELAY_MS: ${IMAP_FETCH_DELAY_MS:-0}
       IMAP_EVENT_CHANNEL_BY_TENANT: ${IMAP_EVENT_CHANNEL_BY_TENANT:-false}
       IMAP_OAUTH_AUTH_MECHANISM: ${IMAP_OAUTH_AUTH_MECHANISM:-XOAUTH2}
+      IMAP_WEBHOOK_URL: ${IMAP_WEBHOOK_URL:-http://server:3000/api/email/webhooks/imap}
+      IMAP_WEBHOOK_TIMEOUT_MS: ${IMAP_WEBHOOK_TIMEOUT_MS:-10000}
+      IMAP_WEBHOOK_MAX_ATTEMPTS: ${IMAP_WEBHOOK_MAX_ATTEMPTS:-3}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       - type: bind
         source: ./secrets/db_password_server
@@ -280,20 +285,6 @@ services:
         condition: service_started
       server:
         condition: service_started
-
-  imap-test-server:
-    image: greenmail/standalone:latest
-    environment:
-      GREENMAIL_OPTS: >-
-        -Dgreenmail.setup.test.all
-        -Dgreenmail.hostname=0.0.0.0
-        -Dgreenmail.users=imap_user:imap_pass
-    ports:
-      - "${EXPOSE_IMAP_TEST_SMTP_PORT:-3025}:3025"
-      - "${EXPOSE_IMAP_TEST_IMAP_PORT:-3143}:3143"
-      - "${EXPOSE_IMAP_TEST_IMAPS_PORT:-3993}:3993"
-    networks:
-      - app-network
 
   hocuspocus:
     extends:

--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -57,6 +57,7 @@ services:
       WORKFLOW_DISTRIBUTED_MODE: "true"
       WORKFLOW_REDIS_STREAM_PREFIX: "workflow:events:"
       WORKFLOW_REDIS_CONSUMER_GROUP: "workflow-workers"
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
       # NinjaOne Integration Configuration
       # These can be set via environment variables OR via secrets files (mounted at /run/secrets/)
       # The secret provider will check filesystem secrets first (if SECRET_READ_CHAIN includes 'filesystem')
@@ -301,6 +302,11 @@ services:
       IMAP_FETCH_DELAY_MS: ${IMAP_FETCH_DELAY_MS:-0}
       IMAP_EVENT_CHANNEL_BY_TENANT: ${IMAP_EVENT_CHANNEL_BY_TENANT:-false}
       IMAP_OAUTH_AUTH_MECHANISM: ${IMAP_OAUTH_AUTH_MECHANISM:-XOAUTH2}
+      IMAP_TLS_REJECT_UNAUTHORIZED: ${IMAP_TLS_REJECT_UNAUTHORIZED:-true}
+      IMAP_WEBHOOK_URL: ${IMAP_WEBHOOK_URL:-http://server:3000/api/email/webhooks/imap}
+      IMAP_WEBHOOK_TIMEOUT_MS: ${IMAP_WEBHOOK_TIMEOUT_MS:-10000}
+      IMAP_WEBHOOK_MAX_ATTEMPTS: ${IMAP_WEBHOOK_MAX_ATTEMPTS:-3}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       - type: bind
         source: ./secrets/db_password_server
@@ -332,20 +338,6 @@ services:
         condition: service_started
       server:
         condition: service_started
-
-  imap-test-server:
-    image: greenmail/standalone:latest
-    environment:
-      GREENMAIL_OPTS: >-
-        -Dgreenmail.setup.test.all
-        -Dgreenmail.hostname=0.0.0.0
-        -Dgreenmail.users=imap_user:imap_pass
-    ports:
-      - "${EXPOSE_IMAP_TEST_SMTP_PORT:-3025}:3025"
-      - "${EXPOSE_IMAP_TEST_IMAP_PORT:-3143}:3143"
-      - "${EXPOSE_IMAP_TEST_IMAPS_PORT:-3993}:3993"
-    networks:
-      - app-network
 
   hocuspocus:
     extends:

--- a/docker-compose.imap-test.yaml
+++ b/docker-compose.imap-test.yaml
@@ -1,0 +1,16 @@
+services:
+  imap-test-server:
+    image: greenmail/standalone:latest
+    profiles:
+      - test
+    environment:
+      GREENMAIL_OPTS: >-
+        -Dgreenmail.setup.test.all
+        -Dgreenmail.hostname=0.0.0.0
+        -Dgreenmail.users=imap_user:imap_pass@localhost
+    ports:
+      - "${EXPOSE_IMAP_TEST_SMTP_PORT:-3025}:3025"
+      - "${EXPOSE_IMAP_TEST_IMAP_PORT:-3143}:3143"
+      - "${EXPOSE_IMAP_TEST_IMAPS_PORT:-3993}:3993"
+    networks:
+      - app-network

--- a/docker-compose.imap.ce.yaml
+++ b/docker-compose.imap.ce.yaml
@@ -105,6 +105,11 @@ services:
       IMAP_FETCH_DELAY_MS: ${IMAP_FETCH_DELAY_MS:-0}
       IMAP_EVENT_CHANNEL_BY_TENANT: ${IMAP_EVENT_CHANNEL_BY_TENANT:-false}
       IMAP_OAUTH_AUTH_MECHANISM: ${IMAP_OAUTH_AUTH_MECHANISM:-XOAUTH2}
+      IMAP_TLS_REJECT_UNAUTHORIZED: ${IMAP_TLS_REJECT_UNAUTHORIZED:-true}
+      IMAP_WEBHOOK_URL: ${IMAP_WEBHOOK_URL:-http://server:3000/api/email/webhooks/imap}
+      IMAP_WEBHOOK_TIMEOUT_MS: ${IMAP_WEBHOOK_TIMEOUT_MS:-10000}
+      IMAP_WEBHOOK_MAX_ATTEMPTS: ${IMAP_WEBHOOK_MAX_ATTEMPTS:-3}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       - type: bind
         source: ./secrets/db_password_server
@@ -136,20 +141,6 @@ services:
         condition: service_started
       server:
         condition: service_started
-
-  imap-test-server:
-    image: greenmail/standalone:latest
-    environment:
-      GREENMAIL_OPTS: >-
-        -Dgreenmail.setup.test.all
-        -Dgreenmail.hostname=0.0.0.0
-        -Dgreenmail.users=imap_user:imap_pass
-    ports:
-      - "${EXPOSE_IMAP_TEST_SMTP_PORT:-3025}:3025"
-      - "${EXPOSE_IMAP_TEST_IMAP_PORT:-3143}:3143"
-      - "${EXPOSE_IMAP_TEST_IMAPS_PORT:-3993}:3993"
-    networks:
-      - app-network
 
 networks:
   app-network:

--- a/docker-compose.prebuilt.ce.yaml
+++ b/docker-compose.prebuilt.ce.yaml
@@ -41,6 +41,7 @@ services:
       EMAIL_USERNAME: ${EMAIL_USERNAME:-noreply@example.com}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES:-86400}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       # Persist user-uploaded documents and generated files
       - files_data:/data/files

--- a/docker-compose.prebuilt.ee.yaml
+++ b/docker-compose.prebuilt.ee.yaml
@@ -46,6 +46,7 @@ services:
       WORKFLOW_DISTRIBUTED_MODE: "true"
       WORKFLOW_REDIS_STREAM_PREFIX: "workflow:events:"
       WORKFLOW_REDIS_CONSUMER_GROUP: "workflow-workers"
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     volumes:
       # Persist user-uploaded documents and generated files
       - files_data:/data/files

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -9,6 +9,7 @@ services:
       # Override defaults for production vault integration
       SECRET_READ_CHAIN: ${SECRET_READ_CHAIN:-env,filesystem,vault}
       SECRET_WRITE_PROVIDER: ${SECRET_WRITE_PROVIDER:-filesystem}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -38,6 +39,7 @@ services:
       APP_ENV: production
       SECRET_READ_CHAIN: ${SECRET_READ_CHAIN:-env,filesystem,vault}
       SECRET_WRITE_PROVIDER: ${SECRET_WRITE_PROVIDER:-filesystem}
+      IMAP_WEBHOOK_SECRET: ${IMAP_WEBHOOK_SECRET:-}
       IMAP_PROVIDER_REFRESH_MS: ${IMAP_PROVIDER_REFRESH_MS:-60000}
       IMAP_POLL_INTERVAL_MS: ${IMAP_POLL_INTERVAL_MS:-30000}
       IMAP_LEASE_TTL_MS: ${IMAP_LEASE_TTL_MS:-120000}

--- a/ee/helm/imap-service/templates/deployment.yaml
+++ b/ee/helm/imap-service/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.vaultAgent.enabled }}
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "{{ .Values.vaultAgent.role }}"
@@ -179,6 +180,15 @@ spec:
               value: "{{ .Values.imap.startupStaggerMs }}"
             - name: IMAP_RECONNECT_JITTER_PCT
               value: "{{ .Values.imap.reconnectJitterPct }}"
+            {{- if .Values.webhook.url }}
+            - name: IMAP_WEBHOOK_URL
+              value: "{{ .Values.webhook.url }}"
+            {{- end }}
+            - name: IMAP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-secrets" (include "imap-service.fullname" .)) .Values.webhook.secretKeyRef.name | quote }}
+                  key: {{ default "IMAP_WEBHOOK_SECRET" .Values.webhook.secretKeyRef.key | quote }}
 
             {{- if not .Values.vaultAgent.enabled }}
             - name: NEXTAUTH_SECRET
@@ -241,4 +251,3 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}
-

--- a/ee/helm/imap-service/templates/secrets.yaml
+++ b/ee/helm/imap-service/templates/secrets.yaml
@@ -12,5 +12,5 @@ stringData:
   NEXTAUTH_SECRET: {{ .Values.secrets.nextauthSecret | quote }}
   TOKEN_SECRET_KEY: {{ .Values.secrets.tokenSecretKey | quote }}
   CRYPTO_KEY: {{ .Values.secrets.cryptoKey | quote }}
+  IMAP_WEBHOOK_SECRET: {{ .Values.secrets.imapWebhookSecret | quote }}
 {{- end }}
-

--- a/ee/helm/imap-service/values.yaml
+++ b/ee/helm/imap-service/values.yaml
@@ -54,6 +54,12 @@ imap:
   startupStaggerMs: 2000
   reconnectJitterPct: 0.5
 
+webhook:
+  url: ""
+  secretKeyRef:
+    name: ""
+    key: "IMAP_WEBHOOK_SECRET"
+
 redis:
   host: "redis.default.svc.cluster.local"
   port: "6379"
@@ -79,6 +85,7 @@ secrets:
   nextauthSecret: "change-me-in-prod"
   tokenSecretKey: "change-me-in-prod"
   cryptoKey: "change-me-in-prod"
+  imapWebhookSecret: "change-me-in-prod"
 
 vaultAgent:
   enabled: false
@@ -138,4 +145,3 @@ serviceAccount:
   name: ""
   annotations: {}
   automountServiceAccountToken: true
-

--- a/helm/templates/deployment-dev.yaml
+++ b/helm/templates/deployment-dev.yaml
@@ -396,6 +396,11 @@ spec:
               secretKeyRef:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: NEXTAUTH_SECRET
+          - name: IMAP_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: IMAP_WEBHOOK_SECRET
           - name: NEXTAUTH_SESSION_EXPIRES
             value: "{{ .Values.auth.nextauth_session_expires }}"
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -408,6 +408,11 @@ spec:
               secretKeyRef:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: NEXTAUTH_SECRET
+          - name: IMAP_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: IMAP_WEBHOOK_SECRET
           - name: NEXTAUTH_SESSION_EXPIRES
             value: "{{ .Values.auth.nextauth_session_expires }}"
 

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -26,6 +26,11 @@ data:
   {{- else }}
   TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.IMAP_WEBHOOK_SECRET }}
+  IMAP_WEBHOOK_SECRET: {{ .Values.secrets.IMAP_WEBHOOK_SECRET | b64enc | quote }}
+  {{- else }}
+  IMAP_WEBHOOK_SECRET: {{ randAlphaNum 48 | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.stripe_secret_key }}
   stripe_secret_key: {{ .Values.secrets.stripe_secret_key | b64enc | quote }}
   {{- end }}
@@ -42,4 +47,5 @@ data:
   NEXTAUTH_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
   CRYPTR_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  IMAP_WEBHOOK_SECRET: {{ randAlphaNum 48 | b64enc | quote }}
   {{- end }}

--- a/packages/integrations/src/components/email/ImapProviderForm.tsx
+++ b/packages/integrations/src/components/email/ImapProviderForm.tsx
@@ -30,10 +30,9 @@ const imapProviderSchema = z.object({
     .refine((value) => {
       const lower = value.toLowerCase();
       const isLocalPartOnly = /^[^\s@]+$/.test(lower);
-      const isLocalhostEmail = /^[^\s@]+@localhost$/.test(lower);
-      const isStandardEmail = z.string().email().safeParse(lower).success;
-      return isLocalPartOnly || isLocalhostEmail || isStandardEmail;
-    }, 'Valid mailbox is required (e.g. user@domain.com, user@localhost, or user)'),
+      const isEmailLike = /^[^\s@]+@[^\s@]+$/.test(lower);
+      return isLocalPartOnly || isEmailLike;
+    }, 'Valid mailbox is required (e.g. user@domain.com, user@localhost, user@test-server, or user)'),
   host: z.string().min(1, 'IMAP host is required'),
   port: z.number().min(1).max(65535),
   secure: z.boolean(),
@@ -199,7 +198,7 @@ export function ImapProviderForm({
   };
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+    <form onSubmit={form.handleSubmit(onSubmit, (errors) => { console.error('Form validation errors:', errors); setHasAttemptedSubmit(true); })} className="space-y-6">
       {error && (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>
@@ -214,15 +213,15 @@ export function ImapProviderForm({
         <CardContent className="space-y-4">
           <div>
             <Label htmlFor="providerName">Provider Name</Label>
-            <Input id="providerName" {...form.register('providerName')} />
+            <Input id="providerName" {...form.register('providerName')} error={form.formState.errors.providerName?.message} />
           </div>
           <div>
             <Label htmlFor="mailbox">Mailbox Address</Label>
-            <Input id="mailbox" type="email" {...form.register('mailbox')} />
+            <Input id="mailbox" type="email" {...form.register('mailbox')} error={form.formState.errors.mailbox?.message} />
           </div>
           <div>
             <Label htmlFor="host">IMAP Host</Label>
-            <Input id="host" {...form.register('host')} />
+            <Input id="host" {...form.register('host')} error={form.formState.errors.host?.message} />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
@@ -265,7 +264,7 @@ export function ImapProviderForm({
           </div>
           <div>
             <Label htmlFor="username">Username</Label>
-            <Input id="username" {...form.register('username')} />
+            <Input id="username" {...form.register('username')} error={form.formState.errors.username?.message} />
           </div>
 
           {authType === 'password' && (
@@ -280,7 +279,7 @@ export function ImapProviderForm({
                 <Input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
-                  {...form.register('password')}
+                  {...form.register('password')} error={form.formState.errors.password?.message}
                 />
                 <button
                   type="button"
@@ -308,15 +307,15 @@ export function ImapProviderForm({
               )}
               <div>
                 <Label htmlFor="oauthAuthorizeUrl">Authorize URL</Label>
-                <Input id="oauthAuthorizeUrl" {...form.register('oauthAuthorizeUrl')} />
+                <Input id="oauthAuthorizeUrl" {...form.register('oauthAuthorizeUrl')} error={form.formState.errors.oauthAuthorizeUrl?.message} />
               </div>
               <div>
                 <Label htmlFor="oauthTokenUrl">Token URL</Label>
-                <Input id="oauthTokenUrl" {...form.register('oauthTokenUrl')} />
+                <Input id="oauthTokenUrl" {...form.register('oauthTokenUrl')} error={form.formState.errors.oauthTokenUrl?.message} />
               </div>
               <div>
                 <Label htmlFor="oauthClientId">OAuth Client ID</Label>
-                <Input id="oauthClientId" {...form.register('oauthClientId')} />
+                <Input id="oauthClientId" {...form.register('oauthClientId')} error={form.formState.errors.oauthClientId?.message} />
               </div>
               <div>
                 <Label htmlFor="oauthClientSecret">OAuth Client Secret</Label>
@@ -324,7 +323,7 @@ export function ImapProviderForm({
                   <Input
                     id="oauthClientSecret"
                     type={showClientSecret ? 'text' : 'password'}
-                    {...form.register('oauthClientSecret')}
+                    {...form.register('oauthClientSecret')} error={form.formState.errors.oauthClientSecret?.message}
                   />
                   <button
                     type="button"
@@ -337,7 +336,7 @@ export function ImapProviderForm({
               </div>
               <div>
                 <Label htmlFor="oauthScopes">OAuth Scopes</Label>
-                <Input id="oauthScopes" {...form.register('oauthScopes')} placeholder="space-delimited scopes" />
+                <Input id="oauthScopes" {...form.register('oauthScopes')} error={form.formState.errors.oauthScopes?.message} placeholder="space-delimited scopes" />
               </div>
             </div>
           )}
@@ -352,7 +351,7 @@ export function ImapProviderForm({
         <CardContent className="space-y-4">
           <div>
             <Label htmlFor="folderFilters">Folder Filters</Label>
-            <Input id="folderFilters" {...form.register('folderFilters')} placeholder="Inbox, Support, Tickets" />
+            <Input id="folderFilters" {...form.register('folderFilters')} error={form.formState.errors.folderFilters?.message} placeholder="Inbox, Support, Tickets" />
           </div>
           <div className="flex items-center justify-between">
             <Label htmlFor="isActive">Active</Label>
@@ -361,7 +360,7 @@ export function ImapProviderForm({
           <CustomSelect
             id="imap-defaults-select"
             label="Ticket Defaults"
-            value={(form.getValues() as any).inboundTicketDefaultsId || ''}
+            value={form.watch('inboundTicketDefaultsId') || ''}
             onValueChange={(v) => form.setValue('inboundTicketDefaultsId', v || undefined)}
             options={defaultsOptions}
             placeholder={defaultsOptions.length ? 'Select defaults...' : 'No defaults available'}

--- a/packages/integrations/src/webhooks/email/imap.ts
+++ b/packages/integrations/src/webhooks/email/imap.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { getAdminConnection } from '@alga-psa/db/admin';
+import { withTransaction } from '@alga-psa/db';
+import { processInboundEmailInApp } from '@alga-psa/shared/services/email/processInboundEmailInApp';
+import type { EmailMessageDetails } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
+
+interface ImapWebhookPayload {
+  providerId?: string;
+  tenant?: string;
+  tenantId?: string;
+  emailData?: Partial<EmailMessageDetails>;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function toDateOrNull(value: unknown): Date | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function safeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function buildEmailData(payload: ImapWebhookPayload, providerId: string, tenant: string): EmailMessageDetails | null {
+  if (!payload.emailData || typeof payload.emailData !== 'object') return null;
+  const messageId = asNonEmptyString(payload.emailData.id);
+  if (!messageId) return null;
+
+  return {
+    ...(payload.emailData as EmailMessageDetails),
+    id: messageId,
+    provider: 'imap',
+    providerId,
+    tenant,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const expectedSecret = asNonEmptyString(process.env.IMAP_WEBHOOK_SECRET);
+    if (!expectedSecret) {
+      console.error('IMAP webhook rejected: IMAP_WEBHOOK_SECRET is not configured');
+      return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+    }
+    const providedSecret = asNonEmptyString(request.headers.get('x-imap-webhook-secret'));
+    if (!providedSecret || !safeEquals(providedSecret, expectedSecret)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let payload: ImapWebhookPayload;
+    try {
+      payload = (await request.json()) as ImapWebhookPayload;
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+
+    const providerId = asNonEmptyString(payload.providerId);
+    if (!providerId) {
+      return NextResponse.json({ error: 'providerId is required' }, { status: 400 });
+    }
+
+    const knex = await getAdminConnection();
+    const provider = await knex('email_providers')
+      .where({ id: providerId, provider_type: 'imap' })
+      .first('id', 'tenant', 'is_active', 'mailbox');
+
+    if (!provider) {
+      return NextResponse.json({ error: 'IMAP provider not found' }, { status: 404 });
+    }
+
+    const tenantHint = asNonEmptyString(payload.tenantId) || asNonEmptyString(payload.tenant);
+    if (tenantHint && tenantHint !== provider.tenant) {
+      return NextResponse.json(
+        { error: `Tenant mismatch for provider ${provider.id}` },
+        { status: 400 }
+      );
+    }
+
+    if (!provider.is_active) {
+      return NextResponse.json({
+        success: true,
+        skipped: true,
+        reason: 'Provider is inactive',
+      });
+    }
+
+    const emailData = buildEmailData(payload, provider.id, provider.tenant);
+    if (!emailData) {
+      return NextResponse.json({ error: 'emailData.id is required' }, { status: 400 });
+    }
+
+    const dedupeWhere = {
+      message_id: emailData.id,
+      provider_id: provider.id,
+      tenant: provider.tenant,
+    };
+
+    let resultSummary: Record<string, unknown> = {};
+
+    await withTransaction(knex, async (trx) => {
+      const tableExists = await trx.schema.hasTable('email_processed_messages');
+      let canUseProcessedMessages = false;
+      if (tableExists) {
+        // In mixed-schema environments, this table may still reference the legacy
+        // email_provider_configs table. Only use it when the provider exists there.
+        const legacyProviderTableExists = await trx.schema.hasTable('email_provider_configs');
+        if (legacyProviderTableExists) {
+          const legacyProvider = await trx('email_provider_configs')
+            .where({ id: provider.id, tenant: provider.tenant })
+            .first('id');
+          canUseProcessedMessages = Boolean(legacyProvider);
+        }
+      }
+
+      if (canUseProcessedMessages) {
+        const existing = await trx('email_processed_messages').where(dedupeWhere).first();
+        if (existing) {
+          resultSummary = {
+            duplicate: true,
+            outcome: existing.processing_status || 'duplicate',
+            ticketId: existing.ticket_id || null,
+          };
+          return;
+        }
+
+        await trx('email_processed_messages').insert({
+          message_id: emailData.id,
+          provider_id: provider.id,
+          tenant: provider.tenant,
+          processed_at: new Date(),
+          processing_status: 'processing',
+          from_email: emailData.from?.email || null,
+          subject: emailData.subject || null,
+          received_at: toDateOrNull(emailData.receivedAt),
+          attachment_count: emailData.attachments?.length || 0,
+          metadata: JSON.stringify({
+            source: 'imap-webhook',
+            webhookReceivedAt: new Date().toISOString(),
+          }),
+        });
+      }
+
+      let processingStatus = 'success';
+      let errorMessage: string | null = null;
+      let ticketId: string | null = null;
+
+      const inAppResult = await processInboundEmailInApp({
+        tenantId: provider.tenant,
+        providerId: provider.id,
+        emailData,
+      });
+
+      if (inAppResult?.outcome === 'skipped') {
+        processingStatus = 'partial';
+        errorMessage = `skipped:${inAppResult?.reason || 'unknown'}`;
+      } else if (inAppResult?.outcome === 'deduped') {
+        processingStatus = 'duplicate';
+      }
+
+      if (
+        inAppResult &&
+        typeof inAppResult === 'object' &&
+        'ticketId' in inAppResult &&
+        typeof inAppResult.ticketId === 'string'
+      ) {
+        ticketId = inAppResult.ticketId;
+      }
+      resultSummary = {
+        duplicate: false,
+        outcome: inAppResult?.outcome || 'processed',
+        ticketId,
+      };
+
+      await trx('email_providers')
+        .where({ id: provider.id, tenant: provider.tenant })
+        .update({
+          last_sync_at: trx.fn.now(),
+          updated_at: trx.fn.now(),
+        });
+
+      if (canUseProcessedMessages) {
+        await trx('email_processed_messages')
+          .where(dedupeWhere)
+          .update({
+            processing_status: processingStatus,
+            ticket_id: ticketId,
+            from_email: emailData.from?.email || null,
+            subject: emailData.subject || null,
+            received_at: toDateOrNull(emailData.receivedAt),
+            attachment_count: emailData.attachments?.length || 0,
+            error_message: errorMessage,
+          });
+      }
+    });
+
+    return NextResponse.json({
+      success: true,
+      providerId: provider.id,
+      tenant: provider.tenant,
+      messageId: emailData.id,
+      ...resultSummary,
+    });
+  } catch (error: any) {
+    console.error('IMAP webhook handler error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/server/src/app/api/email/webhooks/imap/route.ts
+++ b/server/src/app/api/email/webhooks/imap/route.ts
@@ -1,0 +1,2 @@
+export { POST } from '@alga-psa/integrations/webhooks/email/imap';
+

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -483,6 +483,18 @@ export async function processInboundEmailInApp(
   const commentAuthorContactId = matchedSenderContact?.contact_id;
   const commentAuthorUserId = matchedSenderContact?.user_id ?? null;
 
+  // Ticket creation requires a client. If neither defaults nor sender/domain matching
+  // can resolve one, skip without failing the webhook.
+  if (!targetClientId) {
+    console.warn('processInboundEmailInApp: no target client resolved; skipping email', {
+      tenantId,
+      providerId,
+      emailId: emailData.id,
+      senderEmail,
+    });
+    return { outcome: 'skipped', reason: 'missing_defaults' };
+  }
+
   // New-ticket idempotency: ticket could have been created in another parallel process.
   const existingTicketAfterDefaults = await findExistingEmailTicket({
     tenantId,


### PR DESCRIPTION
## Summary
- add dedicated IMAP webhook route and force IMAP inbound processing through `processInboundEmailInApp`
- secure IMAP callback auth with required `IMAP_WEBHOOK_SECRET` and timing-safe header validation
- update IMAP worker to require webhook secret and send signed callbacks
- improve IMAP listener resilience (scoped TLS behavior, reconnect/idle handling) and seed defaults backfill for non-null inbound client
- wire `IMAP_WEBHOOK_SECRET` into compose + Helm (server and imap-service)
- relax IMAP mailbox validation in provider forms for local/test hosts

## Validation
- exercised IMAP callback endpoint locally with/without secret header
- confirmed ticket creation path via in-app inbound processing
- rendered Helm charts with hosted values to verify secret/env wiring
