### PR TITLE
Fix @mention notifications and ticket email errors

### DIFF
--- a/server/src/lib/eventBus/subscribers/internalNotificationSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/internalNotificationSubscriber.ts
@@ -952,21 +952,50 @@ function extractMentionUserIds(content: any): string[] {
 
   try {
     // Parse content if it's a string
-    const blocks = typeof content === 'string' ? JSON.parse(content) : content;
+    const parsed = typeof content === 'string' ? JSON.parse(content) : content;
 
-    if (!Array.isArray(blocks)) return [];
+    // Handle ProseMirror doc wrapper: { type: 'doc', content: [...] }
+    const blocks = parsed?.type === 'doc' && Array.isArray(parsed.content)
+      ? parsed.content
+      : Array.isArray(parsed) ? parsed : [];
 
-    // Traverse blocks to find mention inline content
-    for (const block of blocks) {
-      if (block.content && Array.isArray(block.content)) {
-        for (const inlineContent of block.content) {
-          // Check if this is a mention inline content
-          if (inlineContent.type === 'mention' && inlineContent.props?.userId) {
-            userIds.push(inlineContent.props.userId);
+    // Recursively traverse blocks to find mention inline content
+    function traverseBlocks(blockList: any[]): void {
+      for (const block of blockList) {
+        if (!block || typeof block !== 'object') continue;
+
+        // Check inline content array (BlockNote format)
+        if (block.content && Array.isArray(block.content)) {
+          for (const inlineContent of block.content) {
+            if (inlineContent?.type === 'mention') {
+              // BlockNote format: props.userId
+              const userId = inlineContent.props?.userId
+                // ProseMirror format: attrs.userId or attrs.id
+                || inlineContent.attrs?.userId
+                || inlineContent.attrs?.id;
+              if (userId) {
+                userIds.push(userId);
+              }
+            }
           }
+        }
+
+        // Check ProseMirror node-level mentions (mention as a node, not inline content)
+        if (block.type === 'mention') {
+          const userId = block.props?.userId || block.attrs?.userId || block.attrs?.id;
+          if (userId) {
+            userIds.push(userId);
+          }
+        }
+
+        // Recurse into children (BlockNote nested blocks)
+        if (block.children && Array.isArray(block.children)) {
+          traverseBlocks(block.children);
         }
       }
     }
+
+    traverseBlocks(blocks);
   } catch (error) {
     console.error('[extractMentionUserIds] Error parsing content:', error);
   }

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -526,7 +526,9 @@ function formatTicketDateTime(
 async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId } = payload;
-  
+  // Resolve userId from domain-specific field or base field, falling back to legacy
+  const creatorUserId = (payload as any).createdByUserId || payload.actorUserId || (payload as any).userId;
+
   try {
     console.log('[EmailSubscriber] Creating database connection');
     const db = await getConnection(tenantId);
@@ -647,7 +649,7 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
 
     const ticketingFromAddress = await resolveTicketingFromAddress(db, tenantId);
 
-    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, payload.userId);
+    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, creatorUserId);
 
     const priorityName = safeString(ticket.priority_name) || 'Unspecified';
     const statusName = safeString(ticket.status_name) || 'Unknown';
@@ -657,7 +659,7 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
     const clientName = safeString(ticket.client_name) || 'Unassigned Client';
 
     const createdAt = formatTicketDateTime(ticket.entered_at as string | Date | null, emailTimeZone);
-    const createdByName = safeString(ticket.created_by_name) || payload.userId || 'System';
+    const createdByName = safeString(ticket.created_by_name) || 'System';
     const createdDetails = `${createdAt} · ${createdByName}`;
 
     const assignedToName = safeString(ticket.assigned_to_name) || 'Unassigned';
@@ -872,6 +874,9 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
 
   const { payload } = event;
   const { tenantId } = payload;
+  // Resolve userId from domain-specific field (updatedByUserId) or base field (actorUserId),
+  // falling back to legacy userId for backward compatibility
+  const updaterUserId = (payload as any).updatedByUserId || payload.actorUserId || (payload as any).userId;
 
   try {
     console.log('[EmailSubscriber] Creating tenant database connection:', {
@@ -997,7 +1002,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
       status: ticket.status_name
     });
 
-    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, payload.userId);
+    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, updaterUserId);
 
     const priorityName = safeString(ticket.priority_name) || 'Unspecified';
     const statusName = safeString(ticket.status_name) || 'Unknown';
@@ -1076,9 +1081,11 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
     const formattedChanges = await formatChanges(db, payload.changes || {}, tenantId, emailTimeZone);
 
     // Get updater's name
-    const updater = await db('users')
-      .where({ user_id: payload.userId, tenant: tenantId })
-      .first();
+    const updater = updaterUserId
+      ? await db('users')
+          .where({ user_id: updaterUserId, tenant: tenantId })
+          .first()
+      : null;
 
     const { internalUrl, portalUrl } = await resolveTicketLinks(db, tenantId, ticket.ticket_id, ticket.ticket_number);
 
@@ -1105,7 +1112,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
       categoryDetails,
       locationSummary,
       changes: formattedChanges,
-      updatedBy: updater ? `${updater.first_name} ${updater.last_name}` : payload.userId
+      updatedBy: updater ? `${updater.first_name} ${updater.last_name}` : 'System'
     };
 
     const buildContext = (url: string) => ({
@@ -1151,7 +1158,7 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
           recipientEmail: email,
           recipientUserId: params.recipientUserId,
           isInternal: params.isInternal,
-          userId: payload.userId,
+          userId: updaterUserId || '',
           changes: payload.changes || {}
         });
       };
@@ -1647,6 +1654,8 @@ export async function handleAccumulatedTicketUpdates(notification: PendingNotifi
 async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId } = payload;
+  // Resolve userId from domain-specific field or base field, falling back to legacy
+  const assignerUserId = (payload as any).assignedByUserId || payload.actorUserId || (payload as any).userId;
 
   try {
     const db = await getConnection(tenantId);
@@ -1735,10 +1744,12 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
       return;
     }
 
-    const assignerName = await db('users')
-      .where({ user_id: payload.userId, tenant: tenantId })
-      .first()
-      .then(user => user ? `${user.first_name} ${user.last_name}` : 'System');
+    const assignerName = assignerUserId
+      ? await db('users')
+          .where({ user_id: assignerUserId, tenant: tenantId })
+          .first()
+          .then((user: any) => user ? `${user.first_name} ${user.last_name}` : 'System')
+      : 'System';
 
     const safeString = (value?: unknown) => {
       if (typeof value === 'string') {
@@ -1750,7 +1761,7 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
       return String(value).trim();
     };
 
-    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, payload.userId);
+    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, assignerUserId);
 
     const priorityName = safeString(ticket.priority_name) || 'Unspecified';
     const statusName = safeString(ticket.status_name) || 'Unknown';
@@ -2016,6 +2027,8 @@ async function handleTicketAssigned(event: TicketAssignedEvent): Promise<void> {
 async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId } = payload;
+  // Resolve userId from base field, falling back to legacy
+  const commentUserId = payload.actorUserId || (payload as any).userId;
 
   try {
     const db = await getConnection(tenantId);
@@ -2114,7 +2127,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       return String(value).trim();
     };
 
-    let commentAuthorUserId: string | null = payload.userId || null;
+    let commentAuthorUserId: string | null = commentUserId || null;
     let commentAuthorContactId: string | null = null;
     let commentAuthorEmail = '';
 
@@ -2158,7 +2171,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
       commentAuthorEmail = payload.comment.author.trim();
     }
 
-    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, payload.userId);
+    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, commentUserId);
 
     const priorityName = safeString(ticket.priority_name) || 'Unspecified';
     const statusName = safeString(ticket.status_name) || 'Unknown';
@@ -2583,6 +2596,8 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
 async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
   const { payload } = event;
   const { tenantId } = payload;
+  // Resolve userId from domain-specific field or base field, falling back to legacy
+  const closerUserId = (payload as any).closedByUserId || payload.actorUserId || (payload as any).userId;
 
   try {
     const db = await getConnection(tenantId);
@@ -2681,7 +2696,7 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
       return String(value).trim();
     };
 
-    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, payload.userId);
+    const emailTimeZone = await resolveEffectiveTimeZone(db, tenantId, closerUserId);
 
     const priorityName = safeString(ticket.priority_name) || 'Unspecified';
     const statusName = safeString(ticket.status_name) || 'Unknown';
@@ -2760,10 +2775,12 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
     const changes = await formatChanges(db, payload.changes || {}, tenantId, emailTimeZone);
 
     // Get closer's name
-    const closer = await db('users')
-      .where({ user_id: payload.userId, tenant: tenantId })
-      .first();
-    const closedBy = closer ? `${closer.first_name} ${closer.last_name}` : payload.userId;
+    const closer = closerUserId
+      ? await db('users')
+          .where({ user_id: closerUserId, tenant: tenantId })
+          .first()
+      : null;
+    const closedBy = closer ? `${closer.first_name} ${closer.last_name}` : 'System';
 
     // Get the resolution comment (most recent comment with is_resolution = true)
     const resolutionComment = await db('comments')

--- a/server/src/test/unit/internal-notifications/extractMentionUserIds.test.ts
+++ b/server/src/test/unit/internal-notifications/extractMentionUserIds.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
  *
  * Tests the extraction of user IDs from BlockNote mention inline content,
  * which is the format used by both web and mobile editors.
+ * Also covers ProseMirror format and nested block structures.
  */
 
 // Inline copy of the function from internalNotificationSubscriber.ts
@@ -15,19 +16,51 @@ function extractMentionUserIds(content: any): string[] {
   const userIds: string[] = [];
 
   try {
-    const blocks = typeof content === 'string' ? JSON.parse(content) : content;
+    // Parse content if it's a string
+    const parsed = typeof content === 'string' ? JSON.parse(content) : content;
 
-    if (!Array.isArray(blocks)) return [];
+    // Handle ProseMirror doc wrapper: { type: 'doc', content: [...] }
+    const blocks = parsed?.type === 'doc' && Array.isArray(parsed.content)
+      ? parsed.content
+      : Array.isArray(parsed) ? parsed : [];
 
-    for (const block of blocks) {
-      if (block.content && Array.isArray(block.content)) {
-        for (const inlineContent of block.content) {
-          if (inlineContent.type === 'mention' && inlineContent.props?.userId) {
-            userIds.push(inlineContent.props.userId);
+    // Recursively traverse blocks to find mention inline content
+    function traverseBlocks(blockList: any[]): void {
+      for (const block of blockList) {
+        if (!block || typeof block !== 'object') continue;
+
+        // Check inline content array (BlockNote format)
+        if (block.content && Array.isArray(block.content)) {
+          for (const inlineContent of block.content) {
+            if (inlineContent?.type === 'mention') {
+              // BlockNote format: props.userId
+              const userId = inlineContent.props?.userId
+                // ProseMirror format: attrs.userId or attrs.id
+                || inlineContent.attrs?.userId
+                || inlineContent.attrs?.id;
+              if (userId) {
+                userIds.push(userId);
+              }
+            }
           }
+        }
+
+        // Check ProseMirror node-level mentions (mention as a node, not inline content)
+        if (block.type === 'mention') {
+          const userId = block.props?.userId || block.attrs?.userId || block.attrs?.id;
+          if (userId) {
+            userIds.push(userId);
+          }
+        }
+
+        // Recurse into children (BlockNote nested blocks)
+        if (block.children && Array.isArray(block.children)) {
+          traverseBlocks(block.children);
         }
       }
     }
+
+    traverseBlocks(blocks);
   } catch (error) {
     // Parsing error — return empty
   }
@@ -179,5 +212,124 @@ describe('extractMentionUserIds', () => {
 
   it('should handle malformed JSON string gracefully', () => {
     expect(extractMentionUserIds('{invalid json')).toEqual([]);
+  });
+
+  // --- New tests for nested blocks and ProseMirror format ---
+
+  it('should extract mentions from nested children blocks', () => {
+    const content = [
+      {
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'Item 1' }],
+        children: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'mention', props: { userId: 'user-nested', username: 'nested', displayName: 'Nested User' } },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(extractMentionUserIds(content)).toEqual(['user-nested']);
+  });
+
+  it('should extract mentions from deeply nested children', () => {
+    const content = [
+      {
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'Level 1' }],
+        children: [
+          {
+            type: 'bulletListItem',
+            content: [{ type: 'text', text: 'Level 2' }],
+            children: [
+              {
+                type: 'paragraph',
+                content: [
+                  { type: 'mention', props: { userId: 'deep-user', username: 'deep', displayName: 'Deep User' } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(extractMentionUserIds(content)).toEqual(['deep-user']);
+  });
+
+  it('should extract mentions from both top-level and nested blocks', () => {
+    const content = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'mention', props: { userId: 'top-user', username: 'top', displayName: 'Top User' } },
+        ],
+      },
+      {
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'List item' }],
+        children: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'mention', props: { userId: 'nested-user', username: 'nested', displayName: 'Nested User' } },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(extractMentionUserIds(content)).toEqual(['top-user', 'nested-user']);
+  });
+
+  it('should handle ProseMirror doc wrapper format', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { userId: 'pm-user', username: 'pm', displayName: 'PM User' } },
+          ],
+        },
+      ],
+    };
+
+    expect(extractMentionUserIds(content)).toEqual(['pm-user']);
+  });
+
+  it('should handle ProseMirror attrs.id format', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'pm-id-user' } },
+          ],
+        },
+      ],
+    };
+
+    expect(extractMentionUserIds(content)).toEqual(['pm-id-user']);
+  });
+
+  it('should handle ProseMirror node-level mention (not inside content array)', () => {
+    const content = [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'Hello ' },
+        ],
+        children: [
+          { type: 'mention', props: { userId: 'node-mention' } },
+        ],
+      },
+    ];
+
+    expect(extractMentionUserIds(content)).toEqual(['node-mention']);
   });
 });


### PR DESCRIPTION
  extractMentionUserIds now recursively traverses block.children
  and supports ProseMirror doc/attrs format, fixing missed mentions
  in nested blocks. All ticket email handlers (created, updated,
  assigned, comment, closed) resolve userId from domain-specific
  fields (updatedByUserId, closedByUserId, etc.) instead of the
  non-existent payload.userId, which caused undefined binding errors.

  "But I don't want to go among undefined people," Alice remarked.
  "Oh, you can't help that," said the Cat: "we're all undefined here.
  The payload.userId is undefined. The closerUserId is undefined.
  Even the extractMentionUserIds only looked at the surface and
  never once ventured down the rabbit hole of block.children." 🐇📭🪆