### PR TITLE
Fix Citus migration failure in renewal backfill

### DIFF
--- a/server/migrations/202602211125_backfill_active_client_contract_renewal_defaults.cjs
+++ b/server/migrations/202602211125_backfill_active_client_contract_renewal_defaults.cjs
@@ -79,7 +79,17 @@ exports.up = async function up(knex) {
         ),
         renewal_cycle_start = COALESCE(cc.renewal_cycle_start, cc.start_date::date),
         renewal_cycle_end = COALESCE(cc.renewal_cycle_end, cc.end_date::date),
-        renewal_cycle_key = COALESCE(cc.renewal_cycle_key, CONCAT('fixed-term:', cc.end_date::date::text)),
+        renewal_cycle_key = COALESCE(
+          cc.renewal_cycle_key,
+          (
+            'fixed-term:' ||
+            EXTRACT(YEAR FROM cc.end_date)::int::text ||
+            '-' ||
+            LPAD(EXTRACT(MONTH FROM cc.end_date)::int::text, 2, '0') ||
+            '-' ||
+            LPAD(EXTRACT(DAY FROM cc.end_date)::int::text, 2, '0')
+          )
+        ),
         updated_at = NOW()
       FROM contracts c
       WHERE cc.tenant = c.tenant

--- a/server/src/test/unit/migrations/contractRenewalMigrations.test.ts
+++ b/server/src/test/unit/migrations/contractRenewalMigrations.test.ts
@@ -94,9 +94,11 @@ describe('contract renewal migrations', () => {
     );
     expect(migration).toContain('renewal_cycle_start = COALESCE(cc.renewal_cycle_start, cc.start_date::date)');
     expect(migration).toContain('renewal_cycle_end = COALESCE(cc.renewal_cycle_end, cc.end_date::date)');
-    expect(migration).toContain(
-      "renewal_cycle_key = COALESCE(cc.renewal_cycle_key, CONCAT('fixed-term:', cc.end_date::date::text))"
-    );
+    expect(migration).toContain('renewal_cycle_key = COALESCE(');
+    expect(migration).toContain("'fixed-term:' ||");
+    expect(migration).toContain('EXTRACT(YEAR FROM cc.end_date)::int::text');
+    expect(migration).toContain("LPAD(EXTRACT(MONTH FROM cc.end_date)::int::text, 2, '0')");
+    expect(migration).toContain("LPAD(EXTRACT(DAY FROM cc.end_date)::int::text, 2, '0')");
     expect(migration).toContain("AND cc.is_active = true");
     expect(migration).toContain("AND c.status = 'active'");
     expect(migration).toContain('AND cc.end_date IS NOT NULL');


### PR DESCRIPTION
## Summary
- fixes `202602211125_backfill_active_client_contract_renewal_defaults.cjs` to avoid the Citus error about non-IMMUTABLE functions in CASE/COALESCE
- replaces the `CONCAT(...date::text)` path in `renewal_cycle_key` backfill with a deterministic string build expression compatible with Citus execution constraints
- updates migration unit test expectations accordingly

## Validation
- `npx vitest run --root server --coverage.enabled=false src/test/unit/migrations/contractRenewalMigrations.test.ts`
