### PR TITLE
Fix timesheet interaction flow and dialog stability

### DIFF
--- a/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/PRD.md
+++ b/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/PRD.md
@@ -1,0 +1,154 @@
+# PRD — Timesheet Grid Multi-Entry Focus Filter
+
+- Slug: `timesheet-grid-multi-entry-focus-filter`
+- Date: `2026-04-12`
+- Status: Draft
+
+## Summary
+When a user clicks a timesheet grid cell that represents multiple time entries, do not open a multi-entry editor dialog. Instead, switch to list view, temporarily filter the list to the exact entries from that grid cell, and let the user pick a single entry to edit using the existing single-entry editing screen. Simplify the time-entry dialog so it always edits exactly one entry and no longer supports multi-entry editing or in-dialog entry creation.
+
+## Problem
+The current timesheet entry flow allows a grid cell with multiple entries to open a dialog that contains:
+
+- a list of entries inside the dialog
+- per-entry save behavior
+- a second footer save button
+- an in-dialog `Add Entry` path
+
+This creates an unclear editing model. Users do not know whether they are editing one entry or several, whether they should click the row-level save or the footer save, or what the footer save actually commits.
+
+The core product problem is not that users need a stronger batch editor. It is that the grid compresses multiple entries into a single cell, and the UI does not give them a clear disambiguation step before editing.
+
+## Goals
+- Remove the confusing multi-entry editing experience from the time-entry dialog.
+- Reuse the existing timesheet list view as the disambiguation surface for grid cells containing multiple entries.
+- Let a grid click on a multi-entry cell land the user on a focused list containing only the exact matching entries.
+- Provide a visible filtered-state UI so users understand why only a subset of entries is shown.
+- Keep the time-entry dialog as a single-entry editor with one clear save action.
+
+## Non-goals
+- Redesign the overall timesheet grid or list layouts.
+- Introduce batch edit or bulk-save behavior for multiple entries.
+- Add inline editing to the list view.
+- Change approval, billing, or time-entry permission rules.
+- Add analytics, observability, or rollout-flag scope beyond this UX change.
+
+## Users and Primary Flows
+Primary users:
+
+- Employees editing their own time sheets
+- Delegated editors editing an authorized subject user’s time sheet
+
+Primary flows:
+
+1. User views a timesheet in grid mode.
+2. User clicks an empty cell and creates a single new entry as they do today.
+3. User clicks a cell with exactly one entry and edits that entry directly as they do today.
+4. User clicks a cell with multiple entries.
+5. The UI switches to list view and shows only the entries from that exact work item/date cell.
+6. A banner explains that the list is filtered and offers `Clear filter` and `Back to grid`.
+7. User clicks one filtered list row.
+8. The existing time-entry dialog opens for that single entry only.
+9. User saves or deletes the entry and returns to the focused list context.
+10. User can clear the filter to stay in list view or explicitly return to the grid.
+
+## UX / UI Notes
+### Grid behavior
+- Empty grid cell: preserve current create-entry behavior.
+- Single-entry grid cell: preserve current direct-open edit behavior.
+- Multi-entry grid cell: do not open the dialog directly; switch to list view with a temporary focus filter.
+
+### List view filtered mode
+- When a multi-entry grid cell is clicked, list view should show only the entries that belong to:
+  - the clicked work item
+  - the clicked date
+  - the clicked entry ids
+- All unrelated day groups and unrelated rows should be hidden entirely.
+- The relevant day section should be expanded automatically.
+- Existing row click behavior should remain unchanged: clicking a row opens the single-entry editor dialog.
+
+### Filter banner
+- Show a prominent, dismissible filtered-state banner above the list.
+- The banner should describe what is being shown, for example:
+  - `Showing 3 entries for Missing White Rabbit on Apr 12`
+- The banner should provide:
+  - `Clear filter` — removes the filter and keeps the user in list view
+  - `Back to grid` — clears the filter and returns the user to grid view
+
+### Dialog behavior
+- The time-entry dialog should always represent exactly one entry.
+- The dialog should no longer render:
+  - an internal list of entries
+  - per-entry save actions
+  - a second dialog-level save competing with row-level save
+  - an in-dialog `Add Entry` action
+- Existing-entry editing should still support delete when permitted.
+- New-entry creation should still be supported, but only for one entry at a time.
+
+## Requirements
+
+### Functional Requirements
+1. Clicking a grid cell with multiple entries must switch the timesheet to list view instead of opening the multi-entry dialog.
+2. The list view must support a temporary focus filter that narrows visible rows to the exact entries represented by the clicked grid cell.
+3. The filtered list view must hide unrelated entries and unrelated day groups entirely.
+4. The filtered list must display a visible banner describing the active filter state.
+5. The filtered-state banner must include a `Clear filter` action that removes the filter while leaving the user in list view.
+6. The filtered-state banner must include a `Back to grid` action that clears the filter and returns the user to grid view.
+7. Clicking a row in the filtered list must open the existing time-entry editor for that single entry.
+8. Empty-cell and single-entry grid interactions must continue to behave as they do today.
+9. Manual switching to grid view while a focus filter is active must clear the filter.
+10. The time-entry dialog must be refactored to edit exactly one entry at a time.
+11. The time-entry dialog must no longer expose multiple save actions for multiple entries.
+12. The time-entry dialog must no longer allow creating additional entries from inside the dialog.
+13. Saving or deleting a single entry from filtered mode must return the user to a coherent list state.
+14. If a filtered entry set becomes empty after edit/delete, the UI must clear the filter and leave the user in an understandable destination state.
+
+### Non-functional Requirements
+- The new flow must reuse the existing list-view and dialog interaction model wherever possible.
+- Filter state should be owned in one place so grid/list/dialog transitions remain predictable.
+- The UI must make the filtered state obvious enough that users do not mistake it for missing data.
+- Existing timesheet edit permissions and delegated-edit rules must remain unchanged.
+
+## Data / API / Integrations
+- No new backend API or schema changes are expected.
+- This should be a client-side orchestration change using data already loaded into the timesheet screen.
+- Recommended state ownership:
+  - `TimeSheet.tsx` owns `viewMode` and the new temporary focus filter state.
+  - `TimeSheetTable.tsx` emits enough click context to distinguish empty, single-entry, and multi-entry cells.
+  - `TimeSheetListView.tsx` accepts an optional focus filter and renders the filtered-state UI.
+  - `TimeEntryDialog.tsx` is simplified to a single-entry form surface.
+
+Approach options considered:
+
+1. Switch to list view with a temporary focus filter and clear banner.
+   - Recommended because it reuses the current list row → dialog flow and removes the ambiguous multi-entry dialog path.
+2. Switch to list view with highlighted matching rows but still show the full day list.
+   - Better than today, but still leaves extra visual noise and ambiguity.
+3. Keep the dialog hybrid and rename buttons (`Save This Entry`, `Save All Changes`).
+   - Lowest code churn, but preserves the confusing “one dialog, many editing models” problem.
+
+## Security / Permissions
+- Existing editability rules for timesheets and time entries remain the source of truth.
+- Delegated editing behavior must remain unchanged.
+- The filtered list view must not surface actions the user could not already take in the unfiltered list or single-entry dialog.
+
+## Rollout / Migration
+- No data migration required.
+- Existing timesheets should continue to work with current data.
+- The main risk is UI regression around grid/list/dialog transitions, not stored data.
+
+## Open Questions
+- After save/delete within filtered mode, the intended default is to keep the user in list context unless the filtered set is empty.
+- If implementation reveals other callers depend on multi-entry `TimeEntryDialog` behavior, they should be migrated to single-entry flows rather than preserving hybrid dialog support.
+
+## Acceptance Criteria (Definition of Done)
+- Clicking a multi-entry grid cell switches to list view and shows only the entries from that exact cell.
+- The filtered list shows a visible banner with `Clear filter` and `Back to grid` actions.
+- `Clear filter` returns the user to the full list while staying in list view.
+- `Back to grid` clears the filter and returns the user to grid view.
+- Clicking a filtered row opens a single-entry editor dialog.
+- The time-entry dialog contains only one save action for one entry.
+- The time-entry dialog no longer supports editing multiple entries at once.
+- The time-entry dialog no longer offers in-dialog `Add Entry` behavior.
+- Empty-cell and single-entry grid interactions still behave correctly.
+- Browser navigation from grid → filtered list → single-entry dialog works without console errors or failed requests in the normal happy path.

--- a/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/SCRATCHPAD.md
@@ -1,0 +1,91 @@
+# Scratchpad — Timesheet Grid Multi-Entry Focus Filter
+
+- Plan slug: `timesheet-grid-multi-entry-focus-filter`
+- Created: `2026-04-12`
+
+## Decisions
+
+- (2026-04-12) For grid cells containing multiple entries, the UI should switch to list view rather than opening a multi-entry dialog.
+- (2026-04-12) The list view should enter a temporary focus-filter mode that shows only the exact matching entries from the clicked grid cell.
+- (2026-04-12) The filtered-state UI should include `Clear filter` and `Back to grid` actions.
+- (2026-04-12) `Clear filter` should keep the user in list view; `Back to grid` should explicitly return them to grid mode.
+- (2026-04-12) The time-entry dialog should be simplified to a single-entry editor only.
+- (2026-04-12) The dialog should no longer support in-dialog multi-entry navigation, multiple save actions, or in-dialog `Add Entry`.
+
+## Discoveries / Constraints
+
+- (2026-04-12) `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx` already owns both `viewMode` and the `selectedCell` dialog-opening flow, which makes it the natural place to own a temporary focus filter.
+- (2026-04-12) `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetListView.tsx` already supports clicking a row to open the existing entry editor flow via `onCellClick`.
+- (2026-04-12) `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx` currently renders a multi-entry editing experience with per-entry save affordances plus a footer save button, which is the source of the user confusion.
+- (2026-04-12) `packages/scheduling/src/components/time-management/time-entry/TimeEntryList.tsx` and `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx` currently encode the multi-entry dialog behavior, including per-entry save and in-dialog add-entry controls.
+- (2026-04-12) `packages/ui/src/components/ViewSwitcher.tsx` auto-generates `#grid-view-btn` and `#list-view-btn`, so the list-mode switch already has stable automation hooks.
+
+## Browser Validation
+
+- (2026-04-12) Verified with Alga Dev on `http://localhost:3300/msp/time-entry/timesheet/2641bbde-b74b-45ed-bbe2-929b511e2660` that `#list-view-btn` switches successfully into list view.
+- (2026-04-12) Verified that `#timesheet-list-view` renders after the switch and that clicking an existing list row opens the current time-entry dialog.
+- (2026-04-12) Verified no failed network requests and no browser console errors on the happy-path grid/list navigation; only non-blocking UI reflection unregister warnings were observed after dialog transitions.
+- (2026-04-12) Post-implementation browser recheck on `localhost:3300` confirmed the list/grid view switch still works. The pane intermittently re-posted the page during HMR-driven refreshes, so the focused multi-entry cell drill-in could not be fully replayed end-to-end in-browser from that pane after the code change; automated component/contract coverage was added for the new filtered-list path.
+
+## Completed Work
+
+- (2026-04-12) Implemented `F001`-`F018`:
+  - Added exact-match multi-entry focus filtering in `TimeSheet.tsx` and `TimeSheetListView.tsx`.
+  - Multi-entry grid cell clicks now switch to list view with a visible filter banner instead of opening the dialog directly.
+  - Added `Clear filter` and `Back to grid` controls in list view.
+  - Simplified `TimeEntryDialog.tsx` to a single-entry editor and removed in-dialog multi-entry/add-entry behavior.
+  - Updated timesheet selection plumbing to keep empty-cell create and single-entry edit flows intact.
+- (2026-04-12) Added focused automated coverage:
+  - `packages/scheduling/tests/timeSheetListView.focusFilter.test.tsx`
+  - `packages/scheduling/tests/timeEntryDialog.singleEntry.contract.test.ts`
+  - `packages/scheduling/tests/timeSheet.multiEntryFilter.contract.test.ts`
+  - Re-ran related contracts/feedback tests for list/table/dialog validation.
+- (2026-04-12) Fixed the timesheet render/fetch loop by keeping initial page data on the server side:
+  - `server/src/app/msp/time-entry/timesheet/[id]/page.tsx` now preloads entries, work items, and comments via server actions.
+  - `TimeSheetClient.tsx` / `TimeSheet.tsx` now consume that initial data instead of issuing mount-time server-action fetches from the client.
+  - `TimeSheetTable.tsx` now uses a stable `work_item_id` row key instead of `Math.random()`, removing unnecessary remount churn.
+- (2026-04-12) Fixed the follow-up click storm on multi-entry grid cells by removing duplicate UI-reflection container registrations from the timesheet main/list/table surfaces while preserving DOM automation IDs.
+  - The old pattern registered `timesheet-main`, `timesheet-table`, and `timesheet-list-view` twice (via both `ReflectionContainer` and `useAutomationIdAndRegister`).
+  - After the cleanup, Alga Dev repro on `#timesheet-table > div > table > tbody > tr > td:nth-child(2) > div` switched to filtered list view without the previous `Rendered more hooks than during the previous render` error, and network activity settled after the initial transition.
+- (2026-04-12) Broadened the timesheet interaction-state cleanup to avoid further whack-a-mole render loops:
+  - `TimeSheet.tsx` now owns a single interaction state for dialog/list-focus/quick-add rather than separate transient grid states.
+  - `TimeSheetTable.tsx` no longer mounts hook-heavy quick-add controls on hover; hover shows a lightweight affordance, and the HH:MM editor only appears in an explicit active quick-add state with deterministic per-cell IDs.
+  - Hidden confirmation/add-work-item dialogs in the timesheet surfaces are now conditionally rendered only when open, reducing background dialog registration churn.
+  - Added focused regression coverage in `packages/scheduling/tests/timeSheetTable.quickAddInteraction.test.ts`.
+- (2026-04-12) Fixed the remaining time-entry dialog max-depth loop by stabilizing dialog initialization and removing another unrelated always-mounted generic dialog source:
+  - `TimeEntryProvider.tsx` now memoizes `initializeEntries`, `updateEntry`, `setEditingIndex`, `updateTimeInputs`, and the provider value, preventing `TimeEntryDialog.tsx` from re-initializing entries on every provider rerender.
+  - This stopped the repeated `Creating new time entry with defaults` loop and removed the reproduced `Maximum update depth exceeded` path when opening the full time-entry dialog from quick-add margin clicks.
+  - The generic `dialog-dialog` UI-state registration came from the layout-level AI interrupt `ConfirmationDialog` in `server/src/components/layout/DefaultLayout.tsx`, which was always mounted without an ID; it is now conditionally rendered only when open and uses an explicit ID.
+  - After these changes, Alga Dev no longer showed `dialog-dialog`, `Rendered more hooks than during the previous render`, or `Maximum update depth exceeded` during the quick-add → full-dialog repro.
+- (2026-04-12) Investigated the remaining low-rate POST noise after the timesheet interaction fixes.
+  - The surviving background POSTs are not coming from timesheet grid/list/dialog state anymore.
+  - They come from layout-level polling server actions that post back to the current App Router route:
+    - `server/src/components/layout/Header.tsx` → `JobActivityIndicator` calls `getQueueMetricsAction()` every 15 seconds.
+    - `packages/notifications/src/components/NotificationBell.tsx` → `useInternalNotifications({ enablePolling: true })` falls back to polling `getNotificationsAction()` every 30 seconds when no `NEXT_PUBLIC_HOCUSPOCUS_URL` is configured on localhost.
+  - In the local wired env, `server/.env.local` sets `HOCUSPOCUS_URL`, but the notification hook specifically checks `NEXT_PUBLIC_HOCUSPOCUS_URL`, so localhost remains on polling fallback.
+  - Observed network cadence matches this: one POST roughly every 15 seconds, with an extra near-simultaneous POST every ~30 seconds.
+  - Conclusion: the remaining POSTs are expected background layout activity, not another timesheet-specific render loop.
+
+## Commands / Runbooks
+
+- Inspect timesheet shell: `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx`
+- Inspect grid view: `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx`
+- Inspect list view: `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetListView.tsx`
+- Inspect dialog: `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx`
+- Inspect multi-entry list wrapper: `packages/scheduling/src/components/time-management/time-entry/TimeEntryList.tsx`
+- Inspect row editor form: `packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx`
+- Inspect generated view switch ids: `packages/ui/src/components/ViewSwitcher.tsx`
+- Browser sanity flow:
+  - `alga-dev browser-get-dom --paneId=<pane> --query='#list-view-btn' --pretty`
+  - `alga-dev browser-click --paneId=<pane> --selector='#list-view-btn'`
+  - `alga-dev browser-wait-for --paneId=<pane> --selector='#timesheet-list-view' --state=visible --timeoutMs=10000`
+  - `alga-dev browser-click --paneId=<pane> --selector='[data-automation-id^="time-entry-row-"]'`
+
+## Open Questions
+
+- If save/delete empties the filtered result set, final implementation should decide whether to remain in list view unfiltered or to return to grid view; current recommendation is to clear the filter and remain in list view unless user explicitly chooses `Back to grid`.
+
+## Links / References
+
+- Plan folder: `ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/`
+- Browser screenshot after row click: `/var/folders/8g/3xyjqdpd4hx2h39h4qb2lyvm0000gn/T/ghostty-pane-ide/screenshots/timesheet-after-row-click.png`

--- a/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/features.json
+++ b/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/features.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "F001",
+    "description": "TimeSheet grid click handling distinguishes empty cells, single-entry cells, and multi-entry cells as separate interaction paths.",
+    "implemented": true,
+    "prdRefs": [
+      "Users and Primary Flows",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Clicking a multi-entry grid cell switches the screen into list view instead of opening the time-entry dialog directly.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "TimeSheet owns a temporary focus-filter state describing the clicked work item, date, and entry ids for a multi-entry grid cell.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations",
+      "Requirements > Non-functional Requirements"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "TimeSheetListView accepts the temporary focus filter and renders only the exact matching entries from the clicked grid cell.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Filtered list mode hides unrelated day groups and unrelated entry rows entirely instead of merely dimming or collapsing them.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "A filtered-state banner appears above the list describing the active focus filter with work item name, date, and entry count.",
+    "implemented": true,
+    "prdRefs": [
+      "Filter banner",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "The filtered-state banner includes a Clear filter action that removes the filter while keeping the user in list view.",
+    "implemented": true,
+    "prdRefs": [
+      "Filter banner",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "The filtered-state banner includes a Back to grid action that clears the filter and returns the user to grid view.",
+    "implemented": true,
+    "prdRefs": [
+      "Filter banner",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Manual switching from list view back to grid view clears any active multi-entry focus filter.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Clicking a row from filtered list mode continues to open the existing editor flow for exactly one time entry.",
+    "implemented": true,
+    "prdRefs": [
+      "List view filtered mode",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "TimeEntryDialog is simplified so it always edits exactly one entry and no longer accepts or renders a multi-entry editing mode.",
+    "implemented": true,
+    "prdRefs": [
+      "Dialog behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "TimeEntryDialog exposes only one clear Save action for the active entry and removes the competing multi-entry save model.",
+    "implemented": true,
+    "prdRefs": [
+      "Problem",
+      "Dialog behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "TimeEntryDialog removes its internal entry list and no longer allows users to jump between multiple entries inside the dialog.",
+    "implemented": true,
+    "prdRefs": [
+      "Dialog behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "TimeEntryDialog removes its in-dialog Add Entry affordance so new entries are initiated only from the grid or list surfaces.",
+    "implemented": true,
+    "prdRefs": [
+      "Dialog behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Existing empty-cell create-entry behavior remains unchanged and still opens a single-entry creation flow.",
+    "implemented": true,
+    "prdRefs": [
+      "Grid behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Existing single-entry grid-cell behavior remains unchanged and still opens direct single-entry editing.",
+    "implemented": true,
+    "prdRefs": [
+      "Grid behavior",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "If the active filtered entry set becomes empty after a save or delete, the UI automatically clears the filter and leaves the user in a coherent destination state.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Delegated editing and normal timesheet editability rules continue to govern all grid, list, and dialog actions in the new flow.",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions",
+      "Requirements > Non-functional Requirements"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/tests.json
+++ b/ee/docs/plans/2026-04-12-timesheet-grid-multi-entry-focus-filter/tests.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "T001",
+    "description": "Component: Clicking a grid cell with multiple entries switches the timesheet to list view and does not open the dialog directly.",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F002"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Component: Clicking an empty grid cell still opens the single-entry creation flow.",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F015"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Component: Clicking a single-entry grid cell still opens direct single-entry editing.",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F016"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "Component: TimeSheetListView focus filtering renders only the exact matching rows for the clicked work item/date/entry-id set and hides unrelated groups.",
+    "implemented": true,
+    "featureIds": [
+      "F003",
+      "F004",
+      "F005"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "Component: Filtered list mode shows a banner describing the focus filter and exposes Clear filter and Back to grid actions.",
+    "implemented": true,
+    "featureIds": [
+      "F006",
+      "F007",
+      "F008"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "Interaction: Clear filter removes the focus filter while keeping the user in list view, and Back to grid clears the filter while restoring grid view.",
+    "implemented": true,
+    "featureIds": [
+      "F007",
+      "F008",
+      "F009"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "Interaction: Clicking a row from filtered list mode opens the single-entry time-entry dialog for that row.",
+    "implemented": true,
+    "featureIds": [
+      "F010",
+      "F011"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "Component: TimeEntryDialog renders only one entry editor, one Save action, and no internal multi-entry list or Add Entry action.",
+    "implemented": true,
+    "featureIds": [
+      "F011",
+      "F012",
+      "F013",
+      "F014"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "Regression: Existing delete behavior for a single editable entry still works from the simplified single-entry dialog.",
+    "implemented": true,
+    "featureIds": [
+      "F011",
+      "F018"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "Interaction: If the active filtered row set becomes empty after delete/save, the UI clears the filter and lands in a coherent remaining view state.",
+    "implemented": true,
+    "featureIds": [
+      "F017"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "Manual browser sanity: grid multi-entry cell \u2192 filtered list \u2192 single-entry dialog navigation works without failed network requests or browser console errors in the happy path.",
+    "implemented": false,
+    "featureIds": [
+      "F002",
+      "F004",
+      "F010",
+      "F011"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "Regression: Delegated or read-only timesheet rules continue to suppress editing actions correctly across grid, filtered list, and single-entry dialog flows.",
+    "implemented": false,
+    "featureIds": [
+      "F018"
+    ]
+  }
+]

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useState, useRef, useCallback, memo, useEffect } from 'react';
-import { Temporal } from '@js-temporal/polyfill';
-import { formatISO, parseISO } from 'date-fns';
+import { formatISO } from 'date-fns';
 import { toast } from 'react-hot-toast';
-import { generateUUID } from '@alga-psa/core';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
 import { Dialog, DialogContent, DialogFooter } from '@alga-psa/ui/components/Dialog';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
@@ -12,19 +10,16 @@ import { deleteTimeEntry, fetchTimeEntriesForTimeSheet } from '../../../../actio
 import { Button } from '@alga-psa/ui/components/Button';
 import { 
   ITimeEntry, 
-  ITimeEntryWithWorkItem, 
-  ITimePeriod,
-  ITimePeriodView, 
+  ITimeEntryWithWorkItem,
+  ITimePeriodView,
   TimeSheetStatus, 
   ITimeEntryWithWorkItemString 
 } from '@alga-psa/types';
 import { IExtendedWorkItem } from '@alga-psa/types';
 import { TimeEntryProvider, useTimeEntry } from './TimeEntryProvider';
-import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
 import TimeEntrySkeletons from './TimeEntrySkeletons';
-import TimeEntryList from '../TimeEntryList';
 import SingleTimeEntryForm from './SingleTimeEntryForm';
-import { validateTimeEntry, calculateDuration } from './utils';
+import { validateTimeEntry } from './utils';
 
 interface TimeEntryDialogProps {
   id?: string;
@@ -54,7 +49,6 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     workItem,
     date,
     existingEntries,
-    timePeriod: _timePeriod,
     isEditable,
     defaultStartTime,
     defaultEndTime,
@@ -68,37 +62,27 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     services,
     taxRegions,
     timeInputs,
-    editingIndex,
     totalDurations,
     isLoading,
     initializeEntries,
     updateEntry,
-    setEditingIndex,
     updateTimeInputs,
   } = useTimeEntry();
 
-  // Convert string dates to Temporal.PlainDate for internal use
-  const timePeriod: ITimePeriod = {
-    ...props.timePeriod,
-    start_date: Temporal.PlainDate.from(props.timePeriod.start_date.slice(0, 10)),
-    end_date: Temporal.PlainDate.from(props.timePeriod.end_date.slice(0, 10))
-  };
 
   const lastNoteInputRef = useRef<HTMLTextAreaElement>(null);
-  const [shouldFocusNotes, setShouldFocusNotes] = useState(false);
-  const hasSetInitialEditingIndex = useRef(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; index: number | null }>({
     isOpen: false,
     index: null
   });
   const [closeConfirmation, setCloseConfirmation] = useState(false);
-  const [activeSave, setActiveSave] = useState<{ source: 'dialog' | 'entry'; index: number } | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
-  // Initialize entries when dialog opens
+  // Initialize a single-entry form whenever the dialog opens.
   useEffect(() => {
     if (isOpen) {
       initializeEntries({
-        existingEntries: existingEntries?.map(entry => ({
+        existingEntries: existingEntries?.slice(0, 1).map(entry => ({
           ...entry,
           notes: entry.notes || workItem.description || ''
         })) || [],
@@ -109,74 +93,14 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         date,
       });
     }
-  }, [isOpen]);
-  
-  // Set editing index for single entry - separate effect to avoid infinite loop
-  useEffect(() => {
-    if (isOpen && existingEntries?.length === 1 && !hasSetInitialEditingIndex.current) {
-      setEditingIndex(0);
-      hasSetInitialEditingIndex.current = true;
-    } else if (!isOpen) {
-      // Reset the flag when dialog closes
-      hasSetInitialEditingIndex.current = false;
-    }
-  }, [isOpen, existingEntries?.length]);
+  }, [date, defaultEndTime, defaultStartTime, defaultTaxRegion, existingEntries, initializeEntries, isOpen, workItem]);
 
-  // Focus notes input when adding new entry
-  useEffect(() => {
-    if (isOpen && lastNoteInputRef.current && shouldFocusNotes) {
-      lastNoteInputRef.current.focus();
-      setShouldFocusNotes(false);
-    }
-  }, [isOpen, shouldFocusNotes]);
+  const handleSaveEntry = useCallback(async (index = 0) => {
+    if (!isEditable || isSaving) return;
 
-  const handleAddEntry = useCallback(() => {
-    if (!isEditable) return;
-
-    let defaultStartTime = new Date(date);
-    if (entries.length > 0) {
-      defaultStartTime = parseISO(entries[entries.length - 1].end_time);
-    } else {
-      defaultStartTime.setHours(8, 0, 0, 0);
-    }
-
-    const defaultEndTime = new Date(defaultStartTime);
-    defaultEndTime.setHours(defaultEndTime.getHours() + 1);
-    const duration = calculateDuration(defaultStartTime, defaultEndTime);
-
-    const newEntry = {
-      // Required fields from schema
-      work_item_id: workItem.work_item_id,
-      work_item_type: workItem.type,
-      start_time: formatISO(defaultStartTime),
-      end_time: formatISO(defaultEndTime),
-      billable_duration: duration,
-      notes: '',
-      created_at: formatISO(new Date()),
-      updated_at: formatISO(new Date()),
-      approval_status: 'DRAFT' as TimeSheetStatus,
-      user_id: '',
-      // Optional fields
-      entry_id: '',
-      service_id: '',
-      tax_region: defaultTaxRegion || '',
-      
-      // Local state fields (not sent to server)
-      isNew: true,
-      tempId: generateUUID(),
-    };
-
-    updateEntry(entries.length, newEntry);
-    setEditingIndex(entries.length);
-    setShouldFocusNotes(true);
-  }, [isEditable, date, entries, workItem, defaultTaxRegion, updateEntry, setEditingIndex]);
-
-  const handleSaveEntry = useCallback(async (index: number, source: 'dialog' | 'entry' = 'entry') => {
-    if (!isEditable) return;
-    if (activeSave) return;
-  
     const entry = entries[index];
-    const shouldKeepDialogOpen = entries.length > 1;
+    if (!entry) return;
+
     console.log('Entry to save:', entry);
 
     const isAdHoc = workItem.type === 'ad_hoc';
@@ -210,25 +134,10 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     const loadingToast = toast.loading('Saving time entry...');
 
     try {
-      setActiveSave({ source, index });
+      setIsSaving(true);
       const { isNew, isDirty, tempId, ...cleanedEntry } = entry;
-
-      // Calculate actual duration for validation purposes
-      const actualDuration = calculateDuration(parseISO(entry.start_time), parseISO(entry.end_time));
-
-      // For ad_hoc items, always set billable_duration to 0
-      // For other items, respect the user's billable setting - use entry.billable_duration as-is
       const durationToSend = isAdHoc ? 0 : entry.billable_duration;
 
-      console.log('Preparing time entry with billable_duration:', {
-        entryBillableDuration: entry.billable_duration,
-        actualDuration,
-        durationToSend,
-        isAdHoc,
-        respectingUserBillableSetting: !isAdHoc
-      });
-
-      // Prepare the time entry with all required fields
       const timeEntry = {
         ...cleanedEntry,
         work_item_id: workItem.work_item_id,
@@ -241,23 +150,12 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         updated_at: formatISO(new Date()),
         notes: entry.notes || '',
         approval_status: 'DRAFT' as TimeSheetStatus,
-        // Ensure service_id and tax_region are null/undefined when not applicable
         service_id: entry.service_id || undefined,
         tax_region: entry.tax_region || undefined,
       };
 
-      console.log('Prepared time entry:', timeEntry);
-
-      console.log('Billable duration before sending to backend:', {
-        billableDuration: timeEntry.billable_duration,
-        type: typeof timeEntry.billable_duration,
-        isZero: timeEntry.billable_duration === 0,
-        isNumber: typeof timeEntry.billable_duration === 'number'
-      });
-
       await onSave(timeEntry);
-  
-      // Fetch updated entries
+
       if (onTimeEntriesUpdate && timeSheetId) {
         const fetchedTimeEntries = await fetchTimeEntriesForTimeSheet(timeSheetId);
         const updatedEntries = fetchedTimeEntries.map(entry => ({
@@ -266,60 +164,26 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
           end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time),
         }));
         await onTimeEntriesUpdate(updatedEntries);
-
-        if (shouldKeepDialogOpen) {
-          await initializeEntries({
-            existingEntries: updatedEntries,
-            workItem,
-            date,
-            defaultTaxRegion
-          });
-        }
       }
-  
+
       toast.dismiss(loadingToast);
       toast.success('Time entry saved');
-
-      if (shouldKeepDialogOpen) {
-        setEditingIndex(null);
-      } else {
-        onClose();
-      }
+      onClose();
     } catch (error) {
       toast.dismiss(loadingToast);
       handleError(error, 'Failed to save time entry. Please try again.');
     } finally {
-      setActiveSave(null);
+      setIsSaving(false);
     }
-  }, [activeSave, isEditable, timeSheetId, entries, services, workItem, onSave, onTimeEntriesUpdate, onClose, initializeEntries, date, defaultTaxRegion, setEditingIndex]);
+  }, [entries, isEditable, isSaving, onClose, onSave, onTimeEntriesUpdate, services, timeSheetId, workItem]);
 
   const deleteTimeEntryAtIndex = async (index: number) => {
     try {
       const entry = entries[index];
-      if (entry.entry_id) {
+      if (entry?.entry_id) {
         await deleteTimeEntry(entry.entry_id);
       }
-      
-      // Remove the entry from state and maintain workItem property
-      const newEntries = entries.filter((_, i) => i !== index).map(entry => ({
-        ...entry,
-        workItem: workItem
-      }));
 
-      if (newEntries.length === 0) {
-        // If no entries left, close the form
-        onClose();
-      } else {
-        // Otherwise reinitialize with remaining entries
-        initializeEntries({
-          existingEntries: newEntries,
-          workItem,
-          date,
-          defaultTaxRegion
-        });
-        setEditingIndex(null);
-      }
-      
       if (onTimeEntriesUpdate && timeSheetId) {
         const fetchedTimeEntries = await fetchTimeEntriesForTimeSheet(timeSheetId);
         const updatedEntries = fetchedTimeEntries.map(entry => ({
@@ -327,8 +191,10 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
           start_time: typeof entry.start_time === 'string' ? entry.start_time : formatISO(entry.start_time),
           end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time),
         }));
-        onTimeEntriesUpdate(updatedEntries);
+        await onTimeEntriesUpdate(updatedEntries);
       }
+
+      onClose();
     } catch (error) {
       handleError(error, 'Failed to delete time entry. Please try again.');
     } finally {
@@ -351,109 +217,93 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
   };
 
   const handleCancel = useCallback(() => {
-    // For new entries that were never saved, don't show confirmation - just close
-    const hasOnlyNewUnsavedEntries = entries.every(entry => entry.isNew && !entry.entry_id);
-    const hasSavedEntriesWithChanges = entries.some(entry => entry.isDirty && entry.entry_id);
-    
-    if (hasOnlyNewUnsavedEntries) {
-      // Just close without saving new entries that were never saved
+    const entry = entries[0];
+
+    if (!entry || (entry.isNew && !entry.entry_id)) {
       onClose();
-    } else if (hasSavedEntriesWithChanges) {
-      // Show confirmation for existing entries that have changes
-      setCloseConfirmation(true);
-    } else {
-      onClose();
+      return;
     }
+
+    if (entry.isDirty && entry.entry_id) {
+      setCloseConfirmation(true);
+      return;
+    }
+
+    onClose();
   }, [entries, onClose]);
 
-  const handleSaveAll = useCallback(async () => {
+  const handleSave = useCallback(async () => {
     if (!isEditable) {
       onClose();
       return;
     }
-    if (activeSave) return;
 
-    // Find the first entry that needs to be saved
-    const entryToSave = entries.findIndex(entry => entry.isDirty || entry.isNew);
-    if (entryToSave !== -1) {
-      await handleSaveEntry(entryToSave, 'dialog');
-    } else {
-      onClose();
+    const entry = entries[0];
+    if (!entry) {
+      return;
     }
-  }, [activeSave, entries, handleSaveEntry, isEditable, onClose]);
 
-  const hasExistingEntries = Boolean(existingEntries && existingEntries.length > 0);
-  const title = hasExistingEntries
-    ? `${isEditable ? 'Edit' : 'View'} Time Entries for ${workItem.name}`
+    if (entry.isDirty || entry.isNew) {
+      await handleSaveEntry(0);
+      return;
+    }
+
+    onClose();
+  }, [entries, handleSaveEntry, isEditable, onClose]);
+
+  const hasExistingEntry = Boolean(existingEntries && existingEntries.length > 0);
+  const title = hasExistingEntry
+    ? `${isEditable ? 'Edit' : 'View'} Time Entry for ${workItem.name}`
     : `Add New Time Entry for ${workItem.name}`;
   const content = (
-    <ReflectionContainer id={id} label={title}>
-      <div className="mx-auto w-full max-w-[35rem]">
-        {inDrawer && <h2 className="mb-4 text-lg font-semibold">{title}</h2>}
-        {isLoading ? (
-          <TimeEntrySkeletons />
-        ) : existingEntries && existingEntries.length > 0 ? (
-          <TimeEntryList
+    <div
+      className="mx-auto w-full max-w-[35rem]"
+      data-automation-id={id}
+      data-automation-type="container"
+    >
+      {inDrawer && <h2 className="mb-4 text-lg font-semibold">{title}</h2>}
+      {isLoading ? (
+        <TimeEntrySkeletons />
+      ) : entries[0] ? (
+        <div className="mt-2">
+          <SingleTimeEntryForm
             id={id}
-            entries={entries}
+            entry={entries[0]}
             services={services}
             taxRegions={taxRegions}
             timeInputs={timeInputs}
-            editingIndex={editingIndex}
-            totalDurations={totalDurations}
+            totalDuration={totalDurations[0] || 0}
             isEditable={isEditable}
             lastNoteInputRef={lastNoteInputRef}
-            onSave={handleSaveEntry}
             onDelete={handleDeleteEntry}
-            onEdit={setEditingIndex}
             onUpdateEntry={updateEntry}
             onUpdateTimeInputs={updateTimeInputs}
-            onAddEntry={handleAddEntry}
             date={date}
-            savingEntryIndex={activeSave?.source === 'entry' ? activeSave.index : null}
-            disableSaveActions={activeSave !== null}
+            isNewEntry={!hasExistingEntry}
           />
-        ) : (
-          <div className="mt-2">
-            <SingleTimeEntryForm
-              id={id}
-              entry={entries[0]}
-              services={services}
-              taxRegions={taxRegions}
-              timeInputs={timeInputs}
-              totalDuration={totalDurations[0] || 0}
-              isEditable={isEditable}
-              lastNoteInputRef={lastNoteInputRef}
-              onDelete={handleDeleteEntry}
-              onUpdateEntry={updateEntry}
-              onUpdateTimeInputs={updateTimeInputs}
-              date={date}
-              isNewEntry={!existingEntries || existingEntries.length === 0}
-            />
-          </div>
-        )}
+        </div>
+      ) : null}
 
-        <DialogFooter>
+      <DialogFooter>
+        <Button
+          id={`${id}-cancel-dialog-btn`}
+          onClick={handleCancel}
+          variant="outline"
+        >
+          {isEditable ? 'Cancel' : 'Close'}
+        </Button>
+        {isEditable && (
           <Button
-            id={`${id}-cancel-dialog-btn`}
-            onClick={handleCancel}
-            variant="outline"
+            id={`${id}-save-dialog-btn`}
+            onClick={handleSave}
+            variant="default"
+            disabled={isSaving}
           >
-            {isEditable ? 'Cancel' : 'Close'}
+            {isSaving ? 'Saving...' : 'Save'}
           </Button>
-          {isEditable && (
-            <Button
-              id={`${id}-save-dialog-btn`}
-              onClick={handleSaveAll}
-              variant="default"
-              disabled={activeSave !== null}
-            >
-              {activeSave?.source === 'dialog' ? 'Saving...' : 'Save'}
-            </Button>
-          )}
-        </DialogFooter>
-      </div>
-    </ReflectionContainer>
+        )}
+      </DialogFooter>
+    </div>
   );
 
   return (
@@ -466,7 +316,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
           onClose={handleCancel} 
           title={title} 
           hideCloseButton={false}
-          id={id}
+          id={`__skip_registration_${id}`}
           data-automation-id={id}
           data-automation-type="time-entry-dialog"
         >
@@ -476,34 +326,38 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         </Dialog>
       )}
 
-      <ConfirmationDialog
-        id={`${id}-delete-confirmation`}
-        isOpen={deleteConfirmation.isOpen}
-        onClose={() => setDeleteConfirmation({ isOpen: false, index: null })}
-        onConfirm={async () => {
-          if (deleteConfirmation.index !== null) {
-            await deleteTimeEntryAtIndex(deleteConfirmation.index);
-          }
-        }}
-        title="Delete Time Entry"
-        message="Are you sure you want to delete this time entry?"
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-      />
+      {deleteConfirmation.isOpen && (
+        <ConfirmationDialog
+          id={`${id}-delete-confirmation`}
+          isOpen={true}
+          onClose={() => setDeleteConfirmation({ isOpen: false, index: null })}
+          onConfirm={async () => {
+            if (deleteConfirmation.index !== null) {
+              await deleteTimeEntryAtIndex(deleteConfirmation.index);
+            }
+          }}
+          title="Delete Time Entry"
+          message="Are you sure you want to delete this time entry?"
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+        />
+      )}
 
-      <ConfirmationDialog
-        id={`${id}-close-confirmation`}
-        isOpen={closeConfirmation}
-        onClose={() => setCloseConfirmation(false)}
-        onConfirm={async () => {
-          onClose();
-          setCloseConfirmation(false);
-        }}
-        title="Discard Changes"
-        message="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep Editing"
-      />
+      {closeConfirmation && (
+        <ConfirmationDialog
+          id={`${id}-close-confirmation`}
+          isOpen={true}
+          onClose={() => setCloseConfirmation(false)}
+          onConfirm={async () => {
+            onClose();
+            setCloseConfirmation(false);
+          }}
+          title="Discard Changes"
+          message="You have unsaved changes. Are you sure you want to discard them?"
+          confirmLabel="Discard"
+          cancelLabel="Keep Editing"
+        />
+      )}
     </>
   );
 });

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useReducer, useEffect } from 'react';
+import { createContext, useContext, useReducer, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { ITimeEntry, ITimeEntryWithWorkItem, ITimePeriod, ITimePeriodView } from '@alga-psa/types';
 import { IExtendedWorkItem } from '@alga-psa/types';
@@ -120,7 +120,7 @@ export function TimeEntryProvider({ children }: { children: React.ReactNode }): 
   const { t } = useTranslation('msp/time-entry');
   const [state, dispatch] = useReducer(timeEntryReducer, initialState);
 
-  const initializeEntries = async ({
+  const initializeEntries = useCallback(async ({
     existingEntries,
     defaultStartTime,
     defaultEndTime,
@@ -130,8 +130,7 @@ export function TimeEntryProvider({ children }: { children: React.ReactNode }): 
   }: InitializeEntriesParams): Promise<void> => {
     try {
       dispatch({ type: 'SET_LOADING', payload: true });
-      
-      // Load all required data in parallel
+
       const clientId = (workItem.type === 'ticket' || workItem.type === 'project_task')
         ? await getClientIdForWorkItem(workItem.work_item_id, workItem.type)
         : null;
@@ -147,123 +146,112 @@ export function TimeEntryProvider({ children }: { children: React.ReactNode }): 
         payload: { services, taxRegions },
       });
 
+      let newEntries: ITimeEntryWithNew[] = [];
 
-    let newEntries: ITimeEntryWithNew[] = [];
+      if (existingEntries?.length) {
+        newEntries = existingEntries.map(({ ...rest }): ITimeEntryWithNew => ({
+          ...rest,
+          start_time: formatISO(parseISO(rest.start_time)),
+          end_time: formatISO(parseISO(rest.end_time)),
+          created_at: formatISO(parseISO(rest.created_at)),
+          updated_at: formatISO(parseISO(rest.updated_at)),
+          tax_region: rest.tax_region || defaultTaxRegion || client?.region_code || '',
+          isNew: false,
+          isDirty: false,
+          client_id: clientId || undefined,
+        }));
+      } else if (defaultStartTime && defaultEndTime) {
+        const duration = calculateDuration(defaultStartTime, defaultEndTime);
+        const isBillable = workItem.is_billable === false ? false : true;
+        const prefilledServiceId = workItem.type === 'project_task' && workItem.service_id
+          ? workItem.service_id
+          : '';
 
-    if (existingEntries?.length) {
-      newEntries = existingEntries.map(({ ...rest }): ITimeEntryWithNew => ({
-        ...rest,
-        start_time: formatISO(parseISO(rest.start_time)),
-        end_time: formatISO(parseISO(rest.end_time)),
-        created_at: formatISO(parseISO(rest.created_at)),
-        updated_at: formatISO(parseISO(rest.updated_at)),
-        tax_region: rest.tax_region || defaultTaxRegion || client?.region_code || '',
-        isNew: false,
-        isDirty: false,
-        client_id: clientId || undefined,
-      }));
-    } else if (defaultStartTime && defaultEndTime) {
-      const duration = calculateDuration(defaultStartTime, defaultEndTime);
+        console.log('Creating new time entry with defaults:', {
+          isBillable,
+          duration,
+          billableDuration: isBillable ? duration : 0,
+          prefilledServiceId: prefilledServiceId || null
+        });
 
-      // Determine if the entry should be billable by default
-      const isBillable = workItem.is_billable === false ? false : true;
-
-      // Check if workItem has a service_id (from project task)
-      const prefilledServiceId = workItem.type === 'project_task' && workItem.service_id
-        ? workItem.service_id
-        : '';
-
-      console.log('Creating new time entry with defaults:', {
-        isBillable,
-        duration,
-        billableDuration: isBillable ? duration : 0,
-        prefilledServiceId: prefilledServiceId || null
-      });
-
-      newEntries = [{
-        work_item_id: workItem.work_item_id,
-        start_time: formatISO(defaultStartTime),
-        end_time: formatISO(defaultEndTime),
-        billable_duration: isBillable ? duration : 0,
-        work_item_type: workItem.type,
-        notes: workItem.description || '',
-        entry_id: '',
-        user_id: '',
-        created_at: formatISO(new Date()),
-        updated_at: formatISO(new Date()),
-        approval_status: 'DRAFT',
-        service_id: prefilledServiceId,
-        tax_region: defaultTaxRegion || client?.region_code || '',
-        isNew: true,
-        tempId: generateUUID(),
-        client_id: clientId || undefined,
-        // Service prefill tracking (only for new entries with prefilled service)
-        _isServicePrefilled: !!prefilledServiceId,
-        _originalServiceId: prefilledServiceId || null,
-        _serviceOverridden: false,
-      }];
-    } else {
-      // For ad-hoc items, get the scheduled times from the schedule entry
-      let startTime: Date, endTime: Date;
-      let scheduleEntry: { scheduled_start: string; scheduled_end: string } | null = null;
-      
-      if (workItem.type === 'ad_hoc') {
-        scheduleEntry = await fetchScheduleEntryForWorkItem(workItem.work_item_id);
-      }
-
-      if (scheduleEntry && workItem.type === 'ad_hoc') {
-        startTime = parseISO(scheduleEntry.scheduled_start);
-        endTime = parseISO(scheduleEntry.scheduled_end);
+        newEntries = [{
+          work_item_id: workItem.work_item_id,
+          start_time: formatISO(defaultStartTime),
+          end_time: formatISO(defaultEndTime),
+          billable_duration: isBillable ? duration : 0,
+          work_item_type: workItem.type,
+          notes: workItem.description || '',
+          entry_id: '',
+          user_id: '',
+          created_at: formatISO(new Date()),
+          updated_at: formatISO(new Date()),
+          approval_status: 'DRAFT',
+          service_id: prefilledServiceId,
+          tax_region: defaultTaxRegion || client?.region_code || '',
+          isNew: true,
+          tempId: generateUUID(),
+          client_id: clientId || undefined,
+          _isServicePrefilled: !!prefilledServiceId,
+          _originalServiceId: prefilledServiceId || null,
+          _serviceOverridden: false,
+        }];
       } else {
-        startTime = new Date(date);
-        startTime.setHours(8, 0, 0, 0);
-        endTime = new Date(startTime);
-        endTime.setHours(9, 0, 0, 0);
+        let startTime: Date, endTime: Date;
+        let scheduleEntry: { scheduled_start: string; scheduled_end: string } | null = null;
+
+        if (workItem.type === 'ad_hoc') {
+          scheduleEntry = await fetchScheduleEntryForWorkItem(workItem.work_item_id);
+        }
+
+        if (scheduleEntry && workItem.type === 'ad_hoc') {
+          startTime = parseISO(scheduleEntry.scheduled_start);
+          endTime = parseISO(scheduleEntry.scheduled_end);
+        } else {
+          startTime = new Date(date);
+          startTime.setHours(8, 0, 0, 0);
+          endTime = new Date(startTime);
+          endTime.setHours(9, 0, 0, 0);
+        }
+
+        const duration = calculateDuration(startTime, endTime);
+        const isBillable = workItem.is_billable === false ? false : true;
+
+        console.log('Creating new ad-hoc time entry:', {
+          isBillable,
+          duration,
+          billableDuration: isBillable ? duration : 0
+        });
+
+        newEntries = [{
+          work_item_id: workItem.work_item_id,
+          start_time: formatISO(startTime),
+          end_time: formatISO(endTime),
+          billable_duration: isBillable ? duration : 0,
+          work_item_type: workItem.type,
+          notes: workItem.description || '',
+          entry_id: '',
+          user_id: '',
+          created_at: formatISO(new Date()),
+          updated_at: formatISO(new Date()),
+          approval_status: 'DRAFT',
+          service_id: '',
+          tax_region: defaultTaxRegion || '',
+          isNew: true,
+          tempId: generateUUID(),
+          client_id: clientId || undefined,
+        }];
       }
-
-      const duration = calculateDuration(startTime, endTime);
-      
-      // Always set to billable (true) unless explicitly set to false
-      const isBillable = workItem.is_billable === false ? false : true;
-      
-      console.log('Creating new ad-hoc time entry:', {
-        isBillable,
-        duration,
-        billableDuration: isBillable ? duration : 0
-      });
-
-      newEntries = [{
-        work_item_id: workItem.work_item_id,
-        start_time: formatISO(startTime),
-        end_time: formatISO(endTime),
-        billable_duration: isBillable ? duration : 0,
-        work_item_type: workItem.type,
-        notes: workItem.description || '',
-        entry_id: '',
-        user_id: '',
-        created_at: formatISO(new Date()),
-        updated_at: formatISO(new Date()),
-        approval_status: 'DRAFT',
-        service_id: '',
-        tax_region: defaultTaxRegion || '',
-        isNew: true,
-        tempId: generateUUID(),
-        client_id: clientId || undefined,
-      }];
-    }
 
       const sortedEntries = [...newEntries].sort((a, b) =>
         parseISO(a.start_time).getTime() - parseISO(b.start_time).getTime()
       );
 
       dispatch({ type: 'SET_ENTRIES', payload: sortedEntries });
-      
-      // Set initial editing index
+
       if (sortedEntries.length === 1 && !existingEntries?.length) {
         dispatch({ type: 'SET_EDITING_INDEX', payload: 0 });
       }
 
-      // Calculate initial durations
       const durations = sortedEntries.map(entry =>
         calculateDuration(parseISO(entry.start_time), parseISO(entry.end_time))
       );
@@ -277,29 +265,31 @@ export function TimeEntryProvider({ children }: { children: React.ReactNode }): 
     } finally {
       dispatch({ type: 'SET_LOADING', payload: false });
     }
-  };
+  }, [t]);
 
-  const updateEntry = (index: number, entry: ITimeEntryWithNew) => {
+  const updateEntry = useCallback((index: number, entry: ITimeEntryWithNew) => {
     dispatch({ type: 'UPDATE_ENTRY', payload: { index, entry } });
-  };
+  }, []);
 
-  const setEditingIndex = (index: number | null) => {
+  const setEditingIndex = useCallback((index: number | null) => {
     dispatch({ type: 'SET_EDITING_INDEX', payload: index });
-  };
+  }, []);
 
-  const updateTimeInputs = (inputs: { [key: string]: string }) => {
+  const updateTimeInputs = useCallback((inputs: { [key: string]: string }) => {
     dispatch({ type: 'UPDATE_TIME_INPUTS', payload: inputs });
-  };
+  }, []);
+
+  const contextValue = useMemo(() => ({
+    ...state,
+    initializeEntries,
+    updateEntry,
+    setEditingIndex,
+    updateTimeInputs,
+  }), [state, initializeEntries, updateEntry, setEditingIndex, updateTimeInputs]);
 
   return (
     <TimeEntryContext.Provider
-      value={{
-        ...state,
-        initializeEntries,
-        updateEntry,
-        setEditingIndex,
-        updateTimeInputs,
-      }}
+      value={contextValue}
     >
       {children}
     </TimeEntryContext.Provider>

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
@@ -14,7 +14,7 @@ import {
 import { IExtendedWorkItem } from '@alga-psa/types';
 import TimeEntryDialog from './TimeEntryDialog';
 import { AddWorkItemDialog } from './AddWorkItemDialog';
-import { fetchTimeEntriesForTimeSheet, fetchWorkItemsForTimeSheet, saveTimeEntry, submitTimeSheet, deleteWorkItem } from '../../../../actions/timeEntryActions';
+import { fetchTimeEntriesForTimeSheet, fetchWorkItemsForTimeSheet, submitTimeSheet, deleteWorkItem } from '../../../../actions/timeEntryActions';
 import { updateScheduleEntry } from '@alga-psa/scheduling/actions';
 import { toast } from 'react-hot-toast';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
@@ -24,21 +24,27 @@ import { formatISO, parseISO, format } from 'date-fns';
 import { TimeSheetTable } from './TimeSheetTable';
 import { TimeSheetListView } from './TimeSheetListView';
 import { TimeSheetHeader, TimeSheetViewMode } from './TimeSheetHeader';
-import { TimeSheetDateNavigatorState } from './types';
+import {
+    TimeEntrySelectionRequest,
+    TimeSheetDateNavigatorState,
+    TimeSheetInteractionState,
+    TimeSheetListFocusFilter,
+    TimeSheetQuickAddState,
+} from './types';
 import { TimeSheetComments } from '../../approvals/TimeSheetComments';
 import { WorkItemDrawer } from './WorkItemDrawer';
 import { IntervalSection } from '../../interval-tracking/IntervalSection';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
-import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
-import { ContainerComponent } from '@alga-psa/ui/ui-reflection/types';
-import { CommonActions } from '@alga-psa/ui/ui-reflection/actionBuilders';
 import { useUserPreference } from '@alga-psa/user-composition/hooks';
 
 const TIMESHEET_VIEW_MODE_SETTING = 'timesheet_view_mode';
 
 interface TimeSheetProps {
     timeSheet: ITimeSheetView;
+    initialEntries: ITimeEntryWithWorkItem[];
+    initialWorkItems: IExtendedWorkItem[];
+    initialComments: ITimeSheetComment[];
     onSaveTimeEntry: (timeEntry: ITimeEntry) => Promise<void>;
     isManager?: boolean;
     subjectName?: string;
@@ -120,8 +126,84 @@ function getDatesInPeriod(timePeriod: ITimePeriodView): Date[] {
     return dates;
 }
 
+function getWorkItemDisplayName(workItem: IExtendedWorkItem): string {
+    if (workItem.type === 'ticket') {
+        return workItem.ticket_number
+            ? `${workItem.ticket_number} - ${workItem.title || workItem.name}`
+            : (workItem.title || workItem.name);
+    }
+
+    return workItem.name;
+}
+
+function groupWorkItemsByType(items: IExtendedWorkItem[]): Record<string, IExtendedWorkItem[]> {
+    return items.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
+        if (!acc[item.type]) {
+            acc[item.type] = [];
+        }
+        acc[item.type].push(item);
+        return acc;
+    }, {});
+}
+
+function groupEntriesByWorkItem(
+    entries: ITimeEntryWithWorkItem[],
+    workItemsMap?: Record<string, IExtendedWorkItem[]>,
+): Record<string, ITimeEntryWithWorkItemString[]> {
+    const grouped = entries.reduce((acc: Record<string, ITimeEntryWithWorkItemString[]>, entry: ITimeEntryWithWorkItem) => {
+        const key = `${entry.work_item_id}`;
+        if (!acc[key]) {
+            acc[key] = [];
+        }
+        acc[key].push({
+            ...entry,
+            start_time: typeof entry.start_time === 'string' ? entry.start_time : formatISO(entry.start_time),
+            end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time)
+        });
+        return acc;
+    }, {});
+
+    if (workItemsMap) {
+        Object.values(workItemsMap).forEach((items) => {
+            items.forEach((workItem) => {
+                if (!grouped[workItem.work_item_id]) {
+                    grouped[workItem.work_item_id] = [];
+                }
+            });
+        });
+    }
+
+    return grouped;
+}
+
+function parseQuickAddDurationToMinutes(value: string): number {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return 0;
+    }
+
+    const colonMatch = trimmedValue.match(/^(\d{1,2}):(\d{1,2})$/);
+    if (colonMatch) {
+        const hours = parseInt(colonMatch[1], 10);
+        const minutes = parseInt(colonMatch[2], 10);
+        return Number.isFinite(hours) && Number.isFinite(minutes)
+            ? (hours * 60) + minutes
+            : 0;
+    }
+
+    if (/^(\d+\.?\d*)$/.test(trimmedValue)) {
+        const hours = parseFloat(trimmedValue);
+        return Number.isFinite(hours) ? Math.round(hours * 60) : 0;
+    }
+
+    return 0;
+}
+
 export function TimeSheet({
     timeSheet: initialTimeSheet,
+    initialEntries,
+    initialWorkItems,
+    initialComments,
     onSaveTimeEntry,
     isManager = false,
     subjectName,
@@ -138,14 +220,18 @@ export function TimeSheet({
 }: TimeSheetProps): React.JSX.Element {
     const [showIntervals, setShowIntervals] = useState(false);
     const [dateNavigator, setDateNavigator] = useState<TimeSheetDateNavigatorState | null>(null);
-    const [isLoadingTimeSheetData, setIsLoadingTimeSheetData] = useState(true);
+    const isLoadingTimeSheetData = false;
     const [timeSheet, setTimeSheet] = useState<ITimeSheetView>(initialTimeSheet);
-    const [workItemsByType, setWorkItemsByType] = useState<Record<string, IExtendedWorkItem[]>>({});
-    const [groupedTimeEntries, setGroupedTimeEntries] = useState<Record<string, ITimeEntryWithWorkItemString[]>>({});
+    const [workItemsByType, setWorkItemsByType] = useState<Record<string, IExtendedWorkItem[]>>(() =>
+        groupWorkItemsByType(initialWorkItems)
+    );
+    const [groupedTimeEntries, setGroupedTimeEntries] = useState<Record<string, ITimeEntryWithWorkItemString[]>>(() =>
+        groupEntriesByWorkItem(initialEntries, groupWorkItemsByType(initialWorkItems))
+    );
     const [isAddWorkItemDialogOpen, setIsAddWorkItemDialogOpen] = useState(false);
     const [addWorkItemDate, setAddWorkItemDate] = useState<string | null>(null);
     const [localWorkItems, setLocalWorkItems] = useState<IExtendedWorkItem[]>([]);
-    const [comments, setComments] = useState<ITimeSheetComment[]>([]);
+    const [comments, setComments] = useState<ITimeSheetComment[]>(initialComments);
     const [isLoadingComments, setIsLoadingComments] = useState(false);
     const { openDrawer, closeDrawer } = useDrawer();
 
@@ -159,135 +245,210 @@ export function TimeSheet({
         {
             defaultValue: 'grid',
             localStorageKey: TIMESHEET_VIEW_MODE_SETTING,
-            debounceMs: 300
+            debounceMs: 300,
+            skipServerFetch: true,
         }
     );
 
+    const [interactionState, setInteractionState] = useState<TimeSheetInteractionState>({ type: 'idle' });
+
+    const selectedCell = interactionState.type === 'dialog'
+        ? interactionState.selection
+        : null;
+    const listFocusFilter = interactionState.type === 'list-focus'
+        ? interactionState.filter
+        : null;
+    const activeQuickAdd = interactionState.type === 'quick-add'
+        ? interactionState.quickAdd
+        : null;
+
     const handleViewModeChange = useCallback((newMode: TimeSheetViewMode) => {
+        setInteractionState((currentInteraction) => {
+            if (currentInteraction.type === 'quick-add') {
+                return { type: 'idle' };
+            }
+
+            if (newMode === 'grid' && currentInteraction.type === 'list-focus') {
+                return { type: 'idle' };
+            }
+
+            return currentInteraction;
+        });
         setViewMode(newMode);
     }, [setViewMode]);
 
-    const [selectedCell, setSelectedCell] = useState<{
-        workItem: IExtendedWorkItem;
-        date: string;
-        entries: ITimeEntryWithWorkItemString[];
-        defaultStartTime?: string;
-        defaultEndTime?: string;
-    } | null>(null);
+    const handleClearListFocusFilter = useCallback(() => {
+        setInteractionState((currentInteraction) =>
+            currentInteraction.type === 'list-focus' ? { type: 'idle' } : currentInteraction
+        );
+    }, []);
 
-    const initialDateObj = initialDate ? parseISO(initialDate) : undefined;
-    if (initialDateObj) {
-        initialDateObj.setHours(0, 0, 0, 0);
-    }
+    const handleBackToGrid = useCallback(() => {
+        setInteractionState((currentInteraction) =>
+            currentInteraction.type === 'list-focus' ? { type: 'idle' } : currentInteraction
+        );
+        setViewMode('grid');
+    }, [setViewMode]);
+
+    const handleTimeEntrySelection = useCallback((selection: TimeEntrySelectionRequest) => {
+        const normalizedDate = toDateOnlyString(selection.date);
+
+        if (selection.entries.length > 1) {
+            setInteractionState({
+                type: 'list-focus',
+                filter: {
+                    workItemId: selection.workItem.work_item_id,
+                    workItemLabel: getWorkItemDisplayName(selection.workItem),
+                    date: normalizedDate,
+                    dateLabel: format(parseLocalDate(normalizedDate), 'MMM d'),
+                    entryIds: selection.entries
+                        .map((entry) => entry.entry_id)
+                        .filter((entryId): entryId is string => Boolean(entryId)),
+                    entryCount: selection.entries.length,
+                },
+            });
+            setViewMode('list');
+            return;
+        }
+
+        setInteractionState({
+            type: 'dialog',
+            selection: {
+                ...selection,
+                date: normalizedDate,
+                entries: selection.entries.slice(0, 1),
+            },
+        });
+    }, [setViewMode]);
+
+    const initialDateObj = useMemo(() => {
+        if (!initialDate) {
+            return undefined;
+        }
+
+        const parsedDate = parseISO(initialDate);
+        parsedDate.setHours(0, 0, 0, 0);
+        return parsedDate;
+    }, [initialDate]);
+
+    const syncListFocusFilter = useCallback((entries: ITimeEntryWithWorkItem[]) => {
+        setInteractionState((currentInteraction) => {
+            if (currentInteraction.type !== 'list-focus') {
+                return currentInteraction;
+            }
+
+            const currentFilter = currentInteraction.filter;
+            const matchingEntries = entries.filter((entry) => {
+                const entryDate = entry.work_date?.slice(0, 10) ?? toDateOnlyString(entry.start_time);
+                return entry.work_item_id === currentFilter.workItemId &&
+                    entryDate === currentFilter.date &&
+                    typeof entry.entry_id === 'string' &&
+                    currentFilter.entryIds.includes(entry.entry_id);
+            });
+
+            if (matchingEntries.length === 0) {
+                return { type: 'idle' };
+            }
+
+            return {
+                type: 'list-focus',
+                filter: {
+                    ...currentFilter,
+                    entryIds: matchingEntries
+                        .map((entry) => entry.entry_id)
+                        .filter((entryId): entryId is string => Boolean(entryId)),
+                    entryCount: matchingEntries.length,
+                },
+            };
+        });
+    }, []);
+
+    const applyTimeEntryUpdates = useCallback((entries: ITimeEntryWithWorkItem[], workItemsMap?: Record<string, IExtendedWorkItem[]>) => {
+        setGroupedTimeEntries(groupEntriesByWorkItem(entries, workItemsMap));
+        syncListFocusFilter(entries);
+    }, [syncListFocusFilter]);
+
+    const activateQuickAdd = useCallback((quickAddTarget: Omit<TimeSheetQuickAddState, 'value'>) => {
+        setInteractionState((currentInteraction) => {
+            if (
+                currentInteraction.type === 'quick-add' &&
+                currentInteraction.quickAdd.workItem.work_item_id === quickAddTarget.workItem.work_item_id &&
+                currentInteraction.quickAdd.date === quickAddTarget.date
+            ) {
+                return currentInteraction;
+            }
+
+            return {
+                type: 'quick-add',
+                quickAdd: {
+                    ...quickAddTarget,
+                    value: '',
+                },
+            };
+        });
+    }, []);
+
+    const updateQuickAddValue = useCallback((value: string) => {
+        setInteractionState((currentInteraction) =>
+            currentInteraction.type === 'quick-add'
+                ? {
+                    type: 'quick-add',
+                    quickAdd: {
+                        ...currentInteraction.quickAdd,
+                        value,
+                    },
+                }
+                : currentInteraction
+        );
+    }, []);
+
+    const cancelQuickAdd = useCallback(() => {
+        setInteractionState((currentInteraction) =>
+            currentInteraction.type === 'quick-add' ? { type: 'idle' } : currentInteraction
+        );
+    }, []);
 
     useEffect(() => {
-        const loadComments = async () => {
-            if (timeSheet.approval_status !== 'DRAFT') {
-                setIsLoadingComments(true);
-                try {
-                    const fetchedComments = await fetchTimeSheetComments(timeSheet.id);
-                    setComments(fetchedComments);
-                } catch (error) {
-                    console.error('Failed to fetch comments:', error);
-                } finally {
-                    setIsLoadingComments(false);
-                }
+        if (!initialWorkItem || !initialDateObj || !initialDuration) {
+            return;
+        }
+
+        let endTime = new Date();
+        const durationInMilliseconds = Math.ceil(initialDuration / 60) * 60 * 1000;
+        let startTime = new Date(endTime.getTime() - durationInMilliseconds);
+
+        startTime.setFullYear(initialDateObj.getFullYear(), initialDateObj.getMonth(), initialDateObj.getDate());
+        endTime.setFullYear(initialDateObj.getFullYear(), initialDateObj.getMonth(), initialDateObj.getDate());
+
+        if (startTime < initialDateObj) {
+            startTime = new Date(initialDateObj);
+            startTime.setHours(0, 0, 0, 0);
+            endTime = new Date(startTime.getTime() + durationInMilliseconds);
+        }
+
+        const endOfDay = new Date(initialDateObj);
+        endOfDay.setHours(23, 59, 59, 999);
+        if (endTime > endOfDay) {
+            endTime = new Date(endOfDay);
+            startTime = new Date(endTime.getTime() - durationInMilliseconds);
+
+            if (startTime < initialDateObj) {
+                startTime = new Date(initialDateObj);
+                startTime.setHours(0, 0, 0, 0);
             }
-        };
+        }
 
-        loadComments();
-    }, [timeSheet.id, timeSheet.approval_status]);
-
-    useEffect(() => {
-        const loadData = async () => {
-            setIsLoadingTimeSheetData(true);
-            let groupedLocal: Record<string, ITimeEntryWithWorkItemString[]> = {};
-            try {
-                const [fetchedTimeEntries, fetchedWorkItems, updatedTimeSheet] = await Promise.all([
-                    fetchTimeEntriesForTimeSheet(timeSheet.id),
-                    fetchWorkItemsForTimeSheet(timeSheet.id),
-                    fetchTimeSheet(timeSheet.id)
-                ]);
-
-                setTimeSheet(updatedTimeSheet);
-
-                let workItems = fetchedWorkItems;
-                if (initialWorkItem && !workItems.some(item => item.work_item_id === initialWorkItem.work_item_id)) {
-                    workItems = [...workItems, initialWorkItem];
-                }
-
-                const fetchedWorkItemsByType = workItems.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
-                    if (!acc[item.type]) {
-                        acc[item.type] = [];
-                    }
-                    acc[item.type].push(item);
-                    return acc;
-                }, {});
-                setWorkItemsByType(fetchedWorkItemsByType);
-
-                groupedLocal = fetchedTimeEntries.reduce((acc: Record<string, ITimeEntryWithWorkItemString[]>, entry: ITimeEntryWithWorkItem) => {
-                    const key = `${entry.work_item_id}`;
-                    if (!acc[key]) {
-                        acc[key] = [];
-                    }
-                    acc[key].push({
-                        ...entry,
-                        start_time: typeof entry.start_time === 'string' ? entry.start_time : formatISO(entry.start_time),
-                        end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time)
-                    });
-                    return acc;
-                }, {});
-
-                workItems.forEach(workItem => {
-                    const key = workItem.work_item_id;
-                    if (!groupedLocal[key]) {
-                        groupedLocal[key] = [];
-                    }
-                });
-
-                setGroupedTimeEntries(groupedLocal);
-            } finally {
-                setIsLoadingTimeSheetData(false);
-            }
-
-            if (initialWorkItem && initialDateObj && initialDuration) {
-                let endTime = new Date();
-                const durationInMilliseconds = Math.ceil(initialDuration / 60) * 60 * 1000;
-                let startTime = new Date(endTime.getTime() - durationInMilliseconds);
-
-                startTime.setFullYear(initialDateObj.getFullYear(), initialDateObj.getMonth(), initialDateObj.getDate());
-                endTime.setFullYear(initialDateObj.getFullYear(), initialDateObj.getMonth(), initialDateObj.getDate());
-
-                if (startTime < initialDateObj) {
-                    startTime = new Date(initialDateObj);
-                    startTime.setHours(0, 0, 0, 0);
-                    endTime = new Date(startTime.getTime() + durationInMilliseconds);
-                }
-
-                const endOfDay = new Date(initialDateObj);
-                endOfDay.setHours(23, 59, 59, 999);
-                if (endTime > endOfDay) {
-                    endTime = new Date(endOfDay);
-                    startTime = new Date(endTime.getTime() - durationInMilliseconds);
-
-                    if (startTime < initialDateObj) {
-                        startTime = new Date(initialDateObj);
-                        startTime.setHours(0, 0, 0, 0);
-                    }
-                }
-
-                setSelectedCell({
-                    workItem: initialWorkItem,
-                    date: formatISO(initialDateObj, { representation: 'date' }),
-                    entries: groupedLocal[initialWorkItem.work_item_id] || [],
-                    defaultStartTime: formatISO(startTime),
-                    defaultEndTime: formatISO(endTime)
-                });
-            }
-        };
-
-        loadData();
-    }, [timeSheet.id, initialWorkItem, initialDateObj, initialDuration]);
+        setInteractionState({
+            type: 'dialog',
+            selection: {
+                workItem: initialWorkItem,
+                date: formatISO(initialDateObj, { representation: 'date' }),
+                entries: [],
+                defaultStartTime: formatISO(startTime),
+                defaultEndTime: formatISO(endTime)
+            },
+        });
+    }, [initialWorkItem, initialDateObj, initialDuration]);
 
     const handleQuickAddTimeEntry = async (params: {
         workItem: IExtendedWorkItem;
@@ -348,6 +509,50 @@ export function TimeSheet({
         await handleSaveTimeEntry(timeEntry);
     };
 
+    const refreshTimeSheetData = useCallback(async () => {
+        const [fetchedTimeEntries, fetchedWorkItems] = await Promise.all([
+            fetchTimeEntriesForTimeSheet(timeSheet.id),
+            fetchWorkItemsForTimeSheet(timeSheet.id)
+        ]);
+
+        const fetchedWorkItemsByType = groupWorkItemsByType(fetchedWorkItems);
+        setWorkItemsByType(fetchedWorkItemsByType);
+        applyTimeEntryUpdates(fetchedTimeEntries, fetchedWorkItemsByType);
+
+        return {
+            fetchedTimeEntries,
+            fetchedWorkItems,
+            fetchedWorkItemsByType,
+        };
+    }, [applyTimeEntryUpdates, timeSheet.id]);
+
+    const submitQuickAdd = useCallback(async () => {
+        if (!activeQuickAdd) {
+            return;
+        }
+
+        const durationInMinutes = parseQuickAddDurationToMinutes(activeQuickAdd.value);
+        if (durationInMinutes <= 0) {
+            return;
+        }
+
+        const allEntriesForWorkItem = groupedTimeEntries[activeQuickAdd.workItem.work_item_id] || [];
+        const existingEntry = allEntriesForWorkItem.length > 0 ? allEntriesForWorkItem[0] : undefined;
+
+        try {
+            await handleQuickAddTimeEntry({
+                workItem: activeQuickAdd.workItem,
+                date: activeQuickAdd.date,
+                durationInMinutes,
+                existingEntry,
+            });
+
+            setInteractionState({ type: 'idle' });
+        } catch {
+            // Error handling/toast is already performed downstream in handleSaveTimeEntry.
+        }
+    }, [activeQuickAdd, groupedTimeEntries, handleQuickAddTimeEntry]);
+
     const handleSaveTimeEntry = async (timeEntry: ITimeEntry) => {
         try {
             // Ensure timeEntry has all required fields
@@ -363,47 +568,7 @@ export function TimeSheet({
             // Save the time entry and get the response
             await onSaveTimeEntry(completeTimeEntry);
 
-            // Refresh the data
-            const [fetchedTimeEntries, fetchedWorkItems] = await Promise.all([
-                fetchTimeEntriesForTimeSheet(timeSheet.id),
-                fetchWorkItemsForTimeSheet(timeSheet.id)
-            ]);
-
-            // Update work items state
-            const fetchedWorkItemsByType = fetchedWorkItems.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
-                if (!acc[item.type]) {
-                    acc[item.type] = [];
-                }
-                acc[item.type].push(item);
-                return acc;
-            }, {});
-            setWorkItemsByType(fetchedWorkItemsByType);
-
-            // Update time entries state
-            const grouped = fetchedTimeEntries.reduce((acc: Record<string, ITimeEntryWithWorkItemString[]>, entry: ITimeEntryWithWorkItem) => {
-                const key = `${entry.work_item_id}`;
-                if (!acc[key]) {
-                    acc[key] = [];
-                }
-                acc[key].push({
-                    ...entry,
-                    start_time: typeof entry.start_time === 'string' ? entry.start_time : formatISO(entry.start_time),
-                    end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time)
-                });
-                return acc;
-            }, {});
-
-            // Ensure all work items have an entry in groupedTimeEntries
-            Object.keys(workItemsByType).forEach(type => {
-                workItemsByType[type].forEach(workItem => {
-                    const key = workItem.work_item_id;
-                    if (!grouped[key]) {
-                        grouped[key] = [];
-                    }
-                });
-            });
-
-            setGroupedTimeEntries(grouped);
+            await refreshTimeSheetData();
 
             if (localWorkItems.length > 0) {
                 setLocalWorkItems([]);
@@ -430,6 +595,9 @@ export function TimeSheet({
     };
 
   const openAddWorkItemDialog = useCallback((date?: string) => {
+    setInteractionState((currentInteraction) =>
+      currentInteraction.type === 'quick-add' ? { type: 'idle' } : currentInteraction
+    );
     setAddWorkItemDate(normalizeOptionalDateInput(date));
     setIsAddWorkItemDialogOpen(true);
   }, []);
@@ -484,11 +652,11 @@ export function TimeSheet({
       defaultEndTime.setHours(9, 0, 0, 0); // 9:00 AM (1 hour duration)
     }
 
-    // Open the time entry dialog for the selected work item
-    // The work item will be added to the time sheet only when the time entry is saved
-    setSelectedCell({
+    // Open the time entry dialog for the selected work item.
+    // The work item will be added to the time sheet only when the time entry is saved.
+    handleTimeEntrySelection({
       workItem,
-      date: formatISO(currentDate, { representation: 'date' }), // Format as YYYY-MM-DD string
+      date: formatISO(currentDate, { representation: 'date' }),
       entries: [],
       defaultStartTime: defaultStartTime ? formatISO(defaultStartTime) : undefined,
       defaultEndTime: defaultEndTime ? formatISO(defaultEndTime) : undefined
@@ -512,24 +680,15 @@ export function TimeSheet({
         }
     };
 
-    const handleTaskUpdate = useCallback(async (updated: any) => {
+    const handleTaskUpdate = useCallback(async (_updated: any) => {
         try {
-            const fetchedWorkItems = await fetchWorkItemsForTimeSheet(timeSheet.id);
-            const fetchedWorkItemsByType = fetchedWorkItems.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
-                if (!acc[item.type]) {
-                    acc[item.type] = [];
-                }
-                acc[item.type].push(item);
-                return acc;
-            }, {});
-            setWorkItemsByType(fetchedWorkItemsByType);
-
+            await refreshTimeSheetData();
             toast.success('Task updated successfully');
             closeDrawer();
         } catch (error) {
             handleError(error, 'Failed to update task');
         }
-    }, [timeSheet.id, closeDrawer]); // Added useCallback and dependencies
+    }, [closeDrawer, refreshTimeSheetData]);
 
     const handleScheduleUpdate = useCallback(async (updated: any) => {
         try {
@@ -547,63 +706,38 @@ export function TimeSheet({
                 return;
             }
 
-            const fetchedWorkItems = await fetchWorkItemsForTimeSheet(timeSheet.id);
-            const fetchedWorkItemsByType = fetchedWorkItems.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
-                if (!acc[item.type]) {
-                    acc[item.type] = [];
-                }
-                acc[item.type].push(item);
-                return acc;
-            }, {});
-            setWorkItemsByType(fetchedWorkItemsByType);
-
+            await refreshTimeSheetData();
             toast.success('Changes saved successfully');
             closeDrawer();
         } catch (error) {
             handleError(error, 'Failed to save changes');
         }
-    }, [timeSheet.id, closeDrawer]); // Added useCallback and dependencies
+    }, [closeDrawer, refreshTimeSheetData]);
 
     const handleDeleteWorkItem = useCallback(async (workItemId: string) => {
         try {
             await deleteWorkItem(workItemId);
-
-            // Refresh work items and time entries after deletion
-            const [fetchedTimeEntries, fetchedWorkItems] = await Promise.all([
-                fetchTimeEntriesForTimeSheet(timeSheet.id),
-                fetchWorkItemsForTimeSheet(timeSheet.id)
-            ]);
-
-            // Update work items state
-            const fetchedWorkItemsByType = fetchedWorkItems.reduce((acc: Record<string, IExtendedWorkItem[]>, item) => {
-                if (!acc[item.type]) {
-                    acc[item.type] = [];
+            await refreshTimeSheetData();
+            setInteractionState((currentInteraction) => {
+                if (currentInteraction.type === 'quick-add' && currentInteraction.quickAdd.workItem.work_item_id === workItemId) {
+                    return { type: 'idle' };
                 }
-                acc[item.type].push(item);
-                return acc;
-            }, {});
-            setWorkItemsByType(fetchedWorkItemsByType);
 
-            // Update time entries state
-            const grouped = fetchedTimeEntries.reduce((acc: Record<string, ITimeEntryWithWorkItemString[]>, entry: ITimeEntryWithWorkItem) => {
-                const key = `${entry.work_item_id}`;
-                if (!acc[key]) {
-                    acc[key] = [];
+                if (currentInteraction.type === 'dialog' && currentInteraction.selection.workItem.work_item_id === workItemId) {
+                    return { type: 'idle' };
                 }
-                acc[key].push({
-                    ...entry,
-                    start_time: typeof entry.start_time === 'string' ? entry.start_time : formatISO(entry.start_time),
-                    end_time: typeof entry.end_time === 'string' ? entry.end_time : formatISO(entry.end_time)
-                });
-                return acc;
-            }, {});
 
-            setGroupedTimeEntries(grouped);
+                if (currentInteraction.type === 'list-focus' && currentInteraction.filter.workItemId === workItemId) {
+                    return { type: 'idle' };
+                }
+
+                return currentInteraction;
+            });
             toast.success('Work item deleted successfully');
         } catch (error) {
             handleError(error, 'Failed to delete work item');
         }
-    }, [timeSheet.id]);
+    }, [refreshTimeSheetData]);
 
     const handleWorkItemClick = useCallback((workItem: IExtendedWorkItem) => {
         openDrawer(
@@ -655,26 +789,15 @@ export function TimeSheet({
     const delegatedEditingBlocked = isDelegated && !allowDelegatedEditing;
     const effectiveIsEditable = isEditable && !delegatedEditingBlocked;
 
-    // Register the main TimeSheet container for UI automation
-    const { automationIdProps: timeSheetProps } = useAutomationIdAndRegister<ContainerComponent>({
-        type: 'container',
+    const timeSheetAutomationProps = {
         id: 'timesheet-main',
-        label: 'Time Sheet Management',
-    }, () => [
-        CommonActions.focus('Focus on time sheet'),
-        ...(effectiveIsEditable ? [
-            {
-                type: 'click' as const,
-                available: true,
-                description: 'Add new work item to timesheet',
-                parameters: []
-            }
-        ] : [])
-    ]);
+        'data-automation-id': 'timesheet-main',
+        'data-automation-type': 'container',
+    } as const;
 
     return (
         <ReflectionContainer id="timesheet-main" label="Time Sheet Management">
-            <div className="h-full overflow-y-auto" {...timeSheetProps}>
+            <div className="h-full overflow-y-auto" {...timeSheetAutomationProps}>
                 {delegatedEditingBlocked && (
                     <Alert variant="warning" className="mb-4">
                         <AlertDescription>
@@ -735,9 +858,13 @@ export function TimeSheet({
                     groupedTimeEntries={groupedTimeEntries}
                     isEditable={effectiveIsEditable}
                     isLoading={isLoadingTimeSheetData || isViewModeLoading}
-                    onCellClick={setSelectedCell}
+                    onCellClick={handleTimeEntrySelection}
                     onAddWorkItem={openAddWorkItemDialog}
-                    onQuickAddTimeEntry={handleQuickAddTimeEntry}
+                    activeQuickAdd={activeQuickAdd}
+                    onActivateQuickAdd={activateQuickAdd}
+                    onQuickAddValueChange={updateQuickAddValue}
+                    onQuickAddCancel={cancelQuickAdd}
+                    onQuickAddSubmit={submitQuickAdd}
                     onDateNavigatorChange={setDateNavigator}
                     onWorkItemClick={handleWorkItemClick}
                     onDeleteWorkItem={handleDeleteWorkItem}
@@ -749,10 +876,13 @@ export function TimeSheet({
                     groupedTimeEntries={groupedTimeEntries}
                     isEditable={effectiveIsEditable}
                     isLoading={isLoadingTimeSheetData || isViewModeLoading}
-                    onCellClick={setSelectedCell}
+                    onCellClick={handleTimeEntrySelection}
                     onAddWorkItem={openAddWorkItemDialog}
                     onWorkItemClick={handleWorkItemClick}
                     onDeleteWorkItem={handleDeleteWorkItem}
+                    focusFilter={listFocusFilter}
+                    onClearFocusFilter={handleClearListFocusFilter}
+                    onBackToGrid={handleBackToGrid}
                 />
             )}
 
@@ -760,7 +890,7 @@ export function TimeSheet({
                 <TimeEntryDialog
                     id="time-entry-dialog"
                     isOpen={true}
-                    onClose={() => setSelectedCell(null)}
+                    onClose={() => setInteractionState({ type: 'idle' })}
                     onSave={handleSaveTimeEntry}
                     workItem={selectedCell.workItem}
                     date={parseLocalDate(selectedCell.date)}
@@ -774,34 +904,14 @@ export function TimeSheet({
                     timeSheetId={timeSheet.id}
                     inDrawer={false}
                     onTimeEntriesUpdate={(entries) => {
-                        const grouped = entries.reduce((acc, entry) => {
-                            const key = `${entry.work_item_id}`;
-                            if (!acc[key]) {
-                                acc[key] = [];
-                            }
-                            acc[key].push(entry);
-                            return acc;
-                        }, {} as Record<string, ITimeEntryWithWorkItemString[]>);
-                        setGroupedTimeEntries(grouped);
-                        
-                        if (selectedCell) {
-                            const updatedEntries = entries.filter(entry => 
-                                entry.work_item_id === selectedCell.workItem.work_item_id &&
-                                (entry.work_date?.slice(0, 10) === selectedCell.date ||
-                                  parseISO(entry.start_time).toDateString() === parseLocalDate(selectedCell.date).toDateString())
-                            );
-                            setSelectedCell(prev => prev ? {
-                                ...prev,
-                                entries: updatedEntries
-                            } : null);
-                        }
+                        applyTimeEntryUpdates(entries as ITimeEntryWithWorkItem[]);
                     }}
                 />
             )}
 
-            {timeSheet.time_period && (
+            {timeSheet.time_period && isAddWorkItemDialogOpen && (
                 <AddWorkItemDialog
-                    isOpen={isAddWorkItemDialogOpen}
+                    isOpen={true}
                     onClose={() => {
                         setIsAddWorkItemDialogOpen(false);
                         setAddWorkItemDate(null);

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetClient.tsx
@@ -3,7 +3,15 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import type { ITimeEntry, ITimeSheetView, IUser, IUserWithRoles } from '@alga-psa/types';
+import type {
+  IExtendedWorkItem,
+  ITimeEntry,
+  ITimeEntryWithWorkItem,
+  ITimeSheetComment,
+  ITimeSheetView,
+  IUser,
+  IUserWithRoles,
+} from '@alga-psa/types';
 import { saveTimeEntry, fetchOrCreateTimeSheet } from '@alga-psa/scheduling/actions/timeEntryActions';
 import { fetchEligibleTimeEntrySubjects } from '@alga-psa/scheduling/actions/timeEntryDelegationActions';
 import { fetchTimeSheet, reverseTimeSheetApproval } from '@alga-psa/scheduling/actions/timeSheetActions';
@@ -18,9 +26,20 @@ interface TimeSheetClientProps {
   currentUser: IUserWithRoles;
   isManager: boolean;
   canReopenForEdits: boolean;
+  initialEntries: ITimeEntryWithWorkItem[];
+  initialWorkItems: IExtendedWorkItem[];
+  initialComments: ITimeSheetComment[];
 }
 
-export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUser, isManager, canReopenForEdits }: TimeSheetClientProps) {
+export default function TimeSheetClient({
+  timeSheet: initialTimeSheet,
+  currentUser,
+  isManager,
+  canReopenForEdits,
+  initialEntries,
+  initialWorkItems,
+  initialComments,
+}: TimeSheetClientProps) {
   const { t } = useTranslation('msp/time-entry');
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -117,6 +136,9 @@ export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUs
     <>
       <TimeSheet
         timeSheet={timeSheet}
+        initialEntries={initialEntries}
+        initialWorkItems={initialWorkItems}
+        initialComments={initialComments}
         onSaveTimeEntry={handleSaveTimeEntry}
         isManager={isManager}
         subjectName={allowDelegatedEditing && subjectUser ? formatUserName(subjectUser) : undefined}
@@ -129,18 +151,21 @@ export default function TimeSheetClient({ timeSheet: initialTimeSheet, currentUs
         onBack={handleBack}
       />
 
-      <ConfirmationDialog
-        isOpen={isReopenDialogOpen}
-        onClose={() => setIsReopenDialogOpen(false)}
-        onConfirm={confirmReopenForEdits}
-        title={t('timeSheetClient.reopen.title', { defaultValue: 'Reopen for edits?' })}
-        message={t('timeSheetClient.reopen.message', {
-          defaultValue: 'This will move the time sheet back to Changes Requested so time entries can be edited.'
-        })}
-        confirmLabel={t('common.actions.reopen', { defaultValue: 'Reopen' })}
-        cancelLabel={t('common.actions.cancel', { defaultValue: 'Cancel' })}
-        isConfirming={isReopening}
-      />
+      {isReopenDialogOpen && (
+        <ConfirmationDialog
+          id="timesheet-client-reopen-confirmation"
+          isOpen={true}
+          onClose={() => setIsReopenDialogOpen(false)}
+          onConfirm={confirmReopenForEdits}
+          title={t('timeSheetClient.reopen.title', { defaultValue: 'Reopen for edits?' })}
+          message={t('timeSheetClient.reopen.message', {
+            defaultValue: 'This will move the time sheet back to Changes Requested so time entries can be edited.'
+          })}
+          confirmLabel={t('common.actions.reopen', { defaultValue: 'Reopen' })}
+          cancelLabel={t('common.actions.cancel', { defaultValue: 'Cancel' })}
+          isConfirming={isReopening}
+        />
+      )}
     </>
   );
 }

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetListView.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetListView.tsx
@@ -9,11 +9,9 @@ import { Plus, ClipboardList, ArrowRight, ChevronDown, ChevronRight, Copy, Exter
 import { ITimeEntryWithWorkItemString } from '@alga-psa/types';
 import { IExtendedWorkItem } from '@alga-psa/types';
 import { formatISO, parseISO, format } from 'date-fns';
-import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
 import { BillabilityPercentage, billabilityColorScheme, formatDuration, formatWorkItemType, formatTimeRange } from './utils';
+import { TimeEntrySelectionRequest, TimeSheetListFocusFilter } from './types';
 import { BillableLegend } from './BillableLegend';
-import { ContainerComponent } from '@alga-psa/ui/ui-reflection/types';
-import { CommonActions } from '@alga-psa/ui/ui-reflection/actionBuilders';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
 import { TimeEntryChangeRequestIndicator } from './TimeEntryChangeRequestFeedback';
 
@@ -24,15 +22,12 @@ interface TimeSheetListViewProps {
     isEditable: boolean;
     isLoading?: boolean;
     onDeleteWorkItem: (workItemId: string) => Promise<void>;
-    onCellClick: (params: {
-        workItem: IExtendedWorkItem;
-        date: string;
-        entries: ITimeEntryWithWorkItemString[];
-        defaultStartTime?: string;
-        defaultEndTime?: string;
-    }) => void;
+    onCellClick: (params: TimeEntrySelectionRequest) => void;
     onAddWorkItem: (date?: string) => void;
     onWorkItemClick: (workItem: IExtendedWorkItem) => void;
+    focusFilter?: TimeSheetListFocusFilter | null;
+    onClearFocusFilter?: () => void;
+    onBackToGrid?: () => void;
 }
 
 interface FlattenedEntry {
@@ -61,7 +56,10 @@ export function TimeSheetListView({
     onCellClick,
     onAddWorkItem,
     onWorkItemClick,
-    onDeleteWorkItem
+    onDeleteWorkItem,
+    focusFilter = null,
+    onClearFocusFilter,
+    onBackToGrid,
 }: TimeSheetListViewProps): React.JSX.Element {
     const { t } = useTranslation('msp/time-entry');
     const [selectedWorkItemToDelete, setSelectedWorkItemToDelete] = useState<string | null>(null);
@@ -118,49 +116,81 @@ export function TimeSheetListView({
         return entries;
     }, [groupedTimeEntries, workItemsByType, dateRange]);
 
+    const filteredEntries = useMemo((): FlattenedEntry[] => {
+        if (!focusFilter) {
+            return flattenedEntries;
+        }
+
+        const focusEntryIds = new Set(focusFilter.entryIds);
+        return flattenedEntries.filter(({ entry, workItem, dateKey }) =>
+            workItem.work_item_id === focusFilter.workItemId &&
+            dateKey === focusFilter.date &&
+            typeof entry.entry_id === 'string' &&
+            focusEntryIds.has(entry.entry_id),
+        );
+    }, [flattenedEntries, focusFilter]);
+
     // Group entries by day
     const dayGroups = useMemo((): DayGroup[] => {
         const groups = new Map<string, DayGroup>();
 
-        // Initialize groups for all dates in the period
-        dates.forEach(date => {
-            const dateKey = format(date, 'yyyy-MM-dd');
-            groups.set(dateKey, {
-                dateKey,
-                date,
-                entries: [],
-                totalDuration: 0,
-                totalBillable: 0
+        if (focusFilter) {
+            filteredEntries.forEach((flatEntry) => {
+                const existingGroup = groups.get(flatEntry.dateKey);
+                if (existingGroup) {
+                    existingGroup.entries.push(flatEntry);
+                    existingGroup.totalDuration += flatEntry.duration;
+                    existingGroup.totalBillable += flatEntry.entry.billable_duration;
+                    return;
+                }
+
+                groups.set(flatEntry.dateKey, {
+                    dateKey: flatEntry.dateKey,
+                    date: flatEntry.date,
+                    entries: [flatEntry],
+                    totalDuration: flatEntry.duration,
+                    totalBillable: flatEntry.entry.billable_duration,
+                });
             });
-        });
+        } else {
+            dates.forEach(date => {
+                const dateKey = format(date, 'yyyy-MM-dd');
+                groups.set(dateKey, {
+                    dateKey,
+                    date,
+                    entries: [],
+                    totalDuration: 0,
+                    totalBillable: 0
+                });
+            });
 
-        // Add entries to their respective groups
-        flattenedEntries.forEach(entry => {
-            const group = groups.get(entry.dateKey);
-            if (group) {
-                group.entries.push(entry);
-                group.totalDuration += entry.duration;
-                group.totalBillable += entry.entry.billable_duration;
-            }
-        });
+            filteredEntries.forEach(entry => {
+                const group = groups.get(entry.dateKey);
+                if (group) {
+                    group.entries.push(entry);
+                    group.totalDuration += entry.duration;
+                    group.totalBillable += entry.entry.billable_duration;
+                }
+            });
+        }
 
-        // Sort entries within each group by start time
         groups.forEach(group => {
             group.entries.sort((a, b) => a.date.getTime() - b.date.getTime());
         });
 
         return Array.from(groups.values()).sort((a, b) => a.date.getTime() - b.date.getTime());
-    }, [flattenedEntries, dates]);
+    }, [filteredEntries, dates, focusFilter]);
 
     // Calculate totals
     const totals = useMemo(() => {
-        return flattenedEntries.reduce((acc, { duration, entry }) => ({
+        return filteredEntries.reduce((acc, { duration, entry }) => ({
             totalDuration: acc.totalDuration + duration,
             totalBillable: acc.totalBillable + entry.billable_duration
         }), { totalDuration: 0, totalBillable: 0 });
-    }, [flattenedEntries]);
+    }, [filteredEntries]);
 
     const hasWorkItems = Object.values(workItemsByType).some(items => items.length > 0);
+    const hasVisibleEntries = filteredEntries.length > 0;
 
     const unresolvedFeedbackDayKeys = useMemo(
         () => dayGroups
@@ -206,31 +236,20 @@ export function TimeSheetListView({
         const { entry, workItem } = flatEntry;
         const dateStr = entry.work_date || formatISO(parseISO(entry.start_time), { representation: 'date' });
 
-        // Get all entries for this work item on this date
-        const entriesForDate = (groupedTimeEntries[workItem.work_item_id] || [])
-            .filter(e => {
-                const entryWorkDate = e.work_date?.slice(0, 10);
-                if (entryWorkDate) return entryWorkDate === dateStr.slice(0, 10);
-                return parseISO(e.start_time).toDateString() === parseISO(entry.start_time).toDateString();
-            });
-
         onCellClick({
             workItem,
             date: dateStr,
-            entries: entriesForDate,
+            entries: [entry],
             defaultStartTime: entry.start_time,
             defaultEndTime: entry.end_time
         });
     };
 
-    // Register the list view container
-    const { automationIdProps: listProps } = useAutomationIdAndRegister<ContainerComponent>({
-        type: 'container',
+    const listAutomationProps = {
         id: 'timesheet-list-view',
-        label: 'Time Sheet List View',
-    }, () => [
-        CommonActions.focus('Focus on timesheet list view')
-    ]);
+        'data-automation-id': 'timesheet-list-view',
+        'data-automation-type': 'container',
+    } as const;
 
     // Use the skeleton component
     const renderSkeleton = () => <TimeSheetListViewSkeleton dayCount={Math.min(dates.length, 5)} />;
@@ -239,23 +258,69 @@ export function TimeSheetListView({
         <div>
             <ReflectionContainer id="timesheet-list-view" label="Time Sheet List View">
                 <React.Fragment>
-                    <ConfirmationDialog
-                        isOpen={!!selectedWorkItemToDelete}
-                        onConfirm={async () => {
-                            if (selectedWorkItemToDelete) {
+                    {selectedWorkItemToDelete && (
+                        <ConfirmationDialog
+                            id="timesheet-list-delete-work-item-confirmation"
+                            isOpen={true}
+                            onConfirm={async () => {
                                 await onDeleteWorkItem(selectedWorkItemToDelete);
                                 setSelectedWorkItemToDelete(null);
-                            }
-                        }}
-                        onClose={() => setSelectedWorkItemToDelete(null)}
-                        title={t('timeSheetList.delete.title', { defaultValue: 'Delete Work Item' })}
-                        message={t('timeSheetList.delete.message', {
-                            defaultValue: 'This will permanently delete all time entries for this work item. This action cannot be undone.'
-                        })}
-                        confirmLabel={t('common.actions.delete', { defaultValue: 'Delete' })}
-                    />
+                            }}
+                            onClose={() => setSelectedWorkItemToDelete(null)}
+                            title={t('timeSheetList.delete.title', { defaultValue: 'Delete Work Item' })}
+                            message={t('timeSheetList.delete.message', {
+                                defaultValue: 'This will permanently delete all time entries for this work item. This action cannot be undone.'
+                            })}
+                            confirmLabel={t('common.actions.delete', { defaultValue: 'Delete' })}
+                        />
+                    )}
 
-                    <div className="overflow-hidden bg-white border border-gray-200 rounded-lg shadow-md" {...listProps}>
+                    <div className="overflow-hidden bg-white border border-gray-200 rounded-lg shadow-md" {...listAutomationProps}>
+                        {focusFilter && (
+                            <div
+                                id="timesheet-list-focus-filter"
+                                className="flex flex-wrap items-center justify-between gap-3 border-b border-[rgb(var(--color-primary-200))] bg-[rgb(var(--color-primary-50))] px-3 py-3"
+                            >
+                                <div className="min-w-0">
+                                    <p className="text-sm font-medium text-[rgb(var(--color-primary-700))]">
+                                        {t('timeSheetList.focusFilter.summary', {
+                                            defaultValue: 'Showing {{count}} entries for {{workItem}} on {{date}}',
+                                            count: focusFilter.entryCount,
+                                            workItem: focusFilter.workItemLabel,
+                                            date: focusFilter.dateLabel,
+                                        })}
+                                    </p>
+                                    <p className="text-xs text-[rgb(var(--color-primary-600))]">
+                                        {t('timeSheetList.focusFilter.description', {
+                                            defaultValue: 'Only entries from the selected grid cell are visible.',
+                                        })}
+                                    </p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    {onClearFocusFilter && (
+                                        <Button
+                                            id="clear-time-entry-focus-filter-button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={onClearFocusFilter}
+                                        >
+                                            {t('common.actions.clearFilter', { defaultValue: 'Clear filter' })}
+                                        </Button>
+                                    )}
+                                    {onBackToGrid && (
+                                        <Button
+                                            id="back-to-grid-view-button"
+                                            variant="soft"
+                                            size="sm"
+                                            onClick={onBackToGrid}
+                                        >
+                                            {t('timeSheetList.focusFilter.backToGrid', { defaultValue: 'Back to grid' })}
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+                        )}
+
                         {/* Header with Add button on left, totals right */}
                         <div className="px-3 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
                             <div className="flex items-center gap-3">
@@ -273,7 +338,7 @@ export function TimeSheetListView({
                             </div>
                             <div className="flex items-center gap-4 text-sm text-gray-500">
                                 <span>
-                                    {flattenedEntries.length} {flattenedEntries.length === 1
+                                    {filteredEntries.length} {filteredEntries.length === 1
                                         ? t('timeSheetList.summary.entryOne', { defaultValue: 'entry' })
                                         : t('timeSheetList.summary.entryOther', { defaultValue: 'entries' })}
                                 </span>
@@ -288,7 +353,7 @@ export function TimeSheetListView({
 
                         {isLoading ? (
                             renderSkeleton()
-                        ) : !hasWorkItems || flattenedEntries.length === 0 ? (
+                        ) : !hasWorkItems || !hasVisibleEntries ? (
                             <div className="flex w-full h-48 items-center justify-center py-8 px-4">
                                 <div className="flex flex-col items-center justify-center text-center max-w-md">
                                     <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-3">
@@ -568,7 +633,7 @@ export function TimeSheetListView({
                     </div>
 
                     {/* Billable Legend */}
-                    {flattenedEntries.length > 0 && (
+                    {filteredEntries.length > 0 && (
                         <BillableLegend className="mt-6" />
                     )}
                 </React.Fragment>

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
@@ -523,14 +523,14 @@ export function TimeSheetTable({
                                                     })}
                                                     onMouseLeave={() => setHoveredCell(null)}
                                                 >
-                                                    <div className="relative h-full w-full p-1.5">
+                                                    <div className="relative h-full w-full">
                                                         {isEditable && (
                                                             <button
                                                                 type="button"
-                                                                className={`absolute inset-1.5 rounded-xl transition-colors ${
+                                                                className={`absolute inset-0 transition-colors ${
                                                                     dayEntries.length > 0
-                                                                        ? 'bg-white/70 hover:bg-white/90 dark:bg-gray-900/10 dark:hover:bg-gray-900/20'
-                                                                        : 'hover:bg-white/70 dark:hover:bg-gray-900/10'
+                                                                        ? 'rounded-2xl bg-white/70 hover:bg-white/90 dark:bg-gray-900/10 dark:hover:bg-gray-900/20'
+                                                                        : 'rounded-xl hover:bg-white/70 dark:hover:bg-gray-900/10'
                                                                 }`}
                                                                 data-automation-id={`time-cell-add-area-${workItem.work_item_id}-${dateKey}`}
                                                                 data-automation-type="time-entry-add-area"
@@ -544,7 +544,7 @@ export function TimeSheetTable({
 	                                                    {dayEntries.length > 0 ? (
 	                                                        <button
                                                                 type="button"
-                                                                className="relative z-10 flex h-full w-full items-center justify-center rounded-xl p-3 text-xs shadow-sm transition-transform hover:scale-[1.01]"
+                                                                className="absolute inset-2 z-10 flex items-center justify-center rounded-xl p-3 text-xs shadow-sm transition-transform hover:scale-[1.01]"
 	                                                            style={{
 	                                                                backgroundColor: colors.background,
 	                                                                borderColor: colors.border,

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
@@ -1,20 +1,16 @@
 'use client'
 
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Input } from '@alga-psa/ui/components/Input';
 import { Trash, Plus, Check, X, ClipboardList, ArrowRight } from 'lucide-react';
 import { ITimeEntryWithWorkItemString } from '@alga-psa/types';
 import { IExtendedWorkItem } from '@alga-psa/types';
 import { formatISO, parseISO, format, isToday } from 'date-fns';
-import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
 import { BillabilityPercentage, billabilityColorScheme, formatDuration, formatWorkItemType } from './utils';
 import { BillableLegend } from './BillableLegend';
-import { ContainerComponent } from '@alga-psa/ui/ui-reflection/types';
-import { CommonActions } from '@alga-psa/ui/ui-reflection/actionBuilders';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
-import { TimeSheetDateNavigatorState } from './types';
+import { TimeEntrySelectionRequest, TimeSheetDateNavigatorState, TimeSheetQuickAddState } from './types';
 import { getProminentTimeEntryChangeRequest } from '../../../../lib/timeEntryChangeRequests';
 
 interface TimeSheetTableProps {
@@ -24,21 +20,14 @@ interface TimeSheetTableProps {
     isEditable: boolean;
     isLoading?: boolean;
     onDeleteWorkItem: (workItemId: string) => Promise<void>;
-    onCellClick: (params: {
-        workItem: IExtendedWorkItem;
-        date: string;
-        entries: ITimeEntryWithWorkItemString[];
-        defaultStartTime?: string;
-        defaultEndTime?: string;
-    }) => void;
+    onCellClick: (params: TimeEntrySelectionRequest) => void;
     onAddWorkItem: (date?: string) => void;
     onWorkItemClick: (workItem: IExtendedWorkItem) => void;
-    onQuickAddTimeEntry?: (params: {
-        workItem: IExtendedWorkItem;
-        date: string;
-        durationInMinutes: number;
-        existingEntry?: ITimeEntryWithWorkItemString;
-    }) => Promise<void>;
+    activeQuickAdd?: TimeSheetQuickAddState | null;
+    onActivateQuickAdd: (quickAddTarget: Omit<TimeSheetQuickAddState, 'value'>) => void;
+    onQuickAddValueChange: (value: string) => void;
+    onQuickAddCancel: () => void;
+    onQuickAddSubmit: () => Promise<void>;
     onDateNavigatorChange?: (state: TimeSheetDateNavigatorState) => void;
 }
 
@@ -47,6 +36,37 @@ const WORK_ITEM_COLUMN_WIDTH = 180; // Width of the first column (work item name
 const DAY_COLUMN_WIDTH = 120; // Width of each day column
 const MIN_DAYS_PER_PAGE = 3; // Minimum days to show
 const MAX_DAYS_PER_PAGE = 14; // Maximum days to show
+
+function sanitizeQuickAddInput(value: string): string {
+    const sanitized = value.replace(/[^0-9:.]/g, '');
+
+    if (sanitized.includes(':')) {
+        const parts = sanitized.split(':');
+        if (parts.length === 2) {
+            const hours = parseInt(parts[0], 10) || 0;
+            const minutes = parts[1].substring(0, 2);
+            if (hours <= 24) {
+                return `${hours}:${minutes}`;
+            }
+        }
+        return sanitized.substring(0, 5);
+    }
+
+    if (sanitized.includes('.')) {
+        const decimal = parseFloat(sanitized);
+        if (!isNaN(decimal) && decimal <= 24 && decimal >= 0) {
+            return sanitized.substring(0, 5);
+        }
+        return '';
+    }
+
+    const num = parseInt(sanitized, 10);
+    if (sanitized === '' || (!isNaN(num) && num <= 24)) {
+        return sanitized.substring(0, 2);
+    }
+
+    return '';
+}
 
 export function TimeSheetTable({
     dates,
@@ -58,12 +78,15 @@ export function TimeSheetTable({
     onAddWorkItem,
     onWorkItemClick,
     onDeleteWorkItem,
-    onQuickAddTimeEntry,
+    activeQuickAdd = null,
+    onActivateQuickAdd,
+    onQuickAddValueChange,
+    onQuickAddCancel,
+    onQuickAddSubmit,
     onDateNavigatorChange
 }: TimeSheetTableProps): React.JSX.Element {
     const [selectedWorkItemToDelete, setSelectedWorkItemToDelete] = useState<string | null>(null);
     const [hoveredCell, setHoveredCell] = useState<{ workItemId: string; date: string } | null>(null);
-    const [quickInputValues, setQuickInputValues] = useState<{ [key: string]: string }>({});
 
     // Container ref for measuring available width
     const containerRef = useRef<HTMLDivElement>(null);
@@ -189,55 +212,37 @@ export function TimeSheetTable({
     // Check if there are any work items
     const hasWorkItems = Object.values(workItemsByType).some(items => items.length > 0);
     const lastWorkItemId = Object.values(workItemsByType).flat().at(-1)?.work_item_id;
+    const activeQuickAddCellKey = useMemo(
+        () => activeQuickAdd ? `${activeQuickAdd.workItem.work_item_id}-${activeQuickAdd.date}` : null,
+        [activeQuickAdd]
+    );
 
-    // Register the timesheet table container
-    const { automationIdProps: tableProps } = useAutomationIdAndRegister<ContainerComponent>({
-        type: 'container',
+    const tableAutomationProps = {
         id: 'timesheet-table',
-        label: 'Time Sheet Data Table',
-    }, () => [
-        CommonActions.focus('Focus on timesheet table'),
-        {
-            type: 'click' as const,
-            available: true,
-            description: 'Click on time entry cells to add or edit time entries',
-            parameters: [
-                {
-                    name: 'workItemId',
-                    type: 'string' as const,
-                    required: true,
-                    description: 'ID of the work item'
-                },
-                {
-                    name: 'date',
-                    type: 'string' as const,
-                    required: true,
-                    description: 'Date for the time entry (YYYY-MM-DD format)'
-                }
-            ]
-        }
-    ]);
-
+        'data-automation-id': 'timesheet-table',
+        'data-automation-type': 'container',
+    } as const;
 
     return (
         <div ref={containerRef}>
         <ReflectionContainer id="timesheet-table" label="Time Sheet Data Table">
             <React.Fragment>
-            <ConfirmationDialog
-                isOpen={!!selectedWorkItemToDelete}
-                onConfirm={async () => {
-                    if (selectedWorkItemToDelete) {
+            {selectedWorkItemToDelete && (
+                <ConfirmationDialog
+                    id="timesheet-table-delete-work-item-confirmation"
+                    isOpen={true}
+                    onConfirm={async () => {
                         await onDeleteWorkItem(selectedWorkItemToDelete);
                         setSelectedWorkItemToDelete(null);
-                    }
-                }}
-                onClose={() => setSelectedWorkItemToDelete(null)}
-                title="Delete Work Item"
-                message="This will permanently delete all time entries for this work item. This action cannot be undone."
-                confirmLabel="Delete"
-            />
+                    }}
+                    onClose={() => setSelectedWorkItemToDelete(null)}
+                    title="Delete Work Item"
+                    message="This will permanently delete all time entries for this work item. This action cannot be undone."
+                    confirmLabel="Delete"
+                />
+            )}
 
-        <div className="overflow-hidden bg-white border border-gray-200 rounded-lg shadow-md" {...tableProps}>
+        <div className="overflow-hidden bg-white border border-gray-200 rounded-lg shadow-md" {...tableAutomationProps}>
             <div
                 className="transition-opacity duration-200 ease-in-out"
                 style={{ opacity: isAnimating ? 0 : 1 }}
@@ -351,7 +356,7 @@ export function TimeSheetTable({
                                     const entries = groupedTimeEntries[workItem.work_item_id] || [];
                                     return (
                                         <tr
-                                            key={`${workItem.work_item_id}-${Math.random()}`}
+                                            key={workItem.work_item_id}
                                             className={isLastWorkItemRow ? '' : 'border-b border-gray-200'}
                                         >
                                     <td
@@ -394,7 +399,7 @@ export function TimeSheetTable({
                                         </div>
                                         {isEditable && (
                                             <Button
-                                                id="delete-workitem-button"
+                                                id={`delete-workitem-${workItem.work_item_id}`}
                                                 variant="icon"
                                                 size="sm"
                                                 className="absolute right-1 top-1/2 -translate-y-1/2 p-1 opacity-0 group-hover:opacity-100 hover:opacity-100"
@@ -434,11 +439,18 @@ export function TimeSheetTable({
                                             ) as BillabilityPercentage;
 
                                             const colors = billabilityColorScheme[billabilityTier];
-                                            const cellKey = `${workItem.work_item_id}-${formatISO(date, { representation: 'date' })}`;
+                                            const dateKey = formatISO(date, { representation: 'date' });
+                                            const cellKey = `${workItem.work_item_id}-${dateKey}`;
                                             const isHovered = hoveredCell?.workItemId === workItem.work_item_id &&
-                                                            hoveredCell?.date === formatISO(date, { representation: 'date' });
+                                                hoveredCell?.date === dateKey;
                                             const isTodayDate = isToday(date);
                                             const canOpenCell = isEditable || dayEntries.length > 0;
+                                            const isQuickAddActive = activeQuickAddCellKey === cellKey;
+                                            const shouldShowQuickAddPreview = isEditable && dayEntries.length === 0 && !activeQuickAddCellKey && isHovered;
+                                            const quickAddInputId = `timesheet-quick-input-${cellKey}`;
+                                            const quickAddSaveId = `timesheet-quick-save-${cellKey}`;
+                                            const quickAddCancelId = `timesheet-quick-cancel-${cellKey}`;
+                                            const quickAddTriggerId = `timesheet-quick-trigger-${cellKey}`;
                                             const cellFeedbackState = dayEntries.some((entry) => entry.change_request_state === 'unresolved')
                                               ? 'unresolved'
                                               : dayEntries.some((entry) => entry.change_request_state === 'handled')
@@ -454,15 +466,15 @@ export function TimeSheetTable({
 	                                                    className={`px-3 py-3 text-sm text-gray-500 border-r border-gray-200 transition-all relative h-20 ${
                                                             canOpenCell ? 'cursor-pointer' : 'cursor-default'
                                                         } ${
-	                                                        isHovered && isEditable ? 'bg-gray-50' : ''
+	                                                        (isHovered || isQuickAddActive) && isEditable ? 'bg-gray-50' : ''
 	                                                    } hover:bg-gray-50 ${isTodayDate ? 'bg-[rgb(var(--color-primary-50))]/30' : ''} ${
 	                                                        isLastWorkItemRow ? '' : 'border-b border-gray-200'
 	                                                    }`}
-	                                                    data-automation-id={`time-cell-${workItem.work_item_id}-${formatISO(date, { representation: 'date' })}`}
+	                                                    data-automation-id={`time-cell-${workItem.work_item_id}-${dateKey}`}
 	                                                    data-automation-type="time-entry-cell"
 	                                                    onMouseEnter={() => isEditable && setHoveredCell({
 	                                                        workItemId: workItem.work_item_id,
-	                                                        date: formatISO(date, { representation: 'date' })
+	                                                        date: dateKey
                                                     })}
                                                     onMouseLeave={() => setHoveredCell(null)}
                                                     onClick={() => {
@@ -540,200 +552,82 @@ export function TimeSheetTable({
 	                                                        </div>
 	                                                    ) : (
                                                         <div className="h-full w-full">
-                                                            {/* Empty cell - click anywhere to open full dialog */}
-                                                            {isHovered && isEditable && (
-                                                                <div className="absolute bottom-2 left-2 right-2 flex items-center gap-1 bg-white rounded shadow-sm border border-gray-200 px-1 py-1 z-10"
-                                                                     onClick={(e) => e.stopPropagation()}>
-                                                                    <Input
+                                                            {shouldShowQuickAddPreview && (
+                                                                <div className="absolute bottom-2 left-2 right-2 z-10" onClick={(e) => e.stopPropagation()}>
+                                                                    <button
+                                                                        id={quickAddTriggerId}
+                                                                        type="button"
+                                                                        data-automation-id={quickAddTriggerId}
+                                                                        className="flex w-full items-center justify-center rounded border border-dashed border-gray-300 bg-white/95 px-2 py-1 text-xs font-medium text-gray-500 shadow-sm transition hover:border-[rgb(var(--color-primary-300))] hover:text-[rgb(var(--color-primary-600))]"
+                                                                        onClick={(e) => {
+                                                                            e.stopPropagation();
+                                                                            onActivateQuickAdd({
+                                                                                workItem,
+                                                                                date: dateKey,
+                                                                            });
+                                                                        }}
+                                                                    >
+                                                                        H:MM
+                                                                    </button>
+                                                                </div>
+                                                            )}
+                                                            {isQuickAddActive && activeQuickAdd && (
+                                                                <div
+                                                                    className="absolute bottom-2 left-2 right-2 z-20 flex items-center gap-1 rounded border border-gray-200 bg-white px-1 py-1 shadow-sm"
+                                                                    onClick={(e) => e.stopPropagation()}
+                                                                >
+                                                                    <input
+                                                                        id={quickAddInputId}
+                                                                        data-automation-id={quickAddInputId}
                                                                         type="text"
                                                                         placeholder="H:MM"
-                                                                        className="!py-0.5 !px-1 !text-xs !border-gray-200 !min-h-0"
-                                                                        containerClassName="flex-1 !mb-0"
-                                                                        value={quickInputValues[cellKey] || ''}
-                                                                        onChange={(e) => {
-                                                                            const value = e.target.value;
+                                                                        className="h-7 min-h-0 flex-1 rounded border border-gray-200 px-1 py-0.5 text-xs text-gray-900 outline-none focus:border-[rgb(var(--color-primary-400))] focus:ring-1 focus:ring-[rgb(var(--color-primary-400))]"
+                                                                        value={activeQuickAdd.value}
+                                                                        onChange={(e) => onQuickAddValueChange(sanitizeQuickAddInput(e.target.value))}
+                                                                        onClick={(e) => e.stopPropagation()}
+                                                                        onKeyDown={async (e) => {
+                                                                            if (e.key === 'Enter') {
+                                                                                e.preventDefault();
+                                                                                e.stopPropagation();
+                                                                                await onQuickAddSubmit();
+                                                                            }
 
-                                                                            // Only allow digits, colon, and decimal point
-                                                                            const sanitized = value.replace(/[^0-9:.]/g, '');
-
-                                                                            // Validate the format and reasonable limits
-                                                                            if (sanitized.includes(':')) {
-                                                                                // H:MM or HH:MM format - max 24:00
-                                                                                const parts = sanitized.split(':');
-                                                                                if (parts.length === 2) {
-                                                                                    const hours = parseInt(parts[0], 10) || 0;
-                                                                                    const minutes = parts[1].substring(0, 2); // Max 2 digits for minutes
-                                                                                    if (hours <= 24) {
-                                                                                        setQuickInputValues(prev => ({
-                                                                                            ...prev,
-                                                                                            [cellKey]: `${hours}:${minutes}`
-                                                                                        }));
-                                                                                    }
-                                                                                }
-                                                                            } else if (sanitized.includes('.')) {
-                                                                                // Decimal format (e.g., 1.5) - max 24.0
-                                                                                const decimal = parseFloat(sanitized);
-                                                                                if (!isNaN(decimal) && decimal <= 24 && decimal >= 0) {
-                                                                                    setQuickInputValues(prev => ({
-                                                                                        ...prev,
-                                                                                        [cellKey]: sanitized.substring(0, 5) // Max 5 chars (XX.XX)
-                                                                                    }));
-                                                                                }
-                                                                            } else {
-                                                                                // Simple number format - max 24
-                                                                                const num = parseInt(sanitized, 10);
-                                                                                if (sanitized === '' || (!isNaN(num) && num <= 24)) {
-                                                                                    setQuickInputValues(prev => ({
-                                                                                        ...prev,
-                                                                                        [cellKey]: sanitized.substring(0, 2) // Max 2 digits
-                                                                                    }));
-                                                                                }
+                                                                            if (e.key === 'Escape') {
+                                                                                e.preventDefault();
+                                                                                e.stopPropagation();
+                                                                                onQuickAddCancel();
                                                                             }
                                                                         }}
-                                                                        onClick={(e) => e.stopPropagation()}
-                                                                    onKeyDown={async (e) => {
-                                                                        if (e.key === 'Enter') {
-                                                                            e.stopPropagation();
-                                                                            e.preventDefault();
-
-                                                                            const inputValue = quickInputValues[cellKey] || '';
-                                                                            let durationInMinutes = 0;
-
-                                                                            // Parse various duration formats
-                                                                            // Format: H:MM or HH:MM (e.g., 1:30, 01:30)
-                                                                            const colonMatch = inputValue.match(/^(\d{1,2}):(\d{1,2})$/);
-                                                                            if (colonMatch) {
-                                                                                const hours = parseInt(colonMatch[1], 10);
-                                                                                const minutes = parseInt(colonMatch[2], 10);
-                                                                                durationInMinutes = hours * 60 + minutes;
-                                                                            }
-                                                                            // Format: simple number as hours (e.g., 8 for 8 hours)
-                                                                            else if (inputValue.match(/^(\d+\.?\d*)$/)) {
-                                                                                const hours = parseFloat(inputValue);
-                                                                                durationInMinutes = Math.round(hours * 60);
-                                                                            }
-
-                                                                            if (durationInMinutes > 0 && onQuickAddTimeEntry) {
-                                                                                // Find any existing entry for this work item to copy settings from
-                                                                                const allEntriesForWorkItem = groupedTimeEntries[workItem.work_item_id] || [];
-                                                                                const existingEntry = allEntriesForWorkItem.length > 0 ? allEntriesForWorkItem[0] : undefined;
-
-                                                                                try {
-                                                                                    // Create the time entry directly without opening dialog
-                                                                                    await onQuickAddTimeEntry({
-                                                                                        workItem,
-                                                                                        date: formatISO(date),
-                                                                                        durationInMinutes,
-                                                                                        existingEntry
-                                                                                    });
-
-                                                                                    // Clear the input for this cell
-                                                                                    setQuickInputValues(prev => {
-                                                                                        const newValues = { ...prev };
-                                                                                        delete newValues[cellKey];
-                                                                                        return newValues;
-                                                                                    });
-                                                                                    setHoveredCell(null);
-                                                                                } catch (error) {
-                                                                                    console.error('Failed to create quick time entry:', error);
-                                                                                }
-                                                                            }
-                                                                        } else if (e.key === 'Escape') {
-                                                                            // Clear input on Escape
-                                                                            setQuickInputValues(prev => {
-                                                                                const newValues = { ...prev };
-                                                                                delete newValues[cellKey];
-                                                                                return newValues;
-                                                                            });
-                                                                            setHoveredCell(null);
-                                                                        }
-                                                                    }}
-                                                                    onBlur={(e) => {
-                                                                        // Check if focus is moving to one of our buttons
-                                                                        // If so, don't clear - let the button handler do its job
-                                                                        const relatedTarget = e.relatedTarget as HTMLElement | null;
-                                                                        const isClickingButton = relatedTarget?.closest('#quick-save-time-entry, #quick-cancel-time-entry');
-
-                                                                        if (!isClickingButton) {
-                                                                            // Clear input when focus is truly lost (not to our buttons)
-                                                                            setTimeout(() => {
-                                                                                setQuickInputValues(prev => {
-                                                                                    const newValues = { ...prev };
-                                                                                    delete newValues[cellKey];
-                                                                                    return newValues;
-                                                                                });
-                                                                            }, 200);
-                                                                        }
-                                                                    }}
                                                                         autoFocus
                                                                     />
-                                                                    <Button
-                                                                        id="quick-save-time-entry"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="!h-6 !w-6 !p-0 text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30"
-                                                                    onClick={async (e) => {
-                                                                        e.stopPropagation();
-                                                                        const inputValue = quickInputValues[cellKey] || '';
-                                                                        let durationInMinutes = 0;
-
-                                                                        // Parse various duration formats
-                                                                        const colonMatch = inputValue.match(/^(\d{1,2}):(\d{1,2})$/);
-                                                                        if (colonMatch) {
-                                                                            const hours = parseInt(colonMatch[1], 10);
-                                                                            const minutes = parseInt(colonMatch[2], 10);
-                                                                            durationInMinutes = hours * 60 + minutes;
-                                                                        }
-                                                                        else if (inputValue.match(/^(\d+\.?\d*)$/)) {
-                                                                            const hours = parseFloat(inputValue);
-                                                                            durationInMinutes = Math.round(hours * 60);
-                                                                        }
-
-                                                                        if (durationInMinutes > 0 && onQuickAddTimeEntry) {
-                                                                            const allEntriesForWorkItem = groupedTimeEntries[workItem.work_item_id] || [];
-                                                                            const existingEntry = allEntriesForWorkItem.length > 0 ? allEntriesForWorkItem[0] : undefined;
-
-                                                                            try {
-                                                                                await onQuickAddTimeEntry({
-                                                                                    workItem,
-                                                                                    date: formatISO(date),
-                                                                                    durationInMinutes,
-                                                                                    existingEntry
-                                                                                });
-
-                                                                                setQuickInputValues(prev => {
-                                                                                    const newValues = { ...prev };
-                                                                                    delete newValues[cellKey];
-                                                                                    return newValues;
-                                                                                });
-                                                                                setHoveredCell(null);
-                                                                            } catch (error) {
-                                                                                console.error('Failed to create quick time entry:', error);
-                                                                            }
-                                                                        }
-                                                                    }}
+                                                                    <button
+                                                                        id={quickAddSaveId}
+                                                                        type="button"
+                                                                        data-automation-id={quickAddSaveId}
+                                                                        className="flex h-6 w-6 items-center justify-center rounded text-green-600 hover:bg-green-50"
+                                                                        onClick={async (e) => {
+                                                                            e.preventDefault();
+                                                                            e.stopPropagation();
+                                                                            await onQuickAddSubmit();
+                                                                        }}
                                                                         title="Save time entry"
                                                                     >
                                                                         <Check className="h-3 w-3" />
-                                                                    </Button>
-                                                                    <Button
-                                                                        id="quick-cancel-time-entry"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="!h-6 !w-6 !p-0 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-                                                                    onClick={(e) => {
-                                                                        e.stopPropagation();
-                                                                        setQuickInputValues(prev => {
-                                                                            const newValues = { ...prev };
-                                                                            delete newValues[cellKey];
-                                                                            return newValues;
-                                                                        });
-                                                                        setHoveredCell(null);
-                                                                    }}
+                                                                    </button>
+                                                                    <button
+                                                                        id={quickAddCancelId}
+                                                                        type="button"
+                                                                        data-automation-id={quickAddCancelId}
+                                                                        className="flex h-6 w-6 items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+                                                                        onClick={(e) => {
+                                                                            e.preventDefault();
+                                                                            e.stopPropagation();
+                                                                            onQuickAddCancel();
+                                                                        }}
                                                                         title="Cancel"
                                                                     >
                                                                         <X className="h-3 w-3" />
-                                                                    </Button>
+                                                                    </button>
                                                                 </div>
                                                             )}
                                                         </div>

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/types.ts
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/types.ts
@@ -1,5 +1,10 @@
-import { ITimeEntry, ITimePeriodView } from '@alga-psa/types';
-import { TaxRegion } from '@alga-psa/types';
+import {
+  IExtendedWorkItem,
+  ITimeEntry,
+  ITimeEntryWithWorkItemString,
+  ITimePeriodView,
+  TaxRegion,
+} from '@alga-psa/types';
 
 export interface Service {
   id: string;
@@ -68,3 +73,32 @@ export interface TimeSheetDateNavigatorState {
   goToPreviousPage: () => void;
   goToNextPage: () => void;
 }
+
+export interface TimeEntrySelectionRequest {
+  workItem: IExtendedWorkItem;
+  date: string;
+  entries: ITimeEntryWithWorkItemString[];
+  defaultStartTime?: string;
+  defaultEndTime?: string;
+}
+
+export interface TimeSheetListFocusFilter {
+  workItemId: string;
+  workItemLabel: string;
+  date: string;
+  dateLabel: string;
+  entryIds: string[];
+  entryCount: number;
+}
+
+export interface TimeSheetQuickAddState {
+  workItem: IExtendedWorkItem;
+  date: string;
+  value: string;
+}
+
+export type TimeSheetInteractionState =
+  | { type: 'idle' }
+  | { type: 'quick-add'; quickAdd: TimeSheetQuickAddState }
+  | { type: 'dialog'; selection: TimeEntrySelectionRequest }
+  | { type: 'list-focus'; filter: TimeSheetListFocusFilter };

--- a/packages/scheduling/tests/timeEntryDialog.singleEntry.contract.test.ts
+++ b/packages/scheduling/tests/timeEntryDialog.singleEntry.contract.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readDialogSource(): string {
+  const filePath = path.resolve(
+    __dirname,
+    '../src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx'
+  );
+
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('TimeEntryDialog single-entry contract', () => {
+  it('removes the multi-entry dialog flow and keeps a single-entry form', () => {
+    const source = readDialogSource();
+
+    expect(source).toContain('SingleTimeEntryForm');
+    expect(source).not.toContain('TimeEntryList');
+    expect(source).not.toContain('handleAddEntry');
+    expect(source).not.toContain('Edit Time Entries for');
+    expect(source).toContain("Time Entry for ${workItem.name}");
+    expect(source).not.toContain('add-new-entry-btn');
+  });
+});

--- a/packages/scheduling/tests/timeEntryValidation.contract.test.ts
+++ b/packages/scheduling/tests/timeEntryValidation.contract.test.ts
@@ -12,7 +12,8 @@ describe('time entry service validation contract', () => {
     const formSource = readSource('../src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx');
 
     expect(dialogSource).toContain("toast.error('Please select a service before saving time entries');");
-    expect(formSource).toContain("service: 'Service is required for time entries'");
-    expect(formSource).toContain('Service <span className="text-red-500">*</span>');
+    expect(formSource).toContain("defaultValue: 'Service is required for time entries'");
+    expect(formSource).toContain("defaultValue: 'Service'");
+    expect(formSource).toContain('<span className="text-red-500">*</span>');
   });
 });

--- a/packages/scheduling/tests/timeSheet.multiEntryFilter.contract.test.ts
+++ b/packages/scheduling/tests/timeSheet.multiEntryFilter.contract.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readTimeSheetSource(): string {
+  const filePath = path.resolve(
+    __dirname,
+    '../src/components/time-management/time-entry/time-sheet/TimeSheet.tsx'
+  );
+
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('TimeSheet multi-entry focus filter contract', () => {
+  it('routes multi-entry grid cells into filtered list mode and wires clear/back controls', () => {
+    const source = readTimeSheetSource();
+
+    expect(source).toContain('if (selection.entries.length > 1)');
+    expect(source).toContain("type: 'list-focus'");
+    expect(source).toContain("setViewMode('list');");
+    expect(source).toContain('focusFilter={listFocusFilter}');
+    expect(source).toContain('onClearFocusFilter={handleClearListFocusFilter}');
+    expect(source).toContain('onBackToGrid={handleBackToGrid}');
+  });
+});

--- a/packages/scheduling/tests/timeSheetListView.contract.test.ts
+++ b/packages/scheduling/tests/timeSheetListView.contract.test.ts
@@ -20,7 +20,7 @@ describe('TimeSheetListView row interaction contract', () => {
 
     expect(source).toContain('id={`view-work-item-${entry.entry_id}`}');
     expect(source).toContain('onWorkItemClick(workItem);');
-    expect(source).toContain('title="View details"');
+    expect(source).toContain("defaultValue: 'View details'");
     expect(source).toContain('<ExternalLink className="h-4 w-4" />');
   });
 });

--- a/packages/scheduling/tests/timeSheetListView.focusFilter.test.tsx
+++ b/packages/scheduling/tests/timeSheetListView.focusFilter.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, Root } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    title,
+    id,
+  }: {
+    children: React.ReactNode;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    disabled?: boolean;
+    title?: string;
+    id?: string;
+  }) => React.createElement('button', { type: 'button', onClick, disabled, title, id }, children),
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: () => null,
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/components/skeletons/TimeSheetListViewSkeleton', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', null, 'loading'),
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/ui-reflection/useAutomationIdAndRegister', () => ({
+  useAutomationIdAndRegister: () => ({ automationIdProps: {} }),
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/ui-reflection/actionBuilders', () => ({
+  CommonActions: {
+    focus: () => ({ type: 'focus' }),
+  },
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/ui-reflection/ReflectionContainer', () => ({
+  ReflectionContainer: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}), { virtual: true });
+
+const { TimeSheetListView } = await import('../src/components/time-management/time-entry/time-sheet/TimeSheetListView');
+
+function createEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    entry_id: 'entry-1',
+    work_item_id: 'work-item-1',
+    work_item_type: 'ticket',
+    start_time: '2026-04-12T09:00:00',
+    end_time: '2026-04-12T10:00:00',
+    created_at: '2026-04-12T10:00:00',
+    updated_at: '2026-04-12T10:00:00',
+    billable_duration: 60,
+    notes: 'Follow up',
+    user_id: 'user-1',
+    time_sheet_id: 'sheet-1',
+    approval_status: 'DRAFT',
+    tenant: 'tenant-1',
+    work_date: '2026-04-12',
+    workItem: {
+      work_item_id: 'work-item-1',
+      name: 'Missing White Rabbit',
+      type: 'ticket',
+      description: '',
+      ticket_number: 'TIC1001',
+      is_billable: true,
+    },
+    ...overrides,
+  };
+}
+
+describe('TimeSheetListView focus filter mode', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  async function flushUi() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  const commonProps = {
+    dates: [new Date(2026, 3, 12), new Date(2026, 3, 13)],
+    workItemsByType: {
+      ticket: [
+        {
+          work_item_id: 'work-item-1',
+          name: 'Missing White Rabbit',
+          type: 'ticket',
+          description: '',
+          ticket_number: 'TIC1001',
+          is_billable: true,
+        },
+      ],
+    },
+    isEditable: true,
+    onDeleteWorkItem: vi.fn(async () => undefined),
+    onAddWorkItem: vi.fn(),
+    onWorkItemClick: vi.fn(),
+    onCellClick: vi.fn(),
+  };
+
+  it('shows only the filtered entries and exposes clear/back actions', async () => {
+    const onClearFocusFilter = vi.fn();
+    const onBackToGrid = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        React.createElement(TimeSheetListView, {
+          ...commonProps,
+          groupedTimeEntries: {
+            'work-item-1': [
+              createEntry({ entry_id: 'entry-1', notes: 'First entry' }),
+              createEntry({
+                entry_id: 'entry-2',
+                start_time: '2026-04-12T10:00:00',
+                end_time: '2026-04-12T11:00:00',
+                notes: 'Second entry',
+              }),
+              createEntry({
+                entry_id: 'entry-3',
+                start_time: '2026-04-13T09:00:00',
+                end_time: '2026-04-13T10:00:00',
+                work_date: '2026-04-13',
+                notes: 'Other day entry',
+              }),
+            ],
+          },
+          focusFilter: {
+            workItemId: 'work-item-1',
+            workItemLabel: 'TIC1001 - Missing White Rabbit',
+            date: '2026-04-12',
+            dateLabel: 'Apr 12',
+            entryIds: ['entry-2'],
+            entryCount: 1,
+          },
+          onClearFocusFilter,
+          onBackToGrid,
+        }),
+      );
+    });
+
+    await flushUi();
+    await flushUi();
+
+    const rows = container.querySelectorAll('[data-automation-id^="time-entry-row-"]');
+    expect(rows).toHaveLength(1);
+    expect(container.textContent).toContain('Second entry');
+    expect(container.textContent).not.toContain('First entry');
+    expect(container.textContent).not.toContain('Other day entry');
+    expect(container.textContent).toContain('Showing 1 entries for TIC1001 - Missing White Rabbit on Apr 12');
+
+    const clearButton = container.querySelector('#clear-time-entry-focus-filter-button');
+    const backButton = container.querySelector('#back-to-grid-view-button');
+    if (!clearButton || !backButton) {
+      throw new Error('Expected focus filter actions');
+    }
+
+    clearButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    backButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onClearFocusFilter).toHaveBeenCalledTimes(1);
+    expect(onBackToGrid).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/scheduling/tests/timeSheetTable.feedback.test.ts
+++ b/packages/scheduling/tests/timeSheetTable.feedback.test.ts
@@ -247,6 +247,8 @@ describe('TimeSheetTable feedback markers', () => {
       throw new Error('Expected time entry summary');
     }
 
+    expect(entrySummary.getAttribute('class')).toContain('absolute inset-2');
+
     entrySummary.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(onCellClick).toHaveBeenCalledTimes(1);
@@ -275,6 +277,8 @@ describe('TimeSheetTable feedback markers', () => {
     if (!addArea) {
       throw new Error('Expected time entry add area');
     }
+
+    expect(addArea.getAttribute('class')).toContain('absolute inset-0');
 
     addArea.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 

--- a/packages/scheduling/tests/timeSheetTable.feedback.test.ts
+++ b/packages/scheduling/tests/timeSheetTable.feedback.test.ts
@@ -125,7 +125,11 @@ describe('TimeSheetTable feedback markers', () => {
     onDeleteWorkItem: vi.fn(async () => undefined),
     onAddWorkItem: vi.fn(),
     onWorkItemClick: vi.fn(),
-    onQuickAddTimeEntry: vi.fn(async () => undefined),
+    activeQuickAdd: null,
+    onActivateQuickAdd: vi.fn(),
+    onQuickAddValueChange: vi.fn(),
+    onQuickAddCancel: vi.fn(),
+    onQuickAddSubmit: vi.fn(async () => undefined),
   };
 
   it('T016/T020: shows an X marker for unresolved feedback and preserves cell click behavior', () => {

--- a/packages/scheduling/tests/timeSheetTable.quickAddInteraction.test.ts
+++ b/packages/scheduling/tests/timeSheetTable.quickAddInteraction.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, Root } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+}
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  value: ResizeObserverMock,
+  configurable: true,
+});
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    title,
+    id,
+  }: {
+    children: React.ReactNode;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    disabled?: boolean;
+    title?: string;
+    id?: string;
+  }) => React.createElement('button', { type: 'button', onClick, disabled, title, id }, children),
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: () => null,
+}), { virtual: true });
+
+vi.mock('@alga-psa/ui/ui-reflection/ReflectionContainer', () => ({
+  ReflectionContainer: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}), { virtual: true });
+
+const { TimeSheetTable } = await import('../src/components/time-management/time-entry/time-sheet/TimeSheetTable');
+
+describe('TimeSheetTable quick add interaction state', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const workItem = {
+    work_item_id: 'work-item-1',
+    name: 'Ticket 1001',
+    type: 'ticket',
+    description: '',
+    ticket_number: '1001',
+    is_billable: true,
+  };
+
+  const commonProps = {
+    dates: [new Date(2026, 2, 10)],
+    workItemsByType: {
+      ticket: [workItem],
+    },
+    groupedTimeEntries: {
+      'work-item-1': [],
+    },
+    isEditable: true,
+    onDeleteWorkItem: vi.fn(async () => undefined),
+    onAddWorkItem: vi.fn(),
+    onWorkItemClick: vi.fn(),
+    onDateNavigatorChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    Object.defineProperty(container, 'offsetWidth', { value: 900, configurable: true });
+    document.body.innerHTML = '';
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  it('renders deterministic quick-add editor controls for the active cell', () => {
+    flushSync(() => {
+      root.render(
+        React.createElement(TimeSheetTable, {
+          ...commonProps,
+          onCellClick: vi.fn(),
+          activeQuickAdd: {
+            workItem,
+            date: '2026-03-10',
+            value: '1:30',
+          },
+          onActivateQuickAdd: vi.fn(),
+          onQuickAddValueChange: vi.fn(),
+          onQuickAddCancel: vi.fn(),
+          onQuickAddSubmit: vi.fn(async () => undefined),
+        }),
+      );
+    });
+
+    expect(container.querySelector('#timesheet-quick-input-work-item-1-2026-03-10')).not.toBeNull();
+    expect(container.querySelector('#timesheet-quick-save-work-item-1-2026-03-10')).not.toBeNull();
+    expect(container.querySelector('#timesheet-quick-cancel-work-item-1-2026-03-10')).not.toBeNull();
+  });
+
+  it('keeps quick-add button clicks isolated while cell margin clicks still open the dialog path', () => {
+    const onCellClick = vi.fn();
+    const onQuickAddSubmit = vi.fn(async () => undefined);
+    const onQuickAddCancel = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        React.createElement(TimeSheetTable, {
+          ...commonProps,
+          onCellClick,
+          activeQuickAdd: {
+            workItem,
+            date: '2026-03-10',
+            value: '2',
+          },
+          onActivateQuickAdd: vi.fn(),
+          onQuickAddValueChange: vi.fn(),
+          onQuickAddCancel,
+          onQuickAddSubmit,
+        }),
+      );
+    });
+
+    const saveButton = container.querySelector('#timesheet-quick-save-work-item-1-2026-03-10');
+    const cancelButton = container.querySelector('#timesheet-quick-cancel-work-item-1-2026-03-10');
+    const cell = container.querySelector('[data-automation-id="time-cell-work-item-1-2026-03-10"]');
+
+    if (!saveButton || !cancelButton || !cell) {
+      throw new Error('Expected quick add controls and cell');
+    }
+
+    flushSync(() => {
+      saveButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onQuickAddSubmit).toHaveBeenCalledTimes(1);
+    expect(onCellClick).not.toHaveBeenCalled();
+
+    flushSync(() => {
+      cancelButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onQuickAddCancel).toHaveBeenCalledTimes(1);
+    expect(onCellClick).not.toHaveBeenCalled();
+
+    flushSync(() => {
+      cell.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onCellClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/app/msp/time-entry/timesheet/[id]/page.tsx
+++ b/server/src/app/msp/time-entry/timesheet/[id]/page.tsx
@@ -1,6 +1,11 @@
 import { notFound } from 'next/navigation';
 import { getCurrentUser } from "@alga-psa/user-composition/actions";
-import { fetchTimeSheet } from '@alga-psa/scheduling/actions/timeSheetActions';
+import {
+  fetchTimeSheet,
+  fetchTimeSheetComments,
+} from '@alga-psa/scheduling/actions/timeSheetActions';
+import { fetchTimeEntriesForTimeSheet } from '@alga-psa/scheduling/actions/timeEntryActions';
+import { fetchWorkItemsForTimeSheet } from '@alga-psa/scheduling/actions/timeEntryWorkItemActions';
 import TimeSheetClient from '@alga-psa/scheduling/components/time-management/time-entry/time-sheet/TimeSheetClient';
 import { createTenantKnex } from '@alga-psa/db';
 import { hasPermission } from '@alga-psa/auth';
@@ -50,12 +55,21 @@ export default async function TimeSheetPage({ params }: { params: Promise<{ id: 
       }
     }
 
+    const [initialEntries, initialWorkItems, initialComments] = await Promise.all([
+      fetchTimeEntriesForTimeSheet(timeSheet.id),
+      fetchWorkItemsForTimeSheet(timeSheet.id),
+      timeSheet.approval_status !== 'DRAFT' ? fetchTimeSheetComments(timeSheet.id) : Promise.resolve([]),
+    ]);
+
     return (
       <TimeSheetClient
         timeSheet={timeSheet}
         currentUser={currentUser}
         isManager={isManager}
         canReopenForEdits={canReopenForEdits}
+        initialEntries={initialEntries}
+        initialWorkItems={initialWorkItems}
+        initialComments={initialComments}
       />
     );
   } catch (error) {

--- a/server/src/components/layout/DefaultLayout.tsx
+++ b/server/src/components/layout/DefaultLayout.tsx
@@ -484,37 +484,40 @@ export default function DefaultLayout({ children, initialSidebarCollapsed = fals
             ) : null}
           </div>
         </div>
-        <ConfirmationDialog
-          isOpen={pendingInterruptKind !== null}
-          onClose={closeInterruptDialog}
-          onConfirm={confirmInterruptAction}
-          title={
-            pendingInterruptKind === 'navigate'
-              ? t('dialogs.aiInterrupt.navigate.title', { defaultValue: 'Leave page and cancel AI response?' })
-              : t('dialogs.aiInterrupt.closeChat.title', { defaultValue: 'Close chat and cancel AI response?' })
-          }
-          message={
-            pendingInterruptKind === 'navigate'
-              ? t('dialogs.aiInterrupt.navigate.message', {
-                  defaultValue:
-                    'An AI response or tool action is still in progress. Leaving this page now will cancel it.',
-                })
-              : t('dialogs.aiInterrupt.closeChat.message', {
-                  defaultValue:
-                    'An AI response or tool action is still in progress. Closing the chat now will cancel it.',
-                })
-          }
-          confirmLabel={
-            pendingInterruptKind === 'navigate'
-              ? t('dialogs.aiInterrupt.navigate.confirm', { defaultValue: 'Leave page' })
-              : t('dialogs.aiInterrupt.closeChat.confirm', { defaultValue: 'Close chat' })
-          }
-          cancelLabel={
-            pendingInterruptKind === 'navigate'
-              ? t('dialogs.aiInterrupt.navigate.cancel', { defaultValue: 'Stay on page' })
-              : t('dialogs.aiInterrupt.closeChat.cancel', { defaultValue: 'Keep chat open' })
-          }
-        />
+        {pendingInterruptKind !== null && (
+          <ConfirmationDialog
+            id="default-layout-ai-interrupt-confirmation"
+            isOpen={true}
+            onClose={closeInterruptDialog}
+            onConfirm={confirmInterruptAction}
+            title={
+              pendingInterruptKind === 'navigate'
+                ? t('dialogs.aiInterrupt.navigate.title', { defaultValue: 'Leave page and cancel AI response?' })
+                : t('dialogs.aiInterrupt.closeChat.title', { defaultValue: 'Close chat and cancel AI response?' })
+            }
+            message={
+              pendingInterruptKind === 'navigate'
+                ? t('dialogs.aiInterrupt.navigate.message', {
+                    defaultValue:
+                      'An AI response or tool action is still in progress. Leaving this page now will cancel it.',
+                  })
+                : t('dialogs.aiInterrupt.closeChat.message', {
+                    defaultValue:
+                      'An AI response or tool action is still in progress. Closing the chat now will cancel it.',
+                  })
+            }
+            confirmLabel={
+              pendingInterruptKind === 'navigate'
+                ? t('dialogs.aiInterrupt.navigate.confirm', { defaultValue: 'Leave page' })
+                : t('dialogs.aiInterrupt.closeChat.confirm', { defaultValue: 'Close chat' })
+            }
+            cancelLabel={
+              pendingInterruptKind === 'navigate'
+                ? t('dialogs.aiInterrupt.navigate.cancel', { defaultValue: 'Stay on page' })
+                : t('dialogs.aiInterrupt.closeChat.cancel', { defaultValue: 'Keep chat open' })
+            }
+          />
+        )}
         <DrawerOutlet />
       </QuickAddClientProviderWithCallbacks>
       </MspActivityCrossFeatureProvider>


### PR DESCRIPTION
## Summary
- replace the timesheet multi-entry cell dialog flow with a filtered list-view focus flow
- simplify time entry editing to a single-entry dialog and centralize timesheet interaction ownership
- fix the remaining render-loop and dialog-registration issues, including the quick-add -> dialog path

## Testing
- npm -w packages/scheduling run typecheck
- npm -w server run typecheck
- npm -w packages/scheduling exec vitest run tests/timeEntryDialog.singleEntry.contract.test.ts tests/timeSheet.multiEntryFilter.contract.test.ts tests/timeSheetTable.quickAddInteraction.test.ts tests/timeSheetTable.feedback.test.ts

## Notes
- left the unrelated local `nx.json` modification out of this commit/PR
- verified in Alga Dev that the previous multi-entry and quick-add repro paths no longer hit the hook-order/max-depth failures