### PR TITLE
Normalize legacy invoice field border defaults

### DIFF
--- a/packages/billing/src/actions/renderTemplateOnServer.ast.integration.test.ts
+++ b/packages/billing/src/actions/renderTemplateOnServer.ast.integration.test.ts
@@ -79,6 +79,7 @@ describe('renderTemplateOnServer AST integration', () => {
 
     expect(result.html).toContain('INV-AST-001');
     expect(result.html).toContain('110');
+    expect(result.html).not.toContain('border-bottom:1px solid #cbd5e1');
     expect(typeof result.css).toBe('string');
     expect(getAllTemplatesMock).not.toHaveBeenCalled();
   });

--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx
@@ -334,6 +334,52 @@ describe('InvoiceTemplateEditor preview workspace integration', () => {
     });
   });
 
+  it('materializes missing field border styles as none when reopening and saving a legacy template', async () => {
+    getInvoiceTemplateMock.mockResolvedValueOnce({
+      template_id: 'tpl-legacy-border',
+      name: 'Legacy Border Template',
+      templateAst: {
+        kind: 'invoice-template-ast',
+        version: 1,
+        bindings: {
+          values: {
+            invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+          },
+          collections: {},
+        },
+        layout: {
+          id: 'root',
+          type: 'document',
+          children: [
+            {
+              id: 'legacy-border-field',
+              type: 'field',
+              label: 'Invoice #',
+              binding: { bindingId: 'invoiceNumber' },
+            },
+          ],
+        },
+      },
+      isStandard: false,
+    });
+
+    render(<InvoiceTemplateEditor templateId="tpl-legacy-border" />);
+
+    await waitFor(() => {
+      const fieldNode = useInvoiceDesignerStore.getState().nodesById['legacy-border-field'];
+      expect((fieldNode?.props as any)?.metadata?.fieldBorderStyle).toBe('none');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Template' }));
+    await waitFor(() => expect(saveInvoiceTemplateMock).toHaveBeenCalledTimes(1));
+
+    const savedAst = saveInvoiceTemplateMock.mock.calls[0]?.[0]?.templateAst;
+    const savedField = findLayoutNodeById(savedAst.layout, 'legacy-border-field');
+    expect(savedField?.type).toBe('field');
+    if (!savedField || savedField.type !== 'field') return;
+    expect(savedField.borderStyle).toBe('none');
+  });
+
   it('persists edited field designer placeholders through save and reopen', async () => {
     const workspace = createWorkspaceWithField('placeholder-field');
     getInvoiceTemplateMock.mockResolvedValueOnce({

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -1766,7 +1766,7 @@ export const importTemplateAstToWorkspace = (
           if (inputNode.borderStyle) {
             metadata.fieldBorderStyle = inputNode.borderStyle;
           } else {
-            delete metadata.fieldBorderStyle;
+            metadata.fieldBorderStyle = 'none';
           }
           if (inputNode.label) {
             metadata.label = inputNode.label;

--- a/packages/billing/src/lib/invoice-template-ast/normalize.ts
+++ b/packages/billing/src/lib/invoice-template-ast/normalize.ts
@@ -1,0 +1,39 @@
+import type { TemplateAst, TemplateNode } from '@alga-psa/types';
+
+type TemplateNodeWithChildren = TemplateNode & { children?: TemplateNode[] };
+
+const normalizeTemplateNode = (node: TemplateNode): TemplateNode => {
+  const candidate = node as TemplateNodeWithChildren;
+  const normalizedChildren = Array.isArray(candidate.children)
+    ? candidate.children.map(normalizeTemplateNode)
+    : undefined;
+  const childrenChanged =
+    Array.isArray(candidate.children) &&
+    normalizedChildren?.some((child, index) => child !== candidate.children?.[index]);
+
+  let nextNode: TemplateNode =
+    childrenChanged && normalizedChildren
+      ? ({ ...candidate, children: normalizedChildren } as TemplateNode)
+      : node;
+
+  if (nextNode.type === 'field' && nextNode.borderStyle === undefined) {
+    nextNode = {
+      ...nextNode,
+      borderStyle: 'none',
+    };
+  }
+
+  return nextNode;
+};
+
+export const normalizeTemplateAstFieldBorderDefaults = (ast: TemplateAst): TemplateAst => {
+  const normalizedLayout = normalizeTemplateNode(ast.layout);
+  if (normalizedLayout === ast.layout) {
+    return ast;
+  }
+
+  return {
+    ...ast,
+    layout: normalizedLayout as TemplateAst['layout'],
+  };
+};

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -226,6 +226,37 @@ describe('renderEvaluatedTemplateAst', () => {
     expect(rendered.html).toContain('901 Harbor Ave');
   });
 
+  it('does not render an underline when the field border style is none', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'invoice-number-plain',
+            type: 'field',
+            binding: { bindingId: 'invoiceNumber' },
+            borderStyle: 'none',
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, invoiceFixture);
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('padding:0');
+    expect(rendered.html).toContain('border:0');
+    expect(rendered.html).not.toContain('border-bottom:1px solid #cbd5e1');
+  });
+
   it('removes single-line inset padding for multiline underlined fields', async () => {
     const ast: TemplateAst = {
       kind: 'invoice-template-ast',

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -11,6 +11,7 @@ import type {
 import { formatTemplateFieldValue } from './fieldFormatting';
 import type { TemplateEvaluationResult } from './evaluator';
 import { decodeTemplatePathExpression } from './templateInterpolationFilters';
+import { normalizeTemplateAstFieldBorderDefaults } from './normalize';
 import { resolveTemplatePrintSettingsFromAst } from './printSettings';
 
 type UnknownRecord = Record<string, unknown>;
@@ -617,8 +618,9 @@ export const renderEvaluatedTemplateAst = async (
   // Next.js app router disallows static imports from react-dom/server in shared modules.
   // Use a dynamic import so this renderer remains server-only at call sites.
   const { renderToStaticMarkup } = await import('react-dom/server');
+  const normalizedAst = normalizeTemplateAstFieldBorderDefaults(ast);
   return {
-    html: renderToStaticMarkup(<TemplateAstRenderer ast={ast} evaluation={evaluation} />),
-    css: buildAstCss(ast),
+    html: renderToStaticMarkup(<TemplateAstRenderer ast={normalizedAst} evaluation={evaluation} />),
+    css: buildAstCss(normalizedAst),
   };
 };


### PR DESCRIPTION
## Summary
- normalize legacy invoice template fields with missing border style to  in the shared AST renderer
- materialize the same default when older templates are reopened so a save writes back explicit 
- cover the server render path and template editor reopen/save flow with regressions

## Testing
- npx tsc -p packages/billing/tsconfig.json --noEmit
- cd server && npx vitest run ../packages/billing/src/actions/renderTemplateOnServer.ast.integration.test.ts ../packages/billing/src/components/billing-dashboard/InvoiceTemplateEditor.previewWorkspace.test.tsx ../packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx ../packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx