### PR TITLE
chore: remove beta banners from billing and integrations

### DIFF
--- a/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
+++ b/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
@@ -5,7 +5,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { IClient, IService } from '@alga-psa/types';
 import { IDocument } from '@alga-psa/types';
-import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 // Import all the components
@@ -121,16 +121,6 @@ const BillingDashboard: React.FC<BillingDashboardProps> = ({
       <h1 className="text-3xl font-bold mb-6">
         {t('dashboard.title', { defaultValue: 'Billing' })}
       </h1>
-
-      {/* Beta Warning Banner */}
-      <Alert variant="info" className="mb-4">
-        <AlertTitle>{t('dashboard.beta.title', { defaultValue: 'Beta Release' })}</AlertTitle>
-        <AlertDescription>
-          {t('dashboard.beta.description', {
-            defaultValue: 'Our revamped billing system is currently in beta. You may encounter issues or incomplete features. We appreciate your patience as we continue to improve the experience.',
-          })}
-        </AlertDescription>
-      </Alert>
 
       {error && (
         <Alert variant="destructive" className="mb-4">

--- a/packages/billing/tests/billing-dashboard/BillingDashboard.i18n.test.ts
+++ b/packages/billing/tests/billing-dashboard/BillingDashboard.i18n.test.ts
@@ -22,27 +22,23 @@ function getLeaf(record: Record<string, unknown>, dottedPath: string): unknown {
 }
 
 describe('BillingDashboard i18n wiring contract', () => {
-  it('T027: wires the page title and beta warning banner through msp/billing translations', () => {
+  it('T027: wires the billing dashboard shell labels through msp/billing translations', () => {
     const source = read('../../src/components/billing-dashboard/BillingDashboard.tsx');
 
     expect(source).toContain("const { t } = useTranslation('msp/billing');");
     expect(source).toContain("t('dashboard.title', { defaultValue: 'Billing' })");
-    expect(source).toContain("t('dashboard.beta.title', { defaultValue: 'Beta Release' })");
-    expect(source).toContain("t('dashboard.beta.description', {");
     expect(source).toContain("t('dashboard.errorPrefix', { defaultValue: 'Error:' })");
     expect(source).toContain("t('dashboard.quoteTemplatesHeading', { defaultValue: 'Quote Templates' })");
     expect(source).toContain("t('dashboard.backToPresets', { defaultValue: 'Back to Contract Line Presets List' })");
   });
 
-  it('T028: keeps the billing dashboard shell backed by xx pseudo-locale keys for title and banner', () => {
+  it('T028: keeps the billing dashboard shell backed by xx pseudo-locale keys for remaining shell labels', () => {
     const pseudo = readJson<Record<string, unknown>>(
       '../../../../server/public/locales/xx/msp/billing.json'
     );
 
     const pseudoKeys = [
       'dashboard.title',
-      'dashboard.beta.title',
-      'dashboard.beta.description',
       'dashboard.errorPrefix',
       'dashboard.quoteTemplatesHeading',
       'dashboard.backToPresets',

--- a/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
+++ b/packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.tsx
@@ -10,7 +10,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
-import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import CustomTabs, { TabContent } from '@alga-psa/ui/components/CustomTabs';
 import {
   Building2,
@@ -323,13 +322,6 @@ const IntegrationsSettingsPage: React.FC<IntegrationsSettingsPageProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Beta notice */}
-      <Alert variant="info">
-        <AlertDescription>
-          {t('integrations.betaNotice')}
-        </AlertDescription>
-      </Alert>
-
       {/* Category tabs */}
       <CustomTabs
         tabs={tabContent}


### PR DESCRIPTION
## Summary
- remove the beta release banner from the billing dashboard shell
- update the billing dashboard i18n wiring test for the removed banner
- remove the similar beta notice banner from the integrations settings page

## Validation
- cd server && npx vitest run ../packages/billing/tests/billing-dashboard/BillingDashboard.i18n.test.ts
- attempted: cd server && npx vitest run ../packages/integrations/src/components/settings/integrations/IntegrationsSettingsPage.providers.test.ts
  - this currently fails due to a pre-existing Teams export assertion unrelated to the banner removal
