### PR TITLE
Fix phase hover buttons covering task count

### DIFF
--- a/packages/projects/src/components/PhaseListItem.tsx
+++ b/packages/projects/src/components/PhaseListItem.tsx
@@ -397,7 +397,7 @@ export const PhaseListItem: React.FC<PhaseListItemProps> = ({
             </div>
           </div>
           {/* Hover Action Buttons — absolutely positioned so they don't consume layout space */}
-          <div className="absolute right-2 top-2 flex gap-1 opacity-0 group-hover:opacity-100 bg-inherit rounded">
+          <div className="absolute right-2 bottom-2 flex gap-1 opacity-0 group-hover:opacity-100 bg-inherit rounded">
             <button
               onClick={(e) => {
                 e.stopPropagation();


### PR DESCRIPTION
## Summary
- Moved the edit/delete hover action buttons on phase sidebar items from top-right to bottom-right
- Prevents the buttons from overlapping the task count badge on hover

## Test plan
- [ ] Hover over a phase in the project sidebar and verify edit/delete buttons appear at the bottom-right
- [ ] Confirm the task count badge remains visible on hover