### PR TITLE
fix: allow CE Docker build artifacts in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ npm-debug.log
 dist
 build
 **/dist
+!shared/dist
+!shared/dist/**
 !ee/packages/workflows/dist/**
 !packages/workflow-streams/dist/**
 !packages/event-schemas/dist/**
@@ -64,3 +66,7 @@ temp_wasm_compile
 **/.nx
 .next
 **/.next
+
+# Allow pre-built Next.js artifacts required by Docker builds
+!server/.next
+!server/.next/**


### PR DESCRIPTION
## Summary
- allow `shared/dist` in the Docker build context
- allow `server/.next` in the Docker build context
- prevent CE image builds from failing when Dockerfile copies pre-built artifacts

## Background
This fixes the failure mode seen in workflow `alga-psa-ce-build-8z2cn`, where the Dockerfile expected pre-built artifacts that were excluded by `.dockerignore`.
