### PR TITLE
Fix workflow worker build by restoring storage TS path aliases

### DIFF
--- a/ee/temporal-workflows/tsconfig.json
+++ b/ee/temporal-workflows/tsconfig.json
@@ -48,6 +48,8 @@
       "@alga-psa/db/tenant.js": ["../../packages/db/src/lib/tenant.ts"],
       "@alga-psa/types": ["../../packages/types/src/index.ts"],
       "@alga-psa/types/*": ["../../packages/types/src/*"],
+      "@alga-psa/storage": ["../../packages/storage/src/index.ts"],
+      "@alga-psa/storage/*": ["../../packages/storage/src/*"],
       "@alga-psa/db/admin": ["../../packages/db/src/lib/admin.ts"],
       "@alga-psa/db/admin.js": ["../../packages/db/src/lib/admin.ts"],
       "@temporalio/activity": ["../../node_modules/@temporalio/activity"],


### PR DESCRIPTION
## Summary
- add missing @alga-psa/storage path mapping in ee/temporal-workflows/tsconfig.json
- add missing @alga-psa/storage/* subpath mapping in the same config

## Why
The worker tsconfig defines compilerOptions.paths locally, which overrides inherited base paths. Storage aliases were missing there, causing TS2307 module resolution failures during workflow worker build.

## Validation
- ran a targeted tsc check and confirmed prior storage-related TS2307 errors no longer appear for billing/documents imports