### PR TITLE
fix: preserve project tag filter when loading from URL

### DIFF
--- a/packages/projects/src/components/Projects.tsx
+++ b/packages/projects/src/components/Projects.tsx
@@ -127,6 +127,8 @@ interface ProjectsProps {
   initialProjects: IProject[];
   clients: IClient[];
   initialFilters?: Partial<ProjectListFilters>;
+  initialProjectTags?: Record<string, ITag[]>;
+  initialAllUniqueTags?: ITag[];
 }
 
 export const DEFAULT_PROJECT_FILTERS: ProjectListFilters = {
@@ -135,7 +137,7 @@ export const DEFAULT_PROJECT_FILTERS: ProjectListFilters = {
   pageSize: 10,
 };
 
-export default function Projects({ initialProjects, clients, initialFilters }: ProjectsProps) {
+export default function Projects({ initialProjects, clients, initialFilters, initialProjectTags, initialAllUniqueTags }: ProjectsProps) {
   const { t } = useTranslation(['features/projects', 'common']);
   const projectListT = useCallback((key: string, fallback: string, options?: Record<string, unknown>) =>
     t(`projectList.${key}`, { defaultValue: fallback, ...(options ?? {}) }), [t]);
@@ -167,9 +169,10 @@ export default function Projects({ initialProjects, clients, initialFilters }: P
   const { openDrawer, closeDrawer } = useDrawer();
   const clientDrawer = useClientDrawer();
 
-  // Tag-related state (for display, not filtering — projectTagsRef maps entity tags)
-  const projectTagsRef = useRef<Record<string, ITag[]>>({});
-  const [allUniqueTags, setAllUniqueTags] = useState<ITag[]>([]);
+  // Tag-related state. Seeded from server-fetched tags so URL-based tag filters
+  // work on the very first render (bookmarked/pasted URLs).
+  const projectTagsRef = useRef<Record<string, ITag[]>>(initialProjectTags ?? {});
+  const [allUniqueTags, setAllUniqueTags] = useState<ITag[]>(initialAllUniqueTags ?? []);
   const [tagsVersion, setTagsVersion] = useState(0); // Used to force re-render when tags are fetched
 
   // Picker-internal UI state (not URL-persisted)
@@ -437,7 +440,8 @@ export default function Projects({ initialProjects, clients, initialFilters }: P
     });
 
     return filtered;
-  }, [projects, activeFilters, deadlineFilterValue]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- tagsVersion tracks projectTagsRef mutations
+  }, [projects, activeFilters, deadlineFilterValue, tagsVersion]);
 
   const handleEditProject = (project: IProject) => {
     openDrawer(

--- a/server/src/app/msp/projects/page.tsx
+++ b/server/src/app/msp/projects/page.tsx
@@ -1,6 +1,7 @@
 import Projects from '@alga-psa/projects/components/Projects';
 import { getAllClientsForProjects, getProjects } from '@alga-psa/projects/actions/projectActions';
-import type { IClient, IProject } from '@alga-psa/types';
+import { findTagsByEntityIds, findAllTagsByType } from '@alga-psa/tags/actions';
+import type { IClient, IProject, ITag } from '@alga-psa/types';
 import { isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import type { Metadata } from 'next';
 import type { ProjectListFilters } from '@alga-psa/projects/components/Projects';
@@ -21,6 +22,28 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
   ]);
 
   const projectsData: IProject[] = isActionPermissionError(projectsResult) ? [] : projectsResult;
+
+  // Fetch tags alongside projects so URL-based tag filters work on the first render.
+  // Without this, `findTagsByEntityIds` runs in a client `useEffect` and the filter
+  // applied before tags load matches nothing (breaks bookmarked/pasted tag filter URLs).
+  const projectIds = projectsData
+    .map(project => project.project_id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const [projectTagsList, allProjectTags] = await Promise.all([
+    projectIds.length > 0
+      ? findTagsByEntityIds(projectIds, 'project').catch(() => [] as ITag[])
+      : Promise.resolve([] as ITag[]),
+    findAllTagsByType('project').catch(() => [] as ITag[]),
+  ]);
+
+  const initialProjectTags: Record<string, ITag[]> = {};
+  for (const tag of projectTagsList) {
+    if (!initialProjectTags[tag.tagged_id]) {
+      initialProjectTags[tag.tagged_id] = [];
+    }
+    initialProjectTags[tag.tagged_id].push(tag);
+  }
 
   // Parse search parameters into initial filter values
   const initialFilters: Partial<ProjectListFilters> = {};
@@ -80,6 +103,8 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
       initialProjects={projectsData}
       clients={clientsData}
       initialFilters={initialFilters}
+      initialProjectTags={initialProjectTags}
+      initialAllUniqueTags={allProjectTags}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Project list fetched tags in a client `useEffect`, so bookmarked or pasted URLs with `?tags=...` ran the filter before tags loaded and matched zero projects (tickets already included tags in the initial server fetch, which is why the same pattern worked there).
- Fetch `findTagsByEntityIds` and `findAllTagsByType` on the server in `msp/projects/page.tsx` alongside `getProjects`, and seed the `Projects` client component via new `initialProjectTags` / `initialAllUniqueTags` props so the very first render has tag data.
- Add `tagsVersion` to the `filteredProjects` memo deps so client-side tag mutations (TagManager edits) also re-run the filter.

## Test plan
- [ ] Load `/msp/projects?tags=<tag-with-spaces>` in a new tab: matching projects appear immediately.
- [ ] Bookmark a filtered project URL and reopen it: filter pills show the tags and project list is filtered correctly.
- [ ] Multi-tag URL (`?tags=foo,bar%20baz`) correctly decodes and filters.
- [ ] Add/remove a tag on a project via the TagManager: filter result updates without a refresh.
- [ ] Empty result / no tags on any project still renders without errors.