### PR TITLE
fix: save standard status IDs when creating template from project

### DIFF
--- a/packages/projects/src/actions/projectTemplateActions.ts
+++ b/packages/projects/src/actions/projectTemplateActions.ts
@@ -181,7 +181,7 @@ export const createTemplateFromProject = withAuth(async (
           tenant,
           template_id: template.template_id,
           template_phase_id: templatePhaseId,
-          status_id: mapping.status_id,
+          status_id: mapping.status_id || mapping.standard_status_id,
           custom_status_name: mapping.custom_name,
           display_order: mapping.display_order
         })


### PR DESCRIPTION
## Summary
- `createTemplateFromProject` only copied `status_id` from project status mappings, but standard statuses (To Do, In Progress, In Review, Done, Blocked) use `standard_status_id` instead
- This left template status mappings with no status reference, causing blank/unnamed status columns when viewing the template
- Fix falls back to `standard_status_id` when `status_id` is null

## Test plan
- [ ] Create a project with standard statuses (To Do, In Progress, etc.) and tasks in various status columns
- [ ] Use "Save as Template" on that project
- [ ] Open the saved template and verify status columns show correct names and colors
- [ ] Verify tasks appear in the correct status columns