### PR TITLE
Fix client-owned contracts migration FK for Citus

### DIFF
--- a/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
+++ b/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
@@ -404,7 +404,7 @@ exports.up = async function up(knex) {
           tenant: row.tenant,
           contract_id: row.contract_id,
         })
-        .andWhereNull('owner_client_id')
+        .whereNull('owner_client_id')
         .update({
           owner_client_id: row.owner_client_id,
           updated_at: knex.fn.now(),

--- a/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
+++ b/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
@@ -5,7 +5,8 @@ const {
   buildSharedContractClonePlan,
 } = require('./utils/client_owned_contracts_simplification.cjs');
 
-const CONTRACT_OWNER_FK = 'contracts_owner_client_fkey';
+const CONTRACT_OWNER_FK = 'contracts_owner_client_id_fkey';
+const LEGACY_CONTRACT_OWNER_FK = 'contracts_owner_client_fkey';
 const CONTRACT_OWNER_INDEX = 'idx_contracts_tenant_owner_client_id';
 
 const ensureSequentialMode = async (knex) => {
@@ -60,13 +61,16 @@ const ensureOwnerClientColumn = async (knex) => {
     `CREATE INDEX IF NOT EXISTS ${CONTRACT_OWNER_INDEX} ON contracts(tenant, owner_client_id)`
   );
 
-  if (!await hasConstraint(knex, CONTRACT_OWNER_FK)) {
+  const hasOwnerClientConstraint =
+    await hasConstraint(knex, CONTRACT_OWNER_FK) ||
+    await hasConstraint(knex, LEGACY_CONTRACT_OWNER_FK);
+
+  if (!hasOwnerClientConstraint) {
     await knex.raw(`
       ALTER TABLE contracts
       ADD CONSTRAINT ${CONTRACT_OWNER_FK}
       FOREIGN KEY (tenant, owner_client_id)
       REFERENCES clients (tenant, client_id)
-      ON DELETE SET NULL
     `);
   }
 };

--- a/server/migrations/utils/client_owned_contracts_simplification.cjs
+++ b/server/migrations/utils/client_owned_contracts_simplification.cjs
@@ -179,10 +179,6 @@ function buildSharedContractClonePlan(params, options = {}) {
         ...row,
         contract_id: newContractId,
         contract_line_id: newLineId,
-        cadence_owner:
-          typeof row.cadence_owner === 'string' && row.cadence_owner.length > 0
-            ? row.cadence_owner
-            : 'client',
       };
     });
 


### PR DESCRIPTION
## Summary
- stop the migration from creating a Citus-incompatible composite FK with `ON DELETE SET NULL`
- reuse the canonical owner-client FK name from the prior migration
- treat the legacy and canonical FK names as equivalent so the migration does not create a duplicate constraint

## Testing
- node -c server/migrations/20260316121000_client_owned_contracts_simplification.cjs