### PR TITLE
[codex] Fix email-service runtime import resolution

### DIFF
--- a/services/email-service/tsconfig.json
+++ b/services/email-service/tsconfig.json
@@ -12,7 +12,19 @@
       "@shared": ["shared"],
       "@shared/*": ["shared/*"],
       "@alga-psa/shared": ["shared"],
-      "@alga-psa/shared/*": ["shared/*"]
+      "@alga-psa/shared/*": ["shared/*"],
+      "@alga-psa/core": ["packages/core/src"],
+      "@alga-psa/core/*": ["packages/core/src/*", "packages/core/src/lib/*"],
+      "@alga-psa/db": ["packages/db/src"],
+      "@alga-psa/db/*": ["packages/db/src/*", "packages/db/src/lib/*"],
+      "@alga-psa/types": ["packages/types/src"],
+      "@alga-psa/types/*": ["packages/types/src/*"],
+      "@alga-psa/storage": ["packages/storage/src"],
+      "@alga-psa/storage/*": ["packages/storage/src/*"],
+      "@alga-psa/event-bus": ["packages/event-bus/src"],
+      "@alga-psa/event-bus/*": ["packages/event-bus/src/*"],
+      "@alga-psa/event-schemas": ["packages/event-schemas/src"],
+      "@alga-psa/event-schemas/*": ["packages/event-schemas/src/*"]
     },
     "rootDir": "../..",
     "skipLibCheck": true

--- a/shared/services/email/processInboundEmailArtifacts.ts
+++ b/shared/services/email/processInboundEmailArtifacts.ts
@@ -378,10 +378,7 @@ async function persistDocumentForBuffer(args: {
   mimeType: string;
   buffer: Buffer;
 }): Promise<{ success: boolean; message?: string; documentId?: string; fileId?: string }> {
-  // Keep this specifier non-literal so TypeScript doesn't pull the entire storage/auth tree
-  // into every consumer's compile graph (notably email-service).
-  const storageModuleSpecifier = '@alga-psa/storage/StorageProviderFactory';
-  const storageModule: any = await import(storageModuleSpecifier);
+  const storageModule: any = await import('@alga-psa/storage/StorageProviderFactory');
   const StorageProviderFactory = storageModule.StorageProviderFactory;
   const generateStoragePath = storageModule.generateStoragePath;
 


### PR DESCRIPTION
## What changed
This fixes the built `email-service` runtime graph so Node resolves local emitted `.js` files instead of falling back to workspace package imports that point at TypeScript source.

The change is intentionally service-layer scoped:
- restore the workspace package aliases `email-service` needs in `services/email-service/tsconfig.json` so `tsc-alias --resolve-full-paths` can rewrite those imports into the compiled output
- switch the storage dynamic import in shared inbound-email artifact handling to a direct string literal so the `email-service` build can localize it into the emitted runtime graph

## Why
The built service was still importing package specifiers like `@alga-psa/core/logger` at runtime. In the container, Node followed that package export back to `/app/packages/core/src/lib/logger.ts`, which caused:

`ERR_UNKNOWN_FILE_EXTENSION: Unknown file extension ".ts"`

This PR keeps the fix in the Node service build path rather than changing package exports to reference `dist/` or introducing a server-layer dependency.

## Impact
`email-service` now starts far enough to reach normal service startup and database connection logic instead of crashing during ESM module loading.

## Validation
- `npm --prefix services/email-service run build`
- `node --input-type=module -e "await import('./services/email-service/dist/services/email-service/src/emailService.js'); console.log('email-service-emailService-import-ok')"`
- `node --input-type=module -e "const mod = await import('./services/email-service/dist/shared/core/getSecret.js'); await mod.getSecret('missing'); console.log('shared-getSecret-import-ok')"`
- `timeout 8s node services/email-service/dist/services/email-service/src/index.js`

The last command now reaches service startup and fails later on local Postgres connectivity, which confirms the original `.ts` extension runtime failure is gone.

## Root cause
`services/email-service/tsconfig.json` overrode `paths` and dropped the inherited workspace aliases for `@alga-psa/core/*`, `@alga-psa/db/*`, and related packages. That prevented `tsc-alias` from rewriting those imports into local emitted `.js` paths for the service runtime graph.