### PR TITLE
feat: show time entry history on ticket detail view

### DIFF
--- a/packages/scheduling/src/actions/timeEntryActions.ts
+++ b/packages/scheduling/src/actions/timeEntryActions.ts
@@ -12,6 +12,7 @@ import {
 } from './timeSheetOperations';
 import {
   fetchTimeEntriesForTimeSheet,
+  fetchTimeEntriesForWorkItem,
   saveTimeEntry,
   updateTimeEntryApprovalStatus,
   deleteTimeEntry,
@@ -39,6 +40,7 @@ export {
   fetchTimePeriods,
   fetchOrCreateTimeSheet,
   fetchTimeEntriesForTimeSheet,
+  fetchTimeEntriesForWorkItem,
   saveTimeEntry,
   updateTimeEntryApprovalStatus,
   deleteTimeEntry,

--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -251,6 +251,8 @@ export const fetchTimeEntriesForTimeSheet = withAuth(async (
   return attachTimeEntryChangeRequests(entriesWithWorkItems, changeRequestsByEntryId);
 });
 
+const ALLOWED_WORK_ITEM_TYPES = new Set(['ticket', 'project_task', 'non_billable_category', 'ad_hoc', 'interaction']);
+
 export const fetchTimeEntriesForWorkItem = withAuth(async (
   user,
   { tenant },
@@ -258,6 +260,10 @@ export const fetchTimeEntriesForWorkItem = withAuth(async (
   workItemType: string
 ): Promise<ITimeEntryWithWorkItem[]> => {
   const {knex: db} = await createTenantKnex();
+
+  if (!ALLOWED_WORK_ITEM_TYPES.has(workItemType)) {
+    throw new Error(`Invalid work item type: ${workItemType}`);
+  }
 
   if (!await hasPermission(user, 'timeentry', 'read', db)) {
     throw new Error('Permission denied: Cannot read time entries');

--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -251,6 +251,59 @@ export const fetchTimeEntriesForTimeSheet = withAuth(async (
   return attachTimeEntryChangeRequests(entriesWithWorkItems, changeRequestsByEntryId);
 });
 
+export const fetchTimeEntriesForWorkItem = withAuth(async (
+  user,
+  { tenant },
+  workItemId: string,
+  workItemType: string
+): Promise<ITimeEntryWithWorkItem[]> => {
+  const {knex: db} = await createTenantKnex();
+
+  if (!await hasPermission(user, 'timeentry', 'read', db)) {
+    throw new Error('Permission denied: Cannot read time entries');
+  }
+
+  const timeEntries = await db('time_entries')
+    .where({
+      work_item_id: workItemId,
+      work_item_type: workItemType,
+      tenant
+    })
+    .orderBy('start_time', 'desc')
+    .select('*');
+
+  // Fetch user details for each time entry
+  const userIds = [...new Set(timeEntries.map(e => e.user_id).filter(Boolean))];
+  const users = userIds.length > 0
+    ? await db('users').whereIn('user_id', userIds).andWhere({ tenant }).select('user_id', 'first_name', 'last_name')
+    : [];
+  const userMapLocal = new Map(users.map(u => [u.user_id, u]));
+
+  return timeEntries.map((entry): ITimeEntryWithWorkItem => {
+    const entryUser = userMapLocal.get(entry.user_id);
+    return {
+      ...entry,
+      work_item_id: entry.work_item_id,
+      date: new Date(entry.start_time),
+      start_time: formatISO(entry.start_time),
+      end_time: formatISO(entry.end_time),
+      updated_at: formatISO(entry.updated_at),
+      created_at: formatISO(entry.created_at),
+      work_date: entry.work_date instanceof Date
+        ? entry.work_date.toISOString().slice(0, 10)
+        : (typeof entry.work_date === 'string' ? entry.work_date.slice(0, 10) : undefined),
+      workItem: {
+        work_item_id: entry.work_item_id,
+        name: '',
+        description: '',
+        type: entry.work_item_type,
+        is_billable: entry.billable_duration > 0,
+      },
+      user_name: entryUser ? `${entryUser.first_name} ${entryUser.last_name}`.trim() : undefined,
+    };
+  });
+});
+
 export const saveTimeEntry = withAuth(async (
   user,
   { tenant },

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -200,7 +200,8 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       statuses,
       boards,
       priorities,
-      categories
+      categories,
+      timeEntries
     ] = await Promise.all([
       // Comments
       trx('comments')
@@ -209,7 +210,7 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
           tenant: tenant
         })
         .orderBy('created_at', 'asc'),
-      
+
       // Documents
       trx('documents as d')
         .select('d.*')
@@ -222,7 +223,7 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
           'da.entity_type': 'ticket',
           'd.tenant': tenant
         }),
-      
+
       trx('clients as c')
         .select(
           'c.*',
@@ -241,13 +242,13 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
           ticket_id: ticketId,
           tenant: tenant
         }),
-      
+
       // Users - removed document joins that were causing duplicates
       // Avatar URLs are fetched later using getUserAvatarUrl()
       trx('users')
         .where({ tenant })
         .orderBy('first_name', 'asc'),
-      
+
       // Statuses
       trx('statuses')
         .where({
@@ -256,21 +257,35 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
         })
         .orderBy('order_number', 'asc')
         .orderBy('name', 'asc'),
-      
+
       // Boards
       trx('boards')
         .where({ tenant })
         .orderBy('board_name', 'asc'),
-      
+
       // Priorities - fetch only tenant-specific ticket priorities
       trx('priorities')
         .where({ tenant, item_type: 'ticket' })
         .orderBy('priority_name', 'asc'),
-      
+
       // Categories
       trx('categories')
         .where({ tenant })
-        .orderBy('category_name', 'asc')
+        .orderBy('category_name', 'asc'),
+
+      // Time entries for this ticket (with service name)
+      trx('time_entries as te')
+        .leftJoin('service_catalog as sc', function() {
+          this.on('te.service_id', 'sc.service_id')
+              .andOn('te.tenant', 'sc.tenant');
+        })
+        .where({
+          'te.work_item_id': ticketId,
+          'te.work_item_type': 'ticket',
+          'te.tenant': tenant
+        })
+        .select('te.*', 'sc.service_name')
+        .orderBy('te.start_time', 'desc')
     ]);
 
     // --- Add Logo URL Processing for the fetched 'clients' list ---
@@ -698,7 +713,8 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       categories,
       clients: clientsWithLogos,
       locations,
-      agentSchedules: agentSchedulesList
+      agentSchedules: agentSchedulesList,
+      timeEntries
     };
     } catch (error) {
       console.error('Failed to fetch consolidated ticket data:', error);

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -273,18 +273,22 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
         .where({ tenant })
         .orderBy('category_name', 'asc'),
 
-      // Time entries for this ticket (with service name)
+      // Time entries for this ticket (with service name and user name)
       trx('time_entries as te')
         .leftJoin('service_catalog as sc', function() {
           this.on('te.service_id', 'sc.service_id')
               .andOn('te.tenant', 'sc.tenant');
+        })
+        .leftJoin('users as teu', function() {
+          this.on('te.user_id', 'teu.user_id')
+              .andOn('te.tenant', 'teu.tenant');
         })
         .where({
           'te.work_item_id': ticketId,
           'te.work_item_type': 'ticket',
           'te.tenant': tenant
         })
-        .select('te.*', 'sc.service_name')
+        .select('te.*', 'sc.service_name', trx.raw("concat(teu.first_name, ' ', teu.last_name) as user_name"))
         .orderBy('te.start_time', 'desc')
     ]);
 
@@ -714,7 +718,7 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       clients: clientsWithLogos,
       locations,
       agentSchedules: agentSchedulesList,
-      timeEntries
+      timeEntries: await hasPermission(user, 'timeentry', 'read', trx) ? timeEntries : []
     };
     } catch (error) {
       console.error('Failed to fetch consolidated ticket data:', error);

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -51,6 +51,19 @@ import {
 import { toggleCommentReaction, getCommentsReactionsBatch } from '../../actions/comment-actions/commentReactionActions';
 import type { IAggregatedReaction } from '@alga-psa/types';
 
+interface TicketTimeEntry {
+  entry_id: string;
+  user_id: string;
+  start_time: string;
+  end_time: string;
+  billable_duration: number;
+  notes: string;
+  created_at: string;
+  work_date?: string;
+  approval_status?: string;
+  service_name?: string;
+}
+
 interface TicketConversationProps {
   id?: string;
   ticket: ITicket;
@@ -58,6 +71,7 @@ interface TicketConversationProps {
   documents: IDocument[];
   userMap: Record<string, CommentUserAuthor>;
   contactMap: Record<string, CommentContactAuthor>;
+  timeEntries?: TicketTimeEntry[];
   currentUser: { id: string; name?: string | null; email?: string | null; avatarUrl?: string | null } | null | undefined;
   activeTab: string;
   isEditing: boolean;
@@ -112,6 +126,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
   closedStatusOptions = [],
   onClipboardImageUploaded,
   defaultNewestFirst = false,
+  timeEntries = [],
 }) => {
   const { t } = useTranslation('features/tickets');
   const { t: tCore } = useTranslation('common');
@@ -470,6 +485,71 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
           {renderComments(conversations.filter(conversation =>
             conversation.is_resolution && (!hideInternalTab || !conversation.is_internal)
           ))}
+        </ReflectionContainer>
+      )
+    },
+    {
+      label: t('conversation.timeEntries', 'Time Entries'),
+      content: (
+        <ReflectionContainer id={`${id}-time-entries`} label="Time Entries">
+          {timeEntries.length === 0 ? (
+            <p className="text-sm text-gray-500 py-4">{t('conversation.noTimeEntries', 'No time entries recorded for this ticket.')}</p>
+          ) : (
+            <div className="space-y-3">
+              {timeEntries.map((entry: TicketTimeEntry) => {
+                const entryUser = userMap[entry.user_id];
+                const userName = entryUser
+                  ? `${entryUser.first_name} ${entryUser.last_name}`.trim()
+                  : t('conversation.unknownUser', 'Unknown User');
+                const hours = Math.floor(entry.billable_duration / 60);
+                const mins = entry.billable_duration % 60;
+                const durationStr = hours > 0
+                  ? `${hours}h ${mins > 0 ? `${mins}m` : ''}`
+                  : `${mins}m`;
+                const isBillable = entry.billable_duration > 0;
+                const entryDate = entry.work_date
+                  ? new Date(entry.work_date + 'T00:00:00').toLocaleDateString()
+                  : new Date(entry.start_time).toLocaleDateString();
+                const approvalLabel = entry.approval_status
+                  ? entry.approval_status.charAt(0) + entry.approval_status.slice(1).toLowerCase()
+                  : '';
+                const approvalColor = entry.approval_status === 'APPROVED'
+                  ? 'bg-green-100 text-green-800'
+                  : entry.approval_status === 'SUBMITTED'
+                    ? 'bg-yellow-100 text-yellow-800'
+                    : entry.approval_status === 'CHANGES_REQUESTED'
+                      ? 'bg-red-100 text-red-800'
+                      : 'bg-gray-100 text-gray-600';
+                return (
+                  <div key={entry.entry_id} className="border rounded-lg p-3 bg-white">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm font-medium text-gray-900">{userName}</span>
+                      <span className="text-sm text-gray-500">{entryDate}</span>
+                    </div>
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-sm font-semibold text-indigo-600">{durationStr}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${isBillable ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-600'}`}>
+                        {isBillable ? t('conversation.billable', 'Billable') : t('conversation.nonBillable', 'Non-billable')}
+                      </span>
+                      {approvalLabel && (
+                        <span className={`text-xs px-1.5 py-0.5 rounded ${approvalColor}`}>
+                          {approvalLabel}
+                        </span>
+                      )}
+                    </div>
+                    {(entry.service_name || entry.notes) && (
+                      <div className="text-sm text-gray-600">
+                        {entry.service_name && (
+                          <span className="font-medium">{entry.service_name}{entry.notes ? ' — ' : ''}</span>
+                        )}
+                        {entry.notes && <span>{entry.notes}</span>}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </ReflectionContainer>
       )
     }

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -54,6 +54,7 @@ import type { IAggregatedReaction } from '@alga-psa/types';
 interface TicketTimeEntry {
   entry_id: string;
   user_id: string;
+  user_name?: string;
   start_time: string;
   end_time: string;
   billable_duration: number;
@@ -493,14 +494,14 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
       content: (
         <ReflectionContainer id={`${id}-time-entries`} label="Time Entries">
           {timeEntries.length === 0 ? (
-            <p className="text-sm text-gray-500 py-4">{t('conversation.noTimeEntries', 'No time entries recorded for this ticket.')}</p>
+            <p id={`${compId}-time-entries-empty`} className="text-sm text-gray-500 dark:text-gray-400 py-4">{t('conversation.noTimeEntries', 'No time entries recorded for this ticket.')}</p>
           ) : (
-            <div className="space-y-3">
+            <div id={`${compId}-time-entries-list`} className="space-y-3">
               {timeEntries.map((entry: TicketTimeEntry) => {
                 const entryUser = userMap[entry.user_id];
                 const userName = entryUser
                   ? `${entryUser.first_name} ${entryUser.last_name}`.trim()
-                  : t('conversation.unknownUser', 'Unknown User');
+                  : (entry.user_name || t('conversation.unknownUser', 'Unknown User'));
                 const hours = Math.floor(entry.billable_duration / 60);
                 const mins = entry.billable_duration % 60;
                 const durationStr = hours > 0
@@ -514,21 +515,21 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                   ? entry.approval_status.charAt(0) + entry.approval_status.slice(1).toLowerCase()
                   : '';
                 const approvalColor = entry.approval_status === 'APPROVED'
-                  ? 'bg-green-100 text-green-800'
+                  ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
                   : entry.approval_status === 'SUBMITTED'
-                    ? 'bg-yellow-100 text-yellow-800'
+                    ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300'
                     : entry.approval_status === 'CHANGES_REQUESTED'
-                      ? 'bg-red-100 text-red-800'
-                      : 'bg-gray-100 text-gray-600';
+                      ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300'
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
                 return (
-                  <div key={entry.entry_id} className="border rounded-lg p-3 bg-white">
+                  <div key={entry.entry_id} id={`${compId}-time-entry-${entry.entry_id}`} className="border dark:border-gray-700 rounded-lg p-3 bg-white dark:bg-gray-800">
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm font-medium text-gray-900">{userName}</span>
-                      <span className="text-sm text-gray-500">{entryDate}</span>
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{userName}</span>
+                      <span className="text-sm text-gray-500 dark:text-gray-400">{entryDate}</span>
                     </div>
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="text-sm font-semibold text-indigo-600">{durationStr}</span>
-                      <span className={`text-xs px-1.5 py-0.5 rounded ${isBillable ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-600'}`}>
+                      <span className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">{durationStr}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${isBillable ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}>
                         {isBillable ? t('conversation.billable', 'Billable') : t('conversation.nonBillable', 'Non-billable')}
                       </span>
                       {approvalLabel && (
@@ -538,7 +539,7 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
                       )}
                     </div>
                     {(entry.service_name || entry.notes) && (
-                      <div className="text-sm text-gray-600">
+                      <div className="text-sm text-gray-600 dark:text-gray-300">
                         {entry.service_name && (
                           <span className="font-medium">{entry.service_name}{entry.notes ? ' — ' : ''}</span>
                         )}

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -119,6 +119,7 @@ interface TicketDetailsProps {
     initialClients?: IClient[];
     initialLocations?: IClientLocation[];
     initialAgentSchedules?: { userId: string; minutes: number }[];
+    initialTimeEntries?: any[];
 
     // Current user (for drawer usage)
     currentUser?: IUser | null;
@@ -200,6 +201,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     initialClients = [],
     initialLocations = [],
     initialAgentSchedules = [],
+    initialTimeEntries = [],
     // Current user (for drawer usage)
     currentUser,
     // Optimized handlers
@@ -257,6 +259,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     const [clients, setClients] = useState<IClient[]>(initialClients);
     const [contacts, setContacts] = useState<IContact[]>(initialContacts);
     const [locations, setLocations] = useState<IClientLocation[]>(initialLocations);
+    const [timeEntries, setTimeEntries] = useState<any[]>(initialTimeEntries);
+    useEffect(() => { setTimeEntries(initialTimeEntries); }, [initialTimeEntries]);
     const [dateTimeFormat, setDateTimeFormat] = useState<string>('MMM d, yyyy h:mm a');
     const [responseStateTrackingEnabled, setResponseStateTrackingEnabled] = useState<boolean>(true);
     const [createdRelativeTime, setCreatedRelativeTime] = useState<string>('');
@@ -1287,6 +1291,12 @@ const handleClose = () => {
                 return;
             }
 
+            const baseOnComplete = createTicketTimeEntryOnComplete({
+                stopTracking,
+                setElapsedTime,
+                setIsRunning,
+            });
+
             await launchTimeEntry({
                 openDrawer,
                 closeDrawer,
@@ -1296,11 +1306,11 @@ const handleClose = () => {
                     elapsedTime,
                     timeDescription,
                 }),
-                onComplete: createTicketTimeEntryOnComplete({
-                    stopTracking,
-                    setElapsedTime,
-                    setIsRunning,
-                }),
+                onComplete: () => {
+                    baseOnComplete();
+                    // Refresh to pick up new time entries
+                    router.refresh();
+                },
             });
         } catch (error) {
             handleError(error, 'An error occurred while preparing the time entry. Please try again.');
@@ -2133,6 +2143,7 @@ const handleClose = () => {
                                     documents={documents}
                                     userMap={userMap}
                                     contactMap={contactMap}
+                                    timeEntries={timeEntries}
                                     currentUser={currentUser ? {
                                         id: currentUser.user_id,
                                         name: `${currentUser.first_name} ${currentUser.last_name}`,

--- a/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
@@ -58,6 +58,7 @@ interface TicketDetailsContainerProps {
     clients: any[];
     locations: any[];
     agentSchedules: any[];
+    timeEntries?: any[];
   };
   surveySummaryCard?: React.ReactNode;
   associatedAssets?: React.ReactNode;
@@ -233,6 +234,7 @@ export default function TicketDetailsContainer({
             initialClients={ticketData.clients}
             initialLocations={ticketData.locations}
             initialAgentSchedules={ticketData.agentSchedules}
+            initialTimeEntries={ticketData.timeEntries || []}
             onTicketUpdate={handleTicketUpdate}
             onBatchTicketUpdate={handleBatchTicketUpdate}
             onAddComment={handleAddComment}


### PR DESCRIPTION
Closes #2152

Time entries logged from a ticket weren't visible on the ticket itself — you had to go to Time Management > Time Sheet to see them. The ticket page never queried `time_entries` and had nowhere to display them.

This adds a "Time Entries" tab to the ticket conversation area that shows all entries for that ticket: who logged it, when, duration, service, billable status, and approval status. New entries show up immediately after saving. Tab is MSP portal only, not exposed to client portal.

Doesn't cover the optional enhancements from the issue (time summary totals, inline editing, auto-generated comments) — those can be follow-ups.