### PR TITLE
Fix email registries losing state across chunks

### DIFF
--- a/packages/auth/src/lib/sso/registry.ts
+++ b/packages/auth/src/lib/sso/registry.ts
@@ -102,25 +102,36 @@ const defaultRegistry: SSOProviderRegistry = {
   },
 };
 
-let registry: SSOProviderRegistry = { ...defaultRegistry };
+declare global {
+  // eslint-disable-next-line no-var
+  var __algaSSOProviderRegistry: SSOProviderRegistry | undefined;
+}
+
+function getOrCreateRegistry(): SSOProviderRegistry {
+  if (!globalThis.__algaSSOProviderRegistry) {
+    globalThis.__algaSSOProviderRegistry = { ...defaultRegistry };
+  }
+  return globalThis.__algaSSOProviderRegistry;
+}
 
 /**
  * Register SSO provider implementations (called by EE at startup)
  */
 export function registerSSOProvider(impl: Partial<SSOProviderRegistry>): void {
-  registry = { ...registry, ...impl };
+  const current = getOrCreateRegistry();
+  globalThis.__algaSSOProviderRegistry = { ...current, ...impl };
 }
 
 /**
  * Get the current SSO registry (used by auth code)
  */
 export function getSSORegistry(): SSOProviderRegistry {
-  return registry;
+  return getOrCreateRegistry();
 }
 
 /**
  * Reset to default registry (for testing)
  */
 export function resetSSORegistry(): void {
-  registry = { ...defaultRegistry };
+  globalThis.__algaSSOProviderRegistry = { ...defaultRegistry };
 }

--- a/shared/workflow/runtime/registries/workflowEmailRegistry.ts
+++ b/shared/workflow/runtime/registries/workflowEmailRegistry.ts
@@ -38,28 +38,31 @@ export interface WorkflowEmailProvider {
   };
 }
 
-let provider: WorkflowEmailProvider | null = null;
+declare global {
+  // eslint-disable-next-line no-var
+  var __algaWorkflowEmailProvider: WorkflowEmailProvider | null | undefined;
+}
 
 /**
  * Register email provider implementations (called at app startup)
  */
 export function registerWorkflowEmailProvider(impl: WorkflowEmailProvider): void {
-  provider = impl;
+  globalThis.__algaWorkflowEmailProvider = impl;
 }
 
 /**
  * Get the current email provider (used by workflow actions)
  */
 export function getWorkflowEmailProvider(): WorkflowEmailProvider {
-  if (!provider) {
+  if (!globalThis.__algaWorkflowEmailProvider) {
     throw new Error('Workflow email provider not registered. Ensure registerWorkflowEmailProvider() is called at app startup.');
   }
-  return provider;
+  return globalThis.__algaWorkflowEmailProvider;
 }
 
 /**
  * Reset to default (for testing)
  */
 export function resetWorkflowEmailProvider(): void {
-  provider = null;
+  globalThis.__algaWorkflowEmailProvider = null;
 }


### PR DESCRIPTION
  Move auth email, SSO, and workflow email provider registries from module-level variables to globalThis singletons. Next.js webpack splits instrumentation and server action code into separate chunks, creating duplicate module instances where registrations from initializeApp() never reach server actions.

  "Pay no attention to the module behind the curtain!" cried the Wizard, but Dorothy had already seen it — a second registry, unregistered and empty, lurking in chunk 76692. She clicked her ruby globalThis three times and whispered: "There's no place like a process-wide singleton." 🌪️ 👠✨