### PR TITLE
[codex] Preserve delegated time entry subject selection

### DIFF
--- a/packages/scheduling/src/components/time-management/time-entry/TimeTracking.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/TimeTracking.tsx
@@ -1,8 +1,8 @@
 // src/components/TimeTracking.tsx
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect, useCallback } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { TimePeriodList } from './TimePeriodList';
 import { SkeletonTimeSheet } from './SkeletonTimeSheet';
@@ -24,16 +24,36 @@ interface TimeTrackingProps {
 export default function TimeTracking({ currentUser, isManager: _isManager }: TimeTrackingProps) {
   const { t } = useTranslation('msp/time-entry');
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { enabled: delegatedTimeEntryEnabled, loading: delegatedTimeEntryLoading } = useFeatureFlag(
     'delegated-time-entry',
     { defaultValue: false }
   );
   const isDelegatedTimeEntryUIEnabled = delegatedTimeEntryEnabled && !delegatedTimeEntryLoading;
+  const requestedSubjectUserId = searchParams?.get('subjectUserId');
 
   const [subjectUsers, setSubjectUsers] = useState<IUser[]>([]);
-  const [subjectUserId, setSubjectUserId] = useState(currentUser.user_id);
+  const [subjectUserId, setSubjectUserId] = useState(requestedSubjectUserId ?? currentUser.user_id);
   const [timePeriods, setTimePeriods] = useState<ITimePeriodWithStatusView[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const syncSubjectUserIdToUrl = useCallback((nextSubjectUserId: string) => {
+    if (!pathname) {
+      return;
+    }
+
+    const params = new URLSearchParams(searchParams?.toString());
+    if (nextSubjectUserId !== currentUser.user_id) {
+      params.set('subjectUserId', nextSubjectUserId);
+    } else {
+      params.delete('subjectUserId');
+    }
+
+    const nextQuery = params.toString();
+    const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+    router.replace(nextUrl, { scroll: false });
+  }, [currentUser.user_id, pathname, router, searchParams]);
 
   useEffect(() => {
     if (!isDelegatedTimeEntryUIEnabled) {
@@ -41,27 +61,50 @@ export default function TimeTracking({ currentUser, isManager: _isManager }: Tim
       if (subjectUserId !== currentUser.user_id) {
         setSubjectUserId(currentUser.user_id);
       }
+      if (requestedSubjectUserId) {
+        syncSubjectUserIdToUrl(currentUser.user_id);
+      }
       return;
     }
 
+    let cancelled = false;
+
+    const loadEligibleSubjects = async () => {
+      const users = await fetchEligibleTimeEntrySubjects();
+      if (cancelled) {
+        return;
+      }
+
+      setSubjectUsers(users);
+
+      const nextSubjectUserId = users.some((u) => u.user_id === requestedSubjectUserId)
+        ? requestedSubjectUserId!
+        : currentUser.user_id;
+
+      setSubjectUserId((currentSelection) =>
+        currentSelection === nextSubjectUserId ? currentSelection : nextSubjectUserId
+      );
+
+      const normalizedRequestedSubjectUserId =
+        nextSubjectUserId === currentUser.user_id ? null : nextSubjectUserId;
+
+      if (requestedSubjectUserId !== normalizedRequestedSubjectUserId) {
+        syncSubjectUserIdToUrl(nextSubjectUserId);
+      }
+    };
+
     void loadEligibleSubjects();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser.user_id, isDelegatedTimeEntryUIEnabled]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUser, isDelegatedTimeEntryUIEnabled, requestedSubjectUserId, subjectUserId, syncSubjectUserIdToUrl]);
 
   useEffect(() => {
     setTimePeriods([]);
     setIsLoading(true);
     void loadTimePeriods();
   }, [subjectUserId]);
-
-  const loadEligibleSubjects = async () => {
-    const users = await fetchEligibleTimeEntrySubjects();
-    setSubjectUsers(users);
-
-    if (!users.some((u) => u.user_id === subjectUserId)) {
-      setSubjectUserId(currentUser.user_id);
-    }
-  };
 
   const loadTimePeriods = async () => {
     try {
@@ -75,11 +118,25 @@ export default function TimeTracking({ currentUser, isManager: _isManager }: Tim
   const handleSelectTimePeriod = async (timePeriod: ITimePeriodWithStatusView) => {
     try {
       const timeSheet = await fetchOrCreateTimeSheet(subjectUserId, timePeriod.period_id);
-      // Navigate to the timesheet page with its ID
-      router.push(`/msp/time-entry/timesheet/${timeSheet.id}`);
+      const params = new URLSearchParams();
+      if (subjectUserId !== currentUser.user_id) {
+        params.set('subjectUserId', subjectUserId);
+      }
+
+      const nextQuery = params.toString();
+      const nextUrl = nextQuery
+        ? `/msp/time-entry/timesheet/${timeSheet.id}?${nextQuery}`
+        : `/msp/time-entry/timesheet/${timeSheet.id}`;
+
+      router.push(nextUrl);
     } catch (error) {
       console.error('Error creating/fetching timesheet:', error);
     }
+  };
+
+  const handleSubjectUserChange = (nextSubjectUserId: string) => {
+    setSubjectUserId(nextSubjectUserId);
+    syncSubjectUserIdToUrl(nextSubjectUserId);
   };
 
   if (isLoading) {
@@ -95,7 +152,7 @@ export default function TimeTracking({ currentUser, isManager: _isManager }: Tim
           <UserPicker
             label={t('timeTracking.subjectUserLabel', { defaultValue: 'User' })}
             value={subjectUserId}
-            onValueChange={setSubjectUserId}
+            onValueChange={handleSubjectUserChange}
             users={subjectUsers}
             getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
             buttonWidth="full"

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { ITimeEntry, ITimeSheetView, IUser, IUserWithRoles } from '@alga-psa/types';
@@ -23,6 +23,7 @@ interface TimeSheetClientProps {
 export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUser, isManager, canReopenForEdits }: TimeSheetClientProps) {
   const { t } = useTranslation('msp/time-entry');
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [timeSheet, setTimeSheet] = useState<ITimeSheetView>(initialTimeSheet);
   const [subjectUser, setSubjectUser] = useState<IUser | null>(null);
   const [isReopenDialogOpen, setIsReopenDialogOpen] = useState(false);
@@ -100,6 +101,15 @@ export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUs
   };
 
   const handleBack = () => {
+    const subjectUserIdForBack = searchParams?.get('subjectUserId') ?? (
+      timeSheet.user_id !== currentUser.user_id ? timeSheet.user_id : null
+    );
+
+    if (subjectUserIdForBack && subjectUserIdForBack !== currentUser.user_id) {
+      router.push(`/msp/time-entry?subjectUserId=${encodeURIComponent(subjectUserIdForBack)}`);
+      return;
+    }
+
     router.push('/msp/time-entry');
   };
 


### PR DESCRIPTION
## What changed
Persisted the delegated time-entry subject selection in the URL so manager-selected users survive navigation between the time period list and the timesheet view.

## Why it changed
The selected subject user only lived in `TimeTracking` client state. When a manager opened a timesheet and then used Back, the app returned to `/msp/time-entry` without any subject context, so the page reset to the current user.

## User impact
Managers entering time on behalf of another user now return to the time period list with that same person still selected. The selection also survives reloads and direct navigation because it is stored in the query string.

## Root cause
The delegated subject was not encoded in navigation state. `TimeTracking` pushed timesheet routes without the selected `subjectUserId`, and `TimeSheetClient` always navigated back to the bare `/msp/time-entry` route.

## Validation
- `npm -w @alga-psa/scheduling run typecheck`
