### PR TITLE
[codex] Fix hocuspocus Docker build inputs

### DIFF
--- a/hocuspocus/Dockerfile
+++ b/hocuspocus/Dockerfile
@@ -2,7 +2,10 @@ FROM node:22.5.1 AS builder
 
 WORKDIR /app/hocuspocus
 
-COPY package.json package-lock.json ./
+# Hocuspocus is a standalone package with its own lockfile; installing from the
+# repo root pulls unrelated workspace deps and breaks the prebuilt CE path.
+COPY hocuspocus/package.json ./package.json
+COPY hocuspocus/package-lock.json ./package-lock.json
 RUN npm ci --omit=dev
 
 FROM node:22.5.1-slim
@@ -19,9 +22,9 @@ WORKDIR /app/hocuspocus
 # Create a non-root user
 RUN groupadd -r nodejs && useradd -r -g nodejs nodejs
 
-# Copy built node modules and source files
+# Copy built node modules and service source files only.
 COPY --from=builder /app/hocuspocus/node_modules ./node_modules
-COPY . ./
+COPY hocuspocus/ ./
 
 # Set up entrypoint script
 RUN chmod +x ./entrypoint.sh


### PR DESCRIPTION
## What changed
Fixes the `hocuspocus` Docker build to install from the service's own `package.json` and `package-lock.json`, and copies only the `hocuspocus/` service tree into the runtime image.

## Why
The previous Dockerfile copied the repo-root lockfile into the `hocuspocus` builder stage. That pulled unrelated workspace dependencies into `npm ci`, which failed on the root `next-auth`/`nodemailer` peer dependency conflict and broke the documented prebuilt CE setup flow.

## Impact
This makes the `hocuspocus` image build self-contained and removes an accidental dependency on the root workspace dependency graph. It unblocks the `hocuspocus` portion of the prebuilt CE bring-up path.

## Validation
- `docker build -f hocuspocus/Dockerfile -t alga-hocuspocus-main-pr-test .`
