### PR TITLE
Fix workflow scheduler UI: select overflow and next fire time display

### DIFF
--- a/ee/packages/workflows/package.json
+++ b/ee/packages/workflows/package.json
@@ -100,6 +100,7 @@
     "@alga-psa/validation": "*",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
+    "cron-parser": "^4.9.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.24.6"
   },

--- a/ee/packages/workflows/src/components/automation-hub/Schedules.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/Schedules.tsx
@@ -72,7 +72,7 @@ const formatTimestamp = (value?: string | null): string => {
   if (!value) return '—';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleString();
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 };
 
 const formatRelativeTimestamp = (value?: string | null): string => {

--- a/ee/packages/workflows/src/components/automation-hub/WorkflowScheduleDialog.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/WorkflowScheduleDialog.tsx
@@ -450,23 +450,23 @@ export default function WorkflowScheduleDialog({
       return {
         value: workflow.workflow_id,
         label: (
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-gray-900">{workflow.name}</span>
+          <div className="flex items-center gap-2 overflow-hidden flex-nowrap">
+            <span className="font-medium text-gray-900 truncate">{workflow.name}</span>
+            <span className="flex-shrink-0">
               {workflow.published_version ? (
                 <Badge variant="info" size="sm">v{workflow.published_version}</Badge>
               ) : (
                 <Badge variant="warning" size="sm">Unpublished</Badge>
               )}
-              {String(workflow.payload_schema_mode ?? 'pinned') !== 'pinned' && (
+            </span>
+            {String(workflow.payload_schema_mode ?? 'pinned') !== 'pinned' && (
+              <span className="flex-shrink-0">
                 <Badge variant="warning" size="sm">Inferred schema</Badge>
-              )}
-            </div>
-            {eligibilityMessage && (
-              <div className="text-[11px] text-gray-500">{eligibilityMessage}</div>
+              </span>
             )}
           </div>
         ),
+        dropdownHint: eligibilityMessage || undefined,
         textValue: workflow.name
       };
     }),

--- a/ee/packages/workflows/src/lib/computeNextFireAt.ts
+++ b/ee/packages/workflows/src/lib/computeNextFireAt.ts
@@ -1,0 +1,45 @@
+import { parseExpression } from 'cron-parser';
+
+/**
+ * Compute the next fire time for a recurring cron schedule.
+ *
+ * Delegates to cron-parser which handles the full 5-field cron spec
+ * including steps (asterisk/5), ranges (1-5), month filters, etc.
+ *
+ * Returns an ISO 8601 string (UTC) or null if the expression is invalid.
+ */
+export function computeNextFireAt(
+  cron: string,
+  timezone: string,
+  after?: Date
+): string | null {
+  try {
+    const expression = parseExpression(cron, {
+      currentDate: after ?? new Date(),
+      tz: timezone || 'UTC'
+    });
+    const next = expression.next();
+    return next.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute next_fire_at for a schedule given its timing fields.
+ * Accepts both camelCase (DesiredWorkflowSchedule) and snake_case (DB record) field names.
+ * Returns null for non-recurring, disabled, or unparseable schedules.
+ */
+export function computeNextFireAtForSchedule(params: {
+  triggerType?: string;
+  trigger_type?: string;
+  cron?: string | null;
+  timezone?: string | null;
+  enabled: boolean;
+}): string | null {
+  const triggerType = params.triggerType ?? params.trigger_type;
+  if (triggerType !== 'recurring' || !params.cron || !params.enabled) {
+    return null;
+  }
+  return computeNextFireAt(params.cron, params.timezone ?? 'UTC');
+}

--- a/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
+++ b/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
@@ -11,6 +11,7 @@ import {
   getWorkflowScheduleJobRunner,
   type WorkflowScheduleJobResult as ScheduleJobResult
 } from './jobRunnerProvider';
+import { computeNextFireAtForSchedule } from './computeNextFireAt';
 
 export const WORKFLOW_ONE_TIME_TRIGGER_JOB = 'workflow-time-trigger-once';
 export const WORKFLOW_RECURRING_TRIGGER_JOB = 'workflow-time-trigger-recurring';
@@ -47,6 +48,14 @@ const workflowScheduleSingletonKey = (workflowId: string, scheduleId: string): s
   `workflow-schedule:${workflowId}:${scheduleId}`;
 
 const TERMINAL_JOB_STATUSES = new Set(['completed', 'failed']);
+
+const computeNextFireAtForDesired = (desired: DesiredWorkflowSchedule): string | null =>
+  computeNextFireAtForSchedule({
+    triggerType: desired.triggerType,
+    cron: desired.cron,
+    timezone: desired.timezone,
+    enabled: desired.enabled
+  });
 
 const isTimeTriggerDefinition = (trigger: WorkflowDefinition['trigger']): trigger is WorkflowTimeTrigger =>
   trigger?.type === 'schedule' || trigger?.type === 'recurring';
@@ -211,7 +220,8 @@ async function restorePreviousScheduleRegistration(
     job_id: restored?.jobId ?? null,
     runner_schedule_id: restored?.externalId ?? null,
     enabled: true,
-    status: desired.status
+    status: desired.status,
+    next_fire_at: computeNextFireAtForDesired(desired)
   });
 }
 
@@ -239,6 +249,7 @@ async function persistScheduleCreate(
     status: params.record.desired.status,
     job_id: params.scheduled?.jobId ?? null,
     runner_schedule_id: params.scheduled?.externalId ?? null,
+    next_fire_at: computeNextFireAtForDesired(params.record.desired),
     last_error: null
   });
 }
@@ -264,6 +275,7 @@ async function persistScheduleUpdate(
     status: params.record.desired.status,
     job_id: params.scheduled?.jobId ?? null,
     runner_schedule_id: params.scheduled?.externalId ?? null,
+    next_fire_at: computeNextFireAtForDesired(params.record.desired),
     last_error: null
   });
 }
@@ -531,7 +543,8 @@ export async function syncWorkflowScheduleState(
         status: 'disabled',
         name: existing.name ?? LEGACY_INLINE_SCHEDULE_NAME,
         job_id: null,
-        runner_schedule_id: null
+        runner_schedule_id: null,
+        next_fire_at: null
       });
     } catch (error) {
       await restorePreviousScheduleRegistration(knex, existing).catch(() => undefined);
@@ -557,7 +570,8 @@ export async function syncWorkflowScheduleState(
         enabled: params.desired.enabled,
         status: params.desired.status,
         job_id: scheduled?.jobId ?? null,
-        runner_schedule_id: scheduled?.externalId ?? null
+        runner_schedule_id: scheduled?.externalId ?? null,
+        next_fire_at: computeNextFireAtForDesired(params.desired)
       });
     } catch (error) {
       if (scheduled?.jobId) {
@@ -571,7 +585,8 @@ export async function syncWorkflowScheduleState(
     return WorkflowScheduleStateModel.update(knex, existing.id, {
       workflow_version: params.desired.workflowVersion,
       name: existing.name ?? LEGACY_INLINE_SCHEDULE_NAME,
-      status: params.desired.status
+      status: params.desired.status,
+      next_fire_at: computeNextFireAtForDesired(params.desired)
     });
   }
 
@@ -610,6 +625,7 @@ export async function syncWorkflowScheduleState(
       status: params.desired.status,
       job_id: scheduledReplacement?.jobId ?? null,
       runner_schedule_id: scheduledReplacement?.externalId ?? null,
+      next_fire_at: computeNextFireAtForDesired(params.desired),
       last_error: null
     });
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,7 +308,8 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.24.6"
+        "zod-to-json-schema": "^3.24.6",
+        "cron-parser": "^4.9.0"
       },
       "devDependencies": {
         "@alga-psa/shared": "*",

--- a/packages/ui/src/components/CustomSelect.tsx
+++ b/packages/ui/src/components/CustomSelect.tsx
@@ -12,6 +12,8 @@ export interface SelectOption {
   label: string | React.JSX.Element;
   /** Plain-text value used by Radix for the trigger display when label is JSX */
   textValue?: string;
+  /** Additional content shown only in the dropdown, not in the trigger */
+  dropdownHint?: string | React.JSX.Element;
   className?: string;
   is_inactive?: boolean;
 }
@@ -254,6 +256,7 @@ const CustomSelect = ({
             disabled:pointer-events-none disabled:cursor-not-allowed
             disabled:bg-muted disabled:text-muted-foreground disabled:border-border
             disabled:hover:bg-muted disabled:hover:text-muted-foreground
+            overflow-hidden
             ${className}
             ${customStyles?.trigger || ''}
           `}
@@ -268,9 +271,9 @@ const CustomSelect = ({
         >
           <RadixSelect.Value
             placeholder={placeholder}
-            className="flex-1 text-left"
+            className="flex-1 text-left min-w-0 overflow-hidden"
           >
-            <span className={!selectedOption || disabled ? 'text-muted-foreground' : ''}>
+            <span className={`block truncate ${!selectedOption || disabled ? 'text-muted-foreground' : ''}`}>
               {selectedOption?.label || placeholder}
             </span>
           </RadixSelect.Value>
@@ -334,15 +337,19 @@ const CustomSelect = ({
                   value={option.radixValue}
                   textValue={option.textValue ?? (typeof option.label === 'string' ? option.label : undefined)}
                   className={`
-                    relative flex items-center px-3 py-2 text-sm rounded text-foreground
+                    relative flex px-3 py-2 text-sm rounded text-foreground
                     cursor-pointer hover:bg-muted focus:bg-muted
-                    focus:outline-none select-none whitespace-nowrap
+                    focus:outline-none select-none
                     data-[highlighted]:bg-muted
+                    ${option.dropdownHint ? 'flex-col items-start' : 'items-center whitespace-nowrap'}
                     ${option.className || 'bg-background'}
                     ${customStyles?.item || ''}
                   `}
                 >
                   <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
+                  {option.dropdownHint && (
+                    <div className="text-[11px] text-gray-500 mt-0.5 whitespace-normal">{option.dropdownHint}</div>
+                  )}
                   {customStyles?.itemIndicator && (
                     <RadixSelect.ItemIndicator className={customStyles.itemIndicator}>
                       <ChevronDown className="w-4 h-4 text-muted-foreground" />

--- a/server/src/lib/jobs/handlers/workflowScheduledRunHandlers.ts
+++ b/server/src/lib/jobs/handlers/workflowScheduledRunHandlers.ts
@@ -1,4 +1,5 @@
 import { WorkflowScheduleStateModel } from '@alga-psa/workflows/persistence';
+import { computeNextFireAtForSchedule } from '@alga-psa/workflows/lib/computeNextFireAt';
 import { createTenantKnex } from 'server/src/lib/db';
 import { launchPublishedWorkflowRun } from '@alga-psa/workflows/lib/workflowRunLauncher';
 import type { BaseJobData } from '../interfaces';
@@ -109,7 +110,8 @@ async function runScheduledWorkflow(
           next_fire_at: null
         }
       : {
-          status: schedule.status
+          status: schedule.status,
+          next_fire_at: computeNextFireAtForSchedule(schedule)
         };
 
     await WorkflowScheduleStateModel.update(knex, schedule.id, {


### PR DESCRIPTION
## Summary

- **CustomSelect overflow fix**: Workflow options in the scheduler dialog were overflowing and misaligning the select trigger when eligibility messages (e.g. "No published version") were present. Added a `dropdownHint` prop to `CustomSelect` so hints render only in the dropdown list, not the trigger. Flattened workflow option labels to single-line with truncation.

- **Next fire time for recurring schedules**: The "Next Fire / Run At" column only showed the raw cron expression (e.g. `43 13 * * *`) with a dash for the timestamp. Now the server computes the actual next fire time using `cron-parser` and persists it to the existing `next_fire_at` DB column on every create, update, restore, enable/disable, and after each successful recurring run. Supports the full 5-field cron spec including steps (`*/15`), ranges (`1-5`), and month filters (`*/2`).

- **Timestamp format alignment**: Changed the schedule list's timestamp display from `toLocaleString()` (which included seconds) to `Intl.DateTimeFormat` with `dateStyle: 'medium', timeStyle: 'short'`, matching the rest of the app.

## Files changed

| File | Change |
|------|--------|
| `packages/ui/.../CustomSelect.tsx` | Add `dropdownHint` prop for dropdown-only hint text |
| `ee/.../WorkflowScheduleDialog.tsx` | Use `dropdownHint` for eligibility messages, flatten option layout |
| `ee/.../computeNextFireAt.ts` | New utility wrapping `cron-parser` for timezone-aware next fire computation |
| `ee/.../workflowScheduleLifecycle.ts` | Populate `next_fire_at` on all schedule persist paths |
| `server/.../workflowScheduledRunHandlers.ts` | Update `next_fire_at` after each recurring run fires |
| `ee/.../Schedules.tsx` | Use `dateStyle: 'medium', timeStyle: 'short'` format |
| `ee/.../workflows/package.json` | Add explicit `cron-parser` dependency |

## Test plan

- [ ] Create a recurring schedule via the scheduler dialog — verify "Next Fire / Run At" shows a human-readable date (e.g. "Mar 25, 2026, 1:43 PM") instead of "—"
- [ ] Verify the cron expression + timezone still displays below the timestamp
- [ ] Edit a recurring schedule's cron/timezone — verify the next fire time updates
- [ ] Pause and resume a schedule — verify next fire time clears on pause and recomputes on resume
- [ ] Create a one-time schedule — verify "Next Fire / Run At" shows the run_at time
- [ ] Verify workflow select in the scheduler dialog no longer overflows with long workflow names or eligibility messages
- [ ] Run existing handler tests: `npx vitest run src/test/unit/workflowScheduledRunHandlers.unit.test.ts` (3/3 passing)