### PR TITLE
Flip auth + notifications to pre-built dist/

### DIFF
--- a/packages/auth/project.json
+++ b/packages/auth/project.json
@@ -6,12 +6,11 @@
   "tags": ["scope:auth", "type:horizontal"],
   "targets": {
     "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/dist"],
+      "executor": "nx:run-script",
       "options": {
-        "command": "tsc -b",
-        "cwd": "packages/auth"
-      }
+        "script": "build"
+      },
+      "dependsOn": ["^build"]
     },
     "test": {
       "executor": "@nx/vite:test",

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -1,47 +1,12 @@
 import { defineConfig } from 'tsup';
+import { makeConfig } from '../build-tools/tsup-preset';
 
-export default defineConfig({
-  entry: {
-    'index': 'src/index.ts',
-    'actions/index': 'src/actions/index.ts',
-    'lib/session': 'src/lib/session.ts',
-    'lib/rbac': 'src/lib/rbac.ts',
-    'lib/apiAuth': 'src/lib/apiAuth.ts',
-    'lib/deviceFingerprint': 'src/lib/deviceFingerprint.ts',
-    'lib/ipAddress': 'src/lib/ipAddress.ts',
-    'lib/geolocation': 'src/lib/geolocation.ts',
-    'lib/twoFactorHelpers': 'src/lib/twoFactorHelpers.ts',
-    'lib/nextAuthOptions': 'src/lib/nextAuthOptions.ts',
-    'lib/getCurrentUser': 'src/lib/getCurrentUser.ts',
-    'client': 'src/client.ts',
-    'components/index': 'src/components/index.ts',
-    'types/next-auth': 'src/types/next-auth.ts',
-    'nextauth/auth': 'src/nextauth/auth.ts',
-    'nextauth/edge-auth': 'src/nextauth/edge-auth.ts',
-  },
-  format: ['esm'],
-  dts: false,
-  bundle: true,
-  splitting: true,
-  sourcemap: false,
-  clean: true,
-  outDir: 'dist',
+export default defineConfig(makeConfig({
+  jsxEnabled: true,
   external: [
-    'react',
-    'react-dom',
-    'next',
-    'next/link',
-    'next/navigation',
-    'next/headers',
-    'next/server',
-    'next-auth',
-    'next-auth/react',
-    'next-auth/providers/credentials',
-    'next-auth/providers/google',
+    'react', 'react-dom',
+    'next', 'next/link', 'next/navigation', 'next/headers', 'next/server',
+    'next-auth', 'next-auth/react', 'next-auth/providers/credentials', 'next-auth/providers/google',
     '@auth/core',
-    /^@alga-psa\//,
   ],
-  esbuildOptions(options) {
-    options.jsx = 'automatic';
-  },
-});
+}));

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -2,9 +2,8 @@
   "name": "@alga-psa/notifications",
   "version": "0.1.0",
   "private": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.mjs",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "import": "./src/index.ts",

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -6,7 +6,11 @@
   "tags": ["scope:notifications", "type:horizontal"],
   "targets": {
     "build": {
-      "executor": "nx:noop"
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build"
+      },
+      "dependsOn": ["^build"]
     },
     "test": {
       "executor": "@nx/vite:test",

--- a/packages/notifications/tsup.config.ts
+++ b/packages/notifications/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsup';
+import { makeConfig } from '../build-tools/tsup-preset';
+
+export default defineConfig(makeConfig({
+  jsxEnabled: true,
+  external: ['react', 'react-dom', 'next', 'next/navigation', 'next/link', 'next-auth', 'next-auth/react'],
+}));

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -404,11 +404,9 @@ const nextConfig = {
     '@blocknote/react',
     '@blocknote/mantine',
     '@emoji-mart/data',
-    '@alga-psa/auth',
     '@alga-psa/ui',
     '@alga-psa/scheduling',
     '@alga-psa/users',
-    '@alga-psa/notifications',
     '@alga-psa/email',
     '@alga-psa/teams',
     '@alga-psa/tenancy',
@@ -481,9 +479,10 @@ const nextConfig = {
       '@img/sharp-libvips-dev/include': path.join(__dirname, 'src/empty/shims/empty.ts'),
       '@img/sharp-libvips-dev/cplusplus': path.join(__dirname, 'src/empty/shims/empty.ts'),
       '@img/sharp-wasm32/versions': path.join(__dirname, 'src/empty/shims/empty.ts'),
-      '@alga-psa/auth': path.join(__dirname, '../packages/auth/src'),
       '@alga-psa/ui': path.join(__dirname, '../packages/ui/src'),
       // Pre-built packages: src/ for local dev, dist/ for production (USE_PREBUILT=true)
+      '@alga-psa/auth': prebuiltDirAbs('auth'),
+      '@alga-psa/notifications': prebuiltDirAbs('notifications'),
       '@alga-psa/clients': prebuiltDirAbs('clients'),
       '@alga-psa/types': prebuiltDirAbs('types'),
       '@alga-psa/core': prebuiltDirAbs('core'),
@@ -532,7 +531,7 @@ const nextConfig = {
       // SSO provider buttons - swap between CE stub and EE implementation
       '@alga-psa/auth/sso/entry': isEE
         ? path.join(__dirname, '../ee/server/src/components/auth/SsoProviderButtons.tsx')
-        : path.join(__dirname, '../packages/auth/src/components/SsoProviderButtons.tsx'),
+        : path.join(__dirname, usePrebuilt ? '../packages/auth/dist/components/SsoProviderButtons.js' : '../packages/auth/src/components/SsoProviderButtons.tsx'),
       '@alga-psa/ee-stubs': isEE
         ? path.join(__dirname, '../ee/server/src')
         : path.join(__dirname, '../packages/ee/src'),


### PR DESCRIPTION
  Switch auth and notifications packages to use shared tsup preset and prebuiltDirAbs() in webpack aliases. Remove both from transpilePackages. Auth SSO CE entry respects USE_PREBUILT flag. ~126 more files skip Next.js transpilation in production builds.

  "'I simply cannot transpile another notification,' sighed the White Rabbit, collapsing beside his pocket watch. The Queen decreed that henceforth all auth and notifications shall arrive pre-built from dist/, and only the Looking Glass of USE_PREBUILT shall decide which kingdom — src/ or dist/ — they hail from." 🐇👑📦