### PR TITLE
Add filters to API key management pages

### DIFF
--- a/packages/auth/src/actions/apiKeyActions.ts
+++ b/packages/auth/src/actions/apiKeyActions.ts
@@ -85,6 +85,8 @@ export const adminListApiKeys = withAuth(async (user, { tenant }) => {
     api_key_id: key.api_key_id,
     description: key.description,
     username: key.username,
+    first_name: key.first_name,
+    last_name: key.last_name,
     created_at: key.created_at,
     last_used_at: key.last_used_at,
     expires_at: key.expires_at,

--- a/packages/auth/src/components/settings/api/AdminApiKeysSetup.tsx
+++ b/packages/auth/src/components/settings/api/AdminApiKeysSetup.tsx
@@ -2,22 +2,52 @@
 
 // Auth-owned admin API key management UI.
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, memo } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
+import { Input } from '@alga-psa/ui/components/Input';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
+import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { adminListApiKeys, adminDeactivateApiKey } from '@alga-psa/auth/actions';
+import { Search, RotateCcw } from 'lucide-react';
 
 export interface AdminApiKey {
   api_key_id: string;
   description: string | null;
   username: string;
+  first_name: string | null;
+  last_name: string | null;
   created_at: Date;
   last_used_at: Date | null;
   expires_at: Date | null;
   active: boolean;
 }
+
+const AdminSearchInput = memo(({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+}) => (
+  <div className="relative p-0.5">
+    <Input
+      id="search-admin-api-keys"
+      type="text"
+      placeholder={placeholder}
+      className="border-2 border-gray-200 focus:border-purple-500 rounded-md pl-10 pr-4 py-2 w-64 outline-none bg-white"
+      value={value}
+      onChange={onChange}
+      preserveCursor={true}
+    />
+    <Search size={20} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+  </div>
+));
+AdminSearchInput.displayName = 'AdminSearchInput';
 
 export default function AdminApiKeysSetup() {
   const [apiKeys, setApiKeys] = useState<AdminApiKey[]>([]);
@@ -27,11 +57,67 @@ export default function AdminApiKeysSetup() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
+  // Filter state
+  const [searchInput, setSearchInput] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('active');
+  const [lastUsedAfter, setLastUsedAfter] = useState<Date | undefined>(undefined);
+  const [expiresBeforeDate, setExpiresBeforeDate] = useState<Date | undefined>(undefined);
+
+  const isFiltered = searchTerm !== '' || statusFilter !== 'active' || !!lastUsedAfter || !!expiresBeforeDate;
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchTerm(searchInput);
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(e.target.value);
+  }, []);
+
+  const handleResetFilters = useCallback(() => {
+    setSearchInput('');
+    setSearchTerm('');
+    setStatusFilter('active');
+    setLastUsedAfter(undefined);
+    setExpiresBeforeDate(undefined);
+    setCurrentPage(1);
+  }, []);
+
   // Handle page size change - reset to page 1
   const handlePageSizeChange = (newPageSize: number) => {
     setPageSize(newPageSize);
     setCurrentPage(1);
   };
+
+  // Filter keys client-side
+  const filteredKeys = useMemo(() => {
+    return apiKeys.filter((key) => {
+      if (statusFilter === 'active' && !key.active) return false;
+      if (statusFilter === 'inactive' && key.active) return false;
+      if (searchTerm) {
+        const term = searchTerm.toLowerCase();
+        const matchesDescription = key.description?.toLowerCase().includes(term);
+        const matchesUsername = key.username?.toLowerCase().includes(term);
+        const matchesFirstName = key.first_name?.toLowerCase().includes(term);
+        const matchesLastName = key.last_name?.toLowerCase().includes(term);
+        const fullName = [key.first_name, key.last_name].filter(Boolean).join(' ').toLowerCase();
+        const matchesFullName = fullName.includes(term);
+        if (!matchesDescription && !matchesUsername && !matchesFirstName && !matchesLastName && !matchesFullName) return false;
+      }
+      if (lastUsedAfter) {
+        if (!key.last_used_at || new Date(key.last_used_at) < lastUsedAfter) return false;
+      }
+      if (expiresBeforeDate) {
+        if (!key.expires_at || new Date(key.expires_at) > expiresBeforeDate) return false;
+      }
+      return true;
+    });
+  }, [apiKeys, statusFilter, searchTerm, lastUsedAfter, expiresBeforeDate]);
 
   useEffect(() => {
     loadApiKeys();
@@ -71,6 +157,10 @@ export default function AdminApiKeysSetup() {
       title: 'User',
       dataIndex: 'username',
       width: '15%',
+      render: (_: string, record: AdminApiKey) => {
+        const name = [record.first_name, record.last_name].filter(Boolean).join(' ');
+        return name || record.username;
+      },
     },
     {
       title: 'Description',
@@ -133,9 +223,66 @@ export default function AdminApiKeysSetup() {
             {error}
           </div>
         )}
+        <div className="flex items-center mb-4 gap-4 flex-wrap">
+          <AdminSearchInput
+            value={searchInput}
+            onChange={handleSearchInputChange}
+            placeholder="Search by user or description"
+          />
+          <div className="w-48 shrink-0">
+            <CustomSelect
+              id="admin-api-keys-status-filter"
+              value={statusFilter}
+              onValueChange={(value) => {
+                setStatusFilter(value as 'all' | 'active' | 'inactive');
+                setCurrentPage(1);
+              }}
+              options={[
+                { value: 'all', label: 'All Statuses' },
+                { value: 'active', label: 'Active' },
+                { value: 'inactive', label: 'Inactive' },
+              ]}
+            />
+          </div>
+          <div className="w-48 shrink-0">
+            <DatePicker
+              id="admin-api-keys-last-used-filter"
+              value={lastUsedAfter}
+              onChange={(date) => {
+                setLastUsedAfter(date);
+                setCurrentPage(1);
+              }}
+              clearable
+              placeholder="Last used after"
+            />
+          </div>
+          <div className="w-48 shrink-0">
+            <DatePicker
+              id="admin-api-keys-expires-before-filter"
+              value={expiresBeforeDate}
+              onChange={(date) => {
+                setExpiresBeforeDate(date);
+                setCurrentPage(1);
+              }}
+              clearable
+              placeholder="Expires before"
+            />
+          </div>
+          <Button
+            id="reset-admin-api-keys-filters"
+            variant="ghost"
+            size="sm"
+            className={`shrink-0 flex items-center gap-1 ${isFiltered ? 'text-gray-500 hover:text-gray-700' : 'invisible'}`}
+            onClick={handleResetFilters}
+            disabled={!isFiltered}
+          >
+            <RotateCcw size={14} />
+            Reset
+          </Button>
+        </div>
         <DataTable
           id="admin-api-keys-table"
-          data={apiKeys}
+          data={filteredKeys}
           columns={columns}
           pagination={true}
           currentPage={currentPage}

--- a/packages/auth/src/components/settings/api/ApiKeysSetup.tsx
+++ b/packages/auth/src/components/settings/api/ApiKeysSetup.tsx
@@ -2,18 +2,21 @@
 
 // Auth-owned API key management UI.
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, memo } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
+import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { createApiKey, deactivateApiKey, listApiKeys } from '@alga-psa/auth/actions';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { Search, RotateCcw } from 'lucide-react';
 
 export interface ApiKey {
   api_key_id: string;
@@ -23,6 +26,30 @@ export interface ApiKey {
   expires_at: Date | null;
   active: boolean;
 }
+
+const SearchInput = memo(({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+}) => (
+  <div className="relative p-0.5">
+    <Input
+      id="search-api-keys"
+      type="text"
+      placeholder={placeholder}
+      className="border-2 border-gray-200 focus:border-purple-500 rounded-md pl-10 pr-4 py-2 w-64 outline-none bg-white"
+      value={value}
+      onChange={onChange}
+      preserveCursor={true}
+    />
+    <Search size={20} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+  </div>
+));
+SearchInput.displayName = 'SearchInput';
 
 export default function ApiKeysSetup() {
   const [description, setDescription] = useState('');
@@ -36,11 +63,61 @@ export default function ApiKeysSetup() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
+  // Filter state
+  const [searchInput, setSearchInput] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('active');
+  const [lastUsedAfter, setLastUsedAfter] = useState<Date | undefined>(undefined);
+  const [expiresBeforeDate, setExpiresBeforeDate] = useState<Date | undefined>(undefined);
+
+  const isFiltered = searchTerm !== '' || statusFilter !== 'active' || !!lastUsedAfter || !!expiresBeforeDate;
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchTerm(searchInput);
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(e.target.value);
+  }, []);
+
+  const handleResetFilters = useCallback(() => {
+    setSearchInput('');
+    setSearchTerm('');
+    setStatusFilter('active');
+    setLastUsedAfter(undefined);
+    setExpiresBeforeDate(undefined);
+    setCurrentPage(1);
+  }, []);
+
   // Handle page size change - reset to page 1
   const handlePageSizeChange = (newPageSize: number) => {
     setPageSize(newPageSize);
     setCurrentPage(1);
   };
+
+  // Filter keys client-side
+  const filteredKeys = useMemo(() => {
+    return apiKeys.filter((key) => {
+      if (statusFilter === 'active' && !key.active) return false;
+      if (statusFilter === 'inactive' && key.active) return false;
+      if (searchTerm) {
+        const term = searchTerm.toLowerCase();
+        if (!key.description?.toLowerCase().includes(term)) return false;
+      }
+      if (lastUsedAfter) {
+        if (!key.last_used_at || new Date(key.last_used_at) < lastUsedAfter) return false;
+      }
+      if (expiresBeforeDate) {
+        if (!key.expires_at || new Date(key.expires_at) > expiresBeforeDate) return false;
+      }
+      return true;
+    });
+  }, [apiKeys, statusFilter, searchTerm, lastUsedAfter, expiresBeforeDate]);
 
   const loadApiKeys = useCallback(async () => {
     try {
@@ -193,9 +270,66 @@ export default function ApiKeysSetup() {
 
       <Card className="p-6">
         <h2 className="text-2xl font-semibold mb-4">Your API Keys</h2>
+        <div className="flex items-center mb-4 gap-4 flex-wrap">
+          <SearchInput
+            value={searchInput}
+            onChange={handleSearchInputChange}
+            placeholder="Search by description"
+          />
+          <div className="w-48 shrink-0">
+            <CustomSelect
+              id="api-keys-status-filter"
+              value={statusFilter}
+              onValueChange={(value) => {
+                setStatusFilter(value as 'all' | 'active' | 'inactive');
+                setCurrentPage(1);
+              }}
+              options={[
+                { value: 'all', label: 'All Statuses' },
+                { value: 'active', label: 'Active' },
+                { value: 'inactive', label: 'Inactive' },
+              ]}
+            />
+          </div>
+          <div className="w-48 shrink-0">
+            <DatePicker
+              id="api-keys-last-used-filter"
+              value={lastUsedAfter}
+              onChange={(date) => {
+                setLastUsedAfter(date);
+                setCurrentPage(1);
+              }}
+              clearable
+              placeholder="Last used after"
+            />
+          </div>
+          <div className="w-48 shrink-0">
+            <DatePicker
+              id="api-keys-expires-before-filter"
+              value={expiresBeforeDate}
+              onChange={(date) => {
+                setExpiresBeforeDate(date);
+                setCurrentPage(1);
+              }}
+              clearable
+              placeholder="Expires before"
+            />
+          </div>
+          <Button
+            id="reset-api-keys-filters"
+            variant="ghost"
+            size="sm"
+            className={`shrink-0 flex items-center gap-1 ${isFiltered ? 'text-gray-500 hover:text-gray-700' : 'invisible'}`}
+            onClick={handleResetFilters}
+            disabled={!isFiltered}
+          >
+            <RotateCcw size={14} />
+            Reset
+          </Button>
+        </div>
         <DataTable
           id="api-keys-table"
-          data={apiKeys}
+          data={filteredKeys}
           columns={columns}
           pagination={true}
           currentPage={currentPage}

--- a/packages/auth/src/services/apiKeyService.ts
+++ b/packages/auth/src/services/apiKeyService.ts
@@ -221,16 +221,16 @@ export class ApiKeyService {
   /**
    * List all API keys across users (admin only)
    */
-  static async listAllApiKeys(tenantId?: string): Promise<(ApiKey & { username: string })[]> {
+  static async listAllApiKeys(tenantId?: string): Promise<(ApiKey & { username: string; first_name: string | null; last_name: string | null })[]> {
     const { knex, tenant } = await createTenantKnex(tenantId);
-    
+
     if (!tenant) {
       throw new Error('Tenant context is required for listing API keys');
     }
 
     try {
       return await knex('api_keys')
-        .select('api_keys.*', 'users.username')
+        .select('api_keys.*', 'users.username', 'users.first_name', 'users.last_name')
         .join('users', function() {
           this.on('api_keys.user_id', '=', 'users.user_id')
               .andOn('users.tenant', '=', 'api_keys.tenant');


### PR DESCRIPTION
  Add search, status, last-used date, and expiration date filters to both profile and admin API key pages using existing custom components (CustomSelect, DatePicker, SearchInput). Default status filter to Active. Admin page now displays user's first/last name instead of username in the table while still searching across both name and username.

  "The keys were all locked in a great glass case, but Alice found she could filter them quite nicely by their Active-ness and Expiry dates. 'How curious,' she murmured, 'that a DatePicker should know which keys have
  expired before they've even been used!' The Cheshire Cat's first_name and last_name flickered into view where once only a username had grinned." 🔑📅🐱