### PR TITLE
Inject workflow picker actions via props

### DIFF
--- a/.github/workflows/e2e-fresh-install-tests.yaml
+++ b/.github/workflows/e2e-fresh-install-tests.yaml
@@ -182,8 +182,24 @@ jobs:
           echo "Building all required images with --no-cache to ensure fresh build"
           # Build all images needed for e2e tests upfront
           # Excludes: workflow-worker (EE only, not needed for CE e2e)
+          # Excludes: hocuspocus (built separately below with repo-root context)
           docker-compose -p alga-e2e-test -f docker-compose.base.yaml -f docker-compose.ce.yaml -f docker-compose.prod.yaml build --no-cache \
-            server setup email-service hocuspocus
+            server setup email-service
+        shell: bash
+
+      - name: Build hocuspocus image with repo-root context
+        if: steps.install_docker_compose.outcome == 'success'
+        run: |
+          # hocuspocus/Dockerfile expects repo-root as build context (it does
+          # `COPY hocuspocus/package.json ...`), but docker-compose.ce.yaml sets
+          # `context: ./hocuspocus`, which breaks the build. Build it directly
+          # here with the correct context and tag it with the name compose v2
+          # auto-generates (`<project>-<service>:latest`) so subsequent
+          # `docker-compose up` calls reuse this image instead of rebuilding.
+          docker build --no-cache \
+            -f hocuspocus/Dockerfile \
+            -t alga-e2e-test-hocuspocus:latest \
+            .
         shell: bash
 
       - name: Start foundational services (postgres and redis)

--- a/ee/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/EventsCatalogV2.tsx
@@ -60,6 +60,7 @@ import {
   WorkflowActionInputFixedPicker,
   WORKFLOW_FIXED_PICKER_SUPPORTED_RESOURCES,
   type WorkflowActionInputPickerField,
+  type WorkflowPickerActions,
 } from './WorkflowActionInputFixedPicker';
 import { resolveWorkflowSchemaFieldEditor } from './workflowSchemaFieldEditor';
 
@@ -600,7 +601,8 @@ const SchemaForm: React.FC<{
   value: Record<string, unknown>;
   onChange: (next: Record<string, unknown>) => void;
   errors: ValidationIssue[];
-}> = ({ schema, value, onChange, errors }) => {
+  pickerActions: WorkflowPickerActions;
+}> = ({ schema, value, onChange, errors, pickerActions }) => {
   const renderField = (
     fieldSchema: JsonSchema,
     rootSchema: JsonSchema,
@@ -695,6 +697,7 @@ const SchemaForm: React.FC<{
             onChange={(nextValue) => onChange(setDeepValue(value, path, nextValue) as Record<string, unknown>)}
             idPrefix={`simulate-form-${fieldPath || 'root'}`}
             rootInputMapping={value as InputMapping}
+            actions={pickerActions}
           />
           {resolved.description && <div className="text-[11px] text-gray-500">{resolved.description}</div>}
           {fieldErrors.map((err) => (
@@ -929,7 +932,7 @@ const SimpleSeriesChart: React.FC<{ series: Array<{ day: string; count: number }
   );
 };
 
-export default function EventsCatalogV2() {
+export default function EventsCatalogV2({ pickerActions }: { pickerActions: WorkflowPickerActions }) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -1525,6 +1528,7 @@ export default function EventsCatalogV2() {
         eventType={simulateState.eventType}
         payloadSchemaRef={simulateState.payloadSchemaRef}
         onClose={() => setSimulateState({ open: false, eventType: null, payloadSchemaRef: null })}
+        pickerActions={pickerActions}
       />
 
       {/* Define Custom Event */}
@@ -1730,7 +1734,8 @@ const SimulateDialog: React.FC<{
   eventType: string | null;
   payloadSchemaRef: string | null;
   onClose: () => void;
-}> = ({ open, eventType, payloadSchemaRef, onClose }) => {
+  pickerActions: WorkflowPickerActions;
+}> = ({ open, eventType, payloadSchemaRef, onClose, pickerActions }) => {
   const [mode, setMode] = useState<'form' | 'json'>('form');
   const [schema, setSchema] = useState<any | null>(null);
   const [schemaRefOverride, setSchemaRefOverride] = useState<string>('');
@@ -1918,7 +1923,7 @@ const SimulateDialog: React.FC<{
           {mode === 'form' && (
             <div>
               <div className="text-xs font-medium text-gray-700 mb-2">Payload</div>
-              <SchemaForm schema={schema} value={formValue ?? {}} onChange={setFormValue} errors={errors} />
+              <SchemaForm schema={schema} value={formValue ?? {}} onChange={setFormValue} errors={errors} pickerActions={pickerActions} />
             </div>
           )}
 

--- a/ee/packages/workflows/src/components/automation-hub/WorkflowActionInputFixedPicker.tsx
+++ b/ee/packages/workflows/src/components/automation-hub/WorkflowActionInputFixedPicker.tsx
@@ -88,36 +88,22 @@ const EMPTY_TICKET_FIELD_OPTIONS: TicketFieldOptions = {
   locations: [],
 };
 
-type WorkflowClientActionsModule = {
+export type WorkflowPickerActions = {
   getAllContacts: () => Promise<IContact[]>;
   getContactsByClient: (clientId: string) => Promise<IContact[]>;
-};
-
-type WorkflowIntegrationActionsModule = {
   getAvailableStatuses: (boardId: string) => Promise<{ statuses: TicketFieldOptions['statuses'] }>;
   getTicketFieldOptions: () => Promise<{ options: TicketFieldOptions }>;
+  getTicketById: (ticketId: string) => Promise<{
+    ticket_id?: string;
+    ticket_number?: string | null;
+    title?: string | null;
+    board_id?: string | null;
+  } | null>;
+  getTicketsForList: (input: {
+    boardFilterState: 'active' | 'inactive' | 'all';
+    searchQuery: string;
+  }) => Promise<{ tickets?: WorkflowTicketSearchResult[] } | null>;
 };
-
-type WorkflowTicketActionsModule = {
-  getTicketById: (ticketId: string) => Promise<{ ticket_id?: string; ticket_number?: string | null; title?: string | null; board_id?: string | null } | null>;
-  getTicketsForList: (input: { boardFilterState: 'active' | 'inactive' | 'all'; searchQuery: string }) => Promise<{ tickets?: WorkflowTicketSearchResult[] } | null>;
-};
-
-const loadFeatureActions = async <T,>(featureName: string): Promise<T> => {
-  const modulePath = ['@alga-psa', featureName, 'actions'].join('/');
-  return import(modulePath) as Promise<T>;
-};
-
-const loadClientActions = async () => loadFeatureActions<WorkflowClientActionsModule>('clients');
-const loadIntegrationActions = async () => loadFeatureActions<WorkflowIntegrationActionsModule>('integrations');
-const loadTicketActions = async () => loadFeatureActions<WorkflowTicketActionsModule>('tickets');
-
-const getAllContactsForPicker = async () => (await loadClientActions()).getAllContacts();
-const getContactsByClientForPicker = async (clientId: string) => (await loadClientActions()).getContactsByClient(clientId);
-const getAvailableStatusesForPicker = async (boardId: string) => (await loadIntegrationActions()).getAvailableStatuses(boardId);
-const getTicketFieldOptionsForPicker = async () => (await loadIntegrationActions()).getTicketFieldOptions();
-const getTicketByIdForPicker = async (ticketId: string) => (await loadTicketActions()).getTicketById(ticketId);
-const getTicketsForListForPicker = async (input: { boardFilterState: 'active' | 'inactive' | 'all'; searchQuery: string }) => (await loadTicketActions()).getTicketsForList(input);
 
 const TICKET_PICKER_DEPENDENCY_HINTS: Partial<Record<string, Record<string, string>>> = {
   contact: {
@@ -424,7 +410,8 @@ const appendCurrentValueOption = (
 
 const loadWorkflowPickerData = async (
   kind: string,
-  dependencies: DependencyResolution[]
+  dependencies: DependencyResolution[],
+  actions: WorkflowPickerActions
 ): Promise<WorkflowPickerData> => {
   switch (kind) {
     case 'ticket-status': {
@@ -435,7 +422,7 @@ const loadWorkflowPickerData = async (
       if (fixedBoard?.status === 'fixed' && fixedBoard.value) {
         boardId = fixedBoard.value;
       } else if (fixedTicket?.status === 'fixed' && fixedTicket.value) {
-        const ticket = await getTicketByIdForPicker(fixedTicket.value);
+        const ticket = await actions.getTicketById(fixedTicket.value);
         boardId = ticket?.board_id ?? null;
       }
 
@@ -446,7 +433,7 @@ const loadWorkflowPickerData = async (
         };
       }
 
-      const { statuses } = await getAvailableStatusesForPicker(boardId);
+      const { statuses } = await actions.getAvailableStatuses(boardId);
       return {
         ...EMPTY_PICKER_DATA,
         ticketOptions: {
@@ -458,8 +445,8 @@ const loadWorkflowPickerData = async (
     case 'contact': {
       const fixedClient = dependencies.find((dependency) => dependency.path === 'client_id');
       const contacts = fixedClient?.status === 'fixed' && fixedClient.value
-        ? await getContactsByClientForPicker(fixedClient.value)
-        : await getAllContactsForPicker();
+        ? await actions.getContactsByClient(fixedClient.value)
+        : await actions.getAllContacts();
       return {
         ...EMPTY_PICKER_DATA,
         contacts,
@@ -488,7 +475,7 @@ const loadWorkflowPickerData = async (
     default:
       return {
         ...EMPTY_PICKER_DATA,
-        ticketOptions: (await getTicketFieldOptionsForPicker()).options,
+        ticketOptions: (await actions.getTicketFieldOptions()).options,
       };
   }
 };
@@ -499,7 +486,8 @@ const WorkflowTicketPicker: React.FC<{
   onChange: (value: string | null) => void;
   idPrefix: string;
   disabled?: boolean;
-}> = ({ field, value, onChange, idPrefix, disabled }) => {
+  actions: WorkflowPickerActions;
+}> = ({ field, value, onChange, idPrefix, disabled, actions }) => {
   const [search, setSearch] = useState('');
   const [options, setOptions] = useState<WorkflowPickerOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -515,7 +503,7 @@ const WorkflowTicketPicker: React.FC<{
           try {
             setIsLoading(true);
             setLoadError(null);
-            const ticket = await getTicketByIdForPicker(value);
+            const ticket = await actions.getTicketById(value);
             if (!active) return;
             setOptions(ticket?.ticket_id ? ([{
               value: ticket.ticket_id,
@@ -543,7 +531,7 @@ const WorkflowTicketPicker: React.FC<{
       try {
         setIsLoading(true);
         setLoadError(null);
-        const result = await getTicketsForListForPicker({
+        const result = await actions.getTicketsForList({
           boardFilterState: 'active',
           searchQuery: normalizedSearch,
         });
@@ -575,7 +563,7 @@ const WorkflowTicketPicker: React.FC<{
       active = false;
       window.clearTimeout(timeoutId);
     };
-  }, [search, value]);
+  }, [search, value, actions]);
 
   const placeholder = field.editor?.fixedValueHint?.trim() ?? field.picker?.fixedValueHint?.trim() ?? 'Search tickets by number or title';
 
@@ -612,6 +600,7 @@ const renderDedicatedPicker = ({
   onChange,
   idPrefix,
   disabled,
+  actions,
 }: {
   field: WorkflowActionInputPickerField;
   pickerKind: string;
@@ -621,6 +610,7 @@ const renderDedicatedPicker = ({
   onChange: (value: string | null) => void;
   idPrefix: string;
   disabled?: boolean;
+  actions: WorkflowPickerActions;
 }): React.ReactNode => {
   switch (pickerKind) {
     case 'board': {
@@ -704,6 +694,7 @@ const renderDedicatedPicker = ({
           onChange={onChange}
           idPrefix={idPrefix}
           disabled={disabled}
+          actions={actions}
         />
       );
     default:
@@ -722,6 +713,7 @@ export const WorkflowActionInputFixedPicker: React.FC<{
   onChange: (value: string | null) => void;
   idPrefix: string;
   rootInputMapping: InputMapping;
+  actions: WorkflowPickerActions;
   disabled?: boolean;
 }> = ({
   field,
@@ -729,6 +721,7 @@ export const WorkflowActionInputFixedPicker: React.FC<{
   onChange,
   idPrefix,
   rootInputMapping,
+  actions,
   disabled,
 }) => {
   const [data, setData] = useState<WorkflowPickerData>(EMPTY_PICKER_DATA);
@@ -791,7 +784,7 @@ export const WorkflowActionInputFixedPicker: React.FC<{
     setLoadError(null);
     setLoadedDependencySignature(null);
 
-    loadWorkflowPickerData(pickerKind, dependencyResolutions)
+    loadWorkflowPickerData(pickerKind, dependencyResolutions, actions)
       .then((nextData) => {
         if (!active) return;
         setData(nextData);
@@ -812,7 +805,7 @@ export const WorkflowActionInputFixedPicker: React.FC<{
     return () => {
       active = false;
     };
-  }, [dependencyResolutions, dependencySignature, disabledExplanation, pickerKind]);
+  }, [actions, dependencyResolutions, dependencySignature, disabledExplanation, pickerKind]);
 
   useEffect(() => {
     if (!hasResolvedDependencies || !value || loadedDependencySignature !== dependencySignature) {
@@ -857,6 +850,7 @@ export const WorkflowActionInputFixedPicker: React.FC<{
           onChange,
           idPrefix,
           disabled,
+          actions,
         })
       )}
       {(disabledExplanation || loadError) && (

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -47,6 +47,10 @@ import WorkflowRunDialog from './WorkflowRunDialog';
 import WorkflowGraph from '../workflow-graph/WorkflowGraph';
 import WorkflowListV2 from '@alga-psa/workflows/components/automation-hub/WorkflowList';
 import EventsCatalogV2 from '@alga-psa/workflows/components/automation-hub/EventsCatalogV2';
+import type { WorkflowPickerActions } from '@alga-psa/workflows/components/automation-hub/WorkflowActionInputFixedPicker';
+import { getAllContacts, getContactsByClient } from '@alga-psa/clients/actions';
+import { getAvailableStatuses, getTicketFieldOptions } from '@alga-psa/integrations/actions';
+import { getTicketById, getTicketsForList } from '@alga-psa/tickets/actions';
 import WorkflowSchedules from './WorkflowSchedules';
 import { MappingPanel, type ActionInputField } from './mapping';
 import { ExpressionEditor, type ExpressionEditorHandle, type ExpressionContext, type JsonSchema as ExprJsonSchema } from './expression-editor';
@@ -275,6 +279,15 @@ type PipeSegment = {
 type PipeLocation = {
   pipePath: string;
   label: string;
+};
+
+const workflowPickerActions: WorkflowPickerActions = {
+  getAllContacts,
+  getContactsByClient,
+  getAvailableStatuses,
+  getTicketFieldOptions,
+  getTicketById,
+  getTicketsForList,
 };
 
 const CONTROL_BLOCKS: Array<{ id: Step['type']; label: string; category: string; description: string }> = [
@@ -4640,7 +4653,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
 
   const eventCatalogContent = (
     <div className="h-full min-h-0 overflow-y-auto px-6 py-4">
-      <EventsCatalogV2 />
+      <EventsCatalogV2 pickerActions={workflowPickerActions} />
     </div>
   );
   const schedulesContent = (

--- a/nx.json
+++ b/nx.json
@@ -12,10 +12,18 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "!{projectRoot}/dist/**", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "!{projectRoot}/dist/**",
+      "sharedGlobals"
+    ],
     "sharedGlobals": [
-      { "env": "EDITION" },
-      { "env": "NEXT_PUBLIC_EDITION" }
+      {
+        "env": "EDITION"
+      },
+      {
+        "env": "NEXT_PUBLIC_EDITION"
+      }
     ],
     "production": [
       "default",
@@ -34,17 +42,27 @@
       ]
     },
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ],
       "cache": true
     },
     "next:build": {
-      "inputs": ["production", "^production"],
+      "inputs": [
+        "production",
+        "^production"
+      ],
       "cache": true
     },
     "next:dev": {},
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "cache": true
     },
     "lint": {
@@ -52,7 +70,10 @@
     },
     "typecheck": {
       "cache": true,
-      "inputs": ["default", "^default"]
+      "inputs": [
+        "default",
+        "^default"
+      ]
     }
   },
   "plugins": [
@@ -66,14 +87,29 @@
         "buildDepsTargetName": "build-deps",
         "watchDepsTargetName": "watch-deps"
       },
-      "exclude": ["ee/runner/**", "ee/setup/**", "setup/**", "pgbouncer/**", "redis/**", "docker/**"]
+      "exclude": [
+        "ee/runner/**",
+        "ee/setup/**",
+        "setup/**",
+        "pgbouncer/**",
+        "redis/**",
+        "docker/**"
+      ]
     },
     {
       "plugin": "@nx/playwright/plugin",
       "options": {
         "targetName": "e2e"
       },
-      "exclude": ["ee/runner/**", "ee/setup/**", "ee/server/**", "setup/**", "pgbouncer/**", "redis/**", "docker/**"]
+      "exclude": [
+        "ee/runner/**",
+        "ee/setup/**",
+        "ee/server/**",
+        "setup/**",
+        "pgbouncer/**",
+        "redis/**",
+        "docker/**"
+      ]
     },
     {
       "plugin": "@nx/docker",
@@ -85,7 +121,15 @@
           "name": "docker:run"
         }
       },
-      "exclude": ["ee/runner/**", "ee/setup/**", "setup/**", "pgbouncer/**", "redis/**", "docker/**"]
+      "exclude": [
+        "ee/runner/**",
+        "ee/setup/**",
+        "setup/**",
+        "pgbouncer/**",
+        "redis/**",
+        "docker/**"
+      ]
     }
-  ]
+  ],
+  "analytics": false
 }


### PR DESCRIPTION
  Replace dynamic @alga-psa/* action imports in WorkflowActionInputFixedPicker with an injected WorkflowPickerActions prop, threaded through EventsCatalogV2 and SimulateDialog and supplied by WorkflowDesigner. Also reformat nx.json and disable analytics.

  And thus the Picker, weary of conjuring actions from thin air like the  Cheshire Cat's grin, asked to have its contacts and tickets handed to it on a silver platter — "Curiouser and curiouser!" said Alice, passing the props along. 🎩🐇✨