### PR TITLE
Fix manual workflow runs injecting implicit tenant payload

### DIFF
--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -192,6 +192,46 @@ const isEnterpriseEdition = (): boolean => {
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
+const schemaDeclaresTopLevelProperty = (
+  schemaInput: unknown,
+  propertyName: string,
+  rootInput: unknown = schemaInput
+): boolean => {
+  if (!isObjectRecord(schemaInput) || !isObjectRecord(rootInput)) {
+    return false;
+  }
+
+  const resolved = resolveJsonSchemaRef(schemaInput, rootInput);
+  const properties = resolved.properties;
+  if (isObjectRecord(properties) && Object.prototype.hasOwnProperty.call(properties, propertyName)) {
+    return true;
+  }
+
+  const variants = [
+    ...(Array.isArray(resolved.anyOf) ? resolved.anyOf : []),
+    ...(Array.isArray(resolved.oneOf) ? resolved.oneOf : []),
+  ];
+  return variants.some((variant) => schemaDeclaresTopLevelProperty(variant, propertyName, rootInput));
+};
+
+const stripImplicitTenantIdFromManualRunPayload = (
+  payload: Record<string, unknown>,
+  payloadSchemaJson: unknown
+): Record<string, unknown> => {
+  if (!Object.prototype.hasOwnProperty.call(payload, 'tenantId')) {
+    return payload;
+  }
+  if (!isObjectRecord(payloadSchemaJson)) {
+    return payload;
+  }
+  if (schemaDeclaresTopLevelProperty(payloadSchemaJson, 'tenantId')) {
+    return payload;
+  }
+
+  const { tenantId: _tenantId, ...rest } = payload;
+  return rest;
+};
+
 const formatSchedulePayloadValidationMessage = (issues: Array<{ path?: Array<string | number>; message?: string }>): string => {
   if (!issues.length) {
     return 'Schedule payload failed validation against the latest published workflow schema.';
@@ -2045,9 +2085,16 @@ export const startWorkflowRunAction = withAuth(async (user, { tenant }, input: u
     }
   }
 
+  const payloadSchemaJson = versionRecord.payload_schema_json
+    ?? (schemaRef && schemaRegistry.has(schemaRef) ? schemaRegistry.toJsonSchema(schemaRef) : null);
+
+  if (!inputIsSourcePayload) {
+    // Manual runs already carry authoritative tenant context outside payload; only keep a top-level
+    // tenantId when the workflow schema explicitly declares it as part of the business contract.
+    finalPayload = stripImplicitTenantIdFromManualRunPayload(finalPayload, payloadSchemaJson);
+  }
+
   if (!versionRecord.validation_status || versionRecord.validation_status === 'error') {
-    const payloadSchemaJson = versionRecord.payload_schema_json
-      ?? (schemaRef && schemaRegistry.has(schemaRef) ? schemaRegistry.toJsonSchema(schemaRef) : null);
     const validation = await computeValidation({
       definition: definition ?? {},
       payloadSchemaRef: schemaRef ?? undefined,

--- a/ee/server/src/components/workflow-designer/WorkflowRunDialog.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunDialog.tsx
@@ -144,6 +144,51 @@ const resolveSchemaRef = (schema: JsonSchema, root: JsonSchema): JsonSchema => {
   return current && typeof current === 'object' ? (current as JsonSchema) : schema;
 };
 
+const IMPLICIT_RUN_CONTEXT_FIELD_KEYS = new Set(['tenantId']);
+
+const schemaDeclaresTopLevelProperty = (
+  schema: JsonSchema | null | undefined,
+  propertyName: string,
+  root: JsonSchema | null | undefined = schema
+): boolean => {
+  if (!schema || !root) return false;
+
+  const resolved = resolveSchemaRef(schema, root);
+  if (resolved.properties && Object.prototype.hasOwnProperty.call(resolved.properties, propertyName)) {
+    return true;
+  }
+
+  const variants = [...(resolved.anyOf ?? []), ...(resolved.oneOf ?? [])];
+  return variants.some((variant) => schemaDeclaresTopLevelProperty(variant, propertyName, root));
+};
+
+const shouldInjectImplicitTenantId = (schema: JsonSchema | null | undefined, tenantId?: string | null): boolean => (
+  Boolean(tenantId && schemaDeclaresTopLevelProperty(schema, 'tenantId'))
+);
+
+const stripImplicitRunContextFields = (payload: Record<string, unknown>): Record<string, unknown> => {
+  const next = { ...payload };
+  for (const key of IMPLICIT_RUN_CONTEXT_FIELD_KEYS) {
+    delete next[key];
+  }
+  return next;
+};
+
+const applyImplicitRunContextFields = (
+  payload: Record<string, unknown>,
+  options: { tenantId?: string | null; schema?: JsonSchema | null }
+): Record<string, unknown> => {
+  const next = stripImplicitRunContextFields(payload);
+  if (options.tenantId && shouldInjectImplicitTenantId(options.schema, options.tenantId)) {
+    next.tenantId = options.tenantId;
+  }
+  return next;
+};
+
+const isImplicitRunContextFieldPath = (path: Array<string | number>): boolean => (
+  path.length === 1 && typeof path[0] === 'string' && IMPLICIT_RUN_CONTEXT_FIELD_KEYS.has(path[0])
+);
+
 const buildDefaultValueFromSchema = (schema: JsonSchema, root: JsonSchema): unknown => {
   const resolved = resolveSchemaRef(schema, root);
   if (resolved.default !== undefined) {
@@ -302,31 +347,6 @@ const pathToString = (path: Array<string | number>): string =>
   );
 
 type ValidationError = { path: string; message: string };
-
-const IMPLICIT_RUN_CONTEXT_FIELD_KEYS = new Set(['tenantId']);
-
-const stripImplicitRunContextFields = (payload: Record<string, unknown>): Record<string, unknown> => {
-  const next = { ...payload };
-  for (const key of IMPLICIT_RUN_CONTEXT_FIELD_KEYS) {
-    delete next[key];
-  }
-  return next;
-};
-
-const applyImplicitRunContextFields = (
-  payload: Record<string, unknown>,
-  options: { tenantId?: string | null }
-): Record<string, unknown> => {
-  const next = stripImplicitRunContextFields(payload);
-  if (options.tenantId) {
-    next.tenantId = options.tenantId;
-  }
-  return next;
-};
-
-const isImplicitRunContextFieldPath = (path: Array<string | number>): boolean => (
-  path.length === 1 && typeof path[0] === 'string' && IMPLICIT_RUN_CONTEXT_FIELD_KEYS.has(path[0])
-);
 
 const normalizeSchemaType = (schema?: JsonSchema): string | undefined => {
   if (!schema?.type) return undefined;
@@ -875,7 +895,7 @@ const WorkflowRunDialog: React.FC<WorkflowRunDialogProps> = ({
     })() : formValue;
     const effectiveValue = applyImplicitRunContextFields(
       isObjectRecord(value) ? value : {},
-      { tenantId: currentTenantId }
+      { tenantId: currentTenantId, schema: activeSchema }
     );
     const errors = validateAgainstSchema(activeSchema, effectiveValue, activeSchema)
       .filter((error) => !IMPLICIT_RUN_CONTEXT_FIELD_KEYS.has(error.path));
@@ -1037,7 +1057,7 @@ const WorkflowRunDialog: React.FC<WorkflowRunDialogProps> = ({
     try {
       payload = applyImplicitRunContextFields(
         mode === 'json' ? JSON.parse(runPayloadText || '{}') : (formValue as Record<string, unknown>),
-        { tenantId: currentTenantId }
+        { tenantId: currentTenantId, schema: activeSchema }
       );
     } catch (err) {
       setRunPayloadError(err instanceof Error ? err.message : 'Invalid JSON');

--- a/server/src/test/integration/workflowRuntimeV2.publish.integration.test.ts
+++ b/server/src/test/integration/workflowRuntimeV2.publish.integration.test.ts
@@ -893,6 +893,28 @@ describe('workflow runtime v2 publish + registry + run integration tests', () =>
     await expect(startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: { bar: 123 } })).rejects.toMatchObject({ status: 400 });
   });
 
+  it('Start run strips implicit tenantId for manual runs when the workflow schema does not declare it. Mocks: non-target dependencies.', async () => {
+    const registry = getSchemaRegistry();
+    const strictEmptyRef = `payload.StrictEmpty.${Date.now()}`;
+    registry.register(strictEmptyRef, z.object({}).strict());
+    const workflowId = await createDraftWorkflow({
+      steps: [stateSetStep('state-1', 'READY')],
+      payloadSchemaRef: strictEmptyRef
+    });
+    await publishWorkflow(workflowId, 1);
+
+    const runResult = await startWorkflowRunAction({
+      workflowId,
+      workflowVersion: 1,
+      payload: { tenantId: tenantId }
+    });
+    const run = await WorkflowRunModelV2.getById(db, runResult.runId);
+
+    expect(run?.status).not.toBe('FAILED');
+    expect(run?.input_json ?? {}).toEqual({});
+    expect(run?.error_json ?? null).toBeNull();
+  });
+
   it('Start run blocks execution when published workflow fails validation. Mocks: non-target dependencies.', async () => {
     const workflowId = await createDraftWorkflow({
       steps: [actionCallStep({ id: 'action-1', actionId: 'test.echo', inputMapping: { value: 'ok' } })]


### PR DESCRIPTION
## Summary
- stop auto-injecting `tenantId` into manual run payloads unless the workflow schema explicitly declares it
- harden `startWorkflowRunAction` to strip implicit top-level `tenantId` for manual runs when the schema does not allow it
- add a regression test covering strict empty/manual-run payloads

## Root cause
Green prod was failing to start a test workflow with `Payload failed validation` because the run dialog submitted:

```json
{ "tenantId": "<tenant-uuid>" }
```

for a workflow pinned to `payload.Empty.v1` (`z.object({}).strict()`).

## Validation
- `cd ee/packages/workflows && npm run typecheck`
- `cd ee/server && npm run typecheck -- --pretty false`
- `cd server && npx vitest src/test/integration/workflowRuntimeV2.publish.integration.test.ts -t "Start run strips implicit tenantId for manual runs when the workflow schema does not declare it" --run --coverage.enabled=false`
