### PR TITLE
[codex] Fix Microsoft inbound email image parsing

### DIFF
--- a/server/src/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/server/src/services/email/providers/MicrosoftGraphAdapter.ts
@@ -452,11 +452,16 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
             'internetMessageHeaders,receivedDateTime,subject,body,bodyPreview,from,toRecipients,ccRecipients,conversationId',
         },
         headers: {
-          Prefer: 'outlook.body-content-type="text"',
+          Prefer: 'outlook.body-content-type="html"',
         },
       });
 
       const message = response.data;
+      const bodyContentType = String(message.body?.contentType || '').toLowerCase();
+      const htmlBody = bodyContentType === 'html' ? message.body?.content : undefined;
+      const textBody = bodyContentType === 'text'
+        ? message.body?.content || ''
+        : message.bodyPreview || '';
 
       return {
         id: message.id,
@@ -477,8 +482,8 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         })),
         subject: message.subject || '',
         body: {
-          text: message.body?.content || '',
-          html: message.body?.contentType === 'html' ? message.body?.content : undefined,
+          text: textBody,
+          html: htmlBody,
         },
         attachments: message.attachments?.map((attachment: any) => ({
           id: attachment.id,

--- a/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
+++ b/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
@@ -4,6 +4,7 @@ import type { UnifiedInboundEmailQueueJob } from '@alga-psa/shared/interfaces/in
 const getAdminConnectionMock = vi.fn();
 const processInboundEmailInAppMock = vi.fn();
 const microsoftConnectMock = vi.fn();
+const microsoftDownloadMessageSourceMock = vi.fn();
 const microsoftGetMessageDetailsMock = vi.fn();
 const gmailConnectMock = vi.fn();
 const gmailListMessagesSinceMock = vi.fn();
@@ -28,6 +29,9 @@ vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () =>
   MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
     connect(...args: any[]) {
       return microsoftConnectMock(...args);
+    }
+    downloadMessageSource(...args: any[]) {
+      return microsoftDownloadMessageSourceMock(...args);
     }
     getMessageDetails(...args: any[]) {
       return microsoftGetMessageDetailsMock(...args);
@@ -55,6 +59,7 @@ vi.mock('mailparser', () => ({
 
 vi.mock('imapflow', () => ({
   ImapFlow: class ImapFlow {
+    on() {}
     connect(...args: any[]) {
       return imapConnectMock(...args);
     }
@@ -181,6 +186,7 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     getAdminConnectionMock.mockReset();
     processInboundEmailInAppMock.mockReset();
     microsoftConnectMock.mockReset();
+    microsoftDownloadMessageSourceMock.mockReset();
     microsoftGetMessageDetailsMock.mockReset();
     gmailConnectMock.mockReset();
     gmailListMessagesSinceMock.mockReset();
@@ -219,19 +225,28 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     });
     getAdminConnectionMock.mockResolvedValue(db);
 
-    const microsoftEmail = {
-      id: 'ms-msg-1',
-      provider: 'microsoft',
-      providerId: 'provider-ms-1',
-      tenant: 'tenant-1',
-      receivedAt: new Date().toISOString(),
-      from: { email: 'sender@example.com' },
-      to: [{ email: 'support@example.com' }],
+    const rawMimeBuffer = Buffer.from('microsoft raw mime payload');
+    microsoftDownloadMessageSourceMock.mockResolvedValue(rawMimeBuffer);
+    simpleParserMock.mockResolvedValue({
+      messageId: '<ms-msg-1@example.com>',
+      date: new Date('2026-03-01T00:00:00.000Z'),
+      from: { value: [{ address: 'sender@example.com', name: 'Sender' }] },
+      to: { value: [{ address: 'support@example.com', name: 'Support' }] },
+      cc: { value: [] },
       subject: 'Microsoft Subject',
-      body: { text: 'Body', html: '<p>Body</p>' },
-      attachments: [],
-    } as any;
-    microsoftGetMessageDetailsMock.mockResolvedValue(microsoftEmail);
+      text: 'Microsoft Body',
+      html: '<p>Microsoft Body<img src="cid:inline-image-1" /></p>',
+      attachments: [
+        {
+          contentId: 'inline-image-1',
+          filename: 'image.png',
+          contentType: 'image/png',
+          size: 4,
+          contentDisposition: 'inline',
+          content: Buffer.from('png!'),
+        },
+      ],
+    });
 
     const { processUnifiedInboundEmailQueueJob } = await import(
       '../../services/email/unifiedInboundEmailQueueJobProcessor'
@@ -259,17 +274,22 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
       dedupedCount: 0,
     });
     expect(microsoftConnectMock).toHaveBeenCalledTimes(1);
-    expect(microsoftGetMessageDetailsMock).toHaveBeenCalledWith('ms-msg-1');
-    expect(processInboundEmailInAppMock).toHaveBeenCalledWith(
+    expect(microsoftDownloadMessageSourceMock).toHaveBeenCalledWith('ms-msg-1');
+    expect(microsoftGetMessageDetailsMock).not.toHaveBeenCalled();
+    expect(simpleParserMock).toHaveBeenCalledWith(rawMimeBuffer);
+    const processedEmail = processInboundEmailInAppMock.mock.calls[0][0].emailData;
+    expect(processedEmail).toMatchObject({
+      id: '<ms-msg-1@example.com>',
+      subject: 'Microsoft Subject',
+      rawMimeBase64: rawMimeBuffer.toString('base64'),
+    });
+    expect(processedEmail.attachments).toEqual([
       expect.objectContaining({
-        tenantId: 'tenant-1',
-        providerId: 'provider-ms-1',
-        emailData: expect.objectContaining({
-          id: 'ms-msg-1',
-          subject: 'Microsoft Subject',
-        }),
-      })
-    );
+        contentId: 'inline-image-1',
+        isInline: true,
+        content: Buffer.from('png!').toString('base64'),
+      }),
+    ]);
   });
 
   it('T013: Google pointer fetch resolves full email payload before processing', async () => {
@@ -494,18 +514,18 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     });
     getAdminConnectionMock.mockResolvedValue(db);
 
-    microsoftGetMessageDetailsMock.mockResolvedValue({
-      id: 'ms-idempotent-1',
-      provider: 'microsoft',
-      providerId: 'provider-ms-1',
-      tenant: 'tenant-1',
-      receivedAt: new Date().toISOString(),
-      from: { email: 'sender@example.com' },
-      to: [{ email: 'support@example.com' }],
+    microsoftDownloadMessageSourceMock.mockResolvedValue(Buffer.from('idempotent microsoft mime'));
+    simpleParserMock.mockResolvedValue({
+      messageId: '<ms-idempotent-1@example.com>',
+      date: new Date('2026-03-01T00:00:00.000Z'),
+      from: { value: [{ address: 'sender@example.com' }] },
+      to: { value: [{ address: 'support@example.com' }] },
+      cc: { value: [] },
       subject: 'Idempotent Subject',
-      body: { text: 'Body', html: '<p>Body</p>' },
+      text: 'Body',
+      html: '<p>Body</p>',
       attachments: [],
-    } as any);
+    });
 
     const { processUnifiedInboundEmailQueueJob } = await import(
       '../../services/email/unifiedInboundEmailQueueJobProcessor'
@@ -532,7 +552,7 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     });
     expect(emailProcessedInsertMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        message_id: 'microsoft:ms-idempotent-1',
+        message_id: 'microsoft:<ms-idempotent-1@example.com>',
         provider_id: 'provider-ms-1',
         tenant: 'tenant-1',
         processing_status: 'processing',
@@ -555,18 +575,18 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     getAdminConnectionMock.mockResolvedValue(db);
 
     emailProcessedInsertMock.mockRejectedValueOnce({ code: '23505' });
-    microsoftGetMessageDetailsMock.mockResolvedValue({
-      id: 'ms-idempotent-dup-1',
-      provider: 'microsoft',
-      providerId: 'provider-ms-1',
-      tenant: 'tenant-1',
-      receivedAt: new Date().toISOString(),
-      from: { email: 'sender@example.com' },
-      to: [{ email: 'support@example.com' }],
+    microsoftDownloadMessageSourceMock.mockResolvedValue(Buffer.from('duplicate microsoft mime'));
+    simpleParserMock.mockResolvedValue({
+      messageId: '<ms-idempotent-dup-1@example.com>',
+      date: new Date('2026-03-01T00:00:00.000Z'),
+      from: { value: [{ address: 'sender@example.com' }] },
+      to: { value: [{ address: 'support@example.com' }] },
+      cc: { value: [] },
       subject: 'Duplicate Subject',
-      body: { text: 'Body', html: '<p>Body</p>' },
+      text: 'Body',
+      html: '<p>Body</p>',
       attachments: [],
-    } as any);
+    });
 
     const { processUnifiedInboundEmailQueueJob } = await import(
       '../../services/email/unifiedInboundEmailQueueJobProcessor'

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -495,11 +495,16 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
             'internetMessageHeaders,receivedDateTime,subject,body,bodyPreview,from,toRecipients,ccRecipients,conversationId',
         },
         headers: {
-          Prefer: 'outlook.body-content-type="text"',
+          Prefer: 'outlook.body-content-type="html"',
         },
       });
 
       const message = response.data;
+      const bodyContentType = String(message.body?.contentType || '').toLowerCase();
+      const htmlBody = bodyContentType === 'html' ? message.body?.content : undefined;
+      const textBody = bodyContentType === 'text'
+        ? message.body?.content || ''
+        : message.bodyPreview || '';
 
       return {
         id: message.id,
@@ -520,8 +525,8 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         })),
         subject: message.subject || '',
         body: {
-          text: message.body?.content || '',
-          html: message.body?.contentType === 'html' ? message.body?.content : undefined,
+          text: textBody,
+          html: htmlBody,
         },
         attachments: message.attachments?.map((attachment: any) => ({
           id: attachment.id,

--- a/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
+++ b/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MicrosoftGraphAdapter } from '../MicrosoftGraphAdapter';
 
 function makeJwt(payload: Record<string, any>) {
@@ -149,5 +149,69 @@ describe('MicrosoftGraphAdapter.runMicrosoft365Diagnostics', () => {
 
     const buffer = await adapter.downloadMessageSource('message-1');
     expect(buffer.toString('utf8')).toContain('From: sender@example.com');
+  });
+
+  it('requests html bodies and preserves html for inline image extraction', async () => {
+    const adapter = makeAdapter();
+    const get = vi.fn(async (path: string, options?: any) => {
+      if (path === '/users/support%40example.com/messages/message-1') {
+        return {
+          data: {
+            id: 'message-1',
+            receivedDateTime: '2026-03-31T23:11:12.021Z',
+            subject: 'inline image test',
+            body: {
+              contentType: 'html',
+              content: '<p>Hello<img src="cid:inline-image-1" /></p>',
+            },
+            bodyPreview: 'Hello',
+            from: {
+              emailAddress: {
+                address: 'sender@example.com',
+                name: 'Sender',
+              },
+            },
+            toRecipients: [],
+            ccRecipients: [],
+            conversationId: 'conversation-1',
+            internetMessageHeaders: [],
+            attachments: [
+              {
+                id: 'attachment-1',
+                name: 'image.png',
+                contentType: 'image/png',
+                size: 1234,
+                contentId: 'inline-image-1',
+                isInline: true,
+              },
+            ],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected GET ${path} ${JSON.stringify(options || {})}`);
+    });
+
+    (adapter as any).httpClient = { get };
+
+    const message = await adapter.getMessageDetails('message-1');
+
+    expect(get).toHaveBeenCalledWith(
+      '/users/support%40example.com/messages/message-1',
+      expect.objectContaining({
+        headers: {
+          Prefer: 'outlook.body-content-type="html"',
+        },
+      })
+    );
+    expect(message.body.html).toBe('<p>Hello<img src="cid:inline-image-1" /></p>');
+    expect(message.body.text).toBe('Hello');
+    expect(message.attachments).toEqual([
+      expect.objectContaining({
+        id: 'attachment-1',
+        contentId: 'inline-image-1',
+        isInline: true,
+      }),
+    ]);
   });
 });

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -34,6 +34,8 @@ const DEFAULT_IMAP_CONNECTION_TIMEOUT_MS = 10_000;
 const DEFAULT_IMAP_SOCKET_TIMEOUT_MS = 30_000;
 const DEFAULT_IMAP_FETCH_TIMEOUT_MS = 45_000;
 const DEFAULT_IMAP_PARSE_TIMEOUT_MS = 30_000;
+const DEFAULT_MESSAGE_SOURCE_FETCH_TIMEOUT_MS = 45_000;
+const DEFAULT_MIME_PARSE_TIMEOUT_MS = 30_000;
 const OAUTH_TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
 
 function asNonEmptyString(value: unknown): string | null {
@@ -373,6 +375,118 @@ async function fetchGoogleProviderConfig(job: UnifiedInboundEmailQueueJob): Prom
   return { provider, googleConfig, config };
 }
 
+function mapParsedMimeToEmailMessageDetails(params: {
+  provider: 'microsoft' | 'imap';
+  providerId: string;
+  tenant: string;
+  rawMimeBuffer: Buffer;
+  parsed: any;
+  fallbackMessageId: string;
+}): EmailMessageDetails {
+  const from = params.parsed.from?.value?.[0];
+  const to = params.parsed.to?.value || [];
+  const cc = params.parsed.cc?.value || [];
+  const messageId = asNonEmptyString(params.parsed.messageId) || params.fallbackMessageId;
+  const references = extractMessageIds(params.parsed.references);
+  const inReplyTo = extractMessageIds(params.parsed.inReplyTo)[0];
+  const threadId = references[0] || inReplyTo;
+
+  return {
+    id: messageId,
+    provider: params.provider,
+    providerId: params.providerId,
+    tenant: params.tenant,
+    receivedAt: params.parsed.date ? new Date(params.parsed.date).toISOString() : new Date().toISOString(),
+    from: {
+      email: from?.address || '',
+      name: from?.name || undefined,
+    },
+    to: to.map((item: any) => ({
+      email: item?.address || '',
+      name: item?.name || undefined,
+    })),
+    cc: cc.length
+      ? cc.map((item: any) => ({
+          email: item?.address || '',
+          name: item?.name || undefined,
+        }))
+      : undefined,
+    subject: params.parsed.subject || '',
+    body: {
+      text: params.parsed.text || '',
+      html: params.parsed.html ? String(params.parsed.html) : undefined,
+    },
+    attachments: Array.isArray(params.parsed.attachments)
+      ? params.parsed.attachments.map((attachment: any, index: number) => {
+          const contentBuffer = Buffer.isBuffer(attachment?.content)
+            ? attachment.content
+            : Buffer.from(attachment?.content || '');
+          return {
+            id: String(attachment?.contentId || attachment?.checksum || `${messageId}-att-${index}`),
+            name: String(attachment?.filename || `attachment-${index + 1}`),
+            contentType: String(attachment?.contentType || 'application/octet-stream'),
+            size: Number(attachment?.size || contentBuffer.length || 0),
+            contentId: asNonEmptyString(attachment?.contentId) || undefined,
+            isInline: Boolean(attachment?.contentDisposition === 'inline'),
+            content: contentBuffer.toString('base64'),
+          };
+        })
+      : [],
+    threadId: threadId || undefined,
+    references: references.length ? references : undefined,
+    inReplyTo: inReplyTo || undefined,
+    rawMimeBase64: params.rawMimeBuffer.toString('base64'),
+  };
+}
+
+async function fetchMicrosoftMessageForPointer(job: UnifiedInboundEmailQueueJob): Promise<EmailMessageDetails> {
+  if (job.provider !== 'microsoft') {
+    throw new Error('invalid provider for microsoft fetch');
+  }
+
+  const sourceFetchTimeoutMs = parsePositiveInteger(
+    process.env.INBOUND_EMAIL_SOURCE_FETCH_TIMEOUT_MS,
+    DEFAULT_MESSAGE_SOURCE_FETCH_TIMEOUT_MS
+  );
+  const parseTimeoutMs = parsePositiveInteger(
+    process.env.INBOUND_EMAIL_MIME_PARSE_TIMEOUT_MS,
+    DEFAULT_MIME_PARSE_TIMEOUT_MS
+  );
+
+  const config = await fetchMicrosoftProviderConfig(job);
+  const adapter = new MicrosoftGraphAdapter(config);
+  await adapter.connect();
+
+  let rawMimeBuffer: Buffer;
+  try {
+    rawMimeBuffer = await withTimeout(
+      adapter.downloadMessageSource(job.pointer.messageId),
+      sourceFetchTimeoutMs,
+      'microsoft_message_source'
+    );
+  } catch (error: any) {
+    if (Number(error?.status) === 404) {
+      throw new SourceMessageUnavailableError('microsoft_message_not_found');
+    }
+    throw error;
+  }
+
+  const parsed: any = await withTimeout(
+    simpleParser(rawMimeBuffer),
+    parseTimeoutMs,
+    'microsoft_mime_parse'
+  );
+
+  return mapParsedMimeToEmailMessageDetails({
+    provider: 'microsoft',
+    providerId: config.id,
+    tenant: config.tenant,
+    rawMimeBuffer,
+    parsed,
+    fallbackMessageId: job.pointer.messageId,
+  });
+}
+
 async function fetchImapMessageForPointer(job: UnifiedInboundEmailQueueJob): Promise<EmailMessageDetails> {
   if (job.provider !== 'imap') {
     throw new Error('invalid provider for imap fetch');
@@ -528,60 +642,14 @@ async function fetchImapMessageForPointer(job: UnifiedInboundEmailQueueJob): Pro
           parseTimeoutMs,
           'imap_mime_parse'
         );
-        const from = parsed.from?.value?.[0];
-        const to = parsed.to?.value || [];
-        const cc = parsed.cc?.value || [];
-        const messageId = asNonEmptyString(parsed.messageId) || `imap-uid-${pointerUid}`;
-        const references = extractMessageIds(parsed.references);
-        const inReplyTo = extractMessageIds(parsed.inReplyTo)[0];
-        const threadId = references[0] || inReplyTo;
-
-        return {
-          id: messageId,
+        return mapParsedMimeToEmailMessageDetails({
           provider: 'imap',
           providerId: provider.id,
           tenant: provider.tenant,
-          receivedAt: parsed.date ? new Date(parsed.date).toISOString() : new Date().toISOString(),
-          from: {
-            email: from?.address || '',
-            name: from?.name || undefined,
-          },
-          to: to.map((item: any) => ({
-            email: item?.address || '',
-            name: item?.name || undefined,
-          })),
-          cc: cc.length
-            ? cc.map((item: any) => ({
-                email: item?.address || '',
-                name: item?.name || undefined,
-              }))
-            : undefined,
-          subject: parsed.subject || '',
-          body: {
-            text: parsed.text || '',
-            html: parsed.html ? String(parsed.html) : undefined,
-          },
-          attachments: Array.isArray(parsed.attachments)
-            ? parsed.attachments.map((attachment: any, index: number) => {
-                const contentBuffer = Buffer.isBuffer(attachment?.content)
-                  ? attachment.content
-                  : Buffer.from(attachment?.content || '');
-                return {
-                  id: String(attachment?.contentId || attachment?.checksum || `${messageId}-att-${index}`),
-                  name: String(attachment?.filename || `attachment-${index + 1}`),
-                  contentType: String(attachment?.contentType || 'application/octet-stream'),
-                  size: Number(attachment?.size || contentBuffer.length || 0),
-                  contentId: asNonEmptyString(attachment?.contentId) || undefined,
-                  isInline: Boolean(attachment?.contentDisposition === 'inline'),
-                  content: contentBuffer.toString('base64'),
-                };
-              })
-            : [],
-          threadId: threadId || undefined,
-          references: references.length ? references : undefined,
-          inReplyTo: inReplyTo || undefined,
-          rawMimeBase64: rawMimeBuffer.toString('base64'),
-        };
+          rawMimeBuffer,
+          parsed,
+          fallbackMessageId: `imap-uid-${pointerUid}`,
+        });
       } finally {
         lock.release();
       }
@@ -625,11 +693,7 @@ async function fetchImapMessageForPointer(job: UnifiedInboundEmailQueueJob): Pro
 
 async function fetchEmailPayloadsForJob(job: UnifiedInboundEmailQueueJob): Promise<EmailMessageDetails[]> {
   if (job.provider === 'microsoft') {
-    const config = await fetchMicrosoftProviderConfig(job);
-    const adapter = new MicrosoftGraphAdapter(config);
-    await adapter.connect();
-    const details = await adapter.getMessageDetails(job.pointer.messageId);
-    return [details];
+    return [await fetchMicrosoftMessageForPointer(job)];
   }
 
   if (job.provider === 'google') {


### PR DESCRIPTION
## What changed
This switches the unified inbound Microsoft email path to fetch and parse raw MIME before ticket/comment processing, instead of relying on the Graph JSON body shape alone.

It also preserves HTML in the Microsoft adapters and adds targeted regression coverage at both the adapter layer and the unified inbound queue processor layer.

## Why
Production evidence showed Microsoft inbound emails with inline/CID images were being normalized too early, which meant the downstream embedded-image extraction pipeline did not have the same HTML/MIME structure that IMAP had.

IMAP succeeded because it parsed raw MIME and carried inline image content through the shared artifact pipeline. Microsoft was still using a provider-shaped fetch path.

## Impact
Microsoft inbound emails now enter the shared attachment and embedded-image handling path with:
- parsed RFC822 message identity
- preserved HTML body
- inline attachment content and CID metadata
- raw MIME source retained for downstream processing

This brings the unified inbound queue path much closer to IMAP parity for embedded images.

## Validation
- `npx vitest run --config shared/vitest.config.ts shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts`
- `npx vitest run --config vitest.config.ts src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts` (from `server/`)

## Root cause
Microsoft inbound processing was using Graph message JSON as the primary payload source, while IMAP used raw MIME parsing. That difference meant CID/image handling behavior diverged by provider.