### PR TITLE
Add CE shims for extension client and service host APIs

### DIFF
--- a/packages/ee/src/app/api/internal/ext-clients/install/[installId]/route.ts
+++ b/packages/ee/src/app/api/internal/ext-clients/install/[installId]/route.ts
@@ -1,0 +1,15 @@
+// Community Edition stub for extension client read API
+// This feature is only available in Enterprise Edition
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export async function POST(
+  _req: NextRequest,
+  _ctx: { params?: unknown }
+): Promise<NextResponse> {
+  return NextResponse.json(
+    { error: 'Extension client reads are only available in the Enterprise Edition.', code: 'EE_REQUIRED' },
+    { status: 501 }
+  );
+}

--- a/packages/ee/src/app/api/internal/ext-services/install/[installId]/route.ts
+++ b/packages/ee/src/app/api/internal/ext-services/install/[installId]/route.ts
@@ -1,0 +1,15 @@
+// Community Edition stub for extension service read API
+// This feature is only available in Enterprise Edition
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export async function POST(
+  _req: NextRequest,
+  _ctx: { params?: unknown }
+): Promise<NextResponse> {
+  return NextResponse.json(
+    { error: 'Extension service reads are only available in the Enterprise Edition.', code: 'EE_REQUIRED' },
+    { status: 501 }
+  );
+}

--- a/server/src/app/api/internal/ext-clients/install/[installId]/route.ts
+++ b/server/src/app/api/internal/ext-clients/install/[installId]/route.ts
@@ -1,0 +1,52 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest } from 'next/server';
+
+const isEnterpriseEdition =
+  (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+  (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
+
+type EeRouteModule = {
+  POST: (req: NextRequest, ctx: { params: { installId: string } }) => Promise<Response> | Response;
+};
+
+let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
+
+async function loadEeRoute(): Promise<EeRouteModule | null> {
+  if (!isEnterpriseEdition) {
+    return null;
+  }
+
+  if (!eeRouteModulePromise) {
+    eeRouteModulePromise = import('@enterprise/app/api/internal/ext-clients/install/[installId]/route')
+      .then((module) => module as EeRouteModule)
+      .catch((error) => {
+        console.error('[internal/ext-clients] Failed to load EE route', error);
+        return null;
+      });
+  }
+
+  return eeRouteModulePromise;
+}
+
+function eeUnavailable(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'Extension client reads are only available in the Enterprise Edition.',
+      code: 'EE_REQUIRED',
+    }),
+    { status: 501, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: { installId: string } }
+): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.POST) {
+    return eeUnavailable();
+  }
+  return eeRoute.POST(request, ctx);
+}

--- a/server/src/app/api/internal/ext-services/install/[installId]/route.ts
+++ b/server/src/app/api/internal/ext-services/install/[installId]/route.ts
@@ -1,0 +1,52 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest } from 'next/server';
+
+const isEnterpriseEdition =
+  (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+  (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
+
+type EeRouteModule = {
+  POST: (req: NextRequest, ctx: { params: { installId: string } }) => Promise<Response> | Response;
+};
+
+let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
+
+async function loadEeRoute(): Promise<EeRouteModule | null> {
+  if (!isEnterpriseEdition) {
+    return null;
+  }
+
+  if (!eeRouteModulePromise) {
+    eeRouteModulePromise = import('@enterprise/app/api/internal/ext-services/install/[installId]/route')
+      .then((module) => module as EeRouteModule)
+      .catch((error) => {
+        console.error('[internal/ext-services] Failed to load EE route', error);
+        return null;
+      });
+  }
+
+  return eeRouteModulePromise;
+}
+
+function eeUnavailable(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'Extension service reads are only available in the Enterprise Edition.',
+      code: 'EE_REQUIRED',
+    }),
+    { status: 501, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: { installId: string } }
+): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.POST) {
+    return eeUnavailable();
+  }
+  return eeRoute.POST(request, ctx);
+}

--- a/types/expo-server-sdk.d.ts
+++ b/types/expo-server-sdk.d.ts
@@ -1,0 +1,28 @@
+declare module 'expo-server-sdk' {
+  export interface ExpoPushMessage {
+    to?: string | string[];
+    sound?: 'default' | null;
+    title?: string;
+    body?: string;
+    data?: Record<string, unknown>;
+    priority?: 'default' | 'normal' | 'high';
+    [key: string]: unknown;
+  }
+
+  export interface ExpoPushTicket {
+    status: 'ok' | 'error';
+    id?: string;
+    message?: string;
+    details?: {
+      error?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }
+
+  export default class Expo {
+    static isExpoPushToken(token: string): boolean;
+    chunkPushNotifications(messages: ExpoPushMessage[]): ExpoPushMessage[][];
+    sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]>;
+  }
+}


### PR DESCRIPTION
## Summary
- add CE-side Next route shims for the internal extension client host API
- add CE-side Next route shims for the internal extension service host API
- forward both routes to the EE implementations via @enterprise imports

## Why
The EE route files existed under `ee/server/src/app/api/internal/...`, but the deployed Next app builds from `server/src/app`. Without matching CE-side shim routes, the compiled server output did not emit `/api/internal/ext-clients/...` or `/api/internal/ext-services/...`, and runner calls received a rendered Next 404 page.

## Testing
- verified the live green container includes the EE source routes
- verified the live compiled Next output omitted ext-clients and ext-services while including the other internal extension routes
- added CE-side shims matching the existing storage/scheduler/invoicing pattern
