### PR TITLE
Add labels to workflow designer palette actions

### DIFF
--- a/ee/server/src/components/workflow-designer/PaletteItemWithTooltip.tsx
+++ b/ee/server/src/components/workflow-designer/PaletteItemWithTooltip.tsx
@@ -96,19 +96,19 @@ export const PaletteItemWithTooltip: React.FC<{
       {...provided.draggableProps}
       {...(disabled ? {} : provided.dragHandleProps)}
       className={`
-        group relative flex items-center justify-center
-        w-10 h-10 rounded-lg border cursor-grab
+        group relative flex w-full min-h-[4.5rem] flex-col items-center justify-start gap-1 rounded-lg border px-1 py-2 text-center
         transition-all duration-150
-        ${disabled ? 'cursor-not-allowed opacity-50' : ''}
+        ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab'}
         ${isDragging
-          ? 'shadow-lg ring-2 ring-primary-400 bg-primary-50 border-primary-300 z-50'
-          : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+          ? 'shadow-lg ring-2 ring-primary-400 bg-primary-50 border-primary-300 dark:bg-primary-500/20 dark:border-primary-400 z-50'
+          : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50 dark:border-[rgb(var(--color-border-200))] dark:hover:border-[rgb(var(--color-border-300))] dark:hover:bg-[rgb(var(--color-background))]'
         }
       `}
       id={`workflow-designer-add-${item.id}`}
       data-testid={`palette-item-${item.id}`}
       role="button"
       aria-disabled={disabled}
+      aria-label={item.label}
       onClick={(event) => {
         event.stopPropagation();
         if (disabled) return;
@@ -117,7 +117,15 @@ export const PaletteItemWithTooltip: React.FC<{
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <span className="text-gray-500 group-hover:text-gray-700">{icon}</span>
+      <span className="flex h-5 w-5 items-center justify-center text-gray-500 group-hover:text-gray-700 dark:text-[rgb(var(--color-text-500))] dark:group-hover:text-[rgb(var(--color-text-700))]">
+        {icon}
+      </span>
+      <span
+        className="w-full truncate text-[10px] font-medium leading-tight text-gray-600 group-hover:text-gray-800 dark:text-[rgb(var(--color-text-600))] dark:group-hover:text-[rgb(var(--color-text-800))]"
+        title={item.label}
+      >
+        {item.label}
+      </span>
       <PaletteTooltip
         label={item.label}
         description={item.description}

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
+import { DragDropContext, Draggable, Droppable, DropResult, type DraggableProvided } from '@hello-pangea/dnd';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'react-hot-toast';
 import { createPortal } from 'react-dom';
@@ -3152,6 +3152,10 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     return groupPaletteItemsByCategory(paletteItems);
   }, [paletteItems]);
 
+  const flatPaletteItems = useMemo(() => {
+    return Object.values(groupedPaletteItems).flat();
+  }, [groupedPaletteItems]);
+
   const handlePipeSelect = (pipePath: string) => {
     setSelectedPipePath(pipePath);
   };
@@ -3284,6 +3288,46 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     }
   };
 
+  const renderPaletteItem = (
+    item: typeof paletteItems[0],
+    dragProvided: DraggableProvided,
+    isDragging: boolean
+  ) => {
+    const itemWithAction = item as typeof item & {
+      actionId?: string;
+      actionVersion?: number;
+      groupKey?: string;
+      groupLabel?: string;
+      tileKind?: 'core-object' | 'transform' | 'app' | 'ai';
+    };
+
+    return (
+      <PaletteItemWithTooltip
+        item={itemWithAction}
+        icon={getPaletteIcon(item)}
+        isDragging={isDragging}
+        provided={dragProvided}
+        disabled={!canManage || registryError}
+        onClick={() => {
+          if (itemWithAction.groupKey) {
+            handleAddStep(
+              'action.call',
+              buildGroupedActionStepConfig(itemWithAction, { generateSaveAsName }),
+              itemWithAction.label
+            );
+          } else if (itemWithAction.actionId) {
+            handleAddStep('action.call', {
+              actionId: itemWithAction.actionId,
+              version: itemWithAction.actionVersion
+            });
+          } else {
+            handleAddStep(item.type as Step['type']);
+          }
+        }}
+      />
+    );
+  };
+
   const showInitialDesignerSkeleton = isLoading && !activeDefinition;
 
   const designerContent = (
@@ -3292,7 +3336,15 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
 	      <div ref={designerFloatAnchorRef} className="relative flex flex-col flex-1 min-h-0 overflow-hidden bg-gray-50 dark:bg-[rgb(var(--color-background))]">
         <div className="sticky top-4 z-20 h-0 pointer-events-none">
           {/* Floating Icon-Grid Palette (left) */}
-          <Droppable droppableId="palette" isDropDisabled={true}>
+          <Droppable
+            droppableId="palette"
+            isDropDisabled={true}
+            renderClone={(dragProvided, snapshot, rubric) => {
+              const item = flatPaletteItems[rubric.source.index];
+              if (!item) return <div ref={dragProvided.innerRef} {...dragProvided.draggableProps} />;
+              return renderPaletteItem(item, dragProvided, snapshot.isDragging);
+            }}
+          >
             {(provided) => (
               <WorkflowDesignerPalette
                 visible={Boolean(designerFloatAnchorRect)}
@@ -3305,47 +3357,14 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
                 scrollContainerRef={provided.innerRef}
                 scrollContainerProps={provided.droppableProps}
                 scrollContainerFooter={provided.placeholder}
-                renderItem={(item, _category, itemIndex) => (
+                renderItem={(item, _category, paletteIndex) => (
                   <Draggable
                     key={item.id}
                     draggableId={getPaletteDraggableId(item)}
-                    index={itemIndex}
+                    index={paletteIndex}
                     isDragDisabled={!canManage || registryError}
                   >
-                    {(dragProvided, snapshot) => {
-                      const itemWithAction = item as typeof item & {
-                        actionId?: string;
-                        actionVersion?: number;
-                        groupKey?: string;
-                        groupLabel?: string;
-                        tileKind?: 'core-object' | 'transform' | 'app' | 'ai';
-                      };
-                      return (
-                        <PaletteItemWithTooltip
-                          item={itemWithAction}
-                          icon={getPaletteIcon(item)}
-                          isDragging={snapshot.isDragging}
-                          provided={dragProvided}
-                          disabled={!canManage || registryError}
-                          onClick={() => {
-                            if (itemWithAction.groupKey) {
-                              handleAddStep(
-                                'action.call',
-                                buildGroupedActionStepConfig(itemWithAction, { generateSaveAsName }),
-                                itemWithAction.label
-                              );
-                            } else if (itemWithAction.actionId) {
-                              handleAddStep('action.call', {
-                                actionId: itemWithAction.actionId,
-                                version: itemWithAction.actionVersion
-                              });
-                            } else {
-                              handleAddStep(item.type as Step['type']);
-                            }
-                          }}
-                        />
-                      );
-                    }}
+                    {(dragProvided, snapshot) => renderPaletteItem(item, dragProvided, snapshot.isDragging)}
                   </Draggable>
                 )}
               />

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
@@ -63,14 +63,15 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
         id="workflow-designer-palette-scroll"
         ref={scrollContainerRef}
         {...scrollContainerProps}
-        className="flex-1 min-h-0 overflow-y-auto p-3 space-y-4"
+        className="flex-1 min-h-0 overflow-y-auto pl-3 pr-5 py-3 space-y-4"
+        style={{ scrollbarGutter: 'stable' }}
       >
         {Object.entries(groupedPaletteItems).map(([category, items]) => (
           <div key={category}>
             <div className="text-[10px] font-semibold uppercase text-gray-400 tracking-wider mb-2">
               {category}
             </div>
-            <div className="grid grid-cols-4 gap-1">
+            <div className="grid grid-cols-2 gap-2">
               {items.map((item, itemIndex) => renderItem(item, category, itemIndex))}
             </div>
           </div>

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
@@ -35,6 +35,8 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
   scrollContainerProps,
   scrollContainerFooter,
 }: WorkflowDesignerPaletteProps<TItem>): React.ReactElement {
+  let paletteIndex = 0;
+
   return (
     <aside
       className={`pointer-events-auto w-56 max-h-[calc(100vh-220px)] bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg overflow-hidden flex flex-col min-h-0 z-40 ${visible ? '' : 'hidden'}`}
@@ -72,7 +74,11 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
               {category}
             </div>
             <div className="grid grid-cols-2 gap-2">
-              {items.map((item, itemIndex) => renderItem(item, category, itemIndex))}
+              {items.map((item) => {
+                const currentPaletteIndex = paletteIndex;
+                paletteIndex += 1;
+                return renderItem(item, category, currentPaletteIndex);
+              })}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- add small labels beneath workflow designer palette icons
- switch the palette to a 2-column layout with scrollbar spacing
- fix palette drag previews so the dragged action visibly follows the pointer

## Testing
- not run