### PR TITLE
Fix k8s client v1 API calls in extension provisioning

### DIFF
--- a/ee/temporal-workflows/src/workflows/extension-domain-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/extension-domain-workflow.ts
@@ -5,7 +5,13 @@ const { computeDomain, ensureDomainMapping, updateInstallStatus } = proxyActivit
   ensureDomainMapping: typeof import('../activities/extension-domain-activities.js').ensureDomainMapping,
   updateInstallStatus: typeof import('../activities/extension-domain-activities.js').updateInstallStatus,
 }>({
-  startToCloseTimeout: '1 minute',
+  startToCloseTimeout: '2 minutes',
+  retry: {
+    initialInterval: '2s',
+    backoffCoefficient: 2,
+    maximumInterval: '30s',
+    maximumAttempts: 5,
+  },
 });
 
 export interface ProvisionDomainInput {


### PR DESCRIPTION
  The kubernetes client-node v1 upgrade switched to object-param API calls, but a follow-up "fix" reverted to positional args with `as any`, silently breaking all K8s calls at runtime (status=undefined).

  - Restore proper v1 object-param style for all CustomObjectsApi calls
  - Fix formatHttpError to handle v1 ApiException (e.code, e.body)
  - Add retry policy (5 attempts, exponential backoff) to Temporal workflow
  - Distinguish permanent 404 from transient errors in kservice check

  "Oh my!" said the Scarecrow, "I cast myself `as any` and lost all my types — now every road returns `undefined` and no domain shall ever be mapped again!" 🧠🌪️ ✨