### PR TITLE
Update client/service sample extension UI

### DIFF
--- a/sdk/samples/component/client-service-read-demo/README.md
+++ b/sdk/samples/component/client-service-read-demo/README.md
@@ -9,7 +9,5 @@ Endpoints:
 
 - `GET /api/clients`
 - `GET /api/services`
-- `GET /api/summary`
-- `GET /api/ui-proxy/summary`
 
 The sample intentionally uses host capabilities directly and does not call `http.fetch` for these reads.

--- a/sdk/samples/component/client-service-read-demo/manifest.json
+++ b/sdk/samples/component/client-service-read-demo/manifest.json
@@ -1,15 +1,11 @@
 {
   "name": "com.alga.sample.client-service-read-demo",
   "publisher": "Alga",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "runtime": "wasm-js@1",
   "capabilities": [
     "cap:client.read",
-    "cap:service.read",
-    "cap:user.read",
-    "cap:ui.proxy",
-    "cap:log.emit",
-    "cap:context.read"
+    "cap:service.read"
   ],
   "ui": {
     "type": "iframe",
@@ -21,9 +17,7 @@
   "api": {
     "endpoints": [
       { "method": "GET", "path": "/api/clients", "handler": "dist/main" },
-      { "method": "GET", "path": "/api/services", "handler": "dist/main" },
-      { "method": "GET", "path": "/api/summary", "handler": "dist/main" },
-      { "method": "GET", "path": "/api/ui-proxy/summary", "handler": "dist/main" }
+      { "method": "GET", "path": "/api/services", "handler": "dist/main" }
     ]
   }
 }

--- a/sdk/samples/component/client-service-read-demo/package.json
+++ b/sdk/samples/component/client-service-read-demo/package.json
@@ -3,12 +3,25 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "clean": "rimraf dist bundle.tar.zst bundle.tar.zst.sha256 ui/main.js",
+    "build:js": "esbuild src/index.ts --bundle --format=esm --platform=neutral --target=es2022 --external:alga:extension/* --outfile=dist/js/index.js",
+    "build:component": "jco componentize dist/js/index.js --wit ./wit/extension-runner.wit --world-name runner --disable all --out dist/component.wasm",
+    "build:ui": "esbuild ui/main.tsx --bundle --format=esm --platform=browser --target=es2020 --minify --alias:@alga-psa/ui-kit/theme.css=../../../../packages/ui-kit/src/theme/tokens.css --alias:@alga-psa/ui-kit=../../../../packages/ui-kit/src/index.ts --alias:@alga-psa/extension-iframe-sdk=../../../../sdk/extension-iframe-sdk/src/index.ts --outfile=ui/main.js",
+    "build": "npm run clean && npm run build:js && npm run build:component && npm run build:ui && node ./scripts/postbuild.mjs && node ./scripts/pack.mjs",
     "test": "vitest"
   },
   "dependencies": {
-    "@alga-psa/extension-runtime": "^0.3.0"
+    "@alga-psa/extension-iframe-sdk": "^0.1.0",
+    "@alga-psa/extension-runtime": "^0.3.0",
+    "@alga-psa/ui-kit": "^0.1.0",
+    "@mongodb-js/zstd": "^7.0.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@bytecodealliance/componentize-js": "^0.19.3",
+    "esbuild": "^0.27.3",
+    "rimraf": "^6.0.0",
     "vitest": "^4.0.18"
   }
 }

--- a/sdk/samples/component/client-service-read-demo/scripts/pack.mjs
+++ b/sdk/samples/component/client-service-read-demo/scripts/pack.mjs
@@ -1,0 +1,39 @@
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { compress } from '@mongodb-js/zstd'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const projectPath = resolve(__dirname, '..')
+const outFile = join(projectPath, 'bundle.tar.zst')
+const tempDir = join(projectPath, 'tmp')
+const tempTarFile = join(tempDir, 'bundle.tar')
+
+mkdirSync(tempDir, { recursive: true })
+
+async function main() {
+  execSync(`cd ${projectPath} && tar -cvf ${tempTarFile} manifest.json ui dist/main.wasm`, {
+    stdio: 'inherit',
+  })
+
+  const tarData = readFileSync(tempTarFile)
+  const compressed = await compress(tarData)
+  writeFileSync(outFile, compressed)
+
+  const hash = createHash('sha256').update(compressed).digest('hex')
+  writeFileSync(`${outFile}.sha256`, hash)
+  unlinkSync(tempTarFile)
+
+  console.log(`[pack] wrote ${outFile}`)
+  console.log(`[pack] sha256 ${hash}`)
+}
+
+main().catch((error) => {
+  console.error('[pack] failed')
+  console.error(error)
+  process.exit(1)
+})

--- a/sdk/samples/component/client-service-read-demo/scripts/postbuild.mjs
+++ b/sdk/samples/component/client-service-read-demo/scripts/postbuild.mjs
@@ -1,0 +1,39 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const root = resolve(__dirname, '..')
+const dist = resolve(root, 'dist')
+
+function ensureDir(path) {
+  try {
+    mkdirSync(path, { recursive: true })
+  } catch {}
+}
+
+ensureDir(dist)
+
+const manifestPath = resolve(root, 'manifest.json')
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+const capabilities = manifest.capabilities ?? []
+
+cpSync(manifestPath, resolve(dist, 'manifest.json'))
+
+const metadata = {
+  component: {
+    world: 'alga:extension/runner',
+    file: 'dist/component.wasm',
+  },
+  capabilities,
+}
+
+writeFileSync(resolve(dist, 'component.json'), JSON.stringify(metadata, null, 2), 'utf8')
+
+const componentWasmPath = resolve(dist, 'component.wasm')
+if (existsSync(componentWasmPath)) {
+  cpSync(componentWasmPath, resolve(dist, 'main.wasm'))
+}
+
+console.log('[postbuild] wrote dist/main.wasm, dist/component.json, and dist/manifest.json')

--- a/sdk/samples/component/client-service-read-demo/src/handler.test.ts
+++ b/sdk/samples/component/client-service-read-demo/src/handler.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { createMockHostBindings } from '../../../../extension-runtime/src/index.ts'
 
 import { handler } from './handler.ts'
-import { fetchSummaryViaUiProxy } from './uiProxy.ts'
 
 function decodeJson(response: { body?: Uint8Array | null }) {
   return JSON.parse(new TextDecoder().decode(response.body ?? new Uint8Array()))
@@ -69,38 +68,13 @@ describe('client-service-read-demo', () => {
     expect(body.services.totalCount).toBe(1)
   })
 
-  it('T025: ui proxy summary path returns same read-only summary data as direct summary path', async () => {
-    const directHost = createMockHostBindings({
-      clients: {
-        list: vi.fn().mockResolvedValue({ items: [{ clientId: 'c-1', clientName: 'Acme', clientType: null, isInactive: false, defaultCurrencyCode: 'USD', accountManagerId: null, accountManagerName: null, billingEmail: null }], totalCount: 1, page: 1, pageSize: 10 }),
-        get: vi.fn(),
-      },
-      services: {
-        list: vi.fn().mockResolvedValue({ items: [{ serviceId: 's-1', serviceName: 'Monitoring', itemKind: 'service', billingMethod: 'fixed', serviceTypeId: null, serviceTypeName: null, defaultRate: 100, unitOfMeasure: 'month', isActive: true, sku: null }], totalCount: 1, page: 1, pageSize: 10 }),
-        get: vi.fn(),
-      },
-      user: {
-        getUser: vi.fn().mockResolvedValue({ tenantId: 'tenant-1', clientName: 'Acme', userId: 'user-1', userEmail: 'u@example.com', userName: 'User One', userType: 'msp' }),
-      },
-    })
+  it('T025: returns not_found for removed summary route', async () => {
+    const host = createMockHostBindings()
 
-    const directResponse = await handler(makeRequest('/api/summary') as any, directHost)
-    const directJson = decodeJson(directResponse)
+    const res = await handler(makeRequest('/api/summary') as any, host)
+    const body = decodeJson(res)
 
-    const proxyHost = createMockHostBindings({
-      uiProxy: {
-        callRoute: vi.fn(async (route: string) => {
-          const proxied = await handler(makeRequest(route) as any, directHost)
-          return proxied.body ?? new Uint8Array()
-        }),
-        call: vi.fn(),
-      },
-    })
-
-    const proxiedJson = await fetchSummaryViaUiProxy(proxyHost.uiProxy)
-
-    expect(proxiedJson).toEqual(directJson)
-    expect(proxiedJson.clients.items[0]).toEqual(directJson.clients.items[0])
-    expect(proxiedJson.services.items[0]).toEqual(directJson.services.items[0])
+    expect(res.status).toBe(404)
+    expect(body).toEqual({ error: 'not_found' })
   })
 })

--- a/sdk/samples/component/client-service-read-demo/src/handler.ts
+++ b/sdk/samples/component/client-service-read-demo/src/handler.ts
@@ -1,9 +1,7 @@
 import type {
-  ClientsListResult,
   ExecuteRequest,
   ExecuteResponse,
   HostBindings,
-  ServicesListResult,
 } from '../../../../extension-runtime/src/index.ts'
 
 const encoder = new TextEncoder()
@@ -14,15 +12,6 @@ function jsonResponse(body: unknown, status = 200): ExecuteResponse {
     headers: [{ name: 'content-type', value: 'application/json' }],
     body: encoder.encode(JSON.stringify(body)),
   }
-}
-
-async function readSummary(host: HostBindings): Promise<{ clients: ClientsListResult; services: ServicesListResult }> {
-  const [clients, services] = await Promise.all([
-    host.clients.list({ page: 1, pageSize: 10, includeInactive: false }),
-    host.services.list({ page: 1, pageSize: 10, itemKind: 'service' }),
-  ])
-
-  return { clients, services }
 }
 
 export async function handler(request: ExecuteRequest, host: HostBindings): Promise<ExecuteResponse> {
@@ -41,18 +30,6 @@ export async function handler(request: ExecuteRequest, host: HostBindings): Prom
   if (url.startsWith('/api/services')) {
     const services = await host.services.list({ page: 1, pageSize: 10, itemKind: 'service' })
     return jsonResponse({ services })
-  }
-
-  if (url.startsWith('/api/summary') || url.startsWith('/api/ui-proxy/summary')) {
-    const summary = await readSummary(host)
-    let userId: string | null = null
-    try {
-      const user = await host.user.getUser()
-      userId = user.userId
-    } catch {
-      userId = null
-    }
-    return jsonResponse({ ...summary, userId })
   }
 
   return jsonResponse({ error: 'not_found' }, 404)

--- a/sdk/samples/component/client-service-read-demo/src/index.ts
+++ b/sdk/samples/component/client-service-read-demo/src/index.ts
@@ -1,0 +1,80 @@
+import type {
+  ContextData,
+  ExecuteRequest,
+  ExecuteResponse,
+  HostBindings,
+} from '../../../../extension-runtime/src/index.ts'
+import { normalizeUserData } from '../../../../extension-runtime/src/index.ts'
+
+import { handler as userHandler } from './handler.ts'
+
+// @ts-ignore
+import { getContext } from 'alga:extension/context'
+// @ts-ignore
+import { logInfo, logWarn, logError } from 'alga:extension/logging'
+// @ts-ignore
+import { callRoute as uiProxyCall } from 'alga:extension/ui-proxy'
+// @ts-ignore
+import { getUser } from 'alga:extension/user-v2'
+// @ts-ignore
+import { getClient, listClients } from 'alga:extension/clients'
+// @ts-ignore
+import { getService, listServices } from 'alga:extension/services'
+
+const denied = (name: string) => async () => {
+  throw new Error(`${name} not available for this extension`)
+}
+
+const host: HostBindings = {
+  context: {
+    get: async () => getContext() as unknown as ContextData,
+  },
+  secrets: {
+    get: denied('secrets.get'),
+    list: async () => [],
+  },
+  http: {
+    fetch: denied('http.fetch'),
+  },
+  storage: {
+    get: async () => null,
+    put: denied('storage.put'),
+    delete: denied('storage.delete'),
+    list: async () => [],
+  },
+  logging: {
+    info: async (message: string) => logInfo(message),
+    warn: async (message: string) => logWarn(message),
+    error: async (message: string) => logError(message),
+  },
+  uiProxy: {
+    callRoute: async (route: string, payload?: Uint8Array | null) => uiProxyCall(route, payload),
+    call: async (route: string, payload?: Uint8Array | null) => uiProxyCall(route, payload),
+  },
+  scheduler: {
+    list: async () => [],
+    get: async () => null,
+    create: denied('scheduler.create'),
+    update: denied('scheduler.update'),
+    delete: denied('scheduler.delete'),
+    getEndpoints: async () => [],
+  },
+  invoicing: {
+    createManualInvoice: denied('invoicing.createManualInvoice'),
+  },
+  user: {
+    getUser: async () => normalizeUserData(await getUser()),
+  },
+  clients: {
+    list: async (input) => listClients(input ?? {}),
+    get: async (clientId: string) => getClient(clientId),
+  },
+  services: {
+    list: async (input) => listServices(input ?? {}),
+    get: async (serviceId: string) => getService(serviceId),
+  },
+}
+
+export async function handler(request: ExecuteRequest): Promise<ExecuteResponse> {
+  return userHandler(request, host)
+}

--- a/sdk/samples/component/client-service-read-demo/src/uiProxy.ts
+++ b/sdk/samples/component/client-service-read-demo/src/uiProxy.ts
@@ -1,5 +1,0 @@
-import { callProxyJson } from '../../../../extension-runtime/src/index.ts'
-
-export async function fetchSummaryViaUiProxy(uiProxy: any) {
-  return callProxyJson(uiProxy, '/api/ui-proxy/summary')
-}

--- a/sdk/samples/component/client-service-read-demo/ui/App.tsx
+++ b/sdk/samples/component/client-service-read-demo/ui/App.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo, useState } from 'react';
+
+import { IframeBridge, callHandlerJson } from '@alga-psa/extension-iframe-sdk';
+import { Button, Card, Stack, Text } from '@alga-psa/ui-kit';
+
+const bridge = new IframeBridge({ devAllowWildcard: true });
+bridge.ready();
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runProxyCall(path: string) {
+  return callHandlerJson(bridge, path);
+}
+
+export default function App() {
+  const [activeAction, setActiveAction] = useState<string | null>(null);
+  const [result, setResult] = useState<unknown>('Ready.');
+
+  const output = useMemo(() => JSON.stringify(result, null, 2), [result]);
+
+  const runAction = async (actionKey: string, path: string) => {
+    setActiveAction(actionKey);
+    try {
+      const nextResult = await runProxyCall(path);
+      setResult({ ok: true, path, result: nextResult });
+    } catch (error) {
+      setResult({ ok: false, path, error: formatError(error) });
+    } finally {
+      setActiveAction(null);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        padding: 24,
+        background: 'linear-gradient(180deg, var(--alga-bg) 0%, var(--alga-primary-50) 100%)',
+        color: 'var(--alga-fg)',
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <Stack gap={16}>
+          <Stack gap={6}>
+            <Text as="strong" size="lg" weight={700}>
+              Client/Service Read Demo
+            </Text>
+            <Text as="p" tone="muted" style={{ margin: 0 }}>
+              Uses host capabilities for tenant-scoped client and service reads without calling
+              internal APIs from the handler.
+            </Text>
+          </Stack>
+
+          <Card>
+            <Stack direction="row" gap={10} style={{ flexWrap: 'wrap' }}>
+              <Button
+                variant="secondary"
+                onClick={() => void runAction('clients', '/api/clients')}
+                disabled={activeAction !== null}
+              >
+                {activeAction === 'clients' ? 'Loading...' : 'Load Clients'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => void runAction('services', '/api/services')}
+                disabled={activeAction !== null}
+              >
+                {activeAction === 'services' ? 'Loading...' : 'Load Services'}
+              </Button>
+            </Stack>
+          </Card>
+
+          <div
+            style={{
+              display: 'grid',
+              gap: 16,
+              gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+            }}
+          >
+            <Card>
+              <Stack gap={10}>
+                <Text as="strong" weight={600}>
+                  What It Tests
+                </Text>
+                <Text as="p" tone="muted" size="sm" style={{ margin: 0 }}>
+                  Separate UI actions for the two read capabilities exposed by this sample.
+                </Text>
+                <Stack gap={8}>
+                  <Text size="sm">
+                    <code>GET /api/clients</code>
+                  </Text>
+                  <Text size="sm">
+                    <code>GET /api/services</code>
+                  </Text>
+                </Stack>
+              </Stack>
+            </Card>
+
+            <Card>
+              <Stack gap={10}>
+                <Text as="strong" weight={600}>
+                  Output
+                </Text>
+                <Text as="p" tone="muted" size="sm" style={{ margin: 0 }}>
+                  Live handler response from the installed extension.
+                </Text>
+                <pre
+                  style={{
+                    margin: 0,
+                    padding: '16px',
+                    minHeight: 240,
+                    overflow: 'auto',
+                    borderRadius: 'var(--alga-radius)',
+                    background: 'var(--alga-muted)',
+                    color: 'var(--alga-fg)',
+                    border: '1px solid var(--alga-border)',
+                    fontSize: 12,
+                    lineHeight: 1.5,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {output}
+                </pre>
+              </Stack>
+            </Card>
+          </div>
+        </Stack>
+      </div>
+    </div>
+  );
+}

--- a/sdk/samples/component/client-service-read-demo/ui/index.html
+++ b/sdk/samples/component/client-service-read-demo/ui/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Client/Service Read Demo</title>
+  <link rel="stylesheet" href="./main.css">
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/sdk/samples/component/client-service-read-demo/ui/main.tsx
+++ b/sdk/samples/component/client-service-read-demo/ui/main.tsx
@@ -1,0 +1,15 @@
+import '@alga-psa/ui-kit/theme.css';
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const el = document.getElementById('root');
+
+if (!el) {
+  throw new Error('Missing root element');
+}
+
+const root = createRoot(el);
+root.render(<App />);

--- a/sdk/samples/component/client-service-read-demo/wit/extension-runner.wit
+++ b/sdk/samples/component/client-service-read-demo/wit/extension-runner.wit
@@ -1,267 +1,236 @@
-/// Alga extension runner component interfaces.
-/// Inspired by wasmCloud's capability providers, each interface here
-/// represents a host-provided capability that extensions can import.
-
 package alga:extension;
 
-/// Shared type definitions ---------------------------------------------------
+interface types {
+    record context-data {
+        request-id: option<string>,
+        tenant-id: string,
+        extension-id: string,
+        install-id: option<string>,
+        version-id: option<string>,
+    }
 
-record context-data {
-    request-id: option<string>,
-    tenant-id: string,
-    extension-id: string,
-    install-id: option<string>,
-    version-id: option<string>,
+    enum secret-error {
+        missing,
+        denied,
+        expired,
+        internal,
+    }
+
+    record http-header {
+        name: string,
+        value: string,
+    }
+
+    record http-request {
+        method: string,
+        url: string,
+        headers: list<http-header>,
+        body: option<list<u8>>,
+    }
+
+    record http-response {
+        status: u16,
+        headers: list<http-header>,
+        body: option<list<u8>>,
+    }
+
+    enum http-error {
+        invalid-url,
+        not-allowed,
+        transport,
+        internal,
+    }
+
+    enum storage-error {
+        missing,
+        conflict,
+        denied,
+        internal,
+    }
+
+    record storage-entry {
+        namespace: string,
+        key: string,
+        value: list<u8>,
+        revision: option<u64>,
+    }
+
+    enum proxy-error {
+        route-not-found,
+        denied,
+        bad-request,
+        internal,
+    }
+
+    record user-data-v2 {
+        tenant-id: string,
+        client-name: string,
+        user-id: string,
+        user-email: string,
+        user-name: string,
+        user-type: string,
+        client-id: option<string>,
+        additional-fields: list<tuple<string, string>>,
+    }
+
+    enum user-error {
+        not-available,
+        not-allowed,
+    }
+
+    enum client-read-error {
+        not-allowed,
+        invalid-input,
+        internal,
+    }
+
+    record client-summary {
+        client-id: string,
+        client-name: string,
+        client-type: option<string>,
+        is-inactive: bool,
+        default-currency-code: option<string>,
+        account-manager-id: option<string>,
+        account-manager-name: option<string>,
+        billing-email: option<string>,
+    }
+
+    record clients-list-input {
+        search: option<string>,
+        include-inactive: option<bool>,
+        page: option<u32>,
+        page-size: option<u32>,
+    }
+
+    record clients-list-result {
+        items: list<client-summary>,
+        total-count: u32,
+        page: u32,
+        page-size: u32,
+    }
+
+    enum service-item-kind {
+        service,
+        product,
+    }
+
+    enum service-billing-method {
+        fixed,
+        hourly,
+        usage,
+    }
+
+    enum service-read-error {
+        not-allowed,
+        invalid-input,
+        internal,
+    }
+
+    record service-summary {
+        service-id: string,
+        service-name: string,
+        item-kind: service-item-kind,
+        billing-method: service-billing-method,
+        service-type-id: option<string>,
+        service-type-name: option<string>,
+        default-rate: f64,
+        unit-of-measure: string,
+        is-active: bool,
+        sku: option<string>,
+    }
+
+    record services-list-input {
+        search: option<string>,
+        item-kind: option<service-item-kind>,
+        is-active: option<bool>,
+        billing-method: option<service-billing-method>,
+        page: option<u32>,
+        page-size: option<u32>,
+    }
+
+    record services-list-result {
+        items: list<service-summary>,
+        total-count: u32,
+        page: u32,
+        page-size: u32,
+    }
+
+    record execute-request {
+        context: context-data,
+        http: http-request,
+    }
+
+    record execute-response {
+        status: u16,
+        headers: list<http-header>,
+        body: option<list<u8>>,
+    }
 }
 
-enum secret-error {
-    missing,
-    denied,
-    expired,
-    internal,
-}
-
-record http-header {
-    name: string,
-    value: string,
-}
-
-record http-request {
-    method: string,
-    url: string,
-    headers: list<http-header>,
-    body: option<list<u8>>,
-}
-
-record http-response {
-    status: u16,
-    headers: list<http-header>,
-    body: option<list<u8>>,
-}
-
-enum http-error {
-    invalid-url,
-    not-allowed,
-    transport,
-    internal,
-}
-
-enum storage-error {
-    missing,
-    conflict,
-    denied,
-    internal,
-}
-
-record storage-entry {
-    namespace: string,
-    key: string,
-    value: list<u8>,
-    revision: option<u64>,
-}
-
-enum proxy-error {
-    route-not-found,
-    denied,
-    bad-request,
-    internal,
-}
-
-record user-data {
-    tenant-id: string,
-    client-name: string,
-    user-id: string,
-    user-email: string,
-    user-name: string,
-    user-type: string,
-}
-
-record user-data-v2 {
-    tenant-id: string,
-    client-name: string,
-    user-id: string,
-    user-email: string,
-    user-name: string,
-    user-type: string,
-    client-id: option<string>,
-    additional-fields: list<tuple<string, string>>,
-}
-
-enum user-error {
-    not-available,
-    not-allowed,
-}
-
-enum client-read-error {
-    not-allowed,
-    invalid-input,
-    internal,
-}
-
-record client-summary {
-    client-id: string,
-    client-name: string,
-    client-type: option<string>,
-    is-inactive: bool,
-    default-currency-code: option<string>,
-    account-manager-id: option<string>,
-    account-manager-name: option<string>,
-    billing-email: option<string>,
-}
-
-record clients-list-input {
-    search: option<string>,
-    include-inactive: option<bool>,
-    page: option<u32>,
-    page-size: option<u32>,
-}
-
-record clients-list-result {
-    items: list<client-summary>,
-    total-count: u32,
-    page: u32,
-    page-size: u32,
-}
-
-enum service-item-kind {
-    service,
-    product,
-}
-
-enum service-billing-method {
-    fixed,
-    hourly,
-    usage,
-}
-
-enum service-read-error {
-    not-allowed,
-    invalid-input,
-    internal,
-}
-
-record service-summary {
-    service-id: string,
-    service-name: string,
-    item-kind: service-item-kind,
-    billing-method: service-billing-method,
-    service-type-id: option<string>,
-    service-type-name: option<string>,
-    default-rate: f64,
-    unit-of-measure: string,
-    is-active: bool,
-    sku: option<string>,
-}
-
-record services-list-input {
-    search: option<string>,
-    item-kind: option<service-item-kind>,
-    is-active: option<bool>,
-    billing-method: option<service-billing-method>,
-    page: option<u32>,
-    page-size: option<u32>,
-}
-
-record services-list-result {
-    items: list<service-summary>,
-    total-count: u32,
-    page: u32,
-    page-size: u32,
-}
-
-/// Capability provider interfaces -------------------------------------------
-
-/// Access execution context metadata.
-/// @requires(cap:context.read)
 interface context {
+    use types.{context-data};
     get-context: func() -> context-data;
 }
 
-/// Retrieve install-scoped secrets.
-/// @requires(cap:secrets.get)
 interface secrets {
+    use types.{secret-error};
     get: func(key: string) -> result<string, secret-error>;
-    list: func() -> list<string>;
+    list-keys: func() -> list<string>;
 }
 
-/// Perform outbound HTTP requests with host enforced allowlists.
-/// @requires(cap:http.fetch)
 interface http {
+    use types.{http-request, http-response, http-error};
     fetch: func(request: http-request) -> result<http-response, http-error>;
 }
 
-/// Work with host-backed key/value storage.
-/// @requires(cap:storage.kv)
 interface storage {
+    use types.{storage-entry, storage-error};
     get: func(namespace: string, key: string) -> result<storage-entry, storage-error>;
     put: func(entry: storage-entry) -> result<storage-entry, storage-error>;
-    delete: func(namespace: string, key: string) -> result<(), storage-error>;
-    list: func(namespace: string, cursor: option<string>) -> result<list<storage-entry>, storage-error>;
+    delete: func(namespace: string, key: string) -> result<_, storage-error>;
+    list-entries: func(namespace: string, cursor: option<string>) -> result<list<storage-entry>, storage-error>;
 }
 
-/// Emit structured log messages.
-/// @requires(cap:log.emit)
 interface logging {
-    info: func(message: string);
-    warn: func(message: string);
-    error: func(message: string);
+    log-info: func(message: string);
+    log-warn: func(message: string);
+    log-error: func(message: string);
 }
 
-/// Invoke host-mediated proxy routes for UI flows.
-/// @requires(cap:ui.proxy)
 interface ui-proxy {
-    call: func(route: string, payload: option<list<u8>>) -> result<list<u8>, proxy-error>;
+    use types.{proxy-error};
+    call-route: func(route: string, payload: option<list<u8>>) -> result<list<u8>, proxy-error>;
 }
 
-/// Access current user information.
-/// @requires(cap:user.read)
-interface user {
-    get-user: func() -> result<user-data, user-error>;
-}
-
-/// Access current user information (v2 adds client-id and additional-fields).
-/// @requires(cap:user.read)
 interface user-v2 {
+    use types.{user-data-v2, user-error};
     get-user: func() -> result<user-data-v2, user-error>;
 }
 
-/// Read tenant-scoped client summaries.
-/// @requires(cap:client.read)
 interface clients {
+    use types.{client-read-error, client-summary, clients-list-input, clients-list-result};
     list-clients: func(input: clients-list-input) -> result<clients-list-result, client-read-error>;
     get-client: func(client-id: string) -> result<option<client-summary>, client-read-error>;
 }
 
-/// Read tenant-scoped service catalog summaries.
-/// @requires(cap:service.read)
 interface services {
+    use types.{service-read-error, service-summary, services-list-input, services-list-result};
     list-services: func(input: services-list-input) -> result<services-list-result, service-read-error>;
     get-service: func(service-id: string) -> result<option<service-summary>, service-read-error>;
 }
 
-/// Guest exported HTTP-style handler entrypoint (initial contract).
-record execute-request {
-    context: context-data,
-    http: http-request,
-}
-
-record execute-response {
-    status: u16,
-    headers: list<http-header>,
-    body: option<list<u8>>,
-}
-
-/// World describing the Alga extension runtime contract.
 world runner {
-    import context: interface context;
-    import secrets: interface secrets;
-    import http: interface http;
-    import storage: interface storage;
-    import logging: interface logging;
-    import ui-proxy: interface ui-proxy;
-    import user-v2: interface user-v2;
-    import clients: interface clients;
-    import services: interface services;
+    use types.{execute-request, execute-response};
+
+    import context;
+    import secrets;
+    import http;
+    import storage;
+    import logging;
+    import ui-proxy;
+    import user-v2;
+    import clients;
+    import services;
 
     export handler: func(request: execute-request) -> execute-response;
 }


### PR DESCRIPTION
## Summary
- convert the client/service sample iframe UI to the extension UI kit patterns
- remove the synthetic summary endpoint so the sample only demonstrates client and service reads
- add the sample packaging/build source files and bump the sample manifest version

## Testing
- npm -C sdk/samples/component/client-service-read-demo test -- --run
- npm -C sdk/samples/component/client-service-read-demo run build