### PR TITLE
[codex] Initialize workflow runtime in shared launch path

### DIFF
--- a/ee/packages/workflows/src/lib/workflowRunLauncher.ts
+++ b/ee/packages/workflows/src/lib/workflowRunLauncher.ts
@@ -6,7 +6,11 @@ import {
   WorkflowRunModelV2,
   type WorkflowDefinitionVersionRecord,
 } from '@alga-psa/workflows/persistence';
-import { WorkflowRuntimeV2, getSchemaRegistry } from '@alga-psa/workflows/runtime';
+import {
+  WorkflowRuntimeV2,
+  getSchemaRegistry,
+  initializeWorkflowRuntimeV2,
+} from '@alga-psa/workflows/runtime';
 
 const WORKFLOW_RUN_TRIGGER_FIRE_KEY_UNIQUE = 'workflow_runs_trigger_fire_key_unique';
 
@@ -109,6 +113,8 @@ export async function launchPublishedWorkflowRun(
   knex: Knex,
   request: WorkflowRunLaunchRequest
 ): Promise<WorkflowRunLaunchResult> {
+  initializeWorkflowRuntimeV2();
+
   const workflow = await WorkflowDefinitionModelV2.getById(knex, request.workflowId);
   if (!workflow) {
     throw new Error('Workflow not found');

--- a/server/src/test/unit/workflowRunLauncher.unit.test.ts
+++ b/server/src/test/unit/workflowRunLauncher.unit.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
+  initializeWorkflowRuntimeV2Mock,
   startRunMock,
   executeRunMock,
   getByTriggerFireKeyMock,
@@ -9,6 +10,7 @@ const {
   listWorkflowVersionsMock,
   getWorkflowVersionMock
 } = vi.hoisted(() => ({
+  initializeWorkflowRuntimeV2Mock: vi.fn(),
   startRunMock: vi.fn(),
   executeRunMock: vi.fn(),
   getByTriggerFireKeyMock: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock('@alga-psa/workflows/runtime', async (importOriginal) => {
 
   return {
     ...actual,
+    initializeWorkflowRuntimeV2: () => initializeWorkflowRuntimeV2Mock(),
     WorkflowRuntimeV2: WorkflowRuntimeV2Mock,
     getSchemaRegistry: () => ({
       has: () => false,
@@ -75,6 +78,7 @@ describe('Workflow run launcher', () => {
   });
 
   beforeEach(() => {
+    initializeWorkflowRuntimeV2Mock.mockReset();
     startRunMock.mockReset();
     executeRunMock.mockReset();
     getByTriggerFireKeyMock.mockReset();
@@ -114,6 +118,29 @@ describe('Workflow run launcher', () => {
       workflow_version: data.workflow_version,
       ...data
     }));
+    startRunMock.mockResolvedValue('run-started');
+  });
+
+  it('initializes the workflow runtime before launching a run', async () => {
+    const result = await launchPublishedWorkflowRun(knexMock, {
+      workflowId: 'workflow-1',
+      workflowVersion: 5,
+      tenantId: 'tenant-1',
+      payload: {},
+      execute: true
+    });
+
+    expect(result).toEqual({
+      runId: 'run-started',
+      workflowVersion: 5
+    });
+    expect(initializeWorkflowRuntimeV2Mock).toHaveBeenCalledTimes(1);
+    expect(startRunMock).toHaveBeenCalledTimes(1);
+    expect(executeRunMock).toHaveBeenCalledWith(
+      knexMock,
+      'run-started',
+      expect.stringMatching(/^launch-workflow-1-/)
+    );
   });
 
   it('T044: duplicate recurring fire keys return the existing run without executing twice', async () => {


### PR DESCRIPTION
## What changed
- initialize the workflow runtime inside `launchPublishedWorkflowRun()` so callers do not need to pre-initialize node and action registrations
- add unit coverage that the shared launch path initializes the runtime before starting and executing a run

## Why
A production recurring schedule for workflow `69fdfed8-e21a-4a6d-910b-57c5446d9695` failed even though a manual run of the same workflow version succeeded earlier.

What we proved in production:
- the scheduled run `d9dd46f9-bd61-43ab-8987-0da48f05eb51` fired on time and was consumed by a `sebastian-green` pod
- the run failed at `root.steps[0]` with `Unknown node type action.call`
- the successful manual run `2d82b890-741a-476a-9575-8b457392f2b6` used the same workflow, version, and tenant
- manual workflow start paths explicitly call `initializeWorkflowRuntimeV2()` before launching a run, but the scheduled job handler called `launchPublishedWorkflowRun()` directly without doing that initialization

That meant the scheduled path could hit a process where the runtime registry had not been initialized yet, causing `action.call` to be unknown even though the workflow definition itself was valid.

## Impact
Scheduled and other background-triggered workflow launches now use the same runtime initialization guarantee as manual launches. This removes a process-state difference between launch paths and prevents missing node/action registrations in cold or newly started app pods.

## Validation
- `npm -w server run test -- src/test/unit/workflowRunLauncher.unit.test.ts`
- `npm -w server run typecheck`

## Notes
This PR does not change the separate issue where `tenant_workflow_schedule.last_run_status` may still show `success` even when the underlying `workflow_runs` row is `FAILED`, because the runtime records failure without throwing back through the scheduler handler.
