### PR TITLE
[codex] Clarify duplicate product SKU errors

### DIFF
--- a/packages/billing/src/actions/serviceActions.ts
+++ b/packages/billing/src/actions/serviceActions.ts
@@ -10,8 +10,8 @@ import { validateArray } from '@alga-psa/validation';
 import { ServiceTypeModel } from '../models/serviceType'; // Import ServiceTypeModel
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
-import { permissionError } from '@alga-psa/ui/lib/errorHandling';
-import type { ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { actionError, permissionError } from '@alga-psa/ui/lib/errorHandling';
+import type { ActionMessageError, ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { deleteEntityWithValidation } from '@alga-psa/core';
 
 
@@ -342,6 +342,21 @@ export const getServiceById = withAuth(async (user, { tenant }, serviceId: strin
 // Define a type for the input data
 export type CreateServiceInput = Omit<IService, 'service_id' | 'tenant'>;
 
+function normalizeCreateServiceError(serviceData: CreateServiceInput, error: unknown): ActionMessageError | null {
+    const typedError = error as { code?: string; constraint?: string };
+
+    if (
+        typedError?.code === '23505' &&
+        serviceData.item_kind === 'product' &&
+        serviceData.sku?.trim() &&
+        typedError.constraint?.includes('service_catalog_product_sku_unique')
+    ) {
+        return actionError(`A product with SKU "${serviceData.sku.trim()}" already exists. Use a different SKU or edit the existing product.`);
+    }
+
+    return null;
+}
+
 
 function safeRevalidate(path: string): void {
     try {
@@ -355,7 +370,7 @@ export const createService = withAuth(async (
     user,
     { tenant },
     serviceData: CreateServiceInput
-): Promise<IService | ActionPermissionError> => {
+): Promise<IService | ActionPermissionError | ActionMessageError> => {
     const canCreate = await hasPermission(user, 'service', 'create');
     if (!canCreate) {
       return permissionError('Permission denied: Cannot create services/products');
@@ -409,6 +424,10 @@ export const createService = withAuth(async (
         });
     } catch (error) {
         console.error('[serviceActions] Error creating service:', error);
+        const normalizedError = normalizeCreateServiceError(serviceData, error);
+        if (normalizedError) {
+            return normalizedError;
+        }
         throw error; // Re-throw the error
     }
 });

--- a/packages/billing/src/components/billing-dashboard/ServiceForm.tsx
+++ b/packages/billing/src/components/billing-dashboard/ServiceForm.tsx
@@ -9,7 +9,7 @@ import { getActiveTaxRegions, getTaxRates } from '@alga-psa/billing/actions/taxS
 import { ITaxRate, ITaxRegion } from '@alga-psa/types';
 import { UnitOfMeasureInput } from '@alga-psa/ui/components/UnitOfMeasureInput';
 import { toast } from 'react-hot-toast';
-import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { getErrorMessage, handleError, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 export const ServiceForm: React.FC = () => {
   const [serviceName, setServiceName] = useState('')
@@ -100,6 +100,10 @@ export const ServiceForm: React.FC = () => {
       if (isActionPermissionError(result)) {
         handleError(result.permissionError);
         return;
+      }
+      if (isActionMessageError(result)) {
+        setError(getErrorMessage(result))
+        return
       }
       setError(null)
       // Clear form fields after successful submission

--- a/packages/billing/src/components/settings/billing/QuickAddProduct.tsx
+++ b/packages/billing/src/components/settings/billing/QuickAddProduct.tsx
@@ -20,7 +20,7 @@ import { ITaxRate } from '@alga-psa/types';
 import { IService, IServiceCategory } from '@alga-psa/types';
 import { CURRENCY_OPTIONS, getCurrencySymbol } from '@alga-psa/core';
 import { getServiceCategories } from '@alga-psa/billing/actions';
-import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { getErrorMessage, handleError, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 const LICENSE_TERM_OPTIONS = [
   { value: 'monthly', label: 'Monthly' },
@@ -233,6 +233,10 @@ export function QuickAddProduct({ isOpen, onClose, onProductAdded, product }: Qu
 
         if (isActionPermissionError(created)) {
           handleError(created.permissionError);
+          return;
+        }
+        if (isActionMessageError(created)) {
+          setError(getErrorMessage(created));
           return;
         }
         await setServicePrices(created.service_id, formPrices);

--- a/packages/billing/src/components/settings/billing/QuickAddService.tsx
+++ b/packages/billing/src/components/settings/billing/QuickAddService.tsx
@@ -17,7 +17,7 @@ import { ITaxRate } from '@alga-psa/types'; // Removed ITaxRegion
 import { getServiceCategories } from '@alga-psa/billing/actions'
 import { IService, IServiceCategory, IServiceType } from '@alga-psa/types' // Added IServiceType
 import { useTenant } from '@alga-psa/ui/components/providers/TenantProvider'
-import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling'
+import { getErrorMessage, handleError, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling'
 
 interface QuickAddServiceProps {
   onServiceAdded: () => void;
@@ -256,6 +256,10 @@ console.log('[QuickAddService] Service created successfully:', createdService);
 
 if (isActionPermissionError(createdService)) {
   handleError(createdService.permissionError);
+  return;
+}
+if (isActionMessageError(createdService)) {
+  setError(getErrorMessage(createdService));
   return;
 }
 

--- a/packages/ui/src/lib/errorHandling.ts
+++ b/packages/ui/src/lib/errorHandling.ts
@@ -14,14 +14,36 @@ export interface ActionPermissionError {
 }
 
 /**
+ * Represents a user-safe error returned from a server action.
+ * Use this for expected business-rule failures that should reach the client intact.
+ */
+export interface ActionMessageError {
+  readonly actionError: string;
+}
+
+/**
  * Type guard: checks if a server action result is a permission error.
  */
 export function isActionPermissionError(value: unknown): value is ActionPermissionError {
+  const candidate = value as Record<string, unknown>;
   return (
     typeof value === 'object' &&
     value !== null &&
     'permissionError' in value &&
-    typeof (value as any).permissionError === 'string'
+    typeof candidate.permissionError === 'string'
+  );
+}
+
+/**
+ * Type guard: checks if a server action result is a user-safe action error.
+ */
+export function isActionMessageError(value: unknown): value is ActionMessageError {
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'actionError' in value &&
+    typeof candidate.actionError === 'string'
   );
 }
 
@@ -31,6 +53,13 @@ export function isActionPermissionError(value: unknown): value is ActionPermissi
  */
 export function permissionError(message: string): ActionPermissionError {
   return { permissionError: message };
+}
+
+/**
+ * Creates a user-safe error return value for server actions.
+ */
+export function actionError(message: string): ActionMessageError {
+  return { actionError: message };
 }
 
 // --- Error detection utilities ---
@@ -58,6 +87,9 @@ export function isPermissionError(error: unknown): boolean {
 export function getErrorMessage(error: unknown): string {
   if (isActionPermissionError(error)) {
     return error.permissionError;
+  }
+  if (isActionMessageError(error)) {
+    return error.actionError;
   }
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
## What changed
This updates product and service creation flows to surface a user-safe server-action message when product creation fails because the SKU already exists.

## Why it changed
A user trying to add a product only saw the generic `Failed to create product` message, even though production logs showed the real failure was a Postgres unique-constraint violation on the tenant-scoped product SKU index.

## Impact
Users now see a clear inline message telling them that the SKU already exists and that they should use a different SKU or edit the existing product.

## Root cause
Product creation was relying on a thrown database error from `service_catalog_product_sku_unique`, and the client dialog collapsed that into a generic failure state.

## Validation
- Reproduced the issue from production logs and confirmed the duplicate SKU violation
- `npx eslint packages/ui/src/lib/errorHandling.ts packages/billing/src/actions/serviceActions.ts packages/billing/src/components/settings/billing/QuickAddProduct.tsx packages/billing/src/components/settings/billing/QuickAddService.tsx packages/billing/src/components/billing-dashboard/ServiceForm.tsx`
