### PR TITLE
Always show closed ticket statuses in filter dropdown

### DIFF
--- a/packages/tickets/src/lib/ticketStatusFilter.test.ts
+++ b/packages/tickets/src/lib/ticketStatusFilter.test.ts
@@ -41,7 +41,7 @@ describe('ticketStatusFilter', () => {
     ]);
   });
 
-  it('filters grouped options to open statuses when the open sentinel is selected', () => {
+  it('still shows closed grouped options when the open sentinel is selected', () => {
     const options = buildTicketStatusFilterOptions(
       STATUS_OPTIONS,
       undefined,
@@ -52,6 +52,7 @@ describe('ticketStatusFilter', () => {
       TICKET_STATUS_FILTER_OPEN,
       TICKET_STATUS_FILTER_ALL,
       createTicketStatusNameFilterValue('New'),
+      createTicketStatusNameFilterValue('Closed'),
       createTicketStatusNameFilterValue('Review'),
     ]);
   });

--- a/packages/tickets/src/lib/ticketStatusFilter.ts
+++ b/packages/tickets/src/lib/ticketStatusFilter.ts
@@ -55,8 +55,6 @@ export function buildTicketStatusFilterOptions(
   selectedBoardId?: string | null,
   selectedStatusId?: string | null
 ): TicketStatusFilterOption[] {
-  const parsedSelection = parseTicketStatusFilterValue(selectedStatusId);
-  const restrictToOpenStatuses = parsedSelection.kind === 'open';
   const groupedStatuses = new Map<string, TicketStatusFilterOption>();
 
   for (const option of statusOptions) {
@@ -68,10 +66,6 @@ export function buildTicketStatusFilterOptions(
     }
 
     if (selectedBoardId && option.boardId !== selectedBoardId) {
-      continue;
-    }
-
-    if (restrictToOpenStatuses && option.isClosed) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- keep closed ticket statuses visible in the grouped status filter dropdown
- preserve the existing open-only list query behavior while broadening the available status choices
- update the focused helper test to cover the new dropdown behavior

## Testing
- not run: package-local Vitest is broken in this worktree because required optional runtime deps are missing
- not run: package-local typecheck is blocked by existing workspace dependency/type resolution issues
