### PR TITLE
fix(time-entry): refresh reopened sheets and improve grid add-entry UX

### DIFF
--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -42,6 +42,7 @@ interface TimeEntryDialogProps {
   timeSheetId?: string;
   onTimeEntriesUpdate?: (entries: ITimeEntryWithWorkItemString[]) => void;
   inDrawer?: boolean;
+  startInAddMode?: boolean;
 }
 
 // Main dialog content component
@@ -62,6 +63,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     timeSheetId,
     onTimeEntriesUpdate,
     inDrawer,
+    startInAddMode = false,
   } = props;
   const {
     entries,
@@ -87,6 +89,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
   const lastNoteInputRef = useRef<HTMLTextAreaElement>(null);
   const [shouldFocusNotes, setShouldFocusNotes] = useState(false);
   const hasSetInitialEditingIndex = useRef(false);
+  const hasTriggeredInitialAddMode = useRef(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; index: number | null }>({
     isOpen: false,
     index: null
@@ -170,6 +173,25 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     setEditingIndex(entries.length);
     setShouldFocusNotes(true);
   }, [isEditable, date, entries, workItem, defaultTaxRegion, updateEntry, setEditingIndex]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      hasTriggeredInitialAddMode.current = false;
+      return;
+    }
+
+    if (!startInAddMode || hasTriggeredInitialAddMode.current || !isEditable || isLoading) {
+      return;
+    }
+
+    if (!existingEntries || existingEntries.length === 0) {
+      hasTriggeredInitialAddMode.current = true;
+      return;
+    }
+
+    handleAddEntry();
+    hasTriggeredInitialAddMode.current = true;
+  }, [existingEntries, handleAddEntry, isEditable, isLoading, isOpen, startInAddMode]);
 
   const handleSaveEntry = useCallback(async (index: number, source: 'dialog' | 'entry' = 'entry') => {
     if (!isEditable) return;

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
@@ -34,11 +34,13 @@ import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutoma
 import { ContainerComponent } from '@alga-psa/ui/ui-reflection/types';
 import { CommonActions } from '@alga-psa/ui/ui-reflection/actionBuilders';
 import { useUserPreference } from '@alga-psa/user-composition/hooks';
+import { resolveQuickAddBehavior } from './quickAddUtils';
 
 const TIMESHEET_VIEW_MODE_SETTING = 'timesheet_view_mode';
 
 interface TimeSheetProps {
     timeSheet: ITimeSheetView;
+    onTimeSheetChange: (timeSheet: ITimeSheetView) => void;
     onSaveTimeEntry: (timeEntry: ITimeEntry) => Promise<void>;
     isManager?: boolean;
     subjectName?: string;
@@ -120,8 +122,10 @@ function getDatesInPeriod(timePeriod: ITimePeriodView): Date[] {
     return dates;
 }
 
+
 export function TimeSheet({
-    timeSheet: initialTimeSheet,
+    timeSheet,
+    onTimeSheetChange,
     onSaveTimeEntry,
     isManager = false,
     subjectName,
@@ -139,7 +143,6 @@ export function TimeSheet({
     const [showIntervals, setShowIntervals] = useState(false);
     const [dateNavigator, setDateNavigator] = useState<TimeSheetDateNavigatorState | null>(null);
     const [isLoadingTimeSheetData, setIsLoadingTimeSheetData] = useState(true);
-    const [timeSheet, setTimeSheet] = useState<ITimeSheetView>(initialTimeSheet);
     const [workItemsByType, setWorkItemsByType] = useState<Record<string, IExtendedWorkItem[]>>({});
     const [groupedTimeEntries, setGroupedTimeEntries] = useState<Record<string, ITimeEntryWithWorkItemString[]>>({});
     const [isAddWorkItemDialogOpen, setIsAddWorkItemDialogOpen] = useState(false);
@@ -173,6 +176,7 @@ export function TimeSheet({
         entries: ITimeEntryWithWorkItemString[];
         defaultStartTime?: string;
         defaultEndTime?: string;
+        startInAddMode?: boolean;
     } | null>(null);
 
     const initialDateObj = initialDate ? parseISO(initialDate) : undefined;
@@ -209,7 +213,7 @@ export function TimeSheet({
                     fetchTimeSheet(timeSheet.id)
                 ]);
 
-                setTimeSheet(updatedTimeSheet);
+                onTimeSheetChange(updatedTimeSheet);
 
                 let workItems = fetchedWorkItems;
                 if (initialWorkItem && !workItems.some(item => item.work_item_id === initialWorkItem.work_item_id)) {
@@ -287,7 +291,7 @@ export function TimeSheet({
         };
 
         loadData();
-    }, [timeSheet.id, initialWorkItem, initialDateObj, initialDuration]);
+    }, [initialDateObj, initialDuration, initialWorkItem, onTimeSheetChange, timeSheet.id]);
 
     const handleQuickAddTimeEntry = async (params: {
         workItem: IExtendedWorkItem;
@@ -296,16 +300,16 @@ export function TimeSheet({
         existingEntry?: ITimeEntryWithWorkItemString;
     }) => {
         const { workItem, date, durationInMinutes, existingEntry } = params;
-        
+
         const workDate = date.slice(0, 10);
 
         // Set start time to 8 AM on the selected date (local time)
         const startTime = parseLocalDate(workDate);
         startTime.setHours(8, 0, 0, 0);
-        
+
         // Calculate end time based on duration
         const endTime = new Date(startTime.getTime() + durationInMinutes * 60 * 1000);
-        
+
         // Get entries for this date to check for overlaps
         const entriesForDate = (groupedTimeEntries[workItem.work_item_id] || [])
             .filter(entry => {
@@ -313,17 +317,29 @@ export function TimeSheet({
                 if (entryWorkDate) return entryWorkDate === workDate;
                 return parseISO(entry.start_time).toDateString() === startTime.toDateString();
             });
-        
+
         // If there are existing entries for this date, start after the last one
         if (entriesForDate.length > 0) {
-            const sortedEntries = [...entriesForDate].sort((a, b) => 
+            const sortedEntries = [...entriesForDate].sort((a, b) =>
                 parseISO(b.end_time).getTime() - parseISO(a.end_time).getTime()
             );
             const lastEndTime = parseISO(sortedEntries[0].end_time);
             startTime.setTime(lastEndTime.getTime());
             endTime.setTime(startTime.getTime() + durationInMinutes * 60 * 1000);
         }
-        
+
+        const quickAddBehavior = resolveQuickAddBehavior(workItem, existingEntry);
+        if (quickAddBehavior.mode === 'dialog') {
+            setSelectedCell({
+                workItem,
+                date: workDate,
+                entries: entriesForDate,
+                defaultStartTime: formatISO(startTime),
+                defaultEndTime: formatISO(endTime),
+            });
+            return;
+        }
+
         // Create the time entry, copying settings from existing entry if available
         const timeEntry: ITimeEntry = {
             entry_id: '',
@@ -331,8 +347,8 @@ export function TimeSheet({
             user_id: timeSheet.user_id,
             start_time: formatISO(startTime),
             end_time: formatISO(endTime),
-            billable_duration: existingEntry ? 
-                (existingEntry.billable_duration > 0 ? durationInMinutes : 0) : 
+            billable_duration: existingEntry ?
+                (existingEntry.billable_duration > 0 ? durationInMinutes : 0) :
                 durationInMinutes, // Default to billable if no existing entry
             work_item_type: workItem.type,
             notes: existingEntry?.notes || '',
@@ -340,11 +356,11 @@ export function TimeSheet({
             created_at: formatISO(new Date()),
             updated_at: formatISO(new Date()),
             time_sheet_id: timeSheet.id,
-            service_id: existingEntry?.service_id || undefined,  // Use undefined instead of empty string
-            tax_region: existingEntry?.tax_region || undefined,  // Use undefined instead of empty string
-            contract_line_id: existingEntry?.contract_line_id || undefined  // Also handle contract_line_id
+            service_id: quickAddBehavior.serviceId,
+            tax_region: existingEntry?.tax_region || undefined,
+            contract_line_id: existingEntry?.contract_line_id || undefined
         };
-        
+
         await handleSaveTimeEntry(timeEntry);
     };
 
@@ -420,7 +436,7 @@ export function TimeSheet({
         try {
             await submitTimeSheet(timeSheet.id);
             const updatedTimeSheet = await fetchTimeSheet(timeSheet.id);
-            setTimeSheet(updatedTimeSheet);
+            onTimeSheetChange(updatedTimeSheet);
             if (onSubmitTimeSheet) {
                 await onSubmitTimeSheet();
             }
@@ -736,6 +752,10 @@ export function TimeSheet({
                     isEditable={effectiveIsEditable}
                     isLoading={isLoadingTimeSheetData || isViewModeLoading}
                     onCellClick={setSelectedCell}
+                    onAddEntryForCell={(params) => setSelectedCell({
+                        ...params,
+                        startInAddMode: params.entries.length > 0,
+                    })}
                     onAddWorkItem={openAddWorkItemDialog}
                     onQuickAddTimeEntry={handleQuickAddTimeEntry}
                     onDateNavigatorChange={setDateNavigator}
@@ -773,6 +793,7 @@ export function TimeSheet({
                     defaultStartTime={selectedCell.defaultStartTime ? parseISO(selectedCell.defaultStartTime) : undefined}
                     timeSheetId={timeSheet.id}
                     inDrawer={false}
+                    startInAddMode={selectedCell.startInAddMode}
                     onTimeEntriesUpdate={(entries) => {
                         const grouped = entries.reduce((acc, entry) => {
                             const key = `${entry.work_item_id}`;

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
@@ -40,6 +40,10 @@ export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUs
   const allowDelegatedEditing = delegatedTimeEntryEnabled && !delegatedTimeEntryLoading;
 
   useEffect(() => {
+    setTimeSheet(initialTimeSheet);
+  }, [initialTimeSheet]);
+
+  useEffect(() => {
     const loadSubjectUser = async () => {
       if (!isDelegated || !allowDelegatedEditing) {
         setSubjectUser(currentUser);
@@ -117,6 +121,7 @@ export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUs
     <>
       <TimeSheet
         timeSheet={timeSheet}
+        onTimeSheetChange={setTimeSheet}
         onSaveTimeEntry={handleSaveTimeEntry}
         isManager={isManager}
         subjectName={allowDelegatedEditing && subjectUser ? formatUserName(subjectUser) : undefined}

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
@@ -31,6 +31,13 @@ interface TimeSheetTableProps {
         defaultStartTime?: string;
         defaultEndTime?: string;
     }) => void;
+    onAddEntryForCell: (params: {
+        workItem: IExtendedWorkItem;
+        date: string;
+        entries: ITimeEntryWithWorkItemString[];
+        defaultStartTime?: string;
+        defaultEndTime?: string;
+    }) => void;
     onAddWorkItem: (date?: string) => void;
     onWorkItemClick: (workItem: IExtendedWorkItem) => void;
     onQuickAddTimeEntry?: (params: {
@@ -55,6 +62,7 @@ export function TimeSheetTable({
     isEditable,
     isLoading = false,
     onCellClick,
+    onAddEntryForCell,
     onAddWorkItem,
     onWorkItemClick,
     onDeleteWorkItem,
@@ -117,6 +125,49 @@ export function TimeSheetTable({
     const canGoBack = currentPage > 0;
     const canGoForward = currentPage < totalPages - 1;
     const hasMultiplePages = totalPages > 1;
+
+    const buildCellSelection = useCallback((
+        workItem: IExtendedWorkItem,
+        date: Date,
+        dayEntries: ITimeEntryWithWorkItemString[]
+    ) => {
+        let startTime: Date | undefined;
+        let endTime: Date | undefined;
+
+        if (workItem.type === 'ad_hoc' &&
+            'scheduled_start' in workItem &&
+            'scheduled_end' in workItem &&
+            workItem.scheduled_start &&
+            workItem.scheduled_end) {
+            startTime = typeof workItem.scheduled_start === 'string'
+                ? parseISO(workItem.scheduled_start)
+                : workItem.scheduled_start;
+            endTime = typeof workItem.scheduled_end === 'string'
+                ? parseISO(workItem.scheduled_end)
+                : workItem.scheduled_end;
+        }
+
+        if (!startTime && dayEntries.length > 0) {
+            const sortedEntries = [...dayEntries].sort((a, b) =>
+                parseISO(b.end_time).getTime() - parseISO(a.end_time).getTime()
+            );
+            startTime = parseISO(sortedEntries[0].end_time);
+            endTime = new Date(startTime.getTime() + 60 * 60 * 1000);
+        } else if (!startTime) {
+            startTime = new Date(date);
+            startTime.setHours(8, 0, 0, 0);
+            endTime = new Date(startTime);
+            endTime.setHours(9, 0, 0, 0);
+        }
+
+        return {
+            workItem,
+            date: formatISO(date),
+            entries: dayEntries,
+            defaultStartTime: startTime ? formatISO(startTime) : undefined,
+            defaultEndTime: endTime ? formatISO(endTime) : undefined,
+        };
+    }, []);
 
     // Get visible dates for current page
     const startIndex = currentPage * daysPerPage;
@@ -465,56 +516,40 @@ export function TimeSheetTable({
 	                                                        date: formatISO(date, { representation: 'date' })
                                                     })}
                                                     onMouseLeave={() => setHoveredCell(null)}
-                                                    onClick={() => {
-                                                        if (!canOpenCell) return;
-
-                                                        let startTime: Date | undefined;
-                                                        let endTime: Date | undefined;
-
-                                                        if (workItem.type === 'ad_hoc' &&
-                                                            'scheduled_start' in workItem &&
-                                                            'scheduled_end' in workItem &&
-                                                            workItem.scheduled_start &&
-                                                            workItem.scheduled_end) {
-                                                            startTime = typeof workItem.scheduled_start === 'string' ?
-                                                                parseISO(workItem.scheduled_start) :
-                                                                workItem.scheduled_start;
-                                                            endTime = typeof workItem.scheduled_end === 'string' ?
-                                                                parseISO(workItem.scheduled_end) :
-                                                                workItem.scheduled_end;
-                                                        }
-
-                                                        if (!startTime && dayEntries.length > 0) {
-                                                            const sortedEntries = [...dayEntries].sort((a, b) =>
-                                                                parseISO(b.end_time).getTime() - parseISO(a.end_time).getTime()
-                                                            );
-                                                            startTime = parseISO(sortedEntries[0].end_time);
-                                                            endTime = new Date(startTime.getTime() + 60 * 60 * 1000);
-                                                        } else if (!startTime) {
-                                                            startTime = new Date(date);
-                                                            startTime.setHours(8, 0, 0, 0);
-                                                            endTime = new Date(startTime);
-                                                            endTime.setHours(9, 0, 0, 0);
-                                                        }
-
-                                                        onCellClick({
-                                                            workItem,
-                                                            date: formatISO(date),
-                                                            entries: dayEntries,
-                                                            defaultStartTime: startTime ? formatISO(startTime) : undefined,
-                                                            defaultEndTime: endTime ? formatISO(endTime) : undefined
-                                                        });
-                                                    }}
                                                 >
+                                                    <div className="relative h-full w-full p-1.5">
+                                                        {isEditable && (
+                                                            <button
+                                                                type="button"
+                                                                className={`absolute inset-1.5 rounded-xl transition-colors ${
+                                                                    dayEntries.length > 0
+                                                                        ? 'bg-white/70 hover:bg-white/90 dark:bg-gray-900/10 dark:hover:bg-gray-900/20'
+                                                                        : 'hover:bg-white/70 dark:hover:bg-gray-900/10'
+                                                                }`}
+                                                                data-automation-id={`time-cell-add-area-${workItem.work_item_id}-${formatISO(date, { representation: 'date' })}`}
+                                                                data-automation-type="time-entry-add-area"
+                                                                onClick={() => {
+                                                                    onAddEntryForCell(buildCellSelection(workItem, date, dayEntries));
+                                                                }}
+                                                                aria-label={`Add time entry for ${workItem.name} on ${formatISO(date, { representation: 'date' })}`}
+                                                            />
+                                                        )}
 		                                                    {dayEntries.length > 0 ? (
-		                                                        <div
-		                                                            className="relative rounded-lg p-2 text-xs h-full w-full flex items-center justify-center"
-		                                                            style={{
+		                                                        <button
+                                                                type="button"
+                                                                className="relative z-10 flex h-full w-full items-center justify-center rounded-xl p-3 text-xs shadow-sm transition-transform hover:scale-[1.01]"
+                                                                style={{
 		                                                                backgroundColor: colors.background,
 		                                                                borderColor: colors.border,
 	                                                                borderWidth: '1px',
 	                                                                borderStyle: 'solid'
 		                                                            }}
+                                                                data-automation-id={`time-cell-entry-${workItem.work_item_id}-${formatISO(date, { representation: 'date' })}`}
+                                                                data-automation-type="time-entry-summary"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    onCellClick(buildCellSelection(workItem, date, dayEntries));
+                                                                }}
 		                                                        >
 		                                                            {cellFeedbackState ? (
 		                                                                <span
@@ -537,12 +572,12 @@ export function TimeSheetTable({
 		                                                            <div className="font-medium text-gray-700 text-center">
 		                                                                {formatDuration(totalDuration)}
 		                                                            </div>
-	                                                        </div>
+	                                                        </button>
 	                                                    ) : (
-                                                        <div className="h-full w-full">
+                                                        <div className="h-full w-full rounded-xl">
                                                             {/* Empty cell - click anywhere to open full dialog */}
                                                             {isHovered && isEditable && (
-                                                                <div className="absolute bottom-2 left-2 right-2 flex items-center gap-1 bg-white rounded shadow-sm border border-gray-200 px-1 py-1 z-10"
+                                                                <div className="absolute bottom-3 left-3 right-3 z-10 flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-1 py-1 shadow-sm"
                                                                      onClick={(e) => e.stopPropagation()}>
                                                                     <Input
                                                                         type="text"
@@ -737,8 +772,8 @@ export function TimeSheetTable({
                                                                 </div>
                                                             )}
                                                         </div>
-                                                        )
-                                                    }
+                                                        )}
+                                                    </div>
                                                 </td>
                                             );
                                         })}

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/quickAddUtils.ts
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/quickAddUtils.ts
@@ -1,0 +1,26 @@
+import type { IExtendedWorkItem, ITimeEntryWithWorkItemString } from '@alga-psa/types';
+
+export function resolveQuickAddBehavior(
+  workItem: Pick<IExtendedWorkItem, 'service_id'>,
+  existingEntry?: Pick<ITimeEntryWithWorkItemString, 'service_id'>
+): { mode: 'save'; serviceId: string } | { mode: 'dialog' } {
+  const existingEntryServiceId = existingEntry?.service_id?.trim();
+  if (existingEntryServiceId) {
+    return {
+      mode: 'save',
+      serviceId: existingEntryServiceId,
+    };
+  }
+
+  const workItemServiceId = workItem.service_id?.trim();
+  if (workItemServiceId) {
+    return {
+      mode: 'save',
+      serviceId: workItemServiceId,
+    };
+  }
+
+  return {
+    mode: 'dialog',
+  };
+}

--- a/packages/scheduling/tests/quickAddUtils.test.ts
+++ b/packages/scheduling/tests/quickAddUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveQuickAddBehavior } from '../src/components/time-management/time-entry/time-sheet/quickAddUtils';
+
+describe('resolveQuickAddBehavior', () => {
+  it('uses the existing entry service when one is available', () => {
+    expect(
+      resolveQuickAddBehavior(
+        { service_id: 'work-item-service' } as any,
+        { service_id: 'existing-entry-service' } as any,
+      )
+    ).toEqual({
+      mode: 'save',
+      serviceId: 'existing-entry-service',
+    });
+  });
+
+  it('falls back to the work item service when no existing entry service exists', () => {
+    expect(
+      resolveQuickAddBehavior(
+        { service_id: 'work-item-service' } as any,
+        { service_id: '' } as any,
+      )
+    ).toEqual({
+      mode: 'save',
+      serviceId: 'work-item-service',
+    });
+  });
+
+  it('routes quick add to the full dialog when no service can be inferred', () => {
+    expect(
+      resolveQuickAddBehavior(
+        { service_id: null } as any,
+        undefined,
+      )
+    ).toEqual({
+      mode: 'dialog',
+    });
+  });
+});

--- a/packages/scheduling/tests/timeSheetClient.reopen.test.tsx
+++ b/packages/scheduling/tests/timeSheetClient.reopen.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TimeSheetClient from '../src/components/time-management/time-entry/time-sheet/TimeSheetClient';
+
+const { refresh, push, saveTimeEntry, fetchOrCreateTimeSheet, fetchEligibleTimeEntrySubjects, fetchTimeSheet, reverseTimeSheetApproval, toastSuccess, handleError } = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  push: vi.fn(),
+  saveTimeEntry: vi.fn(),
+  fetchOrCreateTimeSheet: vi.fn(),
+  fetchEligibleTimeEntrySubjects: vi.fn(),
+  fetchTimeSheet: vi.fn(),
+  reverseTimeSheetApproval: vi.fn(),
+  toastSuccess: vi.fn(),
+  handleError: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh, push }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => ({ enabled: false, loading: false }),
+}));
+
+vi.mock('@alga-psa/scheduling/actions/timeEntryActions', () => ({
+  saveTimeEntry,
+  fetchOrCreateTimeSheet,
+}));
+
+vi.mock('@alga-psa/scheduling/actions/timeEntryDelegationActions', () => ({
+  fetchEligibleTimeEntrySubjects,
+}));
+
+vi.mock('@alga-psa/scheduling/actions/timeSheetActions', () => ({
+  fetchTimeSheet,
+  reverseTimeSheetApproval,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: toastSuccess,
+  },
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  handleError,
+}));
+
+vi.mock('../src/components/time-management/time-entry/time-sheet/TimeSheet', () => ({
+  TimeSheet: ({ timeSheet, onReopenForEdits }: any) => (
+    <div>
+      <div data-testid="timesheet-status">{timeSheet.approval_status}</div>
+      <button id="reopen-timesheet-button" onClick={() => void onReopenForEdits?.()}>
+        Reopen for edits
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: ({ isOpen, onConfirm, onClose }: any) =>
+    isOpen ? (
+      <div data-testid="reopen-confirmation-dialog">
+        <button id="confirm-reopen-button" onClick={() => void onConfirm()}>
+          Confirm reopen
+        </button>
+        <button id="cancel-reopen-button" onClick={() => onClose(false)}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
+describe('TimeSheetClient reopen flow', () => {
+  const currentUser = {
+    user_id: 'user-1',
+    first_name: 'Test',
+    last_name: 'User',
+    email: 'test@example.com',
+  };
+
+  const approvedTimeSheet = {
+    id: 'timesheet-1',
+    user_id: 'user-1',
+    period_id: 'period-1',
+    approval_status: 'APPROVED',
+  };
+
+  const reopenedTimeSheet = {
+    ...approvedTimeSheet,
+    approval_status: 'CHANGES_REQUESTED',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reverseTimeSheetApproval.mockResolvedValue(undefined);
+    fetchTimeSheet.mockResolvedValue(reopenedTimeSheet);
+    saveTimeEntry.mockResolvedValue(undefined);
+    fetchOrCreateTimeSheet.mockResolvedValue(approvedTimeSheet);
+    fetchEligibleTimeEntrySubjects.mockResolvedValue([]);
+  });
+
+  it('updates the rendered timesheet immediately after reopen without requiring a refresh', async () => {
+    render(
+      <TimeSheetClient
+        timeSheet={approvedTimeSheet as any}
+        currentUser={currentUser as any}
+        isManager={false}
+        canReopenForEdits={true}
+      />
+    );
+
+    expect(screen.getByTestId('timesheet-status').textContent).toBe('APPROVED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen for edits' }));
+    expect(screen.getByTestId('reopen-confirmation-dialog')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reopen' }));
+
+    await waitFor(() => {
+      expect(reverseTimeSheetApproval).toHaveBeenCalledWith(
+        'timesheet-1',
+        'user-1',
+        'Reopened for edits'
+      );
+    });
+
+    await waitFor(() => {
+      expect(fetchTimeSheet).toHaveBeenCalledWith('timesheet-1');
+      expect(screen.getByTestId('timesheet-status').textContent).toBe('CHANGES_REQUESTED');
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith('Time sheet reopened for edits');
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scheduling/tests/timeSheetTable.feedback.test.ts
+++ b/packages/scheduling/tests/timeSheetTable.feedback.test.ts
@@ -123,6 +123,7 @@ describe('TimeSheetTable feedback markers', () => {
     },
     isEditable: false,
     onDeleteWorkItem: vi.fn(async () => undefined),
+    onAddEntryForCell: vi.fn(),
     onAddWorkItem: vi.fn(),
     onWorkItemClick: vi.fn(),
     onQuickAddTimeEntry: vi.fn(async () => undefined),
@@ -161,12 +162,12 @@ describe('TimeSheetTable feedback markers', () => {
     const marker = container.querySelector('[data-feedback-state="unresolved"]');
     expect(marker).not.toBeNull();
 
-    const cell = container.querySelector('[data-automation-id="time-cell-work-item-1-2026-03-10"]');
-    if (!cell) {
-      throw new Error('Expected time entry cell');
+    const entrySummary = container.querySelector('[data-automation-id="time-cell-entry-work-item-1-2026-03-10"]');
+    if (!entrySummary) {
+      throw new Error('Expected time entry summary');
     }
 
-    cell.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    entrySummary.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onCellClick).toHaveBeenCalledTimes(1);
   });
 
@@ -217,5 +218,63 @@ describe('TimeSheetTable feedback markers', () => {
     });
 
     expect(container.querySelector('[data-feedback-state]')).toBeNull();
+  });
+
+  it('opens the existing entry when the entry summary is clicked', () => {
+    const onCellClick = vi.fn();
+    const onAddEntryForCell = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        React.createElement(TimeSheetTable, {
+          ...commonProps,
+          isEditable: true,
+          groupedTimeEntries: {
+            'work-item-1': [createEntry()],
+          },
+          onCellClick,
+          onAddEntryForCell,
+        }),
+      );
+    });
+
+    const entrySummary = container.querySelector('[data-automation-id="time-cell-entry-work-item-1-2026-03-10"]');
+    if (!entrySummary) {
+      throw new Error('Expected time entry summary');
+    }
+
+    entrySummary.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onCellClick).toHaveBeenCalledTimes(1);
+    expect(onAddEntryForCell).not.toHaveBeenCalled();
+  });
+
+  it('treats the surrounding cell area as add-entry space when editable', () => {
+    const onCellClick = vi.fn();
+    const onAddEntryForCell = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        React.createElement(TimeSheetTable, {
+          ...commonProps,
+          isEditable: true,
+          groupedTimeEntries: {
+            'work-item-1': [createEntry()],
+          },
+          onCellClick,
+          onAddEntryForCell,
+        }),
+      );
+    });
+
+    const addArea = container.querySelector('[data-automation-id="time-cell-add-area-work-item-1-2026-03-10"]');
+    if (!addArea) {
+      throw new Error('Expected time entry add area');
+    }
+
+    addArea.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onAddEntryForCell).toHaveBeenCalledTimes(1);
+    expect(onCellClick).not.toHaveBeenCalled();
   });
 });

--- a/server/src/test/unit/ui/reopenForEdits.test.ts
+++ b/server/src/test/unit/ui/reopenForEdits.test.ts
@@ -29,6 +29,13 @@ describe('reopen for edits (static)', () => {
     );
     expect(client).toContain('ConfirmationDialog');
     expect(client).toContain('reverseTimeSheetApproval');
+    expect(client).toContain('onTimeSheetChange={setTimeSheet}');
+
+    const timeSheet = readRepoFile(
+      'packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx'
+    );
+    expect(timeSheet).toContain('onTimeSheetChange(updatedTimeSheet)');
+    expect(timeSheet).not.toContain('useState<ITimeSheetView>(initialTimeSheet)');
   });
 });
 


### PR DESCRIPTION
## Summary
- make `TimeSheetClient` the canonical owner of timesheet state so reopened sheets become editable immediately without a page refresh
- fix grid quick-add so it reuses an inferred service when possible and falls back to the full dialog instead of throwing a `service_id` validation error
- increase grid-cell breathing room and split interactions so clicking an existing entry opens that entry while clicking the surrounding cell area always starts add-new-entry

## Testing
- `cd server && npx vitest run ../packages/scheduling/tests/timeSheetTable.feedback.test.ts ../packages/scheduling/tests/quickAddUtils.test.ts ../packages/scheduling/tests/timeSheetClient.reopen.test.tsx src/test/unit/ui/reopenForEdits.test.ts`
- `npx tsc -p server/tsconfig.json --noEmit`
- manual browser validation with `algadev` on the timesheet page:
  - reopen for edits updates the UI immediately without refresh
  - quick-add with no inferred service opens the full dialog instead of surfacing the Zod error
  - clicking the grid entry summary opens the existing entry flow
  - clicking the surrounding cell/add area opens add-new-entry flow
