### PR TITLE
Fix workflow schedule time zones

### DIFF
--- a/ee/server/src/__tests__/unit/temporalJobRunner.scheduleRecurringJob.test.ts
+++ b/ee/server/src/__tests__/unit/temporalJobRunner.scheduleRecurringJob.test.ts
@@ -15,7 +15,7 @@ vi.mock('@temporalio/client', () => {
 });
 
 describe('TemporalJobRunner.scheduleRecurringJob', () => {
-  it('uses singletonKey as scheduleId and creates schedule with timezoneName', async () => {
+  it('uses singletonKey as scheduleId and passes IANA timezone on spec (Temporal client field: timezone)', async () => {
     const { TemporalJobRunner } = await import('@ee/lib/jobs/runners/TemporalJobRunner');
     TemporalJobRunner.reset();
 
@@ -56,7 +56,7 @@ describe('TemporalJobRunner.scheduleRecurringJob', () => {
 
     const arg = client.schedule.create.mock.calls[0][0];
     expect(arg.scheduleId).toBe('extsched:install-1:sched-1');
-    expect(arg.spec.timezoneName).toBe('UTC');
+    expect(arg.spec.timezone).toBe('UTC');
     expect(arg.action?.workflowType).toBe('genericJobWorkflow');
   });
 

--- a/ee/server/src/lib/jobs/runners/TemporalJobRunner.ts
+++ b/ee/server/src/lib/jobs/runners/TemporalJobRunner.ts
@@ -308,11 +308,11 @@ export class TemporalJobRunner implements IJobRunner {
 
       // Create a new schedule
       const scheduleSpec = this.parseScheduleSpec(interval);
-      const timezoneName = (options?.metadata as any)?.timezone;
-      const spec: any = { ...scheduleSpec };
-      if (timezoneName && typeof timezoneName === 'string') {
-        // Temporal supports schedule timezones via `timezoneName` on spec.
-        spec.timezoneName = timezoneName;
+      const ianaTimeZone = (options?.metadata as { timezone?: unknown })?.timezone;
+      const spec: Record<string, unknown> = { ...scheduleSpec };
+      if (typeof ianaTimeZone === 'string' && ianaTimeZone.trim().length > 0) {
+        // @temporalio/client encodeScheduleSpec reads `timezone` and maps it to protobuf timezoneName.
+        spec.timezone = ianaTimeZone.trim();
       }
       await this.client.schedule.create({
         scheduleId,

--- a/server/src/lib/jobs/runners/PgBossJobRunner.ts
+++ b/server/src/lib/jobs/runners/PgBossJobRunner.ts
@@ -342,6 +342,10 @@ export class PgBossJobRunner implements IJobRunner {
       }
 
       // Use PG Boss schedule() for cron-based recurring jobs.
+      const cronTz =
+        options?.metadata && typeof (options.metadata as Record<string, unknown>).timezone === 'string'
+          ? String((options.metadata as Record<string, unknown>).timezone).trim() || 'UTC'
+          : 'UTC';
       try {
         await this.boss.schedule(
           queueName,
@@ -350,6 +354,7 @@ export class PgBossJobRunner implements IJobRunner {
           {
             retryLimit: 3,
             retryBackoff: true,
+            tz: cronTz,
           }
         );
         externalId = queueName;


### PR DESCRIPTION
## Summary
- fix Temporal recurring schedule creation to pass the timezone using spec.timezone, which is what @temporalio/client serializes into timezone_name
- fix pg-boss recurring cron scheduling to pass tz from job metadata instead of always using the default UTC timezone
- update the Temporal unit test to assert the correct schedule spec field

## Root cause
Recurring workflow schedules already persisted the configured IANA timezone in job metadata, but the runner implementations were not wiring that value through correctly:
- Temporal was setting spec.timezoneName, while the TypeScript client reads spec.timezone
- pg-boss was not passing tz, so cron schedules defaulted to UTC

## Notes
- existing Temporal schedules created before this fix will continue using UTC until they are recreated

## Validation
- cd ee/server && npx vitest --config vitest.config.ts --run src/__tests__/unit/temporalJobRunner.scheduleRecurringJob.test.ts