### PR TITLE
Disable asset remote access button

### DIFF
--- a/ee/docs/plans/2026-04-15-tanium-asset-enrichment-design.md
+++ b/ee/docs/plans/2026-04-15-tanium-asset-enrichment-design.md
@@ -1,0 +1,109 @@
+# Tanium Asset Enrichment Design
+
+Date: 2026-04-15
+
+## Goal
+
+Enrich Tanium-synced assets so the Alga asset detail page surfaces materially more of the data Tanium already provides, with a strict and explicit mapping.
+
+Target improvements:
+- current user
+- LAN IP
+- WAN/NAT IP
+- uptime
+- manufacturer/model
+- CPU/RAM/storage details
+- installed software inventory
+
+## Current Gap
+
+The current Tanium sync only maps a narrow subset of endpoint fields into the normalized RMM snapshot. As a result, the asset detail page shows a connected Tanium device but still renders sparse panels (`N/A`, `None`, missing model, empty software tab) even though Tanium already has the data.
+
+## Design
+
+### 1. Tanium-native enrichment first
+
+Extend the Tanium endpoint query to include supported native GraphQL fields:
+- `manufacturer`
+- `model`
+- `ipAddresses`
+- `macAddresses`
+- `memory`
+- `processor`
+- `disks`
+- `discover { natIpAddress }`
+- `installedApplications`
+- existing user / OS / IP / serial fields
+
+These fields become the primary source of truth for Tanium asset enrichment.
+
+### 2. Single explicit sensor for uptime
+
+Use a single Tanium sensor for uptime-related enrichment:
+- `Last Reboot`
+
+We will derive `uptimeSeconds` from `lastRebootAt`.
+
+Guardrail:
+- if the sensor query fails or returns an invalid timestamp, leave uptime null
+- do not fail the entire inventory sync over uptime enrichment
+
+### 3. Extend normalized RMM snapshot
+
+Add optional normalized extension fields so Tanium can pass richer hardware/software data through the shared ingestion path:
+- `cpuModel`
+- `cpuCores`
+- `ramGb`
+- `diskUsage`
+- `installedSoftware`
+
+Continue using `systemInfo` for manufacturer/model/chassis/reporting URL/IP lists and other Tanium-specific details that do not have first-class normalized columns yet.
+
+### 4. Persist through shared asset ingestion
+
+Update shared RMM asset ingestion so workstation/server extension rows can store:
+- `cpu_model`
+- `cpu_cores`
+- `ram_gb`
+- `disk_usage`
+- `installed_software`
+- existing cached live fields (`current_user`, `lan_ip`, `wan_ip`, `uptime_seconds`, `last_reboot_at`, etc.)
+- `system_info`
+
+Important behavior:
+- only write optional hardware/software fields when the snapshot explicitly provides them
+- avoid wiping unrelated values for providers that do not supply those fields
+
+### 5. UI refresh coherence
+
+The asset detail refresh flow should refresh both:
+- cached RMM data
+- the main asset payload
+
+This avoids a stale page state where RMM vitals refresh but model/software/hardware remain hidden until a full reload.
+
+## Expected Result
+
+For the current Tanium Mac endpoint, the asset detail page should populate:
+- Current User: `roberisaacs`
+- LAN IP: `192.168.254.190`
+- WAN IP: `10.0.156.6`
+- Uptime: derived from `Last Reboot`
+- Model: `Mac16,5`
+- CPU: `Apple M4 Max 2.4GHz`
+- RAM: `48 GB`
+- Storage: populated from Tanium disks
+- Software tab: installed applications from Tanium
+
+## Non-Goals
+
+- broad sensor fishing
+- dynamic schema fallback logic
+- provider-coupled live UI fetches from asset detail
+- making sync success depend on optional uptime enrichment
+
+## Validation
+
+- focused unit tests for Tanium gateway mapping
+- focused unit tests for shared ingestion persistence
+- live sync and browser validation on the existing Tanium test asset

--- a/ee/server/src/__tests__/unit/integrations/taniumActions.test.ts
+++ b/ee/server/src/__tests__/unit/integrations/taniumActions.test.ts
@@ -300,6 +300,7 @@ describe('taniumActions', () => {
 
     expect(result.success).toBe(true);
     expect(listEndpointsMock).toHaveBeenCalledTimes(1);
+    expect(listEndpointsMock).toHaveBeenCalledWith({ computerGroupId: 'scope_1' });
     expect(ingestNormalizedRmmDeviceSnapshotMock).toHaveBeenCalled();
     expect(state.rmm_integrations[0].sync_status).toBe('completed');
   });
@@ -323,6 +324,7 @@ describe('taniumActions', () => {
     const result = await (triggerTaniumFullSync as any)();
 
     expect(result.success).toBe(true);
+    expect(listEndpointsMock).toHaveBeenCalledWith({ computerGroupId: 'scope_1' });
     expect(ingestNormalizedRmmDeviceSnapshotMock).toHaveBeenCalled();
     const call = ingestNormalizedRmmDeviceSnapshotMock.mock.calls[0]?.[0];
     expect(call?.snapshot?.externalDeviceId).toBe('asset_fallback_1');
@@ -373,6 +375,93 @@ describe('taniumActions', () => {
 
     expect(result.success).toBe(true);
     expect(ingestNormalizedRmmDeviceSnapshotMock.mock.calls[0]?.[0]?.snapshot?.assetType).toBe('server');
+  });
+
+  it('classifies macOS endpoints as workstation assets even when an ipAddress field is present', async () => {
+    state.rmm_organization_mappings.push({
+      tenant: 'tenant_1',
+      mapping_id: 'map_1',
+      integration_id: 'integration_tanium',
+      external_organization_id: 'scope_1',
+      client_id: 'client_1',
+      auto_sync_assets: true,
+    });
+    gatewayEndpointsByScope.scope_1 = [
+      {
+        id: 'mac_1',
+        name: '06:21:32:B6:E3:C2',
+        online: true,
+        osName: 'macOS (26.3.1 (a))',
+        osVersion: 'macOS 26.3',
+        ipAddress: '192.168.254.190',
+        computerGroupId: 'scope_1',
+        metadata: {
+          ipAddress: '192.168.254.190',
+        },
+      },
+    ];
+    ingestNormalizedRmmDeviceSnapshotMock.mockResolvedValue({ action: 'created' });
+
+    const result = await (triggerTaniumFullSync as any)();
+
+    expect(result.success).toBe(true);
+    expect(ingestNormalizedRmmDeviceSnapshotMock.mock.calls[0]?.[0]?.snapshot?.assetType).toBe('workstation');
+  });
+
+  it('maps Tanium enrichment fields into the normalized snapshot during sync', async () => {
+    state.rmm_organization_mappings.push({
+      tenant: 'tenant_1',
+      mapping_id: 'map_1',
+      integration_id: 'integration_tanium',
+      external_organization_id: 'scope_1',
+      client_id: 'client_1',
+      auto_sync_assets: true,
+    });
+    gatewayEndpointsByScope.scope_1 = [
+      {
+        id: 'mac_1',
+        name: 'MacBook Pro',
+        online: true,
+        osName: 'macOS (26.3.1 (a))',
+        osVersion: 'macOS 26.3',
+        currentUser: 'roberisaacs',
+        ipAddress: '192.168.254.190',
+        wanIpAddress: '10.0.156.6',
+        manufacturer: 'Apple',
+        model: 'Mac16,5',
+        cpuModel: 'Apple M4 Max 2.4GHz',
+        cpuLogicalProcessors: 16,
+        memoryTotalGb: 48,
+        lastRebootAt: '2026-04-15T10:00:00Z',
+        diskUsage: [{ name: '/', total_gb: 995, free_gb: 20, utilization_percent: 39 }],
+        installedApplications: [{ name: 'Docker Desktop', version: '4.40.0', uninstallable: true }],
+        computerGroupId: 'scope_1',
+        metadata: {
+          manufacturer: 'Apple',
+          model: 'Mac16,5',
+        },
+      },
+    ];
+    ingestNormalizedRmmDeviceSnapshotMock.mockResolvedValue({ action: 'created' });
+
+    const result = await (triggerTaniumFullSync as any)();
+
+    expect(result.success).toBe(true);
+    expect(ingestNormalizedRmmDeviceSnapshotMock.mock.calls[0]?.[0]?.snapshot?.extension).toMatchObject({
+      currentUser: 'roberisaacs',
+      lanIp: '192.168.254.190',
+      wanIp: '10.0.156.6',
+      lastRebootAt: '2026-04-15T10:00:00Z',
+      cpuModel: 'Apple M4 Max 2.4GHz',
+      cpuCores: 16,
+      ramGb: 48,
+      diskUsage: [{ name: '/', total_gb: 995, free_gb: 20, utilization_percent: 39 }],
+      installedSoftware: [{ name: 'Docker Desktop', version: '4.40.0' }],
+      systemInfo: {
+        manufacturer: 'Apple',
+        model: 'Mac16,5',
+      },
+    });
   });
 
   it('T007: connection test failure keeps integration inactive and returns actionable error', async () => {

--- a/ee/server/src/__tests__/unit/integrations/taniumGatewayClient.test.ts
+++ b/ee/server/src/__tests__/unit/integrations/taniumGatewayClient.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gatewayPostMock = vi.fn();
+const assetGetMock = vi.fn();
+const axiosCreateMock = vi.fn((config: any) => {
+  if (String(config?.baseURL || '').includes('/plugin/products/asset')) {
+    return {
+      get: assetGetMock,
+    };
+  }
+
+  return {
+    post: gatewayPostMock,
+  };
+});
+
+const isAxiosErrorMock = vi.fn((error: unknown) => Boolean((error as any)?.isAxiosError));
+
+vi.mock('axios', () => ({
+  default: {
+    create: (...args: any[]) => axiosCreateMock(...args),
+    isAxiosError: (...args: any[]) => isAxiosErrorMock(...args),
+  },
+}));
+
+import { TaniumGatewayClient } from '../../../lib/integrations/tanium/taniumGatewayClient';
+
+describe('TaniumGatewayClient', () => {
+  beforeEach(() => {
+    gatewayPostMock.mockReset();
+    assetGetMock.mockReset();
+    axiosCreateMock.mockClear();
+    isAxiosErrorMock.mockClear();
+  });
+
+  it('uses the Tanium session header for Gateway and Asset API requests', () => {
+    new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+      assetApiUrl: 'https://tk-nineminds.titankube.com/plugin/products/asset',
+    });
+
+    expect(axiosCreateMock).toHaveBeenCalledTimes(2);
+    expect(axiosCreateMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          session: 'token-valid',
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+    expect(axiosCreateMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          session: 'token-valid',
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+  });
+
+  it('fails fast when the configured API token is missing the token prefix', () => {
+    expect(
+      () =>
+        new TaniumGatewayClient({
+          gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+          apiToken: 'not-a-token',
+        })
+    ).toThrow(/token- prefix/i);
+  });
+
+  it('fails fast when Gateway redirects to authentication', async () => {
+    gatewayPostMock.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 302,
+        headers: {
+          location: 'https://auth.titankube.com/realms/partners/protocol/openid-connect/auth',
+        },
+      },
+    });
+
+    const client = new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+    });
+
+    await expect(client.testConnection()).rejects.toThrow(/redirected to authentication/i);
+  });
+
+  it('fails fast when Gateway returns a non-GraphQL response body', async () => {
+    gatewayPostMock.mockResolvedValue({
+      headers: { 'content-type': 'text/html' },
+      data: '<!doctype html><html><body>login</body></html>',
+    });
+
+    const client = new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+    });
+
+    await expect(client.testConnection()).rejects.toThrow(/non-graphql response/i);
+  });
+
+  it('uses Cursor pagination for computer group queries', async () => {
+    gatewayPostMock.mockResolvedValue({
+      headers: { 'content-type': 'application/json' },
+      data: {
+        data: {
+          computerGroups: {
+            edges: [{ node: { id: '30229', name: 'Nine Minds' } }],
+            pageInfo: { hasNextPage: false, endCursor: 'abc' },
+          },
+        },
+      },
+    });
+
+    const client = new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+    });
+
+    const groups = await client.listComputerGroups();
+
+    expect(groups).toEqual([{ id: '30229', name: 'Nine Minds' }]);
+    const [path, body] = gatewayPostMock.mock.calls[0] || [];
+    expect(path).toBe('/graphql');
+    expect(body?.query).toContain('$after: Cursor');
+    expect(body?.variables).toEqual({ first: 250, after: null });
+  });
+
+  it('queries endpoints with Tanium-supported enrichment fields and memberOf filter', async () => {
+    gatewayPostMock
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'application/json' },
+        data: {
+          data: {
+            endpoints: {
+              edges: [
+                {
+                  node: {
+                    id: 'endpoint-1',
+                    name: 'MacBook Pro',
+                    serialNumber: 'SER-123',
+                    manufacturer: 'Apple',
+                    model: 'Mac16,5',
+                    chassisType: 'Laptop',
+                    domainName: 'No Domain',
+                    eidLastSeen: '2026-04-15T17:07:13Z',
+                    ipAddress: '192.168.254.190',
+                    ipAddresses: ['192.168.254.190', 'fe80::1'],
+                    macAddresses: ['84:2f:57:ab:d8:bd'],
+                    primaryUser: { name: 'Error: No inventory has been collected' },
+                    lastLoggedInUser: 'roberisaacs',
+                    reportingConsoleURL: 'https://tk.example/reporting',
+                    isVirtual: false,
+                    isEncrypted: true,
+                    os: { name: 'macOS (26.3.1 (a))', generation: 'macOS 26.3', platform: 'Mac' },
+                    memory: { total: '48 GB' },
+                    processor: { cpu: 'Apple M4 Max 2.4GHz', logicalProcessors: 16 },
+                    disks: [{ name: '/', free: '20G', total: '995G', usedPercentage: '39%' }],
+                    discover: { natIpAddress: '10.0.156.6' },
+                    networking: {
+                      dnsServers: ['127.0.2.2'],
+                      adapters: [{ name: 'Wi-Fi', manufacturer: 'Apple', type: 'AirPort', macAddress: '84:2f:57:ab:d8:bd', speed: 'unknown', connectionId: 'en0' }],
+                      wirelessAdapters: [{ ssid: 'Frontier0822_6G', state: 'CONNECTED' }],
+                    },
+                    installedApplications: [{ name: 'Docker Desktop', version: '4.40.0', uninstallable: true }],
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: 'abc' },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'application/json' },
+        data: {
+          data: {
+            endpoints: {
+              edges: [
+                {
+                  node: {
+                    id: 'endpoint-1',
+                    lastReboot: { values: ['Sat, 11 Apr 2026 21:50:13 -0400'] },
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: 'def' },
+            },
+          },
+        },
+      });
+
+    const client = new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+    });
+
+    const endpoints = await client.listEndpoints({ computerGroupId: '30229' });
+
+    expect(endpoints).toEqual([
+      {
+        id: 'endpoint-1',
+        name: 'MacBook Pro',
+        computerGroupId: '30229',
+        serialNumber: 'SER-123',
+        lastSeen: '2026-04-15T17:07:13Z',
+        online: null,
+        osName: 'macOS (26.3.1 (a))',
+        osVersion: 'macOS 26.3',
+        currentUser: 'roberisaacs',
+        ipAddress: '192.168.254.190',
+        wanIpAddress: '10.0.156.6',
+        manufacturer: 'Apple',
+        model: 'Mac16,5',
+        cpuModel: 'Apple M4 Max 2.4GHz',
+        cpuLogicalProcessors: 16,
+        memoryTotalGb: 48,
+        lastRebootAt: 'Sat, 11 Apr 2026 21:50:13 -0400',
+        diskUsage: [{ name: '/', free_gb: 20, total_gb: 995, utilization_percent: 39 }],
+        installedApplications: [{ name: 'Docker Desktop', version: '4.40.0', uninstallable: true }],
+        metadata: {
+          manufacturer: 'Apple',
+          model: 'Mac16,5',
+          chassisType: 'Laptop',
+          domainName: 'No Domain',
+          reportingConsoleURL: 'https://tk.example/reporting',
+          isVirtual: false,
+          isEncrypted: true,
+          ipAddresses: ['192.168.254.190', 'fe80::1'],
+          macAddresses: ['84:2f:57:ab:d8:bd'],
+          dnsServers: ['127.0.2.2'],
+          networkAdapters: [{ name: 'Wi-Fi', manufacturer: 'Apple', type: 'AirPort', macAddress: '84:2f:57:ab:d8:bd', speed: 'unknown', connectionId: 'en0' }],
+          wirelessAdapters: [{ ssid: 'Frontier0822_6G', state: 'CONNECTED' }],
+          uptimeSeconds: expect.any(Number),
+        },
+      },
+    ]);
+    const [path, body] = gatewayPostMock.mock.calls[0] || [];
+    expect(path).toBe('/graphql');
+    expect(body?.query).toContain('manufacturer');
+    expect(body?.query).toContain('installedApplications');
+    expect(body?.query).toContain('discover');
+    expect(body?.variables).toEqual({
+      first: 250,
+      after: null,
+      filter: {
+        memberOf: { id: '30229' },
+        op: 'EQ',
+        negated: false,
+        any: false,
+      },
+    });
+    expect(gatewayPostMock.mock.calls[1]?.[1]?.query).toContain('Last Reboot');
+  });
+
+  it('requires the connection probe to return computerGroups data', async () => {
+    gatewayPostMock.mockResolvedValue({
+      headers: { 'content-type': 'application/json' },
+      data: {
+        data: {},
+      },
+    });
+
+    const client = new TaniumGatewayClient({
+      gatewayUrl: 'https://tk-nineminds.titankube.com/plugin/products/gateway',
+      apiToken: 'token-valid',
+    });
+
+    await expect(client.testConnection()).rejects.toThrow(/failed to return computer groups/i);
+  });
+});

--- a/ee/server/src/lib/actions/integrations/taniumActions.ts
+++ b/ee/server/src/lib/actions/integrations/taniumActions.ts
@@ -39,9 +39,9 @@ function withAdvancedAssetsAccess<TArgs extends unknown[], TResult>(
 
 function inferTaniumAssetType(endpoint: TaniumEndpointRecord): NormalizedRmmExternalDeviceSnapshot['assetType'] {
   const fingerprint = [
+    endpoint.name,
     endpoint.osName,
     endpoint.osVersion,
-    endpoint.metadata ? JSON.stringify(endpoint.metadata) : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -81,6 +81,9 @@ function mapEndpointToSnapshot(args: {
 }): NormalizedRmmExternalDeviceSnapshot {
   const endpoint = args.endpoint;
   const isOffline = endpoint.online === false;
+  const uptimeSeconds = endpoint.lastRebootAt
+    ? Math.max(0, Math.floor((Date.now() - new Date(endpoint.lastRebootAt).getTime()) / 1000))
+    : null;
 
   return {
     provider: PROVIDER,
@@ -100,7 +103,19 @@ function mapEndpointToSnapshot(args: {
       osType: endpoint.osName ?? null,
       osVersion: endpoint.osVersion ?? null,
       currentUser: endpoint.currentUser ?? null,
+      uptimeSeconds: Number.isFinite(uptimeSeconds) ? uptimeSeconds : null,
       lanIp: endpoint.ipAddress ?? null,
+      wanIp: endpoint.wanIpAddress ?? null,
+      lastRebootAt: endpoint.lastRebootAt ?? null,
+      cpuModel: endpoint.cpuModel ?? null,
+      cpuCores: endpoint.cpuLogicalProcessors ?? null,
+      ramGb: endpoint.memoryTotalGb ?? null,
+      diskUsage: endpoint.diskUsage ?? [],
+      installedSoftware: endpoint.installedApplications?.map((application) => ({
+        name: application.name,
+        version: application.version ?? null,
+      })) ?? [],
+      systemInfo: endpoint.metadata ?? null,
     },
     metadata: endpoint.metadata ?? {},
   };
@@ -556,22 +571,6 @@ export const triggerTaniumFullSync = withAdvancedAssetsAccess(async (user, { ten
       assetApiUrl: taniumSettings.asset_api_url || undefined,
     });
 
-    const gatewayEndpoints = await client.listEndpoints();
-    const endpointsByScope = new Map<string, TaniumEndpointRecord[]>();
-    for (const endpoint of gatewayEndpoints) {
-      if (!endpoint.computerGroupId) {
-        continue;
-      }
-
-      const groupKey = String(endpoint.computerGroupId);
-      const bucket = endpointsByScope.get(groupKey);
-      if (bucket) {
-        bucket.push(endpoint);
-      } else {
-        endpointsByScope.set(groupKey, [endpoint]);
-      }
-    }
-
     let processed = 0;
     let created = 0;
     let updated = 0;
@@ -581,7 +580,7 @@ export const triggerTaniumFullSync = withAdvancedAssetsAccess(async (user, { ten
     for (const scope of mappedScopes) {
       const externalScopeId = String(scope.external_organization_id);
       const resolvedClientId = String(scope.client_id);
-      let endpoints = endpointsByScope.get(externalScopeId) ?? [];
+      let endpoints = await client.listEndpoints({ computerGroupId: externalScopeId });
 
       if (endpoints.length === 0 && useAssetApiFallback) {
         const fallbackEndpoints = await client.listAgedOutAssetFallback({ computerGroupId: externalScopeId });

--- a/ee/server/src/lib/integrations/tanium/taniumGatewayClient.ts
+++ b/ee/server/src/lib/integrations/tanium/taniumGatewayClient.ts
@@ -1,5 +1,9 @@
 import axios, { AxiosInstance } from 'axios';
 import logger from '@alga-psa/core/logger';
+import type { RmmStorageInfo } from '@alga-psa/types';
+
+const TANIUM_GATEWAY_ERROR_HINT = 'Check the Tanium API token, keep the token- prefix, verify the allowed IP/CIDR, and confirm Gateway access/permissions.';
+const TANIUM_RBAC_ERROR_HINT = 'The Tanium API token may be authenticated but missing required Tanium permissions or content-set access.';
 
 export interface TaniumGatewayClientOptions {
   gatewayUrl: string;
@@ -10,6 +14,12 @@ export interface TaniumGatewayClientOptions {
 export interface TaniumComputerGroup {
   id: string;
   name: string;
+}
+
+export interface TaniumInstalledApplication {
+  name: string;
+  version?: string | null;
+  uninstallable?: boolean | null;
 }
 
 export interface TaniumEndpointRecord {
@@ -23,6 +33,15 @@ export interface TaniumEndpointRecord {
   osVersion?: string | null;
   currentUser?: string | null;
   ipAddress?: string | null;
+  wanIpAddress?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  cpuModel?: string | null;
+  cpuLogicalProcessors?: number | null;
+  memoryTotalGb?: number | null;
+  lastRebootAt?: string | null;
+  diskUsage?: RmmStorageInfo[];
+  installedApplications?: TaniumInstalledApplication[];
   metadata?: Record<string, unknown>;
 }
 
@@ -31,6 +50,97 @@ function ensureHttpUrl(url: string): string {
   if (!trimmed) return '';
   if (/^https?:\/\//i.test(trimmed)) return trimmed.replace(/\/+$/, '');
   return `https://${trimmed.replace(/\/+$/, '')}`;
+}
+
+function ensureTaniumApiToken(token: string): string {
+  const trimmed = String(token || '').trim();
+  if (!trimmed) {
+    throw new Error('Tanium API token is required.');
+  }
+
+  if (!/^token-/i.test(trimmed)) {
+    throw new Error('Tanium API token must include the token- prefix.');
+  }
+
+  return trimmed;
+}
+
+function normalizeCurrentUser(primaryUserName?: string | null, lastLoggedInUser?: string | null): string | null {
+  const trimmedPrimaryUser = primaryUserName?.trim();
+  if (trimmedPrimaryUser && !trimmedPrimaryUser.toLowerCase().startsWith('error:')) {
+    return trimmedPrimaryUser;
+  }
+
+  const trimmedLastLoggedInUser = lastLoggedInUser?.trim();
+  return trimmedLastLoggedInUser || null;
+}
+
+function parseSizeToGb(value?: string | null): number | null {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(/^([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?)(?:B)?$/i);
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  const unit = String(match[2] || 'G').toUpperCase();
+
+  if (!Number.isFinite(amount)) return null;
+
+  if (unit === 'T') return Number((amount * 1024).toFixed(2));
+  if (unit === 'G') return Number(amount.toFixed(2));
+  if (unit === 'M') return Number((amount / 1024).toFixed(2));
+  if (unit === 'K') return Number((amount / (1024 * 1024)).toFixed(4));
+  return Number((amount / (1024 * 1024 * 1024)).toFixed(6));
+}
+
+function parsePercentValue(value?: string | null): number | null {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(/^([0-9]+(?:\.[0-9]+)?)\s*%$/);
+  if (!match) return null;
+
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseTaniumDisks(disks?: Array<{
+  name?: string | null;
+  total?: string | null;
+  free?: string | null;
+  usedPercentage?: string | null;
+}> | null): RmmStorageInfo[] {
+  if (!Array.isArray(disks)) return [];
+
+  return disks
+    .map((disk) => {
+      const name = String(disk?.name || '').trim();
+      const totalGb = parseSizeToGb(disk?.total);
+      const freeGb = parseSizeToGb(disk?.free);
+      const utilizationPercent = parsePercentValue(disk?.usedPercentage);
+
+      if (!name || totalGb === null || freeGb === null || utilizationPercent === null) {
+        return null;
+      }
+
+      return {
+        name,
+        total_gb: totalGb,
+        free_gb: freeGb,
+        utilization_percent: utilizationPercent,
+      } satisfies RmmStorageInfo;
+    })
+    .filter((disk): disk is RmmStorageInfo => disk !== null);
+}
+
+function computeUptimeSeconds(lastRebootAt?: string | null, now = Date.now()): number | null {
+  if (!lastRebootAt) return null;
+  const rebootMs = new Date(lastRebootAt).getTime();
+  if (!Number.isFinite(rebootMs)) return null;
+
+  const diffSeconds = Math.floor((now - rebootMs) / 1000);
+  return diffSeconds >= 0 ? diffSeconds : null;
 }
 
 export class TaniumGatewayClient {
@@ -43,11 +153,14 @@ export class TaniumGatewayClient {
       throw new Error('Tanium Gateway URL is required.');
     }
 
+    const apiToken = ensureTaniumApiToken(options.apiToken);
+
     this.gateway = axios.create({
       baseURL: gatewayUrl,
       timeout: 45_000,
+      maxRedirects: 0,
       headers: {
-        Authorization: `Bearer ${options.apiToken}`,
+        session: apiToken,
         'Content-Type': 'application/json',
       },
     });
@@ -58,29 +171,108 @@ export class TaniumGatewayClient {
           baseURL: normalizedAssetApiUrl,
           timeout: 45_000,
           headers: {
-            Authorization: `Bearer ${options.apiToken}`,
+            session: apiToken,
             'Content-Type': 'application/json',
           },
         })
       : null;
   }
 
-  private async query<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
-    const response = await this.gateway.post('/graphql', { query, variables });
-    if (response.data?.errors?.length) {
-      const message = String(response.data.errors[0]?.message || 'Tanium Gateway query failed');
-      throw new Error(message);
+  private formatGatewayError(error: unknown): Error {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const location = String(error.response?.headers?.location || '');
+      const contentType = String(error.response?.headers?.['content-type'] || '');
+      const responseBody = typeof error.response?.data === 'string' ? error.response.data : '';
+
+      if (status === 302 || /openid-connect|\/login|\/auth/i.test(location)) {
+        return new Error(`Tanium Gateway redirected to authentication. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
+
+      if (status === 403) {
+        return new Error(`Tanium Gateway rejected the configured API token. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
+
+      if (status === 401) {
+        return new Error(`Tanium Gateway returned 401 Unauthorized. ${TANIUM_RBAC_ERROR_HINT}`);
+      }
+
+      if (contentType.toLowerCase().includes('text/html') || /<!doctype html|<html/i.test(responseBody)) {
+        return new Error(`Tanium Gateway returned an HTML login page instead of GraphQL JSON. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
+
+      if (status) {
+        return new Error(`Tanium Gateway request failed with status ${status}. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
     }
-    return response.data?.data as T;
+
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error(`Tanium Gateway request failed. ${TANIUM_GATEWAY_ERROR_HINT}`);
+  }
+
+  private async query<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    try {
+      const response = await this.gateway.post('/graphql', { query, variables });
+      const payload = response.data;
+      const contentType = String(response.headers?.['content-type'] || 'unknown');
+
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new Error(
+          `Tanium Gateway returned a non-GraphQL response (${contentType}). ${TANIUM_GATEWAY_ERROR_HINT}`
+        );
+      }
+
+      if (Array.isArray((payload as any).errors) && (payload as any).errors.length > 0) {
+        const message = String((payload as any).errors[0]?.message || 'Tanium Gateway query failed');
+        throw new Error(message);
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(payload, 'data')) {
+        throw new Error(`Tanium Gateway returned an invalid GraphQL payload. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
+
+      if ((payload as any).data == null) {
+        throw new Error(`Tanium Gateway returned an empty GraphQL payload. ${TANIUM_GATEWAY_ERROR_HINT}`);
+      }
+
+      return (payload as any).data as T;
+    } catch (error) {
+      throw this.formatGatewayError(error);
+    }
   }
 
   async testConnection(): Promise<void> {
-    await this.query<{ __typename: string }>('query TaniumPing { __typename }');
+    const data = await this.query<{
+      computerGroups?: {
+        edges?: Array<{ node?: { id?: string; name?: string } | null }>;
+      };
+    }>(
+      `
+        query TaniumConnectionProbe($first: Int!, $after: Cursor) {
+          computerGroups(first: $first, after: $after) {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      { first: 1, after: null }
+    );
+
+    if (!data?.computerGroups || !Array.isArray(data.computerGroups.edges)) {
+      throw new Error(`Tanium Gateway connection probe failed to return computer groups. ${TANIUM_GATEWAY_ERROR_HINT}`);
+    }
   }
 
   async listComputerGroups(): Promise<TaniumComputerGroup[]> {
     const query = `
-      query TaniumComputerGroups($first: Int!, $after: String) {
+      query TaniumComputerGroups($first: Int!, $after: Cursor) {
         computerGroups(first: $first, after: $after) {
           edges {
             cursor
@@ -129,28 +321,137 @@ export class TaniumGatewayClient {
     return groups;
   }
 
+  private async listEndpointLastRebootTimes(input?: { computerGroupId?: string | null }): Promise<Map<string, string | null>> {
+    const query = `
+      query TaniumEndpointLastReboot($first: Int!, $after: Cursor, $filter: EndpointFieldFilter) {
+        endpoints(first: $first, after: $after, filter: $filter) {
+          edges {
+            cursor
+            node {
+              id
+              lastReboot: sensorReading(sensor: { name: "Last Reboot" }) {
+                values
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    `;
+
+    const filter = input?.computerGroupId
+      ? {
+          memberOf: { id: String(input.computerGroupId) },
+          op: 'EQ',
+          negated: false,
+          any: false,
+        }
+      : null;
+
+    let hasNextPage = true;
+    let after: string | null = null;
+    const lastRebootByEndpointId = new Map<string, string | null>();
+
+    while (hasNextPage) {
+      const data = await this.query<{
+        endpoints?: {
+          edges?: Array<{
+            node?: {
+              id?: string;
+              lastReboot?: { values?: Array<string | null> } | null;
+            } | null;
+          }>;
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+        };
+      }>(query, { first: 250, after, filter });
+
+      const edges = data?.endpoints?.edges || [];
+      for (const edge of edges) {
+        const node = edge?.node;
+        if (!node?.id) continue;
+
+        const lastRebootAt = String(node.lastReboot?.values?.[0] || '').trim() || null;
+        lastRebootByEndpointId.set(String(node.id), lastRebootAt);
+      }
+
+      hasNextPage = Boolean(data?.endpoints?.pageInfo?.hasNextPage);
+      after = data?.endpoints?.pageInfo?.endCursor || null;
+      if (!after) {
+        hasNextPage = false;
+      }
+    }
+
+    return lastRebootByEndpointId;
+  }
+
   async listEndpoints(input?: { computerGroupId?: string | null }): Promise<TaniumEndpointRecord[]> {
     const query = `
-      query TaniumEndpoints($first: Int!, $after: String) {
-        endpoints(first: $first, after: $after) {
+      query TaniumEndpoints($first: Int!, $after: Cursor, $filter: EndpointFieldFilter) {
+        endpoints(first: $first, after: $after, filter: $filter) {
           edges {
             cursor
             node {
               id
               name
               serialNumber
-              lastSeen
-              online
+              manufacturer
+              model
+              chassisType
+              domainName
+              eidLastSeen
               ipAddress
+              ipAddresses
+              macAddresses
+              primaryUser {
+                name
+              }
+              lastLoggedInUser
+              reportingConsoleURL
+              isVirtual
+              isEncrypted
               os {
                 name
-                version
+                generation
+                platform
               }
-              users {
+              memory {
+                total
+              }
+              processor {
+                cpu
+                logicalProcessors
+              }
+              disks {
                 name
+                free
+                total
+                usedPercentage
               }
-              computerGroup {
-                id
+              discover {
+                natIpAddress
+              }
+              networking {
+                dnsServers
+                adapters {
+                  name
+                  manufacturer
+                  type
+                  macAddress
+                  speed
+                  connectionId
+                }
+                wirelessAdapters {
+                  ssid
+                  state
+                }
+              }
+              installedApplications {
+                name
+                version
+                uninstallable
               }
             }
           }
@@ -165,6 +466,14 @@ export class TaniumGatewayClient {
     let hasNextPage = true;
     let after: string | null = null;
     const endpoints: TaniumEndpointRecord[] = [];
+    const filter = input?.computerGroupId
+      ? {
+          memberOf: { id: String(input.computerGroupId) },
+          op: 'EQ',
+          negated: false,
+          any: false,
+        }
+      : null;
 
     while (hasNextPage) {
       const data = await this.query<{
@@ -174,39 +483,109 @@ export class TaniumGatewayClient {
               id?: string;
               name?: string;
               serialNumber?: string | null;
-              lastSeen?: string | null;
-              online?: boolean | null;
+              manufacturer?: string | null;
+              model?: string | null;
+              chassisType?: string | null;
+              domainName?: string | null;
+              eidLastSeen?: string | null;
               ipAddress?: string | null;
-              os?: { name?: string | null; version?: string | null } | null;
-              users?: Array<{ name?: string | null }> | null;
-              computerGroup?: { id?: string | null } | null;
+              ipAddresses?: Array<string | null> | null;
+              macAddresses?: Array<string | null> | null;
+              primaryUser?: { name?: string | null } | null;
+              lastLoggedInUser?: string | null;
+              reportingConsoleURL?: string | null;
+              isVirtual?: boolean | null;
+              isEncrypted?: boolean | null;
+              os?: { name?: string | null; generation?: string | null; platform?: string | null } | null;
+              memory?: { total?: string | null } | null;
+              processor?: { cpu?: string | null; logicalProcessors?: number | null } | null;
+              disks?: Array<{
+                name?: string | null;
+                free?: string | null;
+                total?: string | null;
+                usedPercentage?: string | null;
+              } | null> | null;
+              discover?: { natIpAddress?: string | null } | null;
+              networking?: {
+                dnsServers?: Array<string | null> | null;
+                adapters?: Array<Record<string, unknown> | null> | null;
+                wirelessAdapters?: Array<Record<string, unknown> | null> | null;
+              } | null;
+              installedApplications?: Array<{
+                name?: string | null;
+                version?: string | null;
+                uninstallable?: boolean | null;
+              } | null> | null;
             } | null;
           }>;
           pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
         };
-      }>(query, { first: 250, after });
+      }>(query, { first: 250, after, filter });
 
       const edges = data?.endpoints?.edges || [];
       for (const edge of edges) {
         const node = edge?.node;
         if (!node?.id) continue;
-        const computerGroupId = node.computerGroup?.id ? String(node.computerGroup.id) : null;
-        if (input?.computerGroupId && computerGroupId !== input.computerGroupId) {
-          continue;
-        }
+
+        const installedApplications = Array.isArray(node.installedApplications)
+          ? node.installedApplications
+              .map((application) => {
+                const name = String(application?.name || '').trim();
+                if (!name) return null;
+                return {
+                  name,
+                  version: application?.version ?? null,
+                  uninstallable: typeof application?.uninstallable === 'boolean' ? application.uninstallable : null,
+                } satisfies TaniumInstalledApplication;
+              })
+              .filter((application): application is TaniumInstalledApplication => application !== null)
+          : [];
+
+        const metadata: Record<string, unknown> = {
+          manufacturer: node.manufacturer ?? null,
+          model: node.model ?? null,
+          chassisType: node.chassisType ?? null,
+          domainName: node.domainName ?? null,
+          reportingConsoleURL: node.reportingConsoleURL ?? null,
+          isVirtual: node.isVirtual ?? null,
+          isEncrypted: node.isEncrypted ?? null,
+          ipAddresses: Array.isArray(node.ipAddresses)
+            ? node.ipAddresses.map((value) => String(value || '').trim()).filter(Boolean)
+            : [],
+          macAddresses: Array.isArray(node.macAddresses)
+            ? node.macAddresses.map((value) => String(value || '').trim()).filter(Boolean)
+            : [],
+          dnsServers: Array.isArray(node.networking?.dnsServers)
+            ? node.networking?.dnsServers.map((value) => String(value || '').trim()).filter(Boolean)
+            : [],
+          networkAdapters: Array.isArray(node.networking?.adapters)
+            ? node.networking?.adapters.filter((adapter): adapter is Record<string, unknown> => Boolean(adapter))
+            : [],
+          wirelessAdapters: Array.isArray(node.networking?.wirelessAdapters)
+            ? node.networking?.wirelessAdapters.filter((adapter): adapter is Record<string, unknown> => Boolean(adapter))
+            : [],
+        };
 
         endpoints.push({
           id: String(node.id),
           name: String(node.name || node.id),
-          computerGroupId,
+          computerGroupId: input?.computerGroupId ? String(input.computerGroupId) : null,
           serialNumber: node.serialNumber ?? null,
-          lastSeen: node.lastSeen ?? null,
-          online: typeof node.online === 'boolean' ? node.online : null,
+          lastSeen: node.eidLastSeen ?? null,
+          online: null,
           osName: node.os?.name ?? null,
-          osVersion: node.os?.version ?? null,
-          currentUser: node.users?.[0]?.name ?? null,
+          osVersion: node.os?.generation ?? node.os?.platform ?? null,
+          currentUser: normalizeCurrentUser(node.primaryUser?.name, node.lastLoggedInUser),
           ipAddress: node.ipAddress ?? null,
-          metadata: node as unknown as Record<string, unknown>,
+          wanIpAddress: node.discover?.natIpAddress ?? null,
+          manufacturer: node.manufacturer ?? null,
+          model: node.model ?? null,
+          cpuModel: node.processor?.cpu ?? null,
+          cpuLogicalProcessors: node.processor?.logicalProcessors ?? null,
+          memoryTotalGb: parseSizeToGb(node.memory?.total),
+          diskUsage: parseTaniumDisks(node.disks?.filter((disk): disk is NonNullable<typeof disk> => Boolean(disk)) || []),
+          installedApplications,
+          metadata,
         });
       }
 
@@ -215,6 +594,25 @@ export class TaniumGatewayClient {
       if (!after) {
         hasNextPage = false;
       }
+    }
+
+    try {
+      const lastRebootByEndpointId = await this.listEndpointLastRebootTimes(input);
+      for (const endpoint of endpoints) {
+        endpoint.lastRebootAt = lastRebootByEndpointId.get(endpoint.id) ?? null;
+        const uptimeSeconds = computeUptimeSeconds(endpoint.lastRebootAt);
+        if (uptimeSeconds !== null) {
+          endpoint.metadata = {
+            ...(endpoint.metadata ?? {}),
+            uptimeSeconds,
+          };
+        }
+      }
+    } catch (error) {
+      logger.warn('Tanium Last Reboot sensor query failed; continuing without uptime enrichment', {
+        error: error instanceof Error ? error.message : String(error),
+        computerGroupId: input?.computerGroupId ?? null,
+      });
     }
 
     return endpoints;

--- a/ee/server/src/lib/integrations/tanium/taniumGatewayClient.ts
+++ b/ee/server/src/lib/integrations/tanium/taniumGatewayClient.ts
@@ -528,17 +528,18 @@ export class TaniumGatewayClient {
         if (!node?.id) continue;
 
         const installedApplications = Array.isArray(node.installedApplications)
-          ? node.installedApplications
-              .map((application) => {
-                const name = String(application?.name || '').trim();
-                if (!name) return null;
-                return {
-                  name,
-                  version: application?.version ?? null,
-                  uninstallable: typeof application?.uninstallable === 'boolean' ? application.uninstallable : null,
-                } satisfies TaniumInstalledApplication;
-              })
-              .filter((application): application is TaniumInstalledApplication => application !== null)
+          ? node.installedApplications.reduce<TaniumInstalledApplication[]>((acc, application) => {
+              const name = String(application?.name || '').trim();
+              if (!name) return acc;
+
+              acc.push({
+                name,
+                version: application?.version ?? null,
+                uninstallable: typeof application?.uninstallable === 'boolean' ? application.uninstallable : null,
+              });
+
+              return acc;
+            }, [])
           : [];
 
         const metadata: Record<string, unknown> = {

--- a/packages/assets/src/components/AssetDashboardGrid.tsx
+++ b/packages/assets/src/components/AssetDashboardGrid.tsx
@@ -28,6 +28,7 @@ export const AssetDashboardGrid: React.FC<AssetDashboardGridProps> = ({
       {/* Left Column (2/3 width on large screens) */}
       <div className="lg:col-span-2 flex flex-col gap-6">
         <RmmVitalsPanel 
+          asset={asset}
           data={rmmData} 
           isLoading={isLoading} 
           onRefresh={onRefreshRmm}

--- a/packages/assets/src/components/RemoteAccessButton.tsx
+++ b/packages/assets/src/components/RemoteAccessButton.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 /**
- * Remote Access Button - Dynamic Import Wrapper
+ * Remote Access Button
  *
- * Dynamically imports the EE or CE version of the RemoteAccessButton.
- * EE version provides actual remote access functionality via NinjaOne.
- * CE version renders nothing.
+ * Remote access is temporarily disabled across all asset surfaces.
  */
 
-import dynamic from 'next/dynamic';
 import type { Asset } from '@alga-psa/types';
 
 interface RemoteAccessButtonProps {
@@ -18,23 +15,13 @@ interface RemoteAccessButtonProps {
   className?: string;
 }
 
-// Dynamic import that resolves to EE or CE version based on webpack alias
-const RemoteAccessButton = dynamic(
-  () => import('@enterprise/components/assets/RemoteAccessButton').then(mod => mod.RemoteAccessButton),
-  {
-    ssr: false,
-    loading: () => null, // Don't show loading state
-  }
-);
+function RemoteAccessButton(_: RemoteAccessButtonProps) {
+  return null;
+}
 
-// Also export the indicator component
-const RemoteAccessIndicator = dynamic(
-  () => import('@enterprise/components/assets/RemoteAccessButton').then(mod => mod.RemoteAccessIndicator),
-  {
-    ssr: false,
-    loading: () => null,
-  }
-);
+function RemoteAccessIndicator(_: { asset: Asset; className?: string }) {
+  return null;
+}
 
 export { RemoteAccessButton, RemoteAccessIndicator };
 export type { RemoteAccessButtonProps };

--- a/packages/assets/src/components/panels/HardwareSpecsPanel.tsx
+++ b/packages/assets/src/components/panels/HardwareSpecsPanel.tsx
@@ -20,7 +20,19 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
     return <Card className="h-64 animate-pulse bg-gray-50" />;
   }
 
-  if (!data) {
+  const fallbackData = asset?.workstation || asset?.server
+    ? {
+        cpu_utilization_percent: asset?.workstation?.cpu_utilization_percent ?? asset?.server?.cpu_usage_percent ?? null,
+        memory_utilization_percent: asset?.workstation?.memory_usage_percent ?? asset?.server?.memory_usage_percent ?? null,
+        memory_used_gb: asset?.workstation?.memory_used_gb ?? asset?.server?.memory_used_gb ?? null,
+        memory_total_gb: asset?.workstation?.ram_gb ?? asset?.server?.ram_gb ?? null,
+        storage: asset?.workstation?.disk_usage ?? asset?.server?.disk_usage ?? [],
+      }
+    : null;
+
+  const effectiveData = data ?? fallbackData;
+
+  if (!effectiveData) {
     return (
       <Card className="bg-white">
         <CardHeader>
@@ -59,12 +71,12 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                  </span>
                  <div className="w-32">
                    <UtilizationBar 
-                     value={data.cpu_utilization_percent} 
+                     value={effectiveData.cpu_utilization_percent} 
                      showLabel={false}
                      size="sm"
                    />
                  </div>
-                 <span className="text-sm text-gray-900">{data.cpu_utilization_percent}%</span>
+                 <span className="text-sm text-gray-900">{effectiveData.cpu_utilization_percent ?? '—'}{effectiveData.cpu_utilization_percent != null ? '%' : ''}</span>
                </div>
             </div>
           </div>
@@ -76,10 +88,10 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
             </span>
             <div className="flex-1 flex flex-col sm:flex-row sm:items-center gap-2">
                <span className="text-sm text-gray-900 min-w-[120px]">
-                 {data.memory_total_gb
+                 {effectiveData.memory_total_gb
                    ? t('hardwareSpecsPanel.values.unifiedMemory', {
                      defaultValue: '{{size}}GB Unified Memory',
-                     size: data.memory_total_gb
+                     size: effectiveData.memory_total_gb
                    })
                    : t('hardwareSpecsPanel.values.unknown', { defaultValue: 'Unknown' })}
                </span>
@@ -89,17 +101,17 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                  </span>
                  <div className="w-32">
                    <UtilizationBar 
-                     value={data.memory_utilization_percent} 
+                     value={effectiveData.memory_utilization_percent} 
                      showLabel={false}
                      size="sm"
                    />
                  </div>
                  <span className="text-sm text-gray-900">
-                   {data.memory_utilization_percent}% 
-                   {data.memory_used_gb
+                   {effectiveData.memory_utilization_percent ?? '—'}{effectiveData.memory_utilization_percent != null ? '%' : ''} 
+                   {effectiveData.memory_used_gb
                      ? t('hardwareSpecsPanel.values.memoryUsed', {
                        defaultValue: ' ({{size}}GB Used)',
-                       size: data.memory_used_gb.toFixed(1)
+                       size: effectiveData.memory_used_gb.toFixed(1)
                      })
                      : ''}
                  </span>
@@ -109,7 +121,7 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
 
           {/* Storage */}
           <div>
-             {data.storage.map((drive, index) => (
+             {effectiveData.storage.map((drive, index) => (
               <div key={index} className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2 last:mb-0">
                  <span className="text-sm font-bold text-gray-700 w-16 shrink-0">
                    {t('hardwareSpecsPanel.fields.storage', { defaultValue: 'Storage' })}:
@@ -134,7 +146,7 @@ export const HardwareSpecsPanel: React.FC<HardwareSpecsPanelProps> = ({
                  </div>
               </div>
              ))}
-             {data.storage.length === 0 && (
+             {effectiveData.storage.length === 0 && (
                <p className="text-sm text-gray-500">
                  {t('hardwareSpecsPanel.emptyStorage', { defaultValue: 'No storage drives detected' })}
                </p>

--- a/packages/assets/src/components/panels/RmmVitalsPanel.test.tsx
+++ b/packages/assets/src/components/panels/RmmVitalsPanel.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RmmVitalsPanel } from './RmmVitalsPanel';
+
+vi.mock('@alga-psa/ui/components/Card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardTitle: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('../shared/StatusBadge', () => ({
+  StatusBadge: ({ status }: any) => <span>{status}</span>,
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  formatRelativeDateTime: () => 'moments ago',
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, any>) => options?.defaultValue || _key,
+  }),
+}));
+
+describe('RmmVitalsPanel', () => {
+  it('shows not connected for unmanaged assets with no cached data', () => {
+    const html = renderToStaticMarkup(
+      <RmmVitalsPanel
+        asset={{
+          asset_id: 'asset-1',
+          asset_type: 'workstation',
+          client_id: 'client-1',
+          asset_tag: 'tag-1',
+          name: 'Unmanaged Device',
+          status: 'active',
+          created_at: '2026-04-15T00:00:00Z',
+          updated_at: '2026-04-15T00:00:00Z',
+          tenant: 'tenant-1',
+        } as any}
+        data={null}
+        isLoading={false}
+        onRefresh={() => undefined}
+        isRefreshing={false}
+      />
+    );
+
+    expect(html).toContain('Not connected to RMM');
+  });
+
+  it('treats linked Tanium assets as connected even when cached RMM data is absent', () => {
+    const html = renderToStaticMarkup(
+      <RmmVitalsPanel
+        asset={{
+          asset_id: 'asset-1',
+          asset_type: 'mobile_device',
+          client_id: 'client-1',
+          asset_tag: 'tanium:1',
+          name: '06:21:32:B6:E3:C2',
+          status: 'active',
+          created_at: '2026-04-15T00:00:00Z',
+          updated_at: '2026-04-15T00:00:00Z',
+          tenant: 'tenant-1',
+          rmm_provider: 'tanium',
+          rmm_device_id: '1',
+          agent_status: 'online',
+          last_seen_at: '2026-04-15T17:07:13Z',
+          last_rmm_sync_at: '2026-04-15T17:08:00Z',
+        } as any}
+        data={null}
+        isLoading={false}
+        onRefresh={() => undefined}
+        isRefreshing={false}
+      />
+    );
+
+    expect(html).not.toContain('Not connected to RMM');
+    expect(html).toContain('online');
+    expect(html).toContain('None');
+    expect(html).toContain('N/A');
+  });
+});

--- a/packages/assets/src/components/panels/RmmVitalsPanel.tsx
+++ b/packages/assets/src/components/panels/RmmVitalsPanel.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@alga-psa/ui/components/Card';
 import { Button } from '@alga-psa/ui/components/Button';
 import { RefreshCw, WifiOff } from 'lucide-react';
-import type { RmmCachedData } from '@alga-psa/types';
+import type { Asset, RmmCachedData } from '@alga-psa/types';
 import { StatusBadge } from '../shared/StatusBadge';
 import { formatRelativeDateTime } from '@alga-psa/core';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 interface RmmVitalsPanelProps {
+  asset: Asset;
   data: RmmCachedData | null | undefined;
   isLoading: boolean;
   onRefresh: () => void;
@@ -24,6 +25,7 @@ const VitalRow = ({ label, value }: { label: string, value: React.ReactNode }) =
 );
 
 export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
+  asset,
   data,
   isLoading,
   onRefresh,
@@ -49,7 +51,29 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
     return <Card className="h-64 animate-pulse bg-gray-50" />;
   }
 
-  if (!data) {
+  const extensionData = asset.workstation ?? asset.server;
+
+  const fallbackManagedData: RmmCachedData | null = asset.rmm_provider && asset.rmm_device_id
+    ? {
+        provider: asset.rmm_provider,
+        agent_status: asset.agent_status || 'unknown',
+        last_check_in: asset.last_seen_at || null,
+        last_rmm_sync_at: asset.last_rmm_sync_at || null,
+        current_user: extensionData?.current_user || null,
+        uptime_seconds: extensionData?.uptime_seconds || null,
+        lan_ip: extensionData?.lan_ip || null,
+        wan_ip: extensionData?.wan_ip || null,
+        cpu_utilization_percent: asset.workstation?.cpu_utilization_percent || asset.server?.cpu_usage_percent || null,
+        memory_utilization_percent: extensionData?.memory_usage_percent || null,
+        memory_used_gb: extensionData?.memory_used_gb || null,
+        memory_total_gb: extensionData?.ram_gb || null,
+        storage: extensionData?.disk_usage || [],
+      }
+    : null;
+
+  const effectiveData = data ?? fallbackManagedData;
+
+  if (!effectiveData) {
     return (
       <Card className="bg-white">
         <CardHeader>
@@ -97,12 +121,12 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
             label={t('rmmVitalsPanel.fields.agentStatus', { defaultValue: 'Agent Status' })}
             value={
               <div className="flex items-center gap-2">
-                <StatusBadge status={(data.agent_status as any) || 'unknown'} size="sm" showIcon={false} />
-                {data.last_check_in && (
+                <StatusBadge status={(effectiveData.agent_status as any) || 'unknown'} size="sm" showIcon={false} />
+                {effectiveData.last_check_in && (
                   <span className="text-sm text-gray-500">
                     {t('rmmVitalsPanel.fields.lastCheckIn', {
                       defaultValue: '(Last check-in: {{value}})',
-                      value: formatRelativeDateTime(new Date(data.last_check_in), Intl.DateTimeFormat().resolvedOptions().timeZone)
+                      value: formatRelativeDateTime(new Date(effectiveData.last_check_in), Intl.DateTimeFormat().resolvedOptions().timeZone)
                     })}
                   </span>
                 )}
@@ -112,18 +136,18 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
 
           <VitalRow
             label={t('rmmVitalsPanel.fields.currentUser', { defaultValue: 'Current User' })}
-            value={data.current_user || t('common.states.none', { defaultValue: 'None' })}
+            value={effectiveData.current_user || t('common.states.none', { defaultValue: 'None' })}
           />
           
           <VitalRow
             label={t('rmmVitalsPanel.fields.uptime', { defaultValue: 'Uptime' })}
-            value={formatUptime(data.uptime_seconds)}
+            value={formatUptime(effectiveData.uptime_seconds)}
           />
           
           <VitalRow 
             label={t('rmmVitalsPanel.fields.lastSync', { defaultValue: 'Last RMM Sync' })}
-            value={data.last_rmm_sync_at 
-              ? formatRelativeDateTime(new Date(data.last_rmm_sync_at), Intl.DateTimeFormat().resolvedOptions().timeZone) 
+            value={effectiveData.last_rmm_sync_at 
+              ? formatRelativeDateTime(new Date(effectiveData.last_rmm_sync_at), Intl.DateTimeFormat().resolvedOptions().timeZone) 
               : t('rmmVitalsPanel.values.never', { defaultValue: 'Never' })
             } 
           />
@@ -132,8 +156,8 @@ export const RmmVitalsPanel: React.FC<RmmVitalsPanelProps> = ({
             label={t('rmmVitalsPanel.fields.network', { defaultValue: 'Network' })}
             value={t('rmmVitalsPanel.fields.networkValue', {
               defaultValue: 'LAN IP: {{lan}} | WAN IP: {{wan}}',
-              lan: data.lan_ip || t('common.states.na', { defaultValue: 'N/A' }),
-              wan: data.wan_ip || t('common.states.na', { defaultValue: 'N/A' })
+              lan: effectiveData.lan_ip || t('common.states.na', { defaultValue: 'N/A' }),
+              wan: effectiveData.wan_ip || t('common.states.na', { defaultValue: 'N/A' })
             })}
           />
         </div>

--- a/packages/assets/src/hooks/useAssetDetail.ts
+++ b/packages/assets/src/hooks/useAssetDetail.ts
@@ -33,9 +33,13 @@ export function useAssetDetail(assetId: string) {
 
       try {
         setIsRefreshing(true);
-        const updatedData = await refreshAssetRmmData(assetId);
+        const [updatedData, updatedAsset] = await Promise.all([
+          refreshAssetRmmData(assetId),
+          getAsset(assetId),
+        ]);
 
         await mutateRmmData(updatedData, false);
+        await mutateAsset(updatedAsset, false);
 
         toast.success('RMM data refreshed');
       } catch (error) {
@@ -45,7 +49,7 @@ export function useAssetDetail(assetId: string) {
         setIsRefreshing(false);
       }
     },
-    [assetId, mutateRmmData]
+    [assetId, mutateAsset, mutateRmmData]
   );
 
   return {

--- a/packages/integrations/src/lib/rmm/contracts.ts
+++ b/packages/integrations/src/lib/rmm/contracts.ts
@@ -1,4 +1,4 @@
-import type { RmmAgentStatus, RmmProvider } from '@alga-psa/types';
+import type { RmmAgentStatus, RmmProvider, RmmStorageInfo } from '@alga-psa/types';
 
 export type NormalizedRmmScopeKind = 'organization' | 'site' | 'group' | 'custom';
 
@@ -30,6 +30,11 @@ export interface NormalizedRmmDeviceExtensionSnapshot {
   pendingSoftwarePatches?: number | null;
   failedPatches?: number | null;
   lastPatchScanAt?: string | null;
+  cpuModel?: string | null;
+  cpuCores?: number | null;
+  ramGb?: number | null;
+  diskUsage?: RmmStorageInfo[] | null;
+  installedSoftware?: unknown[] | null;
   systemInfo?: Record<string, unknown> | null;
 }
 

--- a/packages/integrations/src/lib/rmm/sharedAssetIngestionService.test.ts
+++ b/packages/integrations/src/lib/rmm/sharedAssetIngestionService.test.ts
@@ -296,4 +296,81 @@ describe('sharedAssetIngestionService', () => {
       sync_status: 'synced',
     });
   });
+
+  it('reclassifies an existing asset type when the normalized snapshot type changes', async () => {
+    const state: DbState = {
+      assets: [
+        {
+          tenant: 'tenant_1',
+          asset_id: 'asset_existing',
+          asset_type: 'mobile_device',
+          client_id: 'client_1',
+          name: 'Old Name',
+          serial_number: 'OLD',
+          status: 'active',
+          location: 'Old',
+          rmm_provider: 'tanium',
+          rmm_device_id: 'device_1',
+        },
+      ],
+      workstation_assets: [],
+      server_assets: [],
+      tenant_external_entity_mappings: [
+        {
+          id: 'map_existing',
+          tenant: 'tenant_1',
+          integration_type: 'tanium',
+          alga_entity_type: 'asset',
+          alga_entity_id: 'asset_existing',
+          external_entity_id: 'device_1',
+          external_realm_id: 'scope_1',
+          sync_status: 'pending',
+        },
+      ],
+      rmm_organization_mappings: [],
+    };
+    const knex = createFakeKnex(state);
+
+    const result = await ingestNormalizedRmmDeviceSnapshot({
+      tenant: 'tenant_1',
+      snapshot: buildSnapshot({
+        assetType: 'workstation',
+        extension: {
+          osType: 'macOS',
+          osVersion: 'macOS 26.3',
+          currentUser: 'roberisaacs',
+          lanIp: '192.168.254.190',
+          wanIp: '10.0.156.6',
+          lastRebootAt: '2026-04-15T10:00:00Z',
+          cpuModel: 'Apple M4 Max 2.4GHz',
+          cpuCores: 16,
+          ramGb: 48,
+          diskUsage: [{ name: '/', total_gb: 995, free_gb: 20, utilization_percent: 39 }],
+          installedSoftware: [{ name: 'Docker Desktop', version: '4.40.0' }],
+          systemInfo: { manufacturer: 'Apple', model: 'Mac16,5' },
+        },
+      }),
+      knex,
+    });
+
+    expect(result.action).toBe('updated');
+    expect(state.assets[0]).toMatchObject({
+      asset_type: 'workstation',
+    });
+    expect(state.workstation_assets).toHaveLength(1);
+    expect(state.workstation_assets[0]).toMatchObject({
+      asset_id: 'asset_existing',
+      os_type: 'macOS',
+      os_version: 'macOS 26.3',
+      current_user: 'roberisaacs',
+      lan_ip: '192.168.254.190',
+      wan_ip: '10.0.156.6',
+      cpu_model: 'Apple M4 Max 2.4GHz',
+      cpu_cores: 16,
+      ram_gb: 48,
+      disk_usage: JSON.stringify([{ name: '/', total_gb: 995, free_gb: 20, utilization_percent: 39 }]),
+      installed_software: JSON.stringify([{ name: 'Docker Desktop', version: '4.40.0' }]),
+      system_info: JSON.stringify({ manufacturer: 'Apple', model: 'Mac16,5' }),
+    });
+  });
 });

--- a/packages/integrations/src/lib/rmm/sharedAssetIngestionService.ts
+++ b/packages/integrations/src/lib/rmm/sharedAssetIngestionService.ts
@@ -71,7 +71,7 @@ async function upsertAssetExtension(
   if (!table) return;
 
   const ext = args.snapshot.extension ?? {};
-  const patch = {
+  const patch: Record<string, unknown> = {
     os_type: ext.osType ?? null,
     os_version: ext.osVersion ?? null,
     agent_version: ext.agentVersion ?? null,
@@ -87,8 +87,28 @@ async function upsertAssetExtension(
     pending_software_patches: ext.pendingSoftwarePatches ?? null,
     failed_patches: ext.failedPatches ?? null,
     last_patch_scan_at: parseIsoDate(ext.lastPatchScanAt),
-    system_info: ext.systemInfo ?? null,
+    system_info: ext.systemInfo ? JSON.stringify(ext.systemInfo) : null,
   };
+
+  if (typeof ext.cpuModel !== 'undefined') {
+    patch.cpu_model = ext.cpuModel ?? null;
+  }
+
+  if (typeof ext.cpuCores !== 'undefined') {
+    patch.cpu_cores = ext.cpuCores ?? null;
+  }
+
+  if (typeof ext.ramGb !== 'undefined') {
+    patch.ram_gb = ext.ramGb ?? null;
+  }
+
+  if (typeof ext.diskUsage !== 'undefined') {
+    patch.disk_usage = ext.diskUsage ? JSON.stringify(ext.diskUsage) : null;
+  }
+
+  if (typeof ext.installedSoftware !== 'undefined') {
+    patch.installed_software = JSON.stringify(ext.installedSoftware ?? []);
+  }
 
   await trx(table)
     .insert({
@@ -242,6 +262,7 @@ export async function ingestNormalizedRmmDeviceSnapshot(
     if (existingAsset?.asset_id) {
       const assetId = String(existingAsset.asset_id);
       const assetPatch: Record<string, unknown> = {
+        asset_type: assetType,
         name: snapshot.displayName,
         serial_number: snapshot.serialNumber ?? '',
         status: assetStatus,
@@ -265,7 +286,7 @@ export async function ingestNormalizedRmmDeviceSnapshot(
       await upsertAssetExtension(trx, {
         tenant,
         assetId,
-        assetType: normalizeAssetType(existingAsset.asset_type),
+        assetType,
         snapshot,
       });
 


### PR DESCRIPTION
## Summary
- disable the shared asset remote access button wrapper across all asset surfaces
- make both the remote access button and indicator render nothing
- leave the underlying EE implementation/routes intact for future re-enablement

## Testing
- not run