### PR TITLE
Allow editing draft invoice details

### DIFF
--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -119,6 +119,118 @@ async function releaseRecurringServicePeriodInvoiceLinkageForInvoice(
     });
 }
 
+export interface DraftInvoicePropertiesUpdateInput {
+  invoiceNumber: string;
+  invoiceDate: string;
+  dueDate: string | null;
+}
+
+export interface DraftInvoicePropertiesUpdateResult {
+  invoiceId: string;
+  invoiceNumber: string;
+  invoiceDate: string;
+  dueDate: string | null;
+}
+
+export const updateDraftInvoiceProperties = withAuth(async (
+  user,
+  { tenant },
+  invoiceId: string,
+  input: DraftInvoicePropertiesUpdateInput
+): Promise<DraftInvoicePropertiesUpdateResult> => {
+  const trimmedInvoiceNumber = input.invoiceNumber?.trim();
+
+  if (!trimmedInvoiceNumber) {
+    throw new Error('Invoice number is required');
+  }
+
+  if (!input.invoiceDate) {
+    throw new Error('Invoice date is required');
+  }
+
+  let normalizedInvoiceDate: string;
+  let normalizedDueDate: string | null = null;
+
+  try {
+    normalizedInvoiceDate = toISODate(Temporal.PlainDate.from(input.invoiceDate));
+  } catch {
+    throw new Error('Invoice date is invalid');
+  }
+
+  if (input.dueDate) {
+    try {
+      normalizedDueDate = toISODate(Temporal.PlainDate.from(input.dueDate));
+    } catch {
+      throw new Error('Due date is invalid');
+    }
+  }
+
+  const currentDate = Temporal.Now.plainDateISO().toString();
+  const { knex } = await createTenantKnex();
+
+  await withTransaction(knex, async (trx: Knex.Transaction) => {
+    const invoice = await trx('invoices')
+      .where({
+        invoice_id: invoiceId,
+        tenant,
+      })
+      .first();
+
+    if (!invoice) {
+      throw new Error('Invoice not found');
+    }
+
+    if (invoice.finalized_at || invoice.status !== 'draft') {
+      throw new Error('Only draft invoices can be edited');
+    }
+
+    const duplicateInvoice = await trx('invoices')
+      .where({
+        tenant,
+        invoice_number: trimmedInvoiceNumber,
+      })
+      .whereNot({ invoice_id: invoiceId })
+      .first('invoice_id');
+
+    if (duplicateInvoice) {
+      throw new Error('Invoice number already exists. Choose a different number.');
+    }
+
+    try {
+      await trx('invoices')
+        .where({
+          invoice_id: invoiceId,
+          tenant,
+        })
+        .update({
+          invoice_number: trimmedInvoiceNumber,
+          invoice_date: normalizedInvoiceDate,
+          due_date: normalizedDueDate,
+          updated_at: currentDate,
+        });
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === '23505' &&
+        'constraint' in error &&
+        error.constraint === 'unique_invoice_number_per_tenant'
+      ) {
+        throw new Error('Invoice number already exists. Choose a different number.');
+      }
+
+      throw error;
+    }
+  });
+
+  return {
+    invoiceId,
+    invoiceNumber: trimmedInvoiceNumber,
+    invoiceDate: normalizedInvoiceDate,
+    dueDate: normalizedDueDate,
+  };
+});
 
 export const finalizeInvoice = withAuth(async (
   user,

--- a/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import { Button } from '@alga-psa/ui/components/Button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@alga-psa/ui/components/Card';
+import { Input } from '@alga-psa/ui/components/Input';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { formatCurrencyFromMinorUnits, toPlainDate } from '@alga-psa/core';
+import type { InvoiceViewModel as DbInvoiceViewModel } from '@alga-psa/types';
+import {
+  updateDraftInvoiceProperties,
+  type DraftInvoicePropertiesUpdateResult,
+} from '@alga-psa/billing/actions/invoiceModification';
+
+export type DraftInvoiceDetailsSummary = Pick<
+  DbInvoiceViewModel,
+  'invoice_id' | 'invoice_number' | 'invoice_date' | 'due_date' | 'status' | 'total_amount' | 'currencyCode' | 'client'
+>;
+
+interface DraftInvoiceDetailsCardProps {
+  invoice: DraftInvoiceDetailsSummary | null;
+  onSaved?: (updated: DraftInvoicePropertiesUpdateResult) => Promise<void> | void;
+}
+
+interface DraftInvoiceDetailsFormState {
+  invoiceNumber: string;
+  invoiceDate: string;
+  dueDate: string;
+}
+
+const normalizeDateInputValue = (value: DraftInvoiceDetailsSummary['invoice_date'] | DraftInvoiceDetailsSummary['due_date']) => {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    return toPlainDate(value).toString();
+  } catch (error) {
+    console.error('Failed to normalize invoice date for input field:', error);
+    return '';
+  }
+};
+
+const buildFormState = (invoice: DraftInvoiceDetailsSummary): DraftInvoiceDetailsFormState => ({
+  invoiceNumber: invoice.invoice_number ?? '',
+  invoiceDate: normalizeDateInputValue(invoice.invoice_date),
+  dueDate: normalizeDateInputValue(invoice.due_date),
+});
+
+const DraftInvoiceDetailsCard: React.FC<DraftInvoiceDetailsCardProps> = ({
+  invoice,
+  onSaved,
+}) => {
+  const initialState = useMemo(() => (invoice ? buildFormState(invoice) : null), [
+    invoice?.invoice_id,
+    invoice?.invoice_number,
+    invoice ? normalizeDateInputValue(invoice.invoice_date) : '',
+    invoice ? normalizeDateInputValue(invoice.due_date) : '',
+  ]);
+
+  const [formState, setFormState] = useState<DraftInvoiceDetailsFormState>({
+    invoiceNumber: '',
+    invoiceDate: '',
+    dueDate: '',
+  });
+  const [savedState, setSavedState] = useState<DraftInvoiceDetailsFormState>({
+    invoiceNumber: '',
+    invoiceDate: '',
+    dueDate: '',
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [invoiceNumberError, setInvoiceNumberError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!initialState) {
+      setFormState({ invoiceNumber: '', invoiceDate: '', dueDate: '' });
+      setSavedState({ invoiceNumber: '', invoiceDate: '', dueDate: '' });
+      setInvoiceNumberError(null);
+      setFormError(null);
+      return;
+    }
+
+    setFormState(initialState);
+    setSavedState(initialState);
+    setInvoiceNumberError(null);
+    setFormError(null);
+  }, [initialState]);
+
+  if (!invoice) {
+    return null;
+  }
+
+  const hasChanges =
+    formState.invoiceNumber !== savedState.invoiceNumber ||
+    formState.invoiceDate !== savedState.invoiceDate ||
+    formState.dueDate !== savedState.dueDate;
+
+  const handleSave = async () => {
+    const trimmedInvoiceNumber = formState.invoiceNumber.trim();
+
+    if (!trimmedInvoiceNumber) {
+      setInvoiceNumberError('Invoice number is required.');
+      setFormError(null);
+      return;
+    }
+
+    if (!formState.invoiceDate) {
+      setFormError('Invoice date is required.');
+      return;
+    }
+
+    setIsSaving(true);
+    setInvoiceNumberError(null);
+    setFormError(null);
+
+    try {
+      const updated = await updateDraftInvoiceProperties(invoice.invoice_id, {
+        invoiceNumber: trimmedInvoiceNumber,
+        invoiceDate: formState.invoiceDate,
+        dueDate: formState.dueDate || null,
+      });
+
+      const nextSavedState: DraftInvoiceDetailsFormState = {
+        invoiceNumber: updated.invoiceNumber,
+        invoiceDate: updated.invoiceDate,
+        dueDate: updated.dueDate ?? '',
+      };
+
+      setFormState(nextSavedState);
+      setSavedState(nextSavedState);
+
+      try {
+        await onSaved?.(updated);
+      } catch (refreshError) {
+        console.error('Draft invoice details saved, but refresh failed:', refreshError);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to save invoice details.';
+
+      if (
+        message === 'Invoice number is required' ||
+        message === 'Invoice number must be unique' ||
+        message === 'Invoice number already exists. Choose a different number.'
+      ) {
+        setInvoiceNumberError(message === 'Invoice number is required' ? 'Invoice number is required.' : message);
+        setFormError(null);
+      } else {
+        setFormError(message);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormState(savedState);
+    setInvoiceNumberError(null);
+    setFormError(null);
+  };
+
+  return (
+    <Card className="mb-4" id="draft-invoice-details-card">
+      <CardHeader className="pb-4">
+        <CardTitle>Invoice Details</CardTitle>
+        <CardDescription>Edit draft invoice metadata before finalizing.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {formError ? (
+          <Alert variant="destructive">
+            <AlertDescription>{formError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Input
+            id="draft-invoice-number-input"
+            label="Invoice Number"
+            value={formState.invoiceNumber}
+            onChange={(event) => {
+              setFormState((current) => ({ ...current, invoiceNumber: event.target.value }));
+              setInvoiceNumberError(null);
+            }}
+            error={invoiceNumberError ?? undefined}
+            disabled={isSaving}
+          />
+
+          <div className="space-y-1">
+            <span className="block text-sm font-medium text-[rgb(var(--color-text-700))]">Status</span>
+            <div className="h-10 flex items-center">
+              <Badge variant="warning">{invoice.status === 'draft' ? 'Draft' : invoice.status}</Badge>
+            </div>
+          </div>
+
+          <Input
+            id="draft-invoice-date-input"
+            label="Invoice Date"
+            type="date"
+            value={formState.invoiceDate}
+            onChange={(event) => setFormState((current) => ({ ...current, invoiceDate: event.target.value }))}
+            disabled={isSaving}
+            required
+          />
+
+          <Input
+            id="draft-due-date-input"
+            label="Due Date"
+            type="date"
+            value={formState.dueDate}
+            onChange={(event) => setFormState((current) => ({ ...current, dueDate: event.target.value }))}
+            disabled={isSaving}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-1">
+            <span className="block text-sm font-medium text-[rgb(var(--color-text-700))]">Client</span>
+            <div className="min-h-10 rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-background))] px-3 py-2 text-sm text-[rgb(var(--color-text-900))]">
+              {invoice.client?.name || 'Unknown client'}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <span className="block text-sm font-medium text-[rgb(var(--color-text-700))]">Amount</span>
+            <div className="min-h-10 rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-background))] px-3 py-2 text-sm text-[rgb(var(--color-text-900))]">
+              {formatCurrencyFromMinorUnits(Number(invoice.total_amount ?? 0), 'en-US', invoice.currencyCode || 'USD')}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="justify-end gap-2">
+        <Button
+          id="draft-invoice-details-cancel"
+          variant="outline"
+          onClick={handleCancel}
+          disabled={!hasChanges || isSaving}
+        >
+          Cancel
+        </Button>
+        <Button
+          id="draft-invoice-details-save"
+          onClick={handleSave}
+          disabled={!hasChanges || isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default DraftInvoiceDetailsCard;

--- a/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard.tsx
@@ -14,16 +14,19 @@ import {
 import { Input } from '@alga-psa/ui/components/Input';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { formatCurrencyFromMinorUnits, toPlainDate } from '@alga-psa/core';
-import type { InvoiceViewModel as DbInvoiceViewModel } from '@alga-psa/types';
+import type { DateValue, InvoiceViewModel as DbInvoiceViewModel } from '@alga-psa/types';
 import {
   updateDraftInvoiceProperties,
   type DraftInvoicePropertiesUpdateResult,
 } from '@alga-psa/billing/actions/invoiceModification';
 
-export type DraftInvoiceDetailsSummary = Pick<
+export interface DraftInvoiceDetailsSummary extends Pick<
   DbInvoiceViewModel,
-  'invoice_id' | 'invoice_number' | 'invoice_date' | 'due_date' | 'status' | 'total_amount' | 'currencyCode' | 'client'
->;
+  'invoice_id' | 'invoice_number' | 'status' | 'total_amount' | 'currencyCode' | 'client'
+> {
+  invoice_date: DateValue;
+  due_date: DateValue | null;
+}
 
 interface DraftInvoiceDetailsCardProps {
   invoice: DraftInvoiceDetailsSummary | null;

--- a/packages/billing/src/components/billing-dashboard/invoicing/DraftsTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/DraftsTab.tsx
@@ -94,8 +94,10 @@ const DraftsTab: React.FC<DraftsTabProps> = ({
     loadData();
   }, [currentPage, pageSize, debouncedSearchTerm, refreshTrigger]);
 
-  const loadData = async () => {
-    setIsLoading(true);
+  const loadData = async (options: { silent?: boolean } = {}) => {
+    if (!options.silent) {
+      setIsLoading(true);
+    }
     setError(null);
     try {
       const [paginatedResult, fetchedTemplates] = await Promise.all([
@@ -125,7 +127,9 @@ const DraftsTab: React.FC<DraftsTabProps> = ({
       console.error('Error fetching draft invoices data:', err);
       setError('Failed to load draft invoices. Please try again.');
     } finally {
-      setIsLoading(false);
+      if (!options.silent) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -486,8 +490,12 @@ const DraftsTab: React.FC<DraftsTabProps> = ({
                 onFinalize={handleFinalizeFromPreview}
                 onReverse={handleReverseFromPreview}
                 onDownload={handleDownload}
+                onDraftInvoiceUpdated={async () => {
+                  await loadData({ silent: true });
+                }}
                 isFinalized={false}
                 creditApplied={selectedInvoice?.credit_applied || 0}
+                draftInvoiceSummary={selectedInvoice}
               />
             </div>
           </Panel>

--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
@@ -53,6 +53,10 @@ vi.mock('../PaperInvoice', () => ({
   },
 }));
 
+vi.mock('./DraftInvoiceDetailsCard', () => ({
+  default: () => <div data-automation-id="draft-invoice-details-card-mock" />,
+}));
+
 vi.mock('./PurchaseOrderSummaryBanner', () => ({
   PurchaseOrderSummaryBanner: () => <div data-automation-id="po-summary-banner-mock" />,
 }));

--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
@@ -6,8 +6,9 @@ import { Card } from '@alga-psa/ui/components/Card';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { FileText, Settings } from 'lucide-react';
-import type { IInvoiceTemplate, IQuote, TaxSource } from '@alga-psa/types';
+import type { IInvoiceTemplate, IQuote, TaxSource, InvoiceViewModel as DbInvoiceViewModel } from '@alga-psa/types';
 import type { WasmInvoiceViewModel } from '@alga-psa/types';
+import type { DraftInvoicePropertiesUpdateResult } from '@alga-psa/billing/actions/invoiceModification';
 import {
   getInvoiceForRendering,
   getInvoicePurchaseOrderSummary,
@@ -24,6 +25,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { InvoiceTaxSourceBadge } from '../../invoices/InvoiceTaxSourceBadge';
 import { resolveTemplatePrintSettingsFromAst } from '../../../lib/invoice-template-ast/printSettings';
+import DraftInvoiceDetailsCard from './DraftInvoiceDetailsCard';
 
 interface InvoicePreviewPanelProps {
   invoiceId: string | null;
@@ -36,8 +38,10 @@ interface InvoicePreviewPanelProps {
   onEmail?: () => Promise<void>;
   onEdit?: () => void;
   onUnfinalize?: () => Promise<void>;
+  onDraftInvoiceUpdated?: (updated: DraftInvoicePropertiesUpdateResult) => Promise<void> | void;
   isFinalized: boolean;
   creditApplied?: number;
+  draftInvoiceSummary?: DbInvoiceViewModel | null;
 }
 
 const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
@@ -51,8 +55,10 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   onEmail,
   onEdit,
   onUnfinalize,
+  onDraftInvoiceUpdated,
   isFinalized,
-  creditApplied = 0
+  creditApplied = 0,
+  draftInvoiceSummary = null
 }) => {
   const router = useRouter();
   const [detailedInvoiceData, setDetailedInvoiceData] = useState<WasmInvoiceViewModel | null>(null);
@@ -64,6 +70,8 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const [taxSource, setTaxSource] = useState<TaxSource>('internal');
   const [sourceQuote, setSourceQuote] = useState<IQuote | null>(null);
+  const [previewRefreshCounter, setPreviewRefreshCounter] = useState(0);
+  const [draftInvoiceEditorSummary, setDraftInvoiceEditorSummary] = useState<DbInvoiceViewModel | null>(draftInvoiceSummary);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   // Match invoice/PDF rendering: honor an explicit URL template selection first,
@@ -98,6 +106,17 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
     resizeObserver.observe(container);
     return () => resizeObserver.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (!invoiceId) {
+      setDraftInvoiceEditorSummary(null);
+      return;
+    }
+
+    if (draftInvoiceSummary?.invoice_id === invoiceId) {
+      setDraftInvoiceEditorSummary(draftInvoiceSummary);
+    }
+  }, [draftInvoiceSummary, invoiceId]);
 
   useEffect(() => {
     const loadInvoiceData = async () => {
@@ -150,7 +169,7 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
     };
 
     loadInvoiceData();
-  }, [invoiceId]);
+  }, [invoiceId, previewRefreshCounter]);
 
   useEffect(() => {
     let isMounted = true;
@@ -203,6 +222,24 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
     }
   };
 
+  const handleDraftInvoiceUpdated = async (updated: DraftInvoicePropertiesUpdateResult) => {
+    setDraftInvoiceEditorSummary((current) => {
+      if (!current || current.invoice_id !== updated.invoiceId) {
+        return current;
+      }
+
+      return {
+        ...current,
+        invoice_number: updated.invoiceNumber,
+        invoice_date: updated.invoiceDate,
+        due_date: updated.dueDate,
+      };
+    });
+
+    setPreviewRefreshCounter((current) => current + 1);
+    await onDraftInvoiceUpdated?.(updated);
+  };
+
   // Calculate scale based on container width
   const paperShellChromePx = 24;
   const baseInvoiceWidth = resolvedPreviewPrintSettings.pageWidthPx + paperShellChromePx;
@@ -225,6 +262,13 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   return (
     <Card className="h-full">
       <div className="p-6" ref={containerRef}>
+        {!isFinalized && draftInvoiceEditorSummary ? (
+          <DraftInvoiceDetailsCard
+            invoice={draftInvoiceEditorSummary}
+            onSaved={handleDraftInvoiceUpdated}
+          />
+        ) : null}
+
         <div className="mb-4">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-lg font-semibold">Invoice Preview</h3>

--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.tsx
@@ -25,7 +25,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { InvoiceTaxSourceBadge } from '../../invoices/InvoiceTaxSourceBadge';
 import { resolveTemplatePrintSettingsFromAst } from '../../../lib/invoice-template-ast/printSettings';
-import DraftInvoiceDetailsCard from './DraftInvoiceDetailsCard';
+import DraftInvoiceDetailsCard, { type DraftInvoiceDetailsSummary } from './DraftInvoiceDetailsCard';
 
 interface InvoicePreviewPanelProps {
   invoiceId: string | null;
@@ -71,7 +71,7 @@ const InvoicePreviewPanel: React.FC<InvoicePreviewPanelProps> = ({
   const [taxSource, setTaxSource] = useState<TaxSource>('internal');
   const [sourceQuote, setSourceQuote] = useState<IQuote | null>(null);
   const [previewRefreshCounter, setPreviewRefreshCounter] = useState(0);
-  const [draftInvoiceEditorSummary, setDraftInvoiceEditorSummary] = useState<DbInvoiceViewModel | null>(draftInvoiceSummary);
+  const [draftInvoiceEditorSummary, setDraftInvoiceEditorSummary] = useState<DraftInvoiceDetailsSummary | null>(draftInvoiceSummary);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   // Match invoice/PDF rendering: honor an explicit URL template selection first,

--- a/packages/billing/tests/DraftInvoiceDetailsCard.test.tsx
+++ b/packages/billing/tests/DraftInvoiceDetailsCard.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DraftInvoiceDetailsCard from '../src/components/billing-dashboard/invoicing/DraftInvoiceDetailsCard';
+
+const updateDraftInvoicePropertiesMock = vi.fn();
+
+vi.mock('@alga-psa/billing/actions/invoiceModification', () => ({
+  updateDraftInvoiceProperties: (...args: unknown[]) => updateDraftInvoicePropertiesMock(...args),
+}));
+
+const draftInvoice = {
+  invoice_id: 'inv-1',
+  invoice_number: 'INV-1001',
+  invoice_date: '2026-04-01',
+  due_date: '2026-04-15',
+  status: 'draft',
+  total_amount: 10500,
+  currencyCode: 'USD',
+  client: {
+    name: 'Acme Co.',
+    logo: '',
+    address: '',
+  },
+};
+
+describe('DraftInvoiceDetailsCard', () => {
+  beforeEach(() => {
+    cleanup();
+    updateDraftInvoicePropertiesMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('saves updated invoice properties and clears the dirty state', async () => {
+    const onSaved = vi.fn();
+    updateDraftInvoicePropertiesMock.mockResolvedValue({
+      invoiceId: 'inv-1',
+      invoiceNumber: 'INV-2001',
+      invoiceDate: '2026-04-02',
+      dueDate: '2026-04-20',
+    });
+
+    render(<DraftInvoiceDetailsCard invoice={draftInvoice as any} onSaved={onSaved} />);
+
+    const saveButton = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement;
+    const numberInput = screen.getByDisplayValue('INV-1001') as HTMLInputElement;
+    const invoiceDateInput = screen.getByDisplayValue('2026-04-01') as HTMLInputElement;
+
+    expect(saveButton.disabled).toBe(true);
+    expect(cancelButton.disabled).toBe(true);
+
+    fireEvent.change(numberInput, { target: { value: 'INV-2001' } });
+    fireEvent.change(invoiceDateInput, { target: { value: '2026-04-02' } });
+
+    expect(saveButton.disabled).toBe(false);
+    expect(cancelButton.disabled).toBe(false);
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateDraftInvoicePropertiesMock).toHaveBeenCalledWith('inv-1', {
+        invoiceNumber: 'INV-2001',
+        invoiceDate: '2026-04-02',
+        dueDate: '2026-04-15',
+      });
+    });
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith({
+        invoiceId: 'inv-1',
+        invoiceNumber: 'INV-2001',
+        invoiceDate: '2026-04-02',
+        dueDate: '2026-04-20',
+      });
+    });
+
+    expect(saveButton.disabled).toBe(true);
+    expect(cancelButton.disabled).toBe(true);
+    expect(numberInput.value).toBe('INV-2001');
+  });
+
+  it('surfaces duplicate invoice number errors inline', async () => {
+    updateDraftInvoicePropertiesMock.mockRejectedValue(
+      new Error('Invoice number already exists. Choose a different number.')
+    );
+
+    render(<DraftInvoiceDetailsCard invoice={draftInvoice as any} />);
+
+    fireEvent.change(screen.getByDisplayValue('INV-1001'), {
+      target: { value: 'INV-0001' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Invoice number already exists. Choose a different number.')).toBeTruthy();
+  });
+});

--- a/packages/billing/tests/invoiceModification.updateDraftInvoiceProperties.test.ts
+++ b/packages/billing/tests/invoiceModification.updateDraftInvoiceProperties.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = {
+  invoice: {
+    invoice_id: 'invoice-1',
+    tenant: 'tenant-1',
+    status: 'draft',
+    finalized_at: null,
+    invoice_number: 'INV-1001',
+  } as Record<string, any> | null,
+  duplicateInvoice: null as Record<string, any> | null,
+  updates: [] as Array<{ table: string; payload: Record<string, any> }>,
+};
+
+const recalculateInvoiceMock = vi.fn(async () => undefined);
+
+function normalizeWhereArg(arg1: unknown, arg2?: unknown) {
+  if (typeof arg1 === 'string') {
+    return { [arg1]: arg2 };
+  }
+
+  return (arg1 ?? {}) as Record<string, any>;
+}
+
+function createBuilder(table: string) {
+  const whereClauses: Array<Record<string, any>> = [];
+  const whereNotClauses: Array<Record<string, any>> = [];
+
+  const builder: any = {};
+
+  builder.leftJoin = vi.fn(() => builder);
+  builder.join = vi.fn(() => builder);
+  builder.andWhere = vi.fn((arg1: unknown, arg2?: unknown) => {
+    whereClauses.push(normalizeWhereArg(arg1, arg2));
+    return builder;
+  });
+  builder.where = vi.fn((arg1: unknown, arg2?: unknown) => {
+    whereClauses.push(normalizeWhereArg(arg1, arg2));
+    return builder;
+  });
+  builder.whereIn = vi.fn(() => builder);
+  builder.whereNot = vi.fn((arg1: unknown, arg2?: unknown) => {
+    whereNotClauses.push(normalizeWhereArg(arg1, arg2));
+    return builder;
+  });
+  builder.select = vi.fn(() => builder);
+  builder.delete = vi.fn(async () => 1);
+  builder.update = vi.fn(async (payload: Record<string, any>) => {
+    state.updates.push({ table, payload });
+    return 1;
+  });
+  builder.first = vi.fn(async () => {
+    if (table !== 'invoices') {
+      return undefined;
+    }
+
+    const mergedWhere = Object.assign({}, ...whereClauses);
+    const mergedWhereNot = Object.assign({}, ...whereNotClauses);
+
+    if (mergedWhere.invoice_id && mergedWhere.tenant) {
+      return state.invoice;
+    }
+
+    if (mergedWhere.invoice_number && mergedWhere.tenant && mergedWhereNot.invoice_id) {
+      return state.duplicateInvoice;
+    }
+
+    return undefined;
+  });
+  builder.then = vi.fn((onFulfilled?: any, onRejected?: any) => Promise.resolve([]).then(onFulfilled, onRejected));
+
+  return builder;
+}
+
+function createMockTrx() {
+  return ((table: string) => createBuilder(table)) as any;
+}
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => (...args: any[]) =>
+    fn({ user_id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+  getSession: vi.fn(async () => ({ user: { id: 'user-1' } })),
+}));
+
+vi.mock('@alga-psa/db', async () => {
+  const actual = await vi.importActual<any>('@alga-psa/db');
+  return {
+    ...actual,
+    createTenantKnex: vi.fn(async () => ({ knex: {} })),
+    withTransaction: vi.fn(async (_knex: any, callback: any) => callback(createMockTrx())),
+  };
+});
+
+vi.mock('../src/lib/billing/billingEngine', () => ({
+  BillingEngine: class BillingEngine {
+    recalculateInvoice = recalculateInvoiceMock;
+  },
+}));
+
+vi.mock('../src/services/invoiceService', () => ({
+  persistInvoiceCharges: vi.fn(),
+  persistManualInvoiceCharges: vi.fn(),
+}));
+
+vi.mock('../src/models/clientContractLine', () => ({
+  default: {
+    updateClientCredit: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../src/actions/creditActions', () => ({
+  applyCreditToInvoice: vi.fn(),
+}));
+
+vi.mock('@alga-psa/billing/models/invoice', () => ({
+  default: {
+    getFullInvoiceById: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../src/actions/taxSourceActions', () => ({
+  validateInvoiceFinalization: vi.fn(async () => ({ canFinalize: true })),
+}));
+
+describe('updateDraftInvoiceProperties', () => {
+  beforeEach(() => {
+    state.invoice = {
+      invoice_id: 'invoice-1',
+      tenant: 'tenant-1',
+      status: 'draft',
+      finalized_at: null,
+      invoice_number: 'INV-1001',
+    };
+    state.duplicateInvoice = null;
+    state.updates = [];
+    recalculateInvoiceMock.mockClear();
+  });
+
+  it('updates invoice number and dates for draft invoices', async () => {
+    const { updateDraftInvoiceProperties } = await import('../src/actions/invoiceModification.ts');
+
+    await expect(
+      updateDraftInvoiceProperties('invoice-1', {
+        invoiceNumber: ' INV-2001 ',
+        invoiceDate: '2026-04-20',
+        dueDate: null,
+      })
+    ).resolves.toEqual({
+      invoiceId: 'invoice-1',
+      invoiceNumber: 'INV-2001',
+      invoiceDate: '2026-04-20',
+      dueDate: null,
+    });
+
+    expect(state.updates).toEqual([
+      {
+        table: 'invoices',
+        payload: expect.objectContaining({
+          invoice_number: 'INV-2001',
+          invoice_date: '2026-04-20',
+          due_date: null,
+        }),
+      },
+    ]);
+    expect(recalculateInvoiceMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate invoice numbers before updating', async () => {
+    state.duplicateInvoice = { invoice_id: 'invoice-2' };
+    const { updateDraftInvoiceProperties } = await import('../src/actions/invoiceModification.ts');
+
+    await expect(
+      updateDraftInvoiceProperties('invoice-1', {
+        invoiceNumber: 'INV-0001',
+        invoiceDate: '2026-04-20',
+        dueDate: '2026-05-20',
+      })
+    ).rejects.toThrow('Invoice number already exists. Choose a different number.');
+
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it('rejects edits for finalized invoices', async () => {
+    state.invoice = {
+      ...state.invoice,
+      status: 'sent',
+      finalized_at: '2026-04-10',
+    };
+    const { updateDraftInvoiceProperties } = await import('../src/actions/invoiceModification.ts');
+
+    await expect(
+      updateDraftInvoiceProperties('invoice-1', {
+        invoiceNumber: 'INV-2002',
+        invoiceDate: '2026-04-21',
+        dueDate: '2026-05-21',
+      })
+    ).rejects.toThrow('Only draft invoices can be edited');
+
+    expect(state.updates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a draft-only invoice details card above the invoice preview for editing invoice number, invoice date, and due date
- add a server action to persist draft invoice property edits with draft-only enforcement and duplicate invoice number protection
- refresh the drafts list/preview after save and cover the new UI + server action with tests

## Testing
- cd server && npx vitest run --config vitest.config.ts ../packages/billing/tests/DraftInvoiceDetailsCard.test.tsx ../packages/billing/tests/invoiceModification.updateDraftInvoiceProperties.test.ts
- cd server && npx vitest run --config vitest.config.ts ../packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx