### PR TITLE
[codex] Fix core subpath module resolution in dev

### DIFF
--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,0 +1,1 @@
+export * from './lib/encryption';

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,0 +1,1 @@
+export * from '../lib/events';

--- a/packages/core/src/features.ts
+++ b/packages/core/src/features.ts
@@ -1,0 +1,1 @@
+export * from './lib/features';

--- a/packages/core/src/formatters.ts
+++ b/packages/core/src/formatters.ts
@@ -1,0 +1,1 @@
+export * from './lib/formatters';

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -1,0 +1,1 @@
+export * from '../lib/i18n/config';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,1 @@
+export { default } from './lib/logger';

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -1,0 +1,1 @@
+export * from '../lib/secrets';

--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -1,6 +1,5 @@
 import { isEnterprise } from './features';
 import { initializeEventBus, cleanupEventBus } from './eventBus/initialize';
-import { initializeScheduledJobs } from './jobs/initializeScheduledJobs';
 import { logger, registerFeatureFlagChecker } from '@alga-psa/core';
 import { validateEnv } from 'server/src/config/envConfig';
 import { validateRequiredConfiguration, validateDatabaseConnectivity, validateSecretUniqueness } from 'server/src/config/criticalEnvValidation';
@@ -217,6 +216,7 @@ export async function initializeApp() {
 
     // Initialize scheduled jobs
     try {
+      const { initializeScheduledJobs } = await import('./jobs/initializeScheduledJobs');
       await initializeScheduledJobs();
       logger.info('Scheduled jobs initialized');
     } catch (error) {


### PR DESCRIPTION
## What changed
This PR fixes `@alga-psa/core/*` subpath resolution in local Next dev by adding source-level entrypoint shims for public core subpaths and by deferring scheduled-jobs startup loading.

## Why it changed
The server dev config aliases `@alga-psa/core` directly to `packages/core/src`, which bypasses the package `exports` map. That made imports like `@alga-psa/core/logger` resolve against the source tree instead of the package export, but there was no matching `packages/core/src/logger.ts` file. The failure surfaced during eager startup module evaluation through `initializeScheduledJobs`.

## Impact
Server startup no longer crashes on module evaluation for this path, and the aliased dev source tree now contains real files for the public `@alga-psa/core/*` subpaths used by the app.

## Validation
- `tsc --noEmit -p server/tsconfig.json`
- `tsc --noEmit -p packages/core/tsconfig.json`
