### PR TITLE
Show selected service in timesheet approval details

### DIFF
--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -73,12 +73,16 @@ export const fetchTimeEntriesForTimeSheet = withAuth(async (
   await assertCanActOnBehalf(user, tenant, timeSheet.user_id, db);
 
   const timeEntries = await db('time_entries')
-    .where({
-      time_sheet_id: validatedParams.timeSheetId,
-      tenant
+    .leftJoin('service_catalog', function() {
+      this.on('time_entries.service_id', '=', 'service_catalog.service_id')
+        .andOn('time_entries.tenant', '=', 'service_catalog.tenant');
     })
-    .orderBy('start_time', 'desc')
-    .select('*');
+    .where({
+      'time_entries.time_sheet_id': validatedParams.timeSheetId,
+      'time_entries.tenant': tenant
+    })
+    .orderBy('time_entries.start_time', 'desc')
+    .select('time_entries.*', 'service_catalog.service_name');
 
   const changeRequestsByEntryId = await fetchTimeEntryChangeRequestsForEntryIdsFromDb(
     db,

--- a/packages/scheduling/src/components/time-management/approvals/TimeSheetApproval.tsx
+++ b/packages/scheduling/src/components/time-management/approvals/TimeSheetApproval.tsx
@@ -153,6 +153,12 @@ const TimeEntryDetailPanel: React.FC<TimeEntryDetailPanelProps> = ({ entry, onUp
             : t('common.fallbacks.na', { defaultValue: 'N/A' })}
         </span>
         <span className="font-medium text-[rgb(var(--color-text-900))]">
+          {t('approval.labels.service', { defaultValue: 'Service' })}
+        </span>
+        <span className="text-[rgb(var(--color-text-700))]">
+          {entry.service_name || t('common.fallbacks.noServiceSelected', { defaultValue: 'No service selected' })}
+        </span>
+        <span className="font-medium text-[rgb(var(--color-text-900))]">
           {t('approval.labels.duration', { defaultValue: 'Duration' })}
         </span>
         <span className="text-[rgb(var(--color-text-700))]">

--- a/packages/scheduling/src/schemas/timeSheet.schemas.ts
+++ b/packages/scheduling/src/schemas/timeSheet.schemas.ts
@@ -103,6 +103,7 @@ export const timeEntrySchema = tenantSchema.extend({
   time_sheet_id: z.string().optional(),
   approval_status: timeSheetStatusSchema,
   service_id: z.string().optional(),
+  service_name: z.string().nullable().optional(),
   tax_region: z.string().optional(),
   contract_line_id: z.string().nullable().optional(),
   tax_rate_id: z.string().nullable().optional(),

--- a/packages/types/src/interfaces/timeEntry.interfaces.ts
+++ b/packages/types/src/interfaces/timeEntry.interfaces.ts
@@ -53,6 +53,7 @@ export interface ITimeEntry extends TenantEntity  {
   time_sheet_id?: string;
   approval_status: TimeSheetStatus;
   service_id?: string;
+  service_name?: string | null;
   tax_region?: string;
   contract_line_id?: string | null;
   tax_rate_id?: string | null; // ID of the applied tax rate

--- a/server/public/locales/de/msp/time-entry.json
+++ b/server/public/locales/de/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Abrechnungsfähig",
       "nonBillable": "Nicht abrechenbar",
       "workItem": "Arbeitselement",
+      "service": "Service",
       "duration": "Dauer",
       "notes": "Notizen",
       "entryChangeSuggestion": "Vorschlag zur Eintragsänderung",

--- a/server/public/locales/en/msp/time-entry.json
+++ b/server/public/locales/en/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Billable",
       "nonBillable": "Non-Billable",
       "workItem": "Work Item",
+      "service": "Service",
       "duration": "Duration",
       "notes": "Notes",
       "entryChangeSuggestion": "Entry Change Suggestion",

--- a/server/public/locales/es/msp/time-entry.json
+++ b/server/public/locales/es/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "facturable",
       "nonBillable": "No facturable",
       "workItem": "Elemento de trabajo",
+      "service": "Servicio",
       "duration": "Duración",
       "notes": "Notas",
       "entryChangeSuggestion": "Sugerencia de cambio de entrada",

--- a/server/public/locales/fr/msp/time-entry.json
+++ b/server/public/locales/fr/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Facturable",
       "nonBillable": "Non facturable",
       "workItem": "Élément de travail",
+      "service": "Service",
       "duration": "Durée",
       "notes": "Remarques",
       "entryChangeSuggestion": "Suggestion de modification d'entrée",

--- a/server/public/locales/it/msp/time-entry.json
+++ b/server/public/locales/it/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Fatturabile",
       "nonBillable": "Non fatturabile",
       "workItem": "Elemento di lavoro",
+      "service": "Servizio",
       "duration": "Durata",
       "notes": "Note",
       "entryChangeSuggestion": "Suggerimento per la modifica della voce",

--- a/server/public/locales/nl/msp/time-entry.json
+++ b/server/public/locales/nl/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Factureerbaar",
       "nonBillable": "Niet-factureerbaar",
       "workItem": "Werkitem",
+      "service": "Service",
       "duration": "Duur",
       "notes": "Opmerkingen",
       "entryChangeSuggestion": "Suggestie voor wijziging van invoer",

--- a/server/public/locales/pl/msp/time-entry.json
+++ b/server/public/locales/pl/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "Płatne",
       "nonBillable": "Niepodlegające rozliczeniu",
       "workItem": "Przedmiot pracy",
+      "service": "Usługa",
       "duration": "Czas trwania",
       "notes": "Notatki",
       "entryChangeSuggestion": "Sugestia zmiany wpisu",

--- a/server/public/locales/xx/msp/time-entry.json
+++ b/server/public/locales/xx/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "11111",
       "nonBillable": "11111",
       "workItem": "11111",
+      "service": "11111",
       "duration": "11111",
       "notes": "11111",
       "entryChangeSuggestion": "11111",

--- a/server/public/locales/yy/msp/time-entry.json
+++ b/server/public/locales/yy/msp/time-entry.json
@@ -202,6 +202,7 @@
       "billable": "55555",
       "nonBillable": "55555",
       "workItem": "55555",
+      "service": "55555",
       "duration": "55555",
       "notes": "55555",
       "entryChangeSuggestion": "55555",

--- a/server/src/interfaces/timeEntry.interfaces.ts
+++ b/server/src/interfaces/timeEntry.interfaces.ts
@@ -52,6 +52,7 @@ export interface ITimeEntry extends TenantEntity  {
   time_sheet_id?: string;
   approval_status: TimeSheetStatus;
   service_id?: string;
+  service_name?: string | null;
   tax_region?: string;
   contract_line_id?: string | null;
   tax_rate_id?: string | null; // ID of the applied tax rate


### PR DESCRIPTION
## Summary
- show the selected service in expanded timesheet approval entry details
- include `service_name` in fetched timesheet approval entry data
- add the approval label translation for Service

## Testing
- npm -w packages/scheduling exec tsc --noEmit