### PR TITLE
Improve ticket creation dialog UX

### DIFF
--- a/packages/tickets/src/components/QuickAddTicket.tsx
+++ b/packages/tickets/src/components/QuickAddTicket.tsx
@@ -904,6 +904,7 @@ export function QuickAddTicket({
         tags: createdTags,
       });
       resetForm();
+
       onOpenChange(false);
 
       if (openAfterCreate && newTicket.ticket_id) {
@@ -1078,6 +1079,18 @@ export function QuickAddTicket({
                       showPlaceholderInDropdown={false}
                     />
                   )}
+                  <div className={hasAttemptedSubmit && !boardId ? 'ring-1 ring-red-500 rounded-lg' : ''}>
+                    <BoardPicker
+                      id={`${id}-board-picker`}
+                      boards={boards}
+                      onSelect={handleBoardChange}
+                      selectedBoardId={boardId}
+                      onFilterStateChange={setQuickAddBoardFilterState}
+                      filterState={quickAddBoardFilterState}
+                      placeholder="Select Board *"
+                    />
+                  </div>
+
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1">Assigned To</label>
@@ -1236,18 +1249,6 @@ export function QuickAddTicket({
                         />
                       )}
                     </div>
-                  </div>
-
-                  <div className={hasAttemptedSubmit && !boardId ? 'ring-1 ring-red-500 rounded-lg' : ''}>
-                    <BoardPicker
-                      id={`${id}-board-picker`}
-                      boards={boards}
-                      onSelect={handleBoardChange}
-                      selectedBoardId={boardId}
-                      onFilterStateChange={setQuickAddBoardFilterState}
-                      filterState={quickAddBoardFilterState}
-                      placeholder="Select Board *"
-                    />
                   </div>
 
                   {boardId && boardConfig.category_type && (
@@ -1505,24 +1506,24 @@ export function QuickAddTicket({
                     <Button
                       id={`${id}-create-open-btn`}
                       type="button"
-                      variant="default"
+                      variant="secondary"
                       disabled={isSubmitting}
                       onClick={() => {
                         void handleCreateTicket({ openAfterCreate: true });
                       }}
                       className={hasRequiredFieldErrors ? 'opacity-50' : ''}
                     >
-                      {isSubmitting ? 'Saving...' : 'Save + Open'}
+                      {isSubmitting ? 'Creating...' : 'Create + View Ticket'}
                     </Button>
                     <Button
                       id={`${id}-submit-btn`}
-                      type={isEmbedded ? "button" : "submit"}
+                      type="button"
                       variant="default"
                       disabled={isSubmitting}
-                      onClick={isEmbedded ? () => { void handleCreateTicket(); } : undefined}
+                      onClick={() => { void handleCreateTicket(); }}
                       className={hasRequiredFieldErrors ? 'opacity-50' : ''}
                     >
-                      {isSubmitting ? 'Saving...' : 'Save Ticket'}
+                      {isSubmitting ? 'Creating...' : 'Create'}
                     </Button>
                   </DialogFooter>
                 </FormOrDiv>

--- a/packages/tickets/src/components/__tests__/ticket-inline-add-prefill.test.tsx
+++ b/packages/tickets/src/components/__tests__/ticket-inline-add-prefill.test.tsx
@@ -441,7 +441,7 @@ describe('QuickAddTicket prefills', () => {
     expect(screen.getByTestId('due-date')).toHaveValue('2026-02-05T12:00:00.000Z');
   });
 
-  it('navigates to the created ticket when Save + Open is clicked', async () => {
+  it('navigates to the created ticket when Create + View Ticket is clicked', async () => {
     const onTicketAdded = vi.fn();
 
     render(
@@ -458,7 +458,7 @@ describe('QuickAddTicket prefills', () => {
       target: { value: 'New ticket from quick add' }
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save + Open' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create + View Ticket' }));
 
     await waitFor(() => expect(addTicketMock).toHaveBeenCalled());
     await waitFor(() => expect(onTicketAdded).toHaveBeenCalled());
@@ -579,7 +579,7 @@ describe('QuickAddTicket prefills', () => {
     fireEvent.change(screen.getByLabelText('Description'), {
       target: { value: 'Pasted markdown replacement' }
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save Ticket' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
     await waitFor(() => expect(addTicketMock).toHaveBeenCalled());
     const submittedFormData = addTicketMock.mock.calls[0][0] as FormData;
@@ -636,7 +636,7 @@ describe('QuickAddTicket prefills', () => {
       target: { value: 'Ticket body' }
     });
     fireEvent.click(screen.getByRole('button', { name: 'Paste Image' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Save Ticket' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
     await waitFor(() => expect(uploadDocumentMock).toHaveBeenCalled());
     await waitFor(() => expect(updateTicketMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Rename dialog buttons from "Save + Open" / "Save Ticket" to "Create + View Ticket" (secondary) / "Create" (primary) for clearer intent
- Move board picker above assignee dropdown since boards can set a default assignee
- Update related tests to match new button labels

## Test plan
- [ ] Open ticket creation dialog and verify button labels read "Create + View Ticket" and "Create"
- [ ] Verify "Create + View Ticket" button has secondary styling
- [ ] Verify board picker appears above the assignee dropdown
- [ ] Select a board with a default assignee and confirm it auto-populates
- [ ] Create a ticket with each button and verify correct behavior