### PR TITLE
[codex] Sync ticket is_closed with status transitions

### DIFF
--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -1855,6 +1855,15 @@ export const updateTicketWithCache = withAuth(async (user, { tenant }, id: strin
       };
     }
 
+    // Keep the ticket row's denormalized close flag aligned with the selected status.
+    if (updateData.status_id !== undefined && updateData.status_id !== currentTicket.status_id) {
+      const nextIsClosed = !!newStatus?.is_closed;
+      await trx('tickets')
+        .where({ ticket_id: id, tenant: tenant })
+        .update({ is_closed: nextIsClosed });
+      updatedTicket.is_closed = nextIsClosed;
+    }
+
     // Record closed_at / closed_by when transitioning to/from closed status
     if (newStatus?.is_closed && !oldStatus?.is_closed) {
       await trx('tickets')

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -726,6 +726,15 @@ export const updateTicket = withAuth(async (user, { tenant }, id: string, data: 
         };
       }
 
+      // Keep the ticket row's denormalized close flag aligned with the selected status.
+      if (updateData.status_id !== undefined && updateData.status_id !== currentTicket.status_id) {
+        const nextIsClosed = !!newStatus?.is_closed;
+        await trx('tickets')
+          .where({ ticket_id: id, tenant: tenant })
+          .update({ is_closed: nextIsClosed });
+        updatedTicket.is_closed = nextIsClosed;
+      }
+
       // Record closed_at / closed_by when transitioning to/from closed status
       if (newStatus?.is_closed && !oldStatus?.is_closed) {
         await trx('tickets')

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -555,6 +555,11 @@ export class TicketService extends BaseService<ITicket> {
           .where({ status_id: currentTicket.status_id, tenant: context.tenant })
           .first();
 
+        // Keep the ticket row's denormalized close flag aligned with the selected status.
+        await trx('tickets')
+          .where({ ticket_id: id, tenant: context.tenant })
+          .update({ is_closed: !!newStatus?.is_closed });
+
         // Record closed_at / closed_by when transitioning to/from closed status
         if (newStatus?.is_closed && !oldStatus?.is_closed) {
           await trx('tickets')

--- a/server/src/test/integration/ticketBundling.integration.test.ts
+++ b/server/src/test/integration/ticketBundling.integration.test.ts
@@ -10,6 +10,7 @@ vi.mock('server/src/lib/utils/getSecret', () => ({
 }));
 
 vi.mock('@alga-psa/core/secrets', () => ({
+  getSecret: vi.fn(async (_key: string, _envVar?: string, fallback?: string) => fallback ?? ''),
   getSecretProviderInstance: vi.fn(async () => ({
     getAppSecret: async () => '',
   })),
@@ -478,6 +479,7 @@ describe('Ticket bundling integration', () => {
 
     const closedMaster = await db('tickets').where({ tenant: tenantId, ticket_id: masterId }).first();
     expect(closedMaster?.status_id).toBe(statusClosedId);
+    expect(closedMaster?.is_closed).toBe(true);
 
     const replyContent = JSON.stringify([
       {
@@ -499,6 +501,7 @@ describe('Ticket bundling integration', () => {
     const reopenedMaster = await db('tickets').where({ tenant: tenantId, ticket_id: masterId }).first();
     expect(reopenedMaster?.status_id).toBe(statusOpenId);
     expect(reopenedMaster?.closed_at).toBeNull();
+    expect(reopenedMaster?.is_closed).toBe(false);
   });
 
   it('surfaces inbound child public replies on the master as aggregated view-only items', async () => {


### PR DESCRIPTION
## What changed
This updates the centralized ticket status transition paths so `tickets.is_closed` is kept in sync with the selected ticket status.

Specifically:
- update the shared ticket action path used by ticket detail/comment flows
- update the optimized ticket action path used by the newer ticket surfaces
- update the API ticket service path
- extend the existing ticket bundling integration assertions to check `is_closed` on close and reopen

## Why
The application already persisted `closed_at` and `closed_by` when a ticket moved into or out of a closed status, but it did not consistently persist the denormalized `tickets.is_closed` flag. That left the row state inconsistent depending on how the status change was triggered.

## Impact
Any ticket status change that goes through the shared update paths now persists `tickets.is_closed = true` for closed statuses and `false` for reopened tickets. This covers client portal, ticket details, mobile, API, and comment-screen status updates through the common handlers.

## Validation
- verified against the live local database that `TIC001017` changed from `is_closed = false` to `is_closed = true` after moving to a closed status
- attempted a focused integration test rerun, but the existing suite is currently blocked by unrelated stale mocks in `ticketBundling.integration.test.ts` after the merge from `main`

## Notes
Local environment files and `package-lock.json` were intentionally left out of this PR.