### PR TITLE
 Pre-filter bundle masters and surface real errors

### DIFF
--- a/packages/tickets/src/actions/ticketBundleActions.ts
+++ b/packages/tickets/src/actions/ticketBundleActions.ts
@@ -176,7 +176,7 @@ export const bundleTicketsAction = withAuth(async (
     return { ok: true, value: { masterTicketId: data.masterTicketId, childTicketIds: uniqueChildIds, mode: data.mode } };
   });
 
-  if (!txResult.ok) {
+  if ('error' in txResult) {
     return txResult.error;
   }
   const result = txResult.value;
@@ -266,7 +266,7 @@ export const addChildrenToBundleAction = withAuth(async (
     return { ok: true, value: { masterTicketId: data.masterTicketId, childTicketIds: childIds } };
   });
 
-  if (!txResult.ok) {
+  if ('error' in txResult) {
     return txResult.error;
   }
   const result = txResult.value;

--- a/packages/tickets/src/actions/ticketBundleActions.ts
+++ b/packages/tickets/src/actions/ticketBundleActions.ts
@@ -7,6 +7,8 @@ import { z } from 'zod';
 import type { IUser } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
 import { publishWorkflowEvent, type WorkflowEventPublishContext } from '@alga-psa/event-bus/publishers';
+import { actionError } from '@alga-psa/ui/lib/errorHandling';
+import type { ActionMessageError } from '@alga-psa/ui/lib/errorHandling';
 
 function nowIso() {
   return new Date().toISOString();
@@ -24,22 +26,36 @@ function buildTicketBundleWorkflowCtx(params: {
   };
 }
 
-async function ensureTicketsAreNotBundleMasters(
+async function findBundleMasterIds(
   trx: any,
   tenant: string,
   ticketIds: string[]
-) {
-  if (ticketIds.length === 0) return;
+): Promise<string[]> {
+  if (ticketIds.length === 0) return [];
   const rows = await trx('tickets')
-    .select('master_ticket_id')
-    .count('* as count')
+    .distinct('master_ticket_id')
     .where({ tenant })
-    .whereIn('master_ticket_id', ticketIds)
-    .groupBy('master_ticket_id');
+    .whereIn('master_ticket_id', ticketIds);
+  return rows.map((r: any) => r.master_ticket_id).filter(Boolean);
+}
 
-  if (rows.length > 0) {
-    throw new Error('One or more selected tickets are bundle masters and cannot be added as children.');
-  }
+async function buildBundleMasterError(
+  trx: any,
+  tenant: string,
+  masterIds: string[]
+): Promise<ActionMessageError> {
+  const rows = await trx('tickets')
+    .select('ticket_number')
+    .where({ tenant })
+    .whereIn('ticket_id', masterIds);
+  const labels = rows
+    .map((r: any) => r.ticket_number)
+    .filter((n: any): n is string => typeof n === 'string' && n.length > 0);
+  const listText = labels.length > 0 ? labels.join(', ') : masterIds.join(', ');
+  const prefix = masterIds.length === 1
+    ? `Ticket ${listText} is already a bundle master`
+    : `Tickets ${listText} are already bundle masters`;
+  return actionError(`${prefix} and cannot be added as children. Unbundle them first, or use one of them as the master.`);
 }
 
 const bundleTicketsSchema = z.object({
@@ -69,18 +85,25 @@ export const findTicketByNumberAction = withAuth(async (user, { tenant }, input:
   });
 });
 
-export const bundleTicketsAction = withAuth(async (user, { tenant }, input: z.input<typeof bundleTicketsSchema>) => {
+type BundleTicketsResult = { masterTicketId: string; childTicketIds: string[]; mode: 'link_only' | 'sync_updates' };
+type BundleTxResult = { ok: true; value: BundleTicketsResult } | { ok: false; error: ActionMessageError };
+
+export const bundleTicketsAction = withAuth(async (
+  user,
+  { tenant },
+  input: z.input<typeof bundleTicketsSchema>
+): Promise<BundleTicketsResult | ActionMessageError> => {
   const data = bundleTicketsSchema.parse(input);
   const uniqueChildIds = Array.from(new Set(data.childTicketIds)).filter((id) => id !== data.masterTicketId);
   if (uniqueChildIds.length === 0) {
-    throw new Error('Select at least one child ticket different from the master.');
+    return actionError('Select at least one child ticket different from the master.');
   }
 
   const { knex: db } = await createTenantKnex();
   const occurredAt = nowIso();
   const workflowCtx = buildTicketBundleWorkflowCtx({ tenantId: tenant, actorUserId: user.user_id, occurredAt });
 
-  const result = await withTransaction(db, async (trx) => {
+  const txResult = await withTransaction(db, async (trx): Promise<BundleTxResult> => {
     if (!await hasPermission(user, 'ticket', 'update', trx)) {
       throw new Error('Permission denied: Cannot bundle tickets');
     }
@@ -93,30 +116,33 @@ export const bundleTicketsAction = withAuth(async (user, { tenant }, input: z.in
 
     const byId = new Map(tickets.map((t: any) => [t.ticket_id, t]));
     if (!byId.has(data.masterTicketId)) {
-      throw new Error('Master ticket not found');
+      return { ok: false, error: actionError('Master ticket not found.') };
     }
     for (const childId of uniqueChildIds) {
       if (!byId.has(childId)) {
-        throw new Error(`Child ticket not found: ${childId}`);
+        return { ok: false, error: actionError(`Child ticket not found: ${childId}`) };
       }
     }
 
     const master = byId.get(data.masterTicketId);
     if (master.master_ticket_id) {
-      throw new Error('Cannot select a child ticket as the master.');
+      return { ok: false, error: actionError('Cannot select a child ticket as the master.') };
     }
 
     // Prevent nesting bundles: children cannot themselves be masters
-    await ensureTicketsAreNotBundleMasters(trx, tenant, uniqueChildIds);
+    const offendingMasterIds = await findBundleMasterIds(trx, tenant, uniqueChildIds);
+    if (offendingMasterIds.length > 0) {
+      return { ok: false, error: await buildBundleMasterError(trx, tenant, offendingMasterIds) };
+    }
 
     // Ensure children are not already bundled
     for (const childId of uniqueChildIds) {
       const child = byId.get(childId);
       if (child.master_ticket_id) {
-        throw new Error(`Ticket is already bundled: ${child.ticket_number || childId}`);
+        return { ok: false, error: actionError(`Ticket is already bundled: ${child.ticket_number || childId}`) };
       }
       if (childId === data.masterTicketId) {
-        throw new Error('Master ticket cannot also be a child ticket.');
+        return { ok: false, error: actionError('Master ticket cannot also be a child ticket.') };
       }
     }
 
@@ -147,8 +173,13 @@ export const bundleTicketsAction = withAuth(async (user, { tenant }, input: z.in
         mode: data.mode,
       });
 
-    return { masterTicketId: data.masterTicketId, childTicketIds: uniqueChildIds, mode: data.mode };
+    return { ok: true, value: { masterTicketId: data.masterTicketId, childTicketIds: uniqueChildIds, mode: data.mode } };
   });
+
+  if (!txResult.ok) {
+    return txResult.error;
+  }
+  const result = txResult.value;
 
   for (const childTicketId of result.childTicketIds) {
     await publishWorkflowEvent({
@@ -172,18 +203,25 @@ const addChildrenSchema = z.object({
   childTicketIds: z.array(z.string().uuid()).min(1),
 });
 
-export const addChildrenToBundleAction = withAuth(async (user, { tenant }, input: z.input<typeof addChildrenSchema>) => {
+type AddChildrenResult = { masterTicketId: string; childTicketIds: string[] };
+type AddChildrenTxResult = { ok: true; value: AddChildrenResult } | { ok: false; error: ActionMessageError };
+
+export const addChildrenToBundleAction = withAuth(async (
+  user,
+  { tenant },
+  input: z.input<typeof addChildrenSchema>
+): Promise<AddChildrenResult | ActionMessageError> => {
   const data = addChildrenSchema.parse(input);
   const childIds = Array.from(new Set(data.childTicketIds)).filter((id) => id !== data.masterTicketId);
   if (childIds.length === 0) {
-    throw new Error('No child tickets provided');
+    return actionError('No child tickets provided.');
   }
 
   const { knex: db } = await createTenantKnex();
   const occurredAt = nowIso();
   const workflowCtx = buildTicketBundleWorkflowCtx({ tenantId: tenant, actorUserId: user.user_id, occurredAt });
 
-  const result = await withTransaction(db, async (trx) => {
+  const txResult = await withTransaction(db, async (trx): Promise<AddChildrenTxResult> => {
     if (!await hasPermission(user, 'ticket', 'update', trx)) {
       throw new Error('Permission denied: Cannot modify ticket bundles');
     }
@@ -192,8 +230,8 @@ export const addChildrenToBundleAction = withAuth(async (user, { tenant }, input
       .select('ticket_id', 'master_ticket_id')
       .where({ tenant, ticket_id: data.masterTicketId })
       .first();
-    if (!master) throw new Error('Master ticket not found');
-    if (master.master_ticket_id) throw new Error('Cannot add children to a bundled child ticket');
+    if (!master) return { ok: false, error: actionError('Master ticket not found.') };
+    if (master.master_ticket_id) return { ok: false, error: actionError('Cannot add children to a bundled child ticket.') };
 
     const children = await trx('tickets')
       .select('ticket_id', 'ticket_number', 'master_ticket_id')
@@ -202,12 +240,15 @@ export const addChildrenToBundleAction = withAuth(async (user, { tenant }, input
     const byId = new Map(children.map((t: any) => [t.ticket_id, t]));
     for (const childId of childIds) {
       const child = byId.get(childId);
-      if (!child) throw new Error(`Child ticket not found: ${childId}`);
-      if (child.master_ticket_id) throw new Error(`Ticket is already bundled: ${child.ticket_number || childId}`);
+      if (!child) return { ok: false, error: actionError(`Child ticket not found: ${childId}`) };
+      if (child.master_ticket_id) return { ok: false, error: actionError(`Ticket is already bundled: ${child.ticket_number || childId}`) };
     }
 
     // Prevent nesting bundles: children cannot themselves be masters
-    await ensureTicketsAreNotBundleMasters(trx, tenant, childIds);
+    const offendingMasterIds = await findBundleMasterIds(trx, tenant, childIds);
+    if (offendingMasterIds.length > 0) {
+      return { ok: false, error: await buildBundleMasterError(trx, tenant, offendingMasterIds) };
+    }
 
     const updatedChildrenCount = await trx('tickets')
       .where({ tenant })
@@ -222,8 +263,13 @@ export const addChildrenToBundleAction = withAuth(async (user, { tenant }, input
       throw new Error('One or more selected tickets were bundled concurrently. Please refresh and try again.');
     }
 
-    return { masterTicketId: data.masterTicketId, childTicketIds: childIds };
+    return { ok: true, value: { masterTicketId: data.masterTicketId, childTicketIds: childIds } };
   });
+
+  if (!txResult.ok) {
+    return txResult.error;
+  }
+  const result = txResult.value;
 
   for (const childTicketId of result.childTicketIds) {
     await publishWorkflowEvent({
@@ -280,7 +326,10 @@ export const promoteBundleMasterAction = withAuth(async (user, { tenant }, input
     const now = nowIso();
 
     // Prevent nesting bundles: the promoted ticket cannot itself have children
-    await ensureTicketsAreNotBundleMasters(trx, tenant, [data.newMasterTicketId]);
+    const promotedMasterConflicts = await findBundleMasterIds(trx, tenant, [data.newMasterTicketId]);
+    if (promotedMasterConflicts.length > 0) {
+      throw new Error('Promoted ticket already has children of its own.');
+    }
 
     // Move bundle settings to new master
     const settings = await trx('ticket_bundle_settings')
@@ -453,6 +502,27 @@ export const removeChildFromBundleAction = withAuth(async (user, { tenant }, inp
 
 const unbundleSchema = z.object({
   masterTicketId: z.string().uuid(),
+});
+
+const getBundleMasterStatusSchema = z.object({
+  ticketIds: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export const getBundleMasterStatusAction = withAuth(async (
+  user,
+  { tenant },
+  input: z.input<typeof getBundleMasterStatusSchema>
+): Promise<{ masterTicketIds: string[] }> => {
+  const data = getBundleMasterStatusSchema.parse(input);
+  const { knex: db } = await createTenantKnex();
+
+  return withTransaction(db, async (trx) => {
+    if (!await hasPermission(user, 'ticket', 'read', trx)) {
+      throw new Error('Permission denied: Cannot view tickets');
+    }
+    const masterTicketIds = await findBundleMasterIds(trx, tenant, data.ticketIds);
+    return { masterTicketIds };
+  });
 });
 
 const searchEligibleChildTicketsSchema = z.object({

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -27,7 +27,7 @@ import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { ColumnDefinition } from '@alga-psa/types';
 import { deleteTicket, deleteTickets, moveTicketsToBoard } from '../actions/ticketActions';
 import { getBoardTicketStatuses } from '../actions/board-actions/boardTicketStatusActions';
-import { bundleTicketsAction } from '../actions/ticketBundleActions';
+import { bundleTicketsAction, getBundleMasterStatusAction } from '../actions/ticketBundleActions';
 import { fetchBundleChildrenForMaster, getAllMatchingTicketIds } from '../actions/optimizedTicketActions';
 import TicketExportDialog from './TicketExportDialog';
 import TicketImportDialog from './TicketImportDialog';
@@ -39,7 +39,7 @@ import { withDataAutomationId } from '@alga-psa/ui/ui-reflection/withDataAutomat
 import { useIntervalTracking } from '@alga-psa/ui/hooks';
 import type { TicketingDisplaySettings } from '../actions/ticketDisplaySettings';
 import { toast } from 'react-hot-toast';
-import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { handleError, isActionMessageError, getErrorMessage } from '@alga-psa/ui/lib/errorHandling';
 import { createTicketColumns } from '@alga-psa/tickets/lib';
 import Spinner from '@alga-psa/ui/components/Spinner';
 
@@ -181,6 +181,8 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [bundleMasterTicketId, setBundleMasterTicketId] = useState<string | null>(null);
   const [bundleSyncUpdates, setBundleSyncUpdates] = useState(true);
   const [bundleError, setBundleError] = useState<string | null>(null);
+  const [bundleExistingMasterIds, setBundleExistingMasterIds] = useState<Set<string>>(new Set());
+  const [isLoadingBundleMasterStatus, setIsLoadingBundleMasterStatus] = useState(false);
   const [isMultiClientBundleConfirmOpen, setIsMultiClientBundleConfirmOpen] = useState(false);
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
@@ -1190,6 +1192,54 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     }
   }, [selectedTicketIdsArray, clearSelection, currentUser, t]);
 
+  // When the bundle dialog opens, check which of the selected tickets are already
+  // bundle masters of other bundles. Masters can't be added as children, so we must
+  // either force them to BE the master or block the operation entirely.
+  useEffect(() => {
+    if (!isBundleDialogOpen || selectedTicketIdsArray.length === 0) {
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingBundleMasterStatus(true);
+    (async () => {
+      try {
+        const { masterTicketIds } = await getBundleMasterStatusAction({ ticketIds: selectedTicketIdsArray });
+        if (cancelled) return;
+        const masterSet = new Set(masterTicketIds);
+        setBundleExistingMasterIds(masterSet);
+        if (masterSet.size === 1) {
+          // Exactly one of the selected tickets is already a master; force it to be THE master.
+          const [onlyMaster] = Array.from(masterSet);
+          setBundleMasterTicketId(onlyMaster);
+        } else if (masterSet.size > 1) {
+          // Can't bundle: multiple existing masters can't be merged without unbundling first.
+          setBundleError(
+            t(
+              'bulk.bundle.multipleExistingMasters',
+              'Multiple selected tickets are already bundle masters ({{count}}). Unbundle all but one before bundling.',
+              { count: masterSet.size }
+            )
+          );
+          setBundleMasterTicketId(null);
+        } else {
+          setBundleError(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to load bundle master status', error);
+          setBundleExistingMasterIds(new Set());
+        }
+      } finally {
+        if (!cancelled) setIsLoadingBundleMasterStatus(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isBundleDialogOpen, selectedTicketIdsArray, t]);
+
+  const hasMultipleExistingMasters = bundleExistingMasterIds.size > 1;
+
   const performBundleTickets = useCallback(async () => {
     if (selectedTicketIdsArray.length < 2) {
       setBundleError(t('bulk.bundle.selectAtLeastTwo', 'Select at least two tickets to bundle.'));
@@ -1199,14 +1249,24 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       setBundleError(t('bulk.bundle.selectMaster', 'Select a master ticket.'));
       return;
     }
+    if (hasMultipleExistingMasters) {
+      return;
+    }
 
     setBundleError(null);
     try {
-      await bundleTicketsAction({
+      const result = await bundleTicketsAction({
         masterTicketId: bundleMasterTicketId,
         childTicketIds: selectedTicketIdsArray.filter((id) => id !== bundleMasterTicketId),
         mode: bundleSyncUpdates ? 'sync_updates' : 'link_only',
       });
+
+      if (isActionMessageError(result)) {
+        const message = getErrorMessage(result);
+        setBundleError(message);
+        toast.error(message);
+        return;
+      }
 
       toast.success(t('bulk.bundle.success', 'Tickets bundled'));
       setIsBundleDialogOpen(false);
@@ -1215,8 +1275,9 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       // Re-fetch with current filters after bundling
       onFilterChange({});
     } catch (error) {
-      setBundleError(error instanceof Error ? error.message : t('bulk.bundle.failure', 'Failed to bundle tickets'));
-      handleError(error, t('bulk.bundle.failure', 'Failed to bundle tickets'));
+      const message = getErrorMessage(error);
+      setBundleError(message);
+      handleError(error);
     }
   }, [
     selectedTicketIdsArray,
@@ -1225,6 +1286,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     currentUser,
     clearSelection,
     onFilterChange,
+    hasMultipleExistingMasters,
     t,
   ]);
 
@@ -2023,6 +2085,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         onClose={() => {
           setIsBundleDialogOpen(false);
           setBundleError(null);
+          setBundleExistingMasterIds(new Set());
         }}
         id={`${id}-bundle-dialog`}
         title={t('bulk.bundle.dialogTitle', 'Bundle Tickets')}
@@ -2031,6 +2094,16 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           {bundleError && (
             <Alert variant="destructive" className="mb-3">
               <AlertDescription>{bundleError}</AlertDescription>
+            </Alert>
+          )}
+          {bundleExistingMasterIds.size === 1 && !bundleError && (
+            <Alert variant="warning" className="mb-3">
+              <AlertDescription>
+                {t(
+                  'bulk.bundle.existingMasterLocked',
+                  'One selected ticket is already a bundle master. It will be used as the master; the others will be added as children.'
+                )}
+              </AlertDescription>
             </Alert>
           )}
           {(() => {
@@ -2047,12 +2120,27 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
               <CustomSelect
                 id={`${id}-bundle-master-select`}
                 value={bundleMasterTicketId || ''}
-                options={selectedTicketDetails.map(detail => ({
-                  value: detail.ticket_id,
-                  label: detail.ticket_number || detail.title || detail.ticket_id
-                }))}
+                options={selectedTicketDetails.map(detail => {
+                  const baseLabel = detail.ticket_number || detail.title || detail.ticket_id;
+                  const isExistingMaster = bundleExistingMasterIds.has(detail.ticket_id);
+                  return {
+                    value: detail.ticket_id,
+                    label: isExistingMaster
+                      ? `${baseLabel} ${t('bulk.bundle.existingMasterSuffix', '(existing master)')}`
+                      : baseLabel,
+                  };
+                })}
                 onValueChange={(value) => setBundleMasterTicketId(value)}
-                placeholder={t('bulk.bundle.selectMasterTicket', 'Select master ticket...')}
+                placeholder={
+                  isLoadingBundleMasterStatus
+                    ? t('bulk.bundle.checkingMasters', 'Checking existing bundles...')
+                    : t('bulk.bundle.selectMasterTicket', 'Select master ticket...')
+                }
+                disabled={
+                  isLoadingBundleMasterStatus ||
+                  hasMultipleExistingMasters ||
+                  bundleExistingMasterIds.size === 1
+                }
               />
             </div>
 
@@ -2081,6 +2169,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             onClick={() => {
               setIsBundleDialogOpen(false);
               setBundleError(null);
+              setBundleExistingMasterIds(new Set());
             }}
           >
             {t('actions.cancel', 'Cancel')}
@@ -2088,7 +2177,12 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           <Button
             id={`${id}-bundle-confirm`}
             onClick={handleConfirmBundleTickets}
-            disabled={selectedTicketIdsArray.length < 2 || !bundleMasterTicketId}
+            disabled={
+              selectedTicketIdsArray.length < 2 ||
+              !bundleMasterTicketId ||
+              isLoadingBundleMasterStatus ||
+              hasMultipleExistingMasters
+            }
           >
             {t('bulk.bundleTickets', 'Bundle Tickets')}
           </Button>

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -33,7 +33,7 @@ import TicketEmailNotifications from "./TicketEmailNotifications";
 import TicketConversation from "./TicketConversation";
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-hot-toast';
-import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
+import { handleError, isActionPermissionError, isActionMessageError, getErrorMessage } from '@alga-psa/ui/lib/errorHandling';
 import { useDrawer } from "@alga-psa/ui";
 import { useSchedulingCallbacks } from '@alga-psa/ui/context';
 import { findUserById, getCurrentUser, getCurrentUserPermissions } from "@alga-psa/user-composition/actions";
@@ -1631,7 +1631,11 @@ const handleClose = () => {
 
     const performAddChildToBundle = useCallback(async (childTicketId: string) => {
         if (!ticket.ticket_id) return;
-        await addChildrenToBundleAction({ masterTicketId: ticket.ticket_id, childTicketIds: [childTicketId] });
+        const result = await addChildrenToBundleAction({ masterTicketId: ticket.ticket_id, childTicketIds: [childTicketId] });
+        if (isActionMessageError(result)) {
+            toast.error(getErrorMessage(result));
+            return;
+        }
         toast.success('Added ticket to bundle');
         setAddChildTicketNumber('');
         resetChildTicketPickerState();

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Hauptticket auswählen...",
       "syncUpdates": "Synchronisiere Aktualisierungen vom Hauptticket zu den Untertickets (öffentliche Antworten + Workflow-Änderungen)",
       "syncUpdatesHelp": "Untertickets behalten beim Bündeln ihren aktuellen Status. Workflow-Felder sind bei Untertickets standardmäßig gesperrt. Interne Notizen bleiben auf dem Hauptticket.",
-      "childrenDescription": "Untergeordnete behalten ihren aktuellen Status; Workflow-Felder sind bei untergeordneten Tickets gesperrt. Eingehende Antworten auf untergeordnete Tickets werden unten als schreibgeschützt angezeigt."
+      "childrenDescription": "Untergeordnete behalten ihren aktuellen Status; Workflow-Felder sind bei untergeordneten Tickets gesperrt. Eingehende Antworten auf untergeordnete Tickets werden unten als schreibgeschützt angezeigt.",
+      "checkingMasters": "Vorhandene Bündel werden geprüft...",
+      "existingMasterSuffix": "(vorhandenes Hauptticket)",
+      "existingMasterLocked": "Ein ausgewähltes Ticket ist bereits ein Hauptticket. Es wird als Hauptticket verwendet; die anderen werden als Untertickets hinzugefügt.",
+      "multipleExistingMasters": "Mehrere ausgewählte Tickets sind bereits Haupttickets ({{count}}). Hebe die Bündelung aller bis auf eines auf, bevor du bündelst."
     },
     "auth": {
       "moveRequired": "Du musst angemeldet sein, um Tickets zu verschieben",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Select master ticket...",
       "syncUpdates": "Sync updates from master to children (public replies + workflow changes)",
       "syncUpdatesHelp": "Child tickets keep their current status when bundled. Workflow fields are locked on children by default. Internal notes stay on the master.",
-      "childrenDescription": "Children keep their current status; workflow fields are locked on children. Inbound child replies are surfaced below as view-only."
+      "childrenDescription": "Children keep their current status; workflow fields are locked on children. Inbound child replies are surfaced below as view-only.",
+      "checkingMasters": "Checking existing bundles...",
+      "existingMasterSuffix": "(existing master)",
+      "existingMasterLocked": "One selected ticket is already a bundle master. It will be used as the master; the others will be added as children.",
+      "multipleExistingMasters": "Multiple selected tickets are already bundle masters ({{count}}). Unbundle all but one before bundling."
     },
     "auth": {
       "moveRequired": "You must be logged in to move tickets",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Selecciona un ticket maestro...",
       "syncUpdates": "Sincronizar actualizaciones del maestro a los hijos (respuestas públicas + cambios de flujo de trabajo)",
       "syncUpdatesHelp": "Los tickets hijos conservan su estado actual cuando se agrupan. Los campos de flujo de trabajo quedan bloqueados en los hijos por defecto. Las notas internas se mantienen en el maestro.",
-      "childrenDescription": "Los secundarios mantienen su estado actual; los campos de flujo de trabajo están bloqueados en los secundarios. Las respuestas entrantes de los secundarios se muestran abajo como solo lectura."
+      "childrenDescription": "Los secundarios mantienen su estado actual; los campos de flujo de trabajo están bloqueados en los secundarios. Las respuestas entrantes de los secundarios se muestran abajo como solo lectura.",
+      "checkingMasters": "Comprobando agrupaciones existentes...",
+      "existingMasterSuffix": "(maestro existente)",
+      "existingMasterLocked": "Un ticket seleccionado ya es un maestro de agrupación. Se usará como maestro; los demás se añadirán como hijos.",
+      "multipleExistingMasters": "Varios tickets seleccionados ya son maestros de agrupación ({{count}}). Desagrupa todos menos uno antes de agrupar."
     },
     "auth": {
       "moveRequired": "Debes iniciar sesión para mover tickets",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Sélectionnez le ticket principal...",
       "syncUpdates": "Synchroniser les mises à jour du maître vers les enfants (réponses publiques + modifications du workflow)",
       "syncUpdatesHelp": "Les tickets enfants conservent leur statut actuel lorsqu’ils sont regroupés. Les champs de workflow sont verrouillés sur les enfants par défaut. Les notes internes restent sur le maître.",
-      "childrenDescription": "Les enfants conservent leur statut actuel ; les champs de workflow sont verrouillés sur les enfants. Les réponses entrantes des enfants sont affichées ci-dessous en lecture seule."
+      "childrenDescription": "Les enfants conservent leur statut actuel ; les champs de workflow sont verrouillés sur les enfants. Les réponses entrantes des enfants sont affichées ci-dessous en lecture seule.",
+      "checkingMasters": "Vérification des regroupements existants...",
+      "existingMasterSuffix": "(maître existant)",
+      "existingMasterLocked": "Un ticket sélectionné est déjà un ticket principal. Il sera utilisé comme maître ; les autres seront ajoutés comme enfants.",
+      "multipleExistingMasters": "Plusieurs tickets sélectionnés sont déjà des tickets principaux ({{count}}). Dégroupez tous sauf un avant de regrouper."
     },
     "auth": {
       "moveRequired": "Vous devez être connecté pour déplacer des tickets",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Seleziona ticket master...",
       "syncUpdates": "Sincronizza gli aggiornamenti dal master ai figli (risposte pubbliche + modifiche al flusso di lavoro)",
       "syncUpdatesHelp": "I ticket figli mantengono il loro stato attuale quando vengono raggruppati. I campi del flusso di lavoro sono bloccati sui figli per impostazione predefinita. Le note interne restano sul master.",
-      "childrenDescription": "I secondari mantengono il loro stato attuale; i campi del workflow sono bloccati sui secondari. Le risposte in entrata dei secondari sono mostrate sotto in sola lettura."
+      "childrenDescription": "I secondari mantengono il loro stato attuale; i campi del workflow sono bloccati sui secondari. Le risposte in entrata dei secondari sono mostrate sotto in sola lettura.",
+      "checkingMasters": "Verifica dei raggruppamenti esistenti...",
+      "existingMasterSuffix": "(master esistente)",
+      "existingMasterLocked": "Un ticket selezionato è già un master di raggruppamento. Verrà usato come master; gli altri saranno aggiunti come figli.",
+      "multipleExistingMasters": "Più ticket selezionati sono già master di raggruppamento ({{count}}). Annulla il raggruppamento di tutti tranne uno prima di raggruppare."
     },
     "auth": {
       "moveRequired": "Devi aver effettuato l'accesso per spostare i ticket",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Hoofdticket selecteren...",
       "syncUpdates": "Wijzigingen synchroniseren van hoofd- naar onderliggende tickets (openbare reacties + workflowwijzigingen)",
       "syncUpdatesHelp": "Onderliggende tickets behouden hun huidige status wanneer ze worden gebundeld. Workflowvelden zijn standaard vergrendeld op onderliggende tickets. Interne notities blijven op het hoofdticket.",
-      "childrenDescription": "Onderliggende behouden hun huidige status; workflowvelden zijn vergrendeld op onderliggende tickets. Inkomende reacties op onderliggende tickets worden hieronder als alleen-lezen weergegeven."
+      "childrenDescription": "Onderliggende behouden hun huidige status; workflowvelden zijn vergrendeld op onderliggende tickets. Inkomende reacties op onderliggende tickets worden hieronder als alleen-lezen weergegeven.",
+      "checkingMasters": "Bestaande bundels controleren...",
+      "existingMasterSuffix": "(bestaand hoofdticket)",
+      "existingMasterLocked": "Eén geselecteerd ticket is al een hoofdticket. Dit wordt als hoofdticket gebruikt; de andere worden als onderliggende tickets toegevoegd.",
+      "multipleExistingMasters": "Meerdere geselecteerde tickets zijn al hoofdtickets ({{count}}). Ontkoppel alle op één na voordat je bundelt."
     },
     "auth": {
       "moveRequired": "Je moet zijn ingelogd om tickets te verplaatsen",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "Wybierz zgłoszenie nadrzędne...",
       "syncUpdates": "Synchronizuj aktualizacje z nadrzędnego do podrzędnych (publiczne odpowiedzi + zmiany przepływu pracy)",
       "syncUpdatesHelp": "Zgłoszenia podrzędne zachowują obecny status po połączeniu. Pola przepływu pracy są domyślnie zablokowane dla zgłoszeń podrzędnych. Notatki wewnętrzne pozostają w zgłoszeniu nadrzędnym.",
-      "childrenDescription": "Podrzędne zachowują swój obecny status; pola przepływu pracy są zablokowane na zgłoszeniach podrzędnych. Odpowiedzi przychodzące na podrzędne są wyświetlane poniżej jako tylko do odczytu."
+      "childrenDescription": "Podrzędne zachowują swój obecny status; pola przepływu pracy są zablokowane na zgłoszeniach podrzędnych. Odpowiedzi przychodzące na podrzędne są wyświetlane poniżej jako tylko do odczytu.",
+      "checkingMasters": "Sprawdzanie istniejących połączeń...",
+      "existingMasterSuffix": "(istniejące zgłoszenie nadrzędne)",
+      "existingMasterLocked": "Jedno z wybranych zgłoszeń jest już zgłoszeniem nadrzędnym. Zostanie użyte jako nadrzędne; pozostałe zostaną dodane jako podrzędne.",
+      "multipleExistingMasters": "Wiele wybranych zgłoszeń jest już zgłoszeniami nadrzędnymi ({{count}}). Rozłącz wszystkie oprócz jednego przed łączeniem."
     },
     "auth": {
       "moveRequired": "Musisz być zalogowany, aby przenosić zgłoszenia",

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "11111",
       "syncUpdates": "11111",
       "syncUpdatesHelp": "11111",
-      "childrenDescription": "11111"
+      "childrenDescription": "11111",
+      "checkingMasters": "11111",
+      "existingMasterSuffix": "11111",
+      "existingMasterLocked": "11111",
+      "multipleExistingMasters": "11111"
     },
     "auth": {
       "moveRequired": "11111",

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -434,7 +434,11 @@
       "selectMasterTicket": "55555",
       "syncUpdates": "55555",
       "syncUpdatesHelp": "55555",
-      "childrenDescription": "55555"
+      "childrenDescription": "55555",
+      "checkingMasters": "55555",
+      "existingMasterSuffix": "55555",
+      "existingMasterLocked": "55555",
+      "multipleExistingMasters": "55555"
     },
     "auth": {
       "moveRequired": "55555",

--- a/server/src/test/integration/ticketBundling.integration.test.ts
+++ b/server/src/test/integration/ticketBundling.integration.test.ts
@@ -291,11 +291,10 @@ describe('Ticket bundling integration', () => {
     expect(settings?.mode).toBe('sync_updates');
 
     // Cannot add an already-bundled ticket to a bundle
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [child1Id] }, internalUser as any);
-      })
-    ).rejects.toThrow(/already bundled/i);
+    const alreadyBundledResult = await runWithTenant(tenantId, async () => {
+      return addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [child1Id] }, internalUser as any);
+    });
+    expect(alreadyBundledResult).toMatchObject({ actionError: expect.stringMatching(/already bundled/i) });
 
     // Cannot add a bundle master as a child (no nesting)
     const otherMasterId = uuidv4();
@@ -306,11 +305,10 @@ describe('Ticket bundling integration', () => {
       await bundleTicketsAction({ masterTicketId: otherMasterId, childTicketIds: [nestedChildId], mode: 'link_only' }, internalUser as any);
     });
 
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [otherMasterId] }, internalUser as any);
-      })
-    ).rejects.toThrow(/cannot be added as children/i);
+    const nestingResult = await runWithTenant(tenantId, async () => {
+      return addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [otherMasterId] }, internalUser as any);
+    });
+    expect(nestingResult).toMatchObject({ actionError: expect.stringMatching(/already (a bundle master|bundle masters)/i) });
 
     // Cross-tenant bundle attempts fail because foreign-tenant ticket ids won't resolve
     const foreignClient = await createClient(db, otherTenantId, `Other Client ${uuidv4().slice(0, 6)}`);
@@ -328,11 +326,10 @@ describe('Ticket bundling integration', () => {
       boardId: otherTenantRefs.boardId,
     });
 
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [foreignTicketId] }, internalUser as any);
-      })
-    ).rejects.toThrow(/not found/i);
+    const crossTenantResult = await runWithTenant(tenantId, async () => {
+      return addChildrenToBundleAction({ masterTicketId: masterId, childTicketIds: [foreignTicketId] }, internalUser as any);
+    });
+    expect(crossTenantResult).toMatchObject({ actionError: expect.stringMatching(/not found/i) });
 
     // Remove a child only unlinks that ticket.
     await runWithTenant(tenantId, async () => {


### PR DESCRIPTION
  Bundle action now returns ActionMessageError instead of throwing so the real message survives Next.js server-action serialization and reaches the toast. The bundle dialog pre-checks selected tickets via a new  getBundleMasterStatusAction: existing masters get a "(existing master)" suffix, a lone master is auto-locked as master, and multiple masters block the confirm up front. Adds four i18n keys across all locales.

  "Curiouser and curiouser!" cried the ticket, as it discovered it was already the master of its own bundle and could not, under any circumstance, become a child of itself. The Caterpillar of ensureTicketsAreNotBundleMasters was quietly replaced by the butterfly of findBundleMasterIds, and the Cheshire Cat's digest: '2982189633' vanished into a proper toast at last. 🫖 🦋🎩