### PR TITLE
Set bundled standard invoice templates to Letter margins

### DIFF
--- a/docs/plans/2026-04-08-standard-invoice-letter-margins-design.md
+++ b/docs/plans/2026-04-08-standard-invoice-letter-margins-design.md
@@ -1,0 +1,24 @@
+# Standard invoice Letter margins design
+
+## Goal
+Update all bundled standard invoice templates shipped with the application so they use Letter print settings with 10.58mm margins.
+
+## Scope
+- Bundled standard invoice templates only:
+  - `standard-default`
+  - `standard-detailed`
+  - `standard-grouped`
+- Do not modify tenant-customized invoice templates.
+
+## Approach
+1. Update the TypeScript standard invoice AST source definitions to include `printSettings` metadata.
+2. Add a migration that backfills the bundled rows in `standard_invoice_templates` so existing installs receive the same settings.
+3. Extend regression coverage so all shipped standard invoice templates are included and their metadata round-trips through the designer pipeline.
+
+## Print settings
+- `paperPreset: 'Letter'`
+- `marginMm: 10.58`
+
+## Validation
+- Run targeted invoice template regression tests.
+- Verify bundled standard invoice template metadata includes the expected `printSettings`.

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.standardTemplates.regression.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.standardTemplates.regression.test.ts
@@ -59,6 +59,7 @@ describe('workspaceAst standard template regression coverage', () => {
   it.each([
     ['standard-default', ['invoice-number', 'line-items', 'totals']] as const,
     ['standard-detailed', ['issuer-logo', 'party-blocks', 'bill-to-card', 'totals-wrap']] as const,
+    ['standard-grouped', ['issuer-logo', 'recurring-items', 'onetime-items', 'notes-totals-row']] as const,
   ])('keeps invoice template %s structurally stable across designer import/export', (templateCode, criticalNodeIds) => {
     const source = getStandardTemplateAstByCode(templateCode);
     expect(source).toBeTruthy();
@@ -70,6 +71,7 @@ describe('workspaceAst standard template regression coverage', () => {
   it.each([
     ['standard-quote-default', ['quote-number', 'line-items', 'totals', 'signature-block']] as const,
     ['standard-quote-detailed', ['phase-summary', 'line-items-detailed', 'version', 'signature-block']] as const,
+    ['standard-quote-grouped', ['monthly-items', 'onetime-items', 'terms-section', 'signature-block']] as const,
   ])('keeps quote template %s structurally stable across designer import/export', (templateCode, criticalNodeIds) => {
     const source = getStandardQuoteTemplateAstByCode(templateCode);
     expect(source).toBeTruthy();
@@ -79,7 +81,7 @@ describe('workspaceAst standard template regression coverage', () => {
   });
 
   it('covers every shipped standard invoice and quote template code', () => {
-    expect(Object.keys(STANDARD_INVOICE_TEMPLATE_ASTS).sort()).toEqual(['standard-default', 'standard-detailed']);
-    expect(Object.keys(STANDARD_QUOTE_TEMPLATE_ASTS).sort()).toEqual(['standard-quote-default', 'standard-quote-detailed']);
+    expect(Object.keys(STANDARD_INVOICE_TEMPLATE_ASTS).sort()).toEqual(['standard-default', 'standard-detailed', 'standard-grouped']);
+    expect(Object.keys(STANDARD_QUOTE_TEMPLATE_ASTS).sort()).toEqual(['standard-quote-default', 'standard-quote-detailed', 'standard-quote-grouped']);
   });
 });

--- a/packages/billing/src/lib/invoice-template-ast/standardTemplates.ts
+++ b/packages/billing/src/lib/invoice-template-ast/standardTemplates.ts
@@ -1,5 +1,5 @@
 import type { TemplateAst } from '@alga-psa/types';
-import { TEMPLATE_AST_VERSION } from '@alga-psa/types';
+import { DEFAULT_INVOICE_PRINT_SETTINGS, TEMPLATE_AST_VERSION } from '@alga-psa/types';
 
 const cloneAst = (ast: TemplateAst): TemplateAst =>
   JSON.parse(JSON.stringify(ast)) as TemplateAst;
@@ -60,6 +60,7 @@ const buildStandardDefaultAst = (templateName: string): TemplateAst => ({
   version: TEMPLATE_AST_VERSION,
   metadata: {
     templateName,
+    printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
   bindings: buildSharedBindings(),
   layout: {
@@ -148,6 +149,7 @@ const buildStandardDetailedAst = (): TemplateAst => ({
   version: TEMPLATE_AST_VERSION,
   metadata: {
     templateName: 'Detailed Template',
+    printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
   bindings: buildSharedBindings(),
   layout: {
@@ -487,7 +489,7 @@ const buildStandardGroupedAst = (): TemplateAst => ({
   version: TEMPLATE_AST_VERSION,
   metadata: {
     templateName: 'Grouped Template',
-    printSettings: { paperPreset: 'Letter', marginMm: 10.58 },
+    printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
   bindings: buildSharedBindings(),
   layout: {

--- a/server/migrations/20260408120000_set_standard_invoice_template_letter_margins.cjs
+++ b/server/migrations/20260408120000_set_standard_invoice_template_letter_margins.cjs
@@ -1,0 +1,82 @@
+const TABLE_NAME = 'standard_invoice_templates';
+const SET_CODES = ['standard-default', 'standard-detailed', 'standard-grouped'];
+const UNSET_CODES = ['standard-default', 'standard-detailed'];
+const LETTER_PRINT_SETTINGS = { paperPreset: 'Letter', marginMm: 10.58 };
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function assertTemplateAst(ast, code) {
+  if (!ast || typeof ast !== 'object' || Array.isArray(ast)) {
+    throw new Error(`[set_standard_invoice_template_letter_margins] Expected templateAst object for ${code}.`);
+  }
+}
+
+function applyPrintSettings(ast) {
+  const nextAst = cloneJson(ast);
+
+  if (!nextAst.metadata || typeof nextAst.metadata !== 'object' || Array.isArray(nextAst.metadata)) {
+    nextAst.metadata = {};
+  }
+
+  nextAst.metadata.printSettings = LETTER_PRINT_SETTINGS;
+  return nextAst;
+}
+
+function removePrintSettings(ast) {
+  const nextAst = cloneJson(ast);
+
+  if (nextAst.metadata && typeof nextAst.metadata === 'object' && !Array.isArray(nextAst.metadata)) {
+    delete nextAst.metadata.printSettings;
+  }
+
+  return nextAst;
+}
+
+async function loadRowsByCode(knex, codes) {
+  const rows = await knex(TABLE_NAME)
+    .select('standard_invoice_template_code', 'templateAst')
+    .whereIn('standard_invoice_template_code', codes);
+
+  const foundCodes = new Set(rows.map((row) => row.standard_invoice_template_code));
+  const missingCodes = codes.filter((code) => !foundCodes.has(code));
+
+  if (missingCodes.length > 0) {
+    throw new Error(
+      `[set_standard_invoice_template_letter_margins] Missing bundled standard invoice templates: ${missingCodes.join(', ')}`
+    );
+  }
+
+  return rows;
+}
+
+exports.up = async function up(knex) {
+  const rows = await loadRowsByCode(knex, SET_CODES);
+
+  for (const row of rows) {
+    assertTemplateAst(row.templateAst, row.standard_invoice_template_code);
+
+    await knex(TABLE_NAME)
+      .where({ standard_invoice_template_code: row.standard_invoice_template_code })
+      .update({
+        templateAst: JSON.stringify(applyPrintSettings(row.templateAst)),
+        updated_at: knex.fn.now(),
+      });
+  }
+};
+
+exports.down = async function down(knex) {
+  const rows = await loadRowsByCode(knex, UNSET_CODES);
+
+  for (const row of rows) {
+    assertTemplateAst(row.templateAst, row.standard_invoice_template_code);
+
+    await knex(TABLE_NAME)
+      .where({ standard_invoice_template_code: row.standard_invoice_template_code })
+      .update({
+        templateAst: JSON.stringify(removePrintSettings(row.templateAst)),
+        updated_at: knex.fn.now(),
+      });
+  }
+};


### PR DESCRIPTION
## Summary
- set bundled standard invoice template ASTs to use Letter print settings with 10.58mm margins
- backfill existing installs by updating bundled rows in `standard_invoice_templates`
- extend template regression coverage to include grouped standard invoice and quote templates

## Testing
- cd server && npx vitest run --coverage=false ../packages/billing/src/components/invoice-designer/ast/workspaceAst.standardTemplates.regression.test.ts