### PR TITLE
Remove mobile auth enable env toggle

### DIFF
--- a/docs/plans/2026-02-03-alga-psa-mobile-app/ANALYTICS_EVENTS.md
+++ b/docs/plans/2026-02-03-alga-psa-mobile-app/ANALYTICS_EVENTS.md
@@ -11,7 +11,7 @@ Notes:
 | Event | When | Properties (non-exhaustive) |
 |---|---|---|
 | `app.startup.ready` | App boot is complete and navigation state is restored | `durationMs`, `signedIn` |
-| `auth.sign_in.blocked` | User attempted sign-in but CTA was gated | `reason` (`missing_base_url` \| `mobile_disabled` \| `host_not_allowlisted`) |
+| `auth.sign_in.blocked` | User attempted sign-in but CTA was gated | `reason` (`missing_base_url` \| `host_not_allowlisted`) |
 | `auth.sign_in.start` | User tapped Sign In and sign-in state was created | *(none)* |
 | `auth.sign_in.open_failed` | Failed to open the system browser for sign-in | `reason` (`cannot_open_url` \| `exception`) |
 | `auth.sign_in.opened_browser` | System browser opened successfully | *(none)* |

--- a/docs/plans/2026-02-03-alga-psa-mobile-app/AUTH_SUPPORT_RUNBOOK.md
+++ b/docs/plans/2026-02-03-alga-psa-mobile-app/AUTH_SUPPORT_RUNBOOK.md
@@ -12,17 +12,10 @@ Date: `2026-02-03`
 ## Quick triage checklist
 
 1) Confirm the user is on an Alga-hosted environment and using the correct base URL.
-2) Confirm mobile auth is enabled for the environment:
-   - Check `/api/v1/mobile/auth/capabilities` for `mobileEnabled=true`.
-3) Confirm the base URL host is allowlisted (if allowlist enabled).
-4) Confirm the tenant has at least one SSO provider configured (Microsoft/Google).
+2) Confirm the base URL host is allowlisted (if allowlist enabled).
+3) Confirm the tenant has at least one SSO provider configured (Microsoft/Google).
 
 ## Common failure modes
-
-### “Mobile sign-in disabled”
-
-- Cause: mobile auth disabled server-side.
-- Fix: enable mobile auth configuration; redeploy or toggle per environment.
 
 ### “Host not allowlisted”
 
@@ -60,4 +53,3 @@ Date: `2026-02-03`
   - OTT issued/exchanged
   - Refresh succeeded/failed
   - Revoke/logout
-

--- a/docs/plans/2026-02-03-alga-psa-mobile-app/MANUAL_QA_CHECKLIST.md
+++ b/docs/plans/2026-02-03-alga-psa-mobile-app/MANUAL_QA_CHECKLIST.md
@@ -12,7 +12,7 @@ This checklist is used to validate MVP behavior end-to-end in a real device/simu
 - [ ] Session persists across app restart.
 - [ ] Refresh rotates credentials before expiry; revoked sessions force sign-in.
 - [ ] Logout revokes session server-side and clears local storage.
-- [ ] Capability discovery gates sign-in when mobile auth disabled or host not allowlisted.
+- [ ] Capability discovery gates sign-in when host is not allowlisted.
 
 ## Tickets — List
 
@@ -57,4 +57,3 @@ This checklist is used to validate MVP behavior end-to-end in a real device/simu
 - [ ] Account section shows signed-in status, user, and tenant id.
 - [ ] Clear cache clears in-memory caches and prompts confirmation.
 - [ ] About/Legal opens and link-outs to privacy/terms work.
-

--- a/docs/plans/2026-02-03-alga-psa-mobile-app/MOBILE_AUTH_CONFIG.md
+++ b/docs/plans/2026-02-03-alga-psa-mobile-app/MOBILE_AUTH_CONFIG.md
@@ -20,10 +20,6 @@ Mobile login reuses the existing web sign-in (`/auth/signin`) and SSO providers.
 
 ## Environment Variables
 
-### Enablement
-
-- `ALGA_MOBILE_AUTH_ENABLED=true|false`
-
 ### Token TTLs (seconds)
 
 - `ALGA_MOBILE_OTT_TTL_SEC` (default: `60`)
@@ -53,4 +49,3 @@ Migration: `server/migrations/20260203210000_add_mobile_auth_tables.cjs`
   - hashed token storage, TTL, and single-use (`used_at`)
 - `mobile_refresh_tokens`
   - hashed refresh token storage and rotation (`replaced_by_id`)
-

--- a/docs/plans/2026-02-03-alga-psa-mobile-app/ROLLOUT_PLAN.md
+++ b/docs/plans/2026-02-03-alga-psa-mobile-app/ROLLOUT_PLAN.md
@@ -8,7 +8,6 @@ Last updated: 2026-02-03
 
 ### Pre-release
 
-- [ ] Server: mobile auth endpoints enabled behind a feature/config flag per environment.
 - [ ] Server: hosted domain allowlist configured (if used) and includes the production domain(s).
 - [ ] Server: token TTLs/rotation configured; revocation works.
 - [ ] Server: RBAC verified for ticket list/detail/comments/mutations (401/403 behavior).
@@ -38,7 +37,6 @@ Last updated: 2026-02-03
 
 ### Immediate mitigation (minutes)
 
-- Disable mobile auth capability flag server-side (capabilities endpoint returns `mobileEnabled:false`).
 - Revoke/expire refresh tokens for affected tenant(s) if compromise is suspected.
 - Communicate status to testers and support.
 
@@ -51,4 +49,3 @@ Last updated: 2026-02-03
 
 - Root-cause analysis with logs/metrics for auth failures, 401/403 spikes, and API error rates.
 - Patch + re-release with incremented build numbers and updated release notes.
-

--- a/ee/mobile/src/api/mobileAuth.ts
+++ b/ee/mobile/src/api/mobileAuth.ts
@@ -138,7 +138,6 @@ export function revokeSession(
 }
 
 export type MobileAuthCapabilities = {
-  mobileEnabled: boolean;
   providers: {
     microsoft: boolean;
     google: boolean;

--- a/ee/mobile/src/screens/AuthCallbackScreen.tsx
+++ b/ee/mobile/src/screens/AuthCallbackScreen.tsx
@@ -27,8 +27,6 @@ function mapAuthCallbackError(code: string): string {
       return "Too many sign-in attempts. Please wait a moment and try again.";
     case "client_not_allowed":
       return "Client portal users can’t sign in to the mobile app. Please use an internal account.";
-    case "mobile_disabled":
-      return "Mobile sign-in is disabled for this server.";
     case "host_not_allowlisted":
       return "This server domain is not allowed for mobile sign-in.";
     default:

--- a/ee/mobile/src/screens/SignInScreen.tsx
+++ b/ee/mobile/src/screens/SignInScreen.tsx
@@ -78,11 +78,6 @@ export function SignInScreen() {
       setError("Missing configuration. Please set EXPO_PUBLIC_ALGA_BASE_URL.");
       return;
     }
-    if (capabilities && !capabilities.mobileEnabled) {
-      analytics.trackEvent(MobileAnalyticsEvents.authSignInBlocked, { reason: "mobile_disabled" });
-      setError("Mobile sign-in is not enabled for this server.");
-      return;
-    }
     if (!hostAllowed) {
       analytics.trackEvent(MobileAnalyticsEvents.authSignInBlocked, { reason: "host_not_allowlisted" });
       setError("This base URL is not allowed for mobile sign-in.");
@@ -135,7 +130,6 @@ export function SignInScreen() {
           disabled={
             status === "opening" ||
             !baseUrl ||
-            (capabilities !== null && !capabilities.mobileEnabled) ||
             !hostAllowed
           }
           accessibilityLabel={t("auth.signIn.cta")}
@@ -175,10 +169,6 @@ export function SignInScreen() {
         <Text style={{ ...typography.caption, marginTop: spacing.md, textAlign: "center", color: colors.mutedText }}>
           Checking server sign-in support…
         </Text>
-      ) : capabilities && !capabilities.mobileEnabled ? (
-        <Text style={{ ...typography.caption, marginTop: spacing.md, textAlign: "center", color: colors.danger }}>
-          Mobile sign-in is disabled for this server.
-        </Text>
       ) : capabilitiesError ? (
         <View style={{ marginTop: spacing.md, alignItems: "center" }}>
           <Text style={{ ...typography.caption, textAlign: "center", color: colors.mutedText }}>
@@ -193,7 +183,7 @@ export function SignInScreen() {
         <Text style={{ ...typography.caption, marginTop: spacing.md, textAlign: "center", color: colors.danger }}>
           This server domain is not allowed for mobile sign-in.
         </Text>
-      ) : capabilities && capabilities.mobileEnabled && !hasConfiguredSsoProvider ? (
+      ) : capabilities && !hasConfiguredSsoProvider ? (
         <Text style={{ ...typography.caption, marginTop: spacing.md, textAlign: "center", color: colors.mutedText }}>
           Microsoft/Google SSO is not configured for this server. Sign-in may require a password login.
         </Text>

--- a/server/src/lib/mobileAuth/mobileAuthService.ts
+++ b/server/src/lib/mobileAuth/mobileAuthService.ts
@@ -4,7 +4,7 @@ import { getConnection } from '../db/db';
 import { ApiKeyService } from '../services/apiKeyService';
 import { findUserByIdForApi } from '@alga-psa/users/actions';
 import { runWithTenant } from '../db';
-import { ForbiddenError, UnauthorizedError } from '../api/middleware/apiMiddleware';
+import { UnauthorizedError } from '../api/middleware/apiMiddleware';
 import { auditLog } from '../logging/auditLog';
 import { enforceMobileOttExchangeLimit, enforceMobileRefreshLimit } from '../security/mobileAuthRateLimiting';
 
@@ -43,7 +43,6 @@ export const revokeSessionSchema = z.object({
 });
 
 export type MobileAuthConfig = {
-  mobileEnabled: boolean;
   hostedDomainAllowlist: string[];
   ottTtlSec: number;
   accessTtlSec: number;
@@ -51,8 +50,6 @@ export type MobileAuthConfig = {
 };
 
 export function getMobileAuthConfig(): MobileAuthConfig {
-  const enabled = (process.env.ALGA_MOBILE_AUTH_ENABLED ?? '').trim().toLowerCase() === 'true';
-
   const parseNumber = (key: string, fallback: number) => {
     const raw = process.env[key];
     const n = raw ? Number(raw) : NaN;
@@ -65,7 +62,6 @@ export function getMobileAuthConfig(): MobileAuthConfig {
     .filter(Boolean);
 
   return {
-    mobileEnabled: enabled,
     hostedDomainAllowlist: allowlist,
     ottTtlSec: parseNumber('ALGA_MOBILE_OTT_TTL_SEC', 60),
     accessTtlSec: parseNumber('ALGA_MOBILE_ACCESS_TTL_SEC', 15 * 60),
@@ -91,9 +87,6 @@ export async function issueMobileOtt(input: {
   metadata?: Record<string, unknown>;
 }): Promise<IssuedOtt> {
   const config = getMobileAuthConfig();
-  if (!config.mobileEnabled) {
-    throw new ForbiddenError('Mobile auth is disabled');
-  }
 
   const ott = generateOpaqueToken(24);
   const ottHash = sha256(ott);
@@ -243,9 +236,6 @@ export type ExchangeOttResult = {
 
 export async function exchangeOttForSession(input: z.infer<typeof exchangeOttSchema>): Promise<ExchangeOttResult> {
   const config = getMobileAuthConfig();
-  if (!config.mobileEnabled) {
-    throw new ForbiddenError('Mobile auth is disabled');
-  }
 
   const consumed = await consumeMobileOtt({ ott: input.ott, state: input.state, deviceId: input.device?.deviceId });
   if (!consumed) {
@@ -335,9 +325,6 @@ export type RefreshSessionResult = {
 
 export async function refreshMobileSession(input: z.infer<typeof refreshSessionSchema>): Promise<RefreshSessionResult> {
   const config = getMobileAuthConfig();
-  if (!config.mobileEnabled) {
-    throw new ForbiddenError('Mobile auth is disabled');
-  }
 
   const hash = sha256(input.refreshToken);
   const existing = await getActiveRefreshTokenByHash(hash);
@@ -400,11 +387,6 @@ export async function refreshMobileSession(input: z.infer<typeof refreshSessionS
 }
 
 export async function revokeMobileSession(input: z.infer<typeof revokeSessionSchema>): Promise<void> {
-  const config = getMobileAuthConfig();
-  if (!config.mobileEnabled) {
-    throw new ForbiddenError('Mobile auth is disabled');
-  }
-
   const hash = sha256(input.refreshToken);
   const existing = await getActiveRefreshTokenByHash(hash);
   if (!existing) {
@@ -456,7 +438,6 @@ async function safeAuditLog(input: {
 }
 
 export type MobileAuthCapabilities = {
-  mobileEnabled: boolean;
   providers: { microsoft: boolean; google: boolean };
   hostedDomainAllowlist?: string[];
   accessTtlSec?: number;
@@ -467,7 +448,6 @@ export type MobileAuthCapabilities = {
 export function getCapabilitiesResponse(): MobileAuthCapabilities {
   const config = getMobileAuthConfig();
   return {
-    mobileEnabled: config.mobileEnabled,
     providers: { microsoft: true, google: true },
     hostedDomainAllowlist: config.hostedDomainAllowlist.length ? config.hostedDomainAllowlist : undefined,
     accessTtlSec: config.accessTtlSec,

--- a/server/src/test/unit/mobileAuth.test.ts
+++ b/server/src/test/unit/mobileAuth.test.ts
@@ -171,7 +171,6 @@ describe('mobile auth (OTT + refresh rotation)', () => {
     state.mobile_refresh_tokens.length = 0;
     state.sessions.length = 0;
 
-    process.env.ALGA_MOBILE_AUTH_ENABLED = 'true';
     process.env.ALGA_MOBILE_OTT_TTL_SEC = '60';
     process.env.ALGA_MOBILE_ACCESS_TTL_SEC = '900';
     process.env.ALGA_MOBILE_REFRESH_TTL_SEC = '3600';


### PR DESCRIPTION
## Summary
- remove ALGA_MOBILE_AUTH_ENABLED from server mobile auth config and stop gating mobile auth operations on it
- remove mobileEnabled from mobile auth capabilities response/type and mobile app UI gating
- update mobile auth docs/tests to reflect that mobile login is always allowed (allowlist and other auth checks still apply)

## Testing
- Unable to run npx vitest --run server/src/test/unit/mobileAuth.test.ts in this environment because npm registry access failed (ENOTFOUND registry.npmjs.org).