### PR TITLE
Fix recurring invoice config id propagation

### DIFF
--- a/packages/billing/src/lib/billing/billingEngine.ts
+++ b/packages/billing/src/lib/billing/billingEngine.ts
@@ -1977,9 +1977,14 @@ export class BillingEngine {
           })
           .whereNot("sc.item_kind", "product")
           .orderBy("sc.service_id", "asc")
-          .first("sc.service_id", "sc.service_name", "sc.tax_rate_id");
+          .first(
+            "sc.service_id",
+            "sc.service_name",
+            "sc.tax_rate_id",
+            "cls_fallback.config_id",
+          );
 
-        if (!fallbackService?.service_id) {
+        if (!fallbackService?.service_id || !fallbackService?.config_id) {
           return [];
         }
 
@@ -2005,6 +2010,7 @@ export class BillingEngine {
           {
             type: "fixed",
             serviceId: fallbackService.service_id,
+            config_id: fallbackService.config_id,
             serviceName:
               fallbackService.service_name ||
               clientContractLine.contract_line_name ||
@@ -3272,6 +3278,7 @@ export class BillingEngine {
         return {
           serviceId: entry.service_id,
           serviceName: entry.service_name,
+          config_id: serviceConfig?.config.config_id,
           client_contract_line_id: clientContractLine.client_contract_line_id,
           userId: entry.user_id,
           duration,

--- a/packages/billing/src/services/invoiceService.ts
+++ b/packages/billing/src/services/invoiceService.ts
@@ -837,6 +837,9 @@ async function persistFixedInvoiceCharges(
       if (!detail.serviceId) {
         throw new Error('Internal error: Detailed fixed recurring charge must include a serviceId.');
       }
+      if (!detail.config_id) {
+        throw new Error('Internal error: Detailed fixed recurring charge must include a config_id.');
+      }
       const unitPriceCents = detailQuantity !== 0
         ? Math.round(allocatedAmountCents / detailQuantity)
         : allocatedAmountCents;
@@ -845,7 +848,7 @@ async function persistFixedInvoiceCharges(
         item_detail_id: detailId,
         item_id: parentItemId,
         service_id: detail.serviceId,
-        config_id: detail.config_id ?? null,
+        config_id: detail.config_id,
         quantity: detailQuantity,
         rate: unitPriceCents,
         service_period_start: detail.servicePeriodStart ?? null,
@@ -875,7 +878,7 @@ async function persistFixedInvoiceCharges(
         invoiceId,
         invoiceChargeId: parentItemId,
         invoiceChargeDetailId: detailId,
-        configId: detail.config_id ?? null,
+        configId: detail.config_id,
         contractLineId: detail.client_contract_line_id ?? null,
         chargeFamily: 'fixed',
         servicePeriodStart: detail.servicePeriodStart ?? null,
@@ -981,12 +984,15 @@ export async function persistInvoiceCharges(
 
     if (shouldPersistDetail) {
       const detailId = uuidv4();
+      if (!charge.config_id) {
+        throw new Error(`Internal error: Recurring ${charge.type} charge must include a config_id.`);
+      }
 
       await tx('invoice_charge_details').insert({
         item_detail_id: detailId,
         item_id: invoiceItem.item_id,
         service_id: charge.serviceId,
-        config_id: charge.config_id ?? null,
+        config_id: charge.config_id,
         quantity: charge.quantity ?? 1,
         rate: charge.rate ?? 0,
         service_period_start: charge.servicePeriodStart ?? null,
@@ -1004,7 +1010,7 @@ export async function persistInvoiceCharges(
         invoiceId,
         invoiceChargeId: invoiceItem.item_id,
         invoiceChargeDetailId: detailId,
-        configId: charge.config_id ?? null,
+        configId: charge.config_id,
         contractLineId: charge.client_contract_line_id ?? null,
         chargeFamily: recurringChargeFamily,
         servicePeriodStart: charge.servicePeriodStart ?? null,

--- a/server/src/test/unit/billing/billingEngine.endExclusiveQueries.test.ts
+++ b/server/src/test/unit/billing/billingEngine.endExclusiveQueries.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BillingEngine } from '@alga-psa/billing/services';
 
+const mocks = vi.hoisted(() => ({
+  clientServiceConfigs: [] as any[],
+}));
+
 vi.mock('@/lib/db/db');
 vi.mock('@alga-psa/db', () => ({
   withTransaction: vi.fn(async (_knex, callback) => callback(_knex)),
@@ -8,11 +12,21 @@ vi.mock('@alga-psa/db', () => ({
 }));
 vi.mock('@alga-psa/auth', () => ({
   getSession: vi.fn(() => Promise.resolve({ user: { id: 'mock-user-id' } })),
+  withAuth: (action: (...args: any[]) => Promise<unknown>) =>
+    (...args: any[]) =>
+      action(
+        {
+          user_id: 'mock-user-id',
+          tenant: 'test-tenant',
+        },
+        { tenant: 'test-tenant' },
+        ...args,
+      ),
 }));
 vi.mock('server/src/lib/services/clientContractServiceConfigurationService', () => ({
   ClientContractServiceConfigurationService: class {
     async getConfigurationsForClientContractLine(): Promise<any[]> {
-      return [];
+      return mocks.clientServiceConfigs;
     }
   },
 }));
@@ -34,6 +48,7 @@ function createChainableQuery<T>(result: T, whereCalls: Array<unknown[]>): any {
   builder.where = vi.fn(handleWhere);
   builder.andWhere = vi.fn(handleWhere);
   builder.orWhere = vi.fn(handleWhere);
+  builder.whereIn = vi.fn(() => builder);
   builder.whereNull = vi.fn(() => builder);
   builder.whereNotNull = vi.fn(() => builder);
   builder.select = vi.fn(() => builder);
@@ -53,10 +68,13 @@ describe('BillingEngine end-exclusive query boundaries', () => {
   let engine: BillingEngine;
 
   beforeEach(() => {
+    mocks.clientServiceConfigs = [];
     engine = new BillingEngine();
     (engine as any).tenant = 'test-tenant';
     (engine as any).initKnex = vi.fn(async () => undefined);
     vi.spyOn(engine as any, 'getBillingCycle').mockResolvedValue('monthly');
+    vi.spyOn(engine as any, 'getServiceIdsForContractLine').mockResolvedValue(['service-1']);
+    vi.spyOn(engine as any, 'getUniquelyAssignableServiceIdsForLine').mockResolvedValue([]);
   });
 
   it('does not include time entries exactly at period end boundary (end exclusive)', async () => {
@@ -222,6 +240,120 @@ describe('BillingEngine end-exclusive query boundaries', () => {
     expect(endPredicate?.[2]).toBe(recurringTimingSelection.servicePeriodEndExclusive);
     expect(startPredicate?.[2]).not.toBe(billingPeriod.startDate);
     expect(endPredicate?.[2]).not.toBe(billingPeriod.endDate);
+  });
+
+  it('T119: hourly recurring charges preserve config_id from the client line service configuration', async () => {
+    const whereCalls: Array<unknown[]> = [];
+    const billingPeriod = { startDate: '2026-02-01', endDate: '2026-03-01' };
+    const mockClientId = 'client-1';
+    const clientContractLine = {
+      client_contract_line_id: 'ccl-1',
+      contract_line_id: 'cl-1',
+      contract_line_type: 'Hourly',
+      currency_code: 'USD',
+      client_contract_id: 'cc-1',
+      contract_name: 'Contract',
+      cadence_owner: 'client',
+      billing_timing: 'arrears',
+      billing_frequency: 'monthly',
+    } as any;
+
+    (engine as any).knex = vi.fn((table: string) => {
+      if (table === 'clients') {
+        const builder = createChainableQuery(
+          { client_id: mockClientId, tenant: 'test-tenant', is_tax_exempt: false },
+          whereCalls
+        );
+        builder.first = vi.fn(async () => ({ client_id: mockClientId, tenant: 'test-tenant', is_tax_exempt: false }));
+        return builder;
+      }
+      if (table === 'contract_lines') {
+        const builder = createChainableQuery(
+          { contract_line_id: clientContractLine.contract_line_id, tenant: 'test-tenant' },
+          whereCalls
+        );
+        builder.first = vi.fn(async () => ({
+          contract_line_id: clientContractLine.contract_line_id,
+          tenant: 'test-tenant',
+          enable_overtime: false,
+          overtime_threshold: null,
+          overtime_rate: null,
+        }));
+        return builder;
+      }
+      if (table === 'contract_line_services as cls') {
+        return createChainableQuery([
+          {
+            config_id: 'config-hourly-1',
+            configuration_type: 'Hourly',
+            custom_rate: null,
+            quantity: null,
+            created_at: new Date('2026-01-01T00:00:00.000Z'),
+            updated_at: new Date('2026-01-01T00:00:00.000Z'),
+            contract_line_id: clientContractLine.contract_line_id,
+            service_id: 'service-1',
+          },
+        ], whereCalls);
+      }
+      if (table === 'contract_line_service_hourly_configs') {
+        const builder = createChainableQuery([], whereCalls);
+        builder.first = vi.fn(async () => null);
+        return builder;
+      }
+      if (table === 'contract_line_service_hourly_config') {
+        const builder = createChainableQuery([], whereCalls);
+        builder.first = vi.fn(async () => ({
+          config_id: 'config-hourly-1',
+          minimum_billable_time: 0,
+          round_up_to_nearest: 0,
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-01-01T00:00:00.000Z'),
+        }));
+        return builder;
+      }
+      if (table === 'user_type_rates') {
+        return createChainableQuery([], whereCalls);
+      }
+      if (table === 'time_entries') {
+        return createChainableQuery([
+          {
+            entry_id: 'entry-1',
+            user_id: 'user-1',
+            service_id: 'service-1',
+            service_name: 'Software Development',
+            default_rate: 15000,
+            tax_rate_id: null,
+            start_time: new Date('2026-02-13T10:00:00.000Z'),
+            end_time: new Date('2026-02-13T11:00:00.000Z'),
+            user_type: 'technician',
+          },
+        ], whereCalls);
+      }
+      return createChainableQuery([], whereCalls);
+    });
+    (engine as any).knex.raw = vi.fn(() => 'RAW');
+    vi.spyOn(engine as any, 'getUniquelyAssignableServiceIdsForLine').mockResolvedValue([]);
+    vi.spyOn(engine as any, 'getTaxInfoFromService').mockResolvedValue({
+      taxRegion: undefined,
+      isTaxable: false,
+    });
+    vi.spyOn(engine as any, 'getClientDefaultTaxRegionCode').mockResolvedValue('US-NY');
+
+    const charges = await (engine as any).calculateTimeBasedCharges(
+      mockClientId,
+      billingPeriod,
+      clientContractLine,
+    );
+
+    expect(charges).toEqual([
+      expect.objectContaining({
+        type: 'time',
+        entryId: 'entry-1',
+        serviceId: 'service-1',
+        config_id: 'config-hourly-1',
+        client_contract_line_id: 'ccl-1',
+      }),
+    ]);
   });
 
   it('T057: usage recurring billing queries usage records inside the canonical persisted service window when it differs from the invoice window', async () => {

--- a/server/src/test/unit/billing/billingEngine.timing.test.ts
+++ b/server/src/test/unit/billing/billingEngine.timing.test.ts
@@ -74,6 +74,7 @@ const installFixedChargeMocks = (
       service_id: service.service_id,
       service_name: service.service_name,
       tax_rate_id: service.tax_rate_id ?? null,
+      config_id: service.config_id,
     }));
 
   (engine as any).tenant = "test_tenant";
@@ -809,6 +810,7 @@ describe("BillingEngine billing timing", () => {
           service_id: "service-fallback",
           service_name: "Base Rate Only Fixed Fee",
           tax_rate_id: null,
+          config_id: "config-fallback",
         },
       ],
       enableProration: false,
@@ -840,6 +842,7 @@ describe("BillingEngine billing timing", () => {
       expect.objectContaining({
         type: "fixed",
         serviceId: "service-fallback",
+        config_id: "config-fallback",
         serviceName: "Base Rate Only Fixed Fee",
         rate: 12000,
         total: 12000,

--- a/server/src/test/unit/billing/invoiceService.fixedPersistence.test.ts
+++ b/server/src/test/unit/billing/invoiceService.fixedPersistence.test.ts
@@ -177,6 +177,7 @@ describe("invoiceService fixed recurring persistence", () => {
         {
           type: "product",
           serviceId: "service-1",
+          config_id: "config-product-1",
           serviceName: "Managed Router",
           quantity: 2,
           rate: 4500,
@@ -228,6 +229,7 @@ describe("invoiceService fixed recurring persistence", () => {
         {
           type: "license",
           serviceId: "service-2",
+          config_id: "config-license-1",
           serviceName: "Microsoft 365 Business Premium",
           quantity: 3,
           rate: 3200,
@@ -666,6 +668,7 @@ describe("invoiceService fixed recurring persistence", () => {
         {
           type: "time",
           serviceId: "service-hourly",
+          config_id: "config-hourly-1",
           serviceName: "Hourly Support",
           userId: "user-1",
           duration: 2,
@@ -685,6 +688,7 @@ describe("invoiceService fixed recurring persistence", () => {
         {
           type: "usage",
           serviceId: "service-usage",
+          config_id: "config-usage-1",
           serviceName: "Device Usage",
           quantity: 4,
           rate: 300,
@@ -769,6 +773,7 @@ describe("invoiceService fixed recurring persistence", () => {
         {
           type: "fixed",
           serviceId: "service-fallback",
+          config_id: "config-fallback",
           serviceName: "Base Rate Only Fixed Fee",
           quantity: 1,
           rate: 12000,
@@ -807,6 +812,7 @@ describe("invoiceService fixed recurring persistence", () => {
     expect(inserts.invoice_charge_details).toHaveLength(1);
     expect(inserts.invoice_charge_details[0]).toMatchObject({
       service_id: "service-fallback",
+      config_id: "config-fallback",
       service_period_start: "2025-04-01",
       service_period_end: "2025-04-30",
       billing_timing: "advance",


### PR DESCRIPTION
## Summary
- propagate service config ids onto recurring hourly invoice charges so detail persistence uses the real contract-line service configuration
- require config ids for recurring detail-backed invoice charges and preserve fallback fixed-charge config ids during linkage
- add behavioral regression coverage for hourly recurring config propagation and recurring persistence paths

## Validation
- npx tsc -p packages/billing/tsconfig.json --noEmit
- cd server && npx vitest run src/test/unit/billing/invoiceService.fixedPersistence.test.ts
- cd server && npx vitest run src/test/unit/billing/billingEngine.endExclusiveQueries.test.ts -t "T119"  # assertion passed; Vitest still emits an existing coverage cleanup ENOENT after the run