### PR TITLE
Fix automatic invoice backfill filtering

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -150,6 +150,33 @@ function buildPersistedRowAttribution(row: PersistedRecurringDueWorkDbRow): NonN
     };
 }
 
+function buildBackfillSuppressionKey(input: {
+    clientId: string;
+    billingCycleId?: string | null;
+    servicePeriodStart: ISO8601String;
+    servicePeriodEnd: ISO8601String;
+    invoiceWindowStart: ISO8601String;
+    invoiceWindowEnd: ISO8601String;
+}) {
+    const servicePeriodStart = normalizeDateOnly(input.servicePeriodStart);
+    const servicePeriodEnd = normalizeDateOnly(input.servicePeriodEnd);
+    const invoiceWindowStart = normalizeDateOnly(input.invoiceWindowStart);
+    const invoiceWindowEnd = normalizeDateOnly(input.invoiceWindowEnd);
+
+    if (!servicePeriodStart || !servicePeriodEnd || !invoiceWindowStart || !invoiceWindowEnd) {
+        return null;
+    }
+
+    return [
+        input.clientId,
+        input.billingCycleId ?? '',
+        servicePeriodStart,
+        servicePeriodEnd,
+        invoiceWindowStart,
+        invoiceWindowEnd,
+    ].join('|');
+}
+
 function buildUnresolvedRowAttribution(): NonNullable<IRecurringDueWorkRow['attribution']> {
     return {
         source: 'unresolved',
@@ -372,6 +399,7 @@ async function fetchPersistedRecurringDueWorkDbRows(
             'rsp.period_key',
             'rsp.lifecycle_state',
             'rsp.reason_code',
+            'rsp.charge_family',
             'rsp.cadence_owner',
             'rsp.due_position',
             'rsp.service_period_start',
@@ -441,6 +469,7 @@ async function fetchPersistedRecurringDueWorkDbRows(
             'rsp.period_key',
             'rsp.lifecycle_state',
             'rsp.reason_code',
+            'rsp.charge_family',
             'rsp.cadence_owner',
             'rsp.due_position',
             'rsp.service_period_start',
@@ -1263,14 +1292,44 @@ export const getAvailableRecurringDueWork = withAuth(async (
             asOf,
             groupingMetadataByRecordId,
         );
-        const compatibilityBackfillRecordIds = new Set(
-            persistedDbRows
-                .filter((row) => row.reason_code === 'backfill_materialization')
-                .map((row) => row.record_id),
+        const persistedIdentityKeys = new Set(
+            persistedRows.map((row) => row.executionIdentityKey),
         );
-        const readyPersistedRows = persistedRows.filter(
-            (row) => !row.recordId || !compatibilityBackfillRecordIds.has(row.recordId),
+        const materializationGaps = rawMaterializationGaps.filter(
+            (gap) => !persistedIdentityKeys.has(gap.executionIdentityKey),
         );
+        const backfillSuppressionKeys = new Set(
+            materializationGaps
+                .map((gap) =>
+                    buildBackfillSuppressionKey({
+                        clientId: gap.clientId,
+                        billingCycleId: gap.billingCycleId ?? null,
+                        servicePeriodStart: gap.servicePeriodStart,
+                        servicePeriodEnd: gap.servicePeriodEnd,
+                        invoiceWindowStart: gap.invoiceWindowStart,
+                        invoiceWindowEnd: gap.invoiceWindowEnd,
+                    }),
+                )
+                .filter((key): key is string => Boolean(key)),
+        );
+        const readyPersistedRows = persistedRows.filter((row) => {
+            const dbRow = row.recordId
+                ? persistedDbRows.find((candidate) => candidate.record_id === row.recordId)
+                : null;
+            if (!dbRow || dbRow.reason_code !== 'backfill_materialization') {
+                return true;
+            }
+
+            const suppressionKey = buildBackfillSuppressionKey({
+                clientId: dbRow.client_id,
+                billingCycleId: dbRow.billing_cycle_id ?? null,
+                servicePeriodStart: dbRow.service_period_start,
+                servicePeriodEnd: dbRow.service_period_end,
+                invoiceWindowStart: dbRow.invoice_window_start,
+                invoiceWindowEnd: dbRow.invoice_window_end,
+            });
+            return !suppressionKey || !backfillSuppressionKeys.has(suppressionKey);
+        });
         const unresolvedNonContractRows = await fetchUnresolvedNonContractDueWorkRows(
             candidateBillingPeriods,
             asOf,
@@ -1280,12 +1339,6 @@ export const getAvailableRecurringDueWork = withAuth(async (
         const invoiceCandidates = buildRecurringDueWorkInvoiceCandidates(
             [...readyPersistedRows, ...unresolvedNonContractRows],
             groupingMetadataByRecordId,
-        );
-        const persistedIdentityKeys = new Set(
-            persistedRows.map((row) => row.executionIdentityKey),
-        );
-        const materializationGaps = rawMaterializationGaps.filter(
-            (gap) => !persistedIdentityKeys.has(gap.executionIdentityKey),
         );
         const blockedInvoiceCandidates = applyClientCadenceMaterializationGapBlocks(
             invoiceCandidates,

--- a/server/src/test/unit/billing/recurringDueWorkReader.integration.test.ts
+++ b/server/src/test/unit/billing/recurringDueWorkReader.integration.test.ts
@@ -716,6 +716,90 @@ describe('recurring due-work reader', () => {
     ]);
   });
 
+  it('T120: singleton backfill-materialized rows remain ready when they already satisfy the canonical execution identity', async () => {
+    mocks.rowsByTable.client_billing_cycles = [
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-hourly',
+        client_name: 'AI Med Consult',
+        billing_cycle_id: 'cycle-2025-03',
+        billing_cycle: 'monthly',
+        period_start_date: '2025-03-01',
+        period_end_date: '2025-04-01',
+        effective_date: '2025-03-01',
+        invoice_id: null,
+      },
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-hourly',
+        client_name: 'AI Med Consult',
+        billing_cycle_id: 'cycle-2025-04',
+        billing_cycle: 'monthly',
+        period_start_date: '2025-04-01',
+        period_end_date: '2025-05-01',
+        effective_date: '2025-04-01',
+        invoice_id: null,
+      },
+    ];
+
+    mocks.rowsByTable.client_contracts = [
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-hourly',
+        client_contract_line_id: 'assignment-hourly',
+        cadence_owner: 'client',
+        billing_frequency: 'monthly',
+        billing_timing: 'arrears',
+        start_date: '2025-03-01',
+        end_date: null,
+        is_active: true,
+      },
+    ];
+
+    mocks.rowsByTable.recurring_service_periods = [
+      {
+        tenant: 'tenant-1',
+        record_id: 'rsp-ai-med-hourly',
+        schedule_key: 'schedule:tenant-1:client_contract_line:assignment-hourly:client:arrears',
+        period_key: 'period:2025-03-01:2025-04-01',
+        lifecycle_state: 'generated',
+        reason_code: 'backfill_materialization',
+        cadence_owner: 'client',
+        obligation_type: 'client_contract_line',
+        service_period_start: '2025-03-01',
+        service_period_end: '2025-04-01',
+        invoice_window_start: '2025-04-01',
+        invoice_window_end: '2025-05-01',
+        invoice_charge_detail_id: null,
+        client_id: 'client-hourly',
+        client_name: 'AI Med Consult',
+        billing_cycle_id: 'cycle-2025-04',
+        contract_id: 'contract-hourly',
+        contract_name: 'Software Development Services',
+        contract_line_id: 'assignment-hourly',
+        contract_line_name: 'Software Development Services - Hourly',
+      },
+    ];
+
+    const result = await getAvailableRecurringDueWork({
+      page: 1,
+      pageSize: 10,
+      searchTerm: 'AI Med',
+    });
+
+    expect(result.materializationGaps).toEqual([]);
+    expect(result.invoiceCandidates).toHaveLength(1);
+    expect(result.invoiceCandidates[0]).toMatchObject({
+      clientId: 'client-hourly',
+      clientName: 'AI Med Consult',
+      servicePeriodStart: '2025-03-01',
+      servicePeriodEnd: '2025-04-01',
+      windowStart: '2025-04-01',
+      windowEnd: '2025-05-01',
+      cadenceSources: ['client_schedule'],
+    });
+  });
+
   it('T106: due-work candidate grouping keeps one parent candidate per client + invoice window while surfacing financial split reasons', async () => {
     mocks.rowsByTable.recurring_service_periods = [
       {


### PR DESCRIPTION
## Summary
- narrow automatic invoice backfill filtering so singleton backfill-materialized rows stay invoiceable
- suppress backfill rows only when they shadow a visible canonical repair gap for the same invoiceable window
- add a recurring due-work reader regression covering the AI Med Consult-style singleton backfill case

## Validation
- `npx tsc -p packages/billing/tsconfig.json --noEmit`
- `cd server && npx vitest run src/test/unit/billing/recurringDueWorkReader.integration.test.ts`