### PR TITLE
Add board/status CRUD APIs and fix validation

### DIFF
--- a/ee/docs/api-registry/lookups.json
+++ b/ee/docs/api-registry/lookups.json
@@ -153,6 +153,258 @@
     {
       "match": {
         "method": "get",
+        "path": "/api/v1/boards"
+      },
+      "metadata": {
+        "displayName": "List Boards",
+        "summary": "Fetch ticket boards",
+        "description": "Returns paginated board records for the current tenant. Use this to discover valid board_id values before creating tickets or statuses. Each board has its own set of statuses, categories, and priorities.",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Case-insensitive search on board name or description.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "include_inactive",
+            "in": "query",
+            "required": false,
+            "description": "When true, include inactive boards (excluded by default).",
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of records per page (default 25, max 100).",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Pagination page number starting at 1.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "examples": [
+          {
+            "name": "List active boards",
+            "request": {
+              "query": {
+                "limit": 10
+              }
+            },
+            "notes": "Use the board_id from the response when creating tickets or querying statuses. The first active board is a safe default if the user does not specify a board."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/boards/{id}"
+      },
+      "metadata": {
+        "displayName": "Get Board",
+        "summary": "Get board by ID",
+        "description": "Returns a single board record by its UUID.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Board identifier.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "post",
+        "path": "/api/v1/boards"
+      },
+      "metadata": {
+        "displayName": "Create Board",
+        "summary": "Create a new ticket board",
+        "description": "Creates a new board. After creating a board, create at least one status for it via POST /api/v1/statuses so tickets can be assigned to the board.",
+        "approvalRequired": true,
+        "requestBodySchema": {
+          "type": "object",
+          "properties": {
+            "board_name": { "type": "string", "description": "Board display name." },
+            "description": { "type": "string", "description": "Optional board description." },
+            "is_default": { "type": "boolean", "description": "Whether this is the default board." },
+            "is_inactive": { "type": "boolean", "description": "Whether the board is inactive." },
+            "category_type": { "type": "string", "enum": ["custom", "itil"], "description": "Category classification type." },
+            "priority_type": { "type": "string", "enum": ["custom", "itil"], "description": "Priority classification type." }
+          },
+          "required": ["board_name"]
+        },
+        "examples": [
+          {
+            "name": "Create a new board",
+            "request": {
+              "body": {
+                "board_name": "Support",
+                "description": "General support board"
+              }
+            },
+            "notes": "After creating, add statuses via POST /api/v1/statuses with the new board_id and status_type 'ticket'."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "put",
+        "path": "/api/v1/boards/{id}"
+      },
+      "metadata": {
+        "displayName": "Update Board",
+        "summary": "Update a board",
+        "description": "Updates an existing board. All fields are optional — only send the fields you want to change.",
+        "approvalRequired": true,
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Board identifier.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
+        "path": "/api/v1/statuses"
+      },
+      "metadata": {
+        "displayName": "List Statuses",
+        "summary": "Fetch statuses",
+        "description": "Returns paginated status records. For ticket statuses, always filter by board_id to get statuses that belong to a specific board. Use this to resolve a valid status_id before creating or updating tickets.",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter by status type: ticket, project, project_task, or interaction.",
+            "schema": { "type": "string", "enum": ["ticket", "project", "project_task", "interaction"] }
+          },
+          {
+            "name": "board_id",
+            "in": "query",
+            "required": false,
+            "description": "Required when type=ticket. Filter statuses belonging to a specific board.",
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Case-insensitive search on status name.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of records per page (default 25, max 100).",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Pagination page number starting at 1.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "examples": [
+          {
+            "name": "List ticket statuses for a board",
+            "request": {
+              "query": {
+                "type": "ticket",
+                "board_id": "11111111-1111-1111-1111-111111111111",
+                "limit": 25
+              }
+            },
+            "notes": "Always pair type=ticket with board_id. Use the status_id from results when creating tickets — the status_id must belong to the same board_id used on the ticket."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "post",
+        "path": "/api/v1/statuses"
+      },
+      "metadata": {
+        "displayName": "Create Status",
+        "summary": "Create a new status",
+        "description": "Creates a new status. For ticket statuses, board_id is required. The status_type must be one of: ticket, project, project_task, interaction.",
+        "approvalRequired": true,
+        "requestBodySchema": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "description": "Status display name." },
+            "status_type": { "type": "string", "enum": ["ticket", "project", "project_task", "interaction"], "description": "Type of entity this status applies to." },
+            "board_id": { "type": "string", "format": "uuid", "description": "Required for ticket statuses. The board this status belongs to." },
+            "is_closed": { "type": "boolean", "description": "Whether this status represents a closed state." },
+            "is_default": { "type": "boolean", "description": "Whether this is the default status for the board." },
+            "order_number": { "type": "integer", "description": "Display order position." },
+            "color": { "type": "string", "description": "Hex color code (e.g. #3B82F6)." },
+            "icon": { "type": "string", "description": "Lucide icon name (e.g. Clipboard, PlayCircle)." }
+          },
+          "required": ["name", "status_type"]
+        },
+        "examples": [
+          {
+            "name": "Create a ticket status for a board",
+            "request": {
+              "body": {
+                "name": "In Progress",
+                "status_type": "ticket",
+                "board_id": "11111111-1111-1111-1111-111111111111",
+                "is_closed": false,
+                "color": "#3B82F6"
+              }
+            },
+            "notes": "Use GET /api/v1/boards first to resolve the board_id. The board_id is required for ticket statuses."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "put",
+        "path": "/api/v1/statuses/{id}"
+      },
+      "metadata": {
+        "displayName": "Update Status",
+        "summary": "Update a status",
+        "description": "Updates an existing status. All fields are optional — only send the fields you want to change. Cannot change status_type or board_id after creation.",
+        "approvalRequired": true,
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Status identifier.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
         "path": "/api/v1/categories/ticket"
       },
       "metadata": {

--- a/ee/docs/api-registry/tickets.json
+++ b/ee/docs/api-registry/tickets.json
@@ -8,7 +8,7 @@
       "metadata": {
         "displayName": "List Tickets",
         "summary": "List tickets",
-        "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
+        "description": "Returns a paginated list of tickets for the current tenant. Use GET /api/v1/boards and GET /api/v1/statuses for board/status lookups instead of sampling tickets. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
         "rbacResource": "ticket",
         "approvalRequired": false,
         "parameters": [
@@ -182,17 +182,17 @@
       "metadata": {
         "displayName": "Create Ticket",
         "summary": "Create a new ticket",
-        "description": "Creates a new ticket on a specified board with the desired status and priority. Requires the user to have ticket create permissions. Do not invoke this until you have gathered valid UUIDs for board_id, client_id, status_id, and priority_id from prior lookup calls.",
+        "description": "Creates a new ticket on a specified board with the desired status and priority. Requires the user to have ticket create permissions. Do not invoke this until you have gathered valid UUIDs for board_id, client_id, status_id, and priority_id from prior lookup calls. IMPORTANT: status_id must belong to the same board as board_id — use GET /api/v1/statuses?type=ticket&board_id=... to discover valid statuses for the chosen board.",
         "rbacResource": "ticket",
         "approvalRequired": true,
         "requestBodySchema": {
           "type": "object",
           "properties": {
             "title": { "type": "string", "description": "Ticket subject line." },
-            "board_id": { "type": "string", "format": "uuid", "description": "Ticket board identifier. If you do not already know an active board_id, call GET /api/v1/tickets?limit=5 to sample existing tickets and reuse a board_id that is valid for this tenant. Always provide the UUID, never the board name, slug, or display label." },
+            "board_id": { "type": "string", "format": "uuid", "description": "Ticket board identifier. Call GET /api/v1/boards to list available boards and pick a valid board_id. Always provide the UUID, never the board name, slug, or display label." },
             "client_id": { "type": "string", "format": "uuid", "description": "Owning client identifier. Retrieve clients via GET /api/v1/clients (supporting filters such as name or status) to resolve the correct client_id, and provide that UUID in the payload (do not send the client name)." },
-            "status_id": { "type": "string", "format": "uuid", "description": "Initial ticket status identifier. Sample existing tickets via GET /api/v1/tickets?limit=5 to collect a valid status_id and send that UUID (do not send a status label like \"Open\" or a field named \"status\")." },
-            "priority_id": { "type": "string", "format": "uuid", "description": "Ticket priority identifier. Sample existing tickets with GET /api/v1/tickets?limit=5 to obtain a valid priority_id and include the UUID (never send fields named \"priority\" or the textual priority name)." },
+            "status_id": { "type": "string", "format": "uuid", "description": "Initial ticket status identifier. Call GET /api/v1/statuses?type=ticket&board_id=... to list valid statuses for the chosen board. The status_id MUST belong to the same board as board_id. Do not send a status label like \"Open\" or a field named \"status\"." },
+            "priority_id": { "type": "string", "format": "uuid", "description": "Ticket priority identifier. Use GET /api/v1/priorities or sample existing tickets to obtain a valid priority_id. Always include the UUID (never send fields named \"priority\" or the textual priority name)." },
             "contact_name_id": { "type": "string", "format": "uuid", "nullable": true, "description": "Primary contact for this ticket. Look up contacts through GET /api/v1/contacts (optionally filter by client_id) before supplying this reference." },
             "location_id": { "type": "string", "format": "uuid", "nullable": true, "description": "Client location identifier. Call GET /api/v1/clients/{client_id}/locations to enumerate valid locations for the chosen client." },
             "category_id": { "type": "string", "format": "uuid", "nullable": true, "description": "Ticket category identifier. Fetch categories via GET /api/v1/categories/ticket (filter by board_id if necessary) to resolve the correct category_id." },
@@ -244,7 +244,7 @@
                 "contact_name_id": "55555555-5555-5555-5555-555555555555"
               }
             },
-            "notes": "Before calling this endpoint, resolve every referenced identifier by invoking the appropriate lookup APIs. For example, call GET /api/v1/clients to choose client_id, GET /api/v1/contacts?client_id=... for contact_name_id, GET /api/v1/clients/{client_id}/locations for location_id, GET /api/v1/categories/ticket for category/subcategory options, GET /api/v1/users to select the assignee, GET /api/v1/tags to reuse tag names, and GET /api/v1/tickets?limit=5 to sample valid board_id, status_id, and priority_id values already in use. Always send the UUID fields exactly as documented—do not substitute human-readable names such as \"High\" or \"In Progress,\" and do not introduce extra fields that are not part of this schema (e.g., project_id or priority). If the user supplies labels, translate them to *_id values and omit the original textual fields. When sampling tickets for IDs, it is acceptable to reuse the first ticket record that contains non-null values for board_id, status_id, and priority_id."
+            "notes": "Before calling this endpoint, resolve every referenced identifier by invoking the appropriate lookup APIs: GET /api/v1/boards to choose board_id, GET /api/v1/statuses?type=ticket&board_id=... to choose a status_id that belongs to that board, GET /api/v1/clients to choose client_id, GET /api/v1/contacts?client_id=... for contact_name_id, GET /api/v1/clients/{client_id}/locations for location_id, GET /api/v1/categories/ticket for category/subcategory options, GET /api/v1/users to select the assignee, and GET /api/v1/tags to reuse tag names. CRITICAL: status_id must belong to the same board as board_id — mismatched values will be rejected with a 400 error. Always send UUID fields exactly as documented — do not substitute human-readable names such as \"High\" or \"In Progress,\" and do not introduce extra fields that are not part of this schema."
           }
         ]
       }

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -5,6 +5,614 @@ import { ChatApiRegistryEntry } from './apiRegistry.schema';
 
 export const chatApiRegistry: ChatApiRegistryEntry[] = [
   {
+    "id": "get-_api_v1_boards",
+    "method": "get",
+    "path": "/api/v1/boards",
+    "displayName": "List Boards",
+    "summary": "Fetch ticket boards",
+    "description": "Returns paginated board records for the current tenant. Use this to discover valid board_id values before creating tickets or statuses. Each board has its own set of statuses, categories, and priorities.",
+    "tags": [
+      "Boards"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "description": "Case-insensitive search on board name or description.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "include_inactive",
+        "in": "query",
+        "required": false,
+        "description": "When true, include inactive boards (excluded by default).",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Number of records per page (default 25, max 100).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "Pagination page number starting at 1.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/BoardApiResponse"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "List active boards",
+        "request": {
+          "query": {
+            "limit": 10
+          }
+        },
+        "notes": "Use the board_id from the response when creating tickets or querying statuses. The first active board is a safe default if the user does not specify a board."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_boards",
+    "method": "post",
+    "path": "/api/v1/boards",
+    "displayName": "Create Board",
+    "summary": "Create a new ticket board",
+    "description": "Creates a new board. After creating a board, create at least one status for it via POST /api/v1/statuses so tickets can be assigned to the board.",
+    "tags": [
+      "Boards"
+    ],
+    "approvalRequired": true,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "board_name": {
+          "type": "string",
+          "description": "Board display name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional board description."
+        },
+        "is_default": {
+          "type": "boolean",
+          "description": "Whether this is the default board."
+        },
+        "is_inactive": {
+          "type": "boolean",
+          "description": "Whether the board is inactive."
+        },
+        "category_type": {
+          "type": "string",
+          "enum": [
+            "custom",
+            "itil"
+          ],
+          "description": "Category classification type."
+        },
+        "priority_type": {
+          "type": "string",
+          "enum": [
+            "custom",
+            "itil"
+          ],
+          "description": "Priority classification type."
+        }
+      },
+      "required": [
+        "board_name"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/BoardApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "Create a new board",
+        "request": {
+          "body": {
+            "board_name": "Support",
+            "description": "General support board"
+          }
+        },
+        "notes": "After creating, add statuses via POST /api/v1/statuses with the new board_id and status_type 'ticket'."
+      }
+    ]
+  },
+  {
+    "id": "get-_api_v1_boards_id",
+    "method": "get",
+    "path": "/api/v1/boards/{id}",
+    "displayName": "Get Board",
+    "summary": "Get board by ID",
+    "description": "Returns a single board record by its UUID.",
+    "tags": [
+      "Boards"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Board identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/BoardApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "put-_api_v1_boards_id",
+    "method": "put",
+    "path": "/api/v1/boards/{id}",
+    "displayName": "Update Board",
+    "summary": "Update a board",
+    "description": "Updates an existing board. All fields are optional — only send the fields you want to change.",
+    "tags": [
+      "Boards"
+    ],
+    "approvalRequired": true,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Board identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "board_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 1000
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "is_inactive": {
+          "type": "boolean"
+        },
+        "category_type": {
+          "type": "string",
+          "enum": [
+            "custom",
+            "itil"
+          ]
+        },
+        "priority_type": {
+          "type": "string",
+          "enum": [
+            "custom",
+            "itil"
+          ]
+        },
+        "default_assigned_to": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "display_itil_impact": {
+          "type": "boolean"
+        },
+        "display_itil_urgency": {
+          "type": "boolean"
+        },
+        "enable_live_ticket_timer": {
+          "type": "boolean"
+        }
+      },
+      "description": "Payload for updating a board. All fields are optional."
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/BoardApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_boards_id",
+    "method": "delete",
+    "path": "/api/v1/boards/{id}",
+    "displayName": "Delete board",
+    "summary": "Delete board",
+    "description": "Deletes a board by its UUID. This will fail if the board has associated tickets.",
+    "tags": [
+      "Boards"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Board UUID.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Board UUID."
+        }
+      }
+    ]
+  },
+  {
+    "id": "get-_api_v1_statuses",
+    "method": "get",
+    "path": "/api/v1/statuses",
+    "displayName": "List Statuses",
+    "summary": "Fetch statuses",
+    "description": "Returns paginated status records. For ticket statuses, always filter by board_id to get statuses that belong to a specific board. Use this to resolve a valid status_id before creating or updating tickets.",
+    "tags": [
+      "Statuses"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "type",
+        "in": "query",
+        "required": false,
+        "description": "Filter by status type: ticket, project, project_task, or interaction.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ticket",
+            "project",
+            "project_task",
+            "interaction"
+          ]
+        }
+      },
+      {
+        "name": "board_id",
+        "in": "query",
+        "required": false,
+        "description": "Required when type=ticket. Filter statuses belonging to a specific board.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "description": "Case-insensitive search on status name.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Number of records per page (default 25, max 100).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "Pagination page number starting at 1.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/StatusApiResponse"
+          }
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "List ticket statuses for a board",
+        "request": {
+          "query": {
+            "type": "ticket",
+            "board_id": "11111111-1111-1111-1111-111111111111",
+            "limit": 25
+          }
+        },
+        "notes": "Always pair type=ticket with board_id. Use the status_id from results when creating tickets — the status_id must belong to the same board_id used on the ticket."
+      }
+    ]
+  },
+  {
+    "id": "post-_api_v1_statuses",
+    "method": "post",
+    "path": "/api/v1/statuses",
+    "displayName": "Create Status",
+    "summary": "Create a new status",
+    "description": "Creates a new status. For ticket statuses, board_id is required. The status_type must be one of: ticket, project, project_task, interaction.",
+    "tags": [
+      "Statuses"
+    ],
+    "approvalRequired": true,
+    "parameters": [],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Status display name."
+        },
+        "status_type": {
+          "type": "string",
+          "enum": [
+            "ticket",
+            "project",
+            "project_task",
+            "interaction"
+          ],
+          "description": "Type of entity this status applies to."
+        },
+        "board_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Required for ticket statuses. The board this status belongs to."
+        },
+        "is_closed": {
+          "type": "boolean",
+          "description": "Whether this status represents a closed state."
+        },
+        "is_default": {
+          "type": "boolean",
+          "description": "Whether this is the default status for the board."
+        },
+        "order_number": {
+          "type": "integer",
+          "description": "Display order position."
+        },
+        "color": {
+          "type": "string",
+          "description": "Hex color code (e.g. #3B82F6)."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Lucide icon name (e.g. Clipboard, PlayCircle)."
+        }
+      },
+      "required": [
+        "name",
+        "status_type"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/StatusApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "examples": [
+      {
+        "name": "Create a ticket status for a board",
+        "request": {
+          "body": {
+            "name": "In Progress",
+            "status_type": "ticket",
+            "board_id": "11111111-1111-1111-1111-111111111111",
+            "is_closed": false,
+            "color": "#3B82F6"
+          }
+        },
+        "notes": "Use GET /api/v1/boards first to resolve the board_id. The board_id is required for ticket statuses."
+      }
+    ]
+  },
+  {
+    "id": "get-_api_v1_statuses_id",
+    "method": "get",
+    "path": "/api/v1/statuses/{id}",
+    "displayName": "Get status by ID",
+    "summary": "Get status by ID",
+    "description": "Returns a single status by its UUID.",
+    "tags": [
+      "Statuses"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Status UUID.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Status UUID."
+        }
+      }
+    ],
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/StatusApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "put-_api_v1_statuses_id",
+    "method": "put",
+    "path": "/api/v1/statuses/{id}",
+    "displayName": "Update Status",
+    "summary": "Update a status",
+    "description": "Updates an existing status. All fields are optional — only send the fields you want to change. Cannot change status_type or board_id after creation.",
+    "tags": [
+      "Statuses"
+    ],
+    "approvalRequired": true,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Status identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "is_closed": {
+          "type": "boolean"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "order_number": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "icon": {
+          "type": "string",
+          "maxLength": 50
+        }
+      },
+      "description": "Payload for updating a status. All fields are optional."
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/components/schemas/StatusApiResponse"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    }
+  },
+  {
+    "id": "delete-_api_v1_statuses_id",
+    "method": "delete",
+    "path": "/api/v1/statuses/{id}",
+    "displayName": "Delete status",
+    "summary": "Delete status",
+    "description": "Deletes a status by its UUID. Cannot delete the last default status for a board.",
+    "tags": [
+      "Statuses"
+    ],
+    "approvalRequired": false,
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Status UUID.",
+        "schema": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Status UUID."
+        }
+      }
+    ]
+  },
+  {
     "id": "get-_api_v1_categories_service",
     "method": "get",
     "path": "/api/v1/categories/service",
@@ -10538,7 +11146,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tickets",
     "displayName": "List Tickets",
     "summary": "List tickets",
-    "description": "Returns a paginated list of tickets for the current tenant. Use this both for reporting and to sample existing board_id, status_id, priority_id, and assigned_to values before creating a new ticket. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
+    "description": "Returns a paginated list of tickets for the current tenant. Use GET /api/v1/boards and GET /api/v1/statuses for board/status lookups instead of sampling tickets. If you send the fields query parameter, use only these exact field names: ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, or mobile_list. Do not invent aliases such as id, subject, status, priority, client, created_at, or description.",
     "tags": [
       "tickets"
     ],
@@ -10738,7 +11346,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/v1/tickets",
     "displayName": "Create Ticket",
     "summary": "Create a new ticket",
-    "description": "Creates a new ticket on a specified board with the desired status and priority. Requires the user to have ticket create permissions. Do not invoke this until you have gathered valid UUIDs for board_id, client_id, status_id, and priority_id from prior lookup calls.",
+    "description": "Creates a new ticket on a specified board with the desired status and priority. Requires the user to have ticket create permissions. Do not invoke this until you have gathered valid UUIDs for board_id, client_id, status_id, and priority_id from prior lookup calls. IMPORTANT: status_id must belong to the same board as board_id — use GET /api/v1/statuses?type=ticket&board_id=... to discover valid statuses for the chosen board.",
     "tags": [
       "tickets"
     ],
@@ -10755,7 +11363,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "board_id": {
           "type": "string",
           "format": "uuid",
-          "description": "Ticket board identifier. If you do not already know an active board_id, call GET /api/v1/tickets?limit=5 to sample existing tickets and reuse a board_id that is valid for this tenant. Always provide the UUID, never the board name, slug, or display label."
+          "description": "Ticket board identifier. Call GET /api/v1/boards to list available boards and pick a valid board_id. Always provide the UUID, never the board name, slug, or display label."
         },
         "client_id": {
           "type": "string",
@@ -10765,12 +11373,12 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "status_id": {
           "type": "string",
           "format": "uuid",
-          "description": "Initial ticket status identifier. Sample existing tickets via GET /api/v1/tickets?limit=5 to collect a valid status_id and send that UUID (do not send a status label like \"Open\" or a field named \"status\")."
+          "description": "Initial ticket status identifier. Call GET /api/v1/statuses?type=ticket&board_id=... to list valid statuses for the chosen board. The status_id MUST belong to the same board as board_id. Do not send a status label like \"Open\" or a field named \"status\"."
         },
         "priority_id": {
           "type": "string",
           "format": "uuid",
-          "description": "Ticket priority identifier. Sample existing tickets with GET /api/v1/tickets?limit=5 to obtain a valid priority_id and include the UUID (never send fields named \"priority\" or the textual priority name)."
+          "description": "Ticket priority identifier. Use GET /api/v1/priorities or sample existing tickets to obtain a valid priority_id. Always include the UUID (never send fields named \"priority\" or the textual priority name)."
         },
         "contact_name_id": {
           "type": "string",
@@ -10892,7 +11500,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "contact_name_id": "55555555-5555-5555-5555-555555555555"
           }
         },
-        "notes": "Before calling this endpoint, resolve every referenced identifier by invoking the appropriate lookup APIs. For example, call GET /api/v1/clients to choose client_id, GET /api/v1/contacts?client_id=... for contact_name_id, GET /api/v1/clients/{client_id}/locations for location_id, GET /api/v1/categories/ticket for category/subcategory options, GET /api/v1/users to select the assignee, GET /api/v1/tags to reuse tag names, and GET /api/v1/tickets?limit=5 to sample valid board_id, status_id, and priority_id values already in use. Always send the UUID fields exactly as documented—do not substitute human-readable names such as \"High\" or \"In Progress,\" and do not introduce extra fields that are not part of this schema (e.g., project_id or priority). If the user supplies labels, translate them to *_id values and omit the original textual fields. When sampling tickets for IDs, it is acceptable to reuse the first ticket record that contains non-null values for board_id, status_id, and priority_id."
+        "notes": "Before calling this endpoint, resolve every referenced identifier by invoking the appropriate lookup APIs: GET /api/v1/boards to choose board_id, GET /api/v1/statuses?type=ticket&board_id=... to choose a status_id that belongs to that board, GET /api/v1/clients to choose client_id, GET /api/v1/contacts?client_id=... for contact_name_id, GET /api/v1/clients/{client_id}/locations for location_id, GET /api/v1/categories/ticket for category/subcategory options, GET /api/v1/users to select the assignee, and GET /api/v1/tags to reuse tag names. CRITICAL: status_id must belong to the same board as board_id — mismatched values will be rejected with a 400 error. Always send UUID fields exactly as documented — do not substitute human-readable names such as \"High\" or \"In Progress,\" and do not introduce extra fields that are not part of this schema."
       }
     ]
   },
@@ -14880,164 +15488,488 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     }
   },
   {
-    "id": "post-_api_extbundles_abort",
-    "method": "post",
-    "path": "/api/ext-bundles/abort",
-    "displayName": "POST ext-bundles",
-    "summary": "POST ext-bundles",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-    "tags": [
-      "ext-bundles"
-    ],
-    "approvalRequired": false,
-    "parameters": [],
-    "requestBodySchema": {
-      "type": "object",
-      "properties": {}
-    },
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {}
-    }
-  },
-  {
-    "id": "post-_api_extbundles_finalize",
-    "method": "post",
-    "path": "/api/ext-bundles/finalize",
-    "displayName": "POST ext-bundles",
-    "summary": "POST ext-bundles",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-    "tags": [
-      "ext-bundles"
-    ],
-    "approvalRequired": false,
-    "parameters": [],
-    "requestBodySchema": {
-      "type": "object",
-      "properties": {}
-    },
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {}
-    }
-  },
-  {
-    "id": "post-_api_extbundles_uploadproxy",
-    "method": "post",
-    "path": "/api/ext-bundles/upload-proxy",
-    "displayName": "POST ext-bundles",
-    "summary": "POST ext-bundles",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-    "tags": [
-      "ext-bundles"
-    ],
-    "approvalRequired": false,
-    "parameters": [],
-    "requestBodySchema": {
-      "type": "object",
-      "properties": {}
-    },
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {}
-    }
-  },
-  {
-    "id": "get-_api_extensions_installinfo",
+    "id": "get-_api_v1_storage_namespaces_namespace_records",
     "method": "get",
-    "path": "/api/extensions/install-info",
-    "displayName": "GET extensions",
-    "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "path": "/api/v1/storage/namespaces/{namespace}/records",
+    "displayName": "List records in a namespace",
+    "summary": "List records in a namespace",
     "tags": [
-      "extensions"
+      "Storage"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "namespace",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "cursor",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "keyPrefix",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 256
+        }
+      },
+      {
+        "name": "includeValues",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "includeMetadata",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
-      "properties": {}
-    }
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/StorageListItem"
+          }
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "items",
+        "nextCursor"
+      ]
+    },
+    "playbooks": [
+      "storage/list-namespace"
+    ],
+    "examples": [
+      {
+        "name": "List records with prefix filter",
+        "request": {
+          "params": {
+            "namespace": "integrations:zendesk"
+          },
+          "query": {
+            "prefix": "tickets/"
+          }
+        }
+      }
+    ]
   },
   {
-    "id": "get-_api_extensions_registrydbcheck",
+    "id": "post-_api_v1_storage_namespaces_namespace_records",
+    "method": "post",
+    "path": "/api/v1/storage/namespaces/{namespace}/records",
+    "displayName": "Bulk insert or update records",
+    "summary": "Bulk insert or update records",
+    "tags": [
+      "Storage"
+    ],
+    "approvalRequired": true,
+    "parameters": [
+      {
+        "name": "namespace",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    ],
+    "requestBodySchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256
+              },
+              "value": {},
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "ttlSeconds": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "ifRevision": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "schemaVersion": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": [
+              "key"
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "responseBodySchema": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "ttlExpiresAt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "key",
+              "revision",
+              "ttlExpiresAt"
+            ]
+          }
+        }
+      },
+      "required": [
+        "namespace",
+        "items"
+      ]
+    },
+    "playbooks": [
+      "storage/bulk-upsert-records"
+    ],
+    "examples": [
+      {
+        "name": "Bulk upsert configuration values",
+        "request": {
+          "params": {
+            "namespace": "automation:workflow"
+          },
+          "body": {
+            "records": [
+              {
+                "key": "webhook/url",
+                "value": "https://hooks.example.com/inbound",
+                "contentType": "text/plain"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "get-_api_v1_storage_namespaces_namespace_records_key",
     "method": "get",
-    "path": "/api/extensions/registry-db-check",
-    "displayName": "GET extensions",
-    "summary": "GET extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "path": "/api/v1/storage/namespaces/{namespace}/records/{key}",
+    "displayName": "Get a record by key",
+    "summary": "Get a record by key",
     "tags": [
-      "extensions"
+      "Storage"
     ],
     "approvalRequired": false,
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "namespace",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      },
+      {
+        "name": "key",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      {
+        "name": "if-revision-match",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responseBodySchema": {
       "type": "object",
-      "properties": {}
-    }
+      "properties": {
+        "namespace": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "value": {},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "ttlExpiresAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "namespace",
+        "key",
+        "revision",
+        "metadata",
+        "ttlExpiresAt",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "playbooks": [
+      "storage/get-record"
+    ],
+    "examples": [
+      {
+        "name": "Retrieve a workflow record",
+        "request": {
+          "params": {
+            "namespace": "automation:workflow",
+            "key": "webhook/url"
+          }
+        }
+      }
+    ]
   },
   {
-    "id": "post-_api_extensions_reprovision",
-    "method": "post",
-    "path": "/api/extensions/reprovision",
-    "displayName": "POST extensions",
-    "summary": "POST extensions",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "id": "put-_api_v1_storage_namespaces_namespace_records_key",
+    "method": "put",
+    "path": "/api/v1/storage/namespaces/{namespace}/records/{key}",
+    "displayName": "Create or update a record by key",
+    "summary": "Create or update a record by key",
     "tags": [
-      "extensions"
+      "Storage"
     ],
-    "approvalRequired": false,
-    "parameters": [],
+    "approvalRequired": true,
+    "parameters": [
+      {
+        "name": "namespace",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      },
+      {
+        "name": "key",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    ],
     "requestBodySchema": {
       "type": "object",
-      "properties": {}
+      "properties": {
+        "value": {},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "ttlSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "ifRevision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "schemaVersion": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        }
+      }
     },
     "responseBodySchema": {
       "type": "object",
-      "properties": {}
-    }
+      "properties": {
+        "namespace": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "ttlExpiresAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "namespace",
+        "key",
+        "revision",
+        "ttlExpiresAt",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "playbooks": [
+      "storage/put-record"
+    ],
+    "examples": [
+      {
+        "name": "Set workflow webhook URL",
+        "request": {
+          "params": {
+            "namespace": "automation:workflow",
+            "key": "webhook/url"
+          },
+          "body": {
+            "value": "https://hooks.example.com/inbound",
+            "contentType": "text/plain"
+          }
+        }
+      }
+    ]
   },
   {
-    "id": "post-_api_provisioning_tenants",
-    "method": "post",
-    "path": "/api/provisioning/tenants",
-    "displayName": "POST provisioning",
-    "summary": "POST provisioning",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+    "id": "delete-_api_v1_storage_namespaces_namespace_records_key",
+    "method": "delete",
+    "path": "/api/v1/storage/namespaces/{namespace}/records/{key}",
+    "displayName": "Delete a record by key",
+    "summary": "Delete a record by key",
     "tags": [
-      "provisioning"
+      "Storage"
     ],
     "approvalRequired": false,
-    "parameters": [],
-    "requestBodySchema": {
-      "type": "object",
-      "properties": {}
-    },
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {}
-    }
-  },
-  {
-    "id": "post-_api_v1_auth_verify",
-    "method": "post",
-    "path": "/api/v1/auth/verify",
-    "displayName": "POST v1",
-    "summary": "POST v1",
-    "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-    "tags": [
-      "auth"
-    ],
-    "approvalRequired": false,
-    "parameters": [],
-    "requestBodySchema": {
-      "type": "object",
-      "properties": {}
-    },
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {}
-    }
+    "parameters": [
+      {
+        "name": "namespace",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      },
+      {
+        "name": "key",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      {
+        "name": "ifRevision",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    ]
   }
 ];
 

--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -17,10 +17,16 @@
   ],
   "tags": [
     {
+      "name": "Boards"
+    },
+    {
       "name": "Projects"
     },
     {
       "name": "Service Categories"
+    },
+    {
+      "name": "Statuses"
     },
     {
       "name": "Storage"
@@ -209,6 +215,436 @@
       "PlaceholderObject": {
         "type": "object",
         "properties": {}
+      },
+      "BoardIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Board UUID."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "BoardApiResponse": {
+        "type": "object",
+        "properties": {
+          "board_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "board_name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "display_order": {
+            "type": "number"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "display_itil_impact": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "display_itil_urgency": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "inbound_reply_reopen_enabled": {
+            "type": "boolean"
+          },
+          "inbound_reply_reopen_cutoff_hours": {
+            "type": "integer"
+          },
+          "inbound_reply_reopen_status_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "inbound_reply_ai_ack_suppression_enabled": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tenant": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "board_id",
+          "board_name",
+          "description",
+          "display_order",
+          "is_default",
+          "is_inactive",
+          "category_type",
+          "priority_type",
+          "display_itil_impact",
+          "display_itil_urgency",
+          "default_assigned_to",
+          "enable_live_ticket_timer",
+          "tenant"
+        ]
+      },
+      "BoardEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BoardApiResponse"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "BoardListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoardApiResponse"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "BoardCreateRequest": {
+        "type": "object",
+        "properties": {
+          "board_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "display_itil_impact": {
+            "type": "boolean"
+          },
+          "display_itil_urgency": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "board_name"
+        ],
+        "description": "Payload for creating a new board."
+      },
+      "BoardUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "board_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "display_itil_impact": {
+            "type": "boolean"
+          },
+          "display_itil_urgency": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": "boolean"
+          }
+        },
+        "description": "Payload for updating a board. All fields are optional."
+      },
+      "StatusIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Status UUID."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "StatusApiResponse": {
+        "type": "object",
+        "properties": {
+          "status_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status_type": {
+            "type": "string",
+            "enum": [
+              "ticket",
+              "project",
+              "project_task",
+              "interaction"
+            ]
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "item_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "standard_status_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "is_custom": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tenant": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "status_id",
+          "name",
+          "status_type",
+          "order_number",
+          "is_closed",
+          "is_default",
+          "item_type",
+          "standard_status_id",
+          "is_custom",
+          "tenant"
+        ]
+      },
+      "StatusEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StatusApiResponse"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "StatusListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StatusApiResponse"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "StatusCreateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "status_type": {
+            "type": "string",
+            "enum": [
+              "ticket",
+              "project",
+              "project_task",
+              "interaction"
+            ]
+          },
+          "board_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "order_number": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": [
+          "name",
+          "status_type"
+        ],
+        "description": "Payload for creating a new status. For ticket statuses, board_id is required."
+      },
+      "StatusUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "order_number": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "description": "Payload for updating a status. All fields are optional."
       },
       "ServiceCategory": {
         "type": "object",
@@ -993,6 +1429,686 @@
     "parameters": {}
   },
   "paths": {
+    "/api/v1/boards": {
+      "get": {
+        "summary": "List boards",
+        "description": "Returns a paginated list of ticket boards for the current tenant. Use this to discover valid board_id values before creating tickets or statuses.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "List Boards",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Boards returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create board",
+        "description": "Creates a new ticket board. After creating a board, create at least one status for it via POST /api/v1/statuses so tickets can be assigned to the board.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Create Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "requestBody": {
+          "description": "Board creation payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BoardCreateRequest"
+              },
+              "description": "Board creation payload."
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Board created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/boards/{id}": {
+      "get": {
+        "summary": "Get board by ID",
+        "description": "Returns a single board by its UUID.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Get Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Board returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update board",
+        "description": "Updates an existing board. All fields are optional — only send the fields you want to change.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Update Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Board update payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BoardUpdateRequest"
+              },
+              "description": "Board update payload."
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Board updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete board",
+        "description": "Deletes a board by its UUID. This will fail if the board has associated tickets.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Delete Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Board deleted successfully."
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/statuses": {
+      "get": {
+        "summary": "List statuses",
+        "description": "Returns a paginated list of statuses. For ticket statuses, filter by type=ticket and board_id to get statuses that belong to a specific board. The status_id must belong to the same board_id when creating tickets.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "List Statuses",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Statuses returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create status",
+        "description": "Creates a new status. For ticket statuses, board_id is required. The status_type must be one of: ticket, project, project_task, interaction.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Create Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "requestBody": {
+          "description": "Status creation payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusCreateRequest"
+              },
+              "description": "Status creation payload."
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Status created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/statuses/{id}": {
+      "get": {
+        "summary": "Get status by ID",
+        "description": "Returns a single status by its UUID.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Get Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update status",
+        "description": "Updates an existing status. All fields are optional — only send the fields you want to change.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Update Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Status update payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusUpdateRequest"
+              },
+              "description": "Status update payload."
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete status",
+        "description": "Deletes a status by its UUID. Cannot delete the last default status for a board.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Delete Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Status deleted successfully."
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/categories/service": {
       "get": {
         "summary": "List service categories",

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -9,8 +9,10 @@ servers:
   - url: http://localhost:3000
     description: Local development
 tags:
+  - name: Boards
   - name: Projects
   - name: Service Categories
+  - name: Statuses
   - name: Storage
   - name: admin
   - name: assets
@@ -87,6 +89,308 @@ components:
     PlaceholderObject:
       type: object
       properties: {}
+    BoardIdParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Board UUID.
+      required:
+        - id
+    BoardApiResponse:
+      type: object
+      properties:
+        board_id:
+          type: string
+          format: uuid
+        board_name:
+          type: string
+        description:
+          type:
+            - string
+            - "null"
+        display_order:
+          type: number
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - custom
+            - itil
+        priority_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - custom
+            - itil
+        display_itil_impact:
+          type:
+            - boolean
+            - "null"
+        display_itil_urgency:
+          type:
+            - boolean
+            - "null"
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        inbound_reply_reopen_enabled:
+          type: boolean
+        inbound_reply_reopen_cutoff_hours:
+          type: integer
+        inbound_reply_reopen_status_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+        inbound_reply_ai_ack_suppression_enabled:
+          type: boolean
+        enable_live_ticket_timer:
+          type:
+            - boolean
+            - "null"
+        tenant:
+          type: string
+          format: uuid
+      required:
+        - board_id
+        - board_name
+        - description
+        - display_order
+        - is_default
+        - is_inactive
+        - category_type
+        - priority_type
+        - display_itil_impact
+        - display_itil_urgency
+        - default_assigned_to
+        - enable_live_ticket_timer
+        - tenant
+    BoardEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/BoardApiResponse"
+      required:
+        - data
+    BoardListEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BoardApiResponse"
+      required:
+        - data
+    BoardCreateRequest:
+      type: object
+      properties:
+        board_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 1000
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type: string
+          enum: &a1
+            - custom
+            - itil
+        priority_type:
+          type: string
+          enum: &a2
+            - custom
+            - itil
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        display_itil_impact:
+          type: boolean
+        display_itil_urgency:
+          type: boolean
+        enable_live_ticket_timer:
+          type: boolean
+      required:
+        - board_name
+      description: Payload for creating a new board.
+    BoardUpdateRequest:
+      type: object
+      properties:
+        board_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 1000
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type: string
+          enum: *a1
+        priority_type:
+          type: string
+          enum: *a2
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        display_itil_impact:
+          type: boolean
+        display_itil_urgency:
+          type: boolean
+        enable_live_ticket_timer:
+          type: boolean
+      description: Payload for updating a board. All fields are optional.
+    StatusIdParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Status UUID.
+      required:
+        - id
+    StatusApiResponse:
+      type: object
+      properties:
+        status_id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        status_type:
+          type: string
+          enum:
+            - ticket
+            - project
+            - project_task
+            - interaction
+        order_number:
+          type: number
+        is_closed:
+          type: boolean
+        is_default:
+          type:
+            - boolean
+            - "null"
+        item_type:
+          type:
+            - string
+            - "null"
+        standard_status_id:
+          type:
+            - string
+            - "null"
+        is_custom:
+          type:
+            - boolean
+            - "null"
+        tenant:
+          type: string
+          format: uuid
+      required:
+        - status_id
+        - name
+        - status_type
+        - order_number
+        - is_closed
+        - is_default
+        - item_type
+        - standard_status_id
+        - is_custom
+        - tenant
+    StatusEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/StatusApiResponse"
+      required:
+        - data
+    StatusListEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/StatusApiResponse"
+      required:
+        - data
+    StatusCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        status_type:
+          type: string
+          enum:
+            - ticket
+            - project
+            - project_task
+            - interaction
+        board_id:
+          type: string
+          format: uuid
+        is_closed:
+          type: boolean
+        is_default:
+          type: boolean
+        order_number:
+          type: integer
+          minimum: 0
+        color:
+          type: string
+          pattern: ^#[0-9A-Fa-f]{6}$
+        icon:
+          type: string
+          maxLength: 50
+      required:
+        - name
+        - status_type
+      description: Payload for creating a new status. For ticket statuses, board_id is
+        required.
+    StatusUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        is_closed:
+          type: boolean
+        is_default:
+          type: boolean
+        order_number:
+          type: integer
+          minimum: 0
+        color:
+          type: string
+          pattern: ^#[0-9A-Fa-f]{6}$
+        icon:
+          type: string
+          maxLength: 50
+      description: Payload for updating a status. All fields are optional.
     ServiceCategory:
       type: object
       properties:
@@ -646,6 +950,455 @@ components:
           minimum: 0
   parameters: {}
 paths:
+  /api/v1/boards:
+    get:
+      summary: List boards
+      description: Returns a paginated list of ticket boards for the current tenant.
+        Use this to discover valid board_id values before creating tickets or
+        statuses.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: List Boards
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      responses:
+        "200":
+          description: Boards returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardListEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create board
+      description: Creates a new ticket board. After creating a board, create at least
+        one status for it via POST /api/v1/statuses so tickets can be assigned
+        to the board.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Create Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      requestBody:
+        description: Board creation payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BoardCreateRequest"
+            description: Board creation payload.
+      responses:
+        "201":
+          description: Board created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/boards/{id}:
+    get:
+      summary: Get board by ID
+      description: Returns a single board by its UUID.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Get Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Board returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update board
+      description: Updates an existing board. All fields are optional — only send the
+        fields you want to change.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Update Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      requestBody:
+        description: Board update payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BoardUpdateRequest"
+            description: Board update payload.
+      responses:
+        "200":
+          description: Board updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete board
+      description: Deletes a board by its UUID. This will fail if the board has
+        associated tickets.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Delete Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Board deleted successfully.
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/statuses:
+    get:
+      summary: List statuses
+      description: Returns a paginated list of statuses. For ticket statuses, filter
+        by type=ticket and board_id to get statuses that belong to a specific
+        board. The status_id must belong to the same board_id when creating
+        tickets.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: List Statuses
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      responses:
+        "200":
+          description: Statuses returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusListEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create status
+      description: "Creates a new status. For ticket statuses, board_id is required.
+        The status_type must be one of: ticket, project, project_task,
+        interaction."
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Create Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      requestBody:
+        description: Status creation payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusCreateRequest"
+            description: Status creation payload.
+      responses:
+        "201":
+          description: Status created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/statuses/{id}:
+    get:
+      summary: Get status by ID
+      description: Returns a single status by its UUID.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Get Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Status returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update status
+      description: Updates an existing status. All fields are optional — only send the
+        fields you want to change.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Update Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      requestBody:
+        description: Status update payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusUpdateRequest"
+            description: Status update payload.
+      responses:
+        "200":
+          description: Status updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete status
+      description: Deletes a status by its UUID. Cannot delete the last default status
+        for a board.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Delete Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Status deleted successfully.
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/categories/service:
     get:
       summary: List service categories

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -17,10 +17,16 @@
   ],
   "tags": [
     {
+      "name": "Boards"
+    },
+    {
       "name": "Projects"
     },
     {
       "name": "Service Categories"
+    },
+    {
+      "name": "Statuses"
     },
     {
       "name": "Storage"
@@ -209,6 +215,436 @@
       "PlaceholderObject": {
         "type": "object",
         "properties": {}
+      },
+      "BoardIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Board UUID."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "BoardApiResponse": {
+        "type": "object",
+        "properties": {
+          "board_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "board_name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "display_order": {
+            "type": "number"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "display_itil_impact": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "display_itil_urgency": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "inbound_reply_reopen_enabled": {
+            "type": "boolean"
+          },
+          "inbound_reply_reopen_cutoff_hours": {
+            "type": "integer"
+          },
+          "inbound_reply_reopen_status_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "inbound_reply_ai_ack_suppression_enabled": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tenant": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "board_id",
+          "board_name",
+          "description",
+          "display_order",
+          "is_default",
+          "is_inactive",
+          "category_type",
+          "priority_type",
+          "display_itil_impact",
+          "display_itil_urgency",
+          "default_assigned_to",
+          "enable_live_ticket_timer",
+          "tenant"
+        ]
+      },
+      "BoardEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/BoardApiResponse"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "BoardListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoardApiResponse"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "BoardCreateRequest": {
+        "type": "object",
+        "properties": {
+          "board_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "display_itil_impact": {
+            "type": "boolean"
+          },
+          "display_itil_urgency": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "board_name"
+        ],
+        "description": "Payload for creating a new board."
+      },
+      "BoardUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "board_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_inactive": {
+            "type": "boolean"
+          },
+          "category_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "priority_type": {
+            "type": "string",
+            "enum": [
+              "custom",
+              "itil"
+            ]
+          },
+          "default_assigned_to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "display_itil_impact": {
+            "type": "boolean"
+          },
+          "display_itil_urgency": {
+            "type": "boolean"
+          },
+          "enable_live_ticket_timer": {
+            "type": "boolean"
+          }
+        },
+        "description": "Payload for updating a board. All fields are optional."
+      },
+      "StatusIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Status UUID."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "StatusApiResponse": {
+        "type": "object",
+        "properties": {
+          "status_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status_type": {
+            "type": "string",
+            "enum": [
+              "ticket",
+              "project",
+              "project_task",
+              "interaction"
+            ]
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "item_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "standard_status_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "is_custom": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tenant": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "status_id",
+          "name",
+          "status_type",
+          "order_number",
+          "is_closed",
+          "is_default",
+          "item_type",
+          "standard_status_id",
+          "is_custom",
+          "tenant"
+        ]
+      },
+      "StatusEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StatusApiResponse"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "StatusListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StatusApiResponse"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "StatusCreateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "status_type": {
+            "type": "string",
+            "enum": [
+              "ticket",
+              "project",
+              "project_task",
+              "interaction"
+            ]
+          },
+          "board_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "order_number": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": [
+          "name",
+          "status_type"
+        ],
+        "description": "Payload for creating a new status. For ticket statuses, board_id is required."
+      },
+      "StatusUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "is_closed": {
+            "type": "boolean"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "order_number": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          },
+          "icon": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "description": "Payload for updating a status. All fields are optional."
       },
       "ServiceCategory": {
         "type": "object",
@@ -993,6 +1429,686 @@
     "parameters": {}
   },
   "paths": {
+    "/api/v1/boards": {
+      "get": {
+        "summary": "List boards",
+        "description": "Returns a paginated list of ticket boards for the current tenant. Use this to discover valid board_id values before creating tickets or statuses.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "List Boards",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Boards returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create board",
+        "description": "Creates a new ticket board. After creating a board, create at least one status for it via POST /api/v1/statuses so tickets can be assigned to the board.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Create Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "requestBody": {
+          "description": "Board creation payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BoardCreateRequest"
+              },
+              "description": "Board creation payload."
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Board created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/boards/{id}": {
+      "get": {
+        "summary": "Get board by ID",
+        "description": "Returns a single board by its UUID.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Get Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Board returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update board",
+        "description": "Updates an existing board. All fields are optional — only send the fields you want to change.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Update Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Board update payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BoardUpdateRequest"
+              },
+              "description": "Board update payload."
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Board updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete board",
+        "description": "Deletes a board by its UUID. This will fail if the board has associated tickets.",
+        "tags": [
+          "Boards"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Delete Board",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Board UUID."
+            },
+            "required": true,
+            "description": "Board UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Board deleted successfully."
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Board not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/statuses": {
+      "get": {
+        "summary": "List statuses",
+        "description": "Returns a paginated list of statuses. For ticket statuses, filter by type=ticket and board_id to get statuses that belong to a specific board. The status_id must belong to the same board_id when creating tickets.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "List Statuses",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Statuses returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create status",
+        "description": "Creates a new status. For ticket statuses, board_id is required. The status_type must be one of: ticket, project, project_task, interaction.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Create Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "requestBody": {
+          "description": "Status creation payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusCreateRequest"
+              },
+              "description": "Status creation payload."
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Status created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Authenticated user lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/statuses/{id}": {
+      "get": {
+        "summary": "Get status by ID",
+        "description": "Returns a single status by its UUID.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Get Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": false
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update status",
+        "description": "Updates an existing status. All fields are optional — only send the fields you want to change.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Update Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Status update payload.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusUpdateRequest"
+              },
+              "description": "Status update payload."
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete status",
+        "description": "Deletes a status by its UUID. Cannot delete the last default status for a board.",
+        "tags": [
+          "Statuses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-header-required": true,
+          "x-rbac-resource": "ticket",
+          "x-chat-callable": true,
+          "x-chat-display-name": "Delete Status",
+          "x-chat-rbac-resource": "ticket",
+          "x-chat-approval-required": true
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Status UUID."
+            },
+            "required": true,
+            "description": "Status UUID.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Status deleted successfully."
+          },
+          "401": {
+            "description": "Authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/categories/service": {
       "get": {
         "summary": "List service categories",

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -9,8 +9,10 @@ servers:
   - url: http://localhost:3000
     description: Local development
 tags:
+  - name: Boards
   - name: Projects
   - name: Service Categories
+  - name: Statuses
   - name: Storage
   - name: admin
   - name: assets
@@ -87,6 +89,308 @@ components:
     PlaceholderObject:
       type: object
       properties: {}
+    BoardIdParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Board UUID.
+      required:
+        - id
+    BoardApiResponse:
+      type: object
+      properties:
+        board_id:
+          type: string
+          format: uuid
+        board_name:
+          type: string
+        description:
+          type:
+            - string
+            - "null"
+        display_order:
+          type: number
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - custom
+            - itil
+        priority_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - custom
+            - itil
+        display_itil_impact:
+          type:
+            - boolean
+            - "null"
+        display_itil_urgency:
+          type:
+            - boolean
+            - "null"
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        inbound_reply_reopen_enabled:
+          type: boolean
+        inbound_reply_reopen_cutoff_hours:
+          type: integer
+        inbound_reply_reopen_status_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+        inbound_reply_ai_ack_suppression_enabled:
+          type: boolean
+        enable_live_ticket_timer:
+          type:
+            - boolean
+            - "null"
+        tenant:
+          type: string
+          format: uuid
+      required:
+        - board_id
+        - board_name
+        - description
+        - display_order
+        - is_default
+        - is_inactive
+        - category_type
+        - priority_type
+        - display_itil_impact
+        - display_itil_urgency
+        - default_assigned_to
+        - enable_live_ticket_timer
+        - tenant
+    BoardEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/BoardApiResponse"
+      required:
+        - data
+    BoardListEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BoardApiResponse"
+      required:
+        - data
+    BoardCreateRequest:
+      type: object
+      properties:
+        board_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 1000
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type: string
+          enum: &a1
+            - custom
+            - itil
+        priority_type:
+          type: string
+          enum: &a2
+            - custom
+            - itil
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        display_itil_impact:
+          type: boolean
+        display_itil_urgency:
+          type: boolean
+        enable_live_ticket_timer:
+          type: boolean
+      required:
+        - board_name
+      description: Payload for creating a new board.
+    BoardUpdateRequest:
+      type: object
+      properties:
+        board_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 1000
+        is_default:
+          type: boolean
+        is_inactive:
+          type: boolean
+        category_type:
+          type: string
+          enum: *a1
+        priority_type:
+          type: string
+          enum: *a2
+        default_assigned_to:
+          type:
+            - string
+            - "null"
+          format: uuid
+        display_itil_impact:
+          type: boolean
+        display_itil_urgency:
+          type: boolean
+        enable_live_ticket_timer:
+          type: boolean
+      description: Payload for updating a board. All fields are optional.
+    StatusIdParams:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Status UUID.
+      required:
+        - id
+    StatusApiResponse:
+      type: object
+      properties:
+        status_id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        status_type:
+          type: string
+          enum:
+            - ticket
+            - project
+            - project_task
+            - interaction
+        order_number:
+          type: number
+        is_closed:
+          type: boolean
+        is_default:
+          type:
+            - boolean
+            - "null"
+        item_type:
+          type:
+            - string
+            - "null"
+        standard_status_id:
+          type:
+            - string
+            - "null"
+        is_custom:
+          type:
+            - boolean
+            - "null"
+        tenant:
+          type: string
+          format: uuid
+      required:
+        - status_id
+        - name
+        - status_type
+        - order_number
+        - is_closed
+        - is_default
+        - item_type
+        - standard_status_id
+        - is_custom
+        - tenant
+    StatusEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/StatusApiResponse"
+      required:
+        - data
+    StatusListEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/StatusApiResponse"
+      required:
+        - data
+    StatusCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        status_type:
+          type: string
+          enum:
+            - ticket
+            - project
+            - project_task
+            - interaction
+        board_id:
+          type: string
+          format: uuid
+        is_closed:
+          type: boolean
+        is_default:
+          type: boolean
+        order_number:
+          type: integer
+          minimum: 0
+        color:
+          type: string
+          pattern: ^#[0-9A-Fa-f]{6}$
+        icon:
+          type: string
+          maxLength: 50
+      required:
+        - name
+        - status_type
+      description: Payload for creating a new status. For ticket statuses, board_id is
+        required.
+    StatusUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        is_closed:
+          type: boolean
+        is_default:
+          type: boolean
+        order_number:
+          type: integer
+          minimum: 0
+        color:
+          type: string
+          pattern: ^#[0-9A-Fa-f]{6}$
+        icon:
+          type: string
+          maxLength: 50
+      description: Payload for updating a status. All fields are optional.
     ServiceCategory:
       type: object
       properties:
@@ -646,6 +950,455 @@ components:
           minimum: 0
   parameters: {}
 paths:
+  /api/v1/boards:
+    get:
+      summary: List boards
+      description: Returns a paginated list of ticket boards for the current tenant.
+        Use this to discover valid board_id values before creating tickets or
+        statuses.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: List Boards
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      responses:
+        "200":
+          description: Boards returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardListEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create board
+      description: Creates a new ticket board. After creating a board, create at least
+        one status for it via POST /api/v1/statuses so tickets can be assigned
+        to the board.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Create Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      requestBody:
+        description: Board creation payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BoardCreateRequest"
+            description: Board creation payload.
+      responses:
+        "201":
+          description: Board created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/boards/{id}:
+    get:
+      summary: Get board by ID
+      description: Returns a single board by its UUID.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Get Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Board returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update board
+      description: Updates an existing board. All fields are optional — only send the
+        fields you want to change.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Update Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      requestBody:
+        description: Board update payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BoardUpdateRequest"
+            description: Board update payload.
+      responses:
+        "200":
+          description: Board updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BoardEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete board
+      description: Deletes a board by its UUID. This will fail if the board has
+        associated tickets.
+      tags:
+        - Boards
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Delete Board
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Board UUID.
+          required: true
+          description: Board UUID.
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Board deleted successfully.
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Board not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/statuses:
+    get:
+      summary: List statuses
+      description: Returns a paginated list of statuses. For ticket statuses, filter
+        by type=ticket and board_id to get statuses that belong to a specific
+        board. The status_id must belong to the same board_id when creating
+        tickets.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: List Statuses
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      responses:
+        "200":
+          description: Statuses returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusListEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create status
+      description: "Creates a new status. For ticket statuses, board_id is required.
+        The status_type must be one of: ticket, project, project_task,
+        interaction."
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Create Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      requestBody:
+        description: Status creation payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusCreateRequest"
+            description: Status creation payload.
+      responses:
+        "201":
+          description: Status created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Authenticated user lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/statuses/{id}:
+    get:
+      summary: Get status by ID
+      description: Returns a single status by its UUID.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Get Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: false
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Status returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update status
+      description: Updates an existing status. All fields are optional — only send the
+        fields you want to change.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Update Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      requestBody:
+        description: Status update payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StatusUpdateRequest"
+            description: Status update payload.
+      responses:
+        "200":
+          description: Status updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusEnvelope"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete status
+      description: Deletes a status by its UUID. Cannot delete the last default status
+        for a board.
+      tags:
+        - Statuses
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-header-required: true
+        x-rbac-resource: ticket
+        x-chat-callable: true
+        x-chat-display-name: Delete Status
+        x-chat-rbac-resource: ticket
+        x-chat-approval-required: true
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Status UUID.
+          required: true
+          description: Status UUID.
+          name: id
+          in: path
+      responses:
+        "204":
+          description: Status deleted successfully.
+        "401":
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Status not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/categories/service:
     get:
       summary: List service categories

--- a/server/src/app/api/v1/boards/[id]/route.ts
+++ b/server/src/app/api/v1/boards/[id]/route.ts
@@ -1,6 +1,8 @@
 /**
  * Board by ID API Routes
  * GET /api/v1/boards/:id - Get board by ID
+ * PUT /api/v1/boards/:id - Update board
+ * DELETE /api/v1/boards/:id - Delete board
  */
 
 import { ApiBoardController } from '@/lib/api/controllers/ApiBoardController';
@@ -8,6 +10,8 @@ import { ApiBoardController } from '@/lib/api/controllers/ApiBoardController';
 const controller = new ApiBoardController();
 
 export const GET = controller.getById();
+export const PUT = controller.update();
+export const DELETE = controller.delete();
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/boards/route.ts
+++ b/server/src/app/api/v1/boards/route.ts
@@ -1,6 +1,7 @@
 /**
  * Boards API Routes
  * GET /api/v1/boards - List boards
+ * POST /api/v1/boards - Create board
  */
 
 import { ApiBoardController } from '@/lib/api/controllers/ApiBoardController';
@@ -8,6 +9,7 @@ import { ApiBoardController } from '@/lib/api/controllers/ApiBoardController';
 const controller = new ApiBoardController();
 
 export const GET = controller.list();
+export const POST = controller.create();
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/statuses/[id]/route.ts
+++ b/server/src/app/api/v1/statuses/[id]/route.ts
@@ -1,6 +1,8 @@
 /**
  * Status by ID API Routes
  * GET /api/v1/statuses/:id - Get status by ID
+ * PUT /api/v1/statuses/:id - Update status
+ * DELETE /api/v1/statuses/:id - Delete status
  */
 
 import { ApiStatusController } from '@/lib/api/controllers/ApiStatusController';
@@ -8,6 +10,8 @@ import { ApiStatusController } from '@/lib/api/controllers/ApiStatusController';
 const controller = new ApiStatusController();
 
 export const GET = controller.getById();
+export const PUT = controller.update();
+export const DELETE = controller.delete();
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/statuses/route.ts
+++ b/server/src/app/api/v1/statuses/route.ts
@@ -1,6 +1,7 @@
 /**
  * Statuses API Routes
  * GET /api/v1/statuses - List statuses
+ * POST /api/v1/statuses - Create status
  */
 
 import { ApiStatusController } from '@/lib/api/controllers/ApiStatusController';
@@ -8,6 +9,7 @@ import { ApiStatusController } from '@/lib/api/controllers/ApiStatusController';
 const controller = new ApiStatusController();
 
 export const GET = controller.list();
+export const POST = controller.create();
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/server/src/lib/api/controllers/ApiBoardController.ts
+++ b/server/src/lib/api/controllers/ApiBoardController.ts
@@ -5,7 +5,7 @@
 
 import { ApiBaseController, AuthenticatedApiRequest } from './ApiBaseController';
 import { BoardService } from '../services/BoardService';
-import { boardListQuerySchema } from '../schemas/board';
+import { boardListQuerySchema, createBoardSchema, updateBoardSchema } from '../schemas/board';
 
 export class ApiBoardController extends ApiBaseController {
   constructor() {
@@ -13,9 +13,14 @@ export class ApiBoardController extends ApiBaseController {
 
     super(boardService, {
       resource: 'board',
+      createSchema: createBoardSchema,
+      updateSchema: updateBoardSchema,
       querySchema: boardListQuerySchema,
       permissions: {
+        create: 'create',
         read: 'read',
+        update: 'update',
+        delete: 'delete',
         list: 'read'
       }
     });

--- a/server/src/lib/api/controllers/ApiStatusController.ts
+++ b/server/src/lib/api/controllers/ApiStatusController.ts
@@ -5,7 +5,7 @@
 
 import { ApiBaseController, AuthenticatedApiRequest } from './ApiBaseController';
 import { StatusService } from '../services/StatusService';
-import { statusListQuerySchema } from '../schemas/status';
+import { statusListQuerySchema, createStatusSchema, updateStatusSchema } from '../schemas/status';
 
 export class ApiStatusController extends ApiBaseController {
   constructor() {
@@ -13,9 +13,14 @@ export class ApiStatusController extends ApiBaseController {
 
     super(statusService, {
       resource: 'status',
+      createSchema: createStatusSchema,
+      updateSchema: updateStatusSchema,
       querySchema: statusListQuerySchema,
       permissions: {
+        create: 'create',
         read: 'read',
+        update: 'update',
+        delete: 'delete',
         list: 'read'
       }
     });

--- a/server/src/lib/api/openapi/index.ts
+++ b/server/src/lib/api/openapi/index.ts
@@ -1,4 +1,6 @@
 import { registerBaseComponents } from './components';
+import { registerBoardRoutes } from './routes/boards';
+import { registerStatusRoutes } from './routes/statuses';
 import { registerProjectRoutes } from './routes/projects';
 import { registerServiceCategoryRoutes } from './routes/serviceCategories';
 import { registerStorageRoutes } from './routes/extensionStorage';
@@ -10,6 +12,8 @@ export function buildBaseRegistry(options: RegistryInitOptions = {}): ApiOpenApi
   const registry = createRegistry([], options);
   const components = registerBaseComponents(registry);
 
+  registerBoardRoutes(registry, components);
+  registerStatusRoutes(registry, components);
   registerServiceCategoryRoutes(registry, components);
   registerProjectRoutes(registry, components);
   registerInventoryBackfillRoutes(registry, components);

--- a/server/src/lib/api/openapi/routes/boards.ts
+++ b/server/src/lib/api/openapi/routes/boards.ts
@@ -1,0 +1,240 @@
+import type { ZodTypeAny } from 'zod';
+import { createBoardSchema, updateBoardSchema, boardResponseSchema } from '../../schemas/board';
+import { ApiOpenApiRegistry, zOpenApi } from '../registry';
+
+export function registerBoardRoutes(
+  registry: ApiOpenApiRegistry,
+  deps: { ErrorResponse: ZodTypeAny },
+) {
+  const tag = 'Boards';
+
+  const BoardIdParams = registry.registerSchema(
+    'BoardIdParams',
+    zOpenApi.object({
+      id: zOpenApi.string().uuid().describe('Board UUID.'),
+    }),
+  );
+
+  const BoardApiResponse = registry.registerSchema(
+    'BoardApiResponse',
+    boardResponseSchema,
+  );
+
+  const BoardEnvelope = registry.registerSchema(
+    'BoardEnvelope',
+    zOpenApi.object({
+      data: BoardApiResponse,
+    }),
+  );
+
+  const BoardListEnvelope = registry.registerSchema(
+    'BoardListEnvelope',
+    zOpenApi.object({
+      data: zOpenApi.array(BoardApiResponse),
+    }),
+  );
+
+  const BoardCreateRequest = registry.registerSchema(
+    'BoardCreateRequest',
+    createBoardSchema.describe('Payload for creating a new board.'),
+  );
+
+  const BoardUpdateRequest = registry.registerSchema(
+    'BoardUpdateRequest',
+    updateBoardSchema.describe('Payload for updating a board. All fields are optional.'),
+  );
+
+  // GET /api/v1/boards
+  registry.registerRoute({
+    method: 'get',
+    path: '/api/v1/boards',
+    summary: 'List boards',
+    description:
+      'Returns a paginated list of ticket boards for the current tenant. Use this to discover valid board_id values before creating tickets or statuses.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {},
+    responses: {
+      200: {
+        description: 'Boards returned successfully.',
+        schema: BoardListEnvelope,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      403: {
+        description: 'Authenticated user lacks the required permission.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'List Boards',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': false,
+    },
+    edition: 'both',
+  });
+
+  // GET /api/v1/boards/{id}
+  registry.registerRoute({
+    method: 'get',
+    path: '/api/v1/boards/{id}',
+    summary: 'Get board by ID',
+    description: 'Returns a single board by its UUID.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: BoardIdParams,
+    },
+    responses: {
+      200: {
+        description: 'Board returned successfully.',
+        schema: BoardEnvelope,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Board not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Get Board',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': false,
+    },
+    edition: 'both',
+  });
+
+  // POST /api/v1/boards
+  registry.registerRoute({
+    method: 'post',
+    path: '/api/v1/boards',
+    summary: 'Create board',
+    description:
+      'Creates a new ticket board. After creating a board, create at least one status for it via POST /api/v1/statuses so tickets can be assigned to the board.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      body: {
+        schema: BoardCreateRequest,
+        description: 'Board creation payload.',
+      },
+    },
+    responses: {
+      201: {
+        description: 'Board created successfully.',
+        schema: BoardEnvelope,
+      },
+      400: {
+        description: 'Validation error.',
+        schema: deps.ErrorResponse,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      403: {
+        description: 'Authenticated user lacks the required permission.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Create Board',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+
+  // PUT /api/v1/boards/{id}
+  registry.registerRoute({
+    method: 'put',
+    path: '/api/v1/boards/{id}',
+    summary: 'Update board',
+    description: 'Updates an existing board. All fields are optional — only send the fields you want to change.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: BoardIdParams,
+      body: {
+        schema: BoardUpdateRequest,
+        description: 'Board update payload.',
+      },
+    },
+    responses: {
+      200: {
+        description: 'Board updated successfully.',
+        schema: BoardEnvelope,
+      },
+      400: {
+        description: 'Validation error.',
+        schema: deps.ErrorResponse,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Board not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Update Board',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+
+  // DELETE /api/v1/boards/{id}
+  registry.registerRoute({
+    method: 'delete',
+    path: '/api/v1/boards/{id}',
+    summary: 'Delete board',
+    description: 'Deletes a board by its UUID. This will fail if the board has associated tickets.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: BoardIdParams,
+    },
+    responses: {
+      204: {
+        description: 'Board deleted successfully.',
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Board not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Delete Board',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+}

--- a/server/src/lib/api/openapi/routes/statuses.ts
+++ b/server/src/lib/api/openapi/routes/statuses.ts
@@ -1,0 +1,243 @@
+import type { ZodTypeAny } from 'zod';
+import { createStatusSchema, updateStatusSchema, statusResponseSchema } from '../../schemas/status';
+import { ApiOpenApiRegistry, zOpenApi } from '../registry';
+
+export function registerStatusRoutes(
+  registry: ApiOpenApiRegistry,
+  deps: { ErrorResponse: ZodTypeAny },
+) {
+  const tag = 'Statuses';
+
+  const StatusIdParams = registry.registerSchema(
+    'StatusIdParams',
+    zOpenApi.object({
+      id: zOpenApi.string().uuid().describe('Status UUID.'),
+    }),
+  );
+
+  const StatusApiResponse = registry.registerSchema(
+    'StatusApiResponse',
+    statusResponseSchema,
+  );
+
+  const StatusEnvelope = registry.registerSchema(
+    'StatusEnvelope',
+    zOpenApi.object({
+      data: StatusApiResponse,
+    }),
+  );
+
+  const StatusListEnvelope = registry.registerSchema(
+    'StatusListEnvelope',
+    zOpenApi.object({
+      data: zOpenApi.array(StatusApiResponse),
+    }),
+  );
+
+  const StatusCreateRequest = registry.registerSchema(
+    'StatusCreateRequest',
+    createStatusSchema.describe(
+      'Payload for creating a new status. For ticket statuses, board_id is required.',
+    ),
+  );
+
+  const StatusUpdateRequest = registry.registerSchema(
+    'StatusUpdateRequest',
+    updateStatusSchema.describe('Payload for updating a status. All fields are optional.'),
+  );
+
+  // GET /api/v1/statuses
+  registry.registerRoute({
+    method: 'get',
+    path: '/api/v1/statuses',
+    summary: 'List statuses',
+    description:
+      'Returns a paginated list of statuses. For ticket statuses, filter by type=ticket and board_id to get statuses that belong to a specific board. The status_id must belong to the same board_id when creating tickets.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {},
+    responses: {
+      200: {
+        description: 'Statuses returned successfully.',
+        schema: StatusListEnvelope,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      403: {
+        description: 'Authenticated user lacks the required permission.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'List Statuses',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': false,
+    },
+    edition: 'both',
+  });
+
+  // GET /api/v1/statuses/{id}
+  registry.registerRoute({
+    method: 'get',
+    path: '/api/v1/statuses/{id}',
+    summary: 'Get status by ID',
+    description: 'Returns a single status by its UUID.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: StatusIdParams,
+    },
+    responses: {
+      200: {
+        description: 'Status returned successfully.',
+        schema: StatusEnvelope,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Status not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Get Status',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': false,
+    },
+    edition: 'both',
+  });
+
+  // POST /api/v1/statuses
+  registry.registerRoute({
+    method: 'post',
+    path: '/api/v1/statuses',
+    summary: 'Create status',
+    description:
+      'Creates a new status. For ticket statuses, board_id is required. The status_type must be one of: ticket, project, project_task, interaction.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      body: {
+        schema: StatusCreateRequest,
+        description: 'Status creation payload.',
+      },
+    },
+    responses: {
+      201: {
+        description: 'Status created successfully.',
+        schema: StatusEnvelope,
+      },
+      400: {
+        description: 'Validation error.',
+        schema: deps.ErrorResponse,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      403: {
+        description: 'Authenticated user lacks the required permission.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Create Status',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+
+  // PUT /api/v1/statuses/{id}
+  registry.registerRoute({
+    method: 'put',
+    path: '/api/v1/statuses/{id}',
+    summary: 'Update status',
+    description:
+      'Updates an existing status. All fields are optional — only send the fields you want to change.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: StatusIdParams,
+      body: {
+        schema: StatusUpdateRequest,
+        description: 'Status update payload.',
+      },
+    },
+    responses: {
+      200: {
+        description: 'Status updated successfully.',
+        schema: StatusEnvelope,
+      },
+      400: {
+        description: 'Validation error.',
+        schema: deps.ErrorResponse,
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Status not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Update Status',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+
+  // DELETE /api/v1/statuses/{id}
+  registry.registerRoute({
+    method: 'delete',
+    path: '/api/v1/statuses/{id}',
+    summary: 'Delete status',
+    description: 'Deletes a status by its UUID. Cannot delete the last default status for a board.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: StatusIdParams,
+    },
+    responses: {
+      204: {
+        description: 'Status deleted successfully.',
+      },
+      401: {
+        description: 'Authentication failed.',
+        schema: deps.ErrorResponse,
+      },
+      404: {
+        description: 'Status not found.',
+        schema: deps.ErrorResponse,
+      },
+    },
+    extensions: {
+      'x-tenant-header-required': true,
+      'x-rbac-resource': 'ticket',
+      'x-chat-callable': true,
+      'x-chat-display-name': 'Delete Status',
+      'x-chat-rbac-resource': 'ticket',
+      'x-chat-approval-required': true,
+    },
+    edition: 'both',
+  });
+}

--- a/server/src/lib/api/schemas/board.ts
+++ b/server/src/lib/api/schemas/board.ts
@@ -4,7 +4,24 @@
  */
 
 import { z } from 'zod';
-import { paginationQuerySchema, uuidSchema } from './common';
+import { paginationQuerySchema, uuidSchema, createUpdateSchema } from './common';
+
+// Create board schema
+export const createBoardSchema = z.object({
+  board_name: z.string().min(1, 'Board name is required').max(255),
+  description: z.string().max(1000).optional(),
+  is_default: z.boolean().optional(),
+  is_inactive: z.boolean().optional(),
+  category_type: z.enum(['custom', 'itil']).optional(),
+  priority_type: z.enum(['custom', 'itil']).optional(),
+  default_assigned_to: uuidSchema.nullable().optional(),
+  display_itil_impact: z.boolean().optional(),
+  display_itil_urgency: z.boolean().optional(),
+  enable_live_ticket_timer: z.boolean().optional(),
+});
+
+// Update board schema (all fields optional)
+export const updateBoardSchema = createUpdateSchema(createBoardSchema);
 
 // Board response schema
 export const boardResponseSchema = z.object({
@@ -34,5 +51,7 @@ export const boardListQuerySchema = paginationQuerySchema.extend({
 });
 
 // Export types
+export type CreateBoardData = z.infer<typeof createBoardSchema>;
+export type UpdateBoardData = z.infer<typeof updateBoardSchema>;
 export type BoardResponse = z.infer<typeof boardResponseSchema>;
 export type BoardListQuery = z.infer<typeof boardListQuerySchema>;

--- a/server/src/lib/api/schemas/status.ts
+++ b/server/src/lib/api/schemas/status.ts
@@ -4,7 +4,39 @@
  */
 
 import { z } from 'zod';
-import { paginationQuerySchema, uuidSchema } from './common';
+import { paginationQuerySchema, uuidSchema, createUpdateSchema } from './common';
+
+// Create status schema
+export const createStatusSchema = z.object({
+  name: z.string().min(1, 'Status name is required').max(255),
+  status_type: z.enum(['ticket', 'project', 'project_task', 'interaction']),
+  board_id: uuidSchema.optional(),
+  is_closed: z.boolean().optional(),
+  is_default: z.boolean().optional(),
+  order_number: z.number().int().min(0).optional(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a hex code (e.g. #3B82F6)').optional(),
+  icon: z.string().max(50).optional(),
+}).superRefine((value, ctx) => {
+  if (value.status_type === 'ticket' && !value.board_id) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['board_id'],
+      message: 'board_id is required for ticket statuses',
+    });
+  }
+});
+
+// Update status schema (all fields optional)
+export const updateStatusSchema = createUpdateSchema(
+  z.object({
+    name: z.string().min(1, 'Status name is required').max(255),
+    is_closed: z.boolean(),
+    is_default: z.boolean(),
+    order_number: z.number().int().min(0),
+    color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a hex code (e.g. #3B82F6)'),
+    icon: z.string().max(50),
+  })
+);
 
 // Status response schema
 export const statusResponseSchema = z.object({
@@ -36,5 +68,7 @@ export const statusListQuerySchema = paginationQuerySchema.extend({
 });
 
 // Export types
+export type CreateStatusData = z.infer<typeof createStatusSchema>;
+export type UpdateStatusData = z.infer<typeof updateStatusSchema>;
 export type StatusResponse = z.infer<typeof statusResponseSchema>;
 export type StatusListQuery = z.infer<typeof statusListQuerySchema>;

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -730,6 +730,19 @@ export class TicketService extends BaseService<ITicket> {
       const { knex } = await this.getKnex();
   
       return withTransaction(knex, async (trx) => {
+        // Validate status belongs to the specified board before proceeding
+        const statusBelongsToBoard = await TicketModel.validateStatusBelongsToBoard(
+          data.status_id,
+          data.board_id,
+          context.tenant,
+          trx
+        );
+        if (!statusBelongsToBoard.valid) {
+          throw new ValidationError('Validation failed', [
+            { path: ['status_id'], message: `status_id ${data.status_id} does not belong to board_id ${data.board_id}` }
+          ]);
+        }
+
         // Convert API data format to TicketModel input format
         const createTicketInput: CreateTicketInput = {
           title: data.title,
@@ -926,6 +939,19 @@ export class TicketService extends BaseService<ITicket> {
 
       if (!asset) {
         throw new NotFoundError('Asset not found');
+      }
+
+      // Validate status belongs to the specified board
+      const statusBelongsToBoard = await TicketModel.validateStatusBelongsToBoard(
+        data.status_id,
+        data.board_id,
+        context.tenant,
+        trx
+      );
+      if (!statusBelongsToBoard.valid) {
+        throw new ValidationError('Validation failed', [
+          { path: ['status_id'], message: `status_id ${data.status_id} does not belong to board_id ${data.board_id}` }
+        ]);
       }
 
       // Create adapters for API service context


### PR DESCRIPTION
  - Add POST/PUT/DELETE endpoints for /api/v1/boards and /api/v1/statuses
  - Fix ticket create returning 500 on board/status mismatch — now returns proper 400 ValidationError with actionable message including the IDs
  - Register board and status routes in OpenAPI spec and chat AI registry
  - Update AI instructions to use dedicated lookup endpoints instead of sampling existing tickets for board_id/status_id discovery

  "But I don't want to go among mad statuses," Alice remarked. "Oh, you can't help that," said the Board, "we're all validated here. Every status must belong to its board, or the Cheshire Error will appear as a most unhelpful 500 — and nobody wants that." 🎩🐛✨