### PR TITLE
[codex] Refresh package lock for packaging fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,7 @@
         "zustand": "^4.5.7"
       },
       "devDependencies": {
+        "@bytecodealliance/wizer": "^10.0.0",
         "@eslint/js": "^9.17.0",
         "@nx/docker": "22.3.3",
         "@nx/eslint": "22.3.3",
@@ -2316,10 +2317,6 @@
       "resolved": "sdk/extension-iframe-sdk",
       "link": true
     },
-    "node_modules/@alga-psa/extension-runtime": {
-      "resolved": "sdk/extension-runtime",
-      "link": true
-    },
     "node_modules/@alga-psa/formatting": {
       "resolved": "packages/formatting",
       "link": true
@@ -2438,6 +2435,10 @@
     },
     "node_modules/@alga-psa/workflows": {
       "resolved": "ee/packages/workflows",
+      "link": true
+    },
+    "node_modules/@alga-samples/client-service-read-demo": {
+      "resolved": "sdk/samples/component/client-service-read-demo",
       "link": true
     },
     "node_modules/@alga-samples/invoicing-demo": {
@@ -47847,7 +47848,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.17-rc4",
+      "version": "1.0.4-rc5",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -48351,6 +48352,7 @@
         "@alga-psa/clients": "*",
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
+        "@alga-psa/documents": "*",
         "@alga-psa/formatting": "*",
         "@alga-psa/types": "*",
         "@alga-psa/user-composition": "*",
@@ -49517,11 +49519,7 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -51697,6 +51695,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "sdk/samples/component/client-service-read-demo": {
+      "name": "@alga-samples/client-service-read-demo",
+      "dependencies": {
+        "@alga-psa/extension-runtime": "^0.3.0"
+      },
+      "devDependencies": {
+        "vitest": "^4.0.18"
+      }
+    },
+    "sdk/samples/component/client-service-read-demo/node_modules/@alga-psa/extension-runtime": {
+      "resolved": "sdk/extension-runtime",
+      "link": true
+    },
     "sdk/samples/component/invoicing-demo": {
       "name": "@alga-samples/invoicing-demo",
       "dependencies": {
@@ -53620,7 +53631,7 @@
       }
     },
     "server": {
-      "version": "1.0.10-rc4",
+      "version": "1.0.4-rc5",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/workflow-streams": "*",


### PR DESCRIPTION
## Summary
Refresh `package-lock.json` so it matches the current workspace package manifests and packaging metadata.

## What Changed
- Updated root lockfile entries to reflect current declared dev dependencies.
- Refreshed workspace package metadata captured in the lockfile.
- Added the sample workspace package and nested extension-runtime link entries now represented by the current package graph.

## Impact
- Aligns the committed lockfile with the current repository package manifest state.
- Avoids lockfile drift between installs and packaging flows that rely on the committed workspace graph.

## Validation
- Isolated the change on a fresh branch from `main`.
- Verified the PR contains only `package-lock.json`.
- Did not run an automated test suite for this lockfile-only update.