### PR TITLE
[codex] Improve invoice template designer follow-ups

### DIFF
--- a/packages/billing/src/actions/invoiceTemplatePreview.integration.test.ts
+++ b/packages/billing/src/actions/invoiceTemplatePreview.integration.test.ts
@@ -147,6 +147,102 @@ describe('invoiceTemplatePreview authoritative AST integration', () => {
     expect(actionResult.verification.status).toBe('pass');
   });
 
+  it('renders multiline address fields in authoritative preview when displayFormat is set', async () => {
+    const addressWorkspace: DesignerWorkspaceSnapshot = {
+      ...workspace,
+      nodesById: {
+        ...workspace.nodesById,
+        page: {
+          ...workspace.nodesById.page,
+          children: ['field-address'],
+        },
+        'field-address': {
+          id: 'field-address',
+          type: 'field',
+          props: {
+            name: 'Tenant Address',
+            metadata: {
+              bindingKey: 'tenant.address',
+              format: 'text',
+              displayFormat: 'multiline',
+            },
+            size: { width: 220, height: 48 },
+            position: { x: 24, y: 24 },
+          },
+          children: [],
+        },
+      },
+    };
+
+    const actionResult = await (runAuthoritativeInvoiceTemplatePreview as any)(
+      { id: 'test-user' },
+      { tenant: 'test-tenant' },
+      {
+        workspace: addressWorkspace,
+        invoiceData: {
+          ...invoiceData,
+          tenantClient: {
+            ...invoiceData.tenantClient,
+            address: '400 SW Main St, Portland, OR 97204',
+          },
+        },
+      }
+    );
+
+    expect(actionResult.render.status).toBe('success');
+    expect(actionResult.render.html).toContain('white-space:pre-line');
+    expect(actionResult.render.html).toContain('400 SW Main St');
+    expect(actionResult.render.html).toContain('Portland');
+  });
+
+  it('renders client.address bindings in authoritative preview via the customer alias', async () => {
+    const addressWorkspace: DesignerWorkspaceSnapshot = {
+      ...workspace,
+      nodesById: {
+        ...workspace.nodesById,
+        page: {
+          ...workspace.nodesById.page,
+          children: ['field-address'],
+        },
+        'field-address': {
+          id: 'field-address',
+          type: 'field',
+          props: {
+            name: 'Client Address',
+            metadata: {
+              bindingKey: 'client.address',
+              format: 'text',
+              displayFormat: 'multiline',
+            },
+            size: { width: 220, height: 48 },
+            position: { x: 24, y: 24 },
+          },
+          children: [],
+        },
+      },
+    };
+
+    const actionResult = await (runAuthoritativeInvoiceTemplatePreview as any)(
+      { id: 'test-user' },
+      { tenant: 'test-tenant' },
+      {
+        workspace: addressWorkspace,
+        invoiceData: {
+          ...invoiceData,
+          customer: {
+            ...invoiceData.customer,
+            address: '901 Harbor Ave, Seattle, WA 98104',
+          },
+        },
+      }
+    );
+
+    expect(actionResult.render.status).toBe('success');
+    expect(actionResult.render.html).toContain('white-space:pre-line');
+    expect(actionResult.render.html).toContain('901 Harbor Ave');
+    expect(actionResult.render.html).toContain('Seattle');
+  });
+
   it('surfaces structured schema diagnostics with AST context', async () => {
     const schemaSpy = vi.spyOn(schemaModule, 'validateTemplateAst').mockReturnValueOnce({
       success: false,

--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
@@ -334,6 +334,58 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
     });
   });
 
+  it('persists edited field designer placeholders through save and reopen', async () => {
+    const workspace = createWorkspaceWithField('placeholder-field');
+    getInvoiceTemplateMock.mockResolvedValueOnce({
+      template_id: 'tpl-placeholder',
+      name: 'Template Placeholder',
+      templateAst: exportWorkspaceToTemplateAst(workspace as any),
+      isStandard: false,
+    });
+
+    const rendered = render(<InvoiceTemplateEditor templateId="tpl-placeholder" />);
+
+    await waitFor(() => {
+      const fieldNode = useInvoiceDesignerStore.getState().nodesById['placeholder-field'];
+      expect(fieldNode).toBeTruthy();
+      expect((fieldNode?.props as any)?.metadata?.placeholder).toBe('Invoice Number');
+    });
+
+    act(() => {
+      useInvoiceDesignerStore.getState().setNodeProp(
+        'placeholder-field',
+        'metadata.placeholder',
+        'Invoice Reference',
+        true
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Template' }));
+    await waitFor(() => expect(saveInvoiceTemplateMock).toHaveBeenCalledTimes(1));
+
+    const savedAst = saveInvoiceTemplateMock.mock.calls[0]?.[0]?.templateAst;
+    const savedField = findLayoutNodeById(savedAst.layout, 'placeholder-field');
+    expect(savedField?.type).toBe('field');
+    if (!savedField || savedField.type !== 'field') return;
+    expect(savedField.placeholder).toBe('Invoice Reference');
+
+    rendered.unmount();
+    useInvoiceDesignerStore.getState().resetWorkspace();
+    getInvoiceTemplateMock.mockResolvedValueOnce({
+      template_id: 'tpl-placeholder',
+      name: 'Template Placeholder',
+      templateAst: savedAst,
+      isStandard: false,
+    });
+
+    render(<InvoiceTemplateEditor templateId="tpl-placeholder" />);
+
+    await waitFor(() => {
+      const fieldNode = useInvoiceDesignerStore.getState().nodesById['placeholder-field'];
+      expect((fieldNode?.props as any)?.metadata?.placeholder).toBe('Invoice Reference');
+    });
+  });
+
   it('keeps save payload behavior while preview sub-tab is active', async () => {
     render(<InvoiceTemplateEditor templateId="tpl-1" />);
     await waitFor(() => expect(screen.getByTestId('designer-visual-workspace')).toBeTruthy());

--- a/packages/billing/src/components/invoice-designer/DesignerShell.fieldDisplayControls.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.fieldDisplayControls.integration.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInvoiceDesignerStore } from './state/designerStore';
+
+vi.mock('./palette/ComponentPalette', () => ({
+  ComponentPalette: () => <div data-automation-id="component-palette-mock" />,
+}));
+
+vi.mock('./canvas/DesignCanvas', () => ({
+  DesignCanvas: () => <div data-automation-id="design-canvas-mock" />,
+}));
+
+vi.mock('./toolbar/DesignerToolbar', () => ({
+  DesignerToolbar: () => <div data-automation-id="designer-toolbar-mock" />,
+}));
+
+vi.mock('./inspector/DesignerSchemaInspector', () => ({
+  DesignerSchemaInspector: () => <div data-automation-id="designer-schema-inspector-mock" />,
+}));
+
+vi.mock('./inspector/widgets/DocumentImagePickerWidget', () => ({
+  default: () => <div data-automation-id="document-image-picker-mock" />,
+}));
+
+import { DesignerShell } from './DesignerShell';
+
+const seedSelectedField = (bindingKey: string) => {
+  act(() => {
+    useInvoiceDesignerStore.getState().loadWorkspace({
+      nodes: [
+        {
+          id: 'doc-1',
+          type: 'document',
+          props: { name: 'Document' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: null,
+          children: ['page-1'],
+          allowedChildren: ['page'],
+        },
+        {
+          id: 'page-1',
+          type: 'page',
+          props: { name: 'Page' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: 'doc-1',
+          children: ['field-1'],
+          allowedChildren: ['field'],
+        },
+        {
+          id: 'field-1',
+          type: 'field',
+          props: {
+            name: 'Bound Field',
+            metadata: {
+              bindingKey,
+              format: 'text',
+            },
+          },
+          position: { x: 24, y: 24 },
+          size: { width: 220, height: 60 },
+          parentId: 'page-1',
+          children: [],
+          allowedChildren: [],
+        },
+      ],
+      snapToGrid: true,
+      gridSize: 8,
+      showGuides: true,
+      showRulers: true,
+      canvasScale: 1,
+    } as any);
+    useInvoiceDesignerStore.getState().selectNode('field-1');
+  });
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DesignerShell field display controls', () => {
+  beforeEach(() => {
+    useInvoiceDesignerStore.getState().resetWorkspace();
+  });
+
+  it('shows address display formats and persists the selected mode', () => {
+    seedSelectedField('tenant.address');
+
+    render(<DesignerShell />);
+
+    expect(screen.getByText('Display Format')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Display format: Multiline' }));
+
+    const updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.metadata?.displayFormat).toBe('multiline');
+  });
+
+  it('shows address display controls for address aliases like client.address', () => {
+    seedSelectedField('client.address');
+
+    render(<DesignerShell />);
+
+    expect(screen.getByText('Display Format')).toBeTruthy();
+  });
+
+  it('shows address display controls for imported tenantClient.address bindings', () => {
+    seedSelectedField('tenantClient.address');
+
+    render(<DesignerShell />);
+
+    expect(screen.getByText('Display Format')).toBeTruthy();
+  });
+
+  it('shows address display controls for contact.address', () => {
+    seedSelectedField('contact.address');
+
+    render(<DesignerShell />);
+
+    expect(screen.getByText('Display Format')).toBeTruthy();
+  });
+
+  it('does not show address display controls for non-address bindings', () => {
+    seedSelectedField('invoice.number');
+
+    render(<DesignerShell />);
+
+    expect(screen.queryByText('Display Format')).toBeNull();
+  });
+});

--- a/packages/billing/src/components/invoice-designer/DesignerShell.flexItemControls.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.flexItemControls.integration.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInvoiceDesignerStore } from './state/designerStore';
+
+vi.mock('./palette/ComponentPalette', () => ({
+  ComponentPalette: () => <div data-automation-id="component-palette-mock" />,
+}));
+
+vi.mock('./canvas/DesignCanvas', () => ({
+  DesignCanvas: () => <div data-automation-id="design-canvas-mock" />,
+}));
+
+vi.mock('./toolbar/DesignerToolbar', () => ({
+  DesignerToolbar: () => <div data-automation-id="designer-toolbar-mock" />,
+}));
+
+vi.mock('./inspector/DesignerSchemaInspector', () => ({
+  DesignerSchemaInspector: () => <div data-automation-id="designer-schema-inspector-mock" />,
+}));
+
+vi.mock('./inspector/widgets/DocumentImagePickerWidget', () => ({
+  default: () => <div data-automation-id="document-image-picker-mock" />,
+}));
+
+import { DesignerShell } from './DesignerShell';
+
+const seedSelectedFlexChild = () => {
+  act(() => {
+    const store = useInvoiceDesignerStore.getState();
+    store.loadWorkspace({
+      nodes: [
+        {
+          id: 'doc-1',
+          type: 'document',
+          props: { name: 'Document' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: null,
+          children: ['page-1'],
+          allowedChildren: ['page'],
+        },
+        {
+          id: 'page-1',
+          type: 'page',
+          props: { name: 'Page' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: 'doc-1',
+          children: ['section-1'],
+          allowedChildren: ['section'],
+        },
+        {
+          id: 'section-1',
+          type: 'section',
+          props: {
+            name: 'Header Row',
+            layout: {
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '16px',
+              padding: '16px',
+              justifyContent: 'flex-start',
+              alignItems: 'stretch',
+            },
+            metadata: {},
+            style: { width: '520px', height: '160px' },
+          },
+          position: { x: 24, y: 24 },
+          size: { width: 520, height: 160 },
+          parentId: 'page-1',
+          children: ['field-1'],
+          allowedChildren: ['field'],
+        },
+        {
+          id: 'field-1',
+          type: 'field',
+          props: {
+            name: 'Invoice Number',
+            metadata: { bindingKey: 'invoice.number' },
+            style: { width: '180px', height: '48px' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 180, height: 48 },
+          parentId: 'section-1',
+          children: [],
+          allowedChildren: [],
+        },
+      ],
+      snapToGrid: true,
+      gridSize: 8,
+      showGuides: true,
+      showRulers: true,
+      canvasScale: 1,
+    } as any);
+    store.selectNode('field-1');
+  });
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DesignerShell flex item controls', () => {
+  beforeEach(() => {
+    useInvoiceDesignerStore.getState().resetWorkspace();
+  });
+
+  it('applies share preset and advanced preferred size edits for flex children', () => {
+    seedSelectedFlexChild();
+
+    render(<DesignerShell />);
+
+    expect(screen.getByText('Flex Item')).toBeTruthy();
+    expect(screen.getByText(/shares width with its siblings/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Width behavior: Share' }));
+
+    let updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.style?.flexGrow).toBe(1);
+    expect((updated.props as any)?.style?.flexShrink).toBe(1);
+    expect((updated.props as any)?.style?.flexBasis).toBe('0%');
+
+    fireEvent.click(screen.getByText('Advanced Flex Values'));
+    const preferredSizeInput = screen.getByPlaceholderText('auto | 240px | 50%') as HTMLInputElement;
+    fireEvent.change(preferredSizeInput, { target: { value: '320px' } });
+    fireEvent.blur(preferredSizeInput);
+
+    updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.style?.flexBasis).toBe('320px');
+  });
+});

--- a/packages/billing/src/components/invoice-designer/DesignerShell.mediaControls.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.mediaControls.integration.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInvoiceDesignerStore } from './state/designerStore';
+
+vi.mock('./palette/ComponentPalette', () => ({
+  ComponentPalette: () => <div data-automation-id="component-palette-mock" />,
+}));
+
+vi.mock('./canvas/DesignCanvas', () => ({
+  DesignCanvas: () => <div data-automation-id="design-canvas-mock" />,
+}));
+
+vi.mock('./toolbar/DesignerToolbar', () => ({
+  DesignerToolbar: () => <div data-automation-id="designer-toolbar-mock" />,
+}));
+
+vi.mock('./inspector/DesignerSchemaInspector', () => ({
+  DesignerSchemaInspector: () => <div data-automation-id="designer-schema-inspector-mock" />,
+}));
+
+vi.mock('./inspector/widgets/DocumentImagePickerWidget', () => ({
+  default: () => <div data-automation-id="document-image-picker-mock" />,
+}));
+
+import { DesignerShell } from './DesignerShell';
+
+const seedSelectedMediaNode = () => {
+  act(() => {
+    const store = useInvoiceDesignerStore.getState();
+    store.loadWorkspace({
+      nodes: [
+        {
+          id: 'doc-1',
+          type: 'document',
+          props: { name: 'Document' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: null,
+          children: ['page-1'],
+          allowedChildren: ['page'],
+        },
+        {
+          id: 'page-1',
+          type: 'page',
+          props: { name: 'Page' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: 'doc-1',
+          children: ['logo-1'],
+          allowedChildren: ['image', 'logo', 'qr'],
+        },
+        {
+          id: 'logo-1',
+          type: 'logo',
+          props: {
+            name: 'Issuer Logo',
+            style: {
+              objectFit: 'contain',
+            },
+            metadata: {
+              src: '/logo.png',
+              fitMode: 'contain',
+              fit: 'contain',
+            },
+          },
+          position: { x: 24, y: 24 },
+          size: { width: 180, height: 72 },
+          parentId: 'page-1',
+          children: [],
+          allowedChildren: [],
+        },
+      ],
+      snapToGrid: true,
+      gridSize: 8,
+      showGuides: true,
+      showRulers: true,
+      canvasScale: 1,
+    } as any);
+    store.selectNode('logo-1');
+  });
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DesignerShell media controls', () => {
+  beforeEach(() => {
+    useInvoiceDesignerStore.getState().resetWorkspace();
+  });
+
+  it('updates object fit through the icon button control', () => {
+    seedSelectedMediaNode();
+
+    render(<DesignerShell />);
+
+    const containButton = screen.getByRole('button', { name: 'Object Fit: Contain' });
+    const coverButton = screen.getByRole('button', { name: 'Object Fit: Cover' });
+
+    expect(containButton.getAttribute('aria-pressed')).toBe('true');
+    expect(coverButton.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(coverButton);
+
+    const mediaNode = useInvoiceDesignerStore.getState().nodesById['logo-1'];
+    expect((mediaNode.props as any)?.style?.objectFit).toBe('cover');
+    expect((mediaNode.props as any)?.metadata?.fitMode).toBe('cover');
+    expect((mediaNode.props as any)?.metadata?.fit).toBe('cover');
+    expect(screen.getByRole('button', { name: 'Object Fit: Cover' }).getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/packages/billing/src/components/invoice-designer/DesignerShell.sharedSizing.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.sharedSizing.integration.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInvoiceDesignerStore } from './state/designerStore';
+
+vi.mock('./palette/ComponentPalette', () => ({
+  ComponentPalette: () => <div data-automation-id="component-palette-mock" />,
+}));
+
+vi.mock('./canvas/DesignCanvas', () => ({
+  DesignCanvas: () => <div data-automation-id="design-canvas-mock" />,
+}));
+
+vi.mock('./toolbar/DesignerToolbar', () => ({
+  DesignerToolbar: () => <div data-automation-id="designer-toolbar-mock" />,
+}));
+
+vi.mock('./inspector/DesignerSchemaInspector', () => ({
+  DesignerSchemaInspector: () => <div data-automation-id="designer-schema-inspector-mock" />,
+}));
+
+vi.mock('./inspector/widgets/DocumentImagePickerWidget', () => ({
+  default: () => <div data-automation-id="document-image-picker-mock" />,
+}));
+
+import { DesignerShell } from './DesignerShell';
+
+const seedSelectedDynamicTableNode = () => {
+  act(() => {
+    const store = useInvoiceDesignerStore.getState();
+    store.loadWorkspace({
+      nodes: [
+        {
+          id: 'doc-1',
+          type: 'document',
+          props: { name: 'Document' },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: null,
+          children: ['page-1'],
+          allowedChildren: ['page'],
+        },
+        {
+          id: 'page-1',
+          type: 'page',
+          props: {
+            name: 'Page',
+            layout: { display: 'flex', flexDirection: 'column', gap: '32px', padding: '40px' },
+            style: { width: '816px', height: '1056px' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 816, height: 1056 },
+          parentId: 'doc-1',
+          children: ['table-1'],
+          allowedChildren: ['section', 'table', 'dynamic-table', 'totals'],
+        },
+        {
+          id: 'table-1',
+          type: 'dynamic-table',
+          props: {
+            name: 'Line Items',
+            metadata: {
+              collectionBindingKey: 'items',
+              columns: [
+                { id: 'description', header: 'Description', key: 'item.description', type: 'text' },
+                { id: 'total', header: 'Amount', key: 'item.total', type: 'currency' },
+              ],
+            },
+            style: {
+              width: '520px',
+              height: '240px',
+            },
+          },
+          position: { x: 40, y: 80 },
+          size: { width: 520, height: 240 },
+          parentId: 'page-1',
+          children: [],
+          allowedChildren: [],
+        },
+      ],
+      snapToGrid: true,
+      gridSize: 8,
+      showGuides: true,
+      showRulers: true,
+      canvasScale: 1,
+    } as any);
+    store.selectNode('table-1');
+  });
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DesignerShell shared sizing controls', () => {
+  beforeEach(() => {
+    useInvoiceDesignerStore.getState().resetWorkspace();
+  });
+
+  it('preserves fill-width and hug-height sizing across raw property commits', () => {
+    seedSelectedDynamicTableNode();
+
+    render(<DesignerShell />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Width: Fill' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Height: Hug' }));
+
+    const stateAfterModeChange = useInvoiceDesignerStore.getState().nodesById['table-1'];
+    expect((stateAfterModeChange.props as any)?.style?.width).toBe('100%');
+    expect((stateAfterModeChange.props as any)?.style?.height).toBe('auto');
+
+    const spinbuttons = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+    const xInput = spinbuttons[0];
+    const widthInput = spinbuttons[2];
+    const heightInput = spinbuttons[3];
+
+    expect(widthInput.disabled).toBe(true);
+    expect(heightInput.disabled).toBe(true);
+
+    fireEvent.change(xInput, { target: { value: '64' } });
+    fireEvent.blur(xInput);
+
+    const updated = useInvoiceDesignerStore.getState().nodesById['table-1'];
+    expect(updated.position.x).toBe(64);
+    expect((updated.props as any)?.style?.width).toBe('100%');
+    expect((updated.props as any)?.style?.height).toBe('auto');
+  });
+});

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -23,6 +23,7 @@ import {
   clampInvoiceMarginMm,
   listInvoicePaperPresets,
   resolveTemplatePrintSettings,
+  type TemplateFieldDisplayFormat,
   type TemplatePrintSettings,
 } from '@alga-psa/types';
 import { ComponentPalette } from './palette/ComponentPalette';
@@ -81,6 +82,11 @@ import {
   type DesignerWidthMode,
 } from './utils/sizeModes';
 import { resolveDesignerDocumentKind } from './utils/documentKind';
+import {
+  getTemplateFieldDefinition,
+  getTemplateFieldDisplayFormats,
+  resolveTemplateFieldLabel,
+} from './fields/fieldCatalog';
 
 const DROPPABLE_CANVAS_ID = 'designer-canvas';
 
@@ -464,23 +470,6 @@ const inferFlexItemPreset = (style: Partial<DesignerNodeStyle> | undefined): Fle
   return 'custom';
 };
 
-const FIELD_TYPE_LABELS: Record<string, string> = {
-  'invoice.number': 'Invoice Number',
-  'invoice.invoiceNumber': 'Invoice Number',
-  'invoice.issueDate': 'Issue Date',
-  'invoice.dueDate': 'Due Date',
-  'invoice.poNumber': 'PO Number',
-  'invoice.subtotal': 'Subtotal',
-  'invoice.tax': 'Tax',
-  'invoice.discount': 'Discount',
-  'invoice.total': 'Total',
-  'invoice.currencyCode': 'Currency Code',
-  'customer.name': 'Customer Name',
-  'customer.address': 'Customer Address',
-  'tenant.name': 'Tenant Name',
-  'tenant.address': 'Tenant Address',
-};
-
 const humanizeBindingToken = (input: string): string =>
   input
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
@@ -502,11 +491,7 @@ const resolveFieldTypeLabel = (bindingKey: string): string => {
   if (!normalized) {
     return 'Unbound';
   }
-  const known = FIELD_TYPE_LABELS[normalized];
-  if (known) {
-    return known;
-  }
-  return humanizeBindingToken(normalized);
+  return resolveTemplateFieldLabel(normalized);
 };
 
 const resolveSelectedFieldType = (selectedNode: DesignerNode | null): { label: string; bindingKey: string } | null => {
@@ -726,6 +711,12 @@ export const DesignerShell: React.FC = () => {
     () => inferFlexItemPreset(selectedSizingStyle),
     [selectedSizingStyle]
   );
+  const selectedFieldDisplayFormats = useMemo(() => {
+    if (!selectedFieldType) {
+      return [];
+    }
+    return getTemplateFieldDisplayFormats(selectedFieldType.bindingKey);
+  }, [selectedFieldType]);
   const selectedMediaParentSection = useMemo(() => {
     if (!selectedNode || !['image', 'logo', 'qr'].includes(selectedNode.type)) {
       return null;
@@ -1416,6 +1407,74 @@ export const DesignerShell: React.FC = () => {
             </div>
           </div>
         </details>
+      </div>
+    );
+  };
+
+  const renderFieldDisplayControls = () => {
+    if (!selectedNode || selectedNode.type !== 'field' || !selectedFieldType) {
+      return null;
+    }
+
+    const fieldDefinition = getTemplateFieldDefinition(selectedFieldType.bindingKey);
+    if (!fieldDefinition || selectedFieldDisplayFormats.length === 0) {
+      return null;
+    }
+
+    const metadata = getNodeMetadata(selectedNode) as Record<string, unknown>;
+    const selectedDisplayFormat = (
+      metadata.displayFormat === 'single-line' ||
+      metadata.displayFormat === 'multiline' ||
+      metadata.displayFormat === 'raw'
+        ? metadata.displayFormat
+        : 'single-line'
+    ) as TemplateFieldDisplayFormat;
+    const optionLabels: Record<TemplateFieldDisplayFormat, string> = {
+      'single-line': 'Single line',
+      multiline: 'Multiline',
+      raw: 'Raw',
+    };
+    const optionDescriptions: Record<TemplateFieldDisplayFormat, string> = {
+      'single-line': 'Collapse the address onto one line.',
+      multiline: 'Split the address into multiple lines.',
+      raw: 'Use the stored value as-is.',
+    };
+
+    return (
+      <div
+        className="rounded border border-slate-200 dark:border-[rgb(var(--color-border-200))] bg-white dark:bg-[rgb(var(--color-card))] px-3 py-2 space-y-2"
+        data-automation-id="designer-field-display-controls"
+      >
+        <div className="space-y-1">
+          <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">Display Format</p>
+          <p className="text-[11px] text-slate-500">
+            {fieldDefinition.description} This only applies to Data Field nodes.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-2">
+          {selectedFieldDisplayFormats.map((option) => {
+            const isSelected = option === selectedDisplayFormat;
+            return (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setNodeProp(selectedNode.id, 'metadata.displayFormat', option, true)}
+                className={clsx(
+                  'rounded border px-2 py-2 text-left transition-colors',
+                  isSelected
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+                    : 'border-slate-200 dark:border-[rgb(var(--color-border-200))] text-slate-700 dark:text-slate-300 hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800'
+                )}
+                aria-pressed={isSelected}
+                aria-label={`Display format: ${optionLabels[option]}`}
+                data-automation-id={`designer-field-display-format-${option}`}
+              >
+                <div className="text-xs font-medium">{optionLabels[option]}</div>
+                <div className="mt-1 text-[11px] text-slate-500 dark:text-slate-400">{optionDescriptions[option]}</div>
+              </button>
+            );
+          })}
+        </div>
       </div>
     );
   };
@@ -2339,6 +2398,7 @@ export const DesignerShell: React.FC = () => {
                   {renderContainerLayoutControls()}
                   {renderSharedSizingControls()}
                   {renderFlexItemControls()}
+                  {renderFieldDisplayControls()}
                   <DesignerSchemaInspector node={selectedNode} nodesById={nodesById} />
 			              {selectedNode.type === 'section' && (
 			                <div className="space-y-1">

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -71,6 +71,15 @@ import { resolveInsertPositionFromRects } from './utils/dropIndicator';
 import { DesignerSchemaInspector } from './inspector/DesignerSchemaInspector';
 import DocumentImagePickerWidget from './inspector/widgets/DocumentImagePickerWidget';
 import { getNodeLayout, getNodeMetadata, getNodeName, getNodeStyle } from './utils/nodeProps';
+import {
+  inferHeightMode,
+  inferWidthMode,
+  resolveHeightValueForMode,
+  resolveWidthValueForMode,
+  supportsSharedSizingModes,
+  type DesignerHeightMode,
+  type DesignerWidthMode,
+} from './utils/sizeModes';
 import { resolveDesignerDocumentKind } from './utils/documentKind';
 
 const DROPPABLE_CANVAS_ID = 'designer-canvas';
@@ -369,6 +378,17 @@ const MEDIA_OBJECT_FIT_OPTIONS: IconToggleOption[] = [
   { value: 'scale-down', label: 'Scale Down', tooltip: 'Use intrinsic size unless it needs shrinking', icon: Shrink },
 ];
 
+const BLOCK_WIDTH_MODE_OPTIONS: IconToggleOption[] = [
+  { value: 'fixed', label: 'Fixed', tooltip: 'Use an explicit width', icon: BoxSelect },
+  { value: 'fill', label: 'Fill', tooltip: 'Stretch to the available width', icon: Maximize2 },
+  { value: 'hug', label: 'Hug', tooltip: 'Size to the content width', icon: Shrink },
+];
+
+const BLOCK_HEIGHT_MODE_OPTIONS: IconToggleOption[] = [
+  { value: 'fixed', label: 'Fixed', tooltip: 'Use an explicit height', icon: BoxSelect },
+  { value: 'hug', label: 'Hug', tooltip: 'Grow only as tall as the content needs', icon: Shrink },
+];
+
 const GRID_COLUMN_PRESETS: GridColumnPreset[] = [
   { id: 'single', label: '1 column', template: '1fr', tracks: [1] },
   { id: 'two-equal', label: '2 equal columns', template: '1fr 1fr', tracks: [1, 1] },
@@ -566,7 +586,12 @@ export const DesignerShell: React.FC = () => {
   }, [currentPrintSettings.marginMm]);
 
   const resizeNode = useCallback(
-    (id: string, size: Size, commit: boolean = false) => {
+    (
+      id: string,
+      size: Size,
+      commit: boolean = false,
+      options: { widthMode?: DesignerWidthMode; heightMode?: DesignerHeightMode } = {}
+    ) => {
       const node = useInvoiceDesignerStore.getState().nodesById[id];
       if (!node) return;
 
@@ -575,14 +600,16 @@ export const DesignerShell: React.FC = () => {
         width: Math.round(clamped.width),
         height: Math.round(clamped.height),
       };
+      const widthMode = options.widthMode ?? 'fixed';
+      const heightMode = options.heightMode ?? 'fixed';
 
       // Batch updates without generating multiple history entries.
       setNodeProp(id, 'size.width', rounded.width, false);
       setNodeProp(id, 'size.height', rounded.height, false);
       setNodeProp(id, 'baseSize.width', rounded.width, false);
       setNodeProp(id, 'baseSize.height', rounded.height, false);
-      setNodeProp(id, 'style.width', `${rounded.width}px`, false);
-      setNodeProp(id, 'style.height', `${rounded.height}px`, commit);
+      setNodeProp(id, 'style.width', resolveWidthValueForMode(widthMode, { ...node, size: rounded }), false);
+      setNodeProp(id, 'style.height', resolveHeightValueForMode(heightMode, { ...node, size: rounded }), commit);
     },
     [setNodeProp]
   );
@@ -600,12 +627,30 @@ export const DesignerShell: React.FC = () => {
   const selectedPreset = selectedNode?.layoutPresetId ? getPresetById(selectedNode.layoutPresetId) : null;
   const selectedNodeTypeLabel = useMemo(() => resolveSelectedNodeTypeLabel(selectedNode), [selectedNode]);
   const selectedFieldType = useMemo(() => resolveSelectedFieldType(selectedNode), [selectedNode]);
+  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node] as const)), [nodes]);
   const selectedContainerLayout = useMemo(() => {
     if (!selectedNode || (selectedNode.type !== 'container' && selectedNode.type !== 'section')) {
       return undefined;
     }
     return getNodeLayout(selectedNode);
   }, [selectedNode]);
+  const selectedParentNode = useMemo(
+    () => (selectedNode?.parentId ? nodesById.get(selectedNode.parentId) ?? null : null),
+    [nodesById, selectedNode]
+  );
+  const selectedSizingStyle = useMemo(() => getNodeStyle(selectedNode ?? undefined), [selectedNode]);
+  const selectedWidthMode = useMemo(
+    () => inferWidthMode(selectedSizingStyle),
+    [selectedSizingStyle]
+  );
+  const selectedHeightMode = useMemo(
+    () => inferHeightMode(selectedSizingStyle),
+    [selectedSizingStyle]
+  );
+  const selectedSupportsSharedSizingModes = useMemo(
+    () => Boolean(selectedNode && supportsSharedSizingModes(selectedNode.type)),
+    [selectedNode]
+  );
   const selectedMediaParentSection = useMemo(() => {
     if (!selectedNode || !['image', 'logo', 'qr'].includes(selectedNode.type)) {
       return null;
@@ -619,7 +664,6 @@ export const DesignerShell: React.FC = () => {
     }
     return getSectionFitSizeFromChildren(selectedNode, new Map(nodes.map((node) => [node.id, node])));
   }, [nodes, selectedNode]);
-  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node] as const)), [nodes]);
 
 	  useDesignerShortcuts();
 	
@@ -1109,6 +1153,60 @@ export const DesignerShell: React.FC = () => {
               3
             )}
           </>
+        )}
+      </div>
+    );
+  };
+
+  const renderSharedSizingControls = () => {
+    if (!selectedNode || !selectedSupportsSharedSizingModes) {
+      return null;
+    }
+
+    const applyWidthMode = (mode: DesignerWidthMode) => {
+      setNodeProp(selectedNode.id, 'style.width', resolveWidthValueForMode(mode, selectedNode), true);
+    };
+
+    const applyHeightMode = (mode: DesignerHeightMode) => {
+      setNodeProp(selectedNode.id, 'style.height', resolveHeightValueForMode(mode, selectedNode), true);
+    };
+
+    const parentUsesFlowLayout = Boolean(
+      selectedParentNode && (() => {
+        const parentLayout = getNodeLayout(selectedParentNode);
+        return parentLayout?.display === 'flex' || parentLayout?.display === 'grid';
+      })()
+    );
+
+    return (
+      <div
+        className="rounded border border-slate-200 dark:border-[rgb(var(--color-border-200))] bg-white dark:bg-[rgb(var(--color-card))] px-3 py-2 space-y-2"
+        data-automation-id="designer-shared-sizing-controls"
+      >
+        <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">Sizing Mode</p>
+        {renderIconButtonGroup(
+          'block-width-mode',
+          'Width',
+          BLOCK_WIDTH_MODE_OPTIONS,
+          selectedWidthMode,
+          (value) => applyWidthMode(value as DesignerWidthMode),
+          3
+        )}
+        {renderIconButtonGroup(
+          'block-height-mode',
+          'Height',
+          BLOCK_HEIGHT_MODE_OPTIONS,
+          selectedHeightMode,
+          (value) => applyHeightMode(value as DesignerHeightMode),
+          2
+        )}
+        <p className="text-[11px] text-slate-500">
+          Width uses fill, fixed, or hug sizing. Height uses fixed or hug sizing so blocks can grow with their content.
+        </p>
+        {!parentUsesFlowLayout && (
+          <p className="text-[11px] text-amber-600 dark:text-amber-400">
+            Fill sizing works best inside stack or grid parents.
+          </p>
         )}
       </div>
     );
@@ -1742,13 +1840,20 @@ export const DesignerShell: React.FC = () => {
     if (!selectedNodeId) return;
     const liveNodes = useInvoiceDesignerStore.getState().nodes;
     const liveSelectedNode = liveNodes.find((node) => node.id === selectedNodeId) ?? null;
-    const liveParentNode =
-      liveSelectedNode?.parentId ? liveNodes.find((node) => node.id === liveSelectedNode.parentId) ?? null : null;
+    const widthMode = inferWidthMode(getNodeStyle(liveSelectedNode ?? undefined));
+    const heightMode = inferHeightMode(getNodeStyle(liveSelectedNode ?? undefined));
 
     // Avoid creating a separate history entry just for position; the resize commit will snapshot both.
     setNodeProp(selectedNodeId, 'position.x', propertyDraft.x, false);
     setNodeProp(selectedNodeId, 'position.y', propertyDraft.y, false);
-    resizeNode(selectedNodeId, { width: propertyDraft.width, height: propertyDraft.height }, true);
+    if (widthMode === 'fixed' || heightMode === 'fixed') {
+      resizeNode(
+        selectedNodeId,
+        { width: propertyDraft.width, height: propertyDraft.height },
+        true,
+        { widthMode, heightMode }
+      );
+    }
 
     const resolvedNode = useInvoiceDesignerStore.getState().nodes.find((node) => node.id === selectedNodeId);
     if (!resolvedNode) {
@@ -1756,10 +1861,11 @@ export const DesignerShell: React.FC = () => {
     }
 
     const draftSize = {
-      width: Number.isFinite(propertyDraft.width) ? propertyDraft.width : resolvedNode.size.width,
-      height: Number.isFinite(propertyDraft.height) ? propertyDraft.height : resolvedNode.size.height,
+      width: widthMode === 'fixed' && Number.isFinite(propertyDraft.width) ? propertyDraft.width : resolvedNode.size.width,
+      height:
+        heightMode === 'fixed' && Number.isFinite(propertyDraft.height) ? propertyDraft.height : resolvedNode.size.height,
     };
-    if (wasSizeConstrainedFromDraft(draftSize, resolvedNode.size)) {
+    if ((widthMode === 'fixed' || heightMode === 'fixed') && wasSizeConstrainedFromDraft(draftSize, resolvedNode.size)) {
       showDropFeedback('info', 'Size constrained to valid bounds.');
     }
   };
@@ -1957,19 +2063,53 @@ export const DesignerShell: React.FC = () => {
               <div className="grid grid-cols-2 gap-3 text-xs text-slate-500">
                 <div>
                   <label htmlFor="prop-x" className="block mb-1">X</label>
-                  <Input id="prop-x" name="x" type="number" value={propertyDraft.x} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                  <Input
+                    id="prop-x"
+                    name="x"
+                    type="number"
+                    value={propertyDraft.x}
+                    onChange={handlePropertyInput}
+                    onBlur={commitPropertyChanges}
+                    data-automation-id="designer-prop-x"
+                  />
                 </div>
                 <div>
                   <label htmlFor="prop-y" className="block mb-1">Y</label>
-                  <Input id="prop-y" name="y" type="number" value={propertyDraft.y} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                  <Input
+                    id="prop-y"
+                    name="y"
+                    type="number"
+                    value={propertyDraft.y}
+                    onChange={handlePropertyInput}
+                    onBlur={commitPropertyChanges}
+                    data-automation-id="designer-prop-y"
+                  />
                 </div>
                 <div>
                   <label htmlFor="prop-width" className="block mb-1">Width</label>
-                  <Input id="prop-width" name="width" type="number" value={propertyDraft.width} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                  <Input
+                    id="prop-width"
+                    name="width"
+                    type="number"
+                    value={propertyDraft.width}
+                    onChange={handlePropertyInput}
+                    onBlur={commitPropertyChanges}
+                    disabled={selectedSupportsSharedSizingModes && selectedWidthMode !== 'fixed'}
+                    data-automation-id="designer-prop-width"
+                  />
                 </div>
                 <div>
                   <label htmlFor="prop-height" className="block mb-1">Height</label>
-                  <Input id="prop-height" name="height" type="number" value={propertyDraft.height} onChange={handlePropertyInput} onBlur={commitPropertyChanges} />
+                  <Input
+                    id="prop-height"
+                    name="height"
+                    type="number"
+                    value={propertyDraft.height}
+                    onChange={handlePropertyInput}
+                    onBlur={commitPropertyChanges}
+                    disabled={selectedSupportsSharedSizingModes && selectedHeightMode !== 'fixed'}
+                    data-automation-id="designer-prop-height"
+                  />
                 </div>
               </div>
               {selectedPreset && (
@@ -1989,6 +2129,7 @@ export const DesignerShell: React.FC = () => {
 	                </div>
 		              )}
                   {renderContainerLayoutControls()}
+                  {renderSharedSizingControls()}
                   <DesignerSchemaInspector node={selectedNode} nodesById={nodesById} />
 			              {selectedNode.type === 'section' && (
 			                <div className="space-y-1">

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -55,6 +55,7 @@ import {
   AlignRight,
   ArrowDown,
   ArrowRight,
+  ArrowUp,
   ArrowUpDown,
   Grid3X3,
 } from 'lucide-react';
@@ -341,6 +342,18 @@ const CONTAINER_JUSTIFY_CONTENT_OPTIONS: IconToggleOption[] = [
     tooltip: 'Distribute with equal spacing',
     icon: AlignHorizontalDistributeCenter,
   },
+];
+
+const MEDIA_HORIZONTAL_ALIGN_OPTIONS: IconToggleOption[] = [
+  { value: 'left', label: 'Left', tooltip: 'Align image to the left', icon: AlignLeft },
+  { value: 'center', label: 'Center', tooltip: 'Center image horizontally', icon: AlignCenter },
+  { value: 'right', label: 'Right', tooltip: 'Align image to the right', icon: AlignRight },
+];
+
+const MEDIA_VERTICAL_ALIGN_OPTIONS: IconToggleOption[] = [
+  { value: 'top', label: 'Top', tooltip: 'Align image to the top', icon: ArrowUp },
+  { value: 'center', label: 'Center', tooltip: 'Center image vertically', icon: ArrowUpDown },
+  { value: 'bottom', label: 'Bottom', tooltip: 'Align image to the bottom', icon: ArrowDown },
 ];
 
 const GRID_COLUMN_PRESETS: GridColumnPreset[] = [
@@ -954,18 +967,8 @@ export const DesignerShell: React.FC = () => {
     updatePointerLocation(null);
   }, [updatePointerLocation]);
 
-  const renderContainerLayoutControls = () => {
-    if (!selectedNode || (selectedNode.type !== 'container' && selectedNode.type !== 'section') || !selectedContainerLayout) {
-      return null;
-    }
-
-    const layoutMode = selectedContainerLayout.display ?? 'flex';
-    const direction = selectedContainerLayout.flexDirection ?? 'column';
-    const alignItems = selectedContainerLayout.alignItems ?? 'stretch';
-    const justifyContent = selectedContainerLayout.justifyContent ?? 'flex-start';
-    const activeGridTemplateColumns = normalizeGridTemplateColumns(selectedContainerLayout.gridTemplateColumns);
-
-    const renderButtonGroup = (
+  const renderIconButtonGroup = useCallback(
+    (
       keyPrefix: string,
       label: string,
       options: IconToggleOption[],
@@ -992,7 +995,7 @@ export const DesignerShell: React.FC = () => {
                   )}
                   aria-pressed={isSelected}
                   aria-label={`${label}: ${option.label}`}
-                  data-automation-id={`designer-container-layout-${keyPrefix}-${option.value}`}
+                  data-automation-id={`designer-icon-group-${keyPrefix}-${option.value}`}
                 >
                   <Icon className="h-4 w-4" />
                 </button>
@@ -1001,7 +1004,20 @@ export const DesignerShell: React.FC = () => {
           })}
         </div>
       </div>
-    );
+    ),
+    []
+  );
+
+  const renderContainerLayoutControls = () => {
+    if (!selectedNode || (selectedNode.type !== 'container' && selectedNode.type !== 'section') || !selectedContainerLayout) {
+      return null;
+    }
+
+    const layoutMode = selectedContainerLayout.display ?? 'flex';
+    const direction = selectedContainerLayout.flexDirection ?? 'column';
+    const alignItems = selectedContainerLayout.alignItems ?? 'stretch';
+    const justifyContent = selectedContainerLayout.justifyContent ?? 'flex-start';
+    const activeGridTemplateColumns = normalizeGridTemplateColumns(selectedContainerLayout.gridTemplateColumns);
 
     return (
       <div
@@ -1009,7 +1025,7 @@ export const DesignerShell: React.FC = () => {
         data-automation-id="designer-container-layout-controls"
       >
         <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">Layout Controls</p>
-        {renderButtonGroup('mode', 'Layout', CONTAINER_LAYOUT_MODE_OPTIONS, layoutMode, (value) => {
+        {renderIconButtonGroup('layout-mode', 'Layout', CONTAINER_LAYOUT_MODE_OPTIONS, layoutMode, (value) => {
           setNodeProp(selectedNode.id, 'layout.display', value, true);
         }, 2)}
         {layoutMode === 'grid' && (
@@ -1063,14 +1079,14 @@ export const DesignerShell: React.FC = () => {
         )}
         {layoutMode === 'flex' && (
           <>
-            {renderButtonGroup('direction', 'Direction', CONTAINER_FLEX_DIRECTION_OPTIONS, direction, (value) => {
+            {renderIconButtonGroup('layout-direction', 'Direction', CONTAINER_FLEX_DIRECTION_OPTIONS, direction, (value) => {
               setNodeProp(selectedNode.id, 'layout.flexDirection', value, true);
             }, 2)}
-            {renderButtonGroup('align-items', 'Align Items', CONTAINER_ALIGN_ITEMS_OPTIONS, alignItems, (value) => {
+            {renderIconButtonGroup('layout-align-items', 'Align Items', CONTAINER_ALIGN_ITEMS_OPTIONS, alignItems, (value) => {
               setNodeProp(selectedNode.id, 'layout.alignItems', value, true);
             }, 4)}
-            {renderButtonGroup(
-              'justify-content',
+            {renderIconButtonGroup(
+              'layout-justify-content',
               'Justify Content',
               CONTAINER_JUSTIFY_CONTENT_OPTIONS,
               justifyContent,
@@ -1173,6 +1189,29 @@ export const DesignerShell: React.FC = () => {
 		    if (selectedNode.type === 'image' || selectedNode.type === 'logo' || selectedNode.type === 'qr') {
 		      const fitMode = metadata.fitMode ?? metadata.fit ?? 'contain';
         const objectFit = getNodeStyle(selectedNode)?.objectFit ?? fitMode;
+        const rawObjectPosition = getNodeStyle(selectedNode)?.objectPosition ?? 'center center';
+        const parseObjectPosition = (
+          value: string
+        ): { horizontal: 'left' | 'center' | 'right'; vertical: 'top' | 'center' | 'bottom' } => {
+          const tokens = value
+            .trim()
+            .split(/\s+/)
+            .filter(Boolean);
+          const horizontalToken = tokens.find((token) => token === 'left' || token === 'center' || token === 'right');
+          const verticalToken = tokens.find((token) => token === 'top' || token === 'center' || token === 'bottom');
+          return {
+            horizontal: (horizontalToken as 'left' | 'center' | 'right' | undefined) ?? 'center',
+            vertical: (verticalToken as 'top' | 'center' | 'bottom' | undefined) ?? 'center',
+          };
+        };
+        const objectPosition = parseObjectPosition(rawObjectPosition);
+        const applyObjectPosition = (
+          patch: Partial<{ horizontal: 'left' | 'center' | 'right'; vertical: 'top' | 'center' | 'bottom' }>
+        ) => {
+          const nextHorizontal = patch.horizontal ?? objectPosition.horizontal;
+          const nextVertical = patch.vertical ?? objectPosition.vertical;
+          setNodeProp(selectedNode.id, 'style.objectPosition', `${nextHorizontal} ${nextVertical}`, true);
+        };
         const applyAspectRatio = (raw: string, commit: boolean) => {
           const normalized = normalizeCssValue(raw);
           if (normalized === undefined) {
@@ -1229,6 +1268,24 @@ export const DesignerShell: React.FC = () => {
 	              size="sm"
 	            />
 	          </div>
+            <div className="grid grid-cols-2 gap-2">
+              {renderIconButtonGroup(
+                'media-horizontal-align',
+                'Horizontal Align',
+                MEDIA_HORIZONTAL_ALIGN_OPTIONS,
+                objectPosition.horizontal,
+                (value) => applyObjectPosition({ horizontal: value as 'left' | 'center' | 'right' }),
+                3
+              )}
+              {renderIconButtonGroup(
+                'media-vertical-align',
+                'Vertical Align',
+                MEDIA_VERTICAL_ALIGN_OPTIONS,
+                objectPosition.vertical,
+                (value) => applyObjectPosition({ vertical: value as 'top' | 'center' | 'bottom' }),
+                3
+              )}
+            </div>
             <div>
               <label className="text-xs text-slate-500 block mb-1">Aspect ratio</label>
 	              <Input

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -57,6 +57,11 @@ import {
   ArrowRight,
   ArrowUp,
   ArrowUpDown,
+  BoxSelect,
+  Maximize2,
+  Scaling,
+  Shrink,
+  StretchHorizontal,
   Grid3X3,
 } from 'lucide-react';
 import { useDesignerShortcuts } from './hooks/useDesignerShortcuts';
@@ -354,6 +359,14 @@ const MEDIA_VERTICAL_ALIGN_OPTIONS: IconToggleOption[] = [
   { value: 'top', label: 'Top', tooltip: 'Align image to the top', icon: ArrowUp },
   { value: 'center', label: 'Center', tooltip: 'Center image vertically', icon: ArrowUpDown },
   { value: 'bottom', label: 'Bottom', tooltip: 'Align image to the bottom', icon: ArrowDown },
+];
+
+const MEDIA_OBJECT_FIT_OPTIONS: IconToggleOption[] = [
+  { value: 'contain', label: 'Contain', tooltip: 'Scale to fit inside the frame', icon: Scaling },
+  { value: 'cover', label: 'Cover', tooltip: 'Fill the frame and crop overflow', icon: Maximize2 },
+  { value: 'fill', label: 'Fill', tooltip: 'Stretch to fill the frame', icon: StretchHorizontal },
+  { value: 'none', label: 'None', tooltip: 'Keep the intrinsic image size', icon: BoxSelect },
+  { value: 'scale-down', label: 'Scale Down', tooltip: 'Use intrinsic size unless it needs shrinking', icon: Shrink },
 ];
 
 const GRID_COLUMN_PRESETS: GridColumnPreset[] = [
@@ -1247,27 +1260,19 @@ export const DesignerShell: React.FC = () => {
               onBlur={(event) => applyMetadata({ alt: event.target.value }, true)}
             />
 	          </div>
-	          <div>
-	            <label className="text-xs text-slate-500 block mb-1">Object fit</label>
-	            <CustomSelect
-	              id="designer-media-object-fit"
-	              options={[
-	                { value: 'contain', label: 'Contain' },
-	                { value: 'cover', label: 'Cover' },
-	                { value: 'fill', label: 'Fill' },
-	                { value: 'none', label: 'None' },
-	                { value: 'scale-down', label: 'Scale Down' },
-	              ]}
-	              value={objectFit}
-	              onValueChange={(value: string) => {
-	                setNodeProp(selectedNode.id, 'style.objectFit', value, true);
-	                if (value === 'contain' || value === 'cover' || value === 'fill') {
-	                  applyMetadata({ fitMode: value, fit: value }, true);
-	                }
-	              }}
-	              size="sm"
-	            />
-	          </div>
+            {renderIconButtonGroup(
+              'media-object-fit',
+              'Object Fit',
+              MEDIA_OBJECT_FIT_OPTIONS,
+              objectFit,
+              (value) => {
+                setNodeProp(selectedNode.id, 'style.objectFit', value, true);
+                if (value === 'contain' || value === 'cover' || value === 'fill') {
+                  applyMetadata({ fitMode: value, fit: value }, true);
+                }
+              },
+              5
+            )}
             <div className="grid grid-cols-2 gap-2">
               {renderIconButtonGroup(
                 'media-horizontal-align',

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -28,7 +28,7 @@ import {
 import { ComponentPalette } from './palette/ComponentPalette';
 import { DesignCanvas } from './canvas/DesignCanvas';
 import { DesignerToolbar } from './toolbar/DesignerToolbar';
-import type { DesignerComponentType, DesignerNode, Point, Size } from './state/designerStore';
+import type { DesignerComponentType, DesignerNode, DesignerNodeStyle, Point, Size } from './state/designerStore';
 import { clampNodeSizeToPracticalMinimum, getAbsolutePosition, useInvoiceDesignerStore } from './state/designerStore';
 import { AlignmentGuide, resolveFlexPadding } from './utils/layout';
 import { getDefinition } from './constants/componentCatalog';
@@ -317,6 +317,8 @@ type GridColumnPreset = {
   tracks: number[];
 };
 
+type FlexItemPreset = 'natural' | 'fill' | 'share' | 'fixed' | 'custom';
+
 const CONTAINER_LAYOUT_MODE_OPTIONS: IconToggleOption[] = [
   { value: 'flex', label: 'Stack', tooltip: 'Stack (Flex)', icon: AlignJustify },
   { value: 'grid', label: 'Grid', tooltip: 'Grid layout', icon: Grid3X3 },
@@ -389,6 +391,33 @@ const BLOCK_HEIGHT_MODE_OPTIONS: IconToggleOption[] = [
   { value: 'hug', label: 'Hug', tooltip: 'Grow only as tall as the content needs', icon: Shrink },
 ];
 
+const FLEX_ITEM_PRESET_OPTIONS: Array<{
+  value: Exclude<FlexItemPreset, 'custom'>;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'natural',
+    label: 'Natural',
+    description: 'Use the item content size, but allow it to shrink if space is tight.',
+  },
+  {
+    value: 'fill',
+    label: 'Fill',
+    description: 'Expand into leftover space while keeping the item’s preferred size.',
+  },
+  {
+    value: 'share',
+    label: 'Share',
+    description: 'Split available space evenly with other shared items.',
+  },
+  {
+    value: 'fixed',
+    label: 'Fixed',
+    description: 'Keep the item size and do not let flexbox shrink it.',
+  },
+];
+
 const GRID_COLUMN_PRESETS: GridColumnPreset[] = [
   { id: 'single', label: '1 column', template: '1fr', tracks: [1] },
   { id: 'two-equal', label: '2 equal columns', template: '1fr 1fr', tracks: [1, 1] },
@@ -399,6 +428,41 @@ const GRID_COLUMN_PRESETS: GridColumnPreset[] = [
 
 const normalizeGridTemplateColumns = (value: string | undefined): string =>
   typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : '';
+
+const coerceFlexNumber = (value: unknown, fallback: number): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const numeric = Number(value.trim());
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+  }
+  return fallback;
+};
+
+const normalizeCssToken = (value: unknown): string => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+const inferFlexItemPreset = (style: Partial<DesignerNodeStyle> | undefined): FlexItemPreset => {
+  const grow = coerceFlexNumber(style?.flexGrow, 0);
+  const shrink = coerceFlexNumber(style?.flexShrink, 1);
+  const basis = normalizeCssToken(style?.flexBasis);
+
+  if (grow === 0 && shrink === 1 && (basis === '' || basis === 'auto')) {
+    return 'natural';
+  }
+  if (grow === 1 && shrink === 1 && (basis === '' || basis === 'auto')) {
+    return 'fill';
+  }
+  if (grow === 1 && shrink === 1 && (basis === '0' || basis === '0%' || basis === '0px')) {
+    return 'share';
+  }
+  if (grow === 0 && shrink === 0 && (basis === '' || basis === 'auto')) {
+    return 'fixed';
+  }
+  return 'custom';
+};
 
 const FIELD_TYPE_LABELS: Record<string, string> = {
   'invoice.number': 'Invoice Number',
@@ -638,6 +702,13 @@ export const DesignerShell: React.FC = () => {
     () => (selectedNode?.parentId ? nodesById.get(selectedNode.parentId) ?? null : null),
     [nodesById, selectedNode]
   );
+  const selectedParentFlexLayout = useMemo(() => {
+    if (!selectedParentNode) {
+      return null;
+    }
+    const layout = getNodeLayout(selectedParentNode);
+    return layout?.display === 'flex' ? layout : null;
+  }, [selectedParentNode]);
   const selectedSizingStyle = useMemo(() => getNodeStyle(selectedNode ?? undefined), [selectedNode]);
   const selectedWidthMode = useMemo(
     () => inferWidthMode(selectedSizingStyle),
@@ -650,6 +721,10 @@ export const DesignerShell: React.FC = () => {
   const selectedSupportsSharedSizingModes = useMemo(
     () => Boolean(selectedNode && supportsSharedSizingModes(selectedNode.type)),
     [selectedNode]
+  );
+  const selectedFlexItemPreset = useMemo(
+    () => inferFlexItemPreset(selectedSizingStyle),
+    [selectedSizingStyle]
   );
   const selectedMediaParentSection = useMemo(() => {
     if (!selectedNode || !['image', 'logo', 'qr'].includes(selectedNode.type)) {
@@ -1208,6 +1283,139 @@ export const DesignerShell: React.FC = () => {
             Fill sizing works best inside stack or grid parents.
           </p>
         )}
+      </div>
+    );
+  };
+
+  const renderFlexItemControls = () => {
+    if (!selectedNode || !selectedParentFlexLayout) {
+      return null;
+    }
+
+    const mainAxisLabel = selectedParentFlexLayout.flexDirection === 'row' ? 'Width' : 'Height';
+    const mainAxisNoun = selectedParentFlexLayout.flexDirection === 'row' ? 'width' : 'height';
+    const currentFlexGrow = coerceFlexNumber(selectedSizingStyle?.flexGrow, 0);
+    const currentFlexShrink = coerceFlexNumber(selectedSizingStyle?.flexShrink, 1);
+    const currentFlexBasis = typeof selectedSizingStyle?.flexBasis === 'string' ? selectedSizingStyle.flexBasis : '';
+
+    const applyFlexPreset = (preset: Exclude<FlexItemPreset, 'custom'>) => {
+      const patch =
+        preset === 'fill'
+          ? { grow: 1, shrink: 1, basis: 'auto' }
+          : preset === 'share'
+            ? { grow: 1, shrink: 1, basis: '0%' }
+            : preset === 'fixed'
+              ? { grow: 0, shrink: 0, basis: 'auto' }
+              : { grow: 0, shrink: 1, basis: 'auto' };
+      setNodeProp(selectedNode.id, 'style.flexGrow', patch.grow, false);
+      setNodeProp(selectedNode.id, 'style.flexShrink', patch.shrink, false);
+      setNodeProp(selectedNode.id, 'style.flexBasis', patch.basis, true);
+    };
+
+    const applyFlexBasis = (raw: string, commit: boolean) => {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) {
+        unsetNodeProp(selectedNode.id, 'style.flexBasis', commit);
+        return;
+      }
+      setNodeProp(selectedNode.id, 'style.flexBasis', trimmed, commit);
+    };
+
+    const applyFlexNumber = (path: 'style.flexGrow' | 'style.flexShrink', raw: string, commit: boolean) => {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) {
+        unsetNodeProp(selectedNode.id, path, commit);
+        return;
+      }
+      const numeric = Number(trimmed);
+      if (!Number.isFinite(numeric)) {
+        return;
+      }
+      setNodeProp(selectedNode.id, path, numeric, commit);
+    };
+
+    return (
+      <div
+        className="rounded border border-slate-200 dark:border-[rgb(var(--color-border-200))] bg-white dark:bg-[rgb(var(--color-card))] px-3 py-2 space-y-2"
+        data-automation-id="designer-flex-item-controls"
+      >
+        <div className="space-y-1">
+          <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">Flex Item</p>
+          <p className="text-[11px] text-slate-500">
+            In this {selectedParentFlexLayout.flexDirection === 'row' ? 'horizontal' : 'vertical'} stack, these settings control how the item shares {mainAxisNoun} with its siblings.
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <p className="text-xs text-slate-500">{mainAxisLabel} Behavior</p>
+          <div className="grid grid-cols-2 gap-2">
+            {FLEX_ITEM_PRESET_OPTIONS.map((option) => {
+              const isSelected = option.value === selectedFlexItemPreset;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => applyFlexPreset(option.value)}
+                  className={clsx(
+                    'rounded border px-2 py-2 text-left transition-colors',
+                    isSelected
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+                      : 'border-slate-200 dark:border-[rgb(var(--color-border-200))] text-slate-700 dark:text-slate-300 hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800'
+                  )}
+                  aria-pressed={isSelected}
+                  aria-label={`${mainAxisLabel} behavior: ${option.label}`}
+                  data-automation-id={`designer-flex-item-preset-${option.value}`}
+                >
+                  <div className="text-xs font-medium">{option.label}</div>
+                  <div className="mt-1 text-[11px] text-slate-500 dark:text-slate-400">{option.description}</div>
+                </button>
+              );
+            })}
+          </div>
+          {selectedFlexItemPreset === 'custom' && (
+            <p className="text-[11px] text-amber-600 dark:text-amber-400">
+              This item has custom flex values. Choose a preset to simplify it, or adjust the advanced values below.
+            </p>
+          )}
+        </div>
+        <details data-automation-id="designer-flex-item-advanced">
+          <summary className="cursor-pointer text-xs font-medium text-slate-600 dark:text-slate-300">
+            Advanced Flex Values
+          </summary>
+          <div className="mt-2 space-y-2">
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-[10px] text-slate-500 block mb-1">Take extra space</label>
+                <Input
+                  value={String(currentFlexGrow)}
+                  placeholder="0"
+                  onChange={(event) => applyFlexNumber('style.flexGrow', event.target.value, false)}
+                  onBlur={(event) => applyFlexNumber('style.flexGrow', event.target.value, true)}
+                  data-automation-id="designer-flex-grow-input"
+                />
+              </div>
+              <div>
+                <label className="text-[10px] text-slate-500 block mb-1">Allow shrinking</label>
+                <Input
+                  value={String(currentFlexShrink)}
+                  placeholder="1"
+                  onChange={(event) => applyFlexNumber('style.flexShrink', event.target.value, false)}
+                  onBlur={(event) => applyFlexNumber('style.flexShrink', event.target.value, true)}
+                  data-automation-id="designer-flex-shrink-input"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-[10px] text-slate-500 block mb-1">Preferred {mainAxisNoun} size</label>
+              <Input
+                value={currentFlexBasis}
+                placeholder="auto | 240px | 50%"
+                onChange={(event) => applyFlexBasis(event.target.value, false)}
+                onBlur={(event) => applyFlexBasis(event.target.value, true)}
+                data-automation-id="designer-flex-basis-input"
+              />
+            </div>
+          </div>
+        </details>
       </div>
     );
   };
@@ -2130,6 +2338,7 @@ export const DesignerShell: React.FC = () => {
 		              )}
                   {renderContainerLayoutControls()}
                   {renderSharedSizingControls()}
+                  {renderFlexItemControls()}
                   <DesignerSchemaInspector node={selectedNode} nodesById={nodesById} />
 			              {selectedNode.type === 'section' && (
 			                <div className="space-y-1">

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
@@ -168,7 +168,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(divider.style?.inline).toMatchObject({ margin: '8px 0' });
   });
 
-  it('round-trips field properties including optional format, emptyValue, placeholder, and displayFormat', () => {
+  it('round-trips field properties including optional format, emptyValue, placeholder, displayFormat, and borderStyle', () => {
     const ast = createAstDocument(
       [
         {
@@ -184,6 +184,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
               emptyValue: '-',
               placeholder: 'Company Address',
               displayFormat: 'multiline',
+              borderStyle: 'box',
             },
             {
               id: 'field-implicit',
@@ -218,6 +219,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(explicitField.emptyValue).toBe('-');
     expect(explicitField.placeholder).toBe('Company Address');
     expect(explicitField.displayFormat).toBe('multiline');
+    expect(explicitField.borderStyle).toBe('box');
 
     const implicitField = findNodeById(layout, 'field-implicit');
     expect(implicitField?.type).toBe('field');
@@ -227,6 +229,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(Object.prototype.hasOwnProperty.call(implicitField, 'format')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(implicitField, 'emptyValue')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(implicitField, 'displayFormat')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(implicitField, 'borderStyle')).toBe(false);
   });
 
   it('round-trips dynamic-table columns including style and emptyStateText', () => {

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
@@ -168,7 +168,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(divider.style?.inline).toMatchObject({ margin: '8px 0' });
   });
 
-  it('round-trips field properties including optional format and emptyValue', () => {
+  it('round-trips field properties including optional format, emptyValue, placeholder, and displayFormat', () => {
     const ast = createAstDocument(
       [
         {
@@ -178,10 +178,12 @@ describe('workspaceAst roundtrip node/property matrix', () => {
             {
               id: 'field-explicit',
               type: 'field',
-              binding: { bindingId: 'issueDate' },
-              label: 'Issue Date',
-              format: 'date',
+              binding: { bindingId: 'tenantAddress' },
+              label: 'From Address',
+              format: 'text',
               emptyValue: '-',
+              placeholder: 'Company Address',
+              displayFormat: 'multiline',
             },
             {
               id: 'field-implicit',
@@ -197,6 +199,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
           values: {
             issueDate: { id: 'issueDate', kind: 'value', path: 'issueDate' },
             invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+            tenantAddress: { id: 'tenantAddress', kind: 'value', path: 'tenantClient.address' },
           },
           collections: {},
         },
@@ -209,10 +212,12 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     const explicitField = findNodeById(layout, 'field-explicit');
     expect(explicitField?.type).toBe('field');
     if (!explicitField || explicitField.type !== 'field') return;
-    expect(explicitField.binding).toEqual({ bindingId: 'issueDate' });
-    expect(explicitField.label).toBe('Issue Date');
-    expect(explicitField.format).toBe('date');
+    expect(explicitField.binding).toEqual({ bindingId: 'tenantAddress' });
+    expect(explicitField.label).toBe('From Address');
+    expect(explicitField.format).toBe('text');
     expect(explicitField.emptyValue).toBe('-');
+    expect(explicitField.placeholder).toBe('Company Address');
+    expect(explicitField.displayFormat).toBe('multiline');
 
     const implicitField = findNodeById(layout, 'field-implicit');
     expect(implicitField?.type).toBe('field');
@@ -221,6 +226,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(implicitField.label).toBe('Invoice #');
     expect(Object.prototype.hasOwnProperty.call(implicitField, 'format')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(implicitField, 'emptyValue')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(implicitField, 'displayFormat')).toBe(false);
   });
 
   it('round-trips dynamic-table columns including style and emptyStateText', () => {

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.styles.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.styles.test.ts
@@ -36,6 +36,7 @@ describe('workspaceAst roundtrip style matrix', () => {
     { key: 'flexBasis', value: 'auto' },
     { key: 'aspectRatio', value: '16 / 9' },
     { key: 'objectFit', value: 'contain' },
+    { key: 'objectPosition', value: 'right bottom' },
     { key: 'gridTemplateColumns', value: '1fr 2fr' },
     { key: 'gridTemplateRows', value: 'auto auto' },
     { key: 'gridAutoFlow', value: 'row dense' },

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.test.ts
@@ -457,6 +457,25 @@ describe('exportWorkspaceToTemplateAst', () => {
     expect(ast2).toEqual(ast1);
   });
 
+  it('hydrates imported logo nodes from media width and max-height constraints', () => {
+    const sourceAst = getStandardTemplateAstByCode('standard-detailed');
+    expect(sourceAst).toBeTruthy();
+    if (!sourceAst) return;
+
+    const hydrated = importTemplateAstToWorkspace(sourceAst);
+    const hydratedLogo = hydrated.nodesById['issuer-logo'];
+
+    expect(hydratedLogo?.type).toBe('image');
+    expect((hydratedLogo?.props as any)?.style).toMatchObject({
+      width: '180px',
+      maxHeight: '72px',
+    });
+    expect((hydratedLogo?.props as any)?.size).toMatchObject({
+      width: 180,
+      height: 72,
+    });
+  });
+
   it('omits transforms from generated AST when the workspace has no authored transform pipeline', () => {
     const workspace = createWorkspaceWithFieldAndDynamicTable();
     const ast = exportWorkspaceToTemplateAst(workspace);

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -418,6 +418,7 @@ const createNodeStyle = (node: WorkspaceNode): TemplateNode['style'] | undefined
 
   if (style.aspectRatio) inline.aspectRatio = style.aspectRatio;
   if (style.objectFit) inline.objectFit = style.objectFit;
+  if (style.objectPosition) inline.objectPosition = style.objectPosition;
   if (style.margin) inline.margin = style.margin;
   if (style.border) inline.border = style.border;
   if (style.borderRadius) inline.borderRadius = style.borderRadius;
@@ -663,6 +664,9 @@ const coerceNodeStyleFromInlineStyle = (inline: Record<string, unknown> | undefi
   if (aspectRatio) style.aspectRatio = aspectRatio;
   const objectFit = coerceObjectFit(inline.objectFit);
   if (objectFit) style.objectFit = objectFit;
+  if (typeof inline.objectPosition === 'string' && inline.objectPosition.trim().length > 0) {
+    style.objectPosition = inline.objectPosition.trim();
+  }
 
   const margin = coerceCssLength(inline.margin);
   if (margin) style.margin = margin;

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -3,6 +3,7 @@ import type {
   TemplateNode,
   TemplatePrintSettings,
   TemplateNodeStyleRef,
+  TemplateFieldDisplayFormat,
   TemplateTableColumn,
   TemplateTotalsRow,
   TemplateValueExpression,
@@ -51,6 +52,12 @@ const isTemplateValueFormat = (value: unknown): value is TemplateValueFormat =>
 
 const parseTemplateValueFormat = (value: unknown): TemplateValueFormat | undefined =>
   isTemplateValueFormat(value) ? value : undefined;
+
+const isTemplateFieldDisplayFormat = (value: unknown): value is TemplateFieldDisplayFormat =>
+  value === 'single-line' || value === 'multiline' || value === 'raw';
+
+const parseTemplateFieldDisplayFormat = (value: unknown): TemplateFieldDisplayFormat | undefined =>
+  isTemplateFieldDisplayFormat(value) ? value : undefined;
 
 const isTemplateValueExpression = (value: unknown): value is TemplateValueExpression => {
   if (!isRecord(value)) {
@@ -154,6 +161,8 @@ const normalizeInvoiceBindingPath = (bindingKey: string): string => {
   }
   return aliases[normalized] ?? normalized;
 };
+
+const supportsFieldDisplayFormat = (bindingPath: string): boolean => bindingPath.trim().endsWith('.address');
 
 const TEMPLATE_TOKEN_PATTERN = /\{\{\s*([^{}]+?)\s*\}\}/g;
 const SIMPLE_BINDING_ALIASES = new Set([
@@ -960,11 +969,15 @@ const mapDesignerNodeToAstNode = (
       const bindingId = registerValueBinding(bindingPath);
       const explicitLabel = asTrimmedString(metadata.label);
       const format = parseTemplateValueFormat(metadata.format);
+      const displayFormat = parseTemplateFieldDisplayFormat(metadata.displayFormat);
       const astImported = metadata.__astImported === true;
       const hadImportedFormat = metadata.__astFieldHadFormat === true;
       const hadImportedEmptyValue = metadata.__astFieldHadEmptyValue === true;
+      const hadImportedPlaceholder = metadata.__astFieldHadPlaceholder === true;
       const hasExplicitEmptyValue = typeof metadata.emptyValue === 'string';
       const emptyValue = hasExplicitEmptyValue ? asTrimmedString(metadata.emptyValue) : '';
+      const hasExplicitPlaceholder = typeof metadata.placeholder === 'string';
+      const placeholder = hasExplicitPlaceholder ? asTrimmedString(metadata.placeholder) : '';
       const mapped: TemplateNode = {
         ...createBaseNode(node),
         type: 'field',
@@ -982,8 +995,16 @@ const mapDesignerNodeToAstNode = (
         // Designer-authored fields default to empty string; imported templates only retain this when explicitly present.
         mapped.emptyValue = '';
       }
+      if (hasExplicitPlaceholder) {
+        mapped.placeholder = placeholder;
+      } else if (astImported && hadImportedPlaceholder) {
+        mapped.placeholder = '';
+      }
       if (format && (!astImported || hadImportedFormat || format !== 'text')) {
         mapped.format = format;
+      }
+      if (displayFormat && supportsFieldDisplayFormat(bindingPath)) {
+        mapped.displayFormat = displayFormat;
       }
       return mapped;
     }
@@ -1722,14 +1743,21 @@ export const importTemplateAstToWorkspace = (
           metadata.bindingKey = denormalizeBindingPath(bindingPath);
           metadata.__astFieldHadFormat = Object.prototype.hasOwnProperty.call(inputNode, 'format');
           metadata.__astFieldHadEmptyValue = Object.prototype.hasOwnProperty.call(inputNode, 'emptyValue');
+          metadata.__astFieldHadPlaceholder = Object.prototype.hasOwnProperty.call(inputNode, 'placeholder');
           if (inputNode.format) {
             metadata.format = inputNode.format;
+          }
+          if (inputNode.displayFormat) {
+            metadata.displayFormat = inputNode.displayFormat;
           }
           if (inputNode.label) {
             metadata.label = inputNode.label;
           }
           if (typeof inputNode.emptyValue === 'string') {
             metadata.emptyValue = inputNode.emptyValue;
+          }
+          if (typeof inputNode.placeholder === 'string') {
+            metadata.placeholder = inputNode.placeholder;
           }
         } else if (inputNode.type === 'dynamic-table' || inputNode.type === 'table') {
           const collectionPath = resolveImportedCollectionBindingPath(

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -1,5 +1,6 @@
 import type {
   TemplateAst,
+  TemplateFieldBorderStyle,
   TemplateNode,
   TemplatePrintSettings,
   TemplateNodeStyleRef,
@@ -58,6 +59,12 @@ const isTemplateFieldDisplayFormat = (value: unknown): value is TemplateFieldDis
 
 const parseTemplateFieldDisplayFormat = (value: unknown): TemplateFieldDisplayFormat | undefined =>
   isTemplateFieldDisplayFormat(value) ? value : undefined;
+
+const isTemplateFieldBorderStyle = (value: unknown): value is TemplateFieldBorderStyle =>
+  value === 'underline' || value === 'box' || value === 'none';
+
+const parseTemplateFieldBorderStyle = (value: unknown): TemplateFieldBorderStyle | undefined =>
+  isTemplateFieldBorderStyle(value) ? value : undefined;
 
 const isTemplateValueExpression = (value: unknown): value is TemplateValueExpression => {
   if (!isRecord(value)) {
@@ -970,6 +977,7 @@ const mapDesignerNodeToAstNode = (
       const explicitLabel = asTrimmedString(metadata.label);
       const format = parseTemplateValueFormat(metadata.format);
       const displayFormat = parseTemplateFieldDisplayFormat(metadata.displayFormat);
+      const borderStyle = parseTemplateFieldBorderStyle(metadata.fieldBorderStyle);
       const astImported = metadata.__astImported === true;
       const hadImportedFormat = metadata.__astFieldHadFormat === true;
       const hadImportedEmptyValue = metadata.__astFieldHadEmptyValue === true;
@@ -978,6 +986,7 @@ const mapDesignerNodeToAstNode = (
       const emptyValue = hasExplicitEmptyValue ? asTrimmedString(metadata.emptyValue) : '';
       const hasExplicitPlaceholder = typeof metadata.placeholder === 'string';
       const placeholder = hasExplicitPlaceholder ? asTrimmedString(metadata.placeholder) : '';
+      const hasExplicitBorderStyle = typeof metadata.fieldBorderStyle === 'string';
       const mapped: TemplateNode = {
         ...createBaseNode(node),
         type: 'field',
@@ -1005,6 +1014,9 @@ const mapDesignerNodeToAstNode = (
       }
       if (displayFormat && supportsFieldDisplayFormat(bindingPath)) {
         mapped.displayFormat = displayFormat;
+      }
+      if (hasExplicitBorderStyle && borderStyle) {
+        mapped.borderStyle = borderStyle;
       }
       return mapped;
     }
@@ -1744,11 +1756,17 @@ export const importTemplateAstToWorkspace = (
           metadata.__astFieldHadFormat = Object.prototype.hasOwnProperty.call(inputNode, 'format');
           metadata.__astFieldHadEmptyValue = Object.prototype.hasOwnProperty.call(inputNode, 'emptyValue');
           metadata.__astFieldHadPlaceholder = Object.prototype.hasOwnProperty.call(inputNode, 'placeholder');
+          metadata.__astFieldHadBorderStyle = Object.prototype.hasOwnProperty.call(inputNode, 'borderStyle');
           if (inputNode.format) {
             metadata.format = inputNode.format;
           }
           if (inputNode.displayFormat) {
             metadata.displayFormat = inputNode.displayFormat;
+          }
+          if (inputNode.borderStyle) {
+            metadata.fieldBorderStyle = inputNode.borderStyle;
+          } else {
+            delete metadata.fieldBorderStyle;
           }
           if (inputNode.label) {
             metadata.label = inputNode.label;

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -28,6 +28,7 @@ import type {
 import { createEmptyDesignerTransformWorkspace, DOCUMENT_NODE_ID } from '../state/designerStore';
 import { getDefinition } from '../constants/componentCatalog';
 import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
+import { resolveMediaFrameSize } from '../utils/mediaSizing';
 import {
   toTemplateTransformPipeline,
   validateDesignerTransformWorkspace,
@@ -1423,10 +1424,15 @@ const resolveImportedCollectionBindingPath = (
 
 const parseSizeFromStyle = (node: TemplateNode): { width?: number; height?: number } => {
   const inline = node.style?.inline ?? {};
-  return {
-    width: parsePxLength(inline.width),
-    height: parsePxLength(inline.height),
-  };
+
+  if (node.type !== 'image') {
+    return {
+      width: parsePxLength(inline.width),
+      height: parsePxLength(inline.height),
+    };
+  }
+
+  return resolveMediaFrameSize(inline);
 };
 
 export const importTemplateAstToWorkspace = (

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
@@ -57,7 +57,7 @@ describe('DesignCanvas (media aspect-ratio integration)', () => {
         props: {
           name: 'Image',
           metadata: { src: 'https://example.com/test.png', alt: 'Test' },
-          style: { aspectRatio: '16 / 9', objectFit: 'cover' },
+          style: { aspectRatio: '16 / 9', objectFit: 'cover', objectPosition: 'right bottom' },
         },
         position: { x: 0, y: 0 },
         size: { width: 320, height: 180 },
@@ -101,6 +101,7 @@ describe('DesignCanvas (media aspect-ratio integration)', () => {
     expect(img).toBeTruthy();
     if (!img) return;
     expect(img.style.objectFit).toBe('cover');
+    expect(img.style.objectPosition).toBe('right bottom');
   });
 
   it('keeps imported standard logos close to preview sizing constraints in the designer canvas', () => {

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
@@ -2,13 +2,19 @@
 
 import React from 'react';
 import { DndContext } from '@dnd-kit/core';
-import { render, cleanup, screen } from '@testing-library/react';
+import { act, render, cleanup, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { DesignCanvas } from './DesignCanvas';
 import type { DesignerNode } from '../state/designerStore';
+import { useInvoiceDesignerStore } from '../state/designerStore';
+import { importTemplateAstToWorkspace } from '../ast/workspaceAst';
+import { getStandardTemplateAstByCode } from '../../../lib/invoice-template-ast/standardTemplates';
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  useInvoiceDesignerStore.getState().resetWorkspace();
+});
 
 const noop = () => {};
 
@@ -95,5 +101,45 @@ describe('DesignCanvas (media aspect-ratio integration)', () => {
     expect(img).toBeTruthy();
     if (!img) return;
     expect(img.style.objectFit).toBe('cover');
+  });
+
+  it('keeps imported standard logos close to preview sizing constraints in the designer canvas', () => {
+    const ast = getStandardTemplateAstByCode('standard-detailed');
+    expect(ast).toBeTruthy();
+    if (!ast) return;
+
+    const workspace = importTemplateAstToWorkspace(ast);
+    act(() => {
+      useInvoiceDesignerStore.getState().loadWorkspace(workspace);
+    });
+
+    render(
+      <DndContext>
+        <DesignCanvas
+          nodes={useInvoiceDesignerStore.getState().nodes}
+          selectedNodeId={null}
+          showGuides={false}
+          showRulers={false}
+          gridSize={8}
+          canvasScale={1}
+          snapToGrid={false}
+          guides={[]}
+          isDragActive={false}
+          forcedDropTarget={null}
+          droppableId="canvas"
+          onPointerLocationChange={noop}
+          onNodeSelect={noop}
+          onResize={noop}
+          readOnly={false}
+        />
+      </DndContext>
+    );
+
+    const logoEl = document.querySelector('[data-automation-id="designer-canvas-node-issuer-logo"]') as HTMLElement | null;
+    expect(logoEl).toBeTruthy();
+    if (!logoEl) return;
+
+    expect(logoEl.style.width).toBe('180px');
+    expect(logoEl.style.height).toBe('72px');
   });
 });

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.mediaAspect.integration.test.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { DndContext } from '@dnd-kit/core';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { DesignCanvas } from './DesignCanvas';
@@ -88,6 +88,8 @@ describe('DesignCanvas (media aspect-ratio integration)', () => {
     if (!imageEl) return;
 
     expect(imageEl.style.aspectRatio).toBe('16 / 9');
+    expect(imageEl.style.overflow).toBe('hidden');
+    expect(screen.getByText('Image · image')).toBeTruthy();
 
     const img = imageEl.querySelector('img') as HTMLImageElement | null;
     expect(img).toBeTruthy();

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -15,6 +15,7 @@ import { resolveFieldPreviewScaffold, resolveLabelPreviewScaffold } from './prev
 import { resolveContainerLayoutStyle, resolveNodeBoxStyle } from '../utils/cssLayout';
 import { resolveMediaFrameSize } from '../utils/mediaSizing';
 import { getNodeLayout, getNodeMetadata, getNodeName, getNodeStyle } from '../utils/nodeProps';
+import { inferHeightMode } from '../utils/sizeModes';
 import { resolveSortableStrategy } from '../utils/sortableStrategy';
 import {
   formatBoundValue,
@@ -470,7 +471,8 @@ const resolveTotalsRowPreviewModel = (
 
 const renderTablePreview = (
   metadata: Record<string, unknown>,
-  previewData: WasmInvoiceViewModel | null
+  previewData: WasmInvoiceViewModel | null,
+  options: { fillHeight: boolean }
 ): React.ReactNode => {
   const borderConfig = resolveTableBorderConfig(metadata);
   const headerWeightClass = FONT_WEIGHT_CLASS[
@@ -497,7 +499,8 @@ const renderTablePreview = (
   return (
     <div
       className={clsx(
-        'h-full overflow-hidden text-[10px] text-slate-700 dark:text-slate-300 rounded-sm bg-white dark:bg-slate-800',
+        options.fillHeight ? 'h-full' : 'h-auto',
+        'overflow-hidden text-[10px] text-slate-700 dark:text-slate-300 rounded-sm bg-white dark:bg-slate-800',
         borderConfig.outer && ['border', INVOICE_BORDER_STRONG_COLOR_CLASS]
       )}
     >
@@ -734,8 +737,9 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
     }
     case 'table':
     case 'dynamic-table': {
+      const fillHeight = inferHeightMode(getNodeStyle(node)) === 'fixed';
       return {
-        content: renderTablePreview(metadata, previewData),
+        content: renderTablePreview(metadata, previewData, { fillHeight }),
       };
     }
     case 'action-button':

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -13,6 +13,7 @@ import { DesignerNode } from '../state/designerStore';
 import { DESIGNER_CANVAS_WIDTH, DESIGNER_CANVAS_HEIGHT } from '../constants/layout';
 import { resolveFieldPreviewScaffold, resolveLabelPreviewScaffold } from './previewScaffolds';
 import { resolveContainerLayoutStyle, resolveNodeBoxStyle } from '../utils/cssLayout';
+import { resolveMediaFrameSize } from '../utils/mediaSizing';
 import { getNodeLayout, getNodeMetadata, getNodeName, getNodeStyle } from '../utils/nodeProps';
 import { resolveSortableStrategy } from '../utils/sortableStrategy';
 import {
@@ -857,6 +858,9 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
   const allowInferredFlowMinWidth = !astImported || astHadWidth;
   const allowInferredFlowMinHeight = !astImported || astHadHeight;
   const isMediaNode = node.type === 'image' || node.type === 'logo' || node.type === 'qr';
+  const mediaFrameSize = isMediaNode ? resolveMediaFrameSize(resolvedBoxStyle) : {};
+  const resolvedMediaWidth = mediaFrameSize.width;
+  const resolvedMediaHeight = mediaFrameSize.height;
   // Strip visual styles (backgroundColor, color, border) from resolved AST inline styles
   // so that Tailwind dark-mode classes on the canvas node can take effect.
   const { backgroundColor: _bg, color: _fg, border: _bdr, ...layoutBoxStyle } = resolvedBoxStyle;
@@ -866,17 +870,17 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
     boxSizing: 'border-box',
     // In flow layouts (flex/grid), do not force a fixed width/height from legacy node.size.
     // Instead, treat the authored size as a minimum box size so flex/grid can stretch items naturally.
-    width: isFlowPositioning ? resolvedWidth : (resolvedWidth ?? inferredWidth),
-    height: isFlowPositioning ? resolvedHeight : (resolvedHeight ?? inferredHeight),
+    width: isFlowPositioning ? (resolvedWidth ?? resolvedMediaWidth) : (resolvedWidth ?? resolvedMediaWidth ?? inferredWidth),
+    height: isFlowPositioning ? (resolvedHeight ?? resolvedMediaHeight) : (resolvedHeight ?? resolvedMediaHeight ?? inferredHeight),
     minWidth:
       isFlowPositioning
         ? (resolvedBoxStyle.minWidth ??
-          (resolvedWidth ? undefined : allowInferredFlowMinWidth ? inferredWidth : undefined))
+          (resolvedWidth || resolvedMediaWidth ? undefined : allowInferredFlowMinWidth ? inferredWidth : undefined))
         : resolvedBoxStyle.minWidth,
     minHeight:
       isFlowPositioning
         ? (resolvedBoxStyle.minHeight ??
-          (resolvedHeight ? undefined : allowInferredFlowMinHeight ? inferredHeight : undefined))
+          (resolvedHeight || resolvedMediaHeight ? undefined : allowInferredFlowMinHeight ? inferredHeight : undefined))
         : resolvedBoxStyle.minHeight,
     top: isFlowPositioning ? undefined : node.position.y,
     left: isFlowPositioning ? undefined : node.position.x,

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -770,6 +770,7 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
               ? metadata.fit
               : 'contain';
         const objectFit = getNodeStyle(node)?.objectFit ?? fallbackFit;
+        const objectPosition = getNodeStyle(node)?.objectPosition;
 
         if (!src) {
           const label = node.type === 'qr' ? 'QR Code' : node.type === 'logo' ? 'Logo' : 'Image';
@@ -791,6 +792,7 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
                 width: '100%',
                 height: '100%',
                 objectFit,
+                objectPosition,
                 display: 'block',
               }}
             />

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -856,6 +856,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
   const astHadHeight = metadata.__astHadHeight === true;
   const allowInferredFlowMinWidth = !astImported || astHadWidth;
   const allowInferredFlowMinHeight = !astImported || astHadHeight;
+  const isMediaNode = node.type === 'image' || node.type === 'logo' || node.type === 'qr';
   // Strip visual styles (backgroundColor, color, border) from resolved AST inline styles
   // so that Tailwind dark-mode classes on the canvas node can take effect.
   const { backgroundColor: _bg, color: _fg, border: _bdr, ...layoutBoxStyle } = resolvedBoxStyle;
@@ -883,6 +884,11 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
     transform: transform && !isDragging ? CSS.Transform.toString(transform) : undefined,
     transition,
     zIndex: isDragging ? 40 : isSelected ? 30 : 10,
+    ...(isMediaNode && !isContainer
+      ? {
+          overflow: 'hidden',
+        }
+      : {}),
   };
   const shouldDeemphasize = shouldDeemphasizeNode(hasActiveSelection, isInSelectionContext, isDragging);
   const sectionCue = node.type === 'section' ? getSectionSemanticCue(getNodeName(node)) : null;
@@ -891,7 +897,6 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
   const isTextNode = node.type === 'text';
   const isFieldNode = node.type === 'field';
   const fieldDisplayLabel = isFieldNode ? asTrimmedString(metadata.label) : '';
-  const isMediaNode = node.type === 'image' || node.type === 'logo' || node.type === 'qr';
   const labelWeightClass = FONT_WEIGHT_CLASS[
     resolveFontWeightStyle(metadata.fontWeight ?? metadata.labelFontWeight, 'semibold')
   ];
@@ -909,6 +914,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
     node.type !== 'page' &&
     node.type !== 'divider' &&
     node.type !== 'spacer';
+  const showOverlayNodeBadge = isContainer || !isCompactLeaf;
 
   const combinedRef = useCallback(
     (element: HTMLDivElement | null) => {
@@ -1094,17 +1100,19 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
           )}
         />
       )}
+      {showOverlayNodeBadge && (
+        <div className="absolute left-2 top-1 z-10 flex max-w-[calc(100%-1rem)] items-center gap-1.5 rounded bg-slate-900/80 px-2 py-0.5 text-[10px] uppercase tracking-wide text-white pointer-events-none">
+          <span className="truncate">{getNodeName(node)} · {node.type}</span>
+          {sectionCue && (
+            <span className={clsx('rounded border px-1 py-0.5 text-[9px] font-semibold', sectionCue.chipClass)}>
+              {sectionCue.label}
+            </span>
+          )}
+        </div>
+      )}
       {isContainer ? (
         <div className="relative w-full h-full">
           {sectionCue && <div className={clsx('absolute inset-y-0 left-0 w-1 rounded-l-md', sectionCue.accentClass)} />}
-          <div className="absolute left-2 top-1 text-[10px] uppercase tracking-wide text-slate-700 dark:text-slate-300 pointer-events-none z-10 flex items-center gap-1.5">
-            <span>{getNodeName(node)} · {node.type}</span>
-            {sectionCue && (
-              <span className={clsx('rounded border px-1 py-0.5 text-[9px] font-semibold', sectionCue.chipClass)}>
-                {sectionCue.label}
-              </span>
-            )}
-          </div>
           <div
             className="relative w-full h-full"
             style={resolveContainerLayoutStyle(getNodeLayout(node))}
@@ -1153,10 +1161,6 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
           )
         ) : (
           <>
-            <div className="px-2 py-1 border-b bg-slate-50 dark:bg-slate-800 text-xs font-semibold text-slate-600 dark:text-slate-300 flex items-center justify-between">
-              <span className="truncate">{getNodeName(node)}</span>
-              <span className="text-[10px] uppercase tracking-wide text-slate-400">{node.type}</span>
-            </div>
 	            <div
 	              className={clsx(
 	                'text-[11px] text-slate-500',

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -607,11 +607,21 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
         invoice: previewData,
         bindingKey,
         format: metadata.format,
+        displayFormat:
+          metadata.displayFormat === 'single-line' ||
+          metadata.displayFormat === 'multiline' ||
+          metadata.displayFormat === 'raw'
+            ? metadata.displayFormat
+            : undefined,
       });
-      if (boundValue) {
+      if (boundValue.text) {
         return {
-          content: boundValue,
-          singleLine: true,
+          content: boundValue.multiline ? (
+            <span className="whitespace-pre-line break-words">{boundValue.text}</span>
+          ) : (
+            boundValue.text
+          ),
+          singleLine: !boundValue.multiline,
         };
       }
       const preview = resolveFieldPreviewScaffold(node);
@@ -1137,7 +1147,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
               className={clsx(
                 'h-full text-[11px] text-slate-500 gap-1.5',
                 fieldSurfaceClasses,
-                previewContent.singleLine && 'whitespace-nowrap overflow-hidden',
+                previewContent.singleLine ? 'whitespace-nowrap overflow-hidden' : 'items-start',
                 previewContent.isPlaceholder && 'text-slate-400'
               )}
             >
@@ -1149,7 +1159,9 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
                   {fieldDisplayLabel}:
                 </span>
               )}
-              <span className="min-w-0 truncate">{previewContent.content}</span>
+              <span className={clsx('min-w-0', previewContent.singleLine ? 'truncate' : 'whitespace-pre-line break-words')}>
+                {previewContent.content}
+              </span>
             </div>
           ) : (
             <div

--- a/packages/billing/src/components/invoice-designer/fields/fieldCatalog.ts
+++ b/packages/billing/src/components/invoice-designer/fields/fieldCatalog.ts
@@ -1,0 +1,187 @@
+import type { TemplateFieldDisplayFormat } from '@alga-psa/types';
+
+export type InvoiceFieldCategory =
+  | 'Invoice'
+  | 'Customer'
+  | 'Tenant'
+  | 'Line Item'
+  | 'Quote'
+  | 'Quote Totals'
+  | 'Client'
+  | 'Contact';
+
+export type TemplateFieldKind = 'generic' | 'address';
+
+export type TemplateFieldDefinition = {
+  path: string;
+  label: string;
+  category: InvoiceFieldCategory;
+  description: string;
+  kind?: TemplateFieldKind;
+  supportedDisplayFormats?: TemplateFieldDisplayFormat[];
+};
+
+const FIELD_DEFINITIONS: Record<string, TemplateFieldDefinition> = {
+  'invoice.number': {
+    path: 'invoice.number',
+    label: 'Invoice Number',
+    category: 'Invoice',
+    description: 'The invoice number shown to the customer.',
+  },
+  'invoice.invoiceNumber': {
+    path: 'invoice.invoiceNumber',
+    label: 'Invoice Number',
+    category: 'Invoice',
+    description: 'The invoice number shown to the customer.',
+  },
+  'invoice.issueDate': {
+    path: 'invoice.issueDate',
+    label: 'Issue Date',
+    category: 'Invoice',
+    description: 'The date the invoice was issued.',
+  },
+  'invoice.dueDate': {
+    path: 'invoice.dueDate',
+    label: 'Due Date',
+    category: 'Invoice',
+    description: 'The date payment is due.',
+  },
+  'invoice.poNumber': {
+    path: 'invoice.poNumber',
+    label: 'PO Number',
+    category: 'Invoice',
+    description: 'The purchase order reference for this invoice.',
+  },
+  'invoice.subtotal': {
+    path: 'invoice.subtotal',
+    label: 'Subtotal',
+    category: 'Invoice',
+    description: 'The invoice subtotal before tax and discounts.',
+  },
+  'invoice.tax': {
+    path: 'invoice.tax',
+    label: 'Tax',
+    category: 'Invoice',
+    description: 'The tax amount for the invoice.',
+  },
+  'invoice.discount': {
+    path: 'invoice.discount',
+    label: 'Discount',
+    category: 'Invoice',
+    description: 'The invoice discount amount.',
+  },
+  'invoice.total': {
+    path: 'invoice.total',
+    label: 'Total',
+    category: 'Invoice',
+    description: 'The total amount due on the invoice.',
+  },
+  'invoice.currencyCode': {
+    path: 'invoice.currencyCode',
+    label: 'Currency Code',
+    category: 'Invoice',
+    description: 'The ISO currency code for this invoice.',
+  },
+  'customer.name': {
+    path: 'customer.name',
+    label: 'Customer Name',
+    category: 'Customer',
+    description: 'The customer name shown on the invoice.',
+  },
+  'customer.address': {
+    path: 'customer.address',
+    label: 'Customer Address',
+    category: 'Customer',
+    description: 'The customer billing address.',
+    kind: 'address',
+    supportedDisplayFormats: ['single-line', 'multiline', 'raw'],
+  },
+  'client.name': {
+    path: 'client.name',
+    label: 'Client Name',
+    category: 'Client',
+    description: 'The client name shown in quote-style templates.',
+  },
+  'client.address': {
+    path: 'client.address',
+    label: 'Client Address',
+    category: 'Client',
+    description: 'The client address.',
+    kind: 'address',
+    supportedDisplayFormats: ['single-line', 'multiline', 'raw'],
+  },
+  'contact.name': {
+    path: 'contact.name',
+    label: 'Contact Name',
+    category: 'Contact',
+    description: 'The contact name shown in quote-style templates.',
+  },
+  'contact.address': {
+    path: 'contact.address',
+    label: 'Contact Address',
+    category: 'Contact',
+    description: 'The contact address.',
+    kind: 'address',
+    supportedDisplayFormats: ['single-line', 'multiline', 'raw'],
+  },
+  'tenant.name': {
+    path: 'tenant.name',
+    label: 'Tenant Name',
+    category: 'Tenant',
+    description: 'Your company name.',
+  },
+  'tenant.address': {
+    path: 'tenant.address',
+    label: 'Tenant Address',
+    category: 'Tenant',
+    description: 'Your company address.',
+    kind: 'address',
+    supportedDisplayFormats: ['single-line', 'multiline', 'raw'],
+  },
+  'tenantClient.name': {
+    path: 'tenantClient.name',
+    label: 'Tenant Name',
+    category: 'Tenant',
+    description: 'Your company name.',
+  },
+  'tenantClient.address': {
+    path: 'tenantClient.address',
+    label: 'Tenant Address',
+    category: 'Tenant',
+    description: 'Your company address.',
+    kind: 'address',
+    supportedDisplayFormats: ['single-line', 'multiline', 'raw'],
+  },
+};
+
+export const humanizeBindingToken = (input: string): string =>
+  input
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[._\-/#:]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => {
+      if (part.length <= 2) {
+        return part.toUpperCase();
+      }
+      return `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`;
+    })
+    .join(' ');
+
+export const getTemplateFieldDefinition = (bindingKey: string): TemplateFieldDefinition | null => {
+  const normalized = bindingKey.trim();
+  return FIELD_DEFINITIONS[normalized] ?? null;
+};
+
+export const resolveTemplateFieldLabel = (bindingKey: string): string => {
+  const normalized = bindingKey.trim();
+  if (!normalized) {
+    return 'Unbound';
+  }
+  return getTemplateFieldDefinition(normalized)?.label ?? humanizeBindingToken(normalized);
+};
+
+export const getTemplateFieldDisplayFormats = (bindingKey: string): TemplateFieldDisplayFormat[] =>
+  getTemplateFieldDefinition(bindingKey)?.supportedDisplayFormats ?? [];

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
@@ -199,6 +199,7 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
                 label: 'Invoice #',
                 bindingKey: 'invoice.number',
                 format: 'text',
+                placeholder: 'Invoice Number',
               },
             },
             children: [],
@@ -234,6 +235,7 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
 
     let updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
     expect((updated.props as any)?.metadata?.bindingKey).toBe('customer.address');
+    expect((updated.props as any)?.metadata?.placeholder).toBe('Customer Address');
 
     fireEvent.click(screen.getByRole('button', { name: 'Use custom path' }));
 
@@ -244,6 +246,59 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
 
     updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
     expect((updated.props as any)?.metadata?.bindingKey).toBe('invoice.balanceDue');
+  });
+
+  it('does not overwrite a custom placeholder when picking a new field binding', () => {
+    act(() => {
+      const store = useInvoiceDesignerStore.getState();
+      store.loadWorkspace({
+        rootId: 'doc-1',
+        nodesById: {
+          'doc-1': { id: 'doc-1', type: 'document', props: { name: 'Document' }, children: ['page-1'] },
+          'page-1': { id: 'page-1', type: 'page', props: { name: 'Page 1' }, children: ['field-1'] },
+          'field-1': {
+            id: 'field-1',
+            type: 'field',
+            props: {
+              name: 'Invoice Field',
+              metadata: {
+                bindingKey: 'invoice.number',
+                format: 'text',
+                placeholder: 'Reference value',
+              },
+            },
+            children: [],
+          },
+        },
+        snapToGrid: false,
+        gridSize: 8,
+        showGuides: false,
+        showRulers: false,
+        canvasScale: 1,
+      });
+      store.selectNode('field-1');
+    });
+
+    const Wrapper: React.FC = () => {
+      const nodes = useInvoiceDesignerStore((state) => state.nodes);
+      const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+      const node = useInvoiceDesignerStore((state) =>
+        selectedNodeId ? (state.nodesById[selectedNodeId] as DesignerNode | undefined) : undefined
+      );
+      const nodesById = useMemo(() => new Map(nodes.map((n) => [n.id, n] as const)), [nodes]);
+      if (!node) return null;
+      return <DesignerSchemaInspector node={node} nodesById={nodesById} />;
+    };
+
+    render(<Wrapper />);
+
+    const searchInput = screen.getByPlaceholderText('Search fields...') as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'customer address' } });
+    fireEvent.click(screen.getByText('Customer Address'));
+
+    const updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.metadata?.bindingKey).toBe('customer.address');
+    expect((updated.props as any)?.metadata?.placeholder).toBe('Reference value');
   });
 
   it('preserves label spacing while typing and trims on blur commit', () => {

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
@@ -172,8 +172,6 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
 
     const labelInput = screen.getByDisplayValue('Invoice #') as HTMLInputElement;
     expect(labelInput.getAttribute('data-template-insert-target')).toBeNull();
-    const bindingInput = screen.getByDisplayValue('invoice.number') as HTMLInputElement;
-    expect(bindingInput.getAttribute('data-template-insert-target')).toBe('metadata.bindingKey');
     fireEvent.change(labelInput, { target: { value: 'PO #' } });
 
     const emptyValueInput = screen.getByDisplayValue('-') as HTMLInputElement;
@@ -182,6 +180,70 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
     const updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
     expect((updated.props as any)?.metadata?.label).toBe('PO #');
     expect((updated.props as any)?.metadata?.emptyValue).toBe('N/A');
+  });
+
+  it('lets field bindings be selected from a searchable picker with a custom path fallback', () => {
+    act(() => {
+      const store = useInvoiceDesignerStore.getState();
+      store.loadWorkspace({
+        rootId: 'doc-1',
+        nodesById: {
+          'doc-1': { id: 'doc-1', type: 'document', props: { name: 'Document' }, children: ['page-1'] },
+          'page-1': { id: 'page-1', type: 'page', props: { name: 'Page 1' }, children: ['field-1'] },
+          'field-1': {
+            id: 'field-1',
+            type: 'field',
+            props: {
+              name: 'Invoice Field',
+              metadata: {
+                label: 'Invoice #',
+                bindingKey: 'invoice.number',
+                format: 'text',
+              },
+            },
+            children: [],
+          },
+        },
+        snapToGrid: false,
+        gridSize: 8,
+        showGuides: false,
+        showRulers: false,
+        canvasScale: 1,
+      });
+      store.selectNode('field-1');
+    });
+
+    const Wrapper: React.FC = () => {
+      const nodes = useInvoiceDesignerStore((state) => state.nodes);
+      const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+      const node = useInvoiceDesignerStore((state) =>
+        selectedNodeId ? (state.nodesById[selectedNodeId] as DesignerNode | undefined) : undefined
+      );
+      const nodesById = useMemo(() => new Map(nodes.map((n) => [n.id, n] as const)), [nodes]);
+      if (!node) return null;
+      return <DesignerSchemaInspector node={node} nodesById={nodesById} />;
+    };
+
+    render(<Wrapper />);
+
+    expect(screen.getByText('Current')).toBeTruthy();
+
+    const searchInput = screen.getByPlaceholderText('Search fields...') as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'customer address' } });
+    fireEvent.click(screen.getByText('Customer Address'));
+
+    let updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.metadata?.bindingKey).toBe('customer.address');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use custom path' }));
+
+    const customInput = screen.getByDisplayValue('customer.address') as HTMLInputElement;
+    expect(customInput.getAttribute('data-template-insert-target')).toBe('metadata.bindingKey');
+    fireEvent.change(customInput, { target: { value: 'invoice.balanceDue' } });
+    fireEvent.blur(customInput);
+
+    updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.metadata?.bindingKey).toBe('invoice.balanceDue');
   });
 
   it('preserves label spacing while typing and trims on blur commit', () => {

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- Invoice designer inspector uses shared expression-authoring utilities to enumerate template field bindings */
 import React, { useCallback, useMemo, useState } from 'react';
 import { Input } from '@alga-psa/ui/components/Input';
 import ColorPicker from '@alga-psa/ui/components/ColorPicker';

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
@@ -2,6 +2,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Input } from '@alga-psa/ui/components/Input';
 import ColorPicker from '@alga-psa/ui/components/ColorPicker';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import {
+  buildInvoiceExpressionPathOptions,
+  type SharedExpressionPathOption,
+} from '@alga-psa/workflows/expression-authoring';
 import { getComponentSchema } from '../schema/componentSchema';
 import type { DesignerNode } from '../state/designerStore';
 import { useInvoiceDesignerStore } from '../state/designerStore';
@@ -11,6 +15,12 @@ import type {
   DesignerInspectorVisibleWhen,
 } from '../schema/inspectorSchema';
 import { TableEditorWidget } from './widgets/TableEditorWidget';
+import {
+  getTemplateFieldDefinition,
+  humanizeBindingToken,
+  type InvoiceFieldCategory,
+} from '../fields/fieldCatalog';
+import { resolveDesignerDocumentKind } from '../utils/documentKind';
 import {
   normalizeCssColor,
   normalizeCssLength,
@@ -72,6 +82,237 @@ type Props = {
 };
 
 type ApplyNormalized = (path: string, next: unknown, commit: boolean) => void;
+
+type BindingOption = {
+  path: string;
+  label: string;
+  category: InvoiceFieldCategory;
+  description: string;
+  searchText: string;
+};
+
+const categoryLabelByRoot: Record<string, InvoiceFieldCategory> = {
+  invoice: 'Invoice',
+  customer: 'Customer',
+  quote: 'Quote',
+  quoteTotals: 'Quote Totals',
+  client: 'Client',
+  contact: 'Contact',
+  tenant: 'Tenant',
+  item: 'Line Item',
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const toBindingOption = (option: SharedExpressionPathOption): BindingOption | null => {
+  const knownField = getTemplateFieldDefinition(option.path);
+  if (knownField) {
+    return {
+      path: knownField.path,
+      label: knownField.label,
+      category: knownField.category,
+      description: knownField.description,
+      searchText: `${knownField.label} ${knownField.path} ${knownField.description} ${knownField.category}`.toLowerCase(),
+    };
+  }
+  const category = categoryLabelByRoot[option.root];
+  if (!category) return null;
+  const pathSegments = option.path.split('.');
+  if (pathSegments.length < 2 || !option.isLeaf) return null;
+  const fieldName = pathSegments[pathSegments.length - 1]?.replace(/\[\]/g, '') ?? option.path;
+  const categoryPrefix = category === 'Line Item' ? 'Item' : category;
+  const label = category === 'Invoice' ? toTitleCase(fieldName) : `${categoryPrefix} ${toTitleCase(fieldName)}`;
+  const description = option.description ?? option.path;
+  return {
+    path: option.path,
+    label,
+    category,
+    description,
+    searchText: `${label} ${option.path} ${description} ${category}`.toLowerCase(),
+  };
+};
+
+type FieldBindingPickerProps = {
+  nodeId: string;
+  domId: string;
+  label: string;
+  path: string;
+  value: string;
+  applyNormalized: ApplyNormalized;
+};
+
+const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
+  nodeId,
+  domId,
+  label,
+  path,
+  value,
+  applyNormalized,
+}) => {
+  const nodes = useInvoiceDesignerStore((state) => state.nodes);
+  const documentKind = useMemo(() => resolveDesignerDocumentKind(nodes), [nodes]);
+  const normalizedBinding = value.trim();
+  const selectedDefinition = getTemplateFieldDefinition(normalizedBinding);
+  const [query, setQuery] = useState('');
+  const [customMode, setCustomMode] = useState(() => normalizedBinding.length > 0 && !selectedDefinition);
+
+  React.useEffect(() => {
+    setCustomMode(normalizedBinding.length > 0 && !getTemplateFieldDefinition(normalizedBinding));
+    setQuery('');
+  }, [nodeId, normalizedBinding]);
+
+  const options = useMemo(() => {
+    const seen = new Set<string>();
+    return buildInvoiceExpressionPathOptions({
+      mode: 'template',
+      includeRootPaths: false,
+      documentKind,
+    })
+      .map(toBindingOption)
+      .filter((option): option is BindingOption => option !== null)
+      .filter((option) => {
+        if (seen.has(option.path)) {
+          return false;
+        }
+        seen.add(option.path);
+        return true;
+      })
+      .sort((left, right) => {
+        if (left.category !== right.category) {
+          return left.category.localeCompare(right.category);
+        }
+        return left.label.localeCompare(right.label);
+      });
+  }, [documentKind]);
+
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return options;
+    }
+    return options.filter((option) => option.searchText.includes(normalizedQuery));
+  }, [options, query]);
+
+  const groupedOptions = useMemo(
+    () =>
+      filteredOptions.reduce<Record<string, BindingOption[]>>((acc, option) => {
+        if (!acc[option.category]) {
+          acc[option.category] = [];
+        }
+        acc[option.category].push(option);
+        return acc;
+      }, {}),
+    [filteredOptions]
+  );
+
+  const currentLabel =
+    selectedDefinition?.label ?? (normalizedBinding ? humanizeBindingToken(normalizedBinding) : 'No field selected');
+
+  if (customMode) {
+    return (
+      <div key={`${nodeId}-${path}`} className="space-y-2">
+        <label htmlFor={domId} className="text-xs text-slate-500 block mb-1">
+          {label}
+        </label>
+        <Input
+          id={domId}
+          value={value}
+          placeholder="invoice.number"
+          data-template-insert-target={path}
+          onChange={(event) => applyNormalized(path, normalizeStringLive(event.target.value), false)}
+          onBlur={(event) => applyNormalized(path, normalizeString(event.target.value), true)}
+        />
+        <p className="text-[11px] text-slate-500">
+          Type any binding path when the field you need is not listed.
+        </p>
+        <button
+          type="button"
+          className="rounded border border-slate-300 px-2 py-1 text-[11px] font-medium text-slate-600 transition-colors hover:border-slate-400 hover:bg-slate-50"
+          data-automation-id={`${domId}-use-picker`}
+          onClick={() => {
+            setQuery(normalizedBinding);
+            setCustomMode(false);
+          }}
+        >
+          Use field picker
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div key={`${nodeId}-${path}`} className="space-y-2">
+      <label htmlFor={`${domId}-search`} className="text-xs text-slate-500 block mb-1">
+        {label}
+      </label>
+      <div className="rounded-md border border-slate-200 bg-slate-50 px-2 py-2 dark:border-[rgb(var(--color-border-200))] dark:bg-[rgb(var(--color-surface-100))]">
+        <div className="text-[10px] uppercase tracking-wide text-slate-500">Current</div>
+        <div className="text-sm font-medium text-slate-800 dark:text-slate-200">{currentLabel}</div>
+        <div className="text-[11px] font-mono text-slate-500">{normalizedBinding || 'Unbound'}</div>
+      </div>
+      <Input
+        id={`${domId}-search`}
+        value={query}
+        placeholder="Search fields..."
+        data-automation-id={`${domId}-search`}
+        onChange={(event) => setQuery(event.target.value)}
+      />
+      <div
+        className="max-h-56 space-y-2 overflow-y-auto rounded-md border border-slate-200 bg-white px-2 py-2 dark:border-[rgb(var(--color-border-200))] dark:bg-[rgb(var(--color-card))]"
+        data-automation-id={`${domId}-results`}
+      >
+        {filteredOptions.length === 0 ? (
+          <p className="text-[11px] text-slate-500">No matching fields.</p>
+        ) : (
+          Object.entries(groupedOptions).map(([category, categoryOptions]) => (
+            <div key={category} className="space-y-1">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">{category}</p>
+              {categoryOptions.map((option) => {
+                const selected = option.path === normalizedBinding;
+                return (
+                  <button
+                    key={option.path}
+                    type="button"
+                    className={`w-full rounded border px-2 py-1.5 text-left transition-colors ${
+                      selected
+                        ? 'border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-100'
+                        : 'border-slate-200 bg-white text-slate-800 hover:border-blue-200 hover:bg-blue-50/40 dark:border-slate-700 dark:bg-[rgb(var(--color-card))] dark:text-slate-200 dark:hover:border-blue-700 dark:hover:bg-blue-900/20'
+                    }`}
+                    data-automation-id={`${domId}-option-${option.path.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+                    onClick={() => {
+                      applyNormalized(path, option.path, true);
+                      setQuery('');
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-xs font-medium">{option.label}</span>
+                      <span className="shrink-0 text-[10px] font-mono text-slate-500">{option.path}</span>
+                    </div>
+                    <p className="mt-1 text-[10px] text-slate-500">{option.description}</p>
+                  </button>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+      <button
+        type="button"
+        className="rounded border border-slate-300 px-2 py-1 text-[11px] font-medium text-slate-600 transition-colors hover:border-slate-400 hover:bg-slate-50"
+        data-automation-id={`${domId}-use-custom`}
+        onClick={() => setCustomMode(true)}
+      >
+        Use custom path
+      </button>
+    </div>
+  );
+};
 
 type CssLengthFieldProps = {
   domId: string;
@@ -561,6 +802,20 @@ export const DesignerSchemaInspector: React.FC<Props> = ({ node, nodesById }) =>
     if (field.kind === 'widget') {
       if (field.widget === 'table-editor') {
         return <TableEditorWidget key={field.id} node={node} />;
+      }
+      if (field.widget === 'field-binding-picker') {
+        const value = resolveValue(field);
+        return (
+          <FieldBindingPicker
+            key={`${node.id}-${field.id}`}
+            nodeId={node.id}
+            domId={domId}
+            label={field.label}
+            path={field.path}
+            value={typeof value === 'string' ? value : ''}
+            applyNormalized={applyNormalized}
+          />
+        );
       }
       return null;
     }

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
@@ -18,6 +18,7 @@ import { TableEditorWidget } from './widgets/TableEditorWidget';
 import {
   getTemplateFieldDefinition,
   humanizeBindingToken,
+  resolveTemplateFieldLabel,
   type InvoiceFieldCategory,
 } from '../fields/fieldCatalog';
 import { resolveDesignerDocumentKind } from '../utils/documentKind';
@@ -159,8 +160,17 @@ const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
   const documentKind = useMemo(() => resolveDesignerDocumentKind(nodes), [nodes]);
   const normalizedBinding = value.trim();
   const selectedDefinition = getTemplateFieldDefinition(normalizedBinding);
+  const currentNode = useInvoiceDesignerStore((state) => state.nodesById[nodeId] as DesignerNode | undefined);
   const [query, setQuery] = useState('');
   const [customMode, setCustomMode] = useState(() => normalizedBinding.length > 0 && !selectedDefinition);
+  const currentPlaceholder = useMemo(() => {
+    if (!currentNode || !isPlainObject(currentNode.props)) {
+      return '';
+    }
+    const metadata = isPlainObject(currentNode.props.metadata) ? currentNode.props.metadata : null;
+    return typeof metadata?.placeholder === 'string' ? metadata.placeholder.trim() : '';
+  }, [currentNode]);
+  const autoPlaceholderLabel = useMemo(() => resolveTemplateFieldLabel(normalizedBinding), [normalizedBinding]);
 
   React.useEffect(() => {
     setCustomMode(normalizedBinding.length > 0 && !getTemplateFieldDefinition(normalizedBinding));
@@ -286,6 +296,11 @@ const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
                     }`}
                     data-automation-id={`${domId}-option-${option.path.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
                     onClick={() => {
+                      const shouldSyncPlaceholder =
+                        currentPlaceholder.length === 0 || currentPlaceholder === autoPlaceholderLabel;
+                      if (shouldSyncPlaceholder) {
+                        applyNormalized('metadata.placeholder', option.label, false);
+                      }
                       applyNormalized(path, option.path, true);
                       setQuery('');
                     }}

--- a/packages/billing/src/components/invoice-designer/palette/ComponentPalette.fields.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/palette/ComponentPalette.fields.integration.test.tsx
@@ -43,4 +43,17 @@ describe('ComponentPalette fields tab', () => {
     expect(screen.getByText('Currency Code')).toBeTruthy();
     expect(screen.queryByText('Tenant Address')).toBeNull();
   });
+
+  it('keeps address field descriptions neutral in the fields tab', () => {
+    render(
+      <DndContext>
+        <ComponentPalette />
+      </DndContext>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'FIELDS' }));
+
+    expect(screen.getByText('The customer billing address.')).toBeTruthy();
+    expect(screen.queryByText(/property panel/i)).toBeNull();
+  });
 });

--- a/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
+++ b/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
@@ -11,6 +11,7 @@ import { OutlineView } from './OutlineView';
 import clsx from 'clsx';
 import { useInvoiceDesignerStore } from '../state/designerStore';
 import { resolveDesignerDocumentKind } from '../utils/documentKind';
+import { getTemplateFieldDefinition, type InvoiceFieldCategory } from '../fields/fieldCatalog';
 
 interface PaletteProps {
   onSearch?: (query: string) => void;
@@ -30,16 +31,6 @@ const groupByCategory = (components: ComponentDefinition[]) => {
 };
 
 const paletteGroups = groupByCategory(COMPONENT_CATALOG);
-
-type InvoiceFieldCategory =
-  | 'Invoice'
-  | 'Customer'
-  | 'Tenant'
-  | 'Line Item'
-  | 'Quote'
-  | 'Quote Totals'
-  | 'Client'
-  | 'Contact';
 
 type TemplateVariableOption = {
   path: string;
@@ -68,6 +59,15 @@ const toTitleCase = (value: string) =>
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
 const toTemplateVariableOption = (option: SharedExpressionPathOption): TemplateVariableOption | null => {
+  const knownField = getTemplateFieldDefinition(option.path);
+  if (knownField) {
+    return {
+      path: knownField.path,
+      label: knownField.label,
+      category: knownField.category,
+      description: knownField.description,
+    };
+  }
   const category = categoryLabelByRoot[option.root];
   if (!category) return null;
   const pathSegments = option.path.split('.');

--- a/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
+++ b/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
@@ -38,7 +38,7 @@ describe('previewBindings', () => {
       bindingKey: 'invoice.number',
       format: 'text',
     });
-    expect(value).toBe('INV-100');
+    expect(value.text).toBe('INV-100');
   });
 
   it('returns null when binding is missing so scaffold fallback can apply', () => {
@@ -47,7 +47,7 @@ describe('previewBindings', () => {
       bindingKey: 'invoice.unknownField',
       format: 'text',
     });
-    expect(value).toBeNull();
+    expect(value.text).toBeNull();
   });
 
   it('formats date and currency bindings', () => {
@@ -62,8 +62,8 @@ describe('previewBindings', () => {
       format: 'currency',
     });
 
-    expect(dateValue).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
-    expect(currencyValue).toBe('$21.00');
+    expect(dateValue.text).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+    expect(currencyValue.text).toBe('$21.00');
   });
 
   it('derives invoice.discount from subtotal + tax - total', () => {
@@ -78,7 +78,7 @@ describe('previewBindings', () => {
       format: 'currency',
     });
 
-    expect(value).toBe('$2.00');
+    expect(value.text).toBe('$2.00');
   });
 
   it('does not mirror customer address when tenant address is missing', () => {
@@ -91,6 +91,42 @@ describe('previewBindings', () => {
       format: 'text',
     });
 
-    expect(value).toBeNull();
+    expect(value.text).toBeNull();
+  });
+
+  it('formats address bindings as multiline blocks when requested', () => {
+    const value = resolveFieldPreviewValue({
+      invoice: {
+        ...previewInvoice,
+        tenantClient: {
+          ...previewInvoice.tenantClient!,
+          address: '400 SW Main St, , Portland, OR 97204',
+        },
+      },
+      bindingKey: 'tenant.address',
+      format: 'text',
+      displayFormat: 'multiline',
+    });
+
+    expect(value.text).toBe('400 SW Main St\nPortland\nOR 97204');
+    expect(value.multiline).toBe(true);
+  });
+
+  it('treats client.address as a synonym for customer.address', () => {
+    const value = resolveFieldPreviewValue({
+      invoice: {
+        ...previewInvoice,
+        customer: {
+          ...previewInvoice.customer!,
+          address: '901 Harbor Ave, Seattle, WA 98104',
+        },
+      },
+      bindingKey: 'client.address',
+      format: 'text',
+      displayFormat: 'multiline',
+    });
+
+    expect(value.text).toBe('901 Harbor Ave\nSeattle\nWA 98104');
+    expect(value.multiline).toBe(true);
   });
 });

--- a/packages/billing/src/components/invoice-designer/preview/previewBindings.ts
+++ b/packages/billing/src/components/invoice-designer/preview/previewBindings.ts
@@ -1,37 +1,14 @@
-import type { WasmInvoiceViewModel } from '@alga-psa/types';
-
-type FieldFormat = 'text' | 'number' | 'currency' | 'date';
+import type { TemplateFieldDisplayFormat, WasmInvoiceViewModel } from '@alga-psa/types';
+import {
+  formatTemplateFieldValue,
+  normalizeFieldFormat as normalizeTemplateFieldFormat,
+} from '../../../lib/invoice-template-ast/fieldFormatting';
+import { resolveInvoiceTemplateBindingAlias } from '../../../lib/invoice-template-ast/bindingAliases';
 
 const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
 const isNullish = (value: unknown): value is null | undefined => value === null || value === undefined;
-
-const formatCurrency = (value: number, currencyCode: string) => {
-  try {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currencyCode || 'USD',
-    }).format(value / 100);
-  } catch {
-    return `$${(value / 100).toFixed(2)}`;
-  }
-};
-
-const formatDate = (value: string) => {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleDateString('en-US');
-};
-
-export const normalizeFieldFormat = (value: unknown): FieldFormat => {
-  const normalized = asTrimmedString(value).toLowerCase();
-  if (normalized === 'number' || normalized === 'currency' || normalized === 'date') {
-    return normalized;
-  }
-  return 'text';
-};
+const supportsAddressDisplayFormat = (bindingKey: string): boolean => asTrimmedString(bindingKey).endsWith('.address');
 
 const flattenInvoiceBindingMap = (invoice: WasmInvoiceViewModel): Record<string, unknown> => ({
   'invoice.discount': Math.max(0, (invoice.subtotal ?? 0) + (invoice.tax ?? 0) - (invoice.total ?? 0)),
@@ -68,8 +45,16 @@ export const resolveInvoiceBindingRawValue = (
     return mappedValue;
   }
 
+  const aliasedKey = resolveInvoiceTemplateBindingAlias(normalizedKey);
+  if (aliasedKey !== normalizedKey) {
+    const aliasedValue = flattenInvoiceBindingMap(invoice)[aliasedKey];
+    if (!isNullish(aliasedValue)) {
+      return aliasedValue;
+    }
+  }
+
   // Last-chance resolver for direct dotted paths in the model shape.
-  const pathSegments = normalizedKey.split('.').filter(Boolean);
+  const pathSegments = aliasedKey.split('.').filter(Boolean);
   let cursor: unknown = invoice;
   for (const segment of pathSegments) {
     if (isNullish(cursor) || typeof cursor !== 'object') {
@@ -80,66 +65,35 @@ export const resolveInvoiceBindingRawValue = (
   return cursor;
 };
 
+export const normalizeFieldFormat = normalizeTemplateFieldFormat;
+
 export const formatBoundValue = (
   value: unknown,
-  format: FieldFormat,
+  format: unknown,
   currencyCode: string
-): string | null => {
-  if (isNullish(value)) {
-    return null;
-  }
-
-  if (typeof value === 'string') {
-    if (value.length === 0) {
-      return null;
-    }
-    if (format === 'date') {
-      return formatDate(value);
-    }
-    if (format === 'number') {
-      const asNumber = Number(value);
-      return Number.isFinite(asNumber) ? String(asNumber) : value;
-    }
-    if (format === 'currency') {
-      const asNumber = Number(value);
-      if (!Number.isFinite(asNumber)) {
-        return value;
-      }
-      return formatCurrency(asNumber, currencyCode);
-    }
-    return value;
-  }
-
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      return null;
-    }
-    if (format === 'currency') {
-      return formatCurrency(value, currencyCode);
-    }
-    if (format === 'date') {
-      return formatDate(String(value));
-    }
-    return String(value);
-  }
-
-  if (typeof value === 'boolean') {
-    return value ? 'Yes' : 'No';
-  }
-
-  return null;
-};
+): string | null =>
+  formatTemplateFieldValue({
+    value,
+    format,
+    currencyCode,
+  }).text;
 
 export const resolveFieldPreviewValue = (params: {
   invoice: WasmInvoiceViewModel | null;
   bindingKey: string;
   format: unknown;
-}): string | null => {
+  displayFormat?: TemplateFieldDisplayFormat | null;
+}): { text: string | null; multiline: boolean } => {
   const raw = resolveInvoiceBindingRawValue(params.invoice, params.bindingKey);
   if (isNullish(raw)) {
-    return null;
+    return { text: null, multiline: false };
   }
-  return formatBoundValue(raw, normalizeFieldFormat(params.format), params.invoice?.currencyCode ?? 'USD');
+  return formatTemplateFieldValue({
+    value: raw,
+    format: params.format,
+    currencyCode: params.invoice?.currencyCode ?? 'USD',
+    displayFormat: supportsAddressDisplayFormat(params.bindingKey) ? params.displayFormat : undefined,
+  });
 };
 
 export const resolveTableItemBindingRawValue = (

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
@@ -249,34 +249,6 @@ const COMMON_INSPECTOR: DesignerInspectorSchema = {
         },
       ],
     },
-    {
-      id: 'flex-item',
-      title: 'Flex Item',
-      visibleWhen: { kind: 'parentPathEquals', path: 'layout.display', value: 'flex' },
-      fields: [
-        {
-          kind: 'number',
-          id: 'flexGrow',
-          label: 'flex-grow',
-          path: 'style.flexGrow',
-          placeholder: '0',
-        },
-        {
-          kind: 'number',
-          id: 'flexShrink',
-          label: 'flex-shrink',
-          path: 'style.flexShrink',
-          placeholder: '1',
-        },
-        {
-          kind: 'css-length',
-          id: 'flexBasis',
-          label: 'flex-basis',
-          path: 'style.flexBasis',
-          placeholder: 'auto | 240px | 50%',
-        },
-      ],
-    },
   ],
 };
 

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
@@ -634,7 +634,7 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
       metadata: {},
     },
     hierarchy: {
-      allowedChildren: ['section'],
+      allowedChildren: ['section', 'totals', 'table', 'dynamic-table', 'image', 'logo', 'qr', 'signature', 'attachment-list', 'action-button'],
       allowedParents: ['document'],
     },
     inspector: COMMON_INSPECTOR,
@@ -743,11 +743,15 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     category: 'Content',
     defaults: {
       size: { width: 360, height: 140 },
+      style: {
+        width: '100%',
+        height: 'auto',
+      },
       metadata: {},
     },
     hierarchy: {
       allowedChildren: [],
-      allowedParents: ['column', 'container', 'section'],
+      allowedParents: ['page', 'column', 'container', 'section'],
     },
     inspector: COMMON_INSPECTOR,
   },
@@ -758,6 +762,10 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     category: 'Dynamic',
     defaults: {
       size: { width: 520, height: 220 },
+      style: {
+        width: '100%',
+        height: 'auto',
+      },
       metadata: {
         columns: [
           { id: 'col-desc', header: 'Description', key: 'item.description', type: 'text', width: 220 },
@@ -774,7 +782,7 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     },
     hierarchy: {
       allowedChildren: [],
-      allowedParents: ['column', 'container', 'section'],
+      allowedParents: ['page', 'column', 'container', 'section'],
     },
     inspector: mergeInspectorSchemas(COMMON_INSPECTOR, TABLE_INSPECTOR),
   },
@@ -785,6 +793,10 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     category: 'Dynamic',
     defaults: {
       size: { width: 520, height: 240 },
+      style: {
+        width: '100%',
+        height: 'auto',
+      },
       metadata: {
         tableBorderPreset: 'boxed',
         tableOuterBorder: true,
@@ -795,7 +807,7 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     },
     hierarchy: {
       allowedChildren: [],
-      allowedParents: ['column', 'container', 'section'],
+      allowedParents: ['page', 'column', 'container', 'section'],
     },
     inspector: mergeInspectorSchemas(COMMON_INSPECTOR, TABLE_INSPECTOR),
   },

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
@@ -292,12 +292,12 @@ const FIELD_INSPECTOR: DesignerInspectorSchema = {
           placeholder: 'Invoice #',
         },
         {
-          kind: 'string',
+          kind: 'widget',
           id: 'bindingKey',
+          widget: 'field-binding-picker',
           domId: 'designer-field-binding',
           label: 'Binding key',
           path: 'metadata.bindingKey',
-          enableExpressionInsert: true,
         },
         {
           kind: 'enum',
@@ -790,11 +790,15 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
     category: 'Content',
     defaults: {
       size: { width: 200, height: 48 },
+      style: {
+        width: 'auto',
+        height: 'auto',
+      },
       metadata: {
         bindingKey: 'invoice.number',
         format: 'text',
         placeholder: 'Invoice Number',
-        fieldBorderStyle: 'underline',
+        fieldBorderStyle: 'none',
       },
     },
     hierarchy: {

--- a/packages/billing/src/components/invoice-designer/schema/inspectorSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/inspectorSchema.ts
@@ -106,4 +106,13 @@ export type DesignerInspectorField =
       widget: 'table-editor';
       domId?: string;
       visibleWhen?: DesignerInspectorVisibleWhen;
+    }
+  | {
+      kind: 'widget';
+      id: string;
+      widget: 'field-binding-picker';
+      label: string;
+      path: string;
+      domId?: string;
+      visibleWhen?: DesignerInspectorVisibleWhen;
     };

--- a/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
@@ -42,4 +42,24 @@ describe('designerStore addNodeFromPalette', () => {
       height: `${Math.round(schemaSize.height)}px`,
     });
   });
+
+  it('applies shared block sizing defaults for dynamic tables', () => {
+    const store = useInvoiceDesignerStore.getState();
+    const pageId = store.nodes.find((node) => node.type === 'page')?.id;
+    expect(pageId).toBeTruthy();
+    if (!pageId) return;
+
+    store.addNodeFromPalette('dynamic-table', { x: 120, y: 160 }, { parentId: pageId });
+
+    const tableId = useInvoiceDesignerStore.getState().selectedNodeId;
+    expect(tableId).toBeTruthy();
+    if (!tableId) return;
+
+    const table = useInvoiceDesignerStore.getState().nodesById[tableId];
+    expect(table.type).toBe('dynamic-table');
+    expect(table.props.style).toMatchObject({
+      width: '100%',
+      height: 'auto',
+    });
+  });
 });

--- a/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
@@ -62,4 +62,32 @@ describe('designerStore addNodeFromPalette', () => {
       height: 'auto',
     });
   });
+
+  it('applies auto sizing defaults for new data fields', () => {
+    const store = useInvoiceDesignerStore.getState();
+    const pageId = store.nodes.find((node) => node.type === 'page')?.id;
+    expect(pageId).toBeTruthy();
+    if (!pageId) return;
+
+    store.addNodeFromPalette('section', { x: 120, y: 160 }, { parentId: pageId });
+    const sectionId = useInvoiceDesignerStore.getState().selectedNodeId;
+    expect(sectionId).toBeTruthy();
+    if (!sectionId) return;
+
+    store.addNodeFromPalette('field', { x: 140, y: 180 }, { parentId: sectionId });
+
+    const fieldId = useInvoiceDesignerStore.getState().selectedNodeId;
+    expect(fieldId).toBeTruthy();
+    if (!fieldId) return;
+
+    const field = useInvoiceDesignerStore.getState().nodesById[fieldId];
+    expect(field.type).toBe('field');
+    expect(field.props.style).toMatchObject({
+      width: 'auto',
+      height: 'auto',
+    });
+    expect(field.props.metadata).toMatchObject({
+      fieldBorderStyle: 'none',
+    });
+  });
 });

--- a/packages/billing/src/components/invoice-designer/state/designerStore.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.ts
@@ -108,6 +108,7 @@ export interface DesignerNodeStyle {
   // Media
   aspectRatio?: string; // e.g. '16 / 9', '1'
   objectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+  objectPosition?: string;
 
   // Visual
   margin?: CssLength;

--- a/packages/billing/src/components/invoice-designer/utils/cssLayout.test.ts
+++ b/packages/billing/src/components/invoice-designer/utils/cssLayout.test.ts
@@ -62,6 +62,7 @@ describe('cssLayout', () => {
       flexBasis: '240px',
       aspectRatio: '16 / 9',
       objectFit: 'contain',
+      objectPosition: 'right bottom',
     });
 
     expect(style).toMatchObject({
@@ -76,7 +77,7 @@ describe('cssLayout', () => {
       flexBasis: '240px',
       aspectRatio: '16 / 9',
       objectFit: 'contain',
+      objectPosition: 'right bottom',
     });
   });
 });
-

--- a/packages/billing/src/components/invoice-designer/utils/cssLayout.ts
+++ b/packages/billing/src/components/invoice-designer/utils/cssLayout.ts
@@ -48,6 +48,7 @@ export const resolveNodeBoxStyle = (nodeStyle?: DesignerNodeStyle): CSSPropertie
     // Media helpers (applies to replaced elements like <img>, but harmless on a wrapper div).
     aspectRatio: nodeStyle.aspectRatio,
     objectFit: nodeStyle.objectFit,
+    objectPosition: nodeStyle.objectPosition,
 
     // Visual style helpers used by imported AST templates.
     margin: nodeStyle.margin,

--- a/packages/billing/src/components/invoice-designer/utils/mediaSizing.ts
+++ b/packages/billing/src/components/invoice-designer/utils/mediaSizing.ts
@@ -1,0 +1,57 @@
+type MediaSizingStyle = {
+  width?: unknown;
+  height?: unknown;
+  maxWidth?: unknown;
+  maxHeight?: unknown;
+  aspectRatio?: unknown;
+};
+
+const parsePxLength = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const numeric = Number.parseFloat(trimmed.replace(/px$/i, '').trim());
+  return Number.isFinite(numeric) ? numeric : undefined;
+};
+
+const parseAspectRatioNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parts = trimmed.split('/').map((part) => Number.parseFloat(part.trim()));
+  if (parts.length === 2 && Number.isFinite(parts[0]) && Number.isFinite(parts[1]) && parts[0] > 0 && parts[1] > 0) {
+    return parts[0] / parts[1];
+  }
+
+  const numeric = Number.parseFloat(trimmed);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : undefined;
+};
+
+export const resolveMediaFrameSize = (style: MediaSizingStyle): { width?: number; height?: number } => {
+  const width = parsePxLength(style.width) ?? parsePxLength(style.maxWidth);
+  const height = parsePxLength(style.height) ?? parsePxLength(style.maxHeight);
+  const aspectRatio = parseAspectRatioNumber(style.aspectRatio);
+
+  return {
+    width: width ?? (height !== undefined && aspectRatio ? height * aspectRatio : undefined),
+    height: height ?? (width !== undefined && aspectRatio ? width / aspectRatio : undefined),
+  };
+};

--- a/packages/billing/src/components/invoice-designer/utils/nodeProps.ts
+++ b/packages/billing/src/components/invoice-designer/utils/nodeProps.ts
@@ -3,26 +3,26 @@ import type { DesignerContainerLayout, DesignerNode, DesignerNodeStyle } from '.
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-export const getNodeName = (node: DesignerNode): string => {
-  const props = isPlainObject(node.props) ? node.props : {};
+export const getNodeName = (node: DesignerNode | undefined): string => {
+  const props = isPlainObject(node?.props) ? node.props : {};
   if (typeof props.name === 'string') return props.name;
   return '';
 };
 
-export const getNodeMetadata = (node: DesignerNode): Record<string, unknown> => {
-  const props = isPlainObject(node.props) ? node.props : {};
+export const getNodeMetadata = (node: DesignerNode | undefined): Record<string, unknown> => {
+  const props = isPlainObject(node?.props) ? node.props : {};
   if (isPlainObject(props.metadata)) return props.metadata as Record<string, unknown>;
   return {};
 };
 
-export const getNodeLayout = (node: DesignerNode): DesignerContainerLayout | undefined => {
-  const props = isPlainObject(node.props) ? node.props : {};
+export const getNodeLayout = (node: DesignerNode | undefined): DesignerContainerLayout | undefined => {
+  const props = isPlainObject(node?.props) ? node.props : {};
   if (isPlainObject(props.layout)) return props.layout as unknown as DesignerContainerLayout;
   return undefined;
 };
 
-export const getNodeStyle = (node: DesignerNode): DesignerNodeStyle | undefined => {
-  const props = isPlainObject(node.props) ? node.props : {};
+export const getNodeStyle = (node: DesignerNode | undefined): DesignerNodeStyle | undefined => {
+  const props = isPlainObject(node?.props) ? node.props : {};
   if (isPlainObject(props.style)) return props.style as unknown as DesignerNodeStyle;
   return undefined;
 };

--- a/packages/billing/src/components/invoice-designer/utils/sizeModes.ts
+++ b/packages/billing/src/components/invoice-designer/utils/sizeModes.ts
@@ -1,0 +1,60 @@
+import type { DesignerComponentType, DesignerNode, DesignerNodeStyle } from '../state/designerStore';
+
+export type DesignerWidthMode = 'fixed' | 'fill' | 'hug';
+export type DesignerHeightMode = 'fixed' | 'hug';
+
+const SHARED_SIZING_COMPONENT_TYPES = new Set<DesignerComponentType>([
+  'table',
+  'dynamic-table',
+  'totals',
+  'signature',
+  'attachment-list',
+  'action-button',
+]);
+
+const normalizeCssValue = (value: unknown): string => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+export const supportsSharedSizingModes = (type: DesignerComponentType): boolean =>
+  SHARED_SIZING_COMPONENT_TYPES.has(type);
+
+export const inferWidthMode = (style: Partial<DesignerNodeStyle> | undefined): DesignerWidthMode => {
+  const width = normalizeCssValue(style?.width);
+  if (width === '100%') {
+    return 'fill';
+  }
+  if (width === 'fit-content' || width === 'max-content' || width === 'auto') {
+    return 'hug';
+  }
+  return 'fixed';
+};
+
+export const inferHeightMode = (style: Partial<DesignerNodeStyle> | undefined): DesignerHeightMode => {
+  const height = normalizeCssValue(style?.height);
+  if (height === 'auto' || height === 'fit-content' || height === 'max-content') {
+    return 'hug';
+  }
+  return 'fixed';
+};
+
+export const resolveWidthValueForMode = (
+  mode: DesignerWidthMode,
+  node: DesignerNode
+): string => {
+  if (mode === 'fill') {
+    return '100%';
+  }
+  if (mode === 'hug') {
+    return 'fit-content';
+  }
+  return `${Math.round(node.size.width)}px`;
+};
+
+export const resolveHeightValueForMode = (
+  mode: DesignerHeightMode,
+  node: DesignerNode
+): string => {
+  if (mode === 'hug') {
+    return 'auto';
+  }
+  return `${Math.round(node.size.height)}px`;
+};

--- a/packages/billing/src/lib/invoice-template-ast/bindingAliases.ts
+++ b/packages/billing/src/lib/invoice-template-ast/bindingAliases.ts
@@ -1,0 +1,14 @@
+const BINDING_ALIASES: Record<string, string> = {
+  'client.name': 'customer.name',
+  'client.address': 'customer.address',
+  'tenant.name': 'tenantClient.name',
+  'tenant.address': 'tenantClient.address',
+};
+
+export const resolveInvoiceTemplateBindingAlias = (bindingPath: string): string => {
+  const normalized = bindingPath.trim();
+  if (!normalized) {
+    return normalized;
+  }
+  return BINDING_ALIASES[normalized] ?? normalized;
+};

--- a/packages/billing/src/lib/invoice-template-ast/evaluator.ts
+++ b/packages/billing/src/lib/invoice-template-ast/evaluator.ts
@@ -13,6 +13,7 @@ import {
   resolveTemplateStrategy,
 } from './strategies';
 import { validateTemplateAst } from './schema';
+import { resolveInvoiceTemplateBindingAlias } from './bindingAliases';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -135,16 +136,16 @@ const resolveBindingValue = (
 ): unknown => {
   const valueBinding = ast.bindings?.values?.[bindingId];
   if (valueBinding) {
-    const resolved = getPathValue(invoiceData, valueBinding.path);
+    const resolved = getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(valueBinding.path));
     return resolved === undefined ? valueBinding.fallback : resolved;
   }
 
   const collectionBinding = ast.bindings?.collections?.[bindingId];
   if (collectionBinding) {
-    return getPathValue(invoiceData, collectionBinding.path);
+    return getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(collectionBinding.path));
   }
 
-  return getPathValue(invoiceData, bindingId);
+  return getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(bindingId));
 };
 
 const hasBindingReference = (ast: TemplateAst, bindingId: string): boolean =>
@@ -429,11 +430,13 @@ export const evaluateTemplateAst = (
   };
 
   for (const [bindingId, binding] of Object.entries(ast.bindings?.values ?? {})) {
-    const resolved = getPathValue(invoiceData, binding.path);
+    const resolved = getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(binding.path));
     bindings[bindingId] = resolved === undefined ? binding.fallback : resolved;
   }
   for (const [bindingId, binding] of Object.entries(ast.bindings?.collections ?? {})) {
-    bindings[bindingId] = cloneRecordArray(getPathValue(invoiceData, binding.path));
+    bindings[bindingId] = cloneRecordArray(
+      getPathValue(invoiceData, resolveInvoiceTemplateBindingAlias(binding.path))
+    );
   }
 
   if (!ast.transforms) {

--- a/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
+++ b/packages/billing/src/lib/invoice-template-ast/fieldFormatting.ts
@@ -1,0 +1,176 @@
+import type { TemplateFieldDisplayFormat, TemplateValueFormat } from '@alga-psa/types';
+
+type AddressRecord = Record<string, unknown>;
+
+export type ResolvedFieldDisplayValue = {
+  text: string | null;
+  multiline: boolean;
+};
+
+const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const isNullish = (value: unknown): value is null | undefined => value === null || value === undefined;
+
+const formatCurrency = (value: number, currencyCode: string) => {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currencyCode || 'USD',
+    }).format(value / 100);
+  } catch {
+    return `$${(value / 100).toFixed(2)}`;
+  }
+};
+
+const formatDate = (value: string) => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString('en-US');
+};
+
+export const normalizeFieldFormat = (value: unknown): TemplateValueFormat => {
+  const normalized = asTrimmedString(value).toLowerCase();
+  if (normalized === 'number' || normalized === 'currency' || normalized === 'date') {
+    return normalized;
+  }
+  return 'text';
+};
+
+const isAddressRecord = (value: unknown): value is AddressRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const splitAddressSegments = (input: string): string[] =>
+  input
+    .replace(/\r\n?/g, '\n')
+    .split(/\n|,/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+const joinLocationLine = (city: string, state: string, postalCode: string): string => {
+  const left = [city, state].filter(Boolean).join(city && state ? ', ' : '');
+  if (left && postalCode) {
+    return `${left} ${postalCode}`;
+  }
+  return left || postalCode;
+};
+
+const formatStructuredAddress = (value: AddressRecord, displayFormat: TemplateFieldDisplayFormat): ResolvedFieldDisplayValue => {
+  const line1 =
+    asTrimmedString(value.line1) ||
+    asTrimmedString(value.address1) ||
+    asTrimmedString(value.street1) ||
+    asTrimmedString(value.street);
+  const line2 =
+    asTrimmedString(value.line2) ||
+    asTrimmedString(value.address2) ||
+    asTrimmedString(value.street2);
+  const city = asTrimmedString(value.city);
+  const state = asTrimmedString(value.state) || asTrimmedString(value.region) || asTrimmedString(value.province);
+  const postalCode =
+    asTrimmedString(value.postalCode) ||
+    asTrimmedString(value.zip) ||
+    asTrimmedString(value.zipCode);
+  const country = asTrimmedString(value.country);
+  const lines = [line1, line2, joinLocationLine(city, state, postalCode), country].filter(Boolean);
+  if (lines.length === 0) {
+    return { text: null, multiline: false };
+  }
+  if (displayFormat === 'multiline') {
+    return { text: lines.join('\n'), multiline: true };
+  }
+  if (displayFormat === 'raw') {
+    return { text: lines.join('\n'), multiline: true };
+  }
+  return { text: lines.join(', '), multiline: false };
+};
+
+const formatAddressValue = (
+  value: unknown,
+  displayFormat: TemplateFieldDisplayFormat
+): ResolvedFieldDisplayValue => {
+  if (isNullish(value)) {
+    return { text: null, multiline: false };
+  }
+  if (isAddressRecord(value)) {
+    return formatStructuredAddress(value, displayFormat);
+  }
+  if (typeof value !== 'string') {
+    return { text: String(value), multiline: false };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { text: null, multiline: false };
+  }
+  if (displayFormat === 'raw') {
+    return { text: trimmed, multiline: trimmed.includes('\n') };
+  }
+  const parts = splitAddressSegments(trimmed);
+  if (parts.length === 0) {
+    return { text: null, multiline: false };
+  }
+  if (displayFormat === 'multiline') {
+    return { text: parts.join('\n'), multiline: true };
+  }
+  return { text: parts.join(', '), multiline: false };
+};
+
+const formatPrimitiveValue = (
+  value: unknown,
+  format: TemplateValueFormat,
+  currencyCode: string
+): ResolvedFieldDisplayValue => {
+  if (isNullish(value)) {
+    return { text: null, multiline: false };
+  }
+  if (typeof value === 'string') {
+    if (value.length === 0) {
+      return { text: null, multiline: false };
+    }
+    if (format === 'date') {
+      return { text: formatDate(value), multiline: false };
+    }
+    if (format === 'number') {
+      const asNumber = Number(value);
+      const text = Number.isFinite(asNumber) ? String(asNumber) : value;
+      return { text, multiline: text.includes('\n') };
+    }
+    if (format === 'currency') {
+      const asNumber = Number(value);
+      const text = Number.isFinite(asNumber) ? formatCurrency(asNumber, currencyCode) : value;
+      return { text, multiline: text.includes('\n') };
+    }
+    return { text: value, multiline: value.includes('\n') };
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return { text: null, multiline: false };
+    }
+    if (format === 'currency') {
+      return { text: formatCurrency(value, currencyCode), multiline: false };
+    }
+    if (format === 'date') {
+      return { text: formatDate(String(value)), multiline: false };
+    }
+    return { text: String(value), multiline: false };
+  }
+  if (typeof value === 'boolean') {
+    return { text: value ? 'Yes' : 'No', multiline: false };
+  }
+  return { text: null, multiline: false };
+};
+
+export const formatTemplateFieldValue = (params: {
+  value: unknown;
+  format: unknown;
+  currencyCode: string;
+  displayFormat?: TemplateFieldDisplayFormat | null;
+}): ResolvedFieldDisplayValue => {
+  const normalizedFormat = normalizeFieldFormat(params.format);
+  const displayFormat = params.displayFormat;
+  if (displayFormat === 'single-line' || displayFormat === 'multiline' || displayFormat === 'raw') {
+    return formatAddressValue(params.value, displayFormat);
+  }
+  return formatPrimitiveValue(params.value, normalizedFormat, params.currencyCode);
+};

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -186,7 +186,80 @@ describe('renderEvaluatedTemplateAst', () => {
 
     expect(rendered.html).toContain('border:1px solid #cbd5e1');
     expect(rendered.html).toContain('border-bottom:1px solid #cbd5e1');
-    expect(rendered.html).toContain('border:1px solid transparent');
+    expect(rendered.html).toContain('padding:0');
+    expect(rendered.html).toContain('border:0');
+  });
+
+  it('renders multiline plain fields without single-line inset chrome', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          customerAddress: { id: 'customerAddress', kind: 'value', path: 'customer.address' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'customer-address',
+            type: 'field',
+            binding: { bindingId: 'customerAddress' },
+            borderStyle: 'none',
+            displayFormat: 'multiline',
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, {
+      ...invoiceFixture,
+      customer: { address: '901 Harbor Ave, Seattle, WA 98104' },
+    });
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('padding:0');
+    expect(rendered.html).toContain('align-items:flex-start');
+    expect(rendered.html).toContain('white-space:pre-line');
+    expect(rendered.html).toContain('901 Harbor Ave');
+  });
+
+  it('removes single-line inset padding for multiline underlined fields', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          customerAddress: { id: 'customerAddress', kind: 'value', path: 'customer.address' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'customer-address',
+            type: 'field',
+            binding: { bindingId: 'customerAddress' },
+            borderStyle: 'underline',
+            displayFormat: 'multiline',
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, {
+      ...invoiceFixture,
+      customer: { address: '901 Harbor Ave, Seattle, WA 98104' },
+    });
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('padding:0');
+    expect(rendered.html).toContain('border-bottom:1px solid #cbd5e1');
+    expect(rendered.html).toContain('align-items:flex-start');
+    expect(rendered.html).toContain('white-space:pre-line');
   });
 
   it('renders grouped dynamic-table rows from a transformed output binding', async () => {

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -112,6 +112,83 @@ describe('renderEvaluatedTemplateAst', () => {
     expect(rendered.html).toContain('300');
   });
 
+  it('renders multiline address fields with preserved line breaks', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          tenantAddress: { id: 'tenantAddress', kind: 'value', path: 'tenantClient.address' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'issuer-address',
+            type: 'field',
+            binding: { bindingId: 'tenantAddress' },
+            displayFormat: 'multiline',
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, {
+      ...invoiceFixture,
+      tenantClient: { address: '400 SW Main St, Portland, OR 97204' },
+    });
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('400 SW Main St');
+    expect(rendered.html).toContain('Portland');
+    expect(rendered.html).toContain('white-space:pre-line');
+  });
+
+  it('renders field border styles in preview output', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'invoice-number-boxed',
+            type: 'field',
+            binding: { bindingId: 'invoiceNumber' },
+            borderStyle: 'box',
+          },
+          {
+            id: 'invoice-number-underlined',
+            type: 'field',
+            binding: { bindingId: 'invoiceNumber' },
+            borderStyle: 'underline',
+          },
+          {
+            id: 'invoice-number-plain',
+            type: 'field',
+            binding: { bindingId: 'invoiceNumber' },
+            borderStyle: 'none',
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, invoiceFixture);
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('border:1px solid #cbd5e1');
+    expect(rendered.html).toContain('border-bottom:1px solid #cbd5e1');
+    expect(rendered.html).toContain('border:1px solid transparent');
+  });
+
   it('renders grouped dynamic-table rows from a transformed output binding', async () => {
     const ast: TemplateAst = {
       kind: 'invoice-template-ast',

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -126,11 +126,11 @@ const resolveFieldBorderStyle = (
 ): React.CSSProperties => {
   if (borderStyle === 'none') {
     return {
-      padding: '2px 4px',
-      border: '1px solid transparent',
+      padding: '0',
+      border: '0',
       backgroundColor: 'transparent',
       display: 'flex',
-      alignItems: 'center',
+      alignItems: 'flex-start',
     };
   }
   if (borderStyle === 'box') {
@@ -412,7 +412,21 @@ const renderNode = (
         currencyCode: ctx.currencyCode,
         displayFormat: node.displayFormat,
       });
-      const fieldStyle = { ...resolveFieldBorderStyle(node.borderStyle), ...(style ?? {}) };
+      const multilineFieldAdjustments: React.CSSProperties | null = formattedValue.multiline
+        ? {
+            alignItems: 'flex-start',
+            ...(node.borderStyle === 'none' || node.borderStyle === 'underline'
+              ? {
+                  padding: '0',
+                }
+              : null),
+          }
+        : null;
+      const fieldStyle = {
+        ...resolveFieldBorderStyle(node.borderStyle),
+        ...(multilineFieldAdjustments ?? null),
+        ...(style ?? {}),
+      };
       return (
         <div key={node.id} id={node.id} className={elementClassName || undefined} style={fieldStyle}>
           {node.label ? <span>{node.label}: </span> : null}

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import type {
   TemplateAst,
+  TemplateFieldBorderStyle,
   TemplateNode,
   TemplateNodeStyleRef,
   TemplateStyleDeclaration,
   TemplateValueExpression,
   TemplateValueFormat,
 } from '@alga-psa/types';
+import { formatTemplateFieldValue } from './fieldFormatting';
 import type { TemplateEvaluationResult } from './evaluator';
 import { decodeTemplatePathExpression } from './templateInterpolationFilters';
 import { resolveTemplatePrintSettingsFromAst } from './printSettings';
@@ -117,6 +119,39 @@ const resolveStyleRef = (
           .join(' ')
       : null;
   return { className, style: styleDeclarationToReactStyle(styleRef.inline) };
+};
+
+const resolveFieldBorderStyle = (
+  borderStyle: TemplateFieldBorderStyle | undefined
+): React.CSSProperties => {
+  if (borderStyle === 'none') {
+    return {
+      padding: '2px 4px',
+      border: '1px solid transparent',
+      backgroundColor: 'transparent',
+      display: 'flex',
+      alignItems: 'center',
+    };
+  }
+  if (borderStyle === 'box') {
+    return {
+      padding: '6px 8px',
+      border: '1px solid #cbd5e1',
+      borderRadius: '4px',
+      backgroundColor: 'transparent',
+      display: 'flex',
+      alignItems: 'center',
+    };
+  }
+  return {
+    padding: '2px 4px',
+    border: '0',
+    borderBottom: '1px solid #cbd5e1',
+    borderRadius: '0',
+    backgroundColor: 'transparent',
+    display: 'flex',
+    alignItems: 'center',
+  };
 };
 
 const resolveSyntheticRootDocumentStyle = (ast: TemplateAst): React.CSSProperties | undefined => {
@@ -371,10 +406,19 @@ const renderNode = (
     }
     case 'field': {
       const value = evaluation.bindings[node.binding.bindingId];
+      const formattedValue = formatTemplateFieldValue({
+        value: value ?? node.emptyValue ?? '',
+        format: node.format,
+        currencyCode: ctx.currencyCode,
+        displayFormat: node.displayFormat,
+      });
+      const fieldStyle = { ...resolveFieldBorderStyle(node.borderStyle), ...(style ?? {}) };
       return (
-        <div key={node.id} id={node.id} className={elementClassName || undefined} style={style}>
+        <div key={node.id} id={node.id} className={elementClassName || undefined} style={fieldStyle}>
           {node.label ? <span>{node.label}: </span> : null}
-          <span>{formatValue(value ?? node.emptyValue ?? '', node.format, ctx)}</span>
+          <span style={formattedValue.multiline ? { whiteSpace: 'pre-line' } : undefined}>
+            {formattedValue.text ?? ''}
+          </span>
         </div>
       );
     }
@@ -564,4 +608,3 @@ export const renderEvaluatedTemplateAst = async (
     css: buildAstCss(ast),
   };
 };
-

--- a/packages/billing/src/lib/invoice-template-ast/schema.ts
+++ b/packages/billing/src/lib/invoice-template-ast/schema.ts
@@ -46,6 +46,7 @@ const styleDeclarationSchema = z.object({
   flex: z.string().optional(),
   aspectRatio: z.string().optional(),
   objectFit: z.string().optional(),
+  objectPosition: z.string().optional(),
   color: z.string().optional(),
   backgroundColor: z.string().optional(),
   borderColor: z.string().optional(),
@@ -513,4 +514,3 @@ export const parseTemplateAst = (input: unknown): TemplateAst => {
   }
   return result.ast;
 };
-

--- a/packages/billing/src/lib/invoice-template-ast/schema.ts
+++ b/packages/billing/src/lib/invoice-template-ast/schema.ts
@@ -15,6 +15,7 @@ const cssIdentifierSchema = z
   .regex(CSS_SAFE_IDENTIFIER_REGEX, { message: 'Invalid CSS identifier.' });
 
 const valueFormatSchema = z.enum(['text', 'number', 'currency', 'date']);
+const fieldDisplayFormatSchema = z.enum(['single-line', 'multiline', 'raw']);
 const paperPresetSchema = z.enum(INVOICE_PAPER_PRESET_IDS);
 const printSettingsSchema = z.object({
   paperPreset: paperPresetSchema,
@@ -273,7 +274,9 @@ type NodeInput =
       binding: z.infer<typeof bindingRefSchema>;
       label?: string;
       emptyValue?: string;
+      placeholder?: string;
       format?: z.infer<typeof valueFormatSchema>;
+      displayFormat?: z.infer<typeof fieldDisplayFormatSchema>;
     }
   | {
       id: string;
@@ -369,7 +372,9 @@ const nodeSchema: z.ZodTypeAny = z.lazy(() =>
       binding: bindingRefSchema,
       label: z.string().optional(),
       emptyValue: z.string().optional(),
+      placeholder: z.string().optional(),
       format: valueFormatSchema.optional(),
+      displayFormat: fieldDisplayFormatSchema.optional(),
     }).strict(),
     z.object({
       id: z.string().min(1),

--- a/packages/billing/src/lib/invoice-template-ast/schema.ts
+++ b/packages/billing/src/lib/invoice-template-ast/schema.ts
@@ -16,6 +16,7 @@ const cssIdentifierSchema = z
 
 const valueFormatSchema = z.enum(['text', 'number', 'currency', 'date']);
 const fieldDisplayFormatSchema = z.enum(['single-line', 'multiline', 'raw']);
+const fieldBorderStyleSchema = z.enum(['underline', 'box', 'none']);
 const paperPresetSchema = z.enum(INVOICE_PAPER_PRESET_IDS);
 const printSettingsSchema = z.object({
   paperPreset: paperPresetSchema,
@@ -277,6 +278,7 @@ type NodeInput =
       placeholder?: string;
       format?: z.infer<typeof valueFormatSchema>;
       displayFormat?: z.infer<typeof fieldDisplayFormatSchema>;
+      borderStyle?: z.infer<typeof fieldBorderStyleSchema>;
     }
   | {
       id: string;
@@ -375,6 +377,7 @@ const nodeSchema: z.ZodTypeAny = z.lazy(() =>
       placeholder: z.string().optional(),
       format: valueFormatSchema.optional(),
       displayFormat: fieldDisplayFormatSchema.optional(),
+      borderStyle: fieldBorderStyleSchema.optional(),
     }).strict(),
     z.object({
       id: z.string().min(1),

--- a/packages/types/src/lib/invoice-template-ast.ts
+++ b/packages/types/src/lib/invoice-template-ast.ts
@@ -24,6 +24,7 @@ export interface TemplateAstMetadata {
 
 export type TemplateValueFormat = 'text' | 'number' | 'currency' | 'date';
 export type TemplateFieldDisplayFormat = 'single-line' | 'multiline' | 'raw';
+export type TemplateFieldBorderStyle = 'underline' | 'box' | 'none';
 
 export type TemplateNodeType =
   | 'document'
@@ -75,6 +76,7 @@ export interface TemplateFieldNode extends TemplateNodeBase {
   placeholder?: string;
   format?: TemplateValueFormat;
   displayFormat?: TemplateFieldDisplayFormat;
+  borderStyle?: TemplateFieldBorderStyle;
   children?: never;
 }
 

--- a/packages/types/src/lib/invoice-template-ast.ts
+++ b/packages/types/src/lib/invoice-template-ast.ts
@@ -186,6 +186,9 @@ export interface TemplateStyleDeclaration {
   lineHeight?: string | number;
   textAlign?: 'left' | 'center' | 'right' | 'justify';
   flex?: string;
+  aspectRatio?: string;
+  objectFit?: string;
+  objectPosition?: string;
   borderColor?: string;
   fontStyle?: string;
 }

--- a/packages/types/src/lib/invoice-template-ast.ts
+++ b/packages/types/src/lib/invoice-template-ast.ts
@@ -23,6 +23,7 @@ export interface TemplateAstMetadata {
 }
 
 export type TemplateValueFormat = 'text' | 'number' | 'currency' | 'date';
+export type TemplateFieldDisplayFormat = 'single-line' | 'multiline' | 'raw';
 
 export type TemplateNodeType =
   | 'document'
@@ -71,7 +72,9 @@ export interface TemplateFieldNode extends TemplateNodeBase {
   binding: TemplateBindingRef;
   label?: string;
   emptyValue?: string;
+  placeholder?: string;
   format?: TemplateValueFormat;
+  displayFormat?: TemplateFieldDisplayFormat;
   children?: never;
 }
 


### PR DESCRIPTION
## Summary
Follow up the merged grouped-template fix with a broader set of invoice designer quality improvements:

- align designer canvas chrome and media sizing with preview output
- add media alignment and object-fit controls using the property panel’s existing icon-button patterns
- add shared `Fill / Fixed / Hug` sizing controls for block nodes and simplify flex item controls
- persist data-field placeholder and border-style settings through save/reopen and preview rendering
- improve field binding authoring with a searchable picker, address display formats, alias-aware bindings, and placeholder syncing
- default new data fields to `borderStyle: none` and auto sizing so inserted fields behave more naturally

## Why
The invoice designer still had a series of follow-up usability and fidelity issues after the grouped-table work landed:

- designer badges and media sizing did not match preview output closely enough
- media controls used less consistent property-panel affordances
- block sizing and flex item behavior were hard to understand in the inspector
- field placeholder and border-style settings were not fully round-tripping into preview behavior
- binding authoring was still too raw, and address-capable fields needed formatting support and alias handling
- new data fields came in with defaults that created extra cleanup work

## Impact
Invoice template authors now get a more consistent WYSIWYG designer, clearer layout controls, better field-binding ergonomics, and more predictable field defaults and preview behavior.

## Validation
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts ../packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/inspector/TableEditorWidget.integration.test.tsx`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/canvas/DesignCanvas*.test.tsx ../packages/billing/src/components/invoice-designer/canvas/DesignCanvas*.integration.test.tsx`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/DesignerShell.mediaControls.integration.test.tsx ../packages/billing/src/components/invoice-designer/DesignerShell.fitSection.test.ts ../packages/billing/src/components/invoice-designer/DesignerShell.sharedSizing.integration.test.tsx ../packages/billing/src/components/invoice-designer/DesignerShell.flexItemControls.integration.test.tsx ../packages/billing/src/components/invoice-designer/DesignerShell.fieldDisplayControls.integration.test.tsx`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx ../packages/billing/src/components/invoice-designer/palette/ComponentPalette.fields.integration.test.tsx ../packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx ../packages/billing/src/actions/invoiceTemplatePreview.integration.test.ts`
- `cd server && npx vitest run --coverage.enabled=false ../packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts`

## Notes
- The original worktree still has unrelated local edits in `.env.localtest` and `package-lock.json`; those were intentionally excluded from this PR.
- This PR is based on a fresh follow-up branch off `main` because the previous invoice-template PR for this worktree was already merged as #2244.