### PR TITLE
[codex] Fix recurring service period cutover repair flow

### DIFF
--- a/packages/billing/src/actions/recurringServicePeriodActions.ts
+++ b/packages/billing/src/actions/recurringServicePeriodActions.ts
@@ -3,15 +3,19 @@
 import { createTenantKnex, withTransaction } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
+import { v4 as uuidv4 } from 'uuid';
 import { permissionError } from '@alga-psa/ui/lib/errorHandling';
 import type { ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import type {
+  BillingCycleType,
   IRecurringServicePeriodGovernanceRequirement,
   IRecurringServicePeriodInvoiceLinkage,
   IRecurringServicePeriodRecord,
+  ISO8601String,
   RecurringChargeFamily,
   RecurringObligationType,
 } from '@alga-psa/types';
+import { ensureUtcMidnightIsoDate } from '../lib/billing/billingCycleAnchors';
 import {
   getRecurringServicePeriodDisplayState,
 } from '@alga-psa/shared/billingClients/recurringServicePeriodDisplayState';
@@ -26,9 +30,16 @@ import {
 import {
   isClientCadencePostDropObligationType,
   POST_DROP_RECURRING_OBLIGATION_TYPES,
+  buildPersistedClientCadencePostDropObligationRef,
 } from '@alga-psa/shared/billingClients/postDropRecurringObligationIdentity';
+import { getClientBillingCycleAnchor } from '@shared/billingClients/billingSchedule';
+import { backfillRecurringServicePeriods } from '@shared/billingClients/backfillRecurringServicePeriods';
+import { materializeClientCadenceServicePeriods } from '@shared/billingClients/materializeClientCadenceServicePeriods';
+import { materializeContractCadenceServicePeriods } from '@shared/billingClients/materializeContractCadenceServicePeriods';
 
 const RECURRING_SERVICE_PERIOD_PERMISSION_RESOURCE = 'billing.recurring_service_periods';
+const recurringServicePeriodRecordIdFactory = () => uuidv4();
+type SupportedContractCadenceBillingCycle = 'monthly' | 'quarterly' | 'semi-annually' | 'annually';
 
 type DbRecordRow = {
   record_id: string;
@@ -72,6 +83,24 @@ type ObligationContextRow = {
   is_system_managed_default: boolean;
 };
 
+type LiveScheduleContextRow = ObligationContextRow & {
+  contract_line_type: string | null;
+  cadence_owner: 'client' | 'contract' | null;
+  billing_frequency: string | null;
+  billing_timing: 'advance' | 'arrears' | null;
+  assignment_start_date: unknown;
+  assignment_end_date: unknown;
+};
+
+interface ParsedRecurringServicePeriodScheduleKey {
+  scheduleKey: string;
+  tenant: string;
+  obligationType: RecurringObligationType;
+  obligationId: string;
+  cadenceOwner: IRecurringServicePeriodRecord['cadenceOwner'];
+  duePosition: IRecurringServicePeriodRecord['duePosition'];
+}
+
 export interface RecurringServicePeriodManagementRow {
   record: IRecurringServicePeriodRecord;
   displayState: ReturnType<typeof getRecurringServicePeriodDisplayState>;
@@ -109,8 +138,20 @@ export interface RecurringServicePeriodManagementView {
   contractName: string | null;
   contractLineId: string | null;
   contractLineName: string | null;
+  status: 'ready' | 'repair_required';
   summary: RecurringServicePeriodManagementSummary;
   rows: RecurringServicePeriodManagementRow[];
+}
+
+export interface RepairRecurringServicePeriodMaterializationResult {
+  scheduleKey: string;
+  repairedAt: string;
+  historicalBoundaryEnd: string | null;
+  skippedHistoricalCandidates: number;
+  backfilledRows: number;
+  realignedRows: number;
+  supersededRows: number;
+  activeRows: number;
 }
 
 export interface RecurringServicePeriodScheduleSummary {
@@ -171,6 +212,39 @@ function normalizeTimestampValue(value: unknown): string | null {
 function normalizeDateOnlyValue(value: unknown): string | null {
   const normalizedTimestamp = normalizeTimestampValue(value);
   return normalizedTimestamp ? normalizedTimestamp.slice(0, 10) : null;
+}
+
+function normalizeUtcMidnightDateValue(value: unknown): ISO8601String | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return `${value}T00:00:00Z` as ISO8601String;
+    }
+
+    try {
+      return ensureUtcMidnightIsoDate(value);
+    } catch (_error) {
+      const parsed = new Date(value);
+      if (!Number.isNaN(parsed.getTime())) {
+        return `${parsed.toISOString().slice(0, 10)}T00:00:00Z` as ISO8601String;
+      }
+      throw _error;
+    }
+  }
+
+  if (value instanceof Date) {
+    return `${value.toISOString().slice(0, 10)}T00:00:00Z` as ISO8601String;
+  }
+
+  const parsed = new Date(String(value));
+  if (!Number.isNaN(parsed.getTime())) {
+    return `${parsed.toISOString().slice(0, 10)}T00:00:00Z` as ISO8601String;
+  }
+
+  return ensureUtcMidnightIsoDate(String(value));
 }
 
 function mapRecurringServicePeriodRowToRecord(row: DbRecordRow): IRecurringServicePeriodRecord {
@@ -279,6 +353,134 @@ function buildManagementSummary(
   );
 }
 
+function buildEmptyManagementSummary(): RecurringServicePeriodManagementSummary {
+  return {
+    totalRows: 0,
+    exceptionRows: 0,
+    generatedRows: 0,
+    editedRows: 0,
+    skippedRows: 0,
+    lockedRows: 0,
+    billedRows: 0,
+    supersededRows: 0,
+    archivedRows: 0,
+  };
+}
+
+function parseRecurringServicePeriodScheduleKey(
+  scheduleKey: string,
+): ParsedRecurringServicePeriodScheduleKey | null {
+  const match = scheduleKey.match(
+    /^schedule:([^:]+):([^:]+):([^:]+):(client|contract):(advance|arrears)$/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  return {
+    scheduleKey,
+    tenant: match[1]!,
+    obligationType: match[2]! as RecurringObligationType,
+    obligationId: match[3]!,
+    cadenceOwner: match[4]! as IRecurringServicePeriodRecord['cadenceOwner'],
+    duePosition: match[5]! as IRecurringServicePeriodRecord['duePosition'],
+  };
+}
+
+function compareIsoDateOnly(left: ISO8601String, right: ISO8601String) {
+  return left.slice(0, 10).localeCompare(right.slice(0, 10));
+}
+
+function maxIsoDateOnly(left: ISO8601String, right: ISO8601String) {
+  return compareIsoDateOnly(left, right) >= 0 ? left : right;
+}
+
+function resolveRecurringChargeFamily(contractLineType: string | null): RecurringChargeFamily {
+  switch ((contractLineType ?? 'fixed').toLowerCase()) {
+    case 'fixed':
+      return 'fixed';
+    case 'time':
+    case 'hourly':
+      return 'hourly';
+    case 'usage':
+      return 'usage';
+    case 'bucket':
+      return 'bucket';
+    case 'product':
+      return 'product';
+    case 'license':
+      return 'license';
+    default:
+      return 'fixed';
+  }
+}
+
+function normalizeContractCadenceBillingCycle(value: string | null): SupportedContractCadenceBillingCycle | null {
+  switch ((value ?? '').toLowerCase()) {
+    case 'monthly':
+      return 'monthly';
+    case 'quarterly':
+      return 'quarterly';
+    case 'semi-annually':
+    case 'semiannually':
+      return 'semi-annually';
+    case 'annually':
+    case 'annual':
+      return 'annually';
+    default:
+      return null;
+  }
+}
+
+function buildScheduleSourceRuleVersion(
+  billingCycle: BillingCycleType,
+  anchor: Awaited<ReturnType<typeof getClientBillingCycleAnchor>>['anchor'],
+) {
+  return [
+    'client_schedule',
+    billingCycle,
+    `dom:${anchor.dayOfMonth ?? 'none'}`,
+    `moy:${anchor.monthOfYear ?? 'none'}`,
+    `dow:${anchor.dayOfWeek ?? 'none'}`,
+    `ref:${anchor.referenceDate ?? 'none'}`,
+  ].join('|');
+}
+
+function serializeRecurringServicePeriodRecord(record: IRecurringServicePeriodRecord) {
+  return {
+    record_id: record.recordId,
+    tenant: record.sourceObligation.tenant,
+    schedule_key: record.scheduleKey,
+    period_key: record.periodKey,
+    revision: record.revision,
+    obligation_id: record.sourceObligation.obligationId,
+    obligation_type: record.sourceObligation.obligationType,
+    charge_family: record.sourceObligation.chargeFamily,
+    cadence_owner: record.cadenceOwner,
+    due_position: record.duePosition,
+    lifecycle_state: record.lifecycleState,
+    service_period_start: record.servicePeriod.start,
+    service_period_end: record.servicePeriod.end,
+    invoice_window_start: record.invoiceWindow.start,
+    invoice_window_end: record.invoiceWindow.end,
+    activity_window_start: record.activityWindow?.start ?? null,
+    activity_window_end: record.activityWindow?.end ?? null,
+    timing_metadata: record.timingMetadata ?? null,
+    provenance_kind: record.provenance.kind,
+    source_rule_version: record.provenance.sourceRuleVersion,
+    reason_code: record.provenance.reasonCode ?? null,
+    source_run_key: 'sourceRunKey' in record.provenance ? record.provenance.sourceRunKey ?? null : null,
+    supersedes_record_id:
+      'supersedesRecordId' in record.provenance ? record.provenance.supersedesRecordId ?? null : null,
+    invoice_id: record.invoiceLinkage?.invoiceId ?? null,
+    invoice_charge_id: record.invoiceLinkage?.invoiceChargeId ?? null,
+    invoice_charge_detail_id: record.invoiceLinkage?.invoiceChargeDetailId ?? null,
+    invoice_linked_at: record.invoiceLinkage?.linkedAt ?? null,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+  };
+}
+
 async function loadObligationContext(input: {
   trx: any;
   tenant: string;
@@ -364,6 +566,368 @@ async function loadObligationContext(input: {
   };
 }
 
+async function loadLiveScheduleContext(input: {
+  trx: any;
+  tenant: string;
+  obligationType: RecurringObligationType;
+  obligationId: string;
+}): Promise<LiveScheduleContextRow> {
+  const { trx, tenant, obligationType, obligationId } = input;
+
+  if (obligationType !== 'contract_line' && !isClientCadencePostDropObligationType(obligationType)) {
+    return {
+      client_id: null,
+      client_name: null,
+      contract_id: null,
+      contract_name: null,
+      contract_line_id: null,
+      contract_line_name: null,
+      is_system_managed_default: false,
+      contract_line_type: null,
+      cadence_owner: null,
+      billing_frequency: null,
+      billing_timing: null,
+      assignment_start_date: null,
+      assignment_end_date: null,
+    };
+  }
+
+  const row = await trx('contract_lines as cl')
+    .join('contracts as ct', function joinContracts(this: any) {
+      this.on('ct.contract_id', '=', 'cl.contract_id')
+        .andOn('ct.tenant', '=', 'cl.tenant');
+    })
+    .join('clients as c', function joinClients(this: any) {
+      this.on('c.client_id', '=', 'ct.owner_client_id')
+        .andOn('c.tenant', '=', 'ct.tenant');
+    })
+    .leftJoin('client_contracts as cc', function joinClientContracts(this: any) {
+      this.on('cc.contract_id', '=', 'ct.contract_id')
+        .andOn('cc.tenant', '=', 'ct.tenant')
+        .andOn('cc.is_active', '=', trx.raw('?', [true]));
+    })
+    .where('cl.tenant', tenant)
+    .where('cl.contract_line_id', obligationId)
+    .first(
+      'c.client_id',
+      'c.client_name',
+      'ct.contract_id',
+      'ct.contract_name',
+      'cl.contract_line_id',
+      'cl.contract_line_name',
+      'ct.is_system_managed_default',
+      'cl.contract_line_type',
+      'cl.cadence_owner',
+      'cl.billing_frequency',
+      'cl.billing_timing',
+      'cc.start_date as assignment_start_date',
+      'cc.end_date as assignment_end_date',
+    );
+
+  return {
+    client_id: row?.client_id ?? null,
+    client_name: row?.client_name ?? null,
+    contract_id: row?.contract_id ?? null,
+    contract_name: row?.contract_name ?? null,
+    contract_line_id: row?.contract_line_id ?? null,
+    contract_line_name: row?.contract_line_name ?? null,
+    is_system_managed_default: row?.is_system_managed_default === true,
+    contract_line_type: row?.contract_line_type ?? null,
+    cadence_owner: row?.cadence_owner ?? null,
+    billing_frequency: row?.billing_frequency ?? null,
+    billing_timing: row?.billing_timing ?? null,
+    assignment_start_date: row?.assignment_start_date ?? null,
+    assignment_end_date: row?.assignment_end_date ?? null,
+  };
+}
+
+async function loadScheduleRows(input: {
+  trx: any;
+  tenant: string;
+  scheduleKey: string;
+}): Promise<DbRecordRow[]> {
+  const { trx, tenant, scheduleKey } = input;
+
+  return trx('recurring_service_periods')
+    .where({
+      tenant,
+      schedule_key: scheduleKey,
+    })
+    .select([
+      'record_id',
+      'tenant',
+      'schedule_key',
+      'period_key',
+      'revision',
+      'obligation_id',
+      'obligation_type',
+      'charge_family',
+      'cadence_owner',
+      'due_position',
+      'lifecycle_state',
+      'service_period_start',
+      'service_period_end',
+      'invoice_window_start',
+      'invoice_window_end',
+      'activity_window_start',
+      'activity_window_end',
+      'timing_metadata',
+      'provenance_kind',
+      'source_rule_version',
+      'reason_code',
+      'source_run_key',
+      'supersedes_record_id',
+      'invoice_id',
+      'invoice_charge_id',
+      'invoice_charge_detail_id',
+      'invoice_linked_at',
+      'created_at',
+      'updated_at',
+    ])
+    .orderBy('service_period_start', 'asc')
+    .orderBy('revision', 'asc') as Promise<DbRecordRow[]>;
+}
+
+async function loadLastInvoicedClientBillingBoundary(
+  trx: any,
+  params: { tenant: string; clientId: string },
+) {
+  const lastInvoiced = await trx('client_billing_cycles as cbc')
+    .join('invoices as i', function (this: any) {
+      this.on('i.billing_cycle_id', '=', 'cbc.billing_cycle_id').andOn('i.tenant', '=', 'cbc.tenant');
+    })
+    .where('cbc.tenant', params.tenant)
+    .andWhere('cbc.client_id', params.clientId)
+    .orderBy('cbc.period_end_date', 'desc')
+    .first()
+    .select('cbc.period_end_date');
+
+  return lastInvoiced?.period_end_date
+    ? normalizeUtcMidnightDateValue(lastInvoiced.period_end_date)
+    : null;
+}
+
+async function persistRecurringServicePeriodRepair(
+  trx: any,
+  params: {
+    tenant: string;
+    recordsToSupersede: IRecurringServicePeriodRecord[];
+    recordsToInsert: IRecurringServicePeriodRecord[];
+  },
+) {
+  for (const record of params.recordsToSupersede) {
+    await trx('recurring_service_periods')
+      .where({ tenant: params.tenant, record_id: record.recordId })
+      .update({
+        lifecycle_state: record.lifecycleState,
+        updated_at: record.updatedAt,
+      });
+  }
+
+  if (params.recordsToInsert.length > 0) {
+    await trx('recurring_service_periods').insert(
+      params.recordsToInsert.map(serializeRecurringServicePeriodRecord),
+    );
+  }
+}
+
+async function repairScheduleMaterialization(input: {
+  trx: any;
+  tenant: string;
+  schedule: ParsedRecurringServicePeriodScheduleKey;
+  context: LiveScheduleContextRow;
+  existingRecords: IRecurringServicePeriodRecord[];
+}): Promise<RepairRecurringServicePeriodMaterializationResult> {
+  const { trx, tenant, schedule, context, existingRecords } = input;
+  const repairedAt = new Date().toISOString();
+  const chargeFamily = resolveRecurringChargeFamily(context.contract_line_type);
+
+  if (!context.contract_line_id) {
+    throw new Error(`Recurring obligation ${schedule.obligationId} no longer exists.`);
+  }
+
+  if (schedule.cadenceOwner === 'contract') {
+    const assignmentStart =
+      normalizeUtcMidnightDateValue(context.assignment_start_date)
+      ?? ensureUtcMidnightIsoDate(repairedAt);
+    const assignmentEnd = normalizeUtcMidnightDateValue(context.assignment_end_date);
+    const billingCycle = normalizeContractCadenceBillingCycle(context.billing_frequency);
+    if (!billingCycle || context.billing_timing !== schedule.duePosition) {
+      throw new Error('The live contract line no longer matches the requested recurring schedule.');
+    }
+
+    if (assignmentEnd && compareIsoDateOnly(assignmentEnd, assignmentStart) <= 0) {
+      return {
+        scheduleKey: schedule.scheduleKey,
+        repairedAt,
+        historicalBoundaryEnd: null,
+        skippedHistoricalCandidates: 0,
+        backfilledRows: 0,
+        realignedRows: 0,
+        supersededRows: 0,
+        activeRows: 0,
+      };
+    }
+
+    const sourceRuleVersion = [
+      'contract_cadence',
+      `billing_cycle:${billingCycle}`,
+      `anchor:${assignmentStart.slice(0, 10)}`,
+      `due:${schedule.duePosition}`,
+    ].join('|');
+    const sourceRunKey = `operator-repair:${schedule.scheduleKey}:${repairedAt}`;
+    const billedBoundaryEnd = existingRecords
+      .filter((record) => record.lifecycleState === 'billed' || record.invoiceLinkage != null)
+      .map((record) => record.servicePeriod.end)
+      .sort((left, right) => compareIsoDateOnly(right, left))[0] ?? null;
+    const regenerationStart = billedBoundaryEnd
+      ? maxIsoDateOnly(assignmentStart, billedBoundaryEnd)
+      : assignmentStart;
+
+    const candidateRecords = materializeContractCadenceServicePeriods({
+      asOf: regenerationStart,
+      materializedAt: repairedAt,
+      billingCycle,
+      anchorDate: assignmentStart,
+      sourceObligation: {
+        tenant,
+        obligationId: context.contract_line_id,
+        obligationType: 'contract_line',
+        chargeFamily,
+      },
+      duePosition: schedule.duePosition,
+      sourceRuleVersion,
+      sourceRunKey,
+      recordIdFactory: recurringServicePeriodRecordIdFactory,
+    }).records.filter((record) => {
+      if (!assignmentEnd) {
+        return true;
+      }
+      return compareIsoDateOnly(record.servicePeriod.start, assignmentEnd) < 0;
+    });
+
+    const repairPlan = backfillRecurringServicePeriods({
+      candidateRecords,
+      existingRecords,
+      backfilledAt: repairedAt,
+      sourceRuleVersion,
+      sourceRunKey,
+      legacyBilledThroughEnd: billedBoundaryEnd,
+      regenerationReasonCode: 'source_rule_changed',
+      recordIdFactory: recurringServicePeriodRecordIdFactory,
+    });
+
+    await persistRecurringServicePeriodRepair(trx, {
+      tenant,
+      recordsToSupersede: repairPlan.supersededRecords,
+      recordsToInsert: [
+        ...repairPlan.backfilledRecords,
+        ...repairPlan.realignedRecords,
+      ],
+    });
+
+    return {
+      scheduleKey: schedule.scheduleKey,
+      repairedAt,
+      historicalBoundaryEnd: repairPlan.historicalBoundaryEnd,
+      skippedHistoricalCandidates: repairPlan.skippedHistoricalCandidates.length,
+      backfilledRows: repairPlan.backfilledRecords.length,
+      realignedRows: repairPlan.realignedRecords.length,
+      supersededRows: repairPlan.supersededRecords.length,
+      activeRows: repairPlan.activeRecords.length,
+    };
+  }
+
+  if (!isClientCadencePostDropObligationType(schedule.obligationType)) {
+    throw new Error(`Unsupported recurring schedule type ${schedule.obligationType}.`);
+  }
+
+  if (!context.client_id) {
+    throw new Error('The client cadence source for this schedule could not be resolved.');
+  }
+
+  if (context.billing_timing !== schedule.duePosition) {
+    throw new Error('The live client-cadence obligation no longer matches the requested schedule timing.');
+  }
+
+  const billingSchedule = await getClientBillingCycleAnchor(trx, tenant, context.client_id);
+  const billedBoundaryEnd = await loadLastInvoicedClientBillingBoundary(trx, {
+    tenant,
+    clientId: context.client_id,
+  });
+  const obligationStart =
+    normalizeUtcMidnightDateValue(context.assignment_start_date)
+    ?? ensureUtcMidnightIsoDate(repairedAt);
+  const regenerationStart = billedBoundaryEnd
+    ? maxIsoDateOnly(obligationStart, billedBoundaryEnd)
+    : obligationStart;
+  const obligationEnd = normalizeUtcMidnightDateValue(context.assignment_end_date);
+
+  if (obligationEnd && compareIsoDateOnly(obligationEnd, regenerationStart) <= 0) {
+    return {
+      scheduleKey: schedule.scheduleKey,
+      repairedAt,
+      historicalBoundaryEnd: billedBoundaryEnd,
+      skippedHistoricalCandidates: 0,
+      backfilledRows: 0,
+      realignedRows: 0,
+      supersededRows: 0,
+      activeRows: existingRecords.length,
+    };
+  }
+
+  const sourceRuleVersion = buildScheduleSourceRuleVersion(
+    billingSchedule.billingCycle,
+    billingSchedule.anchor,
+  );
+  const sourceRunKey = `operator-repair:${schedule.scheduleKey}:${repairedAt}`;
+  const candidateRecords = materializeClientCadenceServicePeriods({
+    asOf: regenerationStart,
+    materializedAt: repairedAt,
+    billingCycle: billingSchedule.billingCycle,
+    sourceObligation: buildPersistedClientCadencePostDropObligationRef({
+      tenant,
+      contractLineId: context.contract_line_id,
+      chargeFamily,
+    }),
+    duePosition: schedule.duePosition,
+    sourceRuleVersion,
+    sourceRunKey,
+    anchorSettings: billingSchedule.anchor,
+    recordIdFactory: recurringServicePeriodRecordIdFactory,
+  }).records;
+  const repairPlan = backfillRecurringServicePeriods({
+    candidateRecords,
+    existingRecords,
+    backfilledAt: repairedAt,
+    sourceRuleVersion,
+    sourceRunKey,
+    legacyBilledThroughEnd: billedBoundaryEnd,
+    regenerationReasonCode: 'billing_schedule_changed',
+    recordIdFactory: recurringServicePeriodRecordIdFactory,
+  });
+
+  await persistRecurringServicePeriodRepair(trx, {
+    tenant,
+    recordsToSupersede: repairPlan.supersededRecords,
+    recordsToInsert: [
+      ...repairPlan.backfilledRecords,
+      ...repairPlan.realignedRecords,
+    ],
+  });
+
+  return {
+    scheduleKey: schedule.scheduleKey,
+    repairedAt,
+    historicalBoundaryEnd: repairPlan.historicalBoundaryEnd,
+    skippedHistoricalCandidates: repairPlan.skippedHistoricalCandidates.length,
+    backfilledRows: repairPlan.backfilledRecords.length,
+    realignedRows: repairPlan.realignedRecords.length,
+    supersededRows: repairPlan.supersededRecords.length,
+    activeRows: repairPlan.activeRecords.length,
+  };
+}
+
 function previewRecurringServicePeriodInvoiceLinkageRepairResult(
   input: PreviewRecurringServicePeriodInvoiceLinkageRepairInput,
 ) {
@@ -424,47 +988,53 @@ export const getRecurringServicePeriodManagementView = withAuth(async (
 
   const { knex } = await createTenantKnex();
   return withTransaction(knex, async (trx: any) => {
-    const baseRows = await trx('recurring_service_periods')
-      .where({
-        tenant,
-        schedule_key: normalizedScheduleKey,
-      })
-      .select([
-        'record_id',
-        'tenant',
-        'schedule_key',
-        'period_key',
-        'revision',
-        'obligation_id',
-        'obligation_type',
-        'charge_family',
-        'cadence_owner',
-        'due_position',
-        'lifecycle_state',
-        'service_period_start',
-        'service_period_end',
-        'invoice_window_start',
-        'invoice_window_end',
-        'activity_window_start',
-        'activity_window_end',
-        'timing_metadata',
-        'provenance_kind',
-        'source_rule_version',
-        'reason_code',
-        'source_run_key',
-        'supersedes_record_id',
-        'invoice_id',
-        'invoice_charge_id',
-        'invoice_charge_detail_id',
-        'invoice_linked_at',
-        'created_at',
-        'updated_at',
-      ])
-      .orderBy('service_period_start', 'asc')
-      .orderBy('revision', 'asc') as DbRecordRow[];
+    const baseRows = await loadScheduleRows({
+      trx,
+      tenant,
+      scheduleKey: normalizedScheduleKey,
+    });
 
     if (baseRows.length === 0) {
-      throw new Error(`No recurring service periods found for schedule ${normalizedScheduleKey}.`);
+      const parsedScheduleKey = parseRecurringServicePeriodScheduleKey(normalizedScheduleKey);
+      if (!parsedScheduleKey) {
+        throw new Error(`No recurring service periods found for schedule ${normalizedScheduleKey}.`);
+      }
+      if (parsedScheduleKey.tenant !== tenant) {
+        throw new Error(`Schedule ${normalizedScheduleKey} does not belong to tenant ${tenant}.`);
+      }
+
+      const context = await loadLiveScheduleContext({
+        trx,
+        tenant,
+        obligationType: parsedScheduleKey.obligationType,
+        obligationId: parsedScheduleKey.obligationId,
+      });
+      if (context.is_system_managed_default) {
+        throw new Error(
+          'System-managed default contracts are attribution-only and cannot be managed in recurring service period admin tools.',
+        );
+      }
+      if (!context.contract_line_id) {
+        throw new Error(`No recurring service periods found for schedule ${normalizedScheduleKey}.`);
+      }
+
+      return {
+        scheduleKey: normalizedScheduleKey,
+        obligationId: parsedScheduleKey.obligationId,
+        obligationType: parsedScheduleKey.obligationType,
+        cadenceOwner: parsedScheduleKey.cadenceOwner,
+        duePosition: parsedScheduleKey.duePosition,
+        chargeFamily: resolveRecurringChargeFamily(context.contract_line_type),
+        clientId: context.client_id,
+        clientName: context.client_name,
+        contractId: context.contract_id,
+        contractName: context.contract_name,
+        contractLineId: context.contract_line_id,
+        contractLineName: context.contract_line_name,
+        status: 'repair_required',
+        summary: buildEmptyManagementSummary(),
+        rows: [],
+      } satisfies RecurringServicePeriodManagementView;
     }
 
     const firstRow = baseRows[0]!;
@@ -508,9 +1078,67 @@ export const getRecurringServicePeriodManagementView = withAuth(async (
       contractName: context.contract_name,
       contractLineId: context.contract_line_id,
       contractLineName: context.contract_line_name,
+      status: 'ready',
       summary: buildManagementSummary(rows),
       rows,
     } satisfies RecurringServicePeriodManagementView;
+  });
+});
+
+export const repairMissingRecurringServicePeriods = withAuth(async (
+  user,
+  { tenant },
+  scheduleKey: string,
+): Promise<RepairRecurringServicePeriodMaterializationResult | ActionPermissionError> => {
+  const denied = await requireRecurringServicePeriodPermission(
+    user,
+    'regenerate',
+    'Permission denied: Cannot repair recurring service periods',
+  );
+  if (denied) {
+    return denied;
+  }
+
+  const normalizedScheduleKey = scheduleKey.trim();
+  if (!normalizedScheduleKey) {
+    return permissionError('A schedule key is required to repair recurring service periods.');
+  }
+
+  const parsedScheduleKey = parseRecurringServicePeriodScheduleKey(normalizedScheduleKey);
+  if (!parsedScheduleKey) {
+    throw new Error(`Schedule key ${normalizedScheduleKey} is not a supported recurring service-period schedule.`);
+  }
+  if (parsedScheduleKey.tenant !== tenant) {
+    throw new Error(`Schedule ${normalizedScheduleKey} does not belong to tenant ${tenant}.`);
+  }
+
+  const { knex } = await createTenantKnex();
+  return withTransaction(knex, async (trx: any) => {
+    const context = await loadLiveScheduleContext({
+      trx,
+      tenant,
+      obligationType: parsedScheduleKey.obligationType,
+      obligationId: parsedScheduleKey.obligationId,
+    });
+    if (context.is_system_managed_default) {
+      throw new Error(
+        'System-managed default contracts are attribution-only and cannot be repaired in recurring service period admin tools.',
+      );
+    }
+
+    const existingRecords = (await loadScheduleRows({
+      trx,
+      tenant,
+      scheduleKey: normalizedScheduleKey,
+    })).map(mapRecurringServicePeriodRowToRecord);
+
+    return repairScheduleMaterialization({
+      trx,
+      tenant,
+      schedule: parsedScheduleKey,
+      context,
+      existingRecords,
+    });
   });
 });
 

--- a/packages/billing/src/components/billing-dashboard/RecurringServicePeriodsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/RecurringServicePeriodsTab.tsx
@@ -6,7 +6,9 @@ import {
   getRecurringServicePeriodManagementView,
   listRecurringServicePeriodScheduleSummaries,
   previewRecurringServicePeriodRegeneration,
+  repairMissingRecurringServicePeriods,
   type PreviewRecurringServicePeriodRegenerationInput,
+  type RepairRecurringServicePeriodMaterializationResult,
   type RecurringServicePeriodScheduleSummary,
   type RecurringServicePeriodManagementView,
 } from '@alga-psa/billing/actions/recurringServicePeriodActions';
@@ -16,6 +18,7 @@ type ManagementViewResult = RecurringServicePeriodManagementView | ActionPermiss
 type RegenerationPreviewResult =
   | Awaited<ReturnType<typeof previewRecurringServicePeriodRegeneration>>
   | null;
+type RepairResult = RepairRecurringServicePeriodMaterializationResult | null;
 
 function isPermissionError(value: unknown): value is ActionPermissionError {
   return Boolean(
@@ -51,8 +54,13 @@ const RecurringServicePeriodsTab: React.FC<RecurringServicePeriodsTabProps> = ({
   const [candidateRecordsJson, setCandidateRecordsJson] = useState('[]');
   const [previewLoading, setPreviewLoading] = useState(false);
   const [regenerationPreview, setRegenerationPreview] = useState<RegenerationPreviewResult>(null);
+  const [repairLoading, setRepairLoading] = useState(false);
+  const [repairResult, setRepairResult] = useState<RepairResult>(null);
 
-  const loadView = async (targetScheduleKey: string) => {
+  const loadView = async (
+    targetScheduleKey: string,
+    options: { clearRepairResult?: boolean } = {},
+  ) => {
     const normalized = targetScheduleKey.trim();
     if (!normalized) {
       setError('Enter a schedule key to inspect recurring service periods.');
@@ -63,6 +71,9 @@ const RecurringServicePeriodsTab: React.FC<RecurringServicePeriodsTabProps> = ({
     setLoading(true);
     setError(null);
     setRegenerationPreview(null);
+    if (options.clearRepairResult !== false) {
+      setRepairResult(null);
+    }
 
     try {
       const result: ManagementViewResult = await getRecurringServicePeriodManagementView(normalized);
@@ -129,7 +140,7 @@ const RecurringServicePeriodsTab: React.FC<RecurringServicePeriodsTabProps> = ({
   };
 
   const handlePreviewRegeneration = async () => {
-    if (!view) {
+    if (!view || view.status !== 'ready') {
       return;
     }
 
@@ -164,6 +175,34 @@ const RecurringServicePeriodsTab: React.FC<RecurringServicePeriodsTabProps> = ({
       );
     } finally {
       setPreviewLoading(false);
+    }
+  };
+
+  const handleRepairMissingRows = async () => {
+    if (!view || view.status !== 'repair_required') {
+      return;
+    }
+
+    setRepairLoading(true);
+    setError(null);
+
+    try {
+      const result = await repairMissingRecurringServicePeriods(view.scheduleKey);
+      if (isPermissionError(result)) {
+        setError(result.permissionError);
+        return;
+      }
+
+      setRepairResult(result);
+      await loadView(view.scheduleKey, { clearRepairResult: false });
+    } catch (repairError) {
+      setError(
+        repairError instanceof Error
+          ? repairError.message
+          : 'Failed to repair recurring service-period materialization.',
+      );
+    } finally {
+      setRepairLoading(false);
     }
   };
 
@@ -250,122 +289,166 @@ const RecurringServicePeriodsTab: React.FC<RecurringServicePeriodsTabProps> = ({
             </div>
           </div>
 
-          <div className="grid gap-3 md:grid-cols-4">
-            <div className="rounded-lg border p-4">
-              <div className="text-sm text-muted-foreground">Generated</div>
-              <div className="text-2xl font-semibold">{view.summary.generatedRows}</div>
-            </div>
-            <div className="rounded-lg border p-4">
-              <div className="text-sm text-muted-foreground">Edited</div>
-              <div className="text-2xl font-semibold">{view.summary.editedRows}</div>
-            </div>
-            <div className="rounded-lg border p-4">
-              <div className="text-sm text-muted-foreground">Billed</div>
-              <div className="text-2xl font-semibold">{view.summary.billedRows}</div>
-            </div>
-            <div className="rounded-lg border p-4">
-              <div className="text-sm text-muted-foreground">Exceptions</div>
-              <div className="text-2xl font-semibold">{view.summary.exceptionRows}</div>
-            </div>
-          </div>
-
-          <div className="rounded-lg border overflow-hidden">
-            <table className="w-full text-sm" data-testid="recurring-service-periods-table">
-              <thead className="bg-muted/40 text-left">
-                <tr>
-                  <th className="px-4 py-3 font-medium">State</th>
-                  <th className="px-4 py-3 font-medium">Service Period</th>
-                  <th className="px-4 py-3 font-medium">Invoice Window</th>
-                  <th className="px-4 py-3 font-medium">Revision</th>
-                  <th className="px-4 py-3 font-medium">Reason</th>
-                  <th className="px-4 py-3 font-medium">Allowed Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {view.rows.map((row) => (
-                  <tr key={row.record.recordId} className="border-t align-top">
-                    <td className="px-4 py-3">
-                      <div className="font-medium">{row.displayState.label}</div>
-                      <div className="text-xs text-muted-foreground">{row.displayState.detail}</div>
-                    </td>
-                    <td className="px-4 py-3">{formatRange(row.record.servicePeriod.start, row.record.servicePeriod.end)}</td>
-                    <td className="px-4 py-3">{formatRange(row.record.invoiceWindow.start, row.record.invoiceWindow.end)}</td>
-                    <td className="px-4 py-3">r{row.record.revision}</td>
-                    <td className="px-4 py-3">{row.displayState.reasonLabel ?? 'Generated from source cadence'}</td>
-                    <td className="px-4 py-3">
-                      <div className="flex flex-wrap gap-1">
-                        {allowedGovernanceActions(row).map((action) => (
-                          <span
-                            key={`${row.record.recordId}:${action}`}
-                            className="rounded-full border px-2 py-0.5 text-xs"
-                          >
-                            {action}
-                          </span>
-                        ))}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="rounded-lg border p-4 space-y-3">
-            <div>
-              <h3 className="text-lg font-semibold">Regeneration Preview</h3>
-              <p className="text-sm text-muted-foreground">
-                Paste candidate records JSON to preview how preserved edited or billed rows would conflict with
-                regenerated future candidates for this schedule.
-              </p>
-            </div>
-            <label className="block text-sm font-medium">
-              Candidate Records JSON
-              <textarea
-                className="mt-1 min-h-40 w-full rounded-md border px-3 py-2 font-mono text-xs"
-                value={candidateRecordsJson}
-                onChange={(event) => setCandidateRecordsJson(event.target.value)}
-              />
-            </label>
-            <button
-              type="button"
-              className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50"
-              onClick={() => {
-                startTransition(() => {
-                  void handlePreviewRegeneration();
-                });
-              }}
-              disabled={previewLoading}
+          {repairResult ? (
+            <div
+              className="rounded-lg border border-success/30 bg-success/5 p-4 space-y-2"
+              data-testid="repair-result"
             >
-              {previewLoading ? 'Previewing…' : 'Preview Regeneration'}
-            </button>
-
-            {regenerationPreview && !isPermissionError(regenerationPreview) ? (
-              <div className="space-y-2" data-testid="regeneration-preview">
-                <div className="text-sm">
-                  Conflicts: <span className="font-semibold">{regenerationPreview.conflicts.length}</span>
-                </div>
-                {regenerationPreview.conflicts.length > 0 ? (
-                  <ul className="space-y-2 text-sm">
-                    {regenerationPreview.conflicts.map((conflict) => (
-                      <li
-                        key={`${conflict.recordId}:${conflict.kind}`}
-                        className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2"
-                      >
-                        <div className="font-medium">
-                          {conflict.kind.replaceAll('_', ' ')}: {conflict.recordId}
-                        </div>
-                        <div className="text-muted-foreground">{conflict.reason}</div>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-sm">
-                    No regeneration conflicts were detected for the supplied candidates.
-                  </div>
-                )}
+              <div className="text-sm font-medium">Repair completed</div>
+              <div className="text-sm text-muted-foreground">
+                Backfilled {repairResult.backfilledRows} rows, realigned {repairResult.realignedRows}, skipped{' '}
+                {repairResult.skippedHistoricalCandidates} historical candidates, and left{' '}
+                {repairResult.activeRows} active rows on this schedule.
               </div>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
+
+          {view.status === 'repair_required' ? (
+            <div
+              className="rounded-lg border border-warning/30 bg-warning/5 p-4 space-y-3"
+              data-testid="recurring-service-period-repair-state"
+            >
+              <div>
+                <h3 className="text-lg font-semibold">Missing persisted service periods</h3>
+                <p className="text-sm text-muted-foreground">
+                  This recurring schedule exists in live billing metadata but has no persisted service-period rows.
+                  Repair will materialize future rows only, preserve billed history boundaries, and stamp the new
+                  records with backfill provenance.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+                onClick={() => {
+                  startTransition(() => {
+                    void handleRepairMissingRows();
+                  });
+                }}
+                disabled={repairLoading}
+              >
+                {repairLoading ? 'Repairing…' : 'Repair Missing Service Periods'}
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-3 md:grid-cols-4">
+                <div className="rounded-lg border p-4">
+                  <div className="text-sm text-muted-foreground">Generated</div>
+                  <div className="text-2xl font-semibold">{view.summary.generatedRows}</div>
+                </div>
+                <div className="rounded-lg border p-4">
+                  <div className="text-sm text-muted-foreground">Edited</div>
+                  <div className="text-2xl font-semibold">{view.summary.editedRows}</div>
+                </div>
+                <div className="rounded-lg border p-4">
+                  <div className="text-sm text-muted-foreground">Billed</div>
+                  <div className="text-2xl font-semibold">{view.summary.billedRows}</div>
+                </div>
+                <div className="rounded-lg border p-4">
+                  <div className="text-sm text-muted-foreground">Exceptions</div>
+                  <div className="text-2xl font-semibold">{view.summary.exceptionRows}</div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border overflow-hidden">
+                <table className="w-full text-sm" data-testid="recurring-service-periods-table">
+                  <thead className="bg-muted/40 text-left">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">State</th>
+                      <th className="px-4 py-3 font-medium">Service Period</th>
+                      <th className="px-4 py-3 font-medium">Invoice Window</th>
+                      <th className="px-4 py-3 font-medium">Revision</th>
+                      <th className="px-4 py-3 font-medium">Reason</th>
+                      <th className="px-4 py-3 font-medium">Allowed Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {view.rows.map((row) => (
+                      <tr key={row.record.recordId} className="border-t align-top">
+                        <td className="px-4 py-3">
+                          <div className="font-medium">{row.displayState.label}</div>
+                          <div className="text-xs text-muted-foreground">{row.displayState.detail}</div>
+                        </td>
+                        <td className="px-4 py-3">{formatRange(row.record.servicePeriod.start, row.record.servicePeriod.end)}</td>
+                        <td className="px-4 py-3">{formatRange(row.record.invoiceWindow.start, row.record.invoiceWindow.end)}</td>
+                        <td className="px-4 py-3">r{row.record.revision}</td>
+                        <td className="px-4 py-3">{row.displayState.reasonLabel ?? 'Generated from source cadence'}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {allowedGovernanceActions(row).map((action) => (
+                              <span
+                                key={`${row.record.recordId}:${action}`}
+                                className="rounded-full border px-2 py-0.5 text-xs"
+                              >
+                                {action}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="rounded-lg border p-4 space-y-3">
+                <div>
+                  <h3 className="text-lg font-semibold">Regeneration Preview</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Paste candidate records JSON to preview how preserved edited or billed rows would conflict with
+                    regenerated future candidates for this schedule.
+                  </p>
+                </div>
+                <label className="block text-sm font-medium">
+                  Candidate Records JSON
+                  <textarea
+                    className="mt-1 min-h-40 w-full rounded-md border px-3 py-2 font-mono text-xs"
+                    value={candidateRecordsJson}
+                    onChange={(event) => setCandidateRecordsJson(event.target.value)}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50"
+                  onClick={() => {
+                    startTransition(() => {
+                      void handlePreviewRegeneration();
+                    });
+                  }}
+                  disabled={previewLoading}
+                >
+                  {previewLoading ? 'Previewing…' : 'Preview Regeneration'}
+                </button>
+
+                {regenerationPreview && !isPermissionError(regenerationPreview) ? (
+                  <div className="space-y-2" data-testid="regeneration-preview">
+                    <div className="text-sm">
+                      Conflicts: <span className="font-semibold">{regenerationPreview.conflicts.length}</span>
+                    </div>
+                    {regenerationPreview.conflicts.length > 0 ? (
+                      <ul className="space-y-2 text-sm">
+                        {regenerationPreview.conflicts.map((conflict) => (
+                          <li
+                            key={`${conflict.recordId}:${conflict.kind}`}
+                            className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2"
+                          >
+                            <div className="font-medium">
+                              {conflict.kind.replaceAll('_', ' ')}: {conflict.recordId}
+                            </div>
+                            <div className="text-muted-foreground">{conflict.reason}</div>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-sm">
+                        No regeneration conflicts were detected for the supplied candidates.
+                      </div>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            </>
+          )}
         </>
       ) : null}
     </div>

--- a/server/src/test/unit/billing/recurringServicePeriodActions.test.ts
+++ b/server/src/test/unit/billing/recurringServicePeriodActions.test.ts
@@ -12,11 +12,25 @@ function normalizeColumn(column: string): string {
   return column.replace(/^.*\./, '').replace(/\s+as\s+.*$/i, '').trim();
 }
 
-function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
-  let resultRows = [...rows];
+function createQueryBuilder(
+  tableName: string,
+  rowsByTable: Record<string, Row[]>,
+  raw: (sql: string) => string,
+) {
+  let resultRows = [...(rowsByTable[tableName] ?? [])];
+  let firstRowOnly = false;
+
+  const applyEqualityFilter = (column: string, expected: any) => {
+    resultRows = resultRows.filter((row) => row[normalizeColumn(column)] === expected);
+  };
 
   const builder: any = {
-    where: vi.fn((columnOrCriteria: string | Record<string, any>, operatorOrValue?: any) => {
+    where: vi.fn((columnOrCriteria: string | Record<string, any> | ((builder: any) => unknown), operatorOrValue?: any, value?: any) => {
+      if (typeof columnOrCriteria === 'function') {
+        columnOrCriteria(builder);
+        return builder;
+      }
+
       if (typeof columnOrCriteria === 'object') {
         resultRows = resultRows.filter((row) =>
           Object.entries(columnOrCriteria).every(([column, expected]) =>
@@ -26,9 +40,20 @@ function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
         return builder;
       }
 
-      resultRows = resultRows.filter(
-        (row) => row[normalizeColumn(columnOrCriteria)] === operatorOrValue,
-      );
+      const operator = value === undefined ? '=' : operatorOrValue;
+      const expectedValue = value === undefined ? operatorOrValue : value;
+      if (operator === '=') {
+        applyEqualityFilter(columnOrCriteria, expectedValue);
+        return builder;
+      }
+
+      return builder;
+    }),
+    andWhere: vi.fn((...args: any[]) => builder.where(...args)),
+    orWhere: vi.fn(() => builder),
+    whereNull: vi.fn((column: string) => {
+      const normalizedColumn = normalizeColumn(column);
+      resultRows = resultRows.filter((row) => row[normalizedColumn] == null);
       return builder;
     }),
     whereIn: vi.fn((column: string, expectedValues: any[]) => {
@@ -53,12 +78,27 @@ function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
     groupBy: vi.fn(() => builder),
     max: vi.fn(() => builder),
     limit: vi.fn(() => builder),
-    first: vi.fn(async () => resultRows[0]),
+    first: vi.fn(() => {
+      firstRowOnly = true;
+      return builder;
+    }),
     join: vi.fn(() => builder),
     leftJoin: vi.fn(() => builder),
+    update: vi.fn(async (patch: Record<string, unknown>) => {
+      for (const row of resultRows) {
+        Object.assign(row, patch);
+      }
+      return resultRows.length;
+    }),
+    insert: vi.fn(async (rowsToInsert: Row[] | Row) => {
+      const normalizedRows = Array.isArray(rowsToInsert) ? rowsToInsert : [rowsToInsert];
+      rowsByTable[tableName] = [...(rowsByTable[tableName] ?? []), ...normalizedRows];
+      resultRows = [...rowsByTable[tableName]];
+      return normalizedRows.length;
+    }),
     raw,
-    then: (resolve: (value: Row[]) => unknown, reject?: (reason: unknown) => unknown) =>
-      Promise.resolve(resultRows).then(resolve, reject),
+    then: (resolve: (value: Row[] | Row | undefined) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(firstRowOnly ? resultRows[0] : resultRows).then(resolve, reject),
   };
 
   return builder;
@@ -74,7 +114,7 @@ const mocks = vi.hoisted(() => {
       throw new Error(`relation "${normalizedTableName}" does not exist`);
     }
 
-    return createQueryBuilder(rowsByTable[normalizedTableName] ?? [], raw);
+    return createQueryBuilder(normalizedTableName, rowsByTable, raw);
   }) as any;
   knex.raw = raw;
 
@@ -116,6 +156,7 @@ const {
   listRecurringServicePeriodScheduleSummaries,
   previewRecurringServicePeriodInvoiceLinkageRepair,
   previewRecurringServicePeriodRegeneration,
+  repairMissingRecurringServicePeriods,
 } = await import('../../../../../packages/billing/src/actions/recurringServicePeriodActions');
 
 describe('recurring service period actions', () => {
@@ -165,8 +206,25 @@ describe('recurring service period actions', () => {
         contract_name: 'Acme Managed Services',
         contract_line_id: 'line-1',
         contract_line_name: 'Managed Router',
+        contract_line_type: 'fixed',
+        cadence_owner: 'client',
+        billing_frequency: 'monthly',
+        billing_timing: 'arrears',
+        assignment_start_date: '2025-01-01',
+        assignment_end_date: null,
+        is_system_managed_default: false,
       },
     ];
+    mocks.rowsByTable.clients = [
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-1',
+        billing_cycle: 'monthly',
+      },
+    ];
+    mocks.rowsByTable.client_billing_settings = [];
+    mocks.rowsByTable.client_billing_cycles = [];
+    mocks.rowsByTable.invoices = [];
   });
 
   it('T076: service-period view actions require billing.recurring_service_periods.view', async () => {
@@ -338,6 +396,83 @@ describe('recurring service period actions', () => {
         totalRows: 1,
         generatedRows: 1,
       },
+    });
+  });
+
+  it('T304: zero-row schedule management loads a repairable state instead of crashing when the live obligation still exists', async () => {
+    mocks.rowsByTable.recurring_service_periods = [];
+
+    const result = await getRecurringServicePeriodManagementView(
+      'schedule:tenant-1:client_contract_line:line-1:client:arrears',
+    );
+
+    expect(result).toEqual({
+      scheduleKey: 'schedule:tenant-1:client_contract_line:line-1:client:arrears',
+      obligationId: 'line-1',
+      obligationType: 'client_contract_line',
+      cadenceOwner: 'client',
+      duePosition: 'arrears',
+      chargeFamily: 'fixed',
+      clientId: 'client-1',
+      clientName: 'Acme Corp',
+      contractId: 'contract-1',
+      contractName: 'Acme Managed Services',
+      contractLineId: 'line-1',
+      contractLineName: 'Managed Router',
+      status: 'repair_required',
+      summary: {
+        totalRows: 0,
+        exceptionRows: 0,
+        generatedRows: 0,
+        editedRows: 0,
+        skippedRows: 0,
+        lockedRows: 0,
+        billedRows: 0,
+        supersededRows: 0,
+        archivedRows: 0,
+      },
+      rows: [],
+    });
+  });
+
+  it('T306: repairing a missing client-cadence schedule accepts date-only assignment boundaries and materializes future rows', async () => {
+    mocks.rowsByTable.recurring_service_periods = [];
+    mocks.rowsByTable.contract_lines = [
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-1',
+        client_name: 'Acme Corp',
+        contract_id: 'contract-1',
+        contract_name: 'Acme Managed Services',
+        contract_line_id: 'line-1',
+        contract_line_name: 'Managed Router',
+        contract_line_type: 'fixed',
+        cadence_owner: 'client',
+        billing_frequency: 'monthly',
+        billing_timing: 'advance',
+        assignment_start_date: '2026-03-01',
+        assignment_end_date: null,
+        is_system_managed_default: false,
+      },
+    ];
+
+    const result = await repairMissingRecurringServicePeriods(
+      'schedule:tenant-1:client_contract_line:line-1:client:advance',
+    );
+
+    expect(result).toMatchObject({
+      scheduleKey: 'schedule:tenant-1:client_contract_line:line-1:client:advance',
+      backfilledRows: expect.any(Number),
+      realignedRows: 0,
+      supersededRows: 0,
+    });
+    expect((result as any).backfilledRows).toBeGreaterThan(0);
+    expect(mocks.rowsByTable.recurring_service_periods).not.toEqual([]);
+    expect(mocks.rowsByTable.recurring_service_periods[0]).toMatchObject({
+      schedule_key: 'schedule:tenant-1:client_contract_line:line-1:client:advance',
+      service_period_start: expect.stringMatching(/^2026-\d{2}-\d{2}$/),
+      provenance_kind: 'generated',
+      reason_code: 'backfill_materialization',
     });
   });
 

--- a/server/src/test/unit/billing/recurringServicePeriodsTab.ui.test.tsx
+++ b/server/src/test/unit/billing/recurringServicePeriodsTab.ui.test.tsx
@@ -2,10 +2,8 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { buildRecurringServicePeriodRecord } from '../../test-utils/recurringTimingFixtures';
 
@@ -13,12 +11,16 @@ import { buildRecurringServicePeriodRecord } from '../../test-utils/recurringTim
 
 const mocks = vi.hoisted(() => ({
   getRecurringServicePeriodManagementView: vi.fn(),
+  listRecurringServicePeriodScheduleSummaries: vi.fn(),
   previewRecurringServicePeriodRegeneration: vi.fn(),
+  repairMissingRecurringServicePeriods: vi.fn(),
 }));
 
 vi.mock('@alga-psa/billing/actions/recurringServicePeriodActions', () => ({
   getRecurringServicePeriodManagementView: mocks.getRecurringServicePeriodManagementView,
+  listRecurringServicePeriodScheduleSummaries: mocks.listRecurringServicePeriodScheduleSummaries,
   previewRecurringServicePeriodRegeneration: mocks.previewRecurringServicePeriodRegeneration,
+  repairMissingRecurringServicePeriods: mocks.repairMissingRecurringServicePeriods,
 }));
 
 const { default: RecurringServicePeriodsTab } = await import(
@@ -103,6 +105,7 @@ describe('RecurringServicePeriodsTab UI', () => {
       contractName: 'Zenith Annual Support',
       contractLineId: 'line-1',
       contractLineName: 'Managed Services',
+      status: 'ready',
       summary: {
         totalRows: 3,
         exceptionRows: 1,
@@ -176,25 +179,33 @@ describe('RecurringServicePeriodsTab UI', () => {
       newRecords: [],
       conflicts: [],
     });
+    mocks.listRecurringServicePeriodScheduleSummaries.mockResolvedValue([]);
+    mocks.repairMissingRecurringServicePeriods.mockResolvedValue({
+      scheduleKey: generatedRecord.scheduleKey,
+      repairedAt: '2026-03-18T20:10:00.000Z',
+      historicalBoundaryEnd: null,
+      skippedHistoricalCandidates: 0,
+      backfilledRows: 2,
+      realignedRows: 0,
+      supersededRows: 0,
+      activeRows: 2,
+    });
   });
 
   it('T065: billing dashboard keeps the service-period management surface wired for recurring troubleshooting and repair', () => {
-    const billingDashboardSource = readFileSync(
-      resolve(__dirname, '../../../../../packages/billing/src/components/billing-dashboard/BillingDashboard.tsx'),
-      'utf8',
-    );
-    const billingTabsSource = readFileSync(
-      resolve(__dirname, '../../../../../packages/billing/src/components/billing-dashboard/billingTabsConfig.ts'),
-      'utf8',
+    const { billingTabDefinitions } = require(
+      `${process.cwd()}/../packages/billing/src/components/billing-dashboard/billingTabsConfig.ts`
     );
 
-    expect(billingDashboardSource).toContain("import RecurringServicePeriodsTab from './RecurringServicePeriodsTab';");
-    expect(billingDashboardSource).toContain('<Tabs.Content value="service-periods">');
-    expect(billingDashboardSource).toContain(
-      '<RecurringServicePeriodsTab initialScheduleKey={searchParams?.get(\'scheduleKey\') ?? undefined} />',
+    expect(billingTabDefinitions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: 'service-periods',
+          href: '/msp/billing?tab=service-periods',
+          label: 'Service Periods',
+        }),
+      ]),
     );
-    expect(billingTabsSource).toContain("value: 'service-periods'");
-    expect(billingTabsSource).toContain("href: '/msp/billing?tab=service-periods'");
   });
 
   it('T080: service-period management surface can show future generated rows, edited rows, and billed rows for one recurring obligation', async () => {
@@ -221,5 +232,133 @@ describe('RecurringServicePeriodsTab UI', () => {
     expect(within(table).getByText('2026-03-01 to 2026-04-01')).toBeInTheDocument();
     expect(within(table).getByText('Boundary adjusted')).toBeInTheDocument();
     expect(within(table).getByText('Linked to invoice detail detail-1.')).toBeInTheDocument();
+  });
+
+  it('T305: zero-row schedules render a repair flow, re-materialize rows, and then show the schedule table', async () => {
+    const repairedRecord = buildRecurringServicePeriodRecord({
+      recordId: 'rsp-repaired',
+      scheduleKey: 'schedule:tenant-1:client_contract_line:line-1:client:advance',
+      sourceObligation: {
+        tenant: 'tenant-1',
+        obligationId: 'line-1',
+        obligationType: 'client_contract_line',
+        chargeFamily: 'fixed',
+      },
+      cadenceOwner: 'client',
+      duePosition: 'advance',
+      servicePeriod: {
+        start: '2026-04-01',
+        end: '2026-05-01',
+        semantics: 'half_open',
+      },
+      invoiceWindow: {
+        start: '2026-04-01',
+        end: '2026-05-01',
+        semantics: 'half_open',
+      },
+    });
+
+    mocks.getRecurringServicePeriodManagementView
+      .mockResolvedValueOnce({
+        scheduleKey: repairedRecord.scheduleKey,
+        obligationId: 'line-1',
+        obligationType: 'client_contract_line',
+        cadenceOwner: 'client',
+        duePosition: 'advance',
+        chargeFamily: 'fixed',
+        clientId: 'client-1',
+        clientName: 'Zenith Health',
+        contractId: 'contract-1',
+        contractName: 'Zenith Annual Support',
+        contractLineId: 'line-1',
+        contractLineName: 'Managed Services',
+        status: 'repair_required',
+        summary: {
+          totalRows: 0,
+          exceptionRows: 0,
+          generatedRows: 0,
+          editedRows: 0,
+          skippedRows: 0,
+          lockedRows: 0,
+          billedRows: 0,
+          supersededRows: 0,
+          archivedRows: 0,
+        },
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        scheduleKey: repairedRecord.scheduleKey,
+        obligationId: 'line-1',
+        obligationType: 'client_contract_line',
+        cadenceOwner: 'client',
+        duePosition: 'advance',
+        chargeFamily: 'fixed',
+        clientId: 'client-1',
+        clientName: 'Zenith Health',
+        contractId: 'contract-1',
+        contractName: 'Zenith Annual Support',
+        contractLineId: 'line-1',
+        contractLineName: 'Managed Services',
+        status: 'ready',
+        summary: {
+          totalRows: 1,
+          exceptionRows: 0,
+          generatedRows: 1,
+          editedRows: 0,
+          skippedRows: 0,
+          lockedRows: 0,
+          billedRows: 0,
+          supersededRows: 0,
+          archivedRows: 0,
+        },
+        rows: [
+          {
+            record: repairedRecord,
+            displayState: {
+              lifecycleState: 'generated',
+              label: 'Generated',
+              tone: 'neutral',
+              detail: 'Matches the current cadence rules and is awaiting billing or review.',
+              reasonLabel: 'Generated from source cadence',
+            },
+            governance: [],
+            clientId: 'client-1',
+            clientName: 'Zenith Health',
+            contractId: 'contract-1',
+            contractName: 'Zenith Annual Support',
+            contractLineId: 'line-1',
+            contractLineName: 'Managed Services',
+          },
+        ],
+      });
+
+    render(
+      <RecurringServicePeriodsTab
+        initialScheduleKey="schedule:tenant-1:client_contract_line:line-1:client:advance"
+      />,
+    );
+
+    const repairState = await screen.findByTestId('recurring-service-period-repair-state');
+    expect(within(repairState).getByText('Missing persisted service periods')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Repair Missing Service Periods' }));
+
+    await waitFor(() => {
+      expect(mocks.repairMissingRecurringServicePeriods).toHaveBeenCalledWith(
+        'schedule:tenant-1:client_contract_line:line-1:client:advance',
+      );
+    });
+
+    await waitFor(() => {
+      expect(mocks.getRecurringServicePeriodManagementView).toHaveBeenCalledTimes(2);
+    });
+
+    expect(await screen.findByTestId('repair-result')).toHaveTextContent(
+      'Backfilled 2 rows, realigned 0, skipped 0 historical candidates, and left 2 active rows on this schedule.',
+    );
+
+    const table = await screen.findByTestId('recurring-service-periods-table');
+    expect(within(table).getByText('Generated')).toBeInTheDocument();
+    expect(within(table).getAllByText('2026-04-01 to 2026-05-01')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What changed
This fixes the recurring service-period management flow for schedules that exist in live billing metadata but have zero persisted `recurring_service_periods` rows.

The service-period tab now loads those schedules into a repair state instead of throwing, and operators can run a schedule-scoped repair directly from the page. The repair uses the existing backfill/materialization pipeline rather than a separate algorithm.

## Why it changed
On tenants that hit the recurring-invoicing cutover gap, the billing UI sent operators into a broken path:
- the Automatic Invoices warning linked to the service-period management page
- that page assumed persisted rows already existed
- zero-row schedules crashed before any recovery action could run

This change makes the page resilient and gives operators an in-app way to heal the gap.

## Impact
- zero-row recurring schedules no longer hard-fail in the management view
- the page shows a repair-needed state with a repair action
- repair materializes only the target schedule
- billed history is preserved
- repaired rows keep explicit provenance such as `backfill_materialization`

## Root cause
The management action hydrated solely from existing `recurring_service_periods` rows and threw when none were found. That assumption is invalid for cutover-gap schedules where the obligation still exists but persisted rows were never materialized.

The repair implementation also needed to normalize DB date values to canonical UTC-midnight ISO before passing them into the shared cadence generators.

## Validation
- `pnpm vitest run src/test/unit/billing/recurringServicePeriodActions.test.ts src/test/unit/billing/recurringServicePeriodsTab.ui.test.tsx`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- verified the live local-test DB after repair for the synthetic repro schedule:
  - 6 generated rows were created for the repaired schedule
  - all repaired rows used `reason_code = backfill_materialization`
  - no billed or inactive rows were introduced
  - the sibling White Rabbit schedule was not touched by the operator repair run
