### PR TITLE
[codex] Fix grouped invoice template bindings and suggestions

### DIFF
--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
@@ -176,6 +176,25 @@ const buildTransformedTemplateAst = () => {
   return exportWorkspaceToTemplateAst(workspace);
 };
 
+const findLayoutNodeById = (node: any, id: string): any | null => {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+  if (node.id === id) {
+    return node;
+  }
+  if (!Array.isArray(node.children)) {
+    return null;
+  }
+  for (const child of node.children) {
+    const match = findLayoutNodeById(child, id);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+};
+
 const installLocalStorageMock = () => {
   const backing = new Map<string, string>();
   const storageMock: Storage = {
@@ -591,6 +610,13 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
         'aggregate-total',
       ])
     );
+    expect(
+      (
+        useInvoiceDesignerStore.getState().nodesById['grouped-table']?.props as
+          | { metadata?: { collectionBindingKey?: string } }
+          | undefined
+      )?.metadata?.collectionBindingKey
+    ).toBe('lineItems.grouped');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save Template' }));
     await waitFor(() => expect(saveInvoiceTemplateMock).toHaveBeenCalledTimes(1));
@@ -618,6 +644,82 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
       ])
     );
     expect(useInvoiceDesignerStore.getState().transforms.outputBindingId).toBe('lineItems.grouped');
+    expect(
+      (
+        useInvoiceDesignerStore.getState().nodesById['grouped-table']?.props as
+          | { metadata?: { collectionBindingKey?: string } }
+          | undefined
+      )?.metadata?.collectionBindingKey
+    ).toBe('lineItems.grouped');
+  });
+
+  it('persists edited grouped-table aggregate column bindings through save and reopen', async () => {
+    const transformedAst = JSON.parse(JSON.stringify(buildTransformedTemplateAst()));
+    const groupedTable = findLayoutNodeById(transformedAst.layout, 'grouped-table');
+    expect(groupedTable?.type).toBe('dynamic-table');
+    if (!groupedTable || groupedTable.type !== 'dynamic-table') return;
+    groupedTable.columns = groupedTable.columns.map((column: { id: string; value: unknown }) =>
+      column.id === 'col-total'
+        ? {
+            ...column,
+            value: { type: 'path', path: 'total' },
+          }
+        : column
+    );
+
+    getInvoiceTemplateMock.mockResolvedValueOnce({
+      template_id: 'tpl-column-roundtrip',
+      name: 'Template Column Roundtrip',
+      templateAst: transformedAst,
+      isStandard: false,
+    });
+
+    const rendered = render(<InvoiceTemplateEditor templateId="tpl-column-roundtrip" />);
+
+    await waitFor(() => {
+      const groupedTableNode = useInvoiceDesignerStore.getState().nodesById['grouped-table'];
+      expect(groupedTableNode).toBeTruthy();
+      expect((groupedTableNode?.props as any)?.metadata?.columns?.find((column: { id: string }) => column.id === 'col-total')?.key).toBe('item.total');
+    });
+
+    act(() => {
+      useInvoiceDesignerStore.getState().setNodeProp(
+        'grouped-table',
+        'metadata.columns.1.key',
+        'item.aggregates.sumTotal',
+        true
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Template' }));
+    await waitFor(() => expect(saveInvoiceTemplateMock).toHaveBeenCalledTimes(1));
+
+    const savedAst = saveInvoiceTemplateMock.mock.calls[0]?.[0]?.templateAst;
+    const savedGroupedTable = findLayoutNodeById(savedAst.layout, 'grouped-table');
+    expect(savedGroupedTable?.type).toBe('dynamic-table');
+    if (!savedGroupedTable || savedGroupedTable.type !== 'dynamic-table') return;
+    expect(savedGroupedTable.columns.find((column: { id: string }) => column.id === 'col-total')?.value).toEqual({
+      type: 'path',
+      path: 'aggregates.sumTotal',
+    });
+
+    rendered.unmount();
+    useInvoiceDesignerStore.getState().resetWorkspace();
+    getInvoiceTemplateMock.mockResolvedValueOnce({
+      template_id: 'tpl-column-roundtrip',
+      name: 'Template Column Roundtrip',
+      templateAst: savedAst,
+      isStandard: false,
+    });
+
+    render(<InvoiceTemplateEditor templateId="tpl-column-roundtrip" />);
+
+    await waitFor(() => {
+      const groupedTableNode = useInvoiceDesignerStore.getState().nodesById['grouped-table'];
+      expect((groupedTableNode?.props as any)?.metadata?.columns?.find((column: { id: string }) => column.id === 'col-total')?.key).toBe(
+        'item.aggregates.sumTotal'
+      );
+    });
   });
 
   it('preserves reordered transform order through save and reopen', async () => {

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
@@ -300,6 +300,84 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     });
   });
 
+  it('round-trips transform output collection bindings for dynamic tables and totals', () => {
+    const ast = createAstDocument(
+      [
+        {
+          id: 'grouped-line-items',
+          type: 'dynamic-table',
+          repeat: {
+            sourceBinding: { bindingId: 'lineItems.grouped' },
+            itemBinding: 'item',
+          },
+          columns: [
+            {
+              id: 'group-key',
+              header: 'Category',
+              value: { type: 'path', path: 'key' },
+            },
+            {
+              id: 'group-total',
+              header: 'Amount',
+              value: { type: 'path', path: 'aggregates.sumTotal' },
+              format: 'currency',
+            },
+          ],
+        },
+        {
+          id: 'grouped-totals',
+          type: 'totals',
+          sourceBinding: { bindingId: 'lineItems.grouped' },
+          rows: [
+            {
+              id: 'total',
+              label: 'Total',
+              value: { type: 'path', path: 'aggregates.sumTotal' },
+              format: 'currency',
+            },
+          ],
+        },
+      ],
+      {
+        transforms: {
+          sourceBindingId: 'lineItems',
+          outputBindingId: 'lineItems.grouped',
+          operations: [
+            {
+              id: 'group-category',
+              type: 'group',
+              key: 'category',
+            },
+            {
+              id: 'aggregate-total',
+              type: 'aggregate',
+              aggregations: [{ id: 'sumTotal', op: 'sum', path: 'total' }],
+            },
+          ],
+        },
+        bindings: {
+          values: {},
+          collections: {
+            lineItems: { id: 'lineItems', kind: 'collection', path: 'items' },
+          },
+        },
+      }
+    );
+
+    const roundTripped = roundTripAst(ast);
+    const layout = getDocumentNode(roundTripped);
+
+    const groupedTable = findNodeById(layout, 'grouped-line-items');
+    expect(groupedTable?.type).toBe('dynamic-table');
+    if (!groupedTable || groupedTable.type !== 'dynamic-table') return;
+    expect(groupedTable.repeat.sourceBinding.bindingId).toBe('lineItems.grouped');
+
+    const groupedTotals = findNodeById(layout, 'grouped-totals');
+    expect(groupedTotals?.type).toBe('totals');
+    if (!groupedTotals || groupedTotals.type !== 'totals') return;
+    expect(groupedTotals.sourceBinding.bindingId).toBe('lineItems.grouped');
+  });
+
   it('round-trips totals rows with expression, format, and emphasize', () => {
     const ast = createAstDocument(
       [

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.test.ts
@@ -209,6 +209,46 @@ describe('exportWorkspaceToTemplateAst', () => {
     });
   });
 
+  it('exports edited dynamic-table column keys over stale imported path expressions', () => {
+    const workspace = createWorkspaceWithFieldAndDynamicTable();
+    const table = workspace.nodesById['ast-table-1'];
+    if (!table) return;
+
+    workspace.nodesById['ast-table-1'] = {
+      ...table,
+      props: {
+        ...table.props,
+        metadata: {
+          ...(table.props.metadata as Record<string, unknown>),
+          columns: [
+            { id: 'col-desc', header: 'Description', key: 'item.description' },
+            {
+              id: 'col-total',
+              header: 'Amount',
+              key: 'item.aggregates.sumTotal',
+              valueExpression: { type: 'path', path: 'total' },
+              format: 'currency',
+            },
+          ],
+        },
+      },
+    };
+
+    const ast = exportWorkspaceToTemplateAst(workspace);
+    const pageSection = ast.layout.children?.find((child) => child.type === 'section');
+    expect(pageSection).toBeTruthy();
+    if (!pageSection || pageSection.type !== 'section') return;
+
+    const dynamicTable = pageSection.children.find((child) => child.type === 'dynamic-table');
+    expect(dynamicTable).toBeTruthy();
+    if (!dynamicTable || dynamicTable.type !== 'dynamic-table') return;
+
+    expect(dynamicTable.columns.find((column) => column.id === 'col-total')?.value).toEqual({
+      type: 'path',
+      path: 'aggregates.sumTotal',
+    });
+  });
+
   it('roundtrips CSS-like layout/style props through AST inline styles', () => {
     const base = useInvoiceDesignerStore.getState().exportWorkspace();
     const pageNode = Object.values(base.nodesById).find((node) => node.type === 'page');

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -765,11 +765,18 @@ const mapTableColumns = (node: WorkspaceNode): TemplateTableColumn[] => {
         ? column.valueExpression
         : null;
       const parsedFormat = parseTemplateValueFormat(column.format ?? column.type);
+      const placeholderKey = sanitizeId(id);
+      const resolvedValue =
+        preservedExpression?.type === 'path'
+          ? { type: 'path' as const, path: key.length > 0 ? key : 'description' }
+          : key.length > 0 && key !== placeholderKey
+            ? { type: 'path' as const, path: key }
+            : preservedExpression ?? { type: 'path' as const, path: key.length > 0 ? key : 'description' };
 
       const mapped: TemplateTableColumn = {
         id: sanitizeId(id),
         header: header.length > 0 ? header : undefined,
-        value: preservedExpression ?? { type: 'path', path: key.length > 0 ? key : 'description' },
+        value: resolvedValue,
       };
       const style = mapColumnStyle(column.style);
       if (style) {
@@ -1389,6 +1396,31 @@ const denormalizeBindingPath = (path: string): string => {
   return aliases[path] ?? path;
 };
 
+const resolveImportedCollectionBindingPath = (
+  astInput: TemplateAst,
+  bindingId: string,
+  fallbackPath = 'items'
+): string => {
+  const trimmedBindingId = asTrimmedString(bindingId);
+  if (trimmedBindingId.length === 0) {
+    return fallbackPath;
+  }
+
+  const registeredPath = astInput.bindings?.collections?.[trimmedBindingId]?.path;
+  if (typeof registeredPath === 'string' && registeredPath.trim().length > 0) {
+    return registeredPath;
+  }
+
+  const transformOutputBindingId = normalizeInvoiceBindingPath(
+    asTrimmedString(astInput.transforms?.outputBindingId)
+  );
+  if (transformOutputBindingId.length > 0 && normalizeInvoiceBindingPath(trimmedBindingId) === transformOutputBindingId) {
+    return transformOutputBindingId;
+  }
+
+  return fallbackPath;
+};
+
 const parseSizeFromStyle = (node: TemplateNode): { width?: number; height?: number } => {
   const inline = node.style?.inline ?? {};
   return {
@@ -1690,12 +1722,12 @@ export const importTemplateAstToWorkspace = (
             metadata.emptyValue = inputNode.emptyValue;
           }
         } else if (inputNode.type === 'dynamic-table' || inputNode.type === 'table') {
-          const collectionPath =
-            astInput.bindings?.collections?.[
-              inputNode.type === 'dynamic-table'
-                ? inputNode.repeat.sourceBinding.bindingId
-                : inputNode.sourceBinding.bindingId
-            ]?.path ?? 'items';
+          const collectionPath = resolveImportedCollectionBindingPath(
+            astInput,
+            inputNode.type === 'dynamic-table'
+              ? inputNode.repeat.sourceBinding.bindingId
+              : inputNode.sourceBinding.bindingId
+          );
           metadata.collectionBindingKey = denormalizeBindingPath(collectionPath);
           metadata.columns = inputNode.columns.map((column) => {
             const mappedColumn: Record<string, unknown> = {
@@ -1724,9 +1756,11 @@ export const importTemplateAstToWorkspace = (
             if (hs.color) metadata.headerColor = hs.color;
           }
         } else if (inputNode.type === 'totals') {
-          const sourcePath =
-            astInput.bindings?.collections?.[inputNode.sourceBinding.bindingId]?.path ??
-            inputNode.sourceBinding.bindingId;
+          const sourcePath = resolveImportedCollectionBindingPath(
+            astInput,
+            inputNode.sourceBinding.bindingId,
+            inputNode.sourceBinding.bindingId
+          );
           metadata.collectionBindingKey = denormalizeBindingPath(sourcePath);
           metadata.totalsRows = inputNode.rows.map((row) => ({
             id: row.id,

--- a/packages/billing/src/components/invoice-designer/inspector/TableEditorWidget.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/TableEditorWidget.integration.test.tsx
@@ -354,6 +354,10 @@ describe('TableEditorWidget (schema widget integration)', () => {
 
     expect(screen.getAllByText('item.key').length).toBeGreaterThan(0);
     expect(screen.getAllByText('item.aggregates.sumTotal').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'item.description' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'item.unitPrice' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Description' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Rate' })).toBeNull();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'item.aggregates.sumTotal' })[0]!);
 
@@ -380,12 +384,16 @@ describe('TableEditorWidget (schema widget integration)', () => {
     });
 
     expect(screen.getAllByText('item.aggregates.sumTotal').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Description' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'item.description' })).toBeNull();
 
     await selectCustomOption('designer-table-source-binding', 'items (Transforms source)');
 
     await waitFor(() => {
       expect(screen.queryAllByText('item.aggregates.sumTotal')).toHaveLength(0);
       expect(screen.getAllByText('item.description').length).toBeGreaterThan(0);
+      expect(screen.getByRole('button', { name: 'Description' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'item.description' })).toBeTruthy();
     });
   });
 
@@ -408,9 +416,9 @@ describe('TableEditorWidget (schema widget integration)', () => {
     const options = await screen.findAllByRole('option');
     const optionLabels = options.map((option) => option.textContent?.trim());
 
-    expect(optionLabels).toContain('recurringItems (recurring_items)');
-    expect(optionLabels).toContain('onetimeItems (onetime_items)');
-    expect(optionLabels).toContain('serviceItems (service_items)');
-    expect(optionLabels).toContain('productItems (product_items)');
+    expect(optionLabels).toContain('Recurring Items');
+    expect(optionLabels).toContain('One-time Items');
+    expect(optionLabels).toContain('Service Items');
+    expect(optionLabels).toContain('Product Items');
   });
 });

--- a/packages/billing/src/components/invoice-designer/inspector/widgets/TableEditorWidget.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/widgets/TableEditorWidget.tsx
@@ -147,6 +147,13 @@ export const TableEditorWidget: React.FC<Props> = ({ node }) => {
 
   const metadata = useMemo(() => getNodeMetadata(node), [node]);
   const sourceBindingId = useMemo(() => resolveTableSourceBindingId(metadata), [metadata]);
+  const isGroupedTransformsOutput = useMemo(() => {
+    if (sourceBindingId !== transforms.outputBindingId || !hasDesignerTransforms(transforms)) {
+      return false;
+    }
+
+    return transforms.operations.some((operation) => operation.type === 'group');
+  }, [sourceBindingId, transforms]);
 
   const columns: ColumnModel[] = useMemo(() => {
     const raw = (metadata as { columns?: unknown }).columns;
@@ -224,12 +231,7 @@ export const TableEditorWidget: React.FC<Props> = ({ node }) => {
       ...columns.map((column) => asTrimmedString(column.key)),
     ]);
 
-    if (sourceBindingId !== transforms.outputBindingId || !hasDesignerTransforms(transforms)) {
-      return rawSuggestions;
-    }
-
-    const isGroupedOutput = transforms.operations.some((operation) => operation.type === 'group');
-    if (!isGroupedOutput) {
+    if (!isGroupedTransformsOutput) {
       return rawSuggestions;
     }
 
@@ -241,9 +243,8 @@ export const TableEditorWidget: React.FC<Props> = ({ node }) => {
       'item.key',
       'item.items',
       ...aggregateSuggestions,
-      ...columns.map((column) => asTrimmedString(column.key)),
     ]);
-  }, [columns, sourceBindingId, transforms]);
+  }, [columns, isGroupedTransformsOutput, transforms]);
 
   const resolvedBorderPreset: BorderPreset = useMemo(() => {
     const preset = (metadata as { tableBorderPreset?: unknown }).tableBorderPreset;
@@ -422,20 +423,22 @@ export const TableEditorWidget: React.FC<Props> = ({ node }) => {
             + Column
           </Button>
         </div>
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-[11px] text-slate-400 dark:text-slate-500 shrink-0">Quick add:</span>
-          {COLUMN_PRESETS.map((preset) => (
-            <button
-              key={preset.id}
-              id={`designer-add-column-preset-${preset.id}`}
-              type="button"
-              className="inline-flex h-6 items-center rounded-md border border-slate-200 dark:border-[rgb(var(--color-border-200))] bg-slate-50 dark:bg-[rgb(var(--color-background))] px-2 text-[11px] font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-500 transition-colors"
-              onClick={() => handleAddPresetColumn(preset.id)}
-            >
-              {preset.label}
-            </button>
-          ))}
-        </div>
+        {!isGroupedTransformsOutput && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[11px] text-slate-400 dark:text-slate-500 shrink-0">Quick add:</span>
+            {COLUMN_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                id={`designer-add-column-preset-${preset.id}`}
+                type="button"
+                className="inline-flex h-6 items-center rounded-md border border-slate-200 dark:border-[rgb(var(--color-border-200))] bg-slate-50 dark:bg-[rgb(var(--color-background))] px-2 text-[11px] font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-500 transition-colors"
+                onClick={() => handleAddPresetColumn(preset.id)}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Table style */}
@@ -666,12 +669,13 @@ export const TableEditorWidget: React.FC<Props> = ({ node }) => {
               </span>
             </div>
           ))}
-          {COLUMN_PRESETS.map((preset) => (
-            <div key={`legend-${preset.id}`} className="flex items-center justify-between rounded px-2 py-0.5 bg-slate-50 dark:bg-[rgb(var(--color-background))]">
-              <code className="text-[11px] text-slate-600 dark:text-slate-400">{preset.key}</code>
-              <span className="text-[10px] text-slate-400 dark:text-slate-500">{preset.description}</span>
-            </div>
-          ))}
+          {!isGroupedTransformsOutput &&
+            COLUMN_PRESETS.map((preset) => (
+              <div key={`legend-${preset.id}`} className="flex items-center justify-between rounded px-2 py-0.5 bg-slate-50 dark:bg-[rgb(var(--color-background))]">
+                <code className="text-[11px] text-slate-600 dark:text-slate-400">{preset.key}</code>
+                <span className="text-[10px] text-slate-400 dark:text-slate-500">{preset.description}</span>
+              </div>
+            ))}
         </div>
       </details>
     </div>

--- a/packages/billing/src/lib/invoice-template-ast/evaluator.ts
+++ b/packages/billing/src/lib/invoice-template-ast/evaluator.ts
@@ -514,11 +514,18 @@ export const evaluateTemplateAst = (
             operation.id
           );
         }
-        aggregates = computeAggregateFromItems(aggregateSource, operation);
+        const nextAggregates = computeAggregateFromItems(aggregateSource, operation);
+        aggregates = {
+          ...aggregates,
+          ...nextAggregates,
+        };
         if (groups) {
           groups = groups.map((group) => ({
             ...group,
-            aggregates: computeAggregateFromItems(group.items, operation),
+            aggregates: {
+              ...(group.aggregates ?? {}),
+              ...computeAggregateFromItems(group.items, operation),
+            },
           }));
         }
         break;
@@ -598,4 +605,3 @@ export const evaluateAstTransforms = (
   ast: TemplateAst,
   invoiceData: UnknownRecord
 ): TemplateEvaluationResult => evaluateTemplateAst(ast, invoiceData);
-

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -277,6 +277,77 @@ describe('renderEvaluatedTemplateAst', () => {
     expect(rendered.html).toContain('1');
   });
 
+  it('renders grouped dynamic-table rows when aggregate ids are produced across multiple aggregate steps', async () => {
+    const groupedInvoiceFixture = {
+      ...invoiceFixture,
+      items: [
+        { id: 'a', description: 'Consulting', quantity: 2, unitPrice: 100, total: 200, category: 'Services' },
+        { id: 'b', description: 'Support', quantity: 1, unitPrice: 100, total: 100, category: 'Services' },
+        { id: 'c', description: 'Hardware', quantity: 1, unitPrice: 30, total: 30, category: 'Products' },
+      ],
+    };
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {},
+        collections: {
+          lineItems: { id: 'lineItems', kind: 'collection', path: 'items' },
+        },
+      },
+      transforms: {
+        sourceBindingId: 'lineItems',
+        outputBindingId: 'lineItems.grouped',
+        operations: [
+          {
+            id: 'group-category',
+            type: 'group',
+            key: 'category',
+          },
+          {
+            id: 'aggregate-qty',
+            type: 'aggregate',
+            aggregations: [{ id: 'sumQty', op: 'sum', path: 'quantity' }],
+          },
+          {
+            id: 'aggregate-total',
+            type: 'aggregate',
+            aggregations: [{ id: 'sumTotal', op: 'sum', path: 'total' }],
+          },
+        ],
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'grouped-line-items',
+            type: 'dynamic-table',
+            repeat: {
+              sourceBinding: { bindingId: 'lineItems.grouped' },
+              itemBinding: 'item',
+            },
+            columns: [
+              { id: 'group-key', header: 'Category', value: { type: 'path', path: 'key' } },
+              { id: 'group-qty', header: 'Qty', value: { type: 'path', path: 'aggregates.sumQty' }, format: 'number' },
+              { id: 'group-total', header: 'Total', value: { type: 'path', path: 'aggregates.sumTotal' } },
+            ],
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, groupedInvoiceFixture);
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('Services');
+    expect(rendered.html).toContain('Products');
+    expect(rendered.html).toContain('3');
+    expect(rendered.html).toContain('1');
+    expect(rendered.html).toContain('300');
+    expect(rendered.html).toContain('30');
+  });
+
   it('applies class tokens and style declarations consistently', async () => {
     const ast: TemplateAst = {
       kind: 'invoice-template-ast',


### PR DESCRIPTION
## Summary
Fix invoice template grouped-table behavior end to end:

- preserve transforms output bindings when saving and reopening dynamic tables and totals
- persist edited grouped aggregate column keys instead of re-exporting stale imported paths
- merge grouped aggregate values correctly in preview rendering
- limit grouped-table field suggestions to grouped-safe bindings in the inspector while keeping manual custom entry available

## Root Cause
The grouped invoice template flow had several separate regressions:

- AST import only restored collection bindings from `bindings.collections`, so authored transforms output bindings fell back on reopen
- dynamic table export preferred stale imported `valueExpression` over the edited column key
- grouped aggregate evaluation overwrote prior aggregate results instead of merging them
- the inspector continued surfacing raw line-item presets even when the table was bound to grouped transform output

## Impact
Grouped invoice templates now round-trip correctly, preview grouped aggregate values correctly, and guide authors toward bindings that make sense for grouped rows.

## Validation
- `cd server && npx vitest run ../packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts`
- `cd server && npx vitest run ../packages/billing/src/components/invoice-designer/ast/workspaceAst.test.ts`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx`
- `cd server && npx vitest run ../packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx`
- `cd server && npx vitest run ../packages/billing/src/lib/invoice-template-ast/evaluator.test.ts`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/inspector/TableEditorWidget.integration.test.tsx`

## Notes
I could not complete a final live Alga Dev browser smoke check for the last inspector-only change because the local `alga-dev` browser socket started returning `EPERM` while trying to retarget the existing pane.