### PR TITLE
Open ticket links in new tab on cmd/ctrl click

### DIFF
--- a/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
+++ b/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
@@ -154,7 +154,7 @@ export const addSingleTeamMember = withAuth(async (
     if (usage.limit !== null && usage.used >= usage.limit) {
       return {
         success: false,
-        error: `You've reached your internal user licence limit of ${usage.limit}. Please remove or deactivate existing users to add new ones.`
+        error: `You've reached your internal user license limit of ${usage.limit}. Please remove or deactivate existing users to add new ones.`
       };
     }
 
@@ -288,7 +288,7 @@ export const addTeamMembers = withAuth(async (
       if (canAdd === 0) {
         return { 
           success: false, 
-          error: `You've reached your internal user licence limit of ${usage.limit}. Please remove or deactivate existing users to add new ones.`
+          error: `You've reached your internal user license limit of ${usage.limit}. Please remove or deactivate existing users to add new ones.`
         };
       }
       

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -205,6 +205,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
               <Link
                 href={`/msp/tickets/${record.ticket_id}`}
                 onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) return;
                   e.preventDefault();
                   e.stopPropagation();
                   onTicketClick(record.ticket_id as string);
@@ -259,6 +260,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
           <Link
             href={`/msp/tickets/${record.ticket_id}`}
             onClick={(e) => {
+              if (e.metaKey || e.ctrlKey) return;
               e.preventDefault();
               e.stopPropagation();
               onTicketClick(record.ticket_id as string);

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -35,7 +35,7 @@ const ADD_USER_VALIDATION_ERRORS = new Set([
   'Cannot assign MSP role to client portal user',
   'Cannot assign client portal role to MSP user',
   'A user with this email address already exists',
-  "You've reached your MSP user licence limit.",
+  "You've reached your MSP user license limit.",
   SOLO_USER_LIMIT_MESSAGE,
 ]);
 
@@ -149,7 +149,7 @@ export const addUser = withAuth(async (
         }
 
         if (limit !== null && used >= limit) {
-          return { success: false, error: "You've reached your MSP user licence limit." };
+          return { success: false, error: "You've reached your MSP user license limit." };
         }
 
       }


### PR DESCRIPTION
  Skip the custom onClick handler when the user holds meta or ctrl, allowing the browser's native new-tab behavior on ticket links in  the columns view. Also tidies "licence" to "license" in MSP and internal user limit error messages.

  "Curiouser and curiouser!" cried the Cheshire Cat, clicking with one paw while holding ⌘ with another, for a ticket opened in a new tab is twice the ticket, and a licence spelled license is twice as legal in the court of the Queen of Hearts. 🐈‍⬛🎫✨