### PR TITLE
Add inline duplicate action for workflow designer steps

### DIFF
--- a/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
@@ -1018,7 +1018,7 @@ test.describe('Workflow Designer UI - basic', () => {
     }
   });
 
-  test('T079: grouped action steps preserve the current absence of duplicate behavior', async ({ page }) => {
+  test('T079: grouped action steps can be duplicated inline and select the new copy', async ({ page }) => {
     test.setTimeout(120000);
 
     const { db, tenantData, workflowPage } = await setupDesigner(page);
@@ -1026,10 +1026,21 @@ test.describe('Workflow Designer UI - basic', () => {
       await workflowPage.clickNewWorkflow();
       await workflowPage.addButtonFor('ticket').click();
 
-      const stepId = await workflowPage.getFirstStepId();
-      await expect(workflowPage.stepDeleteButton(stepId)).toBeVisible();
-      await expect(page.locator(`#workflow-step-duplicate-${stepId}`)).toHaveCount(0);
-      await expect(page.getByRole('button', { name: /duplicate step/i })).toHaveCount(0);
+      const originalStepId = await workflowPage.getFirstStepId();
+      await expect(workflowPage.stepDeleteButton(originalStepId)).toBeVisible();
+      await expect(workflowPage.stepDuplicateButton(originalStepId)).toBeVisible();
+
+      await workflowPage.stepDuplicateButton(originalStepId).click();
+      await expect(page.locator('[id^="workflow-step-select-"]')).toHaveCount(2);
+
+      const duplicatedStepButton = page.locator('[id^="workflow-step-select-"]').nth(1);
+      const duplicatedStepButtonId = await duplicatedStepButton.getAttribute('id');
+      expect(duplicatedStepButtonId).toBeTruthy();
+      const duplicatedStepId = duplicatedStepButtonId!.replace('workflow-step-select-', '');
+      expect(duplicatedStepId).not.toBe(originalStepId);
+
+      await expect(page.locator(`#workflow-step-saveAs-${duplicatedStepId}`)).toHaveValue('ticketsCreateResult');
+      await expect(page.locator(`#workflow-step-duplicate-${duplicatedStepId}`)).toBeVisible();
     } finally {
       await rollbackTenant(db, tenantData.tenant.tenantId).catch(() => {});
       await db.destroy();

--- a/ee/server/src/__tests__/page-objects/WorkflowDesignerPage.ts
+++ b/ee/server/src/__tests__/page-objects/WorkflowDesignerPage.ts
@@ -289,6 +289,10 @@ export class WorkflowDesignerPage {
     return this.page.locator(`#workflow-step-delete-${stepId}`);
   }
 
+  stepDuplicateButton(stepId: string): Locator {
+    return this.page.locator(`#workflow-step-duplicate-${stepId}`);
+  }
+
   dropStepsHereText(): Locator {
     // Kept for backward compatibility with older pipeline UI, but prefer `emptyPipeline`.
     return this.page.getByText('Drop steps here');

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -1077,6 +1077,56 @@ const generateSaveAsName = (actionId: string): string => {
   return camelCase + 'Result';
 };
 
+const cloneWorkflowStepValue = <T,>(value: T): T => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const duplicateWorkflowStepWithNewIds = (step: Step): Step => {
+  const clonedStep = cloneWorkflowStepValue(step);
+
+  if (clonedStep.type === 'control.if') {
+    const ifStep = clonedStep as IfBlock;
+    return {
+      ...ifStep,
+      id: uuidv4(),
+      then: ifStep.then.map(duplicateWorkflowStepWithNewIds),
+      else: ifStep.else ? ifStep.else.map(duplicateWorkflowStepWithNewIds) : ifStep.else
+    } satisfies IfBlock;
+  }
+
+  if (clonedStep.type === 'control.tryCatch') {
+    const tryCatchStep = clonedStep as TryCatchBlock;
+    return {
+      ...tryCatchStep,
+      id: uuidv4(),
+      try: tryCatchStep.try.map(duplicateWorkflowStepWithNewIds),
+      catch: tryCatchStep.catch.map(duplicateWorkflowStepWithNewIds)
+    } satisfies TryCatchBlock;
+  }
+
+  if (clonedStep.type === 'control.forEach') {
+    const forEachStep = clonedStep as ForEachBlock;
+    return {
+      ...forEachStep,
+      id: uuidv4(),
+      body: forEachStep.body.map(duplicateWorkflowStepWithNewIds)
+    } satisfies ForEachBlock;
+  }
+
+  return {
+    ...clonedStep,
+    id: uuidv4()
+  } as Step;
+};
+
 const createStepFromPalette = (
   type: Step['type'],
   nodeRegistry: Record<string, NodeRegistryItem>
@@ -2747,6 +2797,46 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     if (selectedStepId === stepId) {
       setSelectedStepId(null);
     }
+  };
+
+  const handleDuplicateStep = (stepId: string) => {
+    if (!activeDefinition) return;
+
+    const stepPathMap = buildStepPathMap(activeDefinition.steps as Step[]);
+    const stepPath = stepPathMap[stepId];
+    if (!stepPath) {
+      throw new Error(`Cannot duplicate step ${stepId}: step path was not found`);
+    }
+
+    const stepPathMatch = stepPath.match(/^(.*)\.steps\[(\d+)\]$/);
+    if (!stepPathMatch) {
+      throw new Error(`Cannot duplicate step ${stepId}: step path "${stepPath}" is invalid`);
+    }
+
+    const [, pipePath, stepIndexRaw] = stepPathMatch;
+    const stepIndex = Number(stepIndexRaw);
+    const segments = parsePipePath(pipePath);
+    const pipeSteps = getStepsAtPath(activeDefinition.steps as Step[], segments);
+    const sourceStep = pipeSteps[stepIndex];
+
+    if (!sourceStep) {
+      throw new Error(`Cannot duplicate step ${stepId}: source step was not found in pipe "${pipePath}"`);
+    }
+
+    const duplicatedStep = duplicateWorkflowStepWithNewIds(sourceStep);
+    const nextSteps = [
+      ...pipeSteps.slice(0, stepIndex + 1),
+      duplicatedStep,
+      ...pipeSteps.slice(stepIndex + 1)
+    ];
+
+    setActiveDefinition({
+      ...activeDefinition,
+      steps: updateStepsAtPath(activeDefinition.steps as Step[], segments, nextSteps)
+    });
+    setSelectedPipePath(pipePath);
+    setSelectedStepId(duplicatedStep.id);
+    setPendingInsertPosition(null);
   };
 
   const handleStepUpdate = (stepId: string, updater: (step: Step) => Step) => {
@@ -4578,6 +4668,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
                       selectedStepId={selectedStepId}
                       onSelectStep={setSelectedStepId}
                       onDeleteStep={handleDeleteStep}
+                      onDuplicateStep={handleDuplicateStep}
                       onSelectPipe={handlePipeSelect}
                       onPipeHover={handlePipeHover}
                       onInsertStep={(index) => handleInsertStep('root', index)}
@@ -4870,6 +4961,7 @@ const Pipe: React.FC<{
   selectedStepId: string | null;
   onSelectStep: (id: string) => void;
   onDeleteStep: (id: string) => void;
+  onDuplicateStep: (id: string) => void;
   onSelectPipe: (pipePath: string) => void;
   onPipeHover: (pipePath: string) => void;
   onInsertStep?: (index: number) => void;
@@ -4886,6 +4978,7 @@ const Pipe: React.FC<{
   selectedStepId,
   onSelectStep,
   onDeleteStep,
+  onDuplicateStep,
   onSelectPipe,
   onPipeHover,
   onInsertStep,
@@ -4954,6 +5047,7 @@ const Pipe: React.FC<{
                       selectedStepId={selectedStepId}
                       onSelectStep={onSelectStep}
                       onDeleteStep={onDeleteStep}
+                      onDuplicateStep={onDuplicateStep}
                       onSelectPipe={onSelectPipe}
                       onPipeHover={onPipeHover}
                       onInsertStep={onInsertStep}
@@ -5008,6 +5102,7 @@ const StepCard: React.FC<{
   selectedStepId: string | null;
   onSelectStep: (id: string) => void;
   onDeleteStep: (id: string) => void;
+  onDuplicateStep: (id: string) => void;
   onSelectPipe: (pipePath: string) => void;
   onPipeHover: (pipePath: string) => void;
   onInsertStep?: (index: number) => void;
@@ -5026,6 +5121,7 @@ const StepCard: React.FC<{
   selectedStepId,
   onSelectStep,
   onDeleteStep,
+  onDuplicateStep,
   onSelectPipe,
   onPipeHover,
   onInsertStep,
@@ -5119,6 +5215,18 @@ const StepCard: React.FC<{
                 <GripVertical className="h-4 w-4" />
               </div>
               <Button
+                id={`workflow-step-duplicate-${step.id}`}
+                variant="ghost"
+                size="sm"
+                onClick={() => onDuplicateStep(step.id)}
+                className="text-gray-400 hover:text-primary-600 p-1 h-auto"
+                data-testid={`step-duplicate-${step.id}`}
+                title="Duplicate step"
+                aria-label={`Duplicate ${label} step`}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+              <Button
                 id={`workflow-step-delete-${step.id}`}
                 variant="ghost"
                 size="sm"
@@ -5148,6 +5256,7 @@ const StepCard: React.FC<{
                 selectedStepId={selectedStepId}
                 onSelectStep={onSelectStep}
                 onDeleteStep={onDeleteStep}
+                onDuplicateStep={onDuplicateStep}
                 onSelectPipe={onSelectPipe}
                 onPipeHover={onPipeHover}
                 onInsertStep={onInsertAtPath ? (index) => onInsertAtPath(thenPath, index) : undefined}
@@ -5166,6 +5275,7 @@ const StepCard: React.FC<{
                 selectedStepId={selectedStepId}
                 onSelectStep={onSelectStep}
                 onDeleteStep={onDeleteStep}
+                onDuplicateStep={onDuplicateStep}
                 onSelectPipe={onSelectPipe}
                 onPipeHover={onPipeHover}
                 onInsertStep={onInsertAtPath ? (index) => onInsertAtPath(elsePath, index) : undefined}
@@ -5194,6 +5304,7 @@ const StepCard: React.FC<{
                 selectedStepId={selectedStepId}
                 onSelectStep={onSelectStep}
                 onDeleteStep={onDeleteStep}
+                onDuplicateStep={onDuplicateStep}
                 onSelectPipe={onSelectPipe}
                 onPipeHover={onPipeHover}
                 onInsertStep={onInsertAtPath ? (index) => onInsertAtPath(tryPath, index) : undefined}
@@ -5212,6 +5323,7 @@ const StepCard: React.FC<{
                 selectedStepId={selectedStepId}
                 onSelectStep={onSelectStep}
                 onDeleteStep={onDeleteStep}
+                onDuplicateStep={onDuplicateStep}
                 onSelectPipe={onSelectPipe}
                 onPipeHover={onPipeHover}
                 onInsertStep={onInsertAtPath ? (index) => onInsertAtPath(catchPath, index) : undefined}
@@ -5240,6 +5352,7 @@ const StepCard: React.FC<{
                 selectedStepId={selectedStepId}
                 onSelectStep={onSelectStep}
                 onDeleteStep={onDeleteStep}
+                onDuplicateStep={onDuplicateStep}
                 onSelectPipe={onSelectPipe}
                 onPipeHover={onPipeHover}
                 onInsertStep={onInsertAtPath ? (index) => onInsertAtPath(bodyPath, index) : undefined}


### PR DESCRIPTION
## Summary
- add an inline duplicate action to workflow designer step cards
- deep-clone duplicated steps with fresh ids for nested control-block children
- insert the duplicated step immediately below the source step and select the new copy
- update the workflow designer page object and integration coverage for the new duplicate behavior

## Validation
- `git diff --check`
- manual verification with `alga-dev` in the workflow editor (duplicate button renders, inserts a copy below, and selects the copied step)

## Notes
- `npx tsc -p ee/server/tsconfig.json --noEmit --pretty false` still reports a pre-existing unrelated type error in `WorkflowDesigner.tsx` around `workflowPickerActions` / `getTicketsForList`
