### PR TITLE
Add markdown export and print for text documents

### DIFF
--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -420,6 +420,11 @@ export class PDFGenerationService {
         }
       }
 
+      const escapedTitle = (document.document_name || 'Document')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
       return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -430,6 +435,7 @@ export class PDFGenerationService {
       body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; margin: 0; padding: 5mm; }
       pre { white-space: pre-wrap; word-wrap: break-word; }
       h1, h2, h3, h4, h5, h6 { margin-top: 1em; margin-bottom: 0.5em; }
+      .document-title { margin-top: 0; padding-bottom: 0.4em; border-bottom: 1px solid #e2e8f0; font-size: 1.8em; }
       p { margin-top: 0; margin-bottom: 1em; }
       table { border-collapse: collapse; width: 100%; margin-bottom: 1em; }
       th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
@@ -443,6 +449,7 @@ export class PDFGenerationService {
     </style>
   </head>
   <body>
+    <h1 class="document-title">${escapedTitle}</h1>
     ${htmlContent}
   </body>
 </html>`;

--- a/packages/documents/src/components/DocumentStorageCard.tsx
+++ b/packages/documents/src/components/DocumentStorageCard.tsx
@@ -733,18 +733,21 @@ function DocumentStorageCardComponent({
                     )}
                 </div>
 
-                {!hideActions && (
+                {!hideActions && (() => {
+                    const isTextDocument = document.type_name === 'text/plain' ||
+                                           document.type_name === 'text/markdown' ||
+                                           (!document.type_name && !document.file_id);
+                    const isPdfTarget = isTextDocument;
+
+                    return (
                     <div className="mt-4 pt-3 flex flex-row flex-wrap gap-1 justify-end border-t border-[rgb(var(--color-border-100))]">
-                        <Tooltip content={t('documents.download', 'Download')}>
+                        <Tooltip content={isPdfTarget ? t('documents.downloadAsPdf', 'Download as PDF') : t('documents.download', 'Download')}>
                             <Button
                                 id={`download-document-${document.document_id}-button`}
                                 variant="ghost"
                                 size="sm"
                                 onClick={async (e) => {
                                     e.stopPropagation();
-                                    const isPdfTarget = document.type_name === 'text/plain' ||
-                                                        document.type_name === 'text/markdown' ||
-                                                        (!document.type_name && !document.file_id);
 
                                     let downloadUrl = '#';
                                     if (isPdfTarget) {
@@ -770,6 +773,30 @@ function DocumentStorageCardComponent({
                                 <Download className="w-4 h-4" />
                             </Button>
                         </Tooltip>
+                        {isTextDocument && (
+                            <Tooltip content={t('documents.downloadAsMarkdown', 'Download as Markdown')}>
+                                <Button
+                                    id={`download-document-${document.document_id}-markdown-button`}
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={async (e) => {
+                                        e.stopPropagation();
+                                        if (!document.document_id) return;
+                                        const downloadUrl = `/api/documents/download/${document.document_id}?format=markdown`;
+                                        const filename = `${document.document_name || 'document'}.md`;
+                                        try {
+                                            await downloadDocument(downloadUrl, filename, true);
+                                        } catch (error) {
+                                            console.error('Markdown download failed:', error);
+                                        }
+                                    }}
+                                    disabled={isDeleteProcessing}
+                                    className="text-[rgb(var(--color-text-600))] hover:text-[rgb(var(--color-text-900))] hover:bg-[rgb(var(--color-border-100))] p-1.5"
+                                >
+                                    <FileText className="w-4 h-4" />
+                                </Button>
+                            </Tooltip>
+                        )}
                         {onShare && (
                             <Tooltip content={t('documents.share', 'Share')}>
                                 <Button
@@ -839,7 +866,8 @@ function DocumentStorageCardComponent({
                             </Tooltip>
                         )}
                     </div>
-                )}
+                    );
+                })()}
             </div>
         </ReflectionContainer>
         <DeleteEntityDialog

--- a/packages/documents/src/components/Documents.tsx
+++ b/packages/documents/src/components/Documents.tsx
@@ -23,7 +23,7 @@ import DocumentListView from './DocumentListView';
 import ShareLinkDialog from './ShareLinkDialog';
 import ViewSwitcher from '@alga-psa/ui/components/ViewSwitcher';
 import FolderSelectorModal from './FolderSelectorModal';
-import { Plus, Link, FileText, Edit3, Download, Grid, List as ListIcon, FolderPlus, X, FolderInput, Trash2 } from 'lucide-react';
+import { Plus, Link, FileText, Edit3, Download, Grid, List as ListIcon, FolderPlus, X, FolderInput, Trash2, Printer } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { downloadDocument, getDocumentDownloadUrl } from '@alga-psa/documents/lib/documentUtils';
 import toast from 'react-hot-toast';
@@ -1230,25 +1230,75 @@ const Documents = ({
              selectedDocument.type_name === 'text/markdown' ||
              (!selectedDocument.type_name && !selectedDocument.file_id)
             ) && (
-            <Button
-              id={`${id}-download-pdf-btn`}
-              onClick={async () => {
-                if (selectedDocument) {
-                  const downloadUrl = `/api/documents/download/${selectedDocument.document_id}?format=pdf`;
-                  const filename = `${selectedDocument.document_name || 'document'}.pdf`;
-                  try {
-                    await downloadDocument(downloadUrl, filename, true);
-                  } catch (error) {
-                    console.error('Download failed:', error);
+            <>
+              <Button
+                id={`${id}-download-pdf-btn`}
+                onClick={async () => {
+                  if (selectedDocument) {
+                    const downloadUrl = `/api/documents/download/${selectedDocument.document_id}?format=pdf`;
+                    const filename = `${selectedDocument.document_name || 'document'}.pdf`;
+                    try {
+                      await downloadDocument(downloadUrl, filename, true);
+                    } catch (error) {
+                      console.error('Download failed:', error);
+                    }
                   }
-                }
-              }}
-              variant="outline"
-              size="sm"
-            >
-              <Download className="w-4 h-4 mr-2" />
-              PDF
-            </Button>
+                }}
+                variant="outline"
+                size="sm"
+              >
+                <Download className="w-4 h-4 mr-2" />
+                PDF
+              </Button>
+              <Button
+                id={`${id}-download-md-btn`}
+                onClick={async () => {
+                  if (selectedDocument) {
+                    const downloadUrl = `/api/documents/download/${selectedDocument.document_id}?format=markdown`;
+                    const filename = `${selectedDocument.document_name || 'document'}.md`;
+                    try {
+                      await downloadDocument(downloadUrl, filename, true);
+                    } catch (error) {
+                      console.error('Markdown download failed:', error);
+                    }
+                  }
+                }}
+                variant="outline"
+                size="sm"
+              >
+                <FileText className="w-4 h-4 mr-2" />
+                Markdown
+              </Button>
+              <Button
+                id={`${id}-print-document-btn`}
+                onClick={async () => {
+                  if (!selectedDocument) return;
+                  try {
+                    const res = await fetch(
+                      `/api/documents/download/${selectedDocument.document_id}?format=pdf`,
+                    );
+                    if (!res.ok) throw new Error(`Print fetch failed: ${res.status}`);
+                    const blob = await res.blob();
+                    const blobUrl = URL.createObjectURL(blob);
+                    const printWindow = window.open(blobUrl, '_blank');
+                    if (printWindow) {
+                      printWindow.addEventListener('load', () => {
+                        printWindow.focus();
+                        printWindow.print();
+                      });
+                    }
+                    setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+                  } catch (error) {
+                    console.error('Print failed:', error);
+                  }
+                }}
+                variant="outline"
+                size="sm"
+              >
+                <Printer className="w-4 h-4 mr-2" />
+                Print
+              </Button>
+            </>
           )}
           {!isCreatingNew && !isEditModeInDrawer && selectedDocument && (
             <Button

--- a/packages/formatting/src/blocknoteUtils.ts
+++ b/packages/formatting/src/blocknoteUtils.ts
@@ -957,6 +957,225 @@ export function convertProseMirrorToHTML(doc: unknown): string {
   return renderPMNode(pmDoc);
 }
 
+// ── ProseMirror JSON → Markdown conversion ─────────────────────────
+
+function renderPMMarksMarkdown(text: string, marks: PMNode['marks']): string {
+  if (!text) return text;
+  if (!marks || marks.length === 0) return text;
+
+  // CommonMark forbids leading/trailing whitespace inside emphasis delimiters
+  // (e.g. `*foo *` won't render). Peel whitespace off and restore it outside.
+  const leadingMatch = text.match(/^\s+/);
+  const trailingMatch = text.match(/\s+$/);
+  const leading = leadingMatch ? leadingMatch[0] : '';
+  const trailing = trailingMatch ? trailingMatch[0] : '';
+  let core = text.slice(leading.length, text.length - trailing.length);
+
+  if (core.length === 0) return text;
+
+  for (const mark of marks) {
+    switch (mark.type) {
+      case 'bold':
+        core = `**${core}**`;
+        break;
+      case 'italic':
+        core = `*${core}*`;
+        break;
+      case 'underline':
+        core = `<u>${core}</u>`;
+        break;
+      case 'strike':
+        core = `~~${core}~~`;
+        break;
+      case 'code':
+        core = `\`${core}\``;
+        break;
+      case 'link': {
+        const href = String(mark.attrs?.href ?? '');
+        core = `[${core}](${href})`;
+        break;
+      }
+    }
+  }
+  return `${leading}${core}${trailing}`;
+}
+
+function renderPMInlineMarkdown(nodes: PMNode[] | undefined): string {
+  if (!nodes || nodes.length === 0) return '';
+
+  return nodes.map(node => {
+    if (node.type === 'text' && node.text != null) {
+      return renderPMMarksMarkdown(node.text, node.marks);
+    }
+    if (node.type === 'hard_break' || node.type === 'hardBreak') {
+      return '  \n';
+    }
+    if (node.type === 'mention') {
+      const { username, displayName } = (node.attrs ?? {}) as {
+        username?: string; displayName?: string;
+      };
+      return username ? `@${username}` : `@${displayName || 'Unknown'}`;
+    }
+    if (node.content) return renderPMInlineMarkdown(node.content);
+    return '';
+  }).join('');
+}
+
+function renderPMNodeMarkdown(node: PMNode, listContext?: { ordered: boolean; index: number }): string {
+  switch (node.type) {
+    case 'doc':
+      return (node.content ?? [])
+        .map(child => renderPMNodeMarkdown(child))
+        .join('\n\n');
+
+    case 'paragraph': {
+      const inner = renderPMInlineMarkdown(node.content);
+      return inner;
+    }
+
+    case 'heading': {
+      const level = Math.min(Math.max(Number(node.attrs?.level) || 1, 1), 6);
+      const inner = renderPMInlineMarkdown(node.content);
+      return `${'#'.repeat(level)} ${inner}`;
+    }
+
+    case 'bullet_list':
+    case 'bulletList': {
+      return (node.content ?? [])
+        .map(item => renderPMNodeMarkdown(item, { ordered: false, index: 0 }))
+        .join('\n');
+    }
+
+    case 'ordered_list':
+    case 'orderedList': {
+      const start = Number(node.attrs?.order ?? node.attrs?.start ?? 1);
+      return (node.content ?? [])
+        .map((item, i) => renderPMNodeMarkdown(item, { ordered: true, index: start + i }))
+        .join('\n');
+    }
+
+    case 'list_item':
+    case 'listItem': {
+      const marker = listContext?.ordered ? `${listContext.index}.` : '-';
+      const childBlocks = (node.content ?? []).map(child => renderPMNodeMarkdown(child));
+      const first = (childBlocks[0] ?? '').trim();
+      const rest = childBlocks.slice(1)
+        .map(block => block.split('\n').map(l => (l ? `  ${l}` : l)).join('\n'))
+        .join('\n');
+      return rest ? `${marker} ${first}\n${rest}` : `${marker} ${first}`;
+    }
+
+    case 'task_list':
+    case 'taskList': {
+      return (node.content ?? [])
+        .map(item => renderPMNodeMarkdown(item))
+        .join('\n');
+    }
+
+    case 'task_item':
+    case 'taskItem': {
+      const checked = Boolean(node.attrs?.checked);
+      const inner = (node.content ?? []).map(child => renderPMNodeMarkdown(child)).join('\n').trim();
+      return `- [${checked ? 'x' : ' '}] ${inner}`;
+    }
+
+    case 'blockquote': {
+      const inner = (node.content ?? []).map(child => renderPMNodeMarkdown(child)).join('\n\n');
+      return inner.split('\n').map(line => `> ${line}`).join('\n');
+    }
+
+    case 'code_block':
+    case 'codeBlock': {
+      const lang = node.attrs?.language ? String(node.attrs.language) : '';
+      const code = (node.content ?? []).map(n => n.text ?? '').join('');
+      return `\`\`\`${lang}\n${code}\n\`\`\``;
+    }
+
+    case 'horizontal_rule':
+    case 'horizontalRule':
+      return '---';
+
+    case 'hard_break':
+    case 'hardBreak':
+      return '  \n';
+
+    case 'image': {
+      const src = String(node.attrs?.src ?? '');
+      const alt = String(node.attrs?.alt ?? '');
+      return src ? `![${alt}](${src})` : '';
+    }
+
+    case 'text':
+      return renderPMMarksMarkdown(node.text ?? '', node.marks);
+
+    case 'mention': {
+      const { username, displayName } = (node.attrs ?? {}) as {
+        username?: string; displayName?: string;
+      };
+      return username ? `@${username}` : `@${displayName || 'Unknown'}`;
+    }
+
+    default: {
+      if (node.content) return (node.content).map(child => renderPMNodeMarkdown(child)).join('\n');
+      if (node.text != null) return node.text;
+      return '';
+    }
+  }
+}
+
+/**
+ * Converts ProseMirror JSON ({type: 'doc', content: [...]}) to a Markdown string.
+ * Handles paragraphs, headings, lists, code blocks, blockquotes, marks
+ * (bold, italic, underline, strike, code, link), mention nodes, and emoji.
+ */
+export function convertProseMirrorToMarkdown(doc: unknown): string {
+  if (!doc) return '';
+
+  let parsed: unknown = doc;
+  if (typeof doc === 'string') {
+    try {
+      parsed = JSON.parse(doc);
+    } catch {
+      return typeof doc === 'string' ? doc : '';
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return '';
+
+  const pmDoc = parsed as PMNode;
+  if (pmDoc.type !== 'doc') return '';
+
+  return renderPMNodeMarkdown(pmDoc);
+}
+
+/**
+ * Auto-detects whether block_data is BlockNote or ProseMirror format
+ * and converts it to Markdown using the appropriate converter.
+ */
+export function convertBlockContentToMarkdown(blockData: unknown): string {
+  if (!blockData) return '';
+
+  let parsed: unknown = blockData;
+  if (typeof blockData === 'string') {
+    try {
+      parsed = JSON.parse(blockData);
+    } catch {
+      return convertBlockNoteToMarkdown(blockData);
+    }
+  }
+
+  // ProseMirror format: {type: 'doc', content: [...]}
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const maybeDoc = parsed as { type?: string };
+    if (maybeDoc.type === 'doc') {
+      return convertProseMirrorToMarkdown(parsed);
+    }
+  }
+
+  // BlockNote format: [{type: '...', props: {...}, content: [...]}]
+  return convertBlockNoteToMarkdown(blockData);
+}
+
 /**
  * Auto-detects whether block_data is BlockNote or ProseMirror format
  * and converts it to HTML using the appropriate converter.

--- a/server/src/app/api/documents/download/[fileId]/route.ts
+++ b/server/src/app/api/documents/download/[fileId]/route.ts
@@ -3,6 +3,7 @@ import { createTenantKnex } from 'server/src/lib/db';
 import DocumentBlockContent from 'server/src/lib/models/documentBlockContent';
 import Document from '@alga-psa/documents/models/document';
 import { marked } from 'marked';
+import { convertBlockContentToMarkdown } from '@alga-psa/formatting/blocknoteUtils';
 
 import logger from '@alga-psa/core/logger';
 import { downloadDocument } from '@alga-psa/documents/actions/documentActions';
@@ -32,6 +33,102 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ file
 
   // Wrap in runWithTenant to ensure tenant context persists across async boundaries
   return await runWithTenant(session.user.tenant, async () => {
+    // --- Markdown Export Logic ---
+    if (format === 'markdown' || format === 'md') {
+      logger.info(`Markdown export requested for document ID: ${lookupId}`);
+
+      try {
+        const { knex } = await createTenantKnex();
+        const { document, blockRow, textRow } = await withTransaction(knex, async (trx: Knex.Transaction) => {
+          const doc =
+            (await Document.get(trx, lookupId)) ||
+            (await trx('documents')
+              .where({ file_id: lookupId, tenant: session.user.tenant })
+              .first());
+
+          if (!doc || doc.tenant !== session.user.tenant) {
+            return { document: null, blockRow: null, textRow: null };
+          }
+
+          const [block, text] = await Promise.all([
+            trx('document_block_content')
+              .where({ document_id: doc.document_id, tenant: session.user.tenant })
+              .select('block_data')
+              .first<{ block_data: unknown }>(),
+            trx('document_content')
+              .where({ document_id: doc.document_id, tenant: session.user.tenant })
+              .select('content')
+              .first<{ content: string | null }>(),
+          ]);
+
+          return { document: doc, blockRow: block, textRow: text };
+        });
+
+        if (!document) {
+          logger.warn(`Document not found or tenant mismatch for markdown export. ID: ${lookupId}, Tenant: ${session.user.tenant}`);
+          return NextResponse.json({ error: 'Document not found.' }, { status: 404 });
+        }
+
+        let markdown: string | null = null;
+
+        if (blockRow?.block_data !== undefined && blockRow?.block_data !== null) {
+          const converted = convertBlockContentToMarkdown(blockRow.block_data);
+          if (typeof converted === 'string' && converted.trim().length > 0) {
+            markdown = converted;
+          }
+        }
+
+        if (!markdown && typeof textRow?.content === 'string' && textRow.content.trim().length > 0) {
+          markdown = textRow.content;
+        }
+
+        // Fall back to the stored file for file-backed text documents (e.g. uploaded .txt/.md).
+        if (!markdown && document.file_id) {
+          const mime = (document.mime_type || document.type_name || '').toLowerCase();
+          const looksTextual = mime.startsWith('text/') || mime === 'application/json' || mime === 'application/xml';
+          if (looksTextual) {
+            try {
+              const fileResult = await StorageService.downloadFile(document.file_id);
+              if (fileResult?.buffer) {
+                markdown = fileResult.buffer.toString('utf-8');
+              }
+            } catch (fileError) {
+              logger.warn(`Failed to read file content for markdown export. Document ID: ${lookupId}`, fileError);
+            }
+          }
+        }
+
+        if (!markdown) {
+          logger.warn(`Document has no exportable content for markdown. Document ID: ${lookupId}`);
+          return NextResponse.json({ error: 'Document has no content to export.' }, { status: 404 });
+        }
+
+        // Collapse whitespace-only lines and runs of blank lines left over by the
+        // BlockNote → markdown converter (empty paragraphs → " \n\n").
+        markdown = markdown
+          .replace(/\r\n/g, '\n')
+          .split('\n')
+          .map((line) => (line.trim().length === 0 ? '' : line.replace(/[ \t]+$/, '')))
+          .join('\n')
+          .replace(/\n{3,}/g, '\n\n')
+          .trim() + '\n';
+
+        const safeName = (document.document_name || 'document').replace(/[\r\n"]/g, '_');
+        const headers = new Headers();
+        headers.set('Content-Type', 'text/markdown; charset=utf-8');
+        headers.set(
+          'Content-Disposition',
+          `attachment; filename="${safeName}.md"; filename*=UTF-8''${encodeURIComponent(safeName)}.md`,
+        );
+        headers.set('Cache-Control', 'no-store');
+
+        return new Response(markdown, { status: 200, headers });
+      } catch (error) {
+        logger.error(`Error exporting markdown for document ${lookupId}:`, error);
+        return NextResponse.json({ error: 'Failed to export markdown.' }, { status: 500 });
+      }
+    }
+
     // --- PDF Generation Logic ---
     if (format === 'pdf') {
       logger.info(`PDF generation requested for document ID: ${lookupId}`);


### PR DESCRIPTION
  Introduce a ProseMirror→Markdown converter and a /documents/download ?format=markdown route, wire new Markdown and Print buttons into the document drawer and storage card, and stamp an escaped document title on top of the generated PDF.

  🌪️  And lo, the humble text/plain creature donned three hats at once — Pdf, Markdown, and Print — then tipped its escapedTitle to the Cheshire Cat and whispered, "We're all mad here, but at least we render now." 🎩📄✨