### PR TITLE
Filter time entry services and preserve list add-item context

### DIFF
--- a/packages/scheduling/src/actions/timeEntryServices.ts
+++ b/packages/scheduling/src/actions/timeEntryServices.ts
@@ -205,7 +205,7 @@ export const fetchDefaultClientTaxRateInfoForWorkItem = withAuth(async (
 export const fetchServicesForTimeEntry = withAuth(async (
   user,
   { tenant },
-  workItemType?: string
+  _workItemType?: string
 ): Promise<{ id: string; name: string; type: string; tax_rate_id: string | null; tax_percentage: number | null }[]> => {
   const {knex: db} = await createTenantKnex();
 
@@ -214,16 +214,16 @@ export const fetchServicesForTimeEntry = withAuth(async (
     throw new Error('Permission denied: Cannot read services for time entries');
   }
 
-  let query = db('service_catalog as sc')
-    .leftJoin('service_types as st', function() {
-      this.on('sc.custom_service_type_id', '=', 'st.id')
-          .andOn('sc.tenant', '=', 'st.tenant');
-    })
+  const services = await db('service_catalog as sc')
     .leftJoin('tax_rates as tr', function() {
       this.on('sc.tax_rate_id', '=', 'tr.tax_rate_id')
           .andOn('sc.tenant', '=', 'tr.tenant');
     })
-    .where({ 'sc.tenant': tenant })
+    .where({
+      'sc.tenant': tenant,
+      'sc.item_kind': 'service',
+      'sc.billing_method': 'hourly'
+    })
     .select(
       'sc.service_id as id',
       'sc.service_name as name',
@@ -232,13 +232,6 @@ export const fetchServicesForTimeEntry = withAuth(async (
       'tr.tax_percentage'
     );
 
-  // For ad_hoc entries, only show Time-based services
-  if (workItemType === 'ad_hoc') {
-    // Assuming 'Time' service type maps to 'usage' billing method based on migrations
-    query = query.where('sc.billing_method', 'usage');
-  }
-
-  const services = await query;
   return services;
 });
 

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/AddWorkItemDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/AddWorkItemDialog.tsx
@@ -13,10 +13,11 @@ interface AddWorkItemDialogProps {
   onClose: () => void;
   onAdd: (workItem: IWorkItem) => void;
   availableWorkItems: IWorkItem[];
+  initialWorkItemId?: string | null;
   timePeriod?: ITimePeriodView;
 }
 
-export function AddWorkItemDialog({ isOpen, onClose, onAdd, availableWorkItems, timePeriod }: AddWorkItemDialogProps) {
+export function AddWorkItemDialog({ isOpen, onClose, onAdd, availableWorkItems, initialWorkItemId, timePeriod }: AddWorkItemDialogProps) {
   const { t } = useTranslation('msp/time-entry');
   const handleSelect = (workItem: IWorkItem | null) => {
     if (workItem) {
@@ -61,6 +62,7 @@ export function AddWorkItemDialog({ isOpen, onClose, onAdd, availableWorkItems, 
             <WorkItemPicker 
               onSelect={handleSelect} 
               availableWorkItems={availableWorkItems}
+              initialWorkItemId={initialWorkItemId}
               timePeriod={timePeriod}
             />
           </div>

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheet.tsx
@@ -252,6 +252,7 @@ export function TimeSheet({
     );
 
     const [interactionState, setInteractionState] = useState<TimeSheetInteractionState>({ type: 'idle' });
+    const [persistedListFocusFilter, setPersistedListFocusFilter] = useState<TimeSheetListFocusFilter | null>(null);
 
     useEffect(() => {
         setTimeSheet(initialTimeSheet);
@@ -260,9 +261,7 @@ export function TimeSheet({
     const selectedCell = interactionState.type === 'dialog'
         ? interactionState.selection
         : null;
-    const listFocusFilter = interactionState.type === 'list-focus'
-        ? interactionState.filter
-        : null;
+    const listFocusFilter = persistedListFocusFilter;
     const activeQuickAdd = interactionState.type === 'quick-add'
         ? interactionState.quickAdd
         : null;
@@ -279,16 +278,23 @@ export function TimeSheet({
 
             return currentInteraction;
         });
+
+        if (newMode === 'grid') {
+            setPersistedListFocusFilter(null);
+        }
+
         setViewMode(newMode);
     }, [setViewMode]);
 
     const handleClearListFocusFilter = useCallback(() => {
+        setPersistedListFocusFilter(null);
         setInteractionState((currentInteraction) =>
             currentInteraction.type === 'list-focus' ? { type: 'idle' } : currentInteraction
         );
     }, []);
 
     const handleBackToGrid = useCallback(() => {
+        setPersistedListFocusFilter(null);
         setInteractionState((currentInteraction) =>
             currentInteraction.type === 'list-focus' ? { type: 'idle' } : currentInteraction
         );
@@ -299,18 +305,21 @@ export function TimeSheet({
         const normalizedDate = toDateOnlyString(selection.date);
 
         if (selection.entries.length > 1) {
+            const nextFilter = {
+                workItemId: selection.workItem.work_item_id,
+                workItemLabel: getWorkItemDisplayName(selection.workItem),
+                date: normalizedDate,
+                dateLabel: format(parseLocalDate(normalizedDate), 'MMM d'),
+                entryIds: selection.entries
+                    .map((entry) => entry.entry_id)
+                    .filter((entryId): entryId is string => Boolean(entryId)),
+                entryCount: selection.entries.length,
+            } satisfies TimeSheetListFocusFilter;
+
+            setPersistedListFocusFilter(nextFilter);
             setInteractionState({
                 type: 'list-focus',
-                filter: {
-                    workItemId: selection.workItem.work_item_id,
-                    workItemLabel: getWorkItemDisplayName(selection.workItem),
-                    date: normalizedDate,
-                    dateLabel: format(parseLocalDate(normalizedDate), 'MMM d'),
-                    entryIds: selection.entries
-                        .map((entry) => entry.entry_id)
-                        .filter((entryId): entryId is string => Boolean(entryId)),
-                    entryCount: selection.entries.length,
-                },
+                filter: nextFilter,
             });
             setViewMode('list');
             return;
@@ -350,12 +359,11 @@ export function TimeSheet({
     }, [initialDate]);
 
     const syncListFocusFilter = useCallback((entries: ITimeEntryWithWorkItem[]) => {
-        setInteractionState((currentInteraction) => {
-            if (currentInteraction.type !== 'list-focus') {
-                return currentInteraction;
+        setPersistedListFocusFilter((currentFilter) => {
+            if (!currentFilter) {
+                return currentFilter;
             }
 
-            const currentFilter = currentInteraction.filter;
             const matchingEntries = entries.filter((entry) => {
                 const entryDate = entry.work_date?.slice(0, 10) ?? toDateOnlyString(entry.start_time);
                 return entry.work_item_id === currentFilter.workItemId &&
@@ -365,19 +373,30 @@ export function TimeSheet({
             });
 
             if (matchingEntries.length === 0) {
-                return { type: 'idle' };
+                setInteractionState((currentInteraction) =>
+                    currentInteraction.type === 'list-focus' ? { type: 'idle' } : currentInteraction
+                );
+                return null;
             }
 
-            return {
-                type: 'list-focus',
-                filter: {
-                    ...currentFilter,
-                    entryIds: matchingEntries
-                        .map((entry) => entry.entry_id)
-                        .filter((entryId): entryId is string => Boolean(entryId)),
-                    entryCount: matchingEntries.length,
-                },
+            const nextFilter = {
+                ...currentFilter,
+                entryIds: matchingEntries
+                    .map((entry) => entry.entry_id)
+                    .filter((entryId): entryId is string => Boolean(entryId)),
+                entryCount: matchingEntries.length,
             };
+
+            setInteractionState((currentInteraction) =>
+                currentInteraction.type === 'list-focus'
+                    ? {
+                        type: 'list-focus',
+                        filter: nextFilter,
+                    }
+                    : currentInteraction
+            );
+
+            return nextFilter;
         });
     }, []);
 
@@ -754,6 +773,9 @@ export function TimeSheet({
         try {
             await deleteWorkItem(workItemId);
             await refreshTimeSheetData();
+            setPersistedListFocusFilter((currentFilter) =>
+                currentFilter?.workItemId === workItemId ? null : currentFilter
+            );
             setInteractionState((currentInteraction) => {
                 if (currentInteraction.type === 'quick-add' && currentInteraction.quickAdd.workItem.work_item_id === workItemId) {
                     return { type: 'idle' };
@@ -955,6 +977,7 @@ export function TimeSheet({
                     }}
                     onAdd={handleAddWorkItem}
                     availableWorkItems={Object.values(workItemsByType).flat()}
+                    initialWorkItemId={listFocusFilter?.workItemId ?? null}
                     timePeriod={timeSheet.time_period}
                 />
             )}

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
@@ -112,6 +112,8 @@ const MetaLines: React.FC<MetaLinesProps> = ({
 
 interface WorkItemListProps {
   items: WorkItemWithStatus[];
+  pinnedItem?: WorkItemWithStatus | null;
+  selectedWorkItemId?: string | null;
   isSearching: boolean;
   currentPage: number;
   totalPages: number;
@@ -123,6 +125,8 @@ interface WorkItemListProps {
 
 export function WorkItemList({
   items,
+  pinnedItem = null,
+  selectedWorkItemId = null,
   isSearching,
   currentPage,
   totalPages,
@@ -140,7 +144,7 @@ export function WorkItemList({
       return (
         <>
           <div className="font-medium text-[rgb(var(--color-text-900))] text-lg mb-1">
-            {item.ticket_number} - {item.title || t('common.fallbacks.untitled', { defaultValue: 'Untitled' })}
+            {item.ticket_number} - {item.title || item.name || t('common.fallbacks.untitled', { defaultValue: 'Untitled' })}
           </div>
           <MetaLines
             clientName={item.client_name}
@@ -174,7 +178,7 @@ export function WorkItemList({
       return (
         <>
           <div className="font-medium text-[rgb(var(--color-text-900))] text-lg mb-1">
-            {item.task_name}
+            {item.task_name || item.name || t('common.fallbacks.untitled', { defaultValue: 'Untitled' })}
           </div>
           <div className="text-sm text-[rgb(var(--color-text-600))]">
             {item.project_name} • {item.phase_name}
@@ -282,17 +286,39 @@ export function WorkItemList({
     <div className="flex-1 min-h-[200px] overflow-auto transition-all duration-300">
       <div className="h-full overflow-y-auto">
         <div className="bg-white rounded-md border border-[rgb(var(--color-border-200))]">
-          {items.length > 0 ? (
+          {pinnedItem || items.length > 0 ? (
             <div>
+              {pinnedItem && (
+                <div className="border-b border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-primary-50))] px-4 py-3">
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-[rgb(var(--color-primary-700))]">
+                    {t('workItemList.currentSelection', { defaultValue: 'Current work item' })}
+                  </div>
+                  <button
+                    id="current-work-item-option"
+                    type="button"
+                    className={[
+                      'w-full rounded-md border px-4 py-3 text-left transition-colors duration-150',
+                      selectedWorkItemId === pinnedItem.work_item_id
+                        ? 'border-[rgb(var(--color-primary-400))] bg-[rgb(var(--color-primary-100))]'
+                        : 'border-[rgb(var(--color-border-200))] bg-white hover:bg-[rgb(var(--color-border-50))]',
+                    ].join(' ')}
+                    onClick={() => onSelect(pinnedItem)}
+                  >
+                    {renderItemContent(pinnedItem)}
+                  </button>
+                </div>
+              )}
               <ul className="divide-y divide-[rgb(var(--color-border-200))]">
                 {items.map((item) => {
                   const isDisabled = item.type === 'ticket' && !!item.master_ticket_id;
+                  const isSelected = selectedWorkItemId === item.work_item_id;
                   return (
                     <li
                       key={item.work_item_id}
                       aria-disabled={isDisabled}
                       className={[
                         'bg-[rgb(var(--color-border-50))] transition-colors duration-150',
+                        isSelected ? 'bg-[rgb(var(--color-primary-50))]' : '',
                         isDisabled
                           ? 'opacity-50 cursor-not-allowed'
                           : 'hover:bg-[rgb(var(--color-border-100))] cursor-pointer',
@@ -303,41 +329,46 @@ export function WorkItemList({
                         onSelect(item);
                       }}
                     >
-                      <div className="px-4 py-3">
+                      <div className={[
+                        'px-4 py-3',
+                        isSelected ? 'border-l-4 border-[rgb(var(--color-primary-500))]' : '',
+                      ].join(' ')}>
                         {renderItemContent(item)}
                       </div>
                     </li>
                   );
                 })}
               </ul>
-              <div className="px-6 py-4 border-t border-gray-100 bg-white">
-                <div className="flex items-center justify-between">
-                  <button
-                    onClick={() => onPageChange(currentPage - 1)}
-                    disabled={currentPage === 1 || isSearching}
-                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    id="previous-page-btn"
-                  >
-                    {t('workItemList.pagination.previous', { defaultValue: 'Previous' })}
-                  </button>
-                  <span className="text-sm text-[rgb(var(--color-text-700))]">
-                    {t('workItemList.pagination.pageInfo', {
-                      defaultValue: 'Page {{current}} of {{total}} ({{records}} total records)',
-                      current: currentPage,
-                      total: Math.max(1, totalPages),
-                      records: total
-                    })}
-                  </span>
-                  <button
-                    onClick={() => onPageChange(currentPage + 1)}
-                    disabled={!hasMore || isSearching || currentPage >= totalPages}
-                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    id="next-page-btn"
-                  >
-                    {t('workItemList.pagination.next', { defaultValue: 'Next' })}
-                  </button>
+              {items.length > 0 && (
+                <div className="px-6 py-4 border-t border-gray-100 bg-white">
+                  <div className="flex items-center justify-between">
+                    <button
+                      onClick={() => onPageChange(currentPage - 1)}
+                      disabled={currentPage === 1 || isSearching}
+                      className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      id="previous-page-btn"
+                    >
+                      {t('workItemList.pagination.previous', { defaultValue: 'Previous' })}
+                    </button>
+                    <span className="text-sm text-[rgb(var(--color-text-700))]">
+                      {t('workItemList.pagination.pageInfo', {
+                        defaultValue: 'Page {{current}} of {{total}} ({{records}} total records)',
+                        current: currentPage,
+                        total: Math.max(1, totalPages),
+                        records: total
+                      })}
+                    </span>
+                    <button
+                      onClick={() => onPageChange(currentPage + 1)}
+                      disabled={!hasMore || isSearching || currentPage >= totalPages}
+                      className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      id="next-page-btn"
+                    >
+                      {t('workItemList.pagination.next', { defaultValue: 'Next' })}
+                    </button>
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           ) : (
             <div className="p-4 text-center text-[rgb(var(--color-text-500))]">

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { WorkItemList } from './WorkItemList';
 import { Filter, XCircle } from 'lucide-react';
@@ -29,7 +29,7 @@ interface WorkItemPickerProps {
   timePeriod?: ITimePeriodView;
 }
 
-export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: WorkItemPickerProps) {
+export function WorkItemPicker({ onSelect, availableWorkItems, initialWorkItemId, timePeriod }: WorkItemPickerProps) {
   const { t } = useTranslation('msp/time-entry');
   const { formatDate } = useFormatters();
   const [searchTerm, setSearchTerm] = useState('');
@@ -62,6 +62,23 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
     end?: string;
   }>({});
   const [searchType, setSearchType] = useState<WorkItemType | 'all'>('all');
+  const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | null>(initialWorkItemId ?? null);
+
+  const initialWorkItem = useMemo(() => {
+    if (!initialWorkItemId) {
+      return null;
+    }
+
+    const match = availableWorkItems.find((item) => item.work_item_id === initialWorkItemId);
+    if (!match) {
+      return null;
+    }
+
+    return {
+      ...match,
+      status: 'Active',
+    } as WorkItemWithStatus;
+  }, [availableWorkItems, initialWorkItemId]);
 
   const validateDates = useCallback((start: Date, end: Date) => {
     const errors: { start?: string; end?: string } = {};
@@ -241,6 +258,10 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
     debouncedSearch(searchTerm);
   }, [searchTerm, debouncedSearch]);
 
+  useEffect(() => {
+    setSelectedWorkItemId(initialWorkItemId ?? null);
+  }, [initialWorkItemId]);
+
   const handlePageChange = (newPage: number) => {
     if (!isSearching && newPage >= 1 && newPage <= Math.ceil(total / pageSize)) {
       setCurrentPage(newPage);
@@ -249,6 +270,15 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
   };
 
   const totalPages = Math.ceil(total / pageSize);
+
+  const handleSelectWorkItem = useCallback((workItem: IWorkItem | null) => {
+    if (!workItem) {
+      return;
+    }
+
+    setSelectedWorkItemId(workItem.work_item_id);
+    onSelect(workItem);
+  }, [onSelect]);
 
   return (
     <div className="flex flex-col h-auto max-h-[70vh] min-h-[200px] transition-all duration-300 ease-in-out">
@@ -539,13 +569,15 @@ export function WorkItemPicker({ onSelect, availableWorkItems, timePeriod }: Wor
 
       <WorkItemList
         items={workItems}
+        pinnedItem={initialWorkItem}
+        selectedWorkItemId={selectedWorkItemId}
         isSearching={isSearching}
         currentPage={currentPage}
         totalPages={totalPages}
         total={total}
         hasMore={hasMore}
         onPageChange={handlePageChange}
-        onSelect={onSelect}
+        onSelect={handleSelectWorkItem}
       />
     </div>
   );

--- a/packages/scheduling/tests/addWorkItemDialog.focusSelection.contract.test.ts
+++ b/packages/scheduling/tests/addWorkItemDialog.focusSelection.contract.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, relativePath), 'utf8');
+}
+
+describe('add work item dialog focus-selection wiring', () => {
+  it('threads the focused work item into the add-item picker and highlights it', () => {
+    const timeSheetSource = readSource('../src/components/time-management/time-entry/time-sheet/TimeSheet.tsx');
+    const dialogSource = readSource('../src/components/time-management/time-entry/time-sheet/AddWorkItemDialog.tsx');
+    const pickerSource = readSource('../src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx');
+    const listSource = readSource('../src/components/time-management/time-entry/time-sheet/WorkItemList.tsx');
+
+    expect(timeSheetSource).toContain('const [persistedListFocusFilter, setPersistedListFocusFilter] = useState<TimeSheetListFocusFilter | null>(null);');
+    expect(timeSheetSource).toContain('const listFocusFilter = persistedListFocusFilter;');
+    expect(timeSheetSource).toContain('setPersistedListFocusFilter(nextFilter);');
+    expect(timeSheetSource).toContain('initialWorkItemId={listFocusFilter?.workItemId ?? null}');
+    expect(dialogSource).toContain('initialWorkItemId={initialWorkItemId}');
+    expect(pickerSource).toContain('const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | null>(initialWorkItemId ?? null);');
+    expect(pickerSource).toContain('pinnedItem={initialWorkItem}');
+    expect(pickerSource).toContain('selectedWorkItemId={selectedWorkItemId}');
+    expect(listSource).toContain('id="current-work-item-option"');
+    expect(listSource).toContain("defaultValue: 'Current work item'");
+    expect(listSource).toContain("item.title || item.name || t('common.fallbacks.untitled'");
+    expect(listSource).toContain("item.task_name || item.name || t('common.fallbacks.untitled'");
+  });
+});

--- a/packages/scheduling/tests/timeEntryServicePickerFilters.contract.test.ts
+++ b/packages/scheduling/tests/timeEntryServicePickerFilters.contract.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readTimeEntryServicesSource(): string {
+  return fs.readFileSync(
+    path.resolve(__dirname, '../src/actions/timeEntryServices.ts'),
+    'utf8'
+  );
+}
+
+describe('time entry service picker filters', () => {
+  it('limits time entry services to hourly catalog services', () => {
+    const source = readTimeEntryServicesSource();
+
+    expect(source).toContain("'sc.item_kind': 'service'");
+    expect(source).toContain("'sc.billing_method': 'hourly'");
+    expect(source).not.toContain("query = query.where('sc.billing_method', 'usage')");
+  });
+});


### PR DESCRIPTION
## Summary
- limit the time entry service picker to hourly service catalog items only
- preserve the list-focus work item context after opening/closing the time entry dialog
- preselect and highlight the current filtered work item in the add-item dialog, with proper title/name fallbacks

## Testing
- cd packages/scheduling && npx vitest run tests/timeEntryServicePickerFilters.contract.test.ts tests/addWorkItemDialog.focusSelection.contract.test.ts