### PR TITLE
Improve workflow wait duration authoring granularity

### DIFF
--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -137,6 +137,12 @@ import {
 } from '@alga-psa/workflows/authoring';
 import { validateExpressionSource } from '@alga-psa/workflows/authoring';
 import { partitionStepExpressionValidations, validateStepExpressions } from './expressionValidation';
+import {
+  composeTimeWaitDurationMs,
+  decomposeTimeWaitDurationMs,
+  formatTimeWaitDurationPart,
+  parseTimeWaitDurationPart,
+} from './timeWaitDuration';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 type WorkflowDefinitionRecord = {
@@ -5857,6 +5863,10 @@ export const StepConfigPanel: React.FC<{
   const timeWaitConfig = step.type === 'time.wait'
     ? removeInvalidWaitConfigFields((((step as NodeStep).config as Record<string, unknown> | undefined) ?? {}))
     : null;
+  const timeWaitDurationParts = useMemo(
+    () => decomposeTimeWaitDurationMs(typeof timeWaitConfig?.durationMs === 'number' ? timeWaitConfig.durationMs : undefined),
+    [timeWaitConfig?.durationMs]
+  );
   const selectedWaitEventName = typeof eventWaitConfig?.eventName === 'string' ? eventWaitConfig.eventName : '';
   const selectedWaitEventOption = useMemo(
     () => eventCatalogOptions.find((option) => option.event_type === selectedWaitEventName) ?? null,
@@ -5917,6 +5927,22 @@ export const StepConfigPanel: React.FC<{
       config: removeInvalidWaitConfigFields(nextConfig)
     });
   }, [onChange, removeInvalidWaitConfigFields, step]);
+
+  const updateTimeWaitDurationPart = useCallback((unit: 'days' | 'hours' | 'minutes' | 'seconds', raw: string) => {
+    if (!timeWaitConfig) {
+      return;
+    }
+
+    const nextDurationMs = composeTimeWaitDurationMs({
+      ...timeWaitDurationParts,
+      [unit]: parseTimeWaitDurationPart(raw)
+    });
+
+    updateWaitNodeConfig({
+      ...timeWaitConfig,
+      durationMs: nextDurationMs
+    });
+  }, [timeWaitConfig, timeWaitDurationParts, updateWaitNodeConfig]);
 
   const eventFilters = useMemo(() => {
     if (!eventWaitConfig) return [] as EventWaitFilterClause[];
@@ -6445,20 +6471,46 @@ export const StepConfigPanel: React.FC<{
             disabled={!editable}
           />
           {(timeWaitConfig.mode ?? 'duration') === 'duration' ? (
-            <Input
-              id={`time-wait-duration-${step.id}`}
-              label="Duration (ms)"
-              type="number"
-              value={typeof timeWaitConfig.durationMs === 'number' ? timeWaitConfig.durationMs : ''}
-              disabled={!editable}
-              onChange={(event) => {
-                const raw = event.target.value.trim();
-                updateWaitNodeConfig({
-                  ...timeWaitConfig,
-                  durationMs: raw ? Number(raw) : undefined
-                });
-              }}
-            />
+            <div className="space-y-2">
+              <Label>Duration</Label>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <Input
+                  id={`time-wait-duration-days-${step.id}`}
+                  label="Days"
+                  type="number"
+                  value={formatTimeWaitDurationPart(timeWaitDurationParts.days)}
+                  disabled={!editable}
+                  onChange={(event) => updateTimeWaitDurationPart('days', event.target.value)}
+                />
+                <Input
+                  id={`time-wait-duration-hours-${step.id}`}
+                  label="Hours"
+                  type="number"
+                  value={formatTimeWaitDurationPart(timeWaitDurationParts.hours)}
+                  disabled={!editable}
+                  onChange={(event) => updateTimeWaitDurationPart('hours', event.target.value)}
+                />
+                <Input
+                  id={`time-wait-duration-minutes-${step.id}`}
+                  label="Minutes"
+                  type="number"
+                  value={formatTimeWaitDurationPart(timeWaitDurationParts.minutes)}
+                  disabled={!editable}
+                  onChange={(event) => updateTimeWaitDurationPart('minutes', event.target.value)}
+                />
+                <Input
+                  id={`time-wait-duration-seconds-${step.id}`}
+                  label="Seconds"
+                  type="number"
+                  value={formatTimeWaitDurationPart(timeWaitDurationParts.seconds)}
+                  disabled={!editable}
+                  onChange={(event) => updateTimeWaitDurationPart('seconds', event.target.value)}
+                />
+              </div>
+              <p className="text-xs text-gray-500">
+                Stored as milliseconds in the workflow definition. Use fixed units only.
+              </p>
+            </div>
           ) : (
             <ExpressionField
               idPrefix={`time-wait-until-${step.id}`}
@@ -6604,7 +6656,7 @@ const FIELD_METADATA: Record<string, { label: string; description?: string; adva
   filters: { label: 'Payload Filters', description: 'Optional event payload filters (AND semantics)' },
   timeoutMs: { label: 'Timeout (ms)', description: 'Maximum time to wait in milliseconds', advanced: true },
   mode: { label: 'Wait Mode', description: 'Duration or until time' },
-  durationMs: { label: 'Duration (ms)', description: 'Relative duration in milliseconds' },
+  durationMs: { label: 'Duration', description: 'Relative duration stored in milliseconds' },
   until: { label: 'Until', description: 'Expression resolving to an absolute date/time' },
   state: { label: 'State Name', description: 'The state to transition to' },
   assign: { label: 'Assignments', description: 'Variables to assign' },

--- a/ee/server/src/components/workflow-designer/__tests__/WorkflowWaitEditors.test.tsx
+++ b/ee/server/src/components/workflow-designer/__tests__/WorkflowWaitEditors.test.tsx
@@ -344,8 +344,33 @@ describe('Workflow wait editors', () => {
       />
     );
 
-    fireEvent.change(screen.getByTestId('time-wait-duration-time-step'), { target: { value: '9000' } });
-    expect(onChangeTime).toHaveBeenCalled();
+    fireEvent.change(screen.getByTestId('time-wait-duration-minutes-time-step'), { target: { value: '2' } });
+    expect(onChangeTime).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({
+        mode: 'duration',
+        durationMs: 121000
+      })
+    }));
+  });
+
+  it('decomposes duration waits into day/hour/minute/second fields', () => {
+    render(
+      <StepConfigPanel
+        {...baseProps}
+        step={{
+          id: 'time-step-parts',
+          type: 'time.wait',
+          config: { mode: 'duration', durationMs: 90061000 }
+        } as any}
+        eventCatalogOptions={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('time-wait-duration-days-time-step-parts')).toHaveValue(1);
+    expect(screen.getByTestId('time-wait-duration-hours-time-step-parts')).toHaveValue(1);
+    expect(screen.getByTestId('time-wait-duration-minutes-time-step-parts')).toHaveValue(1);
+    expect(screen.getByTestId('time-wait-duration-seconds-time-step-parts')).toHaveValue(1);
   });
 
   it('T009: wait-filter editor renders typed picker when schema field has picker metadata', async () => {

--- a/ee/server/src/components/workflow-designer/__tests__/timeWaitDuration.test.ts
+++ b/ee/server/src/components/workflow-designer/__tests__/timeWaitDuration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  composeTimeWaitDurationMs,
+  decomposeTimeWaitDurationMs,
+  formatTimeWaitDuration,
+  parseTimeWaitDurationPart,
+} from '../timeWaitDuration';
+
+describe('timeWaitDuration helpers', () => {
+  it('composes fixed units into milliseconds', () => {
+    expect(composeTimeWaitDurationMs({ days: 1, hours: 2, minutes: 3, seconds: 4 })).toBe(93_784_000);
+  });
+
+  it('decomposes milliseconds into fixed units', () => {
+    expect(decomposeTimeWaitDurationMs(93_784_000)).toEqual({
+      days: 1,
+      hours: 2,
+      minutes: 3,
+      seconds: 4,
+    });
+  });
+
+  it('rounds sub-second remainders up to whole seconds for editor fields', () => {
+    expect(decomposeTimeWaitDurationMs(1_500)).toEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 2,
+    });
+  });
+
+  it('formats duration summaries readably', () => {
+    expect(formatTimeWaitDuration(93_784_000)).toBe('1d 2h 3m 4s');
+    expect(formatTimeWaitDuration(1_500)).toBe('1.5s');
+  });
+
+  it('parses positive integer duration parts', () => {
+    expect(parseTimeWaitDurationPart('12.9')).toBe(12);
+    expect(parseTimeWaitDurationPart('')).toBe(0);
+    expect(parseTimeWaitDurationPart('-3')).toBe(0);
+  });
+});

--- a/ee/server/src/components/workflow-designer/pipeline/PipelineComponents.tsx
+++ b/ee/server/src/components/workflow-designer/pipeline/PipelineComponents.tsx
@@ -32,6 +32,7 @@ import { Card } from '@alga-psa/ui/components/Card';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Button } from '@alga-psa/ui/components/Button';
 import type { Step, IfBlock, ForEachBlock, TryCatchBlock, NodeStep } from '@alga-psa/workflows/runtime';
+import { formatTimeWaitDuration } from '../timeWaitDuration';
 
 /**
  * Step type color configuration
@@ -349,7 +350,7 @@ export const StepCardSummary: React.FC<{
   if (step.type === 'time.wait') {
     const config = (step as NodeStep).config as { mode?: string; durationMs?: number } | undefined;
     if (config?.mode === 'duration' && typeof config.durationMs === 'number') {
-      return <span className="text-xs text-gray-500">for {config.durationMs}ms</span>;
+      return <span className="text-xs text-gray-500">for {formatTimeWaitDuration(config.durationMs)}</span>;
     }
     if (config?.mode === 'until') {
       return <span className="text-xs text-gray-500">until expression</span>;

--- a/ee/server/src/components/workflow-designer/timeWaitDuration.ts
+++ b/ee/server/src/components/workflow-designer/timeWaitDuration.ts
@@ -1,0 +1,113 @@
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+export const TIME_WAIT_MAX_DURATION_MS = Number.MAX_SAFE_INTEGER;
+
+export type TimeWaitDurationParts = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+const EMPTY_DURATION_PARTS: TimeWaitDurationParts = {
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+};
+
+function coerceDurationPart(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+export function composeTimeWaitDurationMs(parts: Partial<TimeWaitDurationParts>): number | undefined {
+  const days = coerceDurationPart(parts.days);
+  const hours = coerceDurationPart(parts.hours);
+  const minutes = coerceDurationPart(parts.minutes);
+  const seconds = coerceDurationPart(parts.seconds);
+
+  const total = (days * MS_PER_DAY)
+    + (hours * MS_PER_HOUR)
+    + (minutes * MS_PER_MINUTE)
+    + (seconds * MS_PER_SECOND);
+
+  return total > 0 ? total : undefined;
+}
+
+export function decomposeTimeWaitDurationMs(durationMs?: number | null): TimeWaitDurationParts {
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs) || durationMs <= 0) {
+    return EMPTY_DURATION_PARTS;
+  }
+
+  const normalizedMs = durationMs % MS_PER_SECOND === 0
+    ? durationMs
+    : Math.ceil(durationMs / MS_PER_SECOND) * MS_PER_SECOND;
+
+  let remaining = normalizedMs;
+
+  const days = Math.floor(remaining / MS_PER_DAY);
+  remaining -= days * MS_PER_DAY;
+
+  const hours = Math.floor(remaining / MS_PER_HOUR);
+  remaining -= hours * MS_PER_HOUR;
+
+  const minutes = Math.floor(remaining / MS_PER_MINUTE);
+  remaining -= minutes * MS_PER_MINUTE;
+
+  const seconds = Math.floor(remaining / MS_PER_SECOND);
+
+  return {
+    days,
+    hours,
+    minutes,
+    seconds,
+  };
+}
+
+export function formatTimeWaitDuration(durationMs?: number | null): string {
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs) || durationMs <= 0) {
+    return '0s';
+  }
+
+  if (durationMs < MS_PER_SECOND) {
+    return `${durationMs}ms`;
+  }
+
+  if (durationMs < MS_PER_MINUTE && durationMs % MS_PER_SECOND !== 0) {
+    return `${Math.round((durationMs / MS_PER_SECOND) * 10) / 10}s`;
+  }
+
+  const parts = decomposeTimeWaitDurationMs(durationMs);
+  const tokens: string[] = [];
+
+  if (parts.days > 0) tokens.push(`${parts.days}d`);
+  if (parts.hours > 0) tokens.push(`${parts.hours}h`);
+  if (parts.minutes > 0) tokens.push(`${parts.minutes}m`);
+  if (parts.seconds > 0) tokens.push(`${parts.seconds}s`);
+
+  return tokens.length > 0 ? tokens.join(' ') : '0s';
+}
+
+export function parseTimeWaitDurationPart(raw: string): number {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return Math.floor(value);
+}
+
+export function formatTimeWaitDurationPart(value: number): string {
+  return value > 0 ? String(value) : '';
+}

--- a/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
@@ -1122,8 +1122,8 @@ function parseTimeWaitConfig(config: unknown, stepPath: string): ParsedTimeWaitC
   }
 
   if (mode === 'duration') {
-    if (typeof config.durationMs !== 'number' || !Number.isFinite(config.durationMs) || config.durationMs <= 0) {
-      throw createValidationRuntimeError(stepPath, 'time.wait duration mode requires durationMs > 0');
+    if (typeof config.durationMs !== 'number' || !Number.isSafeInteger(config.durationMs) || config.durationMs <= 0) {
+      throw createValidationRuntimeError(stepPath, 'time.wait duration mode requires a positive safe-integer durationMs');
     }
   } else if (!isExpr(config.until)) {
     throw createValidationRuntimeError(stepPath, 'time.wait until mode requires an until expression');

--- a/shared/workflow/runtime/types.ts
+++ b/shared/workflow/runtime/types.ts
@@ -200,7 +200,7 @@ export type EventWaitConfig = z.infer<typeof eventWaitConfigSchema>;
 
 export const timeWaitConfigSchema = z.object({
   mode: z.enum(['duration', 'until']),
-  durationMs: z.number().int().positive().optional(),
+  durationMs: z.number().int().positive().safe().optional(),
   until: exprSchema.optional(),
   assign: z.record(exprSchema).optional()
 }).strict().superRefine((config, ctx) => {


### PR DESCRIPTION
## Summary
- replace raw wait duration ms editing with day/hour/minute/second inputs in the workflow designer
- keep persisted/runtime semantics on `durationMs` while formatting wait summaries more readably in the designer
- tighten time wait duration validation to safe integers and add helper/unit coverage

## Validation
- `cd ee/server && npx tsc --noEmit -p tsconfig.json`
- `cd ee/server && npx vitest run src/components/workflow-designer/__tests__/timeWaitDuration.test.ts`

## Notes
- `WorkflowWaitEditors.test.tsx` remains blocked in this environment by an existing `@alga-psa/workflow-streams` package-resolution issue during Vitest startup