### PR TITLE
Fix Citus compatibility in client-owned contract migrations

### DIFF
--- a/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
+++ b/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
@@ -66,7 +66,6 @@ const ensureOwnerClientColumn = async (knex) => {
       ADD CONSTRAINT ${CONTRACT_OWNER_FK}
       FOREIGN KEY (tenant, owner_client_id)
       REFERENCES clients (tenant, client_id)
-      ON DELETE SET NULL
     `);
   }
 };

--- a/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
+++ b/server/migrations/20260316121000_client_owned_contracts_simplification.cjs
@@ -399,7 +399,7 @@ exports.up = async function up(knex) {
           tenant: row.tenant,
           contract_id: row.contract_id,
         })
-        .andWhereNull('owner_client_id')
+        .whereNull('owner_client_id')
         .update({
           owner_client_id: row.owner_client_id,
           updated_at: knex.fn.now(),

--- a/server/migrations/20260321110000_create_service_catalog_mode_defaults.cjs
+++ b/server/migrations/20260321110000_create_service_catalog_mode_defaults.cjs
@@ -9,9 +9,32 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
+async function distributeIfCitus(knex, tableName) {
+  const citusFn = await knex.raw(`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_proc WHERE proname = 'create_distributed_table'
+    ) AS exists;
+  `);
+
+  if (citusFn.rows?.[0]?.exists) {
+    const alreadyDistributed = await knex.raw(`
+      SELECT EXISTS (
+        SELECT 1 FROM pg_dist_partition
+        WHERE logicalrelid = '${tableName}'::regclass
+      ) AS is_distributed;
+    `);
+
+    if (!alreadyDistributed.rows?.[0]?.is_distributed) {
+      await knex.raw(`SELECT create_distributed_table('${tableName}', 'tenant')`);
+    }
+  } else {
+    console.warn(`[${tableName}] Skipping create_distributed_table (function unavailable)`);
+  }
+}
+
 exports.up = async function up(knex) {
   await knex.schema.createTable('service_catalog_mode_defaults', (table) => {
-    table.uuid('default_id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('default_id').notNullable().defaultTo(knex.raw('gen_random_uuid()'));
     table.uuid('tenant').notNullable().references('tenant').inTable('tenants').onDelete('CASCADE');
     table.uuid('service_id').notNullable();
     table.text('billing_mode').notNullable();
@@ -20,6 +43,7 @@ exports.up = async function up(knex) {
     table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
     table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
 
+    table.primary(['tenant', 'default_id']);
     table.foreign(['tenant', 'service_id']).references(['tenant', 'service_id']).inTable('service_catalog').onDelete('CASCADE');
     table.unique(
       ['tenant', 'service_id', 'billing_mode', 'currency_code'],
@@ -27,6 +51,8 @@ exports.up = async function up(knex) {
     );
     table.index(['tenant', 'service_id'], 'service_catalog_mode_defaults_tenant_service_idx');
   });
+
+  await distributeIfCitus(knex, 'service_catalog_mode_defaults');
 
   await knex.raw(`
     ALTER TABLE service_catalog_mode_defaults
@@ -48,3 +74,5 @@ exports.up = async function up(knex) {
 exports.down = async function down(knex) {
   await knex.schema.dropTableIfExists('service_catalog_mode_defaults');
 };
+
+exports.config = { transaction: false };

--- a/server/migrations/20260321113000_backfill_service_catalog_mode_defaults.cjs
+++ b/server/migrations/20260321113000_backfill_service_catalog_mode_defaults.cjs
@@ -10,26 +10,41 @@
 
 const ALLOWED_BILLING_MODES = ['fixed', 'hourly', 'usage'];
 
+const normalizeBillingMode = (billingMethod) =>
+  billingMethod === 'per_unit' ? 'usage' : billingMethod;
+
+const chunk = (items, size) => {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 exports.up = async function up(knex) {
   const hasServiceCatalogCurrencyCode = await knex.schema.hasColumn('service_catalog', 'currency_code');
-  const serviceCatalogCurrencyExpression = hasServiceCatalogCurrencyCode
-    ? "COALESCE(sc.currency_code, 'USD')"
-    : "'USD'";
-
-  const normalizeBillingMode = knex.raw(
-    "CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END"
-  );
-
-  const invalidModeRows = await knex('service_catalog as sc')
+  const activeServices = await knex('service_catalog as sc')
     .where('sc.item_kind', 'service')
     .andWhere('sc.is_active', true)
-    .whereNotIn(normalizeBillingMode, ALLOWED_BILLING_MODES)
-    .select('sc.service_id', 'sc.billing_method')
-    .limit(25);
+    .select([
+      'sc.tenant',
+      'sc.service_id',
+      'sc.billing_method',
+      'sc.default_rate',
+      ...(hasServiceCatalogCurrencyCode ? ['sc.currency_code'] : []),
+    ]);
+
+  const invalidModeRows = activeServices
+    .filter((row) => !ALLOWED_BILLING_MODES.includes(normalizeBillingMode(row.billing_method)))
+    .slice(0, 25)
+    .map((row) => ({
+      service_id: row.service_id,
+      billing_method: row.billing_method,
+    }));
 
   if (invalidModeRows.length > 0) {
     throw new Error(
@@ -37,71 +52,95 @@ exports.up = async function up(knex) {
     );
   }
 
-  await knex.raw(`
-    INSERT INTO service_catalog_mode_defaults (tenant, service_id, billing_mode, currency_code, rate)
-    SELECT
-      sp.tenant,
-      sp.service_id,
-      CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END AS billing_mode,
-      sp.currency_code,
-      sp.rate
-    FROM service_prices sp
-    INNER JOIN service_catalog sc
-      ON sc.tenant = sp.tenant
-     AND sc.service_id = sp.service_id
-    WHERE sc.item_kind = 'service'
-      AND sc.is_active = true
-      AND sp.rate >= 0
-      AND CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END IN ('fixed', 'hourly', 'usage')
-    ON CONFLICT (tenant, service_id, billing_mode, currency_code) DO NOTHING
-  `);
+  const servicePrices = await knex('service_prices')
+    .select('tenant', 'service_id', 'currency_code', 'rate');
 
-  await knex.raw(`
-    INSERT INTO service_catalog_mode_defaults (tenant, service_id, billing_mode, currency_code, rate)
-    SELECT
-      sc.tenant,
-      sc.service_id,
-      CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END AS billing_mode,
-      ${serviceCatalogCurrencyExpression} AS currency_code,
-      sc.default_rate AS rate
-    FROM service_catalog sc
-    WHERE sc.item_kind = 'service'
-      AND sc.is_active = true
-      AND sc.default_rate IS NOT NULL
-      AND sc.default_rate >= 0
-      AND CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END IN ('fixed', 'hourly', 'usage')
-      AND NOT EXISTS (
-        SELECT 1
-        FROM service_prices sp
-        WHERE sp.tenant = sc.tenant
-          AND sp.service_id = sc.service_id
-      )
-    ON CONFLICT (tenant, service_id, billing_mode, currency_code) DO NOTHING
-  `);
+  const servicesByKey = new Map(
+    activeServices.map((row) => [`${row.tenant}:${row.service_id}`, row])
+  );
 
-  const missingRows = await knex
-    .select('sc.tenant', 'sc.service_id')
-    .from('service_catalog as sc')
-    .where('sc.item_kind', 'service')
-    .andWhere('sc.is_active', true)
-    .andWhere(function requiredSourceDefaults() {
-      this.whereExists(
-        knex('service_prices as sp')
-          .select(knex.raw('1'))
-          .whereRaw('sp.tenant = sc.tenant')
-          .andWhereRaw('sp.service_id = sc.service_id')
-      ).orWhereNotNull('sc.default_rate');
+  const servicePricesByKey = new Map();
+  for (const priceRow of servicePrices) {
+    const key = `${priceRow.tenant}:${priceRow.service_id}`;
+    const current = servicePricesByKey.get(key) ?? [];
+    current.push(priceRow);
+    servicePricesByKey.set(key, current);
+  }
+
+  const rowsToInsert = [];
+
+  for (const serviceRow of activeServices) {
+    const billingMode = normalizeBillingMode(serviceRow.billing_method);
+    if (!ALLOWED_BILLING_MODES.includes(billingMode)) {
+      continue;
+    }
+
+    const key = `${serviceRow.tenant}:${serviceRow.service_id}`;
+    const pricesForService = servicePricesByKey.get(key) ?? [];
+
+    if (pricesForService.length > 0) {
+      for (const priceRow of pricesForService) {
+        if (priceRow.rate == null || Number(priceRow.rate) < 0) {
+          continue;
+        }
+        rowsToInsert.push({
+          tenant: priceRow.tenant,
+          service_id: priceRow.service_id,
+          billing_mode: billingMode,
+          currency_code: priceRow.currency_code,
+          rate: priceRow.rate,
+        });
+      }
+      continue;
+    }
+
+    if (serviceRow.default_rate != null && Number(serviceRow.default_rate) >= 0) {
+      rowsToInsert.push({
+        tenant: serviceRow.tenant,
+        service_id: serviceRow.service_id,
+        billing_mode: billingMode,
+        currency_code: hasServiceCatalogCurrencyCode ? (serviceRow.currency_code ?? 'USD') : 'USD',
+        rate: serviceRow.default_rate,
+      });
+    }
+  }
+
+  for (const rows of chunk(rowsToInsert, 500)) {
+    await knex('service_catalog_mode_defaults')
+      .insert(rows)
+      .onConflict(['tenant', 'service_id', 'billing_mode', 'currency_code'])
+      .ignore();
+  }
+
+  const insertedDefaults = await knex('service_catalog_mode_defaults')
+    .select('tenant', 'service_id', 'billing_mode');
+
+  const insertedKeys = new Set(
+    insertedDefaults.map((row) => `${row.tenant}:${row.service_id}:${row.billing_mode}`)
+  );
+
+  const missingRows = activeServices
+    .filter((serviceRow) => {
+      const billingMode = normalizeBillingMode(serviceRow.billing_method);
+      if (!ALLOWED_BILLING_MODES.includes(billingMode)) {
+        return false;
+      }
+
+      const key = `${serviceRow.tenant}:${serviceRow.service_id}`;
+      const hasServicePrices = (servicePricesByKey.get(key) ?? []).length > 0;
+      const hasCatalogFallback = serviceRow.default_rate != null;
+
+      if (!hasServicePrices && !hasCatalogFallback) {
+        return false;
+      }
+
+      return !insertedKeys.has(`${serviceRow.tenant}:${serviceRow.service_id}:${billingMode}`);
     })
-    .whereNotExists(
-      knex('service_catalog_mode_defaults as md')
-        .select(knex.raw('1'))
-        .whereRaw('md.tenant = sc.tenant')
-        .andWhereRaw('md.service_id = sc.service_id')
-        .andWhereRaw(
-          "md.billing_mode = CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END"
-        )
-    )
-    .limit(25);
+    .slice(0, 25)
+    .map((row) => ({
+      tenant: row.tenant,
+      service_id: row.service_id,
+    }));
 
   if (missingRows.length > 0) {
     throw new Error(

--- a/server/src/test/unit/migrations/clientOwnedContractsSimplificationMigration.test.ts
+++ b/server/src/test/unit/migrations/clientOwnedContractsSimplificationMigration.test.ts
@@ -180,6 +180,8 @@ function buildKnownSharedContractPlans() {
 describe('client-owned contracts simplification migration', () => {
   it('T001: adds contracts.owner_client_id while only planning shared non-template contract splits', () => {
     expect(migrationSource).toContain("table.uuid('owner_client_id').nullable()");
+    expect(migrationSource).toContain('FOREIGN KEY (tenant, owner_client_id)');
+    expect(migrationSource).not.toContain('ON DELETE SET NULL');
   });
 
   it('T003: identifies shared non-template contracts while leaving template reuse untouched', () => {

--- a/server/src/test/unit/migrations/serviceCatalogModeDefaultsBackfillMigration.test.ts
+++ b/server/src/test/unit/migrations/serviceCatalogModeDefaultsBackfillMigration.test.ts
@@ -10,19 +10,19 @@ function readRepoFile(relativePathFromRepoRoot: string): string {
 describe('service catalog mode defaults backfill migration', () => {
   const migration = readRepoFile('server/migrations/20260321113000_backfill_service_catalog_mode_defaults.cjs');
 
-  it('T004: backfills mode-default rows from service_prices and service_catalog fallback defaults', () => {
-    expect(migration).toContain('INSERT INTO service_catalog_mode_defaults');
-    expect(migration).toContain('FROM service_prices sp');
-    expect(migration).toContain("CASE sc.billing_method WHEN 'per_unit' THEN 'usage' ELSE sc.billing_method END");
-    expect(migration).toContain("COALESCE(sc.currency_code, 'USD')");
-    expect(migration).toContain('AND NOT EXISTS (');
-    expect(migration).toContain('FROM service_prices sp');
+  it('T004: backfills mode-default rows from service_prices and service_catalog fallback defaults without distributed/local SQL joins', () => {
+    expect(migration).toContain("const normalizeBillingMode = (billingMethod) =>");
+    expect(migration).toContain("const servicePrices = await knex('service_prices')");
+    expect(migration).toContain("const activeServices = await knex('service_catalog as sc')");
+    expect(migration).toContain("await knex('service_catalog_mode_defaults')");
+    expect(migration).toContain(".onConflict(['tenant', 'service_id', 'billing_mode', 'currency_code'])");
+    expect(migration).not.toContain('FROM service_prices sp\n    INNER JOIN service_catalog sc');
   });
 
   it('T005: fails fast when source billing modes are unmappable or required defaults remain missing', () => {
     expect(migration).toContain('encountered unmappable billing_method values');
     expect(migration).toContain('Backfill failed; required mode-default mappings are missing for active services');
-    expect(migration).toContain('whereNotIn(normalizeBillingMode, ALLOWED_BILLING_MODES)');
-    expect(migration).toContain('.andWhereNotExists(');
+    expect(migration).toContain('!ALLOWED_BILLING_MODES.includes(normalizeBillingMode(row.billing_method))');
+    expect(migration).toContain('return !insertedKeys.has');
   });
 });

--- a/server/src/test/unit/migrations/serviceCatalogModeDefaultsMigration.test.ts
+++ b/server/src/test/unit/migrations/serviceCatalogModeDefaultsMigration.test.ts
@@ -12,7 +12,9 @@ describe('service catalog mode defaults migration', () => {
 
   it('T003: creates mode-default pricing table keyed by tenant+service+billing_mode+currency', () => {
     expect(migration).toContain("createTable('service_catalog_mode_defaults'");
+    expect(migration).toContain("table.uuid('default_id').notNullable().defaultTo(knex.raw('gen_random_uuid()'))");
     expect(migration).toContain("table.uuid('tenant').notNullable()");
+    expect(migration).toContain("table.primary(['tenant', 'default_id'])");
     expect(migration).toContain("table.uuid('service_id').notNullable()");
     expect(migration).toContain("table.text('billing_mode').notNullable()");
     expect(migration).toContain("table.string('currency_code', 3).notNullable()");
@@ -20,6 +22,8 @@ describe('service catalog mode defaults migration', () => {
     expect(migration).toContain("table.unique(");
     expect(migration).toContain("['tenant', 'service_id', 'billing_mode', 'currency_code']");
     expect(migration).toContain('service_catalog_mode_defaults_tenant_service_mode_currency_uq');
+    expect(migration).toContain("await distributeIfCitus(knex, 'service_catalog_mode_defaults')");
+    expect(migration).toContain("exports.config = { transaction: false }");
   });
 
   it('T003: constrains billing_mode to fixed|hourly|usage and enforces non-negative rates', () => {


### PR DESCRIPTION
## Summary
- remove the Citus-incompatible `ON DELETE SET NULL` behavior from the client-owned contract owner foreign key
- fix the owner contract backfill migration query
- make `service_catalog_mode_defaults` creation Citus-safe by using a tenant-inclusive primary key and distributing the table by `tenant`
- make the service catalog mode-defaults backfill Citus-safe by avoiding distributed/local join patterns
- extend migration tests to cover the new Citus-safe behavior

## Testing
- `cd server && npx vitest run src/test/unit/migrations/clientOwnedContractsSimplificationMigration.test.ts`
- `cd server && npx vitest run src/test/unit/migrations/serviceCatalogModeDefaultsMigration.test.ts src/test/unit/migrations/serviceCatalogModeDefaultsBackfillMigration.test.ts`
