### PR TITLE
Add project task CSV export

### DIFF
--- a/packages/projects/src/actions/projectTaskExportActions.ts
+++ b/packages/projects/src/actions/projectTaskExportActions.ts
@@ -1,0 +1,398 @@
+'use server'
+
+import type { ITag } from '@alga-psa/types';
+import { createTenantKnex, withTransaction } from '@alga-psa/db';
+import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import { findTagsByEntityIds } from '@alga-psa/tags/actions';
+import { Knex } from 'knex';
+
+const MAX_EXPORT_ROWS = 10000;
+
+const CSV_FIELDS = [
+  'task_name',
+  'description',
+  'phase',
+  'status',
+  'is_closed',
+  'task_type',
+  'priority',
+  'assigned_to',
+  'assigned_team',
+  'due_date',
+  'estimated_hours',
+  'actual_hours',
+  'checklist_progress',
+  'tags',
+  'created_at',
+  'updated_at',
+] as const;
+
+const CSV_HEADERS: Record<string, string> = {
+  task_name: 'Task Name',
+  description: 'Description',
+  phase: 'Phase',
+  status: 'Status',
+  is_closed: 'Is Closed',
+  task_type: 'Task Type',
+  priority: 'Priority',
+  assigned_to: 'Assigned To',
+  assigned_team: 'Assigned Team',
+  due_date: 'Due Date',
+  estimated_hours: 'Estimated Hours',
+  actual_hours: 'Actual Hours',
+  checklist_progress: 'Checklist Progress',
+  tags: 'Tags',
+  created_at: 'Created At',
+  updated_at: 'Updated At',
+};
+
+function formatDate(value: string | Date | null | undefined): string {
+  if (!value) return '';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (isNaN(date.getTime())) return '';
+  return date.toISOString();
+}
+
+function formatTaskType(typeKey: string | null | undefined): string {
+  if (!typeKey) return '';
+  // Convert snake_case keys to title case
+  return typeKey
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+interface TaskRow {
+  task_id: string;
+  task_name: string;
+  description: string | null;
+  phase_id: string;
+  assigned_to: string | null;
+  assigned_team_id: string | null;
+  estimated_hours: number | null;
+  actual_hours: number | null;
+  project_status_mapping_id: string;
+  created_at: Date;
+  updated_at: Date;
+  wbs_code: string;
+  due_date: Date | null;
+  priority_id: string | null;
+  task_type_key: string;
+  tenant: string;
+}
+
+interface NameLookups {
+  users: Record<string, string>;
+  teams: Record<string, string>;
+  phases: Record<string, string>;
+  statuses: Record<string, { name: string; is_closed: boolean }>;
+  priorities: Record<string, string>;
+  taskTypes: Record<string, string>;
+}
+
+interface ChecklistCounts {
+  total: number;
+  completed: number;
+}
+
+function taskToRow(
+  task: TaskRow,
+  lookups: NameLookups,
+  taskTags: Record<string, ITag[]>,
+  checklistCounts: Record<string, ChecklistCounts>,
+): Record<string, string> {
+  const assignedToName = task.assigned_to
+    ? lookups.users[task.assigned_to] || ''
+    : '';
+  const assignedTeamName = task.assigned_team_id
+    ? lookups.teams[task.assigned_team_id] || ''
+    : '';
+  const phaseName = lookups.phases[task.phase_id] || '';
+  const statusInfo = lookups.statuses[task.project_status_mapping_id];
+  const statusName = statusInfo?.name || '';
+  const isClosed = statusInfo?.is_closed ? 'Yes' : 'No';
+  const priorityName = task.priority_id
+    ? lookups.priorities[task.priority_id] || ''
+    : '';
+
+  const tags = (taskTags[task.task_id] || []).map(t => t.tag_text).join(', ');
+
+  const checklist = checklistCounts[task.task_id];
+  const checklistProgress = checklist
+    ? `${checklist.completed}/${checklist.total}`
+    : '';
+
+  const taskTypeName = task.task_type_key
+    ? lookups.taskTypes[task.task_type_key] || formatTaskType(task.task_type_key)
+    : '';
+
+  return {
+    task_name: task.task_name || '',
+    description: task.description || '',
+    phase: phaseName,
+    status: statusName,
+    is_closed: isClosed,
+    task_type: taskTypeName,
+    priority: priorityName,
+    assigned_to: assignedToName,
+    assigned_team: assignedTeamName,
+    due_date: formatDate(task.due_date),
+    estimated_hours: task.estimated_hours != null ? String(task.estimated_hours) : '',
+    actual_hours: task.actual_hours != null ? String(task.actual_hours) : '',
+    checklist_progress: checklistProgress,
+    tags,
+    created_at: formatDate(task.created_at),
+    updated_at: formatDate(task.updated_at),
+  };
+}
+
+async function resolveNameLookups(
+  trx: Knex.Transaction,
+  tenant: string,
+  tasks: TaskRow[],
+): Promise<NameLookups> {
+  const userIds = new Set<string>();
+  const teamIds = new Set<string>();
+  const phaseIds = new Set<string>();
+  const statusMappingIds = new Set<string>();
+  const priorityIds = new Set<string>();
+
+  for (const t of tasks) {
+    if (t.assigned_to) userIds.add(t.assigned_to);
+    if (t.assigned_team_id) teamIds.add(t.assigned_team_id);
+    phaseIds.add(t.phase_id);
+    statusMappingIds.add(t.project_status_mapping_id);
+    if (t.priority_id) priorityIds.add(t.priority_id);
+  }
+
+  const lookups: NameLookups = {
+    users: {},
+    teams: {},
+    phases: {},
+    statuses: {},
+    priorities: {},
+    taskTypes: {},
+  };
+
+  const promises: Promise<void>[] = [];
+
+  // Resolve user names
+  if (userIds.size > 0) {
+    promises.push(
+      trx('users')
+        .select('user_id', trx.raw("CONCAT(first_name, ' ', last_name) as full_name"))
+        .whereIn('user_id', Array.from(userIds))
+        .andWhere('tenant', tenant)
+        .then(users => {
+          for (const u of users) {
+            lookups.users[u.user_id] = u.full_name || '';
+          }
+        })
+    );
+  }
+
+  // Resolve team names
+  if (teamIds.size > 0) {
+    promises.push(
+      trx('teams')
+        .select('team_id', 'team_name')
+        .whereIn('team_id', Array.from(teamIds))
+        .andWhere('tenant', tenant)
+        .then(teams => {
+          for (const t of teams) {
+            lookups.teams[t.team_id] = t.team_name || '';
+          }
+        })
+    );
+  }
+
+  // Resolve phase names
+  if (phaseIds.size > 0) {
+    promises.push(
+      trx('project_phases')
+        .select('phase_id', 'phase_name')
+        .whereIn('phase_id', Array.from(phaseIds))
+        .andWhere('tenant', tenant)
+        .then(phases => {
+          for (const p of phases) {
+            lookups.phases[p.phase_id] = p.phase_name || '';
+          }
+        })
+    );
+  }
+
+  // Resolve status names via project_status_mappings
+  if (statusMappingIds.size > 0) {
+    promises.push(
+      trx('project_status_mappings as psm')
+        .leftJoin('statuses as s', function (this: Knex.JoinClause) {
+          this.on('psm.status_id', '=', 's.status_id').andOn('psm.tenant', '=', 's.tenant');
+        })
+        .leftJoin('standard_statuses as ss', function (this: Knex.JoinClause) {
+          this.on('psm.standard_status_id', '=', 'ss.standard_status_id').andOn('psm.tenant', '=', 'ss.tenant');
+        })
+        .whereIn('psm.project_status_mapping_id', Array.from(statusMappingIds))
+        .andWhere('psm.tenant', tenant)
+        .select(
+          'psm.project_status_mapping_id',
+          trx.raw("COALESCE(psm.custom_name, s.name, ss.name, psm.project_status_mapping_id::text) as status_name"),
+          trx.raw('COALESCE(s.is_closed, ss.is_closed, false) as is_closed'),
+        )
+        .then(rows => {
+          for (const r of rows) {
+            lookups.statuses[r.project_status_mapping_id] = {
+              name: r.status_name || '',
+              is_closed: Boolean(r.is_closed),
+            };
+          }
+        })
+    );
+  }
+
+  // Resolve priority names
+  if (priorityIds.size > 0) {
+    promises.push(
+      trx('priorities')
+        .select('priority_id', 'priority_name')
+        .whereIn('priority_id', Array.from(priorityIds))
+        .andWhere('tenant', tenant)
+        .then(priorities => {
+          for (const p of priorities) {
+            lookups.priorities[p.priority_id] = p.priority_name || '';
+          }
+        })
+    );
+  }
+
+  // Resolve task type names (standard + custom)
+  promises.push(
+    Promise.all([
+      trx('standard_task_types')
+        .select('type_key', 'type_name')
+        .where('is_active', true),
+      trx('custom_task_types')
+        .select('type_key', 'type_name')
+        .where({ tenant, is_active: true }),
+    ]).then(([standard, custom]) => {
+      for (const t of standard) {
+        lookups.taskTypes[t.type_key] = t.type_name || '';
+      }
+      // Custom overrides standard
+      for (const t of custom) {
+        lookups.taskTypes[t.type_key] = t.type_name || '';
+      }
+    })
+  );
+
+  await Promise.all(promises);
+  return lookups;
+}
+
+export const exportProjectTasksToCSV = withAuth(async (
+  _user,
+  { tenant },
+  projectId: string,
+  selectedPhaseIds: string[],
+  selectedFields?: string[],
+): Promise<{ csv: string; count: number }> => {
+  const { knex: db } = await createTenantKnex();
+
+  return await withTransaction(db, async (trx: Knex.Transaction) => {
+    const hasRead = await hasPermission(_user, 'project', 'read', trx);
+    if (!hasRead) {
+      throw new Error('Permission denied: Cannot read project');
+    }
+
+    // Get phases for this project, filtered to selected ones
+    const phases = await trx('project_phases')
+      .where({ project_id: projectId, tenant })
+      .whereIn('phase_id', selectedPhaseIds)
+      .select('phase_id');
+
+    const phaseIds = phases.map(p => p.phase_id);
+    if (phaseIds.length === 0) {
+      return { csv: '', count: 0 };
+    }
+
+    // Get all tasks for selected phases
+    const tasks: TaskRow[] = await trx('project_tasks')
+      .whereIn('phase_id', phaseIds)
+      .andWhere('tenant', tenant)
+      .orderBy(['phase_id', 'order_key'])
+      .limit(MAX_EXPORT_ROWS);
+
+    if (tasks.length === 0) {
+      return { csv: '', count: 0 };
+    }
+
+    const taskIds = tasks.map(t => t.task_id);
+
+    // Resolve lookups, tags, and checklist counts in parallel
+    const [lookups, tagsArray, checklistRows] = await Promise.all([
+      resolveNameLookups(trx, tenant, tasks),
+      findTagsByEntityIds(taskIds, 'project_task').catch(() => []),
+      trx('task_checklist_items')
+        .whereIn('task_id', taskIds)
+        .andWhere('tenant', tenant)
+        .select('task_id', 'completed'),
+    ]);
+
+    // Build tag map
+    const taskTags: Record<string, ITag[]> = {};
+    for (const tag of tagsArray) {
+      if (tag.tagged_id) {
+        (taskTags[tag.tagged_id] ??= []).push(tag);
+      }
+    }
+
+    // Build checklist counts map
+    const checklistCounts: Record<string, ChecklistCounts> = {};
+    for (const item of checklistRows) {
+      if (!checklistCounts[item.task_id]) {
+        checklistCounts[item.task_id] = { total: 0, completed: 0 };
+      }
+      checklistCounts[item.task_id].total++;
+      if (item.completed) {
+        checklistCounts[item.task_id].completed++;
+      }
+    }
+
+    const rows = tasks.map(t => taskToRow(t, lookups, taskTags, checklistCounts));
+
+    // Use selected fields if provided, otherwise all fields
+    const allFieldKeys = CSV_FIELDS as readonly string[];
+    const fields = selectedFields
+      ? selectedFields.filter(f => allFieldKeys.includes(f))
+      : [...CSV_FIELDS] as string[];
+
+    if (fields.length === 0) {
+      return { csv: '', count: 0 };
+    }
+
+    // Build header row using friendly names
+    const headerRow = fields.map(f => CSV_HEADERS[f] || f);
+    const dataRows = rows.map(row =>
+      fields.map(f => row[f] || '')
+    );
+
+    const escapeField = (field: string): string => {
+      let str = String(field);
+      // Guard against CSV injection: prefix dangerous leading characters with a single quote
+      if (/^[=+\-@\t\r]/.test(str)) {
+        str = "'" + str;
+      }
+      if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    };
+
+    const csvLines = [
+      headerRow.map(escapeField).join(','),
+      ...dataRows.map(row => row.map(escapeField).join(','))
+    ];
+
+    return { csv: csvLines.join('\n'), count: tasks.length };
+  });
+});

--- a/packages/projects/src/actions/projectTaskExportActions.ts
+++ b/packages/projects/src/actions/projectTaskExportActions.ts
@@ -2,7 +2,7 @@
 
 import type { ITag } from '@alga-psa/types';
 import { createTenantKnex, withTransaction } from '@alga-psa/db';
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, throwPermissionError } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { findTagsByEntityIds } from '@alga-psa/tags/actions';
 import { Knex } from 'knex';
@@ -301,7 +301,7 @@ export const exportProjectTasksToCSV = withAuth(async (
   return await withTransaction(db, async (trx: Knex.Transaction) => {
     const hasRead = await hasPermission(_user, 'project', 'read', trx);
     if (!hasRead) {
-      throw new Error('Permission denied: Cannot read project');
+      throwPermissionError('read project');
     }
 
     // Get phases for this project, filtered to selected ones

--- a/packages/projects/src/components/ProjectInfo.tsx
+++ b/packages/projects/src/components/ProjectInfo.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { IClient, IProject, IUserWithRoles } from '@alga-psa/types';
+import { IClient, IProject, IProjectPhase, IUserWithRoles } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
 import HoursProgressBar from './HoursProgressBar';
 import { calculateProjectCompletion } from '@alga-psa/projects/lib/projectUtils';
-import { Edit2, Save } from 'lucide-react';
+import { Download, Edit2, Save } from 'lucide-react';
 import BackNav from '@alga-psa/ui/components/BackNav';
 import { Button } from '@alga-psa/ui/components/Button';
 import { useDrawer } from "@alga-psa/ui";
@@ -14,9 +14,11 @@ import { TagManager } from '@alga-psa/tags/components';
 import { toast } from 'react-hot-toast';
 import CreateTemplateDialog from './project-templates/CreateTemplateDialog';
 import ProjectMaterialsDrawer from './ProjectMaterialsDrawer';
+import ProjectTaskExportDialog from './ProjectTaskExportDialog';
 
 interface ProjectInfoProps {
   project: IProject;
+  phases: IProjectPhase[];
   contact?: {
     full_name: string;
   };
@@ -33,6 +35,7 @@ interface ProjectInfoProps {
 
 export default function ProjectInfo({
   project,
+  phases,
   contact,
   assignedUser,
   users,
@@ -48,6 +51,7 @@ export default function ProjectInfo({
 
   const [currentProject, setCurrentProject] = useState(project);
   const [showTemplateDialog, setShowTemplateDialog] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
   const [projectMetrics, setProjectMetrics] = useState<{
     taskCompletionPercentage: number;
     hoursCompletionPercentage: number;
@@ -146,6 +150,15 @@ export default function ProjectInfo({
             Save as Template
           </Button>
           <Button
+            id="export-tasks-button"
+            variant="outline"
+            size="sm"
+            onClick={() => setShowExportDialog(true)}
+          >
+            <Download className="h-4 w-4 mr-2" />
+            Export Tasks
+          </Button>
+          <Button
             id="project-materials-button"
             variant="outline"
             size="sm"
@@ -228,6 +241,14 @@ export default function ProjectInfo({
           }}
         />
       )}
+
+      {/* Export Tasks Dialog */}
+      <ProjectTaskExportDialog
+        isOpen={showExportDialog}
+        onClose={() => setShowExportDialog(false)}
+        projectId={currentProject.project_id}
+        phases={phases}
+      />
     </div>
   );
 }

--- a/packages/projects/src/components/ProjectPage.tsx
+++ b/packages/projects/src/components/ProjectPage.tsx
@@ -146,6 +146,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
     <div>
       <ProjectInfo
         project={projectMetadata.project}
+        phases={projectMetadata.phases}
         contact={projectMetadata.contact}
         assignedUser={projectMetadata.assignedUser || undefined}
         users={projectMetadata.users}

--- a/packages/projects/src/components/ProjectTaskExportDialog.tsx
+++ b/packages/projects/src/components/ProjectTaskExportDialog.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Dialog, DialogContent, DialogFooter } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Download, Check, FileSpreadsheet } from 'lucide-react';
+import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { exportProjectTasksToCSV } from '../actions/projectTaskExportActions';
+import type { IProjectPhase } from '@alga-psa/types';
+
+interface ProjectTaskExportDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  phases: IProjectPhase[];
+}
+
+type ExportStep = 'configure' | 'exporting' | 'complete';
+
+const EXPORT_FIELDS = [
+  { key: 'task_name', label: 'Task Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'phase', label: 'Phase' },
+  { key: 'status', label: 'Status' },
+  { key: 'is_closed', label: 'Is Closed' },
+  { key: 'task_type', label: 'Task Type' },
+  { key: 'priority', label: 'Priority' },
+  { key: 'assigned_to', label: 'Assigned To' },
+  { key: 'assigned_team', label: 'Assigned Team' },
+  { key: 'due_date', label: 'Due Date' },
+  { key: 'estimated_hours', label: 'Estimated Hours' },
+  { key: 'actual_hours', label: 'Actual Hours' },
+  { key: 'checklist_progress', label: 'Checklist Progress' },
+  { key: 'tags', label: 'Tags' },
+  { key: 'created_at', label: 'Created At' },
+  { key: 'updated_at', label: 'Updated At' },
+];
+
+const ALL_FIELD_KEYS = EXPORT_FIELDS.map(f => f.key);
+
+const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
+  isOpen,
+  onClose,
+  projectId,
+  phases,
+}) => {
+  const [step, setStep] = useState<ExportStep>('configure');
+  const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(ALL_FIELD_KEYS));
+  const [selectedPhaseIds, setSelectedPhaseIds] = useState<Set<string>>(
+    new Set(phases.map(p => p.phase_id))
+  );
+  const [exportedCount, setExportedCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const allFieldsSelected = selectedFields.size === EXPORT_FIELDS.length;
+  const noFieldsSelected = selectedFields.size === 0;
+  const allPhasesSelected = selectedPhaseIds.size === phases.length;
+  const noPhasesSelected = selectedPhaseIds.size === 0;
+
+  const handleClose = useCallback(() => {
+    if (step === 'exporting') return;
+    setStep('configure');
+    setSelectedFields(new Set(ALL_FIELD_KEYS));
+    setSelectedPhaseIds(new Set(phases.map(p => p.phase_id)));
+    setExportedCount(0);
+    setError(null);
+    onClose();
+  }, [step, onClose, phases]);
+
+  const toggleField = useCallback((key: string) => {
+    setSelectedFields(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAllFields = useCallback(() => {
+    setSelectedFields(prev =>
+      prev.size === EXPORT_FIELDS.length ? new Set() : new Set(ALL_FIELD_KEYS)
+    );
+  }, []);
+
+  const togglePhase = useCallback((phaseId: string) => {
+    setSelectedPhaseIds(prev => {
+      const next = new Set(prev);
+      if (next.has(phaseId)) {
+        next.delete(phaseId);
+      } else {
+        next.add(phaseId);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAllPhases = useCallback(() => {
+    setSelectedPhaseIds(prev =>
+      prev.size === phases.length
+        ? new Set()
+        : new Set(phases.map(p => p.phase_id))
+    );
+  }, [phases]);
+
+  const handleExport = useCallback(async () => {
+    setStep('exporting');
+    setError(null);
+
+    try {
+      const orderedFields = ALL_FIELD_KEYS.filter(k => selectedFields.has(k));
+      const { csv, count } = await exportProjectTasksToCSV(
+        projectId,
+        Array.from(selectedPhaseIds),
+        orderedFields,
+      );
+
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.setAttribute('href', url);
+      link.setAttribute('download', `project-tasks-export-${new Date().toISOString().split('T')[0]}.csv`);
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      setExportedCount(count);
+      setStep('complete');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to export tasks');
+      setStep('configure');
+      handleError(err, 'Failed to export tasks');
+    }
+  }, [projectId, selectedFields, selectedPhaseIds]);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Export Project Tasks"
+      className="max-w-lg"
+    >
+      <DialogContent>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Step 1: Configure */}
+        {step === 'configure' && (
+          <div>
+            {/* Phase selection */}
+            <div className="mb-4">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-[rgb(var(--color-text-200))]">
+                  Phases to export
+                </h3>
+                <button
+                  type="button"
+                  onClick={toggleAllPhases}
+                  className="text-xs text-primary-600 hover:text-primary-700 dark:text-[rgb(var(--color-primary-400))] dark:hover:text-[rgb(var(--color-primary-300))]"
+                >
+                  {allPhasesSelected ? 'Deselect all' : 'Select all'}
+                </button>
+              </div>
+              <div className="border rounded-lg dark:border-[rgb(var(--color-border-200))]">
+                <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 p-3">
+                  {phases.map((phase) => (
+                    <Checkbox
+                      key={phase.phase_id}
+                      id={`export-phase-${phase.phase_id}`}
+                      label={phase.phase_name}
+                      checked={selectedPhaseIds.has(phase.phase_id)}
+                      onChange={() => togglePhase(phase.phase_id)}
+                      size="sm"
+                      containerClassName="mb-0"
+                      skipRegistration
+                    />
+                  ))}
+                </div>
+              </div>
+              <p className="mt-1.5 text-xs text-gray-500 dark:text-[rgb(var(--color-text-500))]">
+                {selectedPhaseIds.size} of {phases.length} phase{phases.length === 1 ? '' : 's'} selected
+              </p>
+            </div>
+
+            {/* Field selection */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-[rgb(var(--color-text-200))]">
+                  Fields to export
+                </h3>
+                <button
+                  type="button"
+                  onClick={toggleAllFields}
+                  className="text-xs text-primary-600 hover:text-primary-700 dark:text-[rgb(var(--color-primary-400))] dark:hover:text-[rgb(var(--color-primary-300))]"
+                >
+                  {allFieldsSelected ? 'Deselect all' : 'Select all'}
+                </button>
+              </div>
+              <div className="border rounded-lg dark:border-[rgb(var(--color-border-200))]">
+                <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 p-3">
+                  {EXPORT_FIELDS.map((field) => (
+                    <Checkbox
+                      key={field.key}
+                      id={`export-field-${field.key}`}
+                      label={field.label}
+                      checked={selectedFields.has(field.key)}
+                      onChange={() => toggleField(field.key)}
+                      size="sm"
+                      containerClassName="mb-0"
+                      skipRegistration
+                    />
+                  ))}
+                </div>
+              </div>
+              <p className="mt-1.5 text-xs text-gray-500 dark:text-[rgb(var(--color-text-500))]">
+                {selectedFields.size} of {EXPORT_FIELDS.length} fields selected
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button
+                id="export-tasks-cancel-btn"
+                variant="outline"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                id="export-tasks-btn"
+                onClick={() => void handleExport()}
+                disabled={noPhasesSelected || noFieldsSelected}
+                className="flex items-center gap-2"
+              >
+                <Download className="h-4 w-4" />
+                Export Tasks
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {/* Step 2: Exporting */}
+        {step === 'exporting' && (
+          <div className="text-center py-12">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-500 mx-auto mb-4" />
+            <p className="text-gray-600 dark:text-[rgb(var(--color-text-400))]">Exporting tasks...</p>
+          </div>
+        )}
+
+        {/* Step 3: Complete */}
+        {step === 'complete' && (
+          <div className="text-center py-8">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100 mb-4">
+              <Check className="h-6 w-6 text-green-600" />
+            </div>
+            <h3 className="text-lg font-medium mb-2">Export Complete</h3>
+            <p className="text-gray-600 dark:text-[rgb(var(--color-text-400))]">
+              Successfully exported {exportedCount} task{exportedCount === 1 ? '' : 's'} to CSV.
+            </p>
+            <DialogFooter>
+              <Button
+                id="export-tasks-done-btn"
+                onClick={handleClose}
+              >
+                Done
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProjectTaskExportDialog;


### PR DESCRIPTION
## Summary
- Adds an "Export Tasks" button to the project detail header (next to Save as Template, Materials, Edit)
- Opens an export dialog where users can select which phases and which fields to include in the CSV
- Server action fetches tasks for selected phases, resolves names (users, teams, statuses, priorities, task types), and generates CSV with proper escaping and injection prevention

## Test plan
- [ ] Navigate to a project detail page and verify the "Export Tasks" button appears in the header
- [ ] Click the button and verify the dialog opens with all phases and fields selected by default
- [ ] Deselect some phases and fields, then export — verify the CSV only contains the selected phases/fields
- [ ] Verify select/deselect all toggles work for both phases and fields
- [ ] Verify the exported CSV opens correctly in a spreadsheet application
- [ ] Verify the export button is disabled when no phases or no fields are selected