### PR TITLE
fix: get email service running in the on-prem appliance

### DIFF
--- a/ee/appliance/README.md
+++ b/ee/appliance/README.md
@@ -153,7 +153,7 @@ If you already have a running cluster and kubeconfig, the same script can be use
 
 Bootstrap mode semantics:
 
-- `fresh`: deletes the appliance namespaces and wipes `/opt/local-path-provisioner` on the node before reinstalling
+- `fresh`: deletes the appliance namespaces and wipes `/var/mnt/alga-data/local-path-provisioner` on the node before reinstalling
 - `recover`: preserves existing PVC-backed appliance state and refuses to generate new database credentials against an existing Postgres PVC
 
 Use the destructive reset helper directly when you need to clear persisted appliance data between test runs:

--- a/ee/appliance/manifests/local-path-storage.yaml
+++ b/ee/appliance/manifests/local-path-storage.yaml
@@ -115,7 +115,7 @@ metadata:
   name: local-path
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
+reclaimPolicy: Retain
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -128,7 +128,7 @@ data:
       "nodePathMap": [
         {
           "node": "DEFAULT_PATH_FOR_NON_LISTED_NODES",
-          "paths": ["/opt/local-path-provisioner"]
+          "paths": ["/var/mnt/alga-data/local-path-provisioner"]
         }
       ]
     }

--- a/ee/appliance/operator/lib/tui.mjs
+++ b/ee/appliance/operator/lib/tui.mjs
@@ -679,7 +679,7 @@ function MainPane({
             React.createElement(
               Text,
               { color: COLOR_ERROR },
-              'Wipes namespace msp, namespace alga-system, and /opt/local-path-provisioner data.',
+              'Wipes namespace msp, namespace alga-system, and /var/mnt/alga-data/local-path-provisioner data.',
             ),
           )
         : null,

--- a/ee/appliance/scripts/install-storage.sh
+++ b/ee/appliance/scripts/install-storage.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 KUBECONFIG_PATH="${KUBECONFIG:-}"
 REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)"
 STORAGE_MANIFEST="$REPO_ROOT/ee/appliance/manifests/local-path-storage.yaml"
+STORAGE_PATH="/var/mnt/alga-data/local-path-provisioner"
 SMOKE_NAMESPACE="storage-smoke"
 DRY_RUN=false
 
@@ -50,6 +51,59 @@ wait_for_rollout() {
   fi
 
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n local-path-storage rollout status deployment/local-path-provisioner --timeout=5m
+}
+
+prepare_storage_path() {
+  local manifest
+
+  if $DRY_RUN; then
+    cat <<EOF
++ kubectl --kubeconfig $KUBECONFIG_PATH apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: local-path-storage-prepare
+  namespace: local-path-storage
+EOF
+    return 0
+  fi
+
+  manifest="$(cat <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: local-path-storage-prepare
+  namespace: local-path-storage
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: prepare
+          image: busybox:1.36
+          securityContext:
+            privileged: true
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p /host${STORAGE_PATH}
+              chmod 0777 /host${STORAGE_PATH}
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+EOF
+)"
+
+  printf '%s\n' "$manifest" | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n local-path-storage wait --for=condition=complete --timeout=5m job/local-path-storage-prepare
 }
 
 run_smoke_test() {
@@ -175,6 +229,7 @@ kubectl_cmd label namespace msp \
   pod-security.kubernetes.io/warn=privileged \
   --overwrite
 
+prepare_storage_path
 wait_for_rollout
 run_smoke_test
 

--- a/ee/appliance/scripts/reset-appliance-data.sh
+++ b/ee/appliance/scripts/reset-appliance-data.sh
@@ -5,7 +5,7 @@ KUBECONFIG_PATH="${KUBECONFIG:-}"
 APP_NAMESPACE="msp"
 RELEASE_NAMESPACE="alga-system"
 RESET_NAMESPACE="appliance-reset"
-STORAGE_PATH="/opt/local-path-provisioner"
+STORAGE_PATH="/var/mnt/alga-data/local-path-provisioner"
 FLUX_NAMESPACE="flux-system"
 GITOPS_SOURCE_NAME="alga-appliance"
 GITOPS_KUSTOMIZATION_NAME="alga-appliance"
@@ -22,7 +22,7 @@ Options:
   --app-namespace <name>       Application namespace to delete (default: msp)
   --release-namespace <name>   Release namespace to delete (default: alga-system)
   --reset-namespace <name>     Temporary namespace for the wipe job (default: appliance-reset)
-  --storage-path <path>        Host path used by local-path storage (default: /opt/local-path-provisioner)
+  --storage-path <path>        Host path used by local-path storage (default: /var/mnt/alga-data/local-path-provisioner)
   --flux-namespace <name>      Flux namespace containing appliance source objects (default: flux-system)
   --gitops-source <name>       GitRepository name to delete before reset (default: alga-appliance)
   --gitops-kustomization <name>
@@ -152,16 +152,17 @@ spec:
             - sh
             - -ec
             - |
-              mkdir -p /host-data
-              find /host-data -mindepth 1 -maxdepth 1 -print -exec rm -rf {} +
+              target="/host${STORAGE_PATH}"
+              mkdir -p "$target"
+              find "$target" -mindepth 1 -maxdepth 1 -print -exec rm -rf {} +
           volumeMounts:
-            - name: host-data
-              mountPath: /host-data
+            - name: host-root
+              mountPath: /host
       volumes:
-        - name: host-data
+        - name: host-root
           hostPath:
-            path: ${STORAGE_PATH}
-            type: DirectoryOrCreate
+            path: /
+            type: Directory
 EOF
 )"
 

--- a/ee/helm/temporal/templates/deployment.yaml
+++ b/ee/helm/temporal/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: temporal
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-          command: ["/bin/sh", "-c", "exec /etc/temporal/entrypoint.sh"]
+          command: ["/bin/sh", "-c", "exec /etc/temporal/entrypoint.sh autosetup"]
           env:
             - name: DB
               value: "{{ .Values.temporal.db }}"

--- a/ee/helm/temporal/templates/ui.yaml
+++ b/ee/helm/temporal/templates/ui.yaml
@@ -26,6 +26,8 @@ spec:
           env:
             - name: TEMPORAL_ADDRESS
               value: "{{ .Values.service.name }}:{{ .Values.service.port }}"
+            - name: TEMPORAL_UI_PORT
+              value: "{{ .Values.ui.service.port }}"
           ports:
             - name: http
               containerPort: {{ .Values.ui.service.port }}

--- a/helm/templates/postgres/statefulSet.yaml
+++ b/helm/templates/postgres/statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
       initContainers:
         - name: volume-prep
           image: busybox
-          command: ['sh', '-c', 'mkdir -p /data']
+          command: ['sh', '-c', 'mkdir -p /data/data']
           volumeMounts:
             - name: db-data
               mountPath: /data    


### PR DESCRIPTION
## Summary
- move appliance local-path storage to `/var/mnt/alga-data/local-path-provisioner` and retain PV data by default
- harden appliance storage/reset scripts so the new storage path is created and wiped reliably on Talos
- fix Postgres PVC prep, Temporal autosetup, and Temporal UI port env so fresh on-prem appliance bootstrap completes cleanly

## Why
The on-prem appliance could not bring `email-service` up because the database/bootstrap chain was fragile:
- local-path PVCs were backed by `/opt/local-path-provisioner`
- the reset/install flow did not reliably prepare the new nested Talos storage path
- Postgres used a `subPath: data` mount without creating the `data/` directory first
- Temporal used the `auto-setup` image without invoking `autosetup`
- Temporal UI inherited Kubernetes service env for `TEMPORAL_UI_PORT`, causing config parsing to fail

These issues prevented the appliance from reaching a healthy state where `email-service` could connect to the `server` database.

## Validation
- `bash -n ee/appliance/scripts/install-storage.sh`
- `bash -n ee/appliance/scripts/reset-appliance-data.sh`
- `kubectl apply --dry-run=client -f ee/appliance/manifests/local-path-storage.yaml`
- live Talos appliance validation on `192.168.64.7`:
  - `alga-core` bootstrapped successfully
  - `email-service` reached `Running`
  - `temporal` and `temporal-ui` reached `Running`

## Follow-up
- `workflow-worker` is still blocked separately by GHCR pull auth for `ghcr.io/nine-minds/workflow-worker:61e4a00e`.