### PR TITLE
Improve AI chat UX and mention reliability

### DIFF
--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -767,8 +767,8 @@ export const Chat: React.FC<ChatProps> = ({
       ]);
     }
 
-    // Filter mentions to only those still referenced in the message text
-    const activeMentions = mentions.filter((m) => trimmedMessage.includes(m.displayText));
+    // Send all mentions that have chips visible — user controls removal via chip X button
+    const activeMentions = mentions;
 
     setMessageText('');
     setMentions([]);
@@ -1619,48 +1619,53 @@ export const Chat: React.FC<ChatProps> = ({
                     <h3 className="function-approval-title">
                       {pendingFunction.metadata.displayName}
                     </h3>
-                    {pendingFunction.metadata.description && (
-                      <p className="function-approval-description">
-                        {pendingFunction.metadata.description}
-                      </p>
-                    )}
                     {previewText && (
                       <p className="function-approval-preview">{previewText}</p>
                     )}
-                    {assistantPlanText ? (
-                      <details className="function-approval-reasoning">
-                        <summary>View assistant plan</summary>
-                        {assistantPlanItems.length ? (
-                          <ol className="function-approval-plan">
-                            {assistantPlanItems.map((item) => (
-                              <li key={item}>{item}</li>
-                            ))}
-                          </ol>
-                        ) : (
-                          <p>{assistantPlanText}</p>
+                    {(pendingFunction.metadata.description || assistantPlanText || pendingFunction.metadata.playbooks?.length || pendingArgumentEntries.length > 0) && (
+                      <details className="function-approval-details">
+                        <summary>View details</summary>
+                        {pendingFunction.metadata.description && (
+                          <p className="function-approval-description">
+                            {pendingFunction.metadata.description}
+                          </p>
+                        )}
+                        {assistantPlanText ? (
+                          <div className="function-approval-reasoning">
+                            <span className="function-arg-key">Plan</span>
+                            {assistantPlanItems.length ? (
+                              <ol className="function-approval-plan">
+                                {assistantPlanItems.map((item) => (
+                                  <li key={item}>{item}</li>
+                                ))}
+                              </ol>
+                            ) : (
+                              <p>{assistantPlanText}</p>
+                            )}
+                          </div>
+                        ) : null}
+                        {pendingFunction.metadata.playbooks?.length ? (
+                          <div className="function-approval-playbooks">
+                            <span className="function-arg-key">Playbooks</span>
+                            <span className="function-arg-value">
+                              {pendingFunction.metadata.playbooks.join(', ')}
+                            </span>
+                          </div>
+                        ) : null}
+                        {pendingArgumentEntries.length > 0 && (
+                          <div className="function-approval-arguments">
+                            <h4>Parameters</h4>
+                            <ul className="function-arg-list">
+                              {pendingArgumentEntries.map(([key, value]) => (
+                                <li key={key} className="function-arg-item">
+                                  <span className="function-arg-key">{formatArgumentKey(key)}</span>
+                                  <span className="function-arg-value">{renderArgumentValue(value)}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
                         )}
                       </details>
-                    ) : null}
-                    {pendingFunction.metadata.playbooks?.length ? (
-                      <div className="function-approval-playbooks">
-                        <span className="function-arg-key">Playbooks</span>
-                        <span className="function-arg-value">
-                          {pendingFunction.metadata.playbooks.join(', ')}
-                        </span>
-                      </div>
-                    ) : null}
-                    {pendingArgumentEntries.length > 0 && (
-                      <div className="function-approval-arguments">
-                        <h4>Parameters</h4>
-                        <ul className="function-arg-list">
-                          {pendingArgumentEntries.map(([key, value]) => (
-                            <li key={key} className="function-arg-item">
-                              <span className="function-arg-key">{formatArgumentKey(key)}</span>
-                              <span className="function-arg-value">{renderArgumentValue(value)}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
                     )}
                     {functionError && (
                       <div className="function-approval-error">{functionError}</div>
@@ -1677,11 +1682,6 @@ export const Chat: React.FC<ChatProps> = ({
                             label={`Auto-approve future ${normalizedMethod} requests`}
                           />
                         </div>
-                        <p className="function-approval-preferences-help">
-                          {autoApprovalEnabledForMethod
-                            ? 'Future requests with this method will run automatically.'
-                            : 'Enable to approve this HTTP method without prompts.'}
-                        </p>
                       </div>
                     ) : null}
                     <div className="function-approval-status">{statusText}</div>

--- a/ee/server/src/components/chat/chat.css
+++ b/ee/server/src/components/chat/chat.css
@@ -379,10 +379,36 @@
   overflow-x: auto;
 }
 
+.function-approval-details {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: rgb(var(--color-text-700));
+}
+
+.function-approval-details summary {
+  cursor: pointer;
+  color: rgb(var(--color-primary-500));
+  font-weight: 600;
+  font-size: 0.8125rem;
+  list-style: none;
+}
+
+.function-approval-details summary::marker {
+  display: none;
+}
+
+.function-approval-details[open] summary {
+  margin-bottom: 0.5rem;
+}
+
+.function-approval-details .function-approval-description {
+  margin-top: 0;
+}
+
 .function-approval-preferences {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .function-approval-preference-toggle {
@@ -391,11 +417,12 @@
   gap: 0.5rem;
 }
 
-.function-approval-preferences-help {
+.function-approval-preference-toggle > div {
+  align-items: center;
+}
+
+.function-approval-preference-toggle label {
   font-size: 0.8125rem;
-  color: rgb(var(--color-text-600));
-  margin: 0;
-  line-height: 1.4;
 }
 
 /* ---------- Mention chips ---------- */

--- a/ee/server/src/components/layout/RightSidebar.tsx
+++ b/ee/server/src/components/layout/RightSidebar.tsx
@@ -36,7 +36,7 @@ const RightSidebar: React.FC<RightSidebarProps> = (props) => {
 
   return (
     <Suspense fallback={
-      <div className="fixed top-0 right-0 z-[45] h-full bg-gray-50 w-96 shadow-xl">
+      <div className="fixed top-0 right-0 z-[45] h-full bg-gray-50 w-[560px] shadow-xl">
         <div className="flex items-center justify-center h-full">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
         </div>

--- a/ee/server/src/components/layout/RightSidebarContent.tsx
+++ b/ee/server/src/components/layout/RightSidebarContent.tsx
@@ -130,7 +130,7 @@ const RightSidebarContent: React.FC<RightSidebarProps> = ({
   onRegisterCancelHandler,
 }) => {
   const [chatKey, setChatKey] = useState(0);
-  const [width, setWidth] = useState(384);
+  const [width, setWidth] = useState(560);
   const [isResizing, setIsResizing] = useState(false);
   const [activeChatId, setActiveChatId] = useState<string | null>(null);
   const [activeChatMessages, setActiveChatMessages] = useState<any[]>([]);
@@ -247,7 +247,7 @@ const RightSidebarContent: React.FC<RightSidebarProps> = ({
     const handleMouseMove = (event: MouseEvent) => {
       if (!isResizing) return;
       const delta = startXRef.current - event.clientX;
-      const newWidth = Math.min(Math.max(startWidthRef.current + delta, 280), 640);
+      const newWidth = Math.min(Math.max(startWidthRef.current + delta, 320), 800);
       if (newWidth !== width) {
         setWidth(newWidth);
       }

--- a/ee/server/src/services/chatCompletionsService.ts
+++ b/ee/server/src/services/chatCompletionsService.ts
@@ -1440,19 +1440,25 @@ export class ChatCompletionsService {
                 const resolution = c.is_resolution ? ' [resolution]' : '';
                 const author = c.author_type || 'unknown';
                 const date = c.created_at || '';
-                // Extract plain text from note (may be HTML/BlockNote JSON)
-                let noteText = c.note || c.markdown_content || '';
-                if (noteText.startsWith('[{') || noteText.startsWith('[')) {
-                  try {
-                    const blocks = JSON.parse(noteText);
-                    noteText = blocks.map((b: any) => {
-                      if (typeof b === 'string') return b;
-                      const content = b.content;
-                      if (!content) return '';
-                      return content.map((c: any) => c.text || '').join('');
-                    }).join('\n');
-                  } catch {
-                    // keep raw text
+                // Prefer markdown_content (clean text) over note (verbose BlockNote JSON)
+                let noteText = c.markdown_content || '';
+                if (!noteText || noteText === '[No content]' || noteText === '[No markdown content]') {
+                  // Fall back to extracting text from BlockNote JSON in note
+                  const raw = c.note || '';
+                  if (raw.startsWith('[{') || raw.startsWith('[')) {
+                    try {
+                      const blocks = JSON.parse(raw);
+                      noteText = blocks.map((b: any) => {
+                        if (typeof b === 'string') return b;
+                        const content = b.content;
+                        if (!content) return '';
+                        return content.map((ic: any) => ic.text || '').join('');
+                      }).filter(Boolean).join('\n');
+                    } catch {
+                      noteText = raw.slice(0, 300);
+                    }
+                  } else {
+                    noteText = raw;
                   }
                 }
                 // Truncate very long comments
@@ -1631,12 +1637,14 @@ export class ChatCompletionsService {
       const entityLines = await this.resolveMentionedEntities(mentions);
       if (entityLines.length > 0) {
         lines.push('');
-        lines.push('Referenced entities (mentioned by the user):');
+        lines.push('IMPORTANT — The following entities were explicitly mentioned by the user via @mentions. Their full details have already been fetched and are provided below. DO NOT call any API endpoints to look up or re-fetch these entities. Use the data below directly in your response.');
+        lines.push('');
         lines.push(...entityLines);
-        lines.push('Instructions for mentioned entities:');
-        lines.push('- Use the details above when answering questions about these entities. The data is already fetched — do not re-fetch unless the user explicitly asks for the latest/refreshed data.');
-        lines.push('- The IDs provided (ticket_id, client_id, contact_name_id, project_id, asset_id, user_id) are real UUIDs. Use them directly when making API calls related to these entities.');
-        lines.push('- If the user asks to perform an action on a mentioned entity (update, close, assign, etc.), use the provided ID to call the appropriate API endpoint without needing to search for the entity first.');
+        lines.push('');
+        lines.push('Rules for mentioned entities:');
+        lines.push('- You ALREADY HAVE all the data for these entities above. DO NOT call List Contacts, List Clients, or any search/list endpoint to find them again.');
+        lines.push('- The IDs provided (ticket_id, client_id, contact_name_id, project_id, asset_id, user_id) are real UUIDs. Use them directly if you need to perform actions (update, close, assign, etc.) via API calls.');
+        lines.push('- Only re-fetch an entity if the user explicitly asks for "latest", "refreshed", or "updated" data.');
         lines.push('- For tickets with comments, consider the conversation history when answering questions about the ticket status, issues, or resolution.');
       }
     }
@@ -1654,7 +1662,7 @@ export class ChatCompletionsService {
       content:
         'You are Alga, an assistant that helps users manage PSA workflows. ' +
         'Always consult the enterprise API registry before executing actions so you understand every required parameter. ' +
-        'When the registry or endpoint descriptions mention prerequisite data (such as IDs for boards, clients, categories, priorities, or other related resources), proactively call the appropriate lookup endpoints to gather that information instead of asking the user. ' +
+        'When the registry or endpoint descriptions mention prerequisite data (such as IDs for boards, clients, categories, priorities, or other related resources): for write operations (create, update, delete), proactively call the appropriate lookup endpoints to gather that information instead of asking the user; for read operations (list, get), call the endpoint directly and only look up prerequisite data if the user explicitly asks to filter by it. ' +
         'For ticket-creation calls, first use search_api_registry to locate the list endpoints you need, gather current data (e.g. call GET /api/v1/tickets to sample board_id/status_id/priority_id combinations and GET /api/v1/clients to confirm client_id), and do not proceed until you have concrete UUIDs for board_id, client_id, status_id, and priority_id collected from prior API responses. When sampling GET /api/v1/tickets, pick the first record with non-null board_id, status_id, and priority_id and reuse those UUIDs unless the user specifies different values. ' +
         'Never invent field names for a fields query parameter. Only send fields values that are explicitly documented in the registry description, parameters, or examples for that exact endpoint. If the registry does not enumerate exact field names, omit fields entirely. For GET /api/v1/tickets specifically, the only valid fields values are ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, and mobile_list. Do not use aliases like id, subject, status, priority, client, created_at, or description. ' +
         'When you only need discovery data, prefer list endpoints with small limits and explicit fields instead of full payloads. Once you have a resource ID, prefer the detail endpoint over repeatedly expanding list responses. ' +
@@ -1662,6 +1670,7 @@ export class ChatCompletionsService {
         'Clearly explain the plan before each tool call, execute the necessary lookup calls to satisfy all requirements, then call the target endpoint once the inputs are ready. ' +
         'Use the documented request schemas exactly as written—populate *_id fields with the UUIDs you retrieved (never human-friendly names), and skip optional fields when you do not have authoritative values. ' +
         'Never include properties that are not defined for the selected endpoint; if the user mentions data that cannot be expressed with the documented schema (for example a project name when the ticket create payload does not accept project_id), acknowledge it in the natural-language response but leave it out of the API request. ' +
+        'When reading ticket comments, use the markdown_content field for readable text. The comment_text field contains raw BlockNote JSON which is not human-readable — ignore it. ' +
         'When handling documents, do not assume null file_id means empty content; in-app documents may store content in document_block_content or document_content. Call GET /api/documents/{documentId}/content to retrieve readable content before concluding the document has no data. ' +
         'Do not create or modify unrelated master data (such as categories, boards, or projects) unless the user explicitly asks for that; prefer reusing existing records you just looked up. ' +
         'When users ask questions that could be answered by internal documentation (e.g. how-to questions, troubleshooting, process questions), proactively search the knowledge base using GET /api/v1/kb-articles with a relevant search query. If matching articles are found, read their content with GET /api/v1/kb-articles/{id}/content and use that information in your response. When creating KB articles from resolved tickets, use POST /api/v1/kb-articles/from-ticket/{ticketId} and then review the generated content. ' +

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -1123,6 +1123,7 @@ export class TicketService extends BaseService<ITicket> {
     return comments.map(comment => ({
       ...comment,
       comment_text: comment.note,
+      markdown_content: comment.markdown_content || null,
       comment_html: renderTicketRichTextHtml(comment.note),
       created_by: comment.user_id ?? null,
       created_by_name: comment.created_by_name || comment.author_contact_name || null,


### PR DESCRIPTION
  - Fix intermittent mention loss by removing fragile displayText filter; all visible chips are now sent with the message
  - Collapse verbose function approval details behind "View details"  toggle, showing only method/endpoint/title by default
  - Widen chat sidebar default from 384px to 560px (max 800px)
  - Strengthen mention context instructions so AI uses injected entity data instead of re-fetching via API calls
  - Prefer markdown_content over raw BlockNote JSON for comments  in both mention context injection and API responses
  - Fix auto-approve toggle alignment in function approval card

  "Why, the Cheshire Cat's grin grew wider and wider until it was exactly 560 pixels across," said Alice. "And all the @mentions floated up like chips of teacup, never once falling through the includes() filter again." 🐱✨🍵