### PR TITLE
Add linked tasks badge to ticket details

### DIFF
--- a/packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx
+++ b/packages/msp-composition/src/tickets/MspTicketDetailsContainerClient.tsx
@@ -7,6 +7,7 @@ import ClientDetails from '@alga-psa/clients/components/clients/ClientDetails';
 import type { IClient, IContact, SurveyTicketSatisfactionSummary } from '@alga-psa/types';
 import CreateTaskFromTicketDialog from '@alga-psa/projects/components/CreateTaskFromTicketDialog';
 import LinkTicketToTaskDialog from '@alga-psa/projects/components/LinkTicketToTaskDialog';
+import TicketLinkedTasksBadge from '@alga-psa/projects/components/TicketLinkedTasksBadge';
 import { IntervalManagement } from '@alga-psa/scheduling/components/time-management/interval-tracking/IntervalManagement';
 import { TicketIntegrationProvider } from '@alga-psa/projects/context/TicketIntegrationContext';
 import { useTicketIntegrationValue } from '../projects/useTicketIntegrationValue';
@@ -45,6 +46,7 @@ export default function MspTicketDetailsContainerClient({ surveySummary, ...prop
   const renderCreateProjectTask = useCallback(
     ({ ticket, additionalAgents }: { ticket: any; additionalAgents?: { user_id: string; name: string }[] }) => (
       <>
+        {ticket.ticket_id && <TicketLinkedTasksBadge ticketId={ticket.ticket_id} />}
         <CreateTaskFromTicketDialog ticket={{ ...ticket, additional_agents: additionalAgents }} />
         <LinkTicketToTaskDialog ticket={ticket} />
       </>

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -15,6 +15,7 @@ import type {
   IProjectTaskDependency,
   IProjectTicketLink,
   IProjectTicketLinkWithDetails,
+  ITicketLinkedTask,
   ITag,
   ITaskChecklistItem,
   ITaskType,
@@ -633,6 +634,23 @@ export const getTaskTicketLinksAction = withAuth(async (
         });
     } catch (error) {
         console.error('Error getting task ticket links:', error);
+        throw error;
+    }
+});
+
+export const getLinkedTasksForTicketAction = withAuth(async (
+    user,
+    { tenant },
+    ticketId: string
+): Promise<ITicketLinkedTask[]> => {
+    try {
+        const {knex: db} = await createTenantKnex();
+        return await withTransaction(db, async (trx: Knex.Transaction) => {
+            await checkPermission(user, 'project', 'read', trx);
+            return await ProjectTaskModel.getLinkedTasksForTicket(trx, tenant, ticketId);
+        });
+    } catch (error) {
+        console.error('Error getting linked tasks for ticket:', error);
         throw error;
     }
 });

--- a/packages/projects/src/components/TicketLinkedTasksBadge.tsx
+++ b/packages/projects/src/components/TicketLinkedTasksBadge.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { ClipboardList, ExternalLink, Loader2 } from 'lucide-react';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Popover, PopoverTrigger, PopoverContent } from '@alga-psa/ui/components/Popover';
+import { useDrawer } from '@alga-psa/ui';
+import { toast } from 'react-hot-toast';
+import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import type { ITicketLinkedTask } from '@alga-psa/types';
+import { getLinkedTasksForTicketAction, getTaskWithDetails } from '../actions/projectTaskActions';
+import { getProjectDetails } from '../actions/projectActions';
+import TaskEdit from './TaskEdit';
+
+interface TicketLinkedTasksBadgeProps {
+  ticketId: string;
+}
+
+export default function TicketLinkedTasksBadge({
+  ticketId,
+}: TicketLinkedTasksBadgeProps): React.JSX.Element | null {
+  const [linkedTasks, setLinkedTasks] = useState<ITicketLinkedTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [openingTaskId, setOpeningTaskId] = useState<string | null>(null);
+  const { openDrawer, closeDrawer } = useDrawer();
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchLinkedTasks = async () => {
+      try {
+        const tasks = await getLinkedTasksForTicketAction(ticketId);
+        if (mounted) {
+          setLinkedTasks(tasks || []);
+        }
+      } catch (error) {
+        console.error('Error fetching linked tasks:', error);
+        if (mounted) {
+          setLinkedTasks([]);
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+    fetchLinkedTasks();
+    return () => { mounted = false; };
+  }, [ticketId]);
+
+  const handleOpenTask = useCallback(async (task: ITicketLinkedTask) => {
+    setOpeningTaskId(task.task_id);
+    try {
+      const [taskDetails, projectDetailsResult] = await Promise.all([
+        getTaskWithDetails(task.task_id),
+        getProjectDetails(task.project_id),
+      ]);
+
+      if (!taskDetails) {
+        toast.error('Failed to load task');
+        return;
+      }
+
+      if (isActionPermissionError(projectDetailsResult)) {
+        handleError(projectDetailsResult.permissionError);
+        return;
+      }
+
+      const projectDetails = projectDetailsResult;
+
+      const phase = projectDetails.phases?.find(
+        (p: { phase_id: string }) => p.phase_id === task.phase_id
+      );
+      if (!phase) {
+        toast.error('Task phase not found');
+        return;
+      }
+
+      const statuses = projectDetails.statuses || [];
+      const users = projectDetails.users || [];
+
+      openDrawer(
+        <TaskEdit
+          task={taskDetails}
+          phase={phase}
+          phases={projectDetails.phases}
+          onClose={closeDrawer}
+          onTaskUpdated={() => {
+            closeDrawer();
+          }}
+          projectStatuses={statuses}
+          users={users}
+          inDrawer
+        />
+      );
+    } catch (error) {
+      handleError(error, 'Failed to open task');
+    } finally {
+      setOpeningTaskId(null);
+    }
+  }, [openDrawer, closeDrawer]);
+
+  if (loading) {
+    return null;
+  }
+
+  if (linkedTasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          id="ticket-linked-tasks-badge"
+          type="button"
+          variant="soft"
+          className="flex items-center"
+        >
+          <ClipboardList className="h-4 w-4 mr-1" />
+          {linkedTasks.length} {linkedTasks.length === 1 ? 'Task' : 'Tasks'}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-0">
+        <div className="px-3 py-2 border-b border-[rgb(var(--color-border-200))]">
+          <h4 className="text-sm font-medium">Linked Project Tasks</h4>
+        </div>
+        <div className="max-h-60 overflow-y-auto">
+          {linkedTasks.map((task) => (
+            <button
+              key={task.link_id}
+              type="button"
+              className="w-full text-left px-3 py-2 hover:bg-[rgb(var(--color-border-100))] flex items-center justify-between gap-2 border-b border-[rgb(var(--color-border-100))] last:border-b-0"
+              onClick={() => handleOpenTask(task)}
+              disabled={openingTaskId === task.task_id}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium truncate">{task.task_name}</div>
+                <div className="text-xs text-[rgb(var(--color-text-400))] truncate">
+                  {task.project_name} &middot; {task.phase_name}
+                </div>
+                {task.status_name && (
+                  <span className="text-xs text-[rgb(var(--color-text-400))]">
+                    {task.status_name}
+                  </span>
+                )}
+              </div>
+              <div className="flex-shrink-0">
+                {openingTaskId === task.task_id ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-[rgb(var(--color-text-400))]" />
+                ) : (
+                  <ExternalLink className="h-4 w-4 text-[rgb(var(--color-text-400))]" />
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/projects/src/models/projectTask.ts
+++ b/packages/projects/src/models/projectTask.ts
@@ -6,6 +6,7 @@ import type {
   IProjectTicketLink,
   IProjectTicketLinkWithDetails,
   IProjectTaskCardInfo,
+  ITicketLinkedTask,
 } from '@alga-psa/types';
 import ProjectModel from './project';
 
@@ -768,6 +769,57 @@ const ProjectTaskModel = {
       }, {});
     } catch (error) {
       console.error('Error getting all task ticket links:', error);
+      throw error;
+    }
+  },
+
+  getLinkedTasksForTicket: async (knexOrTrx: Knex | Knex.Transaction, tenant: string, ticketId: string): Promise<ITicketLinkedTask[]> => {
+    try {
+      if (!tenant) {
+        throw new Error('Tenant context is required');
+      }
+      const links = await knexOrTrx('project_ticket_links')
+        .where('project_ticket_links.ticket_id', ticketId)
+        .andWhere('project_ticket_links.tenant', tenant)
+        .whereNotNull('project_ticket_links.task_id')
+        .leftJoin('project_tasks', function() {
+          this.on('project_ticket_links.task_id', 'project_tasks.task_id')
+              .andOn('project_ticket_links.tenant', 'project_tasks.tenant');
+        })
+        .leftJoin('projects', function() {
+          this.on('project_ticket_links.project_id', 'projects.project_id')
+              .andOn('project_ticket_links.tenant', 'projects.tenant');
+        })
+        .leftJoin('project_phases', function() {
+          this.on('project_tasks.phase_id', 'project_phases.phase_id')
+              .andOn('project_tasks.tenant', 'project_phases.tenant');
+        })
+        .leftJoin('project_status_mappings as psm', function() {
+          this.on('project_tasks.project_status_mapping_id', 'psm.project_status_mapping_id')
+              .andOn('project_tasks.tenant', 'psm.tenant');
+        })
+        .leftJoin('statuses as s', function() {
+          this.on('psm.status_id', 's.status_id')
+              .andOn('psm.tenant', 's.tenant');
+        })
+        .leftJoin('standard_statuses as ss', function() {
+          this.on('psm.standard_status_id', 'ss.standard_status_id')
+              .andOn('psm.tenant', 'ss.tenant');
+        })
+        .select(
+          'project_ticket_links.link_id',
+          'project_tasks.task_id',
+          'project_tasks.task_name',
+          'projects.project_id',
+          'projects.project_name',
+          'project_phases.phase_id',
+          'project_phases.phase_name',
+          knexOrTrx.raw('COALESCE(psm.custom_name, s.name, ss.name) as status_name'),
+          knexOrTrx.raw('COALESCE(s.is_closed, ss.is_closed, false) as is_closed')
+        );
+      return links;
+    } catch (error) {
+      console.error('Error getting linked tasks for ticket:', error);
       throw error;
     }
   },

--- a/packages/types/src/interfaces/project.interfaces.ts
+++ b/packages/types/src/interfaces/project.interfaces.ts
@@ -136,6 +136,18 @@ export interface IProjectTicketLinkWithDetails extends IProjectTicketLink {
   is_closed: boolean;
 }
 
+export interface ITicketLinkedTask {
+  link_id: string;
+  task_id: string;
+  task_name: string;
+  project_id: string;
+  project_name: string;
+  phase_id: string;
+  phase_name: string;
+  status_name: string | null;
+  is_closed: boolean;
+}
+
 export interface ITaskChecklistItem extends TenantEntity {
   checklist_item_id: string;
   task_id: string;


### PR DESCRIPTION
  Show a counter badge on tickets indicating how many project
  tasks are linked. Clicking opens a popover listing each task
  with project/phase/status info and the ability to open the
  task in a drawer for editing.

  - Add ITicketLinkedTask type
  - Add getLinkedTasksForTicket model method and server action
  - Create TicketLinkedTasksBadge component with popover
  - Wire badge into MspTicketDetailsContainerClient

  "We're all linked here," said the Cheshire Badge, grinning from its PopoverContent. "Every ticket has its tasks, every
  task its phases, and every COALESCE its fallback." The Drawer opened wide, and Alice tumbled through six LEFT JOINs
  before landing softly on a ClipboardList. 📋🐱✨