### PR TITLE
Add inline status creation to project dialogs

### DIFF
--- a/packages/projects/src/actions/projectTemplateActions.ts
+++ b/packages/projects/src/actions/projectTemplateActions.ts
@@ -332,6 +332,7 @@ export const applyTemplate = withAuth(async (
   projectData: {
     project_name: string;
     client_id: string;
+    status_id?: string;
     start_date?: string;
     assigned_to?: string;
     options?: {
@@ -391,7 +392,15 @@ export const applyTemplate = withAuth(async (
     if (projectStatuses.length === 0) {
       throw new Error('No project statuses found');
     }
-    const defaultProjectStatus = projectStatuses[0];
+
+    // Use provided status_id or fall back to first available
+    let defaultProjectStatus = projectStatuses[0];
+    if (validatedData.status_id) {
+      const selectedStatus = projectStatuses.find(s => s.status_id === validatedData.status_id);
+      if (selectedStatus) {
+        defaultProjectStatus = selectedStatus;
+      }
+    }
 
     // Generate project number and WBS code
     const projectNumber = await SharedNumberingService.getNextNumber(

--- a/packages/projects/src/components/ProjectQuickAdd.tsx
+++ b/packages/projects/src/components/ProjectQuickAdd.tsx
@@ -17,6 +17,8 @@ import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import UserPicker from '@alga-psa/ui/components/UserPicker';
 import { ContactPicker } from '@alga-psa/ui/components/ContactPicker';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { QuickAddStatus } from '@alga-psa/ui/components/QuickAddStatus';
+import { createStatus as createStatusAction } from '@alga-psa/reference-data/actions';
 import { IContact } from '@alga-psa/types';
 import { getAllUsersBasic, getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
 import { IUser } from '@shared/interfaces/user.interfaces';
@@ -61,6 +63,17 @@ const ProjectQuickAdd: React.FC<ProjectQuickAddProps> = ({ onClose, onProjectAdd
   const [pendingTags, setPendingTags] = useState<PendingTag[]>([]);
   const [clientPortalConfig, setClientPortalConfig] = useState<IClientPortalConfig>(DEFAULT_CLIENT_PORTAL_CONFIG);
   const [showClientPortalConfig, setShowClientPortalConfig] = useState(false);
+  const [showQuickAddProjectStatus, setShowQuickAddProjectStatus] = useState(false);
+  const pendingStatusSelectRef = React.useRef<string | null>(null);
+
+  // Apply pending status selection after statuses array is updated
+  useEffect(() => {
+    if (pendingStatusSelectRef.current) {
+      const id = pendingStatusSelectRef.current;
+      pendingStatusSelectRef.current = null;
+      setSelectedStatusId(id);
+    }
+  }, [statuses]);
 
   const mergedClients = React.useMemo(() => {
     const clientIds = new Set(clients.map(c => c.client_id));
@@ -244,6 +257,8 @@ const ProjectQuickAdd: React.FC<ProjectQuickAddProps> = ({ onClose, onProjectAdd
                   }))}
                   placeholder="Select Status"
                   className={hasAttemptedSubmit && !selectedStatusId ? 'ring-1 ring-red-500' : ''}
+                  onAddNew={() => setShowQuickAddProjectStatus(true)}
+                  addNewLabel="Add new status"
                 />
               </div>
               <div>
@@ -411,6 +426,27 @@ const ProjectQuickAdd: React.FC<ProjectQuickAddProps> = ({ onClose, onProjectAdd
         },
         skipSuccessDialog: true,
       })}
+
+      <QuickAddStatus
+        open={showQuickAddProjectStatus}
+        onOpenChange={setShowQuickAddProjectStatus}
+        onStatusCreated={(newStatus) => {
+          pendingStatusSelectRef.current = newStatus.status_id;
+          setStatuses(prev => [...prev, newStatus]);
+        }}
+        statusType="project"
+        showColorPicker={false}
+        createStatus={async ({ name, statusType, isClosed, color }) =>
+          createStatusAction({
+            name,
+            status_type: statusType,
+            item_type: statusType,
+            is_closed: isClosed,
+            color,
+          })
+        }
+        existingStatuses={statuses}
+      />
     </>
   );
 };

--- a/packages/projects/src/components/project-templates/ApplyTemplateDialog.tsx
+++ b/packages/projects/src/components/project-templates/ApplyTemplateDialog.tsx
@@ -9,13 +9,17 @@ import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Label } from '@alga-psa/ui/components/Label';
 import { RadioGroup } from '@alga-psa/ui/components/RadioGroup';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
-import { IProjectTemplate } from '@alga-psa/types';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { IProjectTemplate, IStatus } from '@alga-psa/types';
 import { IClient } from '@alga-psa/types';
 import { useToast } from '@alga-psa/ui';
 import { useRouter } from 'next/navigation';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
+import { QuickAddStatus } from '@alga-psa/ui/components/QuickAddStatus';
 import { getTemplates, applyTemplate } from '../../actions/projectTemplateActions';
-import { getAllClientsForProjects } from '../../actions/projectActions';
+import { getAllClientsForProjects, getProjectStatuses } from '../../actions/projectActions';
+import { createStatus as createStatusAction } from '@alga-psa/reference-data/actions';
+import { isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 interface ApplyTemplateDialogProps {
   open: boolean;
@@ -31,13 +35,19 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
   const { toast } = useToast();
   const [templates, setTemplates] = useState<IProjectTemplate[]>([]);
   const [clients, setClients] = useState<IClient[]>([]);
+  const [statuses, setStatuses] = useState<IStatus[]>([]);
   const [loading, setLoading] = useState(false);
+  const [showQuickAddStatus, setShowQuickAddStatus] = useState(false);
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const pendingStatusSelectRef = React.useRef<string | null>(null);
 
   const [formData, setFormData] = useState({
     template_id: initialTemplateId || '',
     project_name: '',
     client_id: '',
-    assigned_to: ''
+    assigned_to: '',
+    status_id: ''
   });
   const [startDate, setStartDate] = useState<Date | undefined>();
 
@@ -50,6 +60,15 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
     assignmentOption: 'primary' as AssignmentOption
   });
 
+  // Apply pending status selection after statuses array is updated
+  React.useEffect(() => {
+    if (pendingStatusSelectRef.current) {
+      const id = pendingStatusSelectRef.current;
+      pendingStatusSelectRef.current = null;
+      setFormData(prev => ({ ...prev, status_id: id }));
+    }
+  }, [statuses]);
+
   // Client picker filter states
   const [clientFilterState, setClientFilterState] = useState<'all' | 'active' | 'inactive'>('active');
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
@@ -61,9 +80,12 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
         template_id: initialTemplateId || '',
         project_name: '',
         client_id: '',
-        assigned_to: ''
+        assigned_to: '',
+        status_id: ''
       });
       setStartDate(undefined);
+      setHasAttemptedSubmit(false);
+      setValidationErrors([]);
       setOptions({
         copyPhases: true,
         copyStatuses: true,
@@ -78,13 +100,17 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
 
   async function loadData() {
     try {
-      const [templatesData, clientsData] = await Promise.all([
+      const [templatesData, clientsData, projectStatusesResult] = await Promise.all([
         getTemplates(),
-        getAllClientsForProjects()
+        getAllClientsForProjects(),
+        getProjectStatuses()
       ]);
 
       setTemplates(templatesData);
       setClients(clientsData);
+      if (!isActionPermissionError(projectStatusesResult)) {
+        setStatuses(projectStatusesResult);
+      }
     } catch (error) {
       console.error('[ApplyTemplateDialog] Failed to load data:', error);
       toast({
@@ -98,14 +124,20 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
 
-    if (!formData.template_id || !formData.project_name || !formData.client_id) {
-      toast({
-        title: 'Validation Error',
-        description: 'Template, project name, and client are required',
-        variant: 'destructive'
-      });
+    setHasAttemptedSubmit(true);
+
+    const errors: string[] = [];
+    if (!formData.template_id) errors.push('Template is required');
+    if (!formData.project_name.trim()) errors.push('Project name is required');
+    if (!formData.client_id) errors.push('Client is required');
+    if (!formData.status_id) errors.push('Status is required');
+
+    if (errors.length > 0) {
+      setValidationErrors(errors);
       return;
     }
+
+    setValidationErrors([]);
 
     try {
       setLoading(true);
@@ -113,6 +145,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
       const projectId = await applyTemplate(formData.template_id, {
         project_name: formData.project_name,
         client_id: formData.client_id,
+        status_id: formData.status_id,
         start_date: startDate?.toISOString(),
         assigned_to: formData.assigned_to || undefined,
         options: {
@@ -149,8 +182,21 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
   }
 
   return (
+    <>
     <Dialog isOpen={open} onClose={onClose} title="Create Project from Template" className="max-w-3xl" disableFocusTrap>
       <form onSubmit={handleSubmit} className="space-y-6">
+          {hasAttemptedSubmit && validationErrors.length > 0 && (
+            <Alert variant="destructive">
+              <AlertDescription>
+                Please fix the following errors:
+                <ul className="list-disc pl-5 mt-1 text-sm">
+                  {validationErrors.map((err, index) => (
+                    <li key={index}>{err}</li>
+                  ))}
+                </ul>
+              </AlertDescription>
+            </Alert>
+          )}
           <div>
             <label className="block text-sm font-medium mb-2">
               Template *
@@ -164,6 +210,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
                 label: t.template_name
               }))}
               placeholder="Select a template"
+              className={hasAttemptedSubmit && !formData.template_id ? 'ring-1 ring-red-500' : ''}
             />
           </div>
 
@@ -176,6 +223,7 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
               value={formData.project_name}
               onChange={(e) => setFormData({ ...formData, project_name: e.target.value })}
               placeholder="Enter project name"
+              className={hasAttemptedSubmit && !formData.project_name.trim() ? 'ring-1 ring-red-500' : ''}
             />
           </div>
 
@@ -193,6 +241,26 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
               clientTypeFilter={clientTypeFilter}
               onClientTypeFilterChange={setClientTypeFilter}
               placeholder="Select a client"
+              className={hasAttemptedSubmit && !formData.client_id ? 'ring-1 ring-red-500' : ''}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">
+              Status *
+            </label>
+            <CustomSelect
+              id="apply-template-status"
+              value={formData.status_id}
+              onValueChange={(value) => setFormData({ ...formData, status_id: value })}
+              options={statuses.map(s => ({
+                value: s.status_id,
+                label: s.name
+              }))}
+              placeholder="Select Status"
+              onAddNew={() => setShowQuickAddStatus(true)}
+              addNewLabel="Add new status"
+              className={hasAttemptedSubmit && !formData.status_id ? 'ring-1 ring-red-500' : ''}
             />
           </div>
 
@@ -303,5 +371,26 @@ export function ApplyTemplateDialog({ open, onClose, onSuccess, initialTemplateI
           </div>
         </form>
     </Dialog>
+    <QuickAddStatus
+      open={showQuickAddStatus}
+      onOpenChange={setShowQuickAddStatus}
+      onStatusCreated={(newStatus) => {
+        pendingStatusSelectRef.current = newStatus.status_id;
+        setStatuses(prev => [...prev, newStatus]);
+      }}
+      statusType="project"
+      showColorPicker={false}
+      createStatus={async ({ name, statusType, isClosed, color }) =>
+        createStatusAction({
+          name,
+          status_type: statusType,
+          item_type: statusType,
+          is_closed: isClosed,
+          color,
+        })
+      }
+      existingStatuses={statuses}
+    />
+    </>
   );
 }

--- a/packages/projects/src/schemas/projectTemplate.schemas.ts
+++ b/packages/projects/src/schemas/projectTemplate.schemas.ts
@@ -95,6 +95,10 @@ export const applyTemplateSchema = z.object({
     (val) => val === '' || val === null || val === undefined ? undefined : val,
     z.string().uuid().optional()
   ),
+  status_id: z.preprocess(
+    (val) => val === '' || val === null || val === undefined ? undefined : val,
+    z.string().uuid().optional()
+  ),
   options: z.object({
     copyPhases: z.boolean().default(true),
     copyStatuses: z.boolean().default(true),

--- a/packages/ui/src/components/ClientPicker.tsx
+++ b/packages/ui/src/components/ClientPicker.tsx
@@ -352,14 +352,17 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
       {onAddNew && (
         <>
           <div className="border-t border-gray-200" />
-          <button
+          <Button
+            id="client-picker-add-new-btn"
             type="button"
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-primary hover:bg-gray-100 cursor-pointer"
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 rounded-none text-primary"
             onClick={handleAddNew}
           >
             <Plus className="h-4 w-4" />
             Add new client
-          </button>
+          </Button>
         </>
       )}
     </div>

--- a/packages/ui/src/components/ContactPicker.tsx
+++ b/packages/ui/src/components/ContactPicker.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Input } from './Input';
+import { Button } from './Button';
 import { ChevronDown, Plus, Search } from 'lucide-react';
 import ContactAvatar from './ContactAvatar';
 import type { IContact } from '@alga-psa/types';
@@ -372,14 +373,17 @@ export const ContactPicker = ({
               {onAddNew && (
                 <>
                   <div className="border-t border-gray-200" />
-                  <button
+                  <Button
+                    id="contact-picker-add-new-btn"
                     type="button"
-                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-primary hover:bg-gray-100 cursor-pointer"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start gap-2 rounded-none text-primary"
                     onClick={handleAddNew}
                   >
                     <Plus className="h-4 w-4" />
                     Add new contact
-                  </button>
+                  </Button>
                 </>
               )}
             </div>,

--- a/packages/ui/src/components/CustomSelect.tsx
+++ b/packages/ui/src/components/CustomSelect.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useEffect, useState, useMemo, useId, useRef } from 'react';
-import { ChevronDown } from 'lucide-react';
+import React, { useEffect, useMemo, useId, useRef } from 'react';
+import { ChevronDown, Plus } from 'lucide-react';
 import * as RadixSelect from '@radix-ui/react-select';
+import { Button } from './Button';
 import { useModality } from './ModalityContext';
 import { FormFieldComponent, AutomationProps } from '../ui-reflection/types';
 import { useAutomationIdAndRegister } from '../ui-reflection/useAutomationIdAndRegister';
@@ -54,6 +55,10 @@ interface CustomSelectProps {
   showPlaceholderInDropdown?: boolean;
   /** Size variant for the select trigger */
   size?: SelectSize;
+  /** Callback to add a new item - renders a sticky button at the bottom of the dropdown */
+  onAddNew?: () => void;
+  /** Label for the add new button (default: "Add new") */
+  addNewLabel?: string;
 }
 
 const PLACEHOLDER_VALUE = '__SELECT_PLACEHOLDER__';
@@ -94,6 +99,8 @@ const CustomSelect = ({
   modal,
   showPlaceholderInDropdown = true,
   size = 'md',
+  onAddNew,
+  addNewLabel = 'Add new',
   ...props
 }: CustomSelectProps & AutomationProps) => {
   const { modal: parentModal } = useModality();
@@ -205,6 +212,8 @@ const CustomSelect = ({
   // Explicit prop overrides parent modality context
   const isModal = modal !== undefined ? modal : parentModal;
 
+  const selectTriggerRef = useRef<HTMLButtonElement>(null);
+
   const containerId = finalAutomationProps.id ? `${finalAutomationProps.id}-container` : undefined;
 
   return (
@@ -243,6 +252,7 @@ const CustomSelect = ({
         }}
       >
       <RadixSelect.Trigger
+          ref={selectTriggerRef}
           {...finalAutomationProps}
           data-automation-type={dataAutomationType}
           className={`
@@ -362,6 +372,32 @@ const CustomSelect = ({
             <RadixSelect.ScrollDownButton className="flex items-center justify-center h-6 bg-background dark:bg-[rgb(var(--color-card))] text-foreground cursor-default">
               <ChevronDown className="w-4 h-4" />
             </RadixSelect.ScrollDownButton>
+            {onAddNew && (
+              <>
+                <div className="border-t border-border" />
+                <Button
+                  id="custom-select-add-new-btn"
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start gap-2 rounded-none text-primary"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    // Close dropdown by dispatching Escape on the trigger, then open the add-new UI
+                    selectTriggerRef.current?.dispatchEvent(
+                      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+                    );
+                    // Small delay to let Radix unmount the dropdown before opening the dialog
+                    requestAnimationFrame(() => {
+                      onAddNew?.();
+                    });
+                  }}
+                >
+                  <Plus className="h-4 w-4" />
+                  {addNewLabel}
+                </Button>
+              </>
+            )}
           </RadixSelect.Content>
         </RadixSelect.Portal>
       </RadixSelect.Root>

--- a/packages/ui/src/components/QuickAddStatus.tsx
+++ b/packages/ui/src/components/QuickAddStatus.tsx
@@ -26,6 +26,8 @@ export interface QuickAddStatusProps {
   existingStatuses?: Array<{ name: string }>;
   /** Optional trigger element to open the dialog */
   trigger?: React.ReactNode;
+  /** Whether to show the color picker (default: true) */
+  showColorPicker?: boolean;
 }
 
 /**
@@ -40,6 +42,7 @@ export function QuickAddStatus({
   createStatus,
   existingStatuses = [],
   trigger,
+  showColorPicker = true,
 }: QuickAddStatusProps) {
   const [statusName, setStatusName] = useState('');
   const [statusColor, setStatusColor] = useState(SOLID_COLORS[0]);
@@ -59,10 +62,7 @@ export function QuickAddStatus({
     }
   }, [open]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
+  const handleSubmit = async () => {
     const trimmedName = statusName.trim();
 
     if (!trimmedName) {
@@ -111,7 +111,7 @@ export function QuickAddStatus({
       id="quick-add-status-dialog"
     >
       <DialogContent>
-        <form onSubmit={handleSubmit} id="quick-add-status-form">
+        <div id="quick-add-status-form">
           <div className="space-y-4">
             {/* Status Name */}
             <div>
@@ -125,6 +125,12 @@ export function QuickAddStatus({
                   setStatusName(e.target.value);
                   setError(null);
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
                 placeholder="e.g., In Progress, Review, Done"
                 autoFocus
                 disabled={isSubmitting}
@@ -136,6 +142,7 @@ export function QuickAddStatus({
             </div>
 
             {/* Color Picker */}
+            {showColorPicker && (
             <div>
               <Label className="block text-sm font-medium text-gray-700 mb-2">
                 Status Color
@@ -166,6 +173,7 @@ export function QuickAddStatus({
                 <span className="text-xs text-gray-500">{statusColor}</span>
               </div>
             </div>
+            )}
 
             {/* Is Closed Checkbox */}
             <div className="flex items-start gap-2">
@@ -198,13 +206,14 @@ export function QuickAddStatus({
             </Button>
             <Button
               id="quick-add-status-submit"
-              type="submit"
+              type="button"
+              onClick={handleSubmit}
               disabled={isSubmitting || !statusName.trim()}
             >
               {isSubmitting ? 'Creating...' : 'Create Status'}
             </Button>
           </DialogFooter>
-        </form>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/server/src/lib/schemas/projectTemplate.schemas.ts
+++ b/server/src/lib/schemas/projectTemplate.schemas.ts
@@ -95,6 +95,10 @@ export const applyTemplateSchema = z.object({
     (val) => val === '' || val === null || val === undefined ? undefined : val,
     z.string().uuid().optional()
   ),
+  status_id: z.preprocess(
+    (val) => val === '' || val === null || val === undefined ? undefined : val,
+    z.string().uuid().optional()
+  ),
   options: z.object({
     copyPhases: z.boolean().default(true),
     copyStatuses: z.boolean().default(true),


### PR DESCRIPTION
Add "Add new status" to CustomSelect with onAddNew/addNewLabel props. Integrate QuickAddStatus into ProjectQuickAdd and ApplyTemplateDialog with deferred auto-select via ref+useEffect for Radix timing Add status_id support to applyTemplate action and schema. Standardize picker "add new" buttons to use Button component. Refactor QuickAddStatus: form→div, optional color picker.

"If you want to get somewhere else," said the Cat, "you must first add the status to the options array, then wait one whole render cycle before selecting it—otherwise the Radix Portal shall vanish like a Cheshire grin and leave only the placeholder behind." 🐱✨📋