### PR TITLE
Match client portal ticket status filters to MSP

### DIFF
--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
@@ -16,7 +16,10 @@ import { ServerAnalyticsTracker } from '@alga-psa/analytics';
 import { createTenantKnex, getConnection, withTransaction } from '@alga-psa/db';
 import { publishEvent } from '@alga-psa/event-bus/publishers';
 import { maybeReopenBundleMasterFromChildReply } from '@alga-psa/tickets/actions/ticketBundleUtils';
-import { getTicketOrigin } from '@alga-psa/tickets/lib/ticketOrigin';
+import {
+  getTicketOrigin,
+  parseTicketStatusFilterValue,
+} from '@alga-psa/tickets/lib';
 import { getUserAvatarUrlAction, getContactAvatarUrlAction } from '@alga-psa/user-composition/actions';
 
 const clientTicketSchema = z.object({
@@ -58,6 +61,7 @@ export const getClientTickets = withAuth(async (user, { tenant }, status: string
     console.log('Debug - User ID:', user.user_id);
     console.log('Debug - Tenant:', tenant);
     console.log('Debug - Client user:', user.user_id);
+    const parsedStatusFilter = parseTicketStatusFilterValue(status);
 
     const result = await withTransaction(db, async (trx: Knex.Transaction) => {
       // Get user's client_id
@@ -153,15 +157,16 @@ export const getClientTickets = withAuth(async (user, { tenant }, status: string
       });
 
     // Filter by status
-    if (status === 'all') {
+    if (parsedStatusFilter.kind === 'all') {
       // No filter, show all tickets
-    } else if (status === 'open') {
-      query = query.whereNull('t.closed_at');
-    } else if (status === 'closed') {
-      query = query.whereNotNull('t.closed_at');
-    } else if (status) {
-      // Filter by specific status_id
-      query = query.where('t.status_id', status);
+    } else if (parsedStatusFilter.kind === 'open') {
+      query = query.where('s.is_closed', false);
+    } else if (parsedStatusFilter.kind === 'closed') {
+      query = query.where('s.is_closed', true);
+    } else if (parsedStatusFilter.kind === 'name') {
+      query = query.where('s.name', parsedStatusFilter.statusName);
+    } else if (parsedStatusFilter.kind === 'id') {
+      query = query.where('t.status_id', parsedStatusFilter.statusId);
     }
 
       const tickets = await query.orderBy('t.entered_at', 'desc');

--- a/packages/client-portal/src/components/tickets/TicketList.tsx
+++ b/packages/client-portal/src/components/tickets/TicketList.tsx
@@ -33,6 +33,13 @@ import { ClientAddTicket } from './ClientAddTicket';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
 import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
+import {
+  buildTicketStatusFilterOptions,
+  TICKET_STATUS_FILTER_ALL,
+  TICKET_STATUS_FILTER_CLOSED,
+  TICKET_STATUS_FILTER_OPEN,
+  type TicketStatusFilterOption,
+} from '@alga-psa/tickets/lib';
 
 const useDebounce = <T,>(value: T, delay: number): T => {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
@@ -57,11 +64,11 @@ export function TicketList() {
   const [pageSize, setPageSize] = useState(10);
   const [sortField, setSortField] = useState<string>('entered_at');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
-  const [statusOptions, setStatusOptions] = useState<SelectOption[]>([]);
+  const [rawStatusOptions, setRawStatusOptions] = useState<TicketStatusFilterOption[]>([]);
   const [boardStatusOptions, setBoardStatusOptions] = useState<Record<string, SelectOption[]>>({});
   const [priorityOptions, setPriorityOptions] = useState<{ value: string; label: string }[]>([]);
   const [categories, setCategories] = useState<ITicketCategory[]>([]);
-  const [selectedStatus, setSelectedStatus] = useState<string>('all');
+  const [selectedStatus, setSelectedStatus] = useState<string>(TICKET_STATUS_FILTER_ALL);
   const [selectedResponseStatus, setSelectedResponseStatus] = useState<'all' | 'awaiting_client' | 'awaiting_internal' | 'none'>('all');
   const [selectedPriority, setSelectedPriority] = useState('all');
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
@@ -159,16 +166,16 @@ export function TicketList() {
           getTicketCategories()
         ]);
 
-        setStatusOptions([
-          { value: 'all', label: t('filters.allStatuses') },
-          { value: 'open', label: t('filters.allOpen') },
-          { value: 'closed', label: t('filters.allClosed') },
-          ...statuses.map((status: IStatus): SelectOption => ({
+        setRawStatusOptions(
+          statuses.map((status: IStatus): TicketStatusFilterOption => ({
             value: status.status_id!,
             label: status.name ?? "",
-            className: status.is_closed ? 'bg-gray-200 text-gray-600' : undefined
+            className: status.is_closed ? 'bg-gray-200 text-gray-600' : undefined,
+            statusName: status.name ?? '',
+            boardId: status.board_id ?? null,
+            isClosed: Boolean(status.is_closed),
           }))
-        ]);
+        );
 
         setPriorityOptions([
           { value: 'all', label: t('filters.allPriorities') },
@@ -239,6 +246,21 @@ export function TicketList() {
       active = false;
     };
   }, [tickets]);
+
+  const statusOptions = useMemo<SelectOption[]>(() => {
+    const groupedOptions = buildTicketStatusFilterOptions(rawStatusOptions, undefined, selectedStatus)
+      .filter((option) =>
+        option.value !== TICKET_STATUS_FILTER_ALL &&
+        option.value !== TICKET_STATUS_FILTER_OPEN
+      );
+
+    return [
+      { value: TICKET_STATUS_FILTER_ALL, label: t('filters.allStatuses') },
+      { value: TICKET_STATUS_FILTER_OPEN, label: t('filters.allOpen') },
+      { value: TICKET_STATUS_FILTER_CLOSED, label: t('filters.allClosed') },
+      ...groupedOptions,
+    ];
+  }, [rawStatusOptions, selectedStatus, t]);
 
   const loadTickets = useCallback(async () => {
     setLoading(true);
@@ -350,7 +372,7 @@ export function TicketList() {
     if (!ticketToUpdateStatus) return;
 
     const { ticketId, newStatus } = ticketToUpdateStatus;
-    const newStatusLabel = statusOptions.find(s => s.value === newStatus)?.label || 'Unknown Status';
+    const newStatusLabel = rawStatusOptions.find(s => s.value === newStatus)?.label || 'Unknown Status';
 
     try {
       await updateTicketStatus(ticketId, newStatus);
@@ -364,7 +386,7 @@ export function TicketList() {
     } finally {
       setTicketToUpdateStatus(null);
     }
-  }, [ticketToUpdateStatus, selectedStatus, loadTickets, statusOptions]); 
+  }, [ticketToUpdateStatus, loadTickets, rawStatusOptions]);
 
   const handleCategorySelect = useCallback((categoryIds: string[], excludedIds: string[]) => {
     setSelectedCategories(categoryIds);
@@ -379,7 +401,7 @@ export function TicketList() {
   };
 
   const isFiltered = useMemo(() => {
-    return selectedStatus !== 'all' ||
+    return selectedStatus !== TICKET_STATUS_FILTER_ALL ||
       selectedResponseStatus !== 'all' ||
       selectedPriority !== 'all' ||
       selectedCategories.length > 0 ||
@@ -388,7 +410,7 @@ export function TicketList() {
   }, [selectedStatus, selectedResponseStatus, selectedPriority, selectedCategories, excludedCategories, searchQuery]);
 
   const handleResetFilters = useCallback(() => {
-    setSelectedStatus('all');
+    setSelectedStatus(TICKET_STATUS_FILTER_ALL);
     setSelectedResponseStatus('all');
     setSelectedPriority('all');
     setSelectedCategories([]);
@@ -765,7 +787,7 @@ export function TicketList() {
         onClose={() => setTicketToUpdateStatus(null)}
         onConfirm={handleStatusChange}
         title="Update Ticket Status"
-        message={`Are you sure you want to change the status from "${ticketToUpdateStatus?.currentStatus}" to "${statusOptions.find(s => s.value === ticketToUpdateStatus?.newStatus)?.label}"?`}
+        message={`Are you sure you want to change the status from "${ticketToUpdateStatus?.currentStatus}" to "${rawStatusOptions.find(s => s.value === ticketToUpdateStatus?.newStatus)?.label}"?`}
         confirmLabel="Update"
         cancelLabel="Cancel"
       />

--- a/packages/tickets/src/lib/index.ts
+++ b/packages/tickets/src/lib/index.ts
@@ -21,10 +21,12 @@ export { TicketMobileEditorRuntime } from './ticketMobileEditorRuntime';
 export {
   buildTicketStatusFilterOptions,
   createTicketStatusNameFilterValue,
+  isTicketStatusClosedFilter,
   isTicketStatusOpenFilter,
   parseTicketStatusFilterValue,
   shouldApplyOpenOnlyStatusFilter,
   TICKET_STATUS_FILTER_ALL,
+  TICKET_STATUS_FILTER_CLOSED,
   TICKET_STATUS_FILTER_OPEN,
 } from './ticketStatusFilter';
 export type {

--- a/packages/tickets/src/lib/ticketStatusFilter.test.ts
+++ b/packages/tickets/src/lib/ticketStatusFilter.test.ts
@@ -4,6 +4,7 @@ import {
   createTicketStatusNameFilterValue,
   parseTicketStatusFilterValue,
   TICKET_STATUS_FILTER_ALL,
+  TICKET_STATUS_FILTER_CLOSED,
   TICKET_STATUS_FILTER_OPEN,
   type TicketStatusFilterOption,
 } from './ticketStatusFilter';
@@ -22,6 +23,12 @@ describe('ticketStatusFilter', () => {
     expect(parseTicketStatusFilterValue(createTicketStatusNameFilterValue('Needs Review'))).toEqual({
       kind: 'name',
       statusName: 'Needs Review',
+    });
+  });
+
+  it('parses the closed sentinel filter value', () => {
+    expect(parseTicketStatusFilterValue(TICKET_STATUS_FILTER_CLOSED)).toEqual({
+      kind: 'closed',
     });
   });
 

--- a/packages/tickets/src/lib/ticketStatusFilter.ts
+++ b/packages/tickets/src/lib/ticketStatusFilter.ts
@@ -2,6 +2,7 @@ import type { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 
 export const TICKET_STATUS_FILTER_OPEN = '__status_filter__:open';
 export const TICKET_STATUS_FILTER_ALL = '__status_filter__:all';
+export const TICKET_STATUS_FILTER_CLOSED = '__status_filter__:closed';
 const TICKET_STATUS_NAME_PREFIX = '__status_name__:';
 
 export interface TicketStatusFilterOption extends SelectOption {
@@ -13,11 +14,16 @@ export interface TicketStatusFilterOption extends SelectOption {
 type ParsedTicketStatusFilter =
   | { kind: 'open' }
   | { kind: 'all' }
+  | { kind: 'closed' }
   | { kind: 'name'; statusName: string }
   | { kind: 'id'; statusId: string };
 
 export function isTicketStatusOpenFilter(statusId?: string | null): boolean {
   return statusId === TICKET_STATUS_FILTER_OPEN;
+}
+
+export function isTicketStatusClosedFilter(statusId?: string | null): boolean {
+  return statusId === TICKET_STATUS_FILTER_CLOSED;
 }
 
 export function shouldApplyOpenOnlyStatusFilter(
@@ -40,6 +46,10 @@ export function parseTicketStatusFilterValue(statusId?: string | null): ParsedTi
     return { kind: 'all' };
   }
 
+  if (statusId === TICKET_STATUS_FILTER_CLOSED) {
+    return { kind: 'closed' };
+  }
+
   if (statusId.startsWith(TICKET_STATUS_NAME_PREFIX)) {
     return {
       kind: 'name',
@@ -60,7 +70,8 @@ export function buildTicketStatusFilterOptions(
   for (const option of statusOptions) {
     if (
       option.value === TICKET_STATUS_FILTER_OPEN ||
-      option.value === TICKET_STATUS_FILTER_ALL
+      option.value === TICKET_STATUS_FILTER_ALL ||
+      option.value === TICKET_STATUS_FILTER_CLOSED
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary
- group client portal ticket status filter options by status name instead of raw status ID
- reuse the shared ticket status filter token parsing so portal-specific filtering matches MSP behavior
- keep open, closed, and all sentinel filters while always showing closed statuses in the dropdown

## Testing
- git diff --check
- not run: automated tests (local dependency/build issues in this worktree)