### PR TITLE
Improve AI ticket retrieval and chat autoscroll

### DIFF
--- a/ee/docs/api-registry/tickets.json
+++ b/ee/docs/api-registry/tickets.json
@@ -8,7 +8,7 @@
       "metadata": {
         "displayName": "List Tickets",
         "summary": "List tickets",
-        "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket.",
+        "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
         "rbacResource": "ticket",
         "approvalRequired": false,
         "parameters": [
@@ -60,6 +60,20 @@
             "required": false,
             "description": "When true, only open tickets are returned.",
             "schema": { "type": "boolean" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of fields to return. Use only these exact values: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. If you are not sure, omit fields entirely instead of guessing aliases.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "field_ranges[description_html]",
+            "in": "query",
+            "required": false,
+            "description": "Optional UTF-8 byte range for the description_html field, formatted as start-end (for example 0-4095). When returned data is truncated, inspect meta.truncated_fields for continuation offsets.",
+            "schema": { "type": "string", "pattern": "^\\d+-\\d+$" }
           }
         ],
         "responseBodySchema": {
@@ -111,10 +125,51 @@
             "request": {
               "query": {
                 "limit": 5,
+                "fields": "ticket_id,ticket_number,title,board_id,status_id,priority_id,assigned_to,entered_at",
                 "is_open": true
               }
             },
-            "notes": "Inspect the response payload to reuse board_id, status_id, priority_id, and assigned_to values that are known to be valid. If you only need a single set of identifiers, take the first ticket in the data array that has non-null board_id, status_id, and priority_id and reuse those UUIDs for the new ticket."
+            "notes": "Inspect the response payload to reuse board_id, status_id, priority_id, and assigned_to values that are known to be valid. Prefer fields=... to keep payloads compact, but only use the documented field names exactly as written. If you are unsure which field names are valid, omit fields instead of guessing. If you only need a single set of identifiers, take the first ticket in the data array that has non-null board_id, status_id, and priority_id and reuse those UUIDs for the new ticket."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/tickets/{id}"
+      },
+      "metadata": {
+        "displayName": "Get Ticket",
+        "summary": "Get ticket by ID",
+        "description": "Returns the full ticket record for a specific ticket. Prefer this over expanding list responses when you already know the ticket_id.",
+        "rbacResource": "ticket",
+        "approvalRequired": false,
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ticket identifier.",
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "field_ranges[description_html]",
+            "in": "query",
+            "required": false,
+            "description": "Optional UTF-8 byte range for description_html, formatted as start-end (for example 0-4095). When returned data is truncated, inspect meta.truncated_fields for continuation offsets.",
+            "schema": { "type": "string", "pattern": "^\\d+-\\d+$" }
+          }
+        ],
+        "examples": [
+          {
+            "name": "Read one ticket in detail",
+            "request": {
+              "path": {
+                "id": "11111111-1111-1111-1111-111111111111"
+              }
+            },
+            "notes": "Use this endpoint after a list/search call gives you a ticket_id. If description_html is large, fetch it in byte windows with field_ranges[description_html]=start-end instead of asking for a bigger list payload."
           }
         ]
       }
@@ -195,6 +250,79 @@
       }
     }
     ,
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/tickets/{id}/comments"
+      },
+      "metadata": {
+        "displayName": "Get Ticket Comments",
+        "summary": "List comments for a ticket",
+        "description": "Returns the comments attached to a ticket. Use small limits and field-scoped byte ranges when comment bodies are large.",
+        "rbacResource": "ticket",
+        "approvalRequired": false,
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ticket identifier.",
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of comments to return (1-200). Prefer small values when exploring ticket history.",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Zero-based comment offset.",
+            "schema": { "type": "integer", "minimum": 0 }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Comment sort order.",
+            "schema": { "type": "string", "enum": ["asc", "desc"] }
+          },
+          {
+            "name": "field_ranges[comment_text]",
+            "in": "query",
+            "required": false,
+            "description": "Optional UTF-8 byte range for comment_text, formatted as start-end (for example 0-4095). Use meta.truncated_fields to continue fetching long comments.",
+            "schema": { "type": "string", "pattern": "^\\d+-\\d+$" }
+          },
+          {
+            "name": "field_ranges[comment_html]",
+            "in": "query",
+            "required": false,
+            "description": "Optional UTF-8 byte range for comment_html, formatted as start-end (for example 0-4095).",
+            "schema": { "type": "string", "pattern": "^\\d+-\\d+$" }
+          }
+        ],
+        "examples": [
+          {
+            "name": "Read recent comments with ranged comment text",
+            "request": {
+              "path": {
+                "id": "11111111-1111-1111-1111-111111111111"
+              },
+              "query": {
+                "limit": 5,
+                "order": "desc",
+                "field_ranges[comment_text]": "0-4095"
+              }
+            },
+            "notes": "Prefer this endpoint over large ticket list payloads when the user asks for comment history or long comment bodies."
+          }
+        ]
+      }
+    },
     {
       "match": {
         "method": "post",

--- a/ee/docs/api-registry/tickets.json
+++ b/ee/docs/api-registry/tickets.json
@@ -165,7 +165,7 @@
           {
             "name": "Read one ticket in detail",
             "request": {
-              "path": {
+              "params": {
                 "id": "11111111-1111-1111-1111-111111111111"
               }
             },
@@ -309,7 +309,7 @@
           {
             "name": "Read recent comments with ranged comment text",
             "request": {
-              "path": {
+              "params": {
                 "id": "11111111-1111-1111-1111-111111111111"
               },
               "query": {

--- a/ee/scripts/generate-chat-registry.mjs
+++ b/ee/scripts/generate-chat-registry.mjs
@@ -13,6 +13,120 @@ const OUTPUT_PATH = path.resolve(repoRoot, 'ee/server/src/chat/registry/apiRegis
 const OVERRIDES_DIR = path.resolve(repoRoot, 'ee/docs/api-registry');
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+const PLACEHOLDER_DESCRIPTION =
+  'This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.';
+
+function singularize(segment) {
+  if (segment.endsWith('ies')) {
+    return `${segment.slice(0, -3)}y`;
+  }
+  if (segment.endsWith('ses')) {
+    return segment.slice(0, -2);
+  }
+  if (segment.endsWith('s') && !segment.endsWith('ss')) {
+    return segment.slice(0, -1);
+  }
+  return segment;
+}
+
+function humanizeSegment(segment) {
+  return segment
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function deriveResourceSegments(pathName) {
+  const rawSegments = pathName.split('/').filter(Boolean);
+  const apiIndex = rawSegments.findIndex((segment) => segment === 'api');
+  const segments = apiIndex === -1 ? rawSegments : rawSegments.slice(apiIndex + 1);
+  if (segments[0] && /^v\d+$/i.test(segments[0])) {
+    segments.shift();
+  }
+  return segments;
+}
+
+function deriveFallbackNames(method, pathName) {
+  const segments = deriveResourceSegments(pathName);
+  const nonParamSegments = segments.filter((segment) => !segment.startsWith('{'));
+  const pathParams = segments.filter((segment) => segment.startsWith('{') && segment.endsWith('}'));
+  const primary = nonParamSegments[0] ?? 'resource';
+  const primaryLabel = humanizeSegment(singularize(primary));
+  const trailing = nonParamSegments.slice(1).map((segment) => humanizeSegment(singularize(segment)));
+  const tailLabel = trailing.join(' ');
+
+  if (method === 'get' && pathParams.length === 1 && nonParamSegments.length === 1) {
+    return {
+      displayName: `Get ${primaryLabel}`,
+      summary: `Get ${primaryLabel.toLowerCase()} by ID`,
+    };
+  }
+
+  if (method === 'put' && pathParams.length === 1 && nonParamSegments.length === 1) {
+    return {
+      displayName: `Update ${primaryLabel}`,
+      summary: `Update ${primaryLabel.toLowerCase()} by ID`,
+    };
+  }
+
+  if (method === 'patch' && pathParams.length === 1 && nonParamSegments.length === 1) {
+    return {
+      displayName: `Update ${primaryLabel}`,
+      summary: `Update ${primaryLabel.toLowerCase()} fields by ID`,
+    };
+  }
+
+  if (method === 'delete' && pathParams.length === 1 && nonParamSegments.length === 1) {
+    return {
+      displayName: `Delete ${primaryLabel}`,
+      summary: `Delete ${primaryLabel.toLowerCase()} by ID`,
+    };
+  }
+
+  if (method === 'get' && pathParams.length > 0 && tailLabel) {
+    return {
+      displayName: `List ${primaryLabel} ${tailLabel}`,
+      summary: `List ${tailLabel.toLowerCase()} for a ${primaryLabel.toLowerCase()}`,
+    };
+  }
+
+  return null;
+}
+
+function inferPathParameters(pathName, existingParameters) {
+  const existingPathParamNames = new Set(
+    (existingParameters ?? [])
+      .filter((param) => param.in === 'path')
+      .map((param) => param.name),
+  );
+
+  const inferred = [];
+  for (const match of pathName.matchAll(/\{([^}]+)\}/g)) {
+    const name = match[1];
+    if (!name || existingPathParamNames.has(name)) {
+      continue;
+    }
+
+    inferred.push({
+      name,
+      in: 'path',
+      required: true,
+      description:
+        name === 'id'
+          ? 'Resource identifier.'
+          : `${humanizeSegment(name)} path parameter.`,
+      schema: {
+        type: 'string',
+        ...(name === 'id' ? { format: 'uuid' } : {}),
+      },
+    });
+  }
+
+  return inferred;
+}
 
 function loadSpec(specPath) {
   if (!fs.existsSync(specPath)) {
@@ -195,20 +309,31 @@ function collectOperations(spec) {
 
       const id = createEntryId(method, pathName, operation.operationId);
       const parameters = collectParameters(spec, pathItem, operation);
+      const fallback = deriveFallbackNames(method, pathName);
       const { schema: requestBodySchema, example: requestExample } = extractRequestBody(spec, operation);
       const responseBodySchema = extractResponseBody(spec, operation);
+      const displayName = operation['x-chat-display-name']
+        ?? operation.summary
+        ?? fallback?.displayName
+        ?? `${method.toUpperCase()} ${pathName}`;
+      const summary = operation.summary
+        ?? fallback?.summary
+        ?? `${method.toUpperCase()} ${pathName}`;
+      const description = operation.description;
+      const normalizedDescription =
+        description === PLACEHOLDER_DESCRIPTION && fallback ? undefined : description;
 
       const entry = {
         id,
         method,
         path: pathName,
-        displayName: operation['x-chat-display-name'] ?? operation.summary ?? `${method.toUpperCase()} ${pathName}`,
-        summary: operation.summary,
-        description: operation.description,
+        displayName,
+        summary,
+        description: normalizedDescription,
         tags: Array.isArray(operation.tags) ? operation.tags : [],
         rbacResource: operation['x-chat-rbac-resource'] ?? operation['x-rbac-resource'],
         approvalRequired: Boolean(operation['x-chat-approval-required']),
-        parameters,
+        parameters: [...parameters, ...inferPathParameters(pathName, parameters)],
         requestBodySchema,
         requestExample,
         responseBodySchema,

--- a/ee/scripts/generate-chat-registry.mjs
+++ b/ee/scripts/generate-chat-registry.mjs
@@ -284,11 +284,37 @@ function applyOverrides(entry, overrides) {
       entry.approvalRequired = metadata.approvalRequired;
     }
     if (Array.isArray(metadata.playbooks)) entry.playbooks = metadata.playbooks;
-    if (Array.isArray(metadata.examples)) entry.examples = metadata.examples;
+    if (Array.isArray(metadata.examples)) {
+      entry.examples = metadata.examples.map((example) => normalizeExample(example));
+    }
     if (Array.isArray(metadata.parameters)) entry.parameters = metadata.parameters;
     if (metadata.requestBodySchema !== undefined) entry.requestBodySchema = metadata.requestBodySchema;
     if (metadata.responseBodySchema !== undefined) entry.responseBodySchema = metadata.responseBodySchema;
   }
+}
+
+function normalizeExample(example) {
+  if (!example || typeof example !== 'object') {
+    return example;
+  }
+
+  const normalized = { ...example };
+  const request = normalized.request;
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    return normalized;
+  }
+
+  if ('path' in request && !('params' in request)) {
+    const { path, ...rest } = request;
+    normalized.request = {
+      ...rest,
+      params: path,
+    };
+    return normalized;
+  }
+
+  normalized.request = { ...request };
+  return normalized;
 }
 
 function createEntryId(method, pathName, operationId) {

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -10364,7 +10364,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       {
         "name": "Read one ticket in detail",
         "request": {
-          "path": {
+          "params": {
             "id": "11111111-1111-1111-1111-111111111111"
           }
         },
@@ -10548,7 +10548,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       {
         "name": "Read recent comments with ranged comment text",
         "request": {
-          "path": {
+          "params": {
             "id": "11111111-1111-1111-1111-111111111111"
           },
           "query": {

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -502,7 +502,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "taskId",
+        "in": "path",
+        "required": true,
+        "description": "TaskId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -607,12 +617,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/auth/{nextauth}",
     "displayName": "GET auth",
     "summary": "GET auth",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "auth"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "nextauth",
+        "in": "path",
+        "required": true,
+        "description": "Nextauth path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -629,7 +648,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "auth"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "nextauth",
+        "in": "path",
+        "required": true,
+        "description": "Nextauth path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -704,12 +733,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/chat/stream/{slug}",
     "displayName": "GET chat",
     "summary": "GET chat",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "chat"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "slug",
+        "in": "path",
+        "required": true,
+        "description": "Slug path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -726,7 +764,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "chat"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "slug",
+        "in": "path",
+        "required": true,
+        "description": "Slug path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -742,12 +790,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/documents/download/{fileId}",
     "displayName": "GET documents",
     "summary": "GET documents",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "documents"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "fileId",
+        "in": "path",
+        "required": true,
+        "description": "FileId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -759,12 +816,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/documents/view/{fileId}",
     "displayName": "GET documents",
     "summary": "GET documents",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "documents"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "fileId",
+        "in": "path",
+        "required": true,
+        "description": "FileId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -776,12 +842,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/documents/{documentId}/download",
     "displayName": "GET documents",
     "summary": "GET documents",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "documents"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "documentId",
+        "in": "path",
+        "required": true,
+        "description": "DocumentId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -920,7 +995,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "ext"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "description": "Path path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -937,7 +1031,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "ext"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "description": "Path path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -958,7 +1071,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "ext"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "description": "Path path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -979,7 +1111,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "ext"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "description": "Path path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1000,7 +1151,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "ext"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "description": "Path path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1050,12 +1220,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/softwareone/agreements/{id}",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1105,12 +1285,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/softwareone/statements/{id}",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1122,12 +1312,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/softwareone/statements/{id}/charges",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1160,12 +1360,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/{extensionId}/agreements",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1177,12 +1386,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/{extensionId}/agreements/{id}",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1194,12 +1422,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/{extensionId}/statements",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1211,12 +1448,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/{extensionId}/statements/{id}",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1228,12 +1484,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/extensions/{extensionId}/statements/{id}/charges",
     "displayName": "GET extensions",
     "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1250,7 +1525,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "extensions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "extensionId",
+        "in": "path",
+        "required": true,
+        "description": "ExtensionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1266,12 +1551,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/files/{fileId}/download",
     "displayName": "GET files",
     "summary": "GET files",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "files"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "fileId",
+        "in": "path",
+        "required": true,
+        "description": "FileId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1542,7 +1836,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "associationId",
+        "in": "path",
+        "required": true,
+        "description": "AssociationId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1576,7 +1880,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "scheduleId",
+        "in": "path",
+        "required": true,
+        "description": "ScheduleId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1597,7 +1911,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "scheduleId",
+        "in": "path",
+        "required": true,
+        "description": "ScheduleId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1614,7 +1938,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "relationshipId",
+        "in": "path",
+        "required": true,
+        "description": "RelationshipId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1660,12 +1994,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1677,12 +2021,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1698,12 +2052,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1715,12 +2079,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}/documents",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1737,7 +2111,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1753,12 +2138,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}/history",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1770,12 +2165,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}/maintenance",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1792,7 +2197,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1813,7 +2229,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1829,12 +2256,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/assets/{id}/relationships",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1851,7 +2288,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "assets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -1884,12 +2332,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/automation/executions/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -1906,7 +2364,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2036,12 +2505,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/automation/rules/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2058,7 +2537,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2079,7 +2569,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2096,7 +2597,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2167,12 +2679,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/automation/templates/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2189,7 +2711,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "automation"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2416,12 +2949,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2433,12 +2976,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2454,12 +3007,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2476,7 +3039,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2492,12 +3066,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}/analytics",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2514,7 +3098,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2530,12 +3125,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}/fixed-config",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2552,7 +3157,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2568,12 +3184,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}/services",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2590,7 +3216,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2606,12 +3243,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}/services/{serviceId}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "serviceId",
+        "in": "path",
+        "required": true,
+        "description": "ServiceId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2628,7 +3284,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "serviceId",
+        "in": "path",
+        "required": true,
+        "description": "ServiceId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2649,7 +3325,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "serviceId",
+        "in": "path",
+        "required": true,
+        "description": "ServiceId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2661,12 +3357,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contract-lines/{id}/usage-metrics",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2733,12 +3439,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/categories/service/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2755,7 +3471,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2776,7 +3503,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2917,12 +3655,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/categories/ticket/tree/{boardId}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "boardId",
+        "in": "path",
+        "required": true,
+        "description": "BoardId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2934,12 +3681,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/categories/ticket/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -2956,7 +3713,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -2977,7 +3745,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "categories"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3096,12 +3875,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/clients/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "clients"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3113,12 +3902,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/clients/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "clients"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3134,12 +3933,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/clients/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "clients"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3151,12 +3960,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/clients/{id}/contacts",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "clients"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3236,7 +4055,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "clients"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3290,12 +4120,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/client-contract-lines/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "client-contract-lines"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3449,12 +4289,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contacts/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contacts"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3466,12 +4316,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contacts/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contacts"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3487,12 +4347,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/contacts/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "contacts"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3787,7 +4657,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3808,7 +4689,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3862,12 +4754,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/financial/payment-methods/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3884,7 +4786,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -3905,7 +4818,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -3943,7 +4867,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -4086,12 +5021,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/financial/transactions/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -4108,7 +5053,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "financial"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -4260,7 +5216,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -4466,12 +5432,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/integrations/quickbooks/mappings/{mapping_id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -4488,7 +5463,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -4509,7 +5494,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -4694,12 +5689,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/integrations/quickbooks/sync/status/{sync_id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -4716,7 +5720,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -4737,7 +5751,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "integrations"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5087,7 +6111,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5108,7 +6143,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5137,12 +6183,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5154,12 +6210,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5175,12 +6241,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5197,7 +6273,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5218,7 +6305,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5239,7 +6337,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5260,7 +6369,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5276,12 +6396,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}/items",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5298,7 +6428,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5314,12 +6455,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}/pdf",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5336,7 +6487,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5357,7 +6519,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5378,7 +6551,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5399,7 +6583,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5415,12 +6610,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/invoices/{id}/transactions",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "invoices"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5644,12 +6849,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/permissions/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "permissions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5661,12 +6876,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/permissions/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "permissions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5682,12 +6907,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/permissions/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "permissions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5699,12 +6934,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/permissions/{id}/roles",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "permissions"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5759,7 +7004,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contracts"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "contractId",
+        "in": "path",
+        "required": true,
+        "description": "ContractId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -5780,7 +7035,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contracts"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "contractId",
+        "in": "path",
+        "required": true,
+        "description": "ContractId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "contractLineId",
+        "in": "path",
+        "required": true,
+        "description": "ContractLineId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -5818,7 +7092,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "contract-line-templates"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6001,12 +7286,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/tasks/{taskId}/checklist",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "taskId",
+        "in": "path",
+        "required": true,
+        "description": "TaskId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6023,7 +7317,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "taskId",
+        "in": "path",
+        "required": true,
+        "description": "TaskId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6039,12 +7343,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6056,12 +7370,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6077,12 +7401,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6094,12 +7428,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/{id}/phases",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6116,7 +7460,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6137,7 +7492,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "phaseId",
+        "in": "path",
+        "required": true,
+        "description": "PhaseId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6158,7 +7533,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "phaseId",
+        "in": "path",
+        "required": true,
+        "description": "PhaseId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6170,12 +7565,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/projects/{id}/tickets",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "projects"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6323,7 +7728,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6529,12 +7944,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/quickbooks/mappings/{mapping_id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6551,7 +7975,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6572,7 +8006,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "mapping_id",
+        "in": "path",
+        "required": true,
+        "description": "Mapping Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6757,12 +8201,21 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/quickbooks/sync/status/{sync_id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -6779,7 +8232,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6800,7 +8263,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "quickbooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sync_id",
+        "in": "path",
+        "required": true,
+        "description": "Sync Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -6998,12 +8471,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/roles/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7015,12 +8498,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/roles/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7036,12 +8529,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/roles/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7058,7 +8561,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7074,12 +8588,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/roles/{id}/permissions",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7096,7 +8620,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "roles"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7167,12 +8702,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/schedules/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "schedules"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7184,12 +8729,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/schedules/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "schedules"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7205,12 +8760,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/schedules/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "schedules"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7222,12 +8787,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/schedules/{id}/conflicts",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "schedules"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7458,12 +9033,30 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tags/entity/{entityType}/{entityId}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "entityType",
+        "in": "path",
+        "required": true,
+        "description": "EntityType path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "entityId",
+        "in": "path",
+        "required": true,
+        "description": "EntityId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7480,7 +9073,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "entityType",
+        "in": "path",
+        "required": true,
+        "description": "EntityType path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "entityId",
+        "in": "path",
+        "required": true,
+        "description": "EntityId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7501,7 +9113,26 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "entityType",
+        "in": "path",
+        "required": true,
+        "description": "EntityType path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "entityId",
+        "in": "path",
+        "required": true,
+        "description": "EntityId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7530,12 +9161,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tags/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7547,12 +9188,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tags/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7568,12 +9219,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tags/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7590,7 +9251,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7611,7 +9283,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tags"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7754,12 +9437,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7771,12 +9464,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7792,12 +9495,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7809,12 +9522,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}/analytics",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7831,7 +9554,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7852,7 +9586,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7869,7 +9614,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7885,12 +9641,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}/members",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7907,7 +9673,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7928,7 +9705,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -7949,7 +9737,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "userId",
+        "in": "path",
+        "required": true,
+        "description": "UserId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7961,12 +9769,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}/permissions",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -7983,7 +9801,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8004,7 +9833,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "permissionId",
+        "in": "path",
+        "required": true,
+        "description": "PermissionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -8016,12 +9865,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/teams/{id}/projects",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "teams"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -8050,7 +9909,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tickets",
     "displayName": "List Tickets",
     "summary": "List tickets",
-    "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket.",
+    "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
     "tags": [
       "tickets"
     ],
@@ -8125,6 +9984,25 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "description": "When true, only open tickets are returned.",
         "schema": {
           "type": "boolean"
+        }
+      },
+      {
+        "name": "fields",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated list of fields to return. Use only these exact values: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. If you are not sure, omit fields entirely instead of guessing aliases.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field_ranges[description_html]",
+        "in": "query",
+        "required": false,
+        "description": "Optional UTF-8 byte range for the description_html field, formatted as start-end (for example 0-4095). When returned data is truncated, inspect meta.truncated_fields for continuation offsets.",
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+-\\d+$"
         }
       }
     ],
@@ -8217,10 +10095,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "request": {
           "query": {
             "limit": 5,
+            "fields": "ticket_id,ticket_number,title,board_id,status_id,priority_id,assigned_to,entered_at",
             "is_open": true
           }
         },
-        "notes": "Inspect the response payload to reuse board_id, status_id, priority_id, and assigned_to values that are known to be valid. If you only need a single set of identifiers, take the first ticket in the data array that has non-null board_id, status_id, and priority_id and reuse those UUIDs for the new ticket."
+        "notes": "Inspect the response payload to reuse board_id, status_id, priority_id, and assigned_to values that are known to be valid. Prefer fields=... to keep payloads compact, but only use the documented field names exactly as written. If you are unsure which field names are valid, omit fields instead of guessing. If you only need a single set of identifiers, take the first ticket in the data array that has non-null board_id, status_id, and priority_id and reuse those UUIDs for the new ticket."
       }
     ]
   },
@@ -8447,18 +10326,51 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_tickets_id",
     "method": "get",
     "path": "/api/v1/tickets/{id}",
-    "displayName": "GET v1",
-    "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "displayName": "Get Ticket",
+    "summary": "Get ticket by ID",
+    "description": "Returns the full ticket record for a specific ticket. Prefer this over expanding list responses when you already know the ticket_id.",
     "tags": [
       "tickets"
     ],
+    "rbacResource": "ticket",
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ticket identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "field_ranges[description_html]",
+        "in": "query",
+        "required": false,
+        "description": "Optional UTF-8 byte range for description_html, formatted as start-end (for example 0-4095). When returned data is truncated, inspect meta.truncated_fields for continuation offsets.",
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+-\\d+$"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
-    }
+    },
+    "examples": [
+      {
+        "name": "Read one ticket in detail",
+        "request": {
+          "path": {
+            "id": "11111111-1111-1111-1111-111111111111"
+          }
+        },
+        "notes": "Use this endpoint after a list/search call gives you a ticket_id. If description_html is large, fetch it in byte windows with field_ranges[description_html]=start-end instead of asking for a bigger list payload."
+      }
+    ]
   },
   {
     "id": "put-_api_v1_tickets_id",
@@ -8466,12 +10378,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tickets/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tickets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8487,12 +10409,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tickets/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "tickets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -8509,7 +10441,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tickets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8523,18 +10466,100 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_tickets_id_comments",
     "method": "get",
     "path": "/api/v1/tickets/{id}/comments",
-    "displayName": "GET v1",
-    "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "displayName": "Get Ticket Comments",
+    "summary": "List comments for a ticket",
+    "description": "Returns the comments attached to a ticket. Use small limits and field-scoped byte ranges when comment bodies are large.",
     "tags": [
       "tickets"
     ],
+    "rbacResource": "ticket",
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Ticket identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Maximum number of comments to return (1-200). Prefer small values when exploring ticket history.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200
+        }
+      },
+      {
+        "name": "offset",
+        "in": "query",
+        "required": false,
+        "description": "Zero-based comment offset.",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "Comment sort order.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        }
+      },
+      {
+        "name": "field_ranges[comment_text]",
+        "in": "query",
+        "required": false,
+        "description": "Optional UTF-8 byte range for comment_text, formatted as start-end (for example 0-4095). Use meta.truncated_fields to continue fetching long comments.",
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+-\\d+$"
+        }
+      },
+      {
+        "name": "field_ranges[comment_html]",
+        "in": "query",
+        "required": false,
+        "description": "Optional UTF-8 byte range for comment_html, formatted as start-end (for example 0-4095).",
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+-\\d+$"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
-    }
+    },
+    "examples": [
+      {
+        "name": "Read recent comments with ranged comment text",
+        "request": {
+          "path": {
+            "id": "11111111-1111-1111-1111-111111111111"
+          },
+          "query": {
+            "limit": 5,
+            "order": "desc",
+            "field_ranges[comment_text]": "0-4095"
+          }
+        },
+        "notes": "Prefer this endpoint over large ticket list payloads when the user asks for comment history or long comment bodies."
+      }
+    ]
   },
   {
     "id": "post-_api_v1_tickets_id_comments",
@@ -8598,7 +10623,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "tickets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8847,7 +10883,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-entries"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "description": "SessionId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8880,12 +10926,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-entries/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-entries"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -8897,12 +10953,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-entries/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-entries"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -8918,12 +10984,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-entries/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-entries"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -8990,12 +11066,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-periods/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-periods"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9007,12 +11093,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-periods/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-periods"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9028,12 +11124,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-periods/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-periods"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9050,7 +11156,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-periods"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9071,7 +11188,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-periods"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9180,12 +11308,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-sheets/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9197,12 +11335,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-sheets/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9218,12 +11366,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-sheets/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9240,7 +11398,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9261,7 +11430,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9277,12 +11457,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-sheets/{id}/entries",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9299,7 +11489,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9320,7 +11521,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9337,7 +11549,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9358,7 +11581,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9379,7 +11613,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9395,12 +11640,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/time-sheets/{id}/summary",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "time-sheets"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9675,12 +11930,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9692,12 +11957,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9713,12 +11988,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9735,7 +12020,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9752,7 +12048,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9768,12 +12075,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}/activity",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9790,7 +12107,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9811,7 +12139,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9828,7 +12167,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9844,12 +12194,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}/permissions",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9861,12 +12221,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}/preferences",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9883,7 +12253,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9899,12 +12280,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}/roles",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9921,7 +12312,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9942,7 +12344,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -9963,7 +12376,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9975,12 +12399,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/users/{id}/teams",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -9997,7 +12431,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10018,7 +12463,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "users"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "teamId",
+        "in": "path",
+        "required": true,
+        "description": "TeamId path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10292,12 +12757,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/templates/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10314,7 +12789,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10335,7 +12821,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10352,7 +12849,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10452,12 +12960,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10469,12 +12987,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10490,12 +13018,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10507,12 +13045,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}/analytics",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10524,12 +13072,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}/deliveries",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10541,12 +13099,31 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}/deliveries/{delivery_id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "delivery_id",
+        "in": "path",
+        "required": true,
+        "description": "Delivery Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10563,7 +13140,27 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "delivery_id",
+        "in": "path",
+        "required": true,
+        "description": "Delivery Id path parameter.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10584,7 +13181,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10600,12 +13208,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}/health",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10622,7 +13240,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10638,12 +13267,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/webhooks/{id}/subscriptions",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10660,7 +13299,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10681,7 +13331,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10702,7 +13363,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10723,7 +13395,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "webhooks"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10832,12 +13515,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/events/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10929,12 +13622,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/executions/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -10951,7 +13654,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10972,7 +13686,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -10993,7 +13718,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11014,7 +13750,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11035,7 +13782,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11165,12 +13923,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/tasks/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -11187,7 +13955,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11208,7 +13987,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11229,7 +14019,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11283,12 +14084,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/templates/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -11305,7 +14116,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11326,7 +14148,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -11338,12 +14171,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/{id}",
     "displayName": "GET v1",
     "summary": "GET v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -11355,12 +14198,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/{id}",
     "displayName": "PUT v1",
     "summary": "PUT v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
       "properties": {}
@@ -11376,12 +14229,22 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/workflows/{id}",
     "displayName": "DELETE v1",
     "summary": "DELETE v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
     "tags": [
       "workflows"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
       "properties": {}
@@ -11692,10 +14555,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     },
-    "playbooks": [
-      "kb/search-and-read",
-      "kb/find-relevant-articles"
-    ],
     "examples": [
       {
         "name": "List published articles",
@@ -11707,30 +14566,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "Search articles by keyword",
+        "name": "Search articles",
         "request": {
           "query": {
             "search": "password reset"
-          }
-        },
-        "notes": "Searches by title and slug. Use this to find relevant KB articles before answering user questions."
-      },
-      {
-        "name": "List troubleshooting articles for clients",
-        "request": {
-          "query": {
-            "status": "published",
-            "audience": "client",
-            "article_type": "troubleshooting"
-          }
-        },
-        "notes": "Filter by audience and type to find specific article sets."
-      },
-      {
-        "name": "List articles needing review",
-        "request": {
-          "query": {
-            "status": "review"
           }
         }
       }
@@ -11812,10 +14651,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     },
-    "playbooks": [
-      "kb/create-article",
-      "kb/create-from-resolution"
-    ],
     "examples": [
       {
         "name": "Create a how-to article with markdown content",
@@ -11827,8 +14662,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "content": "# Steps\n\n1. Navigate to Settings > Users\n2. Find the user\n3. Click Reset Password\n4. The user will receive an email with a reset link",
             "content_format": "markdown"
           }
-        },
-        "notes": "Always use content_format 'markdown' when generating content. Articles start in 'draft' status — call POST /api/v1/kb-articles/{id}/publish after creation to make them live."
+        }
       },
       {
         "name": "Create a troubleshooting article for clients",
@@ -11840,22 +14674,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "content": "# Problem\n\nVPN disconnects frequently.\n\n# Solution\n\n1. Check your internet connection\n2. Restart the VPN client\n3. If the issue persists, contact support",
             "content_format": "markdown"
           }
-        },
-        "notes": "Client-audience articles become visible in the client portal once published."
-      },
-      {
-        "name": "Create an FAQ article",
-        "request": {
-          "body": {
-            "title": "How do I change my notification settings?",
-            "article_type": "faq",
-            "audience": "client",
-            "content": "## Question\n\nHow do I change my notification settings?\n\n## Answer\n\nGo to **Settings > Notifications** in the client portal. You can toggle email and in-app notifications for each category.",
-            "content_format": "markdown",
-            "review_cycle_days": 90
-          }
-        },
-        "notes": "FAQ articles should be concise. review_cycle_days ensures articles are reviewed periodically."
+        }
       }
     ]
   },
@@ -12004,10 +14823,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "tags": [
       "Knowledge Base"
     ],
-    "playbooks": [
-      "kb/create-article",
-      "kb/publish-workflow"
-    ],
     "approvalRequired": false,
     "parameters": [
       {
@@ -12066,13 +14881,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/kb-articles/{id}/content",
     "displayName": "Get KB article content",
     "summary": "Get KB article content",
-    "description": "Get the body content of a KB article as readable markdown text. Use this to read what an article currently says. Always call this before answering questions about article content — do not rely on article metadata alone.",
+    "description": "Get the body content of a KB article as readable markdown text. Use this to read what an article currently says.",
     "tags": [
       "Knowledge Base"
-    ],
-    "playbooks": [
-      "kb/search-and-read",
-      "kb/find-relevant-articles"
     ],
     "approvalRequired": false,
     "parameters": [
@@ -12154,9 +14965,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       }
     },
-    "playbooks": [
-      "kb/update-article-content"
-    ],
     "examples": [
       {
         "name": "Update content with markdown",
@@ -12165,18 +14973,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "content": "# Updated Article\n\nNew content goes here.",
             "format": "markdown"
           }
-        },
-        "notes": "Always use format 'markdown' for AI-generated content. Read the existing content first with GET /api/v1/kb-articles/{id}/content to preserve any sections that should remain."
-      },
-      {
-        "name": "Append a troubleshooting section",
-        "request": {
-          "body": {
-            "content": "# Problem\n\nUsers cannot log in after password reset.\n\n# Root Cause\n\nBrowser cached old session cookies.\n\n# Resolution\n\n1. Clear browser cookies for the application domain\n2. Close all browser tabs\n3. Open a new browser window and sign in",
-            "format": "markdown"
-          }
-        },
-        "notes": "When writing troubleshooting articles, structure with Problem, Root Cause, and Resolution sections."
+        }
       }
     ]
   },
@@ -12264,13 +15061,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/kb-articles/from-ticket/{ticketId}",
     "displayName": "Create KB article from ticket",
     "summary": "Create KB article from ticket",
-    "description": "Create a KB article pre-populated from a ticket's title, description, and resolution. Useful for turning resolved tickets into knowledge base documentation. The created article will be a 'troubleshooting' type in 'draft' status — review and publish after creation.",
+    "description": "Create a KB article pre-populated from a ticket's title, description, and resolution. Useful for turning resolved tickets into knowledge base documentation.",
     "tags": [
       "Knowledge Base"
-    ],
-    "playbooks": [
-      "kb/create-from-resolution",
-      "kb/capture-ticket-knowledge"
     ],
     "approvalRequired": false,
     "parameters": [

--- a/ee/server/src/chat/registry/apiRegistry.indexer.ts
+++ b/ee/server/src/chat/registry/apiRegistry.indexer.ts
@@ -19,6 +19,10 @@ function computeScore(entry: ChatApiRegistryEntry, query: string) {
     { key: 'description', value: entry.description },
     { key: 'tags', value: entry.tags.join(' ') },
     { key: 'path', value: entry.path },
+    {
+      key: 'parameters',
+      value: entry.parameters.map((param) => `${param.name} ${param.in} ${param.description ?? ''}`).join(' '),
+    },
   ];
 
   let score = 0;
@@ -37,10 +41,15 @@ function computeScore(entry: ChatApiRegistryEntry, query: string) {
 }
 
 export function searchRegistry(query: string, limit = 5): RegistrySearchResult[] {
+  const normalized = query.trim().toLowerCase();
+  const mentionsIdLookup = /\b(by id|id|details?|detail|single)\b/.test(normalized);
+
   const results = chatApiRegistry
     .map((entry) => {
       const { score, fields } = computeScore(entry, query);
-      return { entry, score, matchedFields: fields };
+      const hasPathId = entry.parameters.some((param) => param.in === 'path' && param.name === 'id');
+      const boostedScore = score + (mentionsIdLookup && hasPathId ? 3 : 0);
+      return { entry, score: boostedScore, matchedFields: fields };
     })
     .filter((result) => result.score > 0)
     .sort((a, b) => b.score - a.score)

--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -309,6 +309,7 @@ export const Chat: React.FC<ChatProps> = ({
   const [functionError, setFunctionError] = useState<string | null>(null);
   const [autoApprovedMethods, setAutoApprovedMethods] = useState<string[]>([]);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const chatScrollRef = useRef<HTMLDivElement | null>(null);
   const [showValidationDialog, setShowValidationDialog] = useState(false);
   const [validationMessage, setValidationMessage] = useState('');
   const autoSendRef = useRef(false);
@@ -319,11 +320,32 @@ export const Chat: React.FC<ChatProps> = ({
   const streamingTextRef = useRef<string | null>(null);
   const generationIdRef = useRef<number>(0);
   const pendingAssistantMessageIdRef = useRef<string | null>(null);
+  const shouldAutoScrollRef = useRef(true);
+
+  const SCROLL_BOTTOM_THRESHOLD_PX = 40;
 
   const resolveMessageId = (candidate?: string | null) =>
     candidate ?? (typeof crypto !== 'undefined' && 'randomUUID' in crypto
       ? crypto.randomUUID()
       : `msg-${Date.now()}-${Math.random()}`);
+
+  const isNearBottom = useCallback((container: HTMLDivElement) => {
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    return distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD_PX;
+  }, []);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
+    const container = chatScrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior,
+    });
+  }, []);
 
   const appendFunctionCallMarker = (
     fn: PendingFunctionState | null,
@@ -448,6 +470,15 @@ export const Chat: React.FC<ChatProps> = ({
       setPendingFunctionAction('none');
     }
   }, [pendingFunction]);
+
+  useEffect(() => {
+    const container = chatScrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    shouldAutoScrollRef.current = isNearBottom(container);
+  }, [isNearBottom]);
 
   const closeValidationDialog = useCallback(() => {
     setShowValidationDialog(false);
@@ -1038,6 +1069,27 @@ export const Chat: React.FC<ChatProps> = ({
     fullMessage.trim().length > 0;
 
   useEffect(() => {
+    if (!shouldAutoScrollRef.current) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      if (!shouldAutoScrollRef.current) {
+        return;
+      }
+      scrollToBottom();
+    });
+  }, [
+    displayMessages.length,
+    incomingMessage,
+    pendingFunction,
+    functionError,
+    fullMessage,
+    fullReasoning,
+    scrollToBottom,
+  ]);
+
+  useEffect(() => {
     onHasMessagesChange?.(hasVisibleMessages);
   }, [hasVisibleMessages, onHasMessagesChange]);
 
@@ -1244,6 +1296,15 @@ export const Chat: React.FC<ChatProps> = ({
     !generatingResponse && !isFunction && !isExecutingFunction && !pendingFunction;
   const canStop = generatingResponse || isExecutingFunction;
 
+  const handleChatScroll = useCallback(() => {
+    const container = chatScrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    shouldAutoScrollRef.current = isNearBottom(container);
+  }, [isNearBottom]);
+
   useEffect(() => {
     onInterruptibleStateChange?.(canStop);
   }, [canStop, onInterruptibleStateChange]);
@@ -1405,7 +1466,11 @@ export const Chat: React.FC<ChatProps> = ({
 
   return (
     <div className="chat-container">
-      <div className="chats">
+      <div
+        ref={chatScrollRef}
+        className="chats"
+        onScroll={handleChatScroll}
+      >
         <div className="mb-auto w-full">
           {!displayMessages.length && !incomingMessage ? (
             <div className="m-auto justify-center flex items-center text-center" style={{ minHeight: '300px' }}>
@@ -1458,123 +1523,122 @@ export const Chat: React.FC<ChatProps> = ({
                   showStreamingCursor={generatingResponse && !isFunction}
                 />
               )}
+              {pendingFunction && (
+                <div className="function-approval-wrapper">
+                  <Image
+                    className="chat-img"
+                    src="/avatar-purple-no-shadow.svg"
+                    alt="Alga"
+                    width={18}
+                    height={18}
+                  />
+                  <div className="function-approval-bubble">
+                    <div className="function-approval-header">
+                      <span className="function-approval-badge">{method}</span>
+                      <span className="function-approval-endpoint">{endpointLabel}</span>
+                    </div>
+                    <h3 className="function-approval-title">
+                      {pendingFunction.metadata.displayName}
+                    </h3>
+                    {pendingFunction.metadata.description && (
+                      <p className="function-approval-description">
+                        {pendingFunction.metadata.description}
+                      </p>
+                    )}
+                    {previewText && (
+                      <p className="function-approval-preview">{previewText}</p>
+                    )}
+                    {assistantPlanText ? (
+                      <details className="function-approval-reasoning">
+                        <summary>View assistant plan</summary>
+                        {assistantPlanItems.length ? (
+                          <ol className="function-approval-plan">
+                            {assistantPlanItems.map((item) => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ol>
+                        ) : (
+                          <p>{assistantPlanText}</p>
+                        )}
+                      </details>
+                    ) : null}
+                    {pendingFunction.metadata.playbooks?.length ? (
+                      <div className="function-approval-playbooks">
+                        <span className="function-arg-key">Playbooks</span>
+                        <span className="function-arg-value">
+                          {pendingFunction.metadata.playbooks.join(', ')}
+                        </span>
+                      </div>
+                    ) : null}
+                    {pendingArgumentEntries.length > 0 && (
+                      <div className="function-approval-arguments">
+                        <h4>Parameters</h4>
+                        <ul className="function-arg-list">
+                          {pendingArgumentEntries.map(([key, value]) => (
+                            <li key={key} className="function-arg-item">
+                              <span className="function-arg-key">{formatArgumentKey(key)}</span>
+                              <span className="function-arg-value">{renderArgumentValue(value)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {functionError && (
+                      <div className="function-approval-error">{functionError}</div>
+                    )}
+                    {isHttpMethod && normalizedMethod && autoApprovalCheckboxId ? (
+                      <div className="function-approval-preferences">
+                        <div className="function-approval-preference-toggle">
+                          <Switch
+                            id={autoApprovalCheckboxId}
+                            checked={autoApprovalEnabledForMethod}
+                            onCheckedChange={(checked) =>
+                              handleAutoApprovePreferenceChange(normalizedMethod, checked)
+                            }
+                            label={`Auto-approve future ${normalizedMethod} requests`}
+                          />
+                        </div>
+                        <p className="function-approval-preferences-help">
+                          {autoApprovalEnabledForMethod
+                            ? 'Future requests with this method will run automatically.'
+                            : 'Enable to approve this HTTP method without prompts.'}
+                        </p>
+                      </div>
+                    ) : null}
+                    <div className="function-approval-status">{statusText}</div>
+                    <div className="function-approval-actions">
+                      <Button
+                        id="chat-approve-function"
+                        label="Approve function call"
+                        size="sm"
+                        variant="default"
+                        onClick={() => handleFunctionAction('approve')}
+                        disabled={isExecutingFunction}
+                      >
+                        {isExecutingFunction && pendingFunctionAction === 'approve'
+                          ? 'Approving…'
+                          : 'Approve'}
+                      </Button>
+                      <Button
+                        id="chat-decline-function"
+                        label="Decline function call"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleFunctionAction('decline')}
+                        disabled={isExecutingFunction}
+                      >
+                        {isExecutingFunction && pendingFunctionAction === 'decline'
+                          ? 'Processing…'
+                          : 'Deny'}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>
       </div>
-
-      {pendingFunction && (
-        <div className="function-approval-wrapper">
-          <Image
-            className="chat-img"
-            src="/avatar-purple-no-shadow.svg"
-            alt="Alga"
-            width={18}
-            height={18}
-          />
-          <div className="function-approval-bubble">
-            <div className="function-approval-header">
-              <span className="function-approval-badge">{method}</span>
-              <span className="function-approval-endpoint">{endpointLabel}</span>
-            </div>
-            <h3 className="function-approval-title">
-              {pendingFunction.metadata.displayName}
-            </h3>
-            {pendingFunction.metadata.description && (
-              <p className="function-approval-description">
-                {pendingFunction.metadata.description}
-              </p>
-            )}
-            {previewText && (
-              <p className="function-approval-preview">{previewText}</p>
-            )}
-            {assistantPlanText ? (
-              <details className="function-approval-reasoning">
-                <summary>View assistant plan</summary>
-                {assistantPlanItems.length ? (
-                  <ol className="function-approval-plan">
-                    {assistantPlanItems.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ol>
-                ) : (
-                  <p>{assistantPlanText}</p>
-                )}
-              </details>
-            ) : null}
-            {pendingFunction.metadata.playbooks?.length ? (
-              <div className="function-approval-playbooks">
-                <span className="function-arg-key">Playbooks</span>
-                <span className="function-arg-value">
-                  {pendingFunction.metadata.playbooks.join(', ')}
-                </span>
-              </div>
-            ) : null}
-            {pendingArgumentEntries.length > 0 && (
-              <div className="function-approval-arguments">
-                <h4>Parameters</h4>
-                <ul className="function-arg-list">
-                  {pendingArgumentEntries.map(([key, value]) => (
-                    <li key={key} className="function-arg-item">
-                      <span className="function-arg-key">{formatArgumentKey(key)}</span>
-                      <span className="function-arg-value">{renderArgumentValue(value)}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {functionError && (
-              <div className="function-approval-error">{functionError}</div>
-            )}
-            {isHttpMethod && normalizedMethod && autoApprovalCheckboxId ? (
-              <div className="function-approval-preferences">
-                <div className="function-approval-preference-toggle">
-                  <Switch
-                    id={autoApprovalCheckboxId}
-                    checked={autoApprovalEnabledForMethod}
-                    onCheckedChange={(checked) =>
-                      handleAutoApprovePreferenceChange(normalizedMethod, checked)
-                    }
-                    label={`Auto-approve future ${normalizedMethod} requests`}
-                  />
-                </div>
-                <p className="function-approval-preferences-help">
-                  {autoApprovalEnabledForMethod
-                    ? 'Future requests with this method will run automatically.'
-                    : 'Enable to approve this HTTP method without prompts.'}
-                </p>
-              </div>
-            ) : null}
-            <div className="function-approval-status">{statusText}</div>
-            <div className="function-approval-actions">
-              <Button
-                id="chat-approve-function"
-                label="Approve function call"
-                size="sm"
-                variant="default"
-                onClick={() => handleFunctionAction('approve')}
-                disabled={isExecutingFunction}
-              >
-                {isExecutingFunction && pendingFunctionAction === 'approve'
-                  ? 'Approving…'
-                  : 'Approve'}
-              </Button>
-              <Button
-                id="chat-decline-function"
-                label="Decline function call"
-                size="sm"
-                variant="outline"
-                onClick={() => handleFunctionAction('decline')}
-                disabled={isExecutingFunction}
-              >
-                {isExecutingFunction && pendingFunctionAction === 'decline'
-                  ? 'Processing…'
-                  : 'Deny'}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
 
       <footer className="chat-footer">
         <div className="chat-footer__inner">

--- a/ee/server/src/components/chat/chat.css
+++ b/ee/server/src/components/chat/chat.css
@@ -201,7 +201,8 @@
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
-  margin: 1rem 1.5rem;
+  width: 100%;
+  margin: 0;
   padding: 1rem;
   border-radius: 0.5rem;
   border: 1px solid rgb(var(--color-border-200));

--- a/ee/server/src/services/chatCompletionsService.ts
+++ b/ee/server/src/services/chatCompletionsService.ts
@@ -620,7 +620,8 @@ export class ChatCompletionsService {
             properties: {
               query: {
                 type: 'string',
-                description: 'Natural language description of what you want to do (e.g., "list active service categories").',
+                description:
+                  'Natural language description of what you want to do (e.g., "list active service categories" or "get ticket by id").',
               },
               limit: {
                 type: isVertex ? 'number' : 'integer',
@@ -636,7 +637,7 @@ export class ChatCompletionsService {
         function: {
           name: EXECUTE_TOOL_NAME,
           description:
-            'Invoke a documented API endpoint by its registry identifier. Include any path, query, header, or body parameters required by that endpoint.',
+            'Invoke a documented API endpoint by its registry identifier. Include any path, query, header, or body parameters required by that endpoint. Prefer narrow list calls with limit/fields, then use detail endpoints when you have an ID. For large text fields, request byte windows with query parameters such as field_ranges[comment_text]=0-4095.',
           parameters: {
             type: 'object',
             properties: {
@@ -747,35 +748,47 @@ export class ChatCompletionsService {
     const limit = Math.max(1, Math.min(typeof limitValue === 'number' ? limitValue : parseInt(String(limitValue ?? ''), 10) || 5, 25));
     const terms = text.toLowerCase().split(/\s+/).filter(Boolean);
     const registry = getRegistry();
+    const mentionsIdLookup = /\b(by id|id|details?|detail|single)\b/.test(text);
+    const mentionsList = /\b(list|search|find|all|recent|latest)\b/.test(text);
 
     const scored = registry
       .map((entry, index) => {
         const haystack = [
           entry.displayName,
+          entry.summary,
           entry.description,
           entry.path,
           entry.tags?.join(' '),
           entry.id,
+          entry.parameters?.map((param) => `${param.name} ${param.in}`).join(' '),
         ]
           .join(' ')
           .toLowerCase();
+        const hasPathId = entry.parameters?.some((param) => param.in === 'path' && param.name === 'id') ?? false;
+        const isGetById = entry.method === 'get' && /\{id\}/.test(entry.path);
+        const isListEndpoint = entry.method === 'get' && !/\{[^}]+\}/.test(entry.path);
         const score =
           terms.reduce((acc, term) => (haystack.includes(term) ? acc + 2 : acc), 0) +
+          (mentionsIdLookup && hasPathId ? 8 : 0) +
+          (mentionsIdLookup && isGetById ? 6 : 0) +
+          (mentionsList && isListEndpoint ? 4 : 0) +
           (entry.playbooks?.length ?? 0) +
           Math.max(0, 3 - index * 0.1);
         return { entry, score };
       })
       .sort((a, b) => b.score - a.score);
 
-    const top = scored.slice(0, limit).map(({ entry }) => ({
-      id: entry.id,
-      displayName: entry.displayName,
-      description: entry.description,
-      method: entry.method.toUpperCase(),
-      path: entry.path,
-      approvalRequired: entry.approvalRequired,
-      tags: entry.tags ?? [],
-    }));
+      const top = scored.slice(0, limit).map(({ entry }) => ({
+        id: entry.id,
+        displayName: entry.displayName,
+        description: entry.description,
+        method: entry.method.toUpperCase(),
+        path: entry.path,
+        approvalRequired: entry.approvalRequired,
+        tags: entry.tags ?? [],
+        parameters: entry.parameters ?? [],
+        examples: entry.examples?.slice(0, 1) ?? [],
+      }));
 
     return top;
   }
@@ -1418,6 +1431,9 @@ export class ChatCompletionsService {
         'Always consult the enterprise API registry before executing actions so you understand every required parameter. ' +
         'When the registry or endpoint descriptions mention prerequisite data (such as IDs for boards, clients, categories, priorities, or other related resources), proactively call the appropriate lookup endpoints to gather that information instead of asking the user. ' +
         'For ticket-creation calls, first use search_api_registry to locate the list endpoints you need, gather current data (e.g. call GET /api/v1/tickets to sample board_id/status_id/priority_id combinations and GET /api/v1/clients to confirm client_id), and do not proceed until you have concrete UUIDs for board_id, client_id, status_id, and priority_id collected from prior API responses. When sampling GET /api/v1/tickets, pick the first record with non-null board_id, status_id, and priority_id and reuse those UUIDs unless the user specifies different values. ' +
+        'Never invent field names for a fields query parameter. Only send fields values that are explicitly documented in the registry description, parameters, or examples for that exact endpoint. If the registry does not enumerate exact field names, omit fields entirely. For GET /api/v1/tickets specifically, the only valid fields values are ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, and mobile_list. Do not use aliases like id, subject, status, priority, client, created_at, or description. ' +
+        'When you only need discovery data, prefer list endpoints with small limits and explicit fields instead of full payloads. Once you have a resource ID, prefer the detail endpoint over repeatedly expanding list responses. ' +
+        'Some GET endpoints support field-scoped range retrieval for large text fields. When an endpoint description mentions field_ranges support or a response meta.truncated_fields map indicates truncation, continue fetching with query parameters like field_ranges[comment_text]=0-4095 or field=description_html&range=4096-8191. Treat those ranges as UTF-8 byte windows and use the returned meta.truncated_fields metadata to continue from the correct byte offsets. ' +
         'Clearly explain the plan before each tool call, execute the necessary lookup calls to satisfy all requirements, then call the target endpoint once the inputs are ready. ' +
         'Use the documented request schemas exactly as written—populate *_id fields with the UUIDs you retrieved (never human-friendly names), and skip optional fields when you do not have authoritative values. ' +
         'Never include properties that are not defined for the selected endpoint; if the user mentions data that cannot be expressed with the documented schema (for example a project name when the ticket create payload does not accept project_id), acknowledge it in the natural-language response but leave it out of the API request. ' +

--- a/server/src/lib/api/controllers/ApiBaseController.ts
+++ b/server/src/lib/api/controllers/ApiBaseController.ts
@@ -234,7 +234,8 @@ export abstract class ApiBaseController {
             result.total,
             page,
             limit,
-            { sort, order, filters }
+            { sort, order, filters },
+            apiRequest,
           );
         });
       } catch (error) {
@@ -264,7 +265,7 @@ export abstract class ApiBaseController {
             throw new NotFoundError(`${this.options.resource} not found`);
           }
           
-          return createSuccessResponse(resource);
+          return createSuccessResponse(resource, 200, undefined, apiRequest);
         });
       } catch (error) {
         return handleApiError(error);

--- a/server/src/lib/api/controllers/ApiTicketController.ts
+++ b/server/src/lib/api/controllers/ApiTicketController.ts
@@ -304,7 +304,7 @@ export class ApiTicketController extends ApiBaseController {
             { limit, offset, order }
           );
 
-          return createSuccessResponse(comments);
+          return createSuccessResponse(comments, 200, undefined, apiRequest);
         });
       } catch (error) {
         return handleApiError(error);
@@ -326,7 +326,7 @@ export class ApiTicketController extends ApiBaseController {
           const ticketId = await this.extractIdFromPath(apiRequest);
           const documents = await this.ticketService.getTicketDocuments(ticketId, apiRequest.context!);
 
-          return createSuccessResponse(documents);
+          return createSuccessResponse(documents, 200, undefined, apiRequest);
         });
       } catch (error) {
         return handleApiError(error);

--- a/server/src/lib/api/middleware/apiMiddleware.ts
+++ b/server/src/lib/api/middleware/apiMiddleware.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { applyFieldRangeRequests } from '../utils/fieldRange';
 import { ZodSchema, ZodError } from 'zod';
 import { ApiKeyService } from '../../services/apiKeyService';
 import { hasPermission } from '../../auth/rbac';
@@ -363,16 +364,27 @@ export function handleApiError(error: any): NextResponse {
 /**
  * Success response helper
  */
-export function createSuccessResponse(data: any, status: number = 200, metadata?: any): NextResponse {
+export function createSuccessResponse(
+  data: any,
+  status: number = 200,
+  metadata?: any,
+  request?: NextRequest | URL | string,
+): NextResponse {
   // For 204 No Content, return empty response
   if (status === 204) {
     return new NextResponse(null, { status: 204 });
   }
 
-  const response: any = { data };
+  const ranged = applyFieldRangeRequests(data, request);
+  const response: any = { data: ranged.data };
+  const mergedMetadata = metadata ? { ...metadata } : undefined;
 
-  if (metadata) {
-    response.meta = metadata;
+  if (ranged.truncatedFields) {
+    const nextMeta = mergedMetadata ?? {};
+    nextMeta.truncated_fields = ranged.truncatedFields;
+    response.meta = nextMeta;
+  } else if (mergedMetadata) {
+    response.meta = mergedMetadata;
   }
 
   const headers: HeadersInit = {
@@ -399,9 +411,20 @@ export function createPaginatedResponse(
   total: number,
   page: number,
   limit: number,
-  metadata?: any
+  metadata?: any,
+  request?: NextRequest | URL | string,
 ): NextResponse {
   const totalPages = Math.ceil(total / limit);
+  const ranged = applyFieldRangeRequests(data, request);
+  const mergedMetadata = metadata ? { ...metadata } : undefined;
+
+  if (ranged.truncatedFields) {
+    const nextMeta = mergedMetadata ?? {};
+    nextMeta.truncated_fields = ranged.truncatedFields;
+    metadata = nextMeta;
+  } else {
+    metadata = mergedMetadata;
+  }
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json'
@@ -417,7 +440,7 @@ export function createPaginatedResponse(
   }
 
   return NextResponse.json({
-    data,
+    data: ranged.data,
     pagination: {
       page,
       limit,

--- a/server/src/lib/api/utils/fieldRange.ts
+++ b/server/src/lib/api/utils/fieldRange.ts
@@ -1,0 +1,288 @@
+import { NextRequest } from 'next/server';
+
+export interface FieldRangeRequest {
+  selector: string;
+  start: number;
+  end: number;
+}
+
+export interface TruncatedFieldMetadata {
+  selector: string;
+  total_bytes: number;
+  returned_bytes: number;
+  requested_range_start: number;
+  requested_range_end: number;
+  actual_range_start: number;
+  actual_range_end: number | null;
+  truncated: boolean;
+  has_more: boolean;
+  encoding: 'utf-8';
+}
+
+interface ApplyFieldRangeResult<T> {
+  data: T;
+  truncatedFields?: Record<string, TruncatedFieldMetadata>;
+}
+
+const FIELD_RANGES_PARAM = /^field_ranges\[(.+)\]$/;
+const BYTE_RANGE_PATTERN = /^(\d+)-(\d+)$/;
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+function parseRangeSpec(range: string): { start: number; end: number } | null {
+  const match = BYTE_RANGE_PATTERN.exec(range.trim());
+  if (!match) {
+    return null;
+  }
+
+  const start = Number.parseInt(match[1] ?? '', 10);
+  const end = Number.parseInt(match[2] ?? '', 10);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start) {
+    return null;
+  }
+
+  return { start, end };
+}
+
+function readSearchParams(source?: NextRequest | URL | string): URLSearchParams | null {
+  if (!source) {
+    return null;
+  }
+
+  if (source instanceof NextRequest) {
+    return source.nextUrl.searchParams;
+  }
+
+  if (source instanceof URL) {
+    return source.searchParams;
+  }
+
+  try {
+    return new URL(source).searchParams;
+  } catch {
+    return null;
+  }
+}
+
+export function parseFieldRangeRequests(
+  source?: NextRequest | URL | string,
+): FieldRangeRequest[] {
+  const searchParams = readSearchParams(source);
+  if (!searchParams) {
+    return [];
+  }
+
+  const requests = new Map<string, FieldRangeRequest>();
+
+  for (const [key, value] of searchParams.entries()) {
+    const range = parseRangeSpec(value);
+    if (!range) {
+      continue;
+    }
+
+    const bracketMatch = FIELD_RANGES_PARAM.exec(key);
+    if (!bracketMatch) {
+      continue;
+    }
+
+    const selector = (bracketMatch[1] ?? '').trim();
+    if (!selector) {
+      continue;
+    }
+
+    requests.set(selector, { selector, ...range });
+  }
+
+  const selector = searchParams.get('field')?.trim();
+  const rangeValue = searchParams.get('range');
+  if (selector && rangeValue) {
+    const range = parseRangeSpec(rangeValue);
+    if (range) {
+      requests.set(selector, { selector, ...range });
+    }
+  }
+
+  return Array.from(requests.values());
+}
+
+function cloneContainer<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return [...value] as T;
+  }
+
+  if (value && typeof value === 'object') {
+    return { ...(value as Record<string, unknown>) } as T;
+  }
+
+  return value;
+}
+
+function selectorMatches(selector: string, pathSegments: string[]): boolean {
+  const normalizedPath = pathSegments.filter((segment) => !/^\d+$/.test(segment));
+  if (normalizedPath.length === 0) {
+    return false;
+  }
+
+  const selectorSegments = selector
+    .split('.')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (selectorSegments.length === 0) {
+    return false;
+  }
+
+  if (selectorSegments.length === 1) {
+    return normalizedPath[normalizedPath.length - 1] === selectorSegments[0];
+  }
+
+  if (selectorSegments.length > normalizedPath.length) {
+    return false;
+  }
+
+  const startIndex = normalizedPath.length - selectorSegments.length;
+  return selectorSegments.every((segment, index) => normalizedPath[startIndex + index] === segment);
+}
+
+function toResponsePath(pathSegments: string[]): string {
+  if (pathSegments.length === 0) {
+    return 'data';
+  }
+
+  let rendered = 'data';
+  for (const segment of pathSegments) {
+    rendered += /^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`;
+  }
+  return rendered;
+}
+
+function decodeRange(buffer: Buffer, start: number, endInclusive: number): {
+  text: string;
+  actualStart: number;
+  actualEnd: number | null;
+} {
+  if (buffer.length === 0 || start >= buffer.length) {
+    return { text: '', actualStart: Math.min(start, buffer.length), actualEnd: null };
+  }
+
+  const clampedStart = Math.max(0, start);
+  const clampedEndExclusive = Math.min(buffer.length, endInclusive + 1);
+  if (clampedEndExclusive <= clampedStart) {
+    return { text: '', actualStart: clampedStart, actualEnd: null };
+  }
+
+  for (let startOffset = 0; startOffset < 4 && clampedStart + startOffset < clampedEndExclusive; startOffset += 1) {
+    const candidateStart = clampedStart + startOffset;
+    for (let endOffset = 0; endOffset < 4 && clampedEndExclusive - endOffset > candidateStart; endOffset += 1) {
+      const candidateEndExclusive = clampedEndExclusive - endOffset;
+      try {
+        const text = utf8Decoder.decode(buffer.subarray(candidateStart, candidateEndExclusive));
+        return {
+          text,
+          actualStart: candidateStart,
+          actualEnd: candidateEndExclusive - 1,
+        };
+      } catch {
+        // Try a narrower byte window until we land on valid UTF-8 boundaries.
+      }
+    }
+  }
+
+  return { text: '', actualStart: clampedStart, actualEnd: null };
+}
+
+function truncateString(
+  value: string,
+  request: FieldRangeRequest,
+): { value: string; metadata: TruncatedFieldMetadata } {
+  const buffer = Buffer.from(value, 'utf8');
+  const totalBytes = buffer.length;
+  const decoded = decodeRange(buffer, request.start, request.end);
+  const returnedBytes = Buffer.byteLength(decoded.text, 'utf8');
+  const truncated =
+    totalBytes > returnedBytes ||
+    decoded.actualStart !== 0 ||
+    (decoded.actualEnd ?? -1) < totalBytes - 1;
+
+  return {
+    value: decoded.text,
+    metadata: {
+      selector: request.selector,
+      total_bytes: totalBytes,
+      returned_bytes: returnedBytes,
+      requested_range_start: request.start,
+      requested_range_end: request.end,
+      actual_range_start: decoded.actualStart,
+      actual_range_end: decoded.actualEnd,
+      truncated,
+      has_more: totalBytes > 0 && ((decoded.actualEnd ?? -1) < totalBytes - 1),
+      encoding: 'utf-8',
+    },
+  };
+}
+
+function applyRequestsRecursively(
+  value: unknown,
+  requests: FieldRangeRequest[],
+  pathSegments: string[],
+  truncatedFields: Record<string, TruncatedFieldMetadata>,
+): unknown {
+  if (typeof value === 'string') {
+    const matchingRequest = requests.find((request) => selectorMatches(request.selector, pathSegments));
+    if (!matchingRequest) {
+      return value;
+    }
+
+    const truncated = truncateString(value, matchingRequest);
+    truncatedFields[toResponsePath(pathSegments)] = truncated.metadata;
+    return truncated.value;
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item, index) => {
+      const updated = applyRequestsRecursively(item, requests, [...pathSegments, String(index)], truncatedFields);
+      if (!Object.is(updated, item)) {
+        changed = true;
+      }
+      return updated;
+    });
+    return changed ? next : value;
+  }
+
+  if (value && typeof value === 'object') {
+    let changed = false;
+    const clone = cloneContainer(value as Record<string, unknown>);
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      const updated = applyRequestsRecursively(child, requests, [...pathSegments, key], truncatedFields);
+      if (!Object.is(updated, child)) {
+        changed = true;
+        (clone as Record<string, unknown>)[key] = updated;
+      }
+    }
+    return changed ? clone : value;
+  }
+
+  return value;
+}
+
+export function applyFieldRangeRequests<T>(
+  data: T,
+  source?: NextRequest | URL | string,
+): ApplyFieldRangeResult<T> {
+  const requests = parseFieldRangeRequests(source);
+  if (requests.length === 0) {
+    return { data };
+  }
+
+  const truncatedFields: Record<string, TruncatedFieldMetadata> = {};
+  const nextData = applyRequestsRecursively(data, requests, [], truncatedFields) as T;
+
+  if (Object.keys(truncatedFields).length === 0) {
+    return { data: nextData };
+  }
+
+  return {
+    data: nextData,
+    truncatedFields,
+  };
+}


### PR DESCRIPTION
## Summary
- add field-scoped response range support and truncated-field metadata for API responses used by AI flows
- improve generated API registry metadata and model guidance for ticket list/detail endpoints and exact field usage
- keep chat auto-scrolling during streamed assistant and reasoning output plus function approval cards unless the user scrolls away from the bottom

## Testing
- not run
