### PR TITLE
Fix ticket-closed email: event casing and resolution

### DIFF
--- a/packages/email/src/providers/ResendEmailProvider.ts
+++ b/packages/email/src/providers/ResendEmailProvider.ts
@@ -147,7 +147,7 @@ export class ResendEmailProvider implements IEmailProvider {
             to: response.data.to,
             createdAt: response.data.created_at,
           },
-          sentAt: new Date(response.data.created_at),
+          sentAt: response.data.created_at ? new Date(response.data.created_at) : new Date(),
         };
       } catch (error: any) {
         logger.error(`[ResendEmailProvider:${this.providerId}] Failed to send email (attempt ${attempt + 1}):`, {

--- a/packages/integrations/src/email/domains/providers/ResendEmailProvider.ts
+++ b/packages/integrations/src/email/domains/providers/ResendEmailProvider.ts
@@ -145,7 +145,7 @@ export class ResendEmailProvider implements IEmailProvider {
             to: response.data.to,
             createdAt: response.data.created_at,
           },
-          sentAt: new Date(response.data.created_at),
+          sentAt: response.data.created_at ? new Date(response.data.created_at) : new Date(),
         };
       } catch (error: any) {
         logger.error(`[ResendEmailProvider:${this.providerId}] Failed to send email (attempt ${attempt + 1}):`, {

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -888,7 +888,7 @@ export class TicketService extends BaseService<ITicket> {
         }
 
         if (newStatus?.is_closed) {
-          await this.safePublishEvent('TicketClosed', {
+          await this.safePublishEvent('TICKET_CLOSED', {
             id: require("crypto").randomUUID(),
             eventType: "TICKET_CLOSED" as const,
             timestamp: new Date().toISOString(),
@@ -901,7 +901,7 @@ export class TicketService extends BaseService<ITicket> {
         }
       }
 
-      await this.safePublishEvent('TicketUpdated', {
+      await this.safePublishEvent('TICKET_UPDATED', {
         id: require("crypto").randomUUID(),
         eventType: "TICKET_UPDATED" as const,
         timestamp: new Date().toISOString(),

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -2765,6 +2765,17 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
       .first();
     const closedBy = closer ? `${closer.first_name} ${closer.last_name}` : payload.userId;
 
+    // Get the resolution comment (most recent comment with is_resolution = true)
+    const resolutionComment = await db('comments')
+      .where({ ticket_id: payload.ticketId, tenant: tenantId, is_resolution: true })
+      .orderBy('created_at', 'desc')
+      .first();
+    let resolutionHtml = '';
+    if (resolutionComment) {
+      const resolutionFormatting = formatBlockNoteContent(resolutionComment.note);
+      resolutionHtml = resolutionFormatting.html || resolutionFormatting.text || '';
+    }
+
     const { internalUrl, portalUrl } = await resolveTicketLinks(db, tenantId, ticket.ticket_id, ticket.ticket_number);
 
     const baseTicketContext = {
@@ -2791,7 +2802,7 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
       locationSummary,
       changes,
       closedBy,
-      resolution: ticket.resolution || ''
+      resolution: resolutionHtml
     };
 
     const externalContext = {


### PR DESCRIPTION
  - Fix TICKET_CLOSED and TICKET_UPDATED events published with  PascalCase instead of SCREAMING_SNAKE_CASE, causing EventBus to reject them as unknown event types
  - Fetch resolution comment (is_resolution=true) from comments table for ticket-closed email instead of referencing a   non-existent ticket.resolution column
  - Guard against NaN timestamps in email_sending_logs when Resend API returns undefined created_at
  "But I don't want to go among mad events," Alice remarked.

  "Oh, you can't help that," said the Cat. "We're all SCREAMING_SNAKE_CASE here. The PascalCase ones simply vanish into NaN-NaN-NaNland, and no resolution is ever found — unless one thinks to actually look in the comments." 🐱📧✨