### PR TITLE
fix: harden Talos appliance bootstrap and worker defaults

### DIFF
--- a/ee/appliance/flux/profiles/talos-single-node/values/temporal-worker.talos-single-node.yaml
+++ b/ee/appliance/flux/profiles/talos-single-node/values/temporal-worker.talos-single-node.yaml
@@ -26,3 +26,8 @@ db:
     key: DB_PASSWORD_SUPERUSER
 
 applicationUrl: http://alga-core.msp.svc.cluster.local:3000
+
+portalDomain:
+  certificateNamespace: ""
+  gatewayNamespace: ""
+  secretReplicationEnabled: false

--- a/ee/appliance/flux/profiles/talos-single-node/values/temporal-worker.talos-single-node.yaml
+++ b/ee/appliance/flux/profiles/talos-single-node/values/temporal-worker.talos-single-node.yaml
@@ -27,7 +27,13 @@ db:
 
 applicationUrl: http://alga-core.msp.svc.cluster.local:3000
 
+auth:
+  nextauthSecretSecret:
+    name: alga-core-sebastian-secrets
+    key: NEXTAUTH_SECRET
+
 portalDomain:
   certificateNamespace: ""
   gatewayNamespace: ""
   secretReplicationEnabled: false
+  baseVirtualService: ""

--- a/ee/appliance/flux/profiles/talos-single-node/values/workflow-worker.talos-single-node.yaml
+++ b/ee/appliance/flux/profiles/talos-single-node/values/workflow-worker.talos-single-node.yaml
@@ -29,3 +29,9 @@ db:
   adminPasswordSecret:
     name: db-credentials
     key: DB_PASSWORD_SUPERUSER
+
+livenessProbe:
+  enabled: false
+
+readinessProbe:
+  enabled: false

--- a/ee/appliance/scripts/bootstrap-appliance.sh
+++ b/ee/appliance/scripts/bootstrap-appliance.sh
@@ -173,6 +173,42 @@ print(parsed.netloc)
 PY
 }
 
+infer_node_ip_from_kubeconfig() {
+  [ -f "$KUBECONFIG_PATH" ] || return 0
+
+  python3 - "$KUBECONFIG_PATH" <<'PY'
+import re
+import sys
+from urllib.parse import urlparse
+
+text = open(sys.argv[1], 'r', encoding='utf-8').read()
+match = re.search(r'^\s*server:\s*(\S+)\s*$', text, re.MULTILINE)
+if not match:
+    raise SystemExit(0)
+parsed = urlparse(match.group(1))
+if parsed.hostname:
+    print(parsed.hostname)
+PY
+}
+
+resolve_default_app_url() {
+  local inferred_ip="${NODE_IP:-}"
+
+  if [ -z "$inferred_ip" ] && [ -f "$CONFIG_DIR/node-ip" ]; then
+    inferred_ip="$(tr -d '\n' < "$CONFIG_DIR/node-ip")"
+  fi
+
+  if [ -z "$inferred_ip" ]; then
+    inferred_ip="$(infer_node_ip_from_kubeconfig || true)"
+  fi
+
+  if [ -n "$inferred_ip" ]; then
+    printf 'http://%s:3000\n' "$inferred_ip"
+  else
+    printf 'http://localhost:3000\n'
+  fi
+}
+
 run_cmd() {
   if $DRY_RUN; then
     printf '+'
@@ -275,8 +311,13 @@ resolve_runtime_inputs() {
     HOSTNAME_VALUE="$SITE_ID"
   fi
 
+  if [ -z "$APP_URL" ] && [ -f "$CONFIG_DIR/app-url" ]; then
+    APP_URL="$(tr -d '\n' < "$CONFIG_DIR/app-url")"
+  fi
+
   if [ -z "$APP_URL" ]; then
-    local default_app_url="http://${NODE_IP}:3000"
+    local default_app_url
+    default_app_url="$(resolve_default_app_url)"
     if is_interactive; then
       APP_URL="$(prompt_value "Public application URL" "$default_app_url")"
     else
@@ -882,6 +923,7 @@ install_gitops_sync() {
     --url="$REPO_URL" \
     --branch="$REPO_BRANCH" \
     --interval=1m \
+    --timeout=5m \
     --export | kubectl --kubeconfig "$KUBECONFIG_PATH" apply -f -
 
   flux --kubeconfig "$KUBECONFIG_PATH" create kustomization alga-appliance \
@@ -930,6 +972,37 @@ prepull_images() {
   talos_cmd image pull "ghcr.io/nine-minds/temporal-worker:${TEMPORAL_WORKER_TAG}"
 }
 
+promote_bootstrap_mode_to_recover() {
+  local values_file
+  local requested_at
+
+  if [ "$BOOTSTRAP_MODE" != "fresh" ]; then
+    return 0
+  fi
+
+  if $DRY_RUN; then
+    echo "+ promote bootstrap.mode from fresh to recover after successful initial bootstrap"
+    return 0
+  fi
+
+  values_file="$TEMP_PROFILE_DIR/values/alga-core.$PROFILE.yaml"
+  if [ -f "$values_file" ]; then
+    set_yaml_value "$values_file" "bootstrap.mode" "recover"
+  fi
+
+  values_file="$CONFIG_DIR/values/alga-core.$PROFILE.yaml"
+  if [ -f "$values_file" ]; then
+    set_yaml_value "$values_file" "bootstrap.mode" "recover"
+  fi
+
+  kubectl --kubeconfig "$KUBECONFIG_PATH" apply -k "$TEMP_PROFILE_DIR"
+  requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n alga-system annotate helmrelease alga-core \
+    reconcile.fluxcd.io/requestedAt="$requested_at" --overwrite >/dev/null
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n alga-system wait --for=condition=Ready --timeout=30m helmrelease/alga-core
+  BOOTSTRAP_MODE="recover"
+}
+
 wait_for_bootstrap() {
   if $DRY_RUN; then
     cat <<EOF
@@ -949,6 +1022,7 @@ EOF
     kubectl --kubeconfig "$KUBECONFIG_PATH" -n msp wait --for=condition=complete --timeout=20m "job/${bootstrap_job}"
   fi
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n msp rollout status deployment/alga-core-sebastian --timeout=20m
+  promote_bootstrap_mode_to_recover
 }
 
 while [ "$#" -gt 0 ]; do

--- a/ee/helm/temporal-worker/templates/deployment.yaml
+++ b/ee/helm/temporal-worker/templates/deployment.yaml
@@ -188,6 +188,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal-worker.fullname" . }}-secrets
                   key: ALGA_AUTH_KEY
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.nextauthSecretSecret.name }}
+                  name: {{ .Values.auth.nextauthSecretSecret.name }}
+                  key: {{ .Values.auth.nextauthSecretSecret.key | default "NEXTAUTH_SECRET" }}
+                  {{- else }}
+                  name: {{ include "temporal-worker.fullname" . }}-secrets
+                  key: NEXTAUTH_SECRET
+                  {{- end }}
+            {{- end }}
+
+            {{- if .Values.portalDomain.baseVirtualService }}
+            - name: PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE
+              value: {{ .Values.portalDomain.baseVirtualService | quote }}
             {{- end }}
             
             # NM Store callback configuration

--- a/ee/helm/temporal-worker/templates/rbac.yaml
+++ b/ee/helm/temporal-worker/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- $replicationEnabled := default true .Values.portalDomain.secretReplicationEnabled -}}
+{{- $replicationEnabled := default false .Values.portalDomain.secretReplicationEnabled -}}
 {{- $gatewayNamespace := default "" .Values.portalDomain.gatewayNamespace -}}
 {{- $certificateNamespace := default "" .Values.portalDomain.certificateNamespace -}}
 {{- if and .Values.enabled $replicationEnabled }}

--- a/ee/helm/temporal-worker/templates/secrets.yaml
+++ b/ee/helm/temporal-worker/templates/secrets.yaml
@@ -11,4 +11,5 @@ type: Opaque
 stringData:
   INTERNAL_API_SHARED_SECRET: {{ .Values.secrets.internalApiSharedSecret | quote }}
   ALGA_AUTH_KEY: {{ .Values.secrets.algaAuthKey | quote }}
+  NEXTAUTH_SECRET: {{ .Values.secrets.nextauthSecret | quote }}
 {{- end }}

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -163,10 +163,10 @@ extraEnv: []
 portalDomain:
   # Namespace where TLS certificates are issued (source secrets)
   certificateNamespace: ""  # Set to your certificate namespace
-  # Namespace where Istio gateway resources (and replicated TLS secrets) live
-  gatewayNamespace: istio-system
+  # Namespace where gateway resources (and replicated TLS secrets) live when secret replication is enabled
+  gatewayNamespace: ""
   # Whether to create RBAC bindings that allow the worker to sync TLS secrets
-  secretReplicationEnabled: true
+  secretReplicationEnabled: false
 
 # Additional volumes
 extraVolumes: []

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -65,6 +65,7 @@ vault:
 secrets:
   internalApiSharedSecret: "change-me-in-production"
   algaAuthKey: "change-me-in-production"
+  nextauthSecret: "change-me-in-production"
 
 # Service Account configuration
 serviceAccount:
@@ -159,6 +160,12 @@ extraEnv: []
   # - name: EXTRA_VAR
   #   value: "extra-value"
 
+# Auth configuration
+auth:
+  nextauthSecretSecret:
+    name: ""
+    key: NEXTAUTH_SECRET
+
 # Portal domain management configuration
 portalDomain:
   # Namespace where TLS certificates are issued (source secrets)
@@ -167,6 +174,9 @@ portalDomain:
   gatewayNamespace: ""
   # Whether to create RBAC bindings that allow the worker to sync TLS secrets
   secretReplicationEnabled: false
+  # Optional base VirtualService reference (<namespace>/<name>) for portal-domain workflows.
+  # Leave empty when portal-domain routing is not managed in this environment.
+  baseVirtualService: ""
 
 # Additional volumes
 extraVolumes: []

--- a/ee/helm/workflow-worker/templates/deployment.yaml
+++ b/ee/helm/workflow-worker/templates/deployment.yaml
@@ -191,6 +191,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
 
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /health
@@ -200,7 +201,9 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+          {{- end }}
 
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /health
@@ -210,6 +213,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+          {{- end }}
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/ee/helm/workflow-worker/values.yaml
+++ b/ee/helm/workflow-worker/values.yaml
@@ -88,6 +88,7 @@ vault:
 
 # Health check probe configuration
 livenessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 30
   timeoutSeconds: 10
@@ -95,6 +96,7 @@ livenessProbe:
   successThreshold: 1
 
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 15
   periodSeconds: 10
   timeoutSeconds: 5

--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -70,6 +70,7 @@ COPY ./server/src/ ./server/src/
 COPY ./ee/server/src /app/ee/server/src
 COPY ./ee/server/migrations/ ./server/migrations/
 COPY ./ee/server/seeds/ ./server/seeds/
+COPY ./ee/server/seeds/ /app/ee/server/seeds/
 
 # Copy core package.json for version info
 COPY packages/core/package.json /app/packages/core/package.json

--- a/ee/temporal-workflows/src/config/startupValidation.ts
+++ b/ee/temporal-workflows/src/config/startupValidation.ts
@@ -41,7 +41,6 @@ const REQUIRED_CONFIGS = {
   TEMPORAL_ADDRESS: 'Temporal server address (e.g., temporal-frontend:7233)',
   TEMPORAL_NAMESPACE: 'Temporal namespace (e.g., default)',
   TEMPORAL_TASK_QUEUE: 'Temporal task queue name',
-  PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE: 'Existing VirtualService name that anchors portal routing',
 } as const;
 
 /**
@@ -142,7 +141,7 @@ export async function validateRequiredConfiguration(): Promise<void> {
     TEMPORAL_NAMESPACE: validatedConfigs.TEMPORAL_NAMESPACE,
     TEMPORAL_TASK_QUEUE: validatedConfigs.TEMPORAL_TASK_QUEUE,
     PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE:
-      validatedConfigs.PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE,
+      process.env.PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE || 'not set (portal-domain sync disabled)',
   });
 }
 

--- a/helm/templates/appliance-bootstrap-configmap.yaml
+++ b/helm/templates/appliance-bootstrap-configmap.yaml
@@ -274,7 +274,11 @@ data:
       if check_seeds_status; then
         log "Seeds already exist; skipping"
       else
-        log "Running seeds"
+        if [ -n "${SEEDS_DIR:-}" ] && [ ! -d "${SEEDS_DIR}" ]; then
+          log "ERROR: Configured seed directory does not exist: ${SEEDS_DIR}"
+          exit 1
+        fi
+        log "Running seeds from ${SEEDS_DIR:-./seeds/dev}"
         NODE_ENV=migration timeout 300 npx knex seed:run --knexfile /app/server/knexfile.cjs --verbose
       fi
     else

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -106,10 +106,17 @@ spec:
           args:
             - |
               if [ "${SETUP_RUN_SEEDS}" = "true" ]; then
-                echo "Waiting for bootstrap seeds to create initial data..."
-                until PGPASSWORD="${DB_PASSWORD_ADMIN}" psql -h "${DB_HOST_ADMIN}" -p "${DB_PORT_ADMIN}" -U "${DB_USER_ADMIN}" -d "${DB_NAME_SERVER}" -Atqc "SELECT EXISTS (SELECT 1 FROM users LIMIT 1);" 2>/dev/null | grep -q '^t$'; do
-                  sleep 2
-                done
+                if [ "${APPLIANCE_BOOTSTRAP_ENABLED}" = "true" ]; then
+                  echo "Waiting for appliance bootstrap migrations to finish..."
+                  until PGPASSWORD="${DB_PASSWORD_ADMIN}" psql -h "${DB_HOST_ADMIN}" -p "${DB_PORT_ADMIN}" -U "${DB_USER_ADMIN}" -d "${DB_NAME_SERVER}" -Atqc "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users');" 2>/dev/null | grep -q '^t$'; do
+                    sleep 2
+                  done
+                else
+                  echo "Waiting for bootstrap seeds to create initial data..."
+                  until PGPASSWORD="${DB_PASSWORD_ADMIN}" psql -h "${DB_HOST_ADMIN}" -p "${DB_PORT_ADMIN}" -U "${DB_USER_ADMIN}" -d "${DB_NAME_SERVER}" -Atqc "SELECT EXISTS (SELECT 1 FROM users LIMIT 1);" 2>/dev/null | grep -q '^t$'; do
+                    sleep 2
+                  done
+                fi
               elif [ "${SETUP_RUN_MIGRATIONS}" = "true" ]; then
                 echo "Waiting for bootstrap job to create application databases..."
                 until PGPASSWORD="${DB_PASSWORD_ADMIN}" psql -h "${DB_HOST_ADMIN}" -p "${DB_PORT_ADMIN}" -U "${DB_USER_ADMIN}" -d postgres -Atqc "SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname='${DB_NAME_SERVER}');" 2>/dev/null | grep -q '^t$'; do
@@ -123,6 +130,8 @@ spec:
               value: {{ ternary "true" "false" .Values.setup.runSeeds | quote }}
             - name: DB_NAME_SERVER
               value: "server"
+            - name: APPLIANCE_BOOTSTRAP_ENABLED
+              value: {{ ternary "true" "false" .Values.setup.applianceBootstrap.enabled | quote }}
             - name: DB_USER_ADMIN
               value: "postgres"
             {{- if .Values.db.enabled }}

--- a/helm/templates/jobs.yaml
+++ b/helm/templates/jobs.yaml
@@ -213,6 +213,10 @@ spec:
               value: {{ .Values.setup.applianceBootstrap.waitTimeoutSeconds | default 300 | quote }}
             - name: BOOTSTRAP_WAIT_RETRY_SECONDS
               value: {{ .Values.setup.applianceBootstrap.retryIntervalSeconds | default 2 | quote }}
+            {{- if .Values.setup.applianceBootstrap.enabled }}
+            - name: SEEDS_DIR
+              value: "/app/ee/server/seeds/onboarding"
+            {{- end }}
 
             # Secret provider configuration for setup jobs
             - name: SECRET_READ_CHAIN

--- a/server/knexfile.cjs
+++ b/server/knexfile.cjs
@@ -57,6 +57,8 @@ const getClient = () => {
 
 const { validate: uuidValidate } = require('uuid');
 
+const seedsDirectory = process.env.SEEDS_DIR || './seeds/dev';
+
 function isValidTenantId(tenantId) {
   if (!tenantId) return true;
   if (tenantId === 'default') return true;
@@ -102,7 +104,7 @@ const migrationConfig = {
     loadExtensions: ['.cjs', '.js']
   },
   seeds: {
-    directory: "./seeds/dev",
+    directory: seedsDirectory,
     loadExtensions: ['.cjs', '.js']
   }
 };
@@ -130,7 +132,7 @@ const knexfile = {
     // But keeps postgres user connection for migrations
     migrations: migrationConfig.migrations,
     seeds: {
-      directory: "./seeds/dev",
+      directory: seedsDirectory,
       loadExtensions: ['.cjs', '.js']
     }
   },


### PR DESCRIPTION
## Summary
- switch appliance bootstrap to onboarding seeds in appliance-only flows
- ship onboarding seed files in the EE runtime image
- allow appliance bootstrap to complete without requiring seeded users
- harden Talos appliance bootstrap/app URL handling and promote fresh installs to recover after initial bootstrap
- make appliance worker defaults converge without manual live patches

## What changed
- add `SEEDS_DIR` support in `server/knexfile.cjs` and wire appliance bootstrap jobs to `ee/server/seeds/onboarding`
- fail fast when the configured appliance seed directory is missing
- copy `ee/server/seeds` into the EE server image
- change appliance bootstrap wait logic to check for schema presence instead of seeded `users` rows
- update `bootstrap-appliance.sh` to:
  - derive/reuse a sane `APP_URL`
  - avoid malformed `http://:3000` values
  - use a longer Flux source timeout
  - promote `bootstrap.mode` from `fresh` to `recover` after successful initial bootstrap
- make `workflow-worker` probes configurable and disable them in the Talos appliance profile
- make `temporal-worker` appliance startup less coupled to portal-domain/Istio-specific settings
- add `NEXTAUTH_SECRET` wiring for `temporal-worker`
- keep appliance `temporal-worker` secret replication/Istio defaults disabled

## Validation
- `bash -n ee/appliance/scripts/bootstrap-appliance.sh`
- `helm template` for:
  - `./helm` with appliance bootstrap enabled
  - `./ee/helm/workflow-worker`
  - `./ee/helm/temporal-worker`
- live Talos appliance validation on `192.168.64.7` using Flux revision `temp/appliance-bootstrap-20260408@sha1:b37a3bbde2e4150e473bb9d9e28402204aef6332`
  - `alga-core`, `email-service`, `temporal`, `temporal-ui`, `temporal-worker`, and `workflow-worker` all reached Ready
  - final deployed images:
    - `ghcr.io/nine-minds/alga-psa-ee:06cdccd0`
    - `ghcr.io/nine-minds/email-service:61e4a00e`
    - `ghcr.io/nine-minds/workflow-worker:d8e558df`
    - `ghcr.io/nine-minds/temporal-worker:8f029cc7`
  - database state after fresh bootstrap remained non-demo (`users=0`, `tenants=0`)

## Notes
- this PR is based on the temporary validation branch used to prove the Talos appliance flow end-to-end.
