### PR TITLE
[codex] Rehydrate workflow schedule PG Boss handlers on startup

### DIFF
--- a/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
+++ b/ee/packages/workflows/src/lib/workflowScheduleLifecycle.ts
@@ -44,7 +44,7 @@ type WorkflowScheduleJobData = {
   scheduleId: string;
 };
 
-const workflowScheduleSingletonKey = (workflowId: string, scheduleId: string): string =>
+export const buildWorkflowScheduleSingletonKey = (workflowId: string, scheduleId: string): string =>
   `workflow-schedule:${workflowId}:${scheduleId}`;
 
 const TERMINAL_JOB_STATUSES = new Set(['completed', 'failed']);
@@ -149,7 +149,7 @@ async function scheduleDesiredWorkflow(
     workflowId,
     scheduleId
   };
-  const singletonKey = workflowScheduleSingletonKey(workflowId, scheduleId);
+  const singletonKey = buildWorkflowScheduleSingletonKey(workflowId, scheduleId);
 
   if (desired.triggerType === 'schedule') {
     const runAt = desired.runAt ? new Date(desired.runAt) : null;

--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -387,6 +387,15 @@ async function initializeJobScheduler(storageService: StorageService) {
   try {
     const jobRunner = await initializeJobRunner();
     logger.info(`Job runner initialized: ${jobRunner.getRunnerType()}`);
+
+    if (isEnterprise) {
+      try {
+        const { reconcileWorkflowSchedulePgBossHandlers } = await import('./jobs/reconcileWorkflowSchedulePgBossHandlers');
+        await reconcileWorkflowSchedulePgBossHandlers(jobRunner);
+      } catch (error) {
+        logger.error('Failed to reconcile workflow schedule PG Boss handlers:', error);
+      }
+    }
   } catch (error) {
     logger.error('Failed to initialize new job runner abstraction:', error);
     // Fall back to legacy scheduler

--- a/server/src/lib/jobs/reconcileWorkflowSchedulePgBossHandlers.ts
+++ b/server/src/lib/jobs/reconcileWorkflowSchedulePgBossHandlers.ts
@@ -1,0 +1,85 @@
+import logger from '@alga-psa/core/logger';
+import { getAdminConnection } from '@alga-psa/db/admin';
+import {
+  WorkflowScheduleStateModel,
+  type WorkflowScheduleStateRecord,
+} from '@alga-psa/workflows/persistence';
+import {
+  buildWorkflowScheduleSingletonKey,
+  WORKFLOW_RECURRING_TRIGGER_JOB,
+} from '@alga-psa/workflows/lib/workflowScheduleLifecycle';
+
+import type { IJobRunner, JobHandlerConfig } from './interfaces';
+import {
+  workflowRecurringScheduledRunHandler,
+  type WorkflowScheduledRunJobData,
+} from './handlers/workflowScheduledRunHandlers';
+
+type IntrospectablePgBossRunner = IJobRunner & {
+  hasHandler?: (jobName: string) => boolean;
+};
+
+const buildRecurringWorkflowScheduleHandler = (
+  queueName: string,
+): JobHandlerConfig<WorkflowScheduledRunJobData> => ({
+  name: queueName,
+  handler: async (jobId, data) => {
+    await workflowRecurringScheduledRunHandler(jobId, data);
+  },
+  retry: { maxAttempts: 3 },
+  timeoutMs: 300000,
+});
+
+const shouldRehydrateRecurringWorkflowSchedule = (
+  schedule: WorkflowScheduleStateRecord,
+): boolean => (
+  schedule.enabled === true
+  && schedule.status === 'scheduled'
+  && schedule.trigger_type === 'recurring'
+  && typeof schedule.cron === 'string'
+  && schedule.cron.trim().length > 0
+);
+
+export async function reconcileWorkflowSchedulePgBossHandlers(
+  runner: IJobRunner,
+): Promise<{ registered: number; skipped: number }> {
+  if (runner.getRunnerType() !== 'pgboss') {
+    return { registered: 0, skipped: 0 };
+  }
+
+  const introspectableRunner = runner as IntrospectablePgBossRunner;
+  if (typeof introspectableRunner.hasHandler !== 'function') {
+    logger.warn('Skipping workflow schedule PG Boss reconciliation because runner introspection is unavailable');
+    return { registered: 0, skipped: 0 };
+  }
+
+  const adminKnex = await getAdminConnection();
+  const schedules = await WorkflowScheduleStateModel.list(adminKnex);
+  let registered = 0;
+  let skipped = 0;
+
+  for (const schedule of schedules) {
+    if (!shouldRehydrateRecurringWorkflowSchedule(schedule)) {
+      skipped += 1;
+      continue;
+    }
+
+    const queueName = buildWorkflowScheduleSingletonKey(schedule.workflow_id, schedule.id);
+    if (introspectableRunner.hasHandler(queueName)) {
+      skipped += 1;
+      continue;
+    }
+
+    runner.registerHandler(buildRecurringWorkflowScheduleHandler(queueName));
+    registered += 1;
+  }
+
+  logger.info('Reconciled workflow schedule PG Boss handlers', {
+    registered,
+    skipped,
+    totalSchedules: schedules.length,
+    jobName: WORKFLOW_RECURRING_TRIGGER_JOB,
+  });
+
+  return { registered, skipped };
+}

--- a/server/src/test/unit/reconcileWorkflowSchedulePgBossHandlers.unit.test.ts
+++ b/server/src/test/unit/reconcileWorkflowSchedulePgBossHandlers.unit.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAdminConnectionMock = vi.fn();
+const listSchedulesMock = vi.fn();
+const workflowRecurringScheduledRunHandlerMock = vi.fn();
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: () => getAdminConnectionMock(),
+}));
+
+vi.mock('@alga-psa/workflows/persistence', () => ({
+  WorkflowScheduleStateModel: {
+    list: (...args: unknown[]) => listSchedulesMock(...args),
+  },
+}));
+
+vi.mock('@/lib/jobs/handlers/workflowScheduledRunHandlers', () => ({
+  workflowRecurringScheduledRunHandler: (...args: unknown[]) =>
+    workflowRecurringScheduledRunHandlerMock(...args),
+}));
+
+import { reconcileWorkflowSchedulePgBossHandlers } from '@/lib/jobs/reconcileWorkflowSchedulePgBossHandlers';
+
+describe('reconcileWorkflowSchedulePgBossHandlers', () => {
+  beforeEach(() => {
+    getAdminConnectionMock.mockReset();
+    listSchedulesMock.mockReset();
+    workflowRecurringScheduledRunHandlerMock.mockReset();
+  });
+
+  it('re-registers only missing recurring workflow schedule queues for PG Boss', async () => {
+    const adminKnex = {};
+    const registerHandler = vi.fn();
+    const hasHandler = vi.fn((jobName: string) => jobName === 'workflow-schedule:workflow-2:schedule-2');
+    const runner = {
+      getRunnerType: () => 'pgboss' as const,
+      hasHandler,
+      registerHandler,
+    };
+
+    getAdminConnectionMock.mockResolvedValue(adminKnex);
+    listSchedulesMock.mockResolvedValue([
+      {
+        id: 'schedule-1',
+        tenant_id: 'tenant-1',
+        workflow_id: 'workflow-1',
+        workflow_version: 1,
+        name: 'Daily 1',
+        trigger_type: 'recurring',
+        cron: '0 9 * * *',
+        timezone: 'UTC',
+        enabled: true,
+        status: 'scheduled',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      {
+        id: 'schedule-2',
+        tenant_id: 'tenant-1',
+        workflow_id: 'workflow-2',
+        workflow_version: 1,
+        name: 'Daily 2',
+        trigger_type: 'recurring',
+        cron: '15 10 * * *',
+        timezone: 'UTC',
+        enabled: true,
+        status: 'scheduled',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      {
+        id: 'schedule-3',
+        tenant_id: 'tenant-1',
+        workflow_id: 'workflow-3',
+        workflow_version: 1,
+        name: 'Disabled',
+        trigger_type: 'recurring',
+        cron: '0 11 * * *',
+        timezone: 'UTC',
+        enabled: false,
+        status: 'paused',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      {
+        id: 'schedule-4',
+        tenant_id: 'tenant-1',
+        workflow_id: 'workflow-4',
+        workflow_version: 1,
+        name: 'One-time',
+        trigger_type: 'schedule',
+        run_at: '2099-01-01T00:00:00.000Z',
+        enabled: true,
+        status: 'scheduled',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await reconcileWorkflowSchedulePgBossHandlers(runner as any);
+
+    expect(getAdminConnectionMock).toHaveBeenCalledTimes(1);
+    expect(listSchedulesMock).toHaveBeenCalledWith(adminKnex);
+    expect(hasHandler).toHaveBeenCalledWith('workflow-schedule:workflow-1:schedule-1');
+    expect(hasHandler).toHaveBeenCalledWith('workflow-schedule:workflow-2:schedule-2');
+    expect(registerHandler).toHaveBeenCalledTimes(1);
+
+    const handlerConfig = registerHandler.mock.calls[0]?.[0];
+    expect(handlerConfig.name).toBe('workflow-schedule:workflow-1:schedule-1');
+
+    await handlerConfig.handler('job-1', {
+      tenantId: 'tenant-1',
+      workflowId: 'workflow-1',
+      scheduleId: 'schedule-1',
+    });
+
+    expect(workflowRecurringScheduledRunHandlerMock).toHaveBeenCalledWith('job-1', {
+      tenantId: 'tenant-1',
+      workflowId: 'workflow-1',
+      scheduleId: 'schedule-1',
+    });
+    expect(result).toEqual({ registered: 1, skipped: 3 });
+  });
+
+  it('skips reconciliation for non-PG Boss runners', async () => {
+    const runner = {
+      getRunnerType: () => 'temporal' as const,
+      registerHandler: vi.fn(),
+    };
+
+    const result = await reconcileWorkflowSchedulePgBossHandlers(runner as any);
+
+    expect(getAdminConnectionMock).not.toHaveBeenCalled();
+    expect(listSchedulesMock).not.toHaveBeenCalled();
+    expect(runner.registerHandler).not.toHaveBeenCalled();
+    expect(result).toEqual({ registered: 0, skipped: 0 });
+  });
+});


### PR DESCRIPTION
## What changed
- add a startup reconciliation step that re-registers missing per-schedule PG Boss handlers for persisted recurring workflow schedules
- invoke that reconciliation during server job-runner initialization in enterprise mode
- export the workflow schedule singleton-key builder so startup reconciliation and schedule creation use the same queue naming
- add unit coverage for the PG Boss reconciliation path and the non-PG Boss no-op path

## Why
Recurring workflow schedules in PG Boss rely on dynamically registered per-schedule queue handlers. Those handlers were only registered when the schedule was created. After a server reschedule or pod restart, the persisted cron schedules still existed in PG Boss and in the application database, but the in-memory handler registrations were gone, so recurring schedules stopped being consumed.

## Impact
After deploy, PG Boss-backed recurring workflow schedules should resume firing after server restarts without requiring the schedule to be recreated.

## Validation
- `npm -w server run test -- src/test/unit/reconcileWorkflowSchedulePgBossHandlers.unit.test.ts`
- `npm -w server run test -- src/test/unit/workflowScheduledRunHandlers.unit.test.ts`
- `npm -w server run typecheck`
