### PR TITLE
Fix extension UI theming and Citus query errors

### DIFF
--- a/ee/extensions/nineminds-reporting/src/handler.ts
+++ b/ee/extensions/nineminds-reporting/src/handler.ts
@@ -165,6 +165,7 @@ async function processRequest(request: ExecuteRequest, host: HostBindings): Prom
       'PUT /notifications/:id - Update a notification',
       'DELETE /notifications/:id - Delete a notification',
       'GET /notifications/:id/stats - Get notification stats',
+      'GET /notifications/:id/reads - Get per-user read/dismiss data',
       'POST /notifications/resolve-recipients - Resolve matching users',
       'GET /audit - List audit logs',
       'GET /health - Health check',

--- a/ee/server/src/components/settings/extensions/Extensions.tsx
+++ b/ee/server/src/components/settings/extensions/Extensions.tsx
@@ -11,9 +11,10 @@ import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContai
 import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
 import { ContainerComponent } from '@alga-psa/ui/ui-reflection/types';
 import { Extension } from '../../../lib/extensions/types';
-import { CheckCircleIcon, XCircleIcon, Settings, EyeIcon } from 'lucide-react';
+import { CheckCircleIcon, XCircleIcon, Settings, EyeIcon, Terminal } from 'lucide-react';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
 import { fetchInstalledExtensionsV2, toggleExtensionV2, uninstallExtensionV2 } from '../../../lib/actions/extRegistryV2Actions';
 import { getInstallInfo, reprovisionExtension } from '../../../lib/actions/extensionDomainActions';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
@@ -138,7 +139,7 @@ export default function Extensions() {
     <ReflectionContainer id="extensions-page" label="Extensions Management">
       <div className="p-6" {...automationIdProps}>
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-semibold text-gray-900">Extensions</h1>
+          <h1 className="text-2xl font-semibold text-foreground">Extensions</h1>
         </div>
         
         {loading && (
@@ -161,16 +162,16 @@ export default function Extensions() {
         )}
         
         {!loading && !error && extensions.length === 0 && (
-          <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-            <h3 className="text-lg font-medium text-gray-900 mb-2">No extensions installed</h3>
-            <p className="text-gray-600 mb-4">
+          <div className="bg-card border border-border rounded-lg p-8 text-center">
+            <h3 className="text-lg font-medium text-foreground mb-2">No extensions installed</h3>
+            <p className="text-muted-foreground mb-4">
               Install extensions to add new features and functionality to Alga PSA.
             </p>
           </div>
         )}
         
         {!loading && !error && extensions.length > 0 && (
-          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+          <div className="bg-card rounded-lg border border-border overflow-hidden">
             <ExtensionsTable
               rows={extensions}
               installInfo={installInfo}
@@ -242,17 +243,17 @@ function ExtensionsTable({
       title: 'Extension',
       dataIndex: 'name',
       width: '320px',
-      headerClassName: 'sticky left-0 bg-white z-20',
-      cellClassName: 'sticky left-0 bg-white z-10',
+      headerClassName: 'sticky left-0 bg-card z-20',
+      cellClassName: 'sticky left-0 bg-card z-10',
       render: (_v, extension) => (
         <div className="min-w-0">
-          <div className="text-sm font-medium text-gray-900 truncate">
+          <div className="text-sm font-medium text-foreground truncate">
             <Link href={`/msp/settings/extensions/${extension.id}`} className="hover:text-primary-600">
               {extension.name}
             </Link>
           </div>
           {extension.description && (
-            <div className="text-sm text-gray-500 truncate">{extension.description}</div>
+            <div className="text-sm text-muted-foreground truncate">{extension.description}</div>
           )}
           <div className="mt-1 flex items-center gap-2">
             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
@@ -285,7 +286,7 @@ function ExtensionsTable({
       dataIndex: ['manifest','version'],
       width: '40px',
       render: (value) => (
-        <span className="text-sm text-gray-900">{String(value ?? '—')}</span>
+        <span className="text-sm text-foreground">{String(value ?? '—')}</span>
       )
     },
     {
@@ -294,16 +295,15 @@ function ExtensionsTable({
       width: '40px',
       render: (value) => {
         const label = typeof value === 'string' ? value : (value?.name ?? '—');
-        return <span className="text-sm text-gray-900">{label}</span>;
+        return <span className="text-sm text-foreground">{label}</span>;
       }
     },
     {
       title: 'Domain',
       dataIndex: 'id',
-      // No fixed width: allow Domain column to flex and absorb remaining space
       render: (_v, extension) => (
         <div className="flex flex-col gap-1">
-          <div className="text-sm text-gray-900 truncate">
+          <div className="text-sm text-foreground truncate">
             {installInfo[extension.id]?.domain ? (
               <a
                 href={`https://${installInfo[extension.id]?.domain}`}
@@ -315,7 +315,7 @@ function ExtensionsTable({
               </a>
             ) : '—'}
           </div>
-          <div className="text-xs text-gray-500">
+          <div className="text-xs text-muted-foreground">
             {(installInfo[extension.id]?.status?.state) ? String(installInfo[extension.id]?.status?.state) : ''}
           </div>
         </div>
@@ -325,40 +325,45 @@ function ExtensionsTable({
       title: 'Actions',
       dataIndex: 'id',
       width: '380px',
-      headerClassName: 'text-right sticky right-0 bg-white z-20',
-      cellClassName: 'sticky right-0 bg-white z-10',
+      headerClassName: 'text-right sticky right-0 bg-card z-20',
+      cellClassName: 'sticky right-0 bg-card z-10',
       render: (_v, extension) => (
         <div className="grid grid-cols-2 gap-2 justify-items-stretch">
-          <button
+          <Button
+            id={`extension-view-${extension.id}`}
+            variant="outline"
+            size="xs"
             onClick={() => onView(extension)}
-            className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
-            data-automation-id={`extension-view-${extension.id}`}
           >
             <EyeIcon className="h-3.5 w-3.5 mr-1" />
             View
-          </button>
-          <Link
-            href={`/msp/settings/extensions/${extension.id}/settings`}
-            className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-info/15 text-info-foreground hover:bg-info/25"
-            data-automation-id={`extension-settings-${extension.id}`}
+          </Button>
+          <Button
+            id={`extension-settings-${extension.id}`}
+            variant="soft"
+            size="xs"
+            asChild
           >
-            <Settings className="h-3.5 w-3.5 mr-1" />
-            Settings
-          </Link>
+            <Link href={`/msp/settings/extensions/${extension.id}/settings`}>
+              <Settings className="h-3.5 w-3.5 mr-1" />
+              Settings
+            </Link>
+          </Button>
           {installInfo[extension.id]?.domain ? null : (
-            <button
+            <Button
+              id={`extension-provision-${extension.id}`}
+              variant="outline"
+              size="xs"
               onClick={() => onReprovision(extension.id)}
-              className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-warning/15 text-warning-foreground hover:bg-warning/25"
             >
               Provision
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            id={`extension-toggle-${extension.id}`}
+            variant="secondary"
+            size="xs"
             onClick={() => { void onToggle(extension.id, extension.is_enabled); }}
-            className={`inline-flex items-center justify-center px-3 py-1 border border-transparent text-xs font-medium rounded-md ${
-              extension.is_enabled ? 'bg-warning/15 text-warning-foreground hover:bg-warning/25' : 'bg-success/15 text-success hover:bg-success/25'
-            }`}
-            data-automation-id={`extension-toggle-${extension.id}`}
           >
             {extension.is_enabled ? (
               <>
@@ -371,25 +376,26 @@ function ExtensionsTable({
                 Enable
               </>
             )}
-          </button>
-          <button
+          </Button>
+          <Button
+            id={`extension-remove-${extension.id}`}
+            variant="destructive"
+            size="xs"
             onClick={() => { void onRemove(extension.id); }}
-            className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-destructive/15 text-destructive hover:bg-destructive/25"
-            data-automation-id={`extension-remove-${extension.id}`}
           >
             Remove
-          </button>
-          {/* Per-extension debug console entrypoint.
-              Uses only the extension id; tenant scoping is enforced server-side
-              based on the authenticated session in /api/ext-debug/stream. */}
-          <Link
-            href={`/msp/extensions/${extension.id}/debug`}
-            className="inline-flex items-center justify-center px-3 py-1 border border-violet-500/30 text-violet-600 bg-violet-500/10 hover:bg-violet-500/20 hover:border-violet-500/40 text-[10px] font-medium transition-colors"
-            data-automation-id={`extension-debug-${extension.id}`}
+          </Button>
+          <Button
+            id={`extension-debug-${extension.id}`}
+            variant="ghost"
+            size="xs"
+            asChild
           >
-            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-            Debug
-          </Link>
+            <Link href={`/msp/extensions/${extension.id}/debug`}>
+              <Terminal className="h-3.5 w-3.5 mr-1" />
+              Debug
+            </Link>
+          </Button>
         </div>
       )
     }

--- a/ee/server/src/components/settings/extensions/ExtensionsSimple.tsx
+++ b/ee/server/src/components/settings/extensions/ExtensionsSimple.tsx
@@ -12,6 +12,7 @@ import { Extension } from '../../../lib/extensions/types';
 import ExtensionDetailsModal from './ExtensionDetailsModal';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Button } from '@alga-psa/ui/components/Button';
 
 // Define local interface to match UI expectations
 interface ExtensionUI {
@@ -122,13 +123,13 @@ export default function Extensions() {
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Extensions</h2>
+        <h2 className="text-xl font-semibold text-foreground">Extensions</h2>
       </div>
       
       {loading && (
         <div className="flex justify-center items-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-          <span className="ml-3 text-gray-600">Loading extensions...</span>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500"></div>
+          <span className="ml-3 text-muted-foreground">Loading extensions...</span>
         </div>
       )}
       
@@ -142,64 +143,64 @@ export default function Extensions() {
       )}
       
       {!loading && !error && extensions.length === 0 && (
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No extensions installed</h3>
-          <p className="text-gray-600 mb-4">
+        <div className="bg-card border border-border rounded-lg p-8 text-center">
+          <h3 className="text-lg font-medium text-foreground mb-2">No extensions installed</h3>
+          <p className="text-muted-foreground mb-4">
             Install extensions to add new features and functionality to Alga PSA.
           </p>
         </div>
       )}
       
       {!loading && !error && extensions.length > 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+        <div className="bg-card rounded-lg border border-border overflow-hidden">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted/50">
               <tr>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Extension
                 </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Version
                 </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Author
                 </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Status
                 </th>
-                <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-card divide-y divide-border">
               {extensions.map((extension): React.ReactElement => (
-                <tr key={extension.id} className="hover:bg-gray-50">
+                <tr key={extension.id} className="hover:bg-muted/30">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
                       <div>
-                        <div className="text-sm font-medium text-gray-900">
-                          <button 
+                        <div className="text-sm font-medium text-foreground">
+                          <button
                             onClick={() => {
                               setSelectedExtension(extension);
                               setShowModal(true);
                             }}
-                            className="hover:text-blue-600 text-left"
+                            className="hover:text-primary-600 text-left"
                           >
                             {extension.name}
                           </button>
                         </div>
-                        <div className="text-sm text-gray-500">
+                        <div className="text-sm text-muted-foreground">
                           {extension.description}
                         </div>
                       </div>
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">{extension.version}</div>
+                    <div className="text-sm text-foreground">{extension.version}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">{extension.author || 'Unknown'}</div>
+                    <div className="text-sm text-foreground">{extension.author || 'Unknown'}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
@@ -212,59 +213,41 @@ export default function Extensions() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <div className="flex justify-end space-x-2">
-                      <button
+                      <Button
+                        id={`extension-view-${extension.id}`}
+                        variant="outline"
+                        size="xs"
                         onClick={() => {
                           setSelectedExtension(extension);
                           setShowModal(true);
                         }}
-                        className="inline-flex items-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
                       >
-                        <svg className="h-3.5 w-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                        </svg>
                         View
-                      </button>
-                      <button
+                      </Button>
+                      <Button
+                        id={`extension-settings-${extension.id}`}
+                        variant="soft"
+                        size="xs"
                         onClick={() => alert('Extension settings will be available in the next update.')}
-                        className="inline-flex items-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-info/15 text-info-foreground hover:bg-info/25"
                       >
-                        <svg className="h-3.5 w-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        </svg>
                         Settings
-                      </button>
-                      <button
+                      </Button>
+                      <Button
+                        id={`extension-toggle-${extension.id}`}
+                        variant="secondary"
+                        size="xs"
                         onClick={() => void handleToggleExtension(extension.id, extension.isEnabled)}
-                        className={`inline-flex items-center px-3 py-1 border border-transparent text-xs font-medium rounded-md ${
-                          extension.isEnabled
-                            ? 'bg-warning/15 text-warning-foreground hover:bg-warning/25'
-                            : 'bg-success/15 text-success hover:bg-success/25'
-                        }`}
                       >
-                        {extension.isEnabled ? (
-                          <>
-                            <svg className="h-3.5 w-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            Disable
-                          </>
-                        ) : (
-                          <>
-                            <svg className="h-3.5 w-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            Enable
-                          </>
-                        )}
-                      </button>
-                      <button
+                        {extension.isEnabled ? 'Disable' : 'Enable'}
+                      </Button>
+                      <Button
+                        id={`extension-remove-${extension.id}`}
+                        variant="destructive"
+                        size="xs"
                         onClick={() => void handleRemoveExtension(extension.id)}
-                        className="inline-flex items-center px-3 py-1 border border-transparent text-xs font-medium rounded-md bg-destructive/15 text-destructive hover:bg-destructive/25"
                       >
                         Remove
-                      </button>
+                      </Button>
                     </div>
                   </td>
                 </tr>

--- a/ee/server/src/lib/platformNotifications/platformNotificationService.ts
+++ b/ee/server/src/lib/platformNotifications/platformNotificationService.ts
@@ -386,16 +386,19 @@ export class PlatformNotificationService {
 
     if (tenantIds.length > 0) {
       try {
+        // Use LEFT JOINs so tenants with partial Stripe data (e.g. customer but no
+        // subscription, or subscription but no matching price/product) still appear
+        // with whatever data is available.
         const subRows = await knex('stripe_customers as sc')
-          .join('stripe_subscriptions as ss', function () {
+          .leftJoin('stripe_subscriptions as ss', function () {
             this.on('sc.tenant', '=', 'ss.tenant')
               .andOn('sc.stripe_customer_id', '=', 'ss.stripe_customer_id');
           })
-          .join('stripe_prices as sp', function () {
+          .leftJoin('stripe_prices as sp', function () {
             this.on('ss.tenant', '=', 'sp.tenant')
               .andOn('ss.stripe_price_id', '=', 'sp.stripe_price_id');
           })
-          .join('stripe_products as sprod', function () {
+          .leftJoin('stripe_products as sprod', function () {
             this.on('sp.tenant', '=', 'sprod.tenant')
               .andOn('sp.stripe_product_id', '=', 'sprod.stripe_product_id');
           })
@@ -410,27 +413,31 @@ export class PlatformNotificationService {
 
         // Keep the most relevant subscription per tenant (active > trialing > others, then newest)
         for (const row of subRows) {
+          const status = row.subscription_status as string | null;
           const existing = tenantSubMap.get(row.tenant as string);
           if (!existing) {
-            tenantSubMap.set(row.tenant as string, {
-              subscription_status: row.subscription_status as string,
-              product_name: row.product_name as string,
-            });
+            if (status) {
+              tenantSubMap.set(row.tenant as string, {
+                subscription_status: status,
+                product_name: (row.product_name as string) || '',
+              });
+            }
           } else {
             // Prefer active/trialing over other statuses
             const priority: Record<string, number> = { active: 0, trialing: 1, past_due: 2, canceled: 3 };
             const existingPrio = priority[existing.subscription_status] ?? 4;
-            const newPrio = priority[row.subscription_status as string] ?? 4;
+            const newPrio = priority[status ?? ''] ?? 4;
             if (newPrio < existingPrio) {
               tenantSubMap.set(row.tenant as string, {
-                subscription_status: row.subscription_status as string,
-                product_name: row.product_name as string,
+                subscription_status: status!,
+                product_name: (row.product_name as string) || '',
               });
             }
           }
         }
-      } catch {
-        // Stripe tables may not exist in CE — continue without subscription data
+      } catch (err) {
+        // Stripe tables may not exist in CE — log and continue without subscription data
+        console.warn('[PlatformNotificationService] Failed to fetch subscription data for recipient filtering:', err);
       }
     }
 
@@ -525,41 +532,86 @@ export class PlatformNotificationService {
   async getNotificationReads(notificationId: string): Promise<NotificationRecipientRead[]> {
     const knex = await getAdminConnection();
 
-    const rows = await knex('platform_notification_recipients as r')
-      .leftJoin('users as u', function () {
-        this.on('r.tenant', '=', 'u.tenant').andOn('r.user_id', '=', 'u.user_id');
-      })
-      .leftJoin('tenants as t', 'r.tenant', 't.tenant')
-      .where('r.notification_id', notificationId)
-      .whereNull('r.excluded_at')
-      .select(
-        'r.user_id',
-        'r.tenant',
-        't.client_name as tenant_name',
-        'u.email',
-        'u.first_name',
-        'u.last_name',
-        'r.matched_at',
-        'r.dismissed_at',
-        'r.detail_viewed_at'
-      )
-      .orderBy([
-        { column: 'r.detail_viewed_at', order: 'desc', nulls: 'last' },
-        { column: 'r.dismissed_at', order: 'desc', nulls: 'last' },
-        { column: 'u.last_name', order: 'asc' },
-      ]);
+    // Step 1: Fetch recipients (distributed by tenant — avoids cross-shard join with users)
+    const recipientRows = await knex('platform_notification_recipients')
+      .where({ notification_id: notificationId })
+      .whereNull('excluded_at')
+      .select('user_id', 'tenant', 'matched_at', 'dismissed_at', 'detail_viewed_at');
 
-    return rows.map((row: Record<string, unknown>) => ({
-      user_id: row.user_id as string,
-      tenant: row.tenant as string,
-      tenant_name: (row.tenant_name as string) || null,
-      email: row.email as string,
-      first_name: (row.first_name as string) || null,
-      last_name: (row.last_name as string) || null,
-      matched_at: row.matched_at ? (row.matched_at as Date).toISOString() : null,
-      dismissed_at: row.dismissed_at ? (row.dismissed_at as Date).toISOString() : null,
-      detail_viewed_at: row.detail_viewed_at ? (row.detail_viewed_at as Date).toISOString() : null,
-    }));
+    if (recipientRows.length === 0) return [];
+
+    // Step 2: Batch-fetch user info per tenant to keep queries shard-local
+    const tenantGroups = new Map<string, string[]>();
+    for (const r of recipientRows) {
+      const list = tenantGroups.get(r.tenant as string) || [];
+      list.push(r.user_id as string);
+      tenantGroups.set(r.tenant as string, list);
+    }
+
+    const userMap = new Map<string, { email: string; first_name: string | null; last_name: string | null }>();
+    for (const [tenant, userIds] of tenantGroups) {
+      const users = await knex('users')
+        .where('tenant', tenant)
+        .whereIn('user_id', userIds)
+        .select('user_id', 'tenant', 'email', 'first_name', 'last_name');
+      for (const u of users) {
+        userMap.set(`${u.tenant}:${u.user_id}`, {
+          email: u.email as string,
+          first_name: (u.first_name as string) || null,
+          last_name: (u.last_name as string) || null,
+        });
+      }
+    }
+
+    // Step 3: Fetch tenant names (reference table — no shard issues)
+    const tenantIds = [...tenantGroups.keys()];
+    const tenantNameMap = new Map<string, string>();
+    if (tenantIds.length > 0) {
+      const tenantRows = await knex('tenants')
+        .whereIn('tenant', tenantIds)
+        .select('tenant', 'client_name');
+      for (const t of tenantRows) {
+        tenantNameMap.set(t.tenant as string, (t.client_name as string) || '');
+      }
+    }
+
+    // Step 4: Merge and sort
+    const results: NotificationRecipientRead[] = recipientRows.map((r: Record<string, unknown>) => {
+      const user = userMap.get(`${r.tenant}:${r.user_id}`);
+      return {
+        user_id: r.user_id as string,
+        tenant: r.tenant as string,
+        tenant_name: tenantNameMap.get(r.tenant as string) || null,
+        email: user?.email || '',
+        first_name: user?.first_name || null,
+        last_name: user?.last_name || null,
+        matched_at: r.matched_at ? (r.matched_at as Date).toISOString() : null,
+        dismissed_at: r.dismissed_at ? (r.dismissed_at as Date).toISOString() : null,
+        detail_viewed_at: r.detail_viewed_at ? (r.detail_viewed_at as Date).toISOString() : null,
+      };
+    });
+
+    // Sort: viewed first, then dismissed, then pending; within each group by last_name
+    results.sort((a, b) => {
+      // detail_viewed_at desc nulls last
+      if (a.detail_viewed_at && !b.detail_viewed_at) return -1;
+      if (!a.detail_viewed_at && b.detail_viewed_at) return 1;
+      if (a.detail_viewed_at && b.detail_viewed_at) {
+        const cmp = b.detail_viewed_at.localeCompare(a.detail_viewed_at);
+        if (cmp !== 0) return cmp;
+      }
+      // dismissed_at desc nulls last
+      if (a.dismissed_at && !b.dismissed_at) return -1;
+      if (!a.dismissed_at && b.dismissed_at) return 1;
+      if (a.dismissed_at && b.dismissed_at) {
+        const cmp = b.dismissed_at.localeCompare(a.dismissed_at);
+        if (cmp !== 0) return cmp;
+      }
+      // last_name asc
+      return (a.last_name || '').localeCompare(b.last_name || '');
+    });
+
+    return results;
   }
 
   // ── Private helpers ──

--- a/server/src/components/settings/extensions/ExtensionManagement.tsx
+++ b/server/src/components/settings/extensions/ExtensionManagement.tsx
@@ -71,7 +71,7 @@ export default function ExtensionManagement() {
                         </span>
                         <Link
                           href="/msp/extensions/d773f8f7-c46d-4c9d-a79b-b55903dd5074/debug"
-                          className="inline-flex items-center gap-1 px-2 py-1 rounded border border-violet-200 text-violet-700 bg-violet-50 hover:bg-violet-100 hover:border-violet-300 transition-colors"
+                          className="inline-flex items-center gap-1 px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
                         >
                           <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
                           {t('extensions.links.debugConsole')}


### PR DESCRIPTION
  - Replace inline-styled buttons with themed Button component variants (outline, soft, secondary, destructive, ghost) for dark mode support in extension settings pages
  - Use semantic color tokens (text-foreground, bg-card, etc.) instead of hardcoded gray/white classes
  - Fix Citus cross-shard join error in getNotificationReads by splitting into per-tenant queries merged in application code
  - Change Stripe data lookup to LEFT JOINs and add error logging instead of silently swallowing all exceptions

  "But I don't want to go among mad shards," Alice remarked.
  "Oh, you can't help that," said the Cat: "we're all distributed
  here. The buttons are all one colour, the JOINs are all INNER,
  and the catches catch nothing at all." 🐱🎨🗃️