### PR TITLE
Fix board deletion blocked by undeletable statuses

### DIFF
--- a/packages/tickets/src/actions/board-actions/boardActions.ts
+++ b/packages/tickets/src/actions/board-actions/boardActions.ts
@@ -248,6 +248,43 @@ export const createBoard = withAuth(async (user, { tenant }, boardData: CreateBo
 });
 
 /**
+ * Remove all ticket statuses owned by a board, plus their child rows in
+ * other tables that hold FK references back to `statuses`.
+ *
+ * This bypasses the normal "at least one default status per board"
+ * enforcement because the entire board is going away.  The caller MUST
+ * have already verified that zero tickets reference these statuses.
+ */
+async function cleanupBoardStatuses(
+  trx: Knex | Knex.Transaction,
+  tenant: string,
+  boardId: string
+): Promise<void> {
+  const statusIds = await trx('statuses')
+    .where({ tenant, board_id: boardId, status_type: 'ticket' })
+    .pluck('status_id');
+
+  if (statusIds.length === 0) return;
+
+  // 1. Clear the board's own FK back to statuses (circular ref)
+  await trx('boards')
+    .where({ tenant, board_id: boardId })
+    .whereIn('inbound_reply_reopen_status_id', statusIds)
+    .update({ inbound_reply_reopen_status_id: null });
+
+  // 2. Remove SLA pause config rows that reference these statuses
+  await trx('status_sla_pause_config')
+    .where({ tenant })
+    .whereIn('status_id', statusIds)
+    .delete();
+
+  // 3. Delete the statuses themselves
+  await trx('statuses')
+    .where({ tenant, board_id: boardId, status_type: 'ticket' })
+    .delete();
+}
+
+/**
  * Delete a board with hasDependencies pattern (like deleteClient).
  *
  * - If board is default → BLOCK
@@ -354,15 +391,38 @@ export const deleteBoard = withAuth(async (
       };
     }
 
+    // 6b. Count board ticket statuses (informational — these are always
+    // auto-cleaned because the "at least one default" rule makes manual
+    // deletion impossible)
+    const statusCountResult = await trx('statuses')
+      .where({ tenant, board_id: boardId, status_type: 'ticket' })
+      .count('status_id as count')
+      .first();
+    const statusCount = Number(statusCountResult?.count || 0);
+
     // 7. If custom board has categories and force=false, prompt for confirmation
     // ITIL categories are shared and handled separately via ITIL cleanup
     if (!isItilCategoryBoard && allCategoryIds.length > 0 && !force) {
+      const statusInfo = statusCount > 0
+        ? ` and ${statusCount} ticket status${statusCount === 1 ? '' : 'es'}`
+        : '';
       return {
         success: false,
         code: 'BOARD_HAS_CATEGORIES',
-        message: `Board has ${allCategoryIds.length} categor${allCategoryIds.length === 1 ? 'y' : 'ies'}. Delete them too?`,
-        dependencies: ['categories'],
-        counts: { categories: allCategoryIds.length }
+        message: `Board has ${allCategoryIds.length} categor${allCategoryIds.length === 1 ? 'y' : 'ies'}${statusInfo}. Delete them too?`,
+        dependencies: ['categories', ...(statusCount > 0 ? ['statuses'] : [])],
+        counts: { categories: allCategoryIds.length, ...(statusCount > 0 ? { statuses: statusCount } : {}) }
+      };
+    }
+
+    // 7b. If board has statuses and user hasn't confirmed, inform them
+    if (!force && statusCount > 0 && allCategoryIds.length === 0) {
+      return {
+        success: false,
+        code: 'BOARD_HAS_STATUSES',
+        message: `Board has ${statusCount} ticket status${statusCount === 1 ? '' : 'es'} that will also be removed.`,
+        dependencies: ['statuses'],
+        counts: { statuses: statusCount }
       };
     }
 
@@ -395,6 +455,11 @@ export const deleteBoard = withAuth(async (
 
     if (!force && !isLastItilBoard && allCategoryIds.length === 0) {
       const result = await deleteEntityWithValidation('board', boardId, db, tenant, async (boardTrx, tenantId) => {
+        // Clean up board statuses (can't be deleted manually due to
+        // "at least one default status" enforcement, safe because
+        // we already confirmed zero tickets above)
+        await cleanupBoardStatuses(boardTrx, tenantId, boardId);
+
         const deletedCount = await boardTrx('boards')
           .where({ tenant: tenantId, board_id: boardId })
           .delete();
@@ -426,12 +491,17 @@ export const deleteBoard = withAuth(async (
         .delete();
     }
 
-    // 10. Delete the board
+    // 10. Clean up board statuses (can't be deleted manually due to
+    // "at least one default status" enforcement, safe because
+    // we already confirmed zero tickets above)
+    await cleanupBoardStatuses(trx, tenant, boardId);
+
+    // 11. Delete the board
     await trx('boards')
       .where({ tenant, board_id: boardId })
       .delete();
 
-    // 11. If last ITIL board and cleanup confirmed, remove unused ITIL data
+    // 12. If last ITIL board and cleanup confirmed, remove unused ITIL data
     let itilCleanupMessage = '';
     if (isLastItilBoard && cleanupItil) {
       const cleanupResult = await ItilStandardsService.cleanupUnusedItilStandards(trx, tenant);

--- a/packages/tickets/src/actions/board-actions/boardActions.ts
+++ b/packages/tickets/src/actions/board-actions/boardActions.ts
@@ -6,7 +6,7 @@ import { createTenantKnex } from '@alga-psa/db';
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { ItilStandardsService } from '../../services/itilStandardsService';
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, hasPermission } from '@alga-psa/auth';
 import { deleteEntityWithValidation } from '@alga-psa/core';
 import { v4 as uuidv4 } from 'uuid';
 import { BoardTicketStatusInput, saveBoardTicketStatusesForBoard } from './boardTicketStatusActions';
@@ -252,8 +252,11 @@ export const createBoard = withAuth(async (user, { tenant }, boardData: CreateBo
  * other tables that hold FK references back to `statuses`.
  *
  * This bypasses the normal "at least one default status per board"
- * enforcement because the entire board is going away.  The caller MUST
- * have already verified that zero tickets reference these statuses.
+ * enforcement because the entire board is going away.
+ *
+ * MUST be called inside the same transaction that verified zero tickets
+ * reference these statuses — otherwise there is a race where a ticket
+ * could be created between the check and the delete.
  */
 async function cleanupBoardStatuses(
   trx: Knex | Knex.Transaction,
@@ -306,12 +309,16 @@ interface DeleteBoardResult {
 }
 
 export const deleteBoard = withAuth(async (
-  _user,
+  user,
   { tenant },
   boardId: string,
   force = false,
   cleanupItil = false
 ): Promise<DeleteBoardResult> => {
+  if (!await hasPermission(user, 'ticket', 'delete')) {
+    throw new Error('Permission denied: Cannot delete boards');
+  }
+
   const { knex: db } = await createTenantKnex();
 
   return withTransaction(db, async (trx: Knex.Transaction): Promise<DeleteBoardResult> => {

--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -439,7 +439,8 @@ const BoardsSettings: React.FC = () => {
       // Handle different error codes
       switch (result.code) {
         case 'BOARD_HAS_CATEGORIES':
-          // Show confirmation dialog to force delete categories
+        case 'BOARD_HAS_STATUSES':
+          // Show confirmation dialog to force delete categories/statuses
           setDeleteDialog({
             ...deleteDialog,
             confirmForce: true,


### PR DESCRIPTION
  Clean up board-owned ticket statuses during board deletion. The "at least one default status" enforcement made it impossible  to manually remove statuses before deleting a board, causing FK  constraint violations.

  - Add cleanupBoardStatuses() to remove statuses, SLA pause configs,  and circular FK refs in both deletion paths
  - Count and surface status counts in BOARD_HAS_CATEGORIES response
  - Add BOARD_HAS_STATUSES confirmation so users see what will be removed
  - Handle BOARD_HAS_STATUSES in BoardsSettings confirmation dialog

  "Off with their statuses!" cried the Queen of Boards. "But Your Majesty," whispered the Knave, "the default status rule says we must keep at least one!"
   "Nonsense," she replied, "when the whole board falls down the rabbit hole, the statuses fall with it — circular references and all." 🃏♠️ 🗑️