### PR TITLE
Resolve invoice preview template selection

### DIFF
--- a/packages/billing/src/actions/invoiceQueries.ts
+++ b/packages/billing/src/actions/invoiceQueries.ts
@@ -561,6 +561,46 @@ export const getInvoiceForRendering = withAuth(async (
   }
 });
 
+export const getResolvedInvoiceTemplateId = withAuth(async (
+  user,
+  { tenant },
+  invoiceId: string
+): Promise<string | null> => {
+  const { knex } = await createTenantKnex();
+
+  const invoice = await knex('invoices')
+    .select('client_id')
+    .where({
+      invoice_id: invoiceId,
+      tenant
+    })
+    .first();
+
+  if (!invoice?.client_id) {
+    return null;
+  }
+
+  try {
+    const client = await knex('clients')
+      .select('invoice_template_id')
+      .where({
+        client_id: invoice.client_id,
+        tenant
+      })
+      .first();
+
+    if (client?.invoice_template_id) {
+      return client.invoice_template_id;
+    }
+  } catch {
+    // Fall back to tenant default template selection below.
+  }
+
+  const templates = await Invoice.getAllTemplates(knex, tenant);
+  const defaultTemplate = templates.find((template) => template.is_default || template.isTenantDefault) ?? templates[0];
+  return defaultTemplate?.template_id ?? null;
+});
+
 export type InvoicePurchaseOrderSummary = {
   invoice_id: string;
   client_contract_id: string;

--- a/packages/billing/src/components/billing-dashboard/invoicing/DraftsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/DraftsTab.tsx
@@ -174,10 +174,9 @@ const DraftsTab: React.FC<DraftsTabProps> = ({
     if (selectedInvoiceId === invoice.invoice_id) {
       updateUrlParams({ invoiceId: null, templateId: null });
     } else {
-      const defaultTemplateId = templates.length > 0 ? templates[0].template_id : null;
       updateUrlParams({
         invoiceId: invoice.invoice_id,
-        templateId: selectedTemplateId || defaultTemplateId
+        templateId: selectedTemplateId
       });
     }
   };

--- a/packages/billing/src/components/billing-dashboard/invoicing/FinalizedTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/FinalizedTab.tsx
@@ -162,10 +162,9 @@ const FinalizedTab: React.FC<FinalizedTabProps> = ({
     if (selectedInvoiceId === invoice.invoice_id) {
       updateUrlParams({ invoiceId: null, templateId: null });
     } else {
-      const defaultTemplateId = templates.length > 0 ? templates[0].template_id : null;
       updateUrlParams({
         invoiceId: invoice.invoice_id,
-        templateId: selectedTemplateId || defaultTemplateId
+        templateId: selectedTemplateId
       });
     }
   };

--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoicePreviewPanel from './InvoicePreviewPanel';
+
+const getInvoiceForRenderingMock = vi.fn();
+const getInvoicePurchaseOrderSummaryMock = vi.fn();
+const getResolvedInvoiceTemplateIdMock = vi.fn();
+const getQuoteByConvertedInvoiceIdMock = vi.fn();
+const mapDbInvoiceToWasmViewModelMock = vi.fn();
+const templateRendererMock = vi.fn();
+const paperInvoiceMock = vi.fn();
+const routerPushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
+  getInvoiceForRendering: (...args: unknown[]) => getInvoiceForRenderingMock(...args),
+  getInvoicePurchaseOrderSummary: (...args: unknown[]) => getInvoicePurchaseOrderSummaryMock(...args),
+  getResolvedInvoiceTemplateId: (...args: unknown[]) => getResolvedInvoiceTemplateIdMock(...args),
+}));
+
+vi.mock('@alga-psa/billing/actions/quoteActions', () => ({
+  getQuoteByConvertedInvoiceId: (...args: unknown[]) => getQuoteByConvertedInvoiceIdMock(...args),
+}));
+
+vi.mock('../../../lib/adapters/invoiceAdapters', () => ({
+  mapDbInvoiceToWasmViewModel: (...args: unknown[]) => mapDbInvoiceToWasmViewModelMock(...args),
+}));
+
+vi.mock('../TemplateRenderer', () => ({
+  TemplateRenderer: (props: any) => {
+    templateRendererMock(props);
+    return (
+      <div data-automation-id="template-renderer-mock">
+        {props?.invoiceData?.invoiceNumber ?? 'NO_INVOICE'}::{props?.template?.template_id ?? 'NO_TEMPLATE'}
+      </div>
+    );
+  },
+}));
+
+vi.mock('../PaperInvoice', () => ({
+  default: (props: { children: React.ReactNode; templateAst?: unknown }) => {
+    paperInvoiceMock(props);
+    return <div data-automation-id="paper-invoice-mock">{props.children}</div>;
+  },
+}));
+
+vi.mock('./PurchaseOrderSummaryBanner', () => ({
+  PurchaseOrderSummaryBanner: () => <div data-automation-id="po-summary-banner-mock" />,
+}));
+
+vi.mock('../CreditExpirationInfo', () => ({
+  default: () => <div data-automation-id="credit-expiration-mock" />,
+}));
+
+vi.mock('../../invoices/InvoiceTaxSourceBadge', () => ({
+  InvoiceTaxSourceBadge: ({ taxSource }: { taxSource: string }) => (
+    <div data-automation-id="invoice-tax-source-badge-mock">{taxSource}</div>
+  ),
+}));
+
+const defaultTemplates = [
+  {
+    template_id: 'tpl-first',
+    name: 'First Template',
+    isStandard: false,
+    is_default: false,
+  },
+  {
+    template_id: 'tpl-resolved',
+    name: 'Resolved Template',
+    isStandard: false,
+    is_default: true,
+  },
+];
+
+const defaultInvoiceData = {
+  invoice_id: 'inv-1',
+  tax_source: 'internal',
+};
+
+const defaultViewModel = {
+  invoiceNumber: 'INV-1001',
+  issueDate: '2026-04-01',
+  dueDate: '2026-04-15',
+  currencyCode: 'USD',
+  poNumber: null,
+  customer: { name: 'AI Med Consult', address: '123 Main St' },
+  tenantClient: { name: 'Northwind MSP', address: '400 SW Main', logoUrl: null },
+  items: [],
+  subtotal: 1000,
+  tax: 100,
+  total: 1100,
+};
+
+describe('InvoicePreviewPanel', () => {
+  beforeEach(() => {
+    cleanup();
+    routerPushMock.mockReset();
+    getInvoiceForRenderingMock.mockReset();
+    getInvoicePurchaseOrderSummaryMock.mockReset();
+    getResolvedInvoiceTemplateIdMock.mockReset();
+    getQuoteByConvertedInvoiceIdMock.mockReset();
+    mapDbInvoiceToWasmViewModelMock.mockReset();
+    templateRendererMock.mockReset();
+    paperInvoiceMock.mockReset();
+
+    class ResizeObserverMock {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+    getInvoiceForRenderingMock.mockResolvedValue(defaultInvoiceData);
+    getInvoicePurchaseOrderSummaryMock.mockResolvedValue(null);
+    getResolvedInvoiceTemplateIdMock.mockResolvedValue('tpl-resolved');
+    getQuoteByConvertedInvoiceIdMock.mockResolvedValue(null);
+    mapDbInvoiceToWasmViewModelMock.mockReturnValue(defaultViewModel);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the invoice-resolved template when no explicit template is selected', async () => {
+    render(
+      <InvoicePreviewPanel
+        invoiceId="inv-1"
+        templates={defaultTemplates as any}
+        selectedTemplateId={null}
+        onTemplateChange={vi.fn()}
+        isFinalized={false}
+      />
+    );
+
+    await waitFor(() => expect(getResolvedInvoiceTemplateIdMock).toHaveBeenCalledWith('inv-1'));
+    expect(await screen.findByText('INV-1001::tpl-resolved')).toBeTruthy();
+    expect(templateRendererMock.mock.calls.at(-1)?.[0]?.template?.template_id).toBe('tpl-resolved');
+  });
+
+  it('keeps an explicit template selection over the resolved invoice template', async () => {
+    render(
+      <InvoicePreviewPanel
+        invoiceId="inv-1"
+        templates={defaultTemplates as any}
+        selectedTemplateId="tpl-first"
+        onTemplateChange={vi.fn()}
+        isFinalized={false}
+      />
+    );
+
+    expect(await screen.findByText('INV-1001::tpl-first')).toBeTruthy();
+    expect(templateRendererMock.mock.calls.at(-1)?.[0]?.template?.template_id).toBe('tpl-first');
+  });
+});

--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
@@ -8,7 +8,12 @@ import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { FileText, Settings } from 'lucide-react';
 import type { IInvoiceTemplate, IQuote, TaxSource } from '@alga-psa/types';
 import type { WasmInvoiceViewModel } from '@alga-psa/types';
-import { getInvoiceForRendering, getInvoicePurchaseOrderSummary, type InvoicePurchaseOrderSummary } from '@alga-psa/billing/actions/invoiceQueries';
+import {
+  getInvoiceForRendering,
+  getInvoicePurchaseOrderSummary,
+  getResolvedInvoiceTemplateId,
+  type InvoicePurchaseOrderSummary
+} from '@alga-psa/billing/actions/invoiceQueries';
 import { getQuoteByConvertedInvoiceId } from '@alga-psa/billing/actions/quoteActions';
 import { mapDbInvoiceToWasmViewModel } from '../../../lib/adapters/invoiceAdapters';
 import { PurchaseOrderSummaryBanner } from './PurchaseOrderSummaryBanner';
@@ -52,6 +57,7 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   const router = useRouter();
   const [detailedInvoiceData, setDetailedInvoiceData] = useState<WasmInvoiceViewModel | null>(null);
   const [poSummary, setPoSummary] = useState<InvoicePurchaseOrderSummary | null>(null);
+  const [resolvedTemplateId, setResolvedTemplateId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isActionLoading, setIsActionLoading] = useState(false);
@@ -60,10 +66,13 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   const [sourceQuote, setSourceQuote] = useState<IQuote | null>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
-  // Match Drafts/Finalized row selection: default to first template when URL has invoiceId but no templateId (e.g. deep link from recurring history).
+  // Match invoice/PDF rendering: honor an explicit URL template selection first,
+  // then fall back to the invoice's resolved client/default template.
   const effectiveTemplateId =
     selectedTemplateId && templates.some((t) => t.template_id === selectedTemplateId)
       ? selectedTemplateId
+      : resolvedTemplateId && templates.some((t) => t.template_id === resolvedTemplateId)
+        ? resolvedTemplateId
       : templates[0]?.template_id ?? null;
 
   const selectedTemplate = effectiveTemplateId
@@ -95,6 +104,7 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
       if (!invoiceId) {
         setDetailedInvoiceData(null);
         setTaxSource('internal');
+        setResolvedTemplateId(null);
         return;
       }
 
@@ -104,7 +114,11 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
       setPoSummary(null);
 
       try {
-        const dbInvoiceData = await getInvoiceForRendering(invoiceId);
+        const [dbInvoiceData, summary, templateId] = await Promise.all([
+          getInvoiceForRendering(invoiceId),
+          getInvoicePurchaseOrderSummary(invoiceId),
+          getResolvedInvoiceTemplateId(invoiceId),
+        ]);
 
         if (!dbInvoiceData) {
           throw new Error(`Invoice data for ID ${invoiceId} not found.`);
@@ -119,8 +133,8 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
           throw new Error(`Failed to map invoice data for ID ${invoiceId} to view model.`);
         }
 
-        const summary = await getInvoicePurchaseOrderSummary(invoiceId);
         setPoSummary(summary);
+        setResolvedTemplateId(templateId);
 
         setDetailedInvoiceData(viewModel);
       } catch (err) {
@@ -129,6 +143,7 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
         setError(`Failed to load preview: ${message}`);
         setDetailedInvoiceData(null);
         setPoSummary(null);
+        setResolvedTemplateId(null);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
Summary
- resolve the effective template for draft and finalized invoice preview using the same client/default selection logic as invoice rendering
- stop forcing the first template into the URL when selecting a draft or finalized invoice
- add a focused preview-panel regression covering resolved-template fallback and explicit template override

Testing
- npx tsc -p packages/billing/tsconfig.json --noEmit
- cd server && npx vitest run ../packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx