### PR TITLE
Workflow designer: collapsible palette, graph drag-drop, icon refresh

### DIFF
--- a/ee/server/src/components/workflow-designer/PaletteItemWithTooltip.tsx
+++ b/ee/server/src/components/workflow-designer/PaletteItemWithTooltip.tsx
@@ -96,7 +96,7 @@ export const PaletteItemWithTooltip: React.FC<{
       {...provided.draggableProps}
       {...(disabled ? {} : provided.dragHandleProps)}
       className={`
-        group relative flex w-full min-h-[4.5rem] flex-col items-center justify-start gap-1 rounded-lg border px-1 py-2 text-center
+        group relative flex w-full min-h-[3.25rem] flex-col items-center justify-center gap-1 rounded-lg border px-1 py-1.5 text-center
         transition-all duration-150
         ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab'}
         ${isDragging

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -14,7 +14,9 @@ import {
   FileText, Layers, Box, Cog, Terminal, Globe, Search, GripVertical,
   // Business operations icons
   MessageSquare, Edit, UserPlus, CheckCircle, Paperclip, Building, Users, Bot,
-  Bell, Calendar, SquareCheck, StickyNote, ClipboardList
+  Bell, Calendar, SquareCheck, StickyNote, ClipboardList, Ticket,
+  FolderKanban, Handshake, Contact, Wand2, AppWindow, Hourglass, ShieldAlert,
+  CalendarPlus, Timer, BellRing
 } from 'lucide-react';
 import {
   getStepTypeColor,
@@ -30,6 +32,7 @@ import {
 import { Button } from '@alga-psa/ui/components/Button';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { Input } from '@alga-psa/ui/components/Input';
+import ViewSwitcher from '@alga-psa/ui/components/ViewSwitcher';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Badge } from '@alga-psa/ui/components/Badge';
@@ -274,8 +277,11 @@ const areStructurallyEqual = (left: unknown, right: unknown): boolean => stableS
 const DESIGNER_FLOAT_EDGE_GUTTER = 8;
 const DESIGNER_FLOAT_PANEL_OFFSET = 16;
 const DESIGNER_FLOAT_MIN_HEIGHT = 160;
-const DESIGNER_PALETTE_WIDTH = 224;
-const DESIGNER_CENTER_LEFT_EXTRA_PADDING = 48;
+const DESIGNER_PALETTE_WIDTH = 280;
+const DESIGNER_PALETTE_COLLAPSED_WIDTH = 32;
+// Toggle chevron pokes ~16px beyond the palette's right edge (right: -12px + half button width)
+const DESIGNER_PALETTE_TOGGLE_OVERHANG = 16;
+const DESIGNER_CENTER_LEFT_EXTRA_PADDING = 16;
 const DESIGNER_CENTER_RIGHT_EXTRA_PADDING = 24;
 
 type PipeSegment = {
@@ -1272,6 +1278,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
   const [triggerSourceSchemaStatus, setTriggerSourceSchemaStatus] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const [triggerSourceSchemaLoadedRef, setTriggerSourceSchemaLoadedRef] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [isPaletteCollapsed, setIsPaletteCollapsed] = useState(false);
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
   const [selectedPipePath, setSelectedPipePath] = useState<string>('root');
   // For insert-between functionality: stores where to insert the next step
@@ -1451,11 +1458,14 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
       Math.max(DESIGNER_FLOAT_EDGE_GUTTER, designerFloatAnchorRect.top + DESIGNER_FLOAT_PANEL_OFFSET),
       window.innerHeight - DESIGNER_FLOAT_MIN_HEIGHT
     );
+    const currentPaletteWidth = isPaletteCollapsed
+      ? DESIGNER_PALETTE_COLLAPSED_WIDTH
+      : DESIGNER_PALETTE_WIDTH;
     const paletteLeft = Math.min(
       Math.max(DESIGNER_FLOAT_EDGE_GUTTER, designerFloatAnchorRect.left + DESIGNER_FLOAT_PANEL_OFFSET),
-      window.innerWidth - DESIGNER_FLOAT_EDGE_GUTTER - DESIGNER_PALETTE_WIDTH
+      window.innerWidth - DESIGNER_FLOAT_EDGE_GUTTER - currentPaletteWidth
     );
-    const paletteRight = paletteLeft + DESIGNER_PALETTE_WIDTH;
+    const paletteRight = paletteLeft + currentPaletteWidth + DESIGNER_PALETTE_TOGGLE_OVERHANG;
     const sidebarLeft = Math.min(
       Math.max(
         DESIGNER_FLOAT_EDGE_GUTTER,
@@ -1495,7 +1505,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
         paddingRight: `${centerPaddingRight}px`,
       } as React.CSSProperties,
     };
-  }, [designerFloatAnchorRect, designerSidebarWidth]);
+  }, [designerFloatAnchorRect, designerSidebarWidth, isPaletteCollapsed]);
 
   const stepPathMap = useMemo(() => {
     return activeDefinition ? buildStepPathMap(activeDefinition.steps as Step[]) : {};
@@ -3255,17 +3265,17 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
 
     if (itemWithAction.groupKey || itemWithAction.iconToken) {
       switch (itemWithAction.iconToken ?? itemWithAction.groupKey) {
-        case 'ticket': return <ClipboardList className={iconClass} />;
-        case 'contact': return <Users className={iconClass} />;
+        case 'ticket': return <Ticket className={iconClass} />;
+        case 'contact': return <Contact className={iconClass} />;
         case 'client': return <Building className={iconClass} />;
         case 'communication': return <Mail className={iconClass} />;
         case 'scheduling': return <Calendar className={iconClass} />;
-        case 'project': return <SquareCheck className={iconClass} />;
+        case 'project': return <FolderKanban className={iconClass} />;
         case 'time': return <Clock className={iconClass} />;
-        case 'crm': return <StickyNote className={iconClass} />;
-        case 'transform': return <Settings className={iconClass} />;
+        case 'crm': return <Handshake className={iconClass} />;
+        case 'transform': return <Wand2 className={iconClass} />;
         case 'ai': return <Bot className={iconClass} />;
-        case 'app': return <Box className={iconClass} />;
+        case 'app': return <AppWindow className={iconClass} />;
         default: return <Box className={iconClass} />;
       }
     }
@@ -3275,7 +3285,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
       const actionId = itemWithAction.actionId.toLowerCase();
       
       // Business Operations - Tickets
-      if (actionId === 'tickets.create') return <ClipboardList className={iconClass} />;
+      if (actionId === 'tickets.create') return <Ticket className={iconClass} />;
       if (actionId === 'tickets.add_comment') return <MessageSquare className={iconClass} />;
       if (actionId === 'tickets.update_fields') return <Edit className={iconClass} />;
       if (actionId === 'tickets.assign') return <UserPlus className={iconClass} />;
@@ -3299,13 +3309,13 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
       if (actionId === 'notifications.send_in_app') return <Bell className={iconClass} />;
       
       // Business Operations - Scheduling
-      if (actionId === 'scheduling.assign_user') return <Calendar className={iconClass} />;
+      if (actionId === 'scheduling.assign_user') return <CalendarPlus className={iconClass} />;
       
       // Business Operations - Projects
       if (actionId === 'projects.create_task') return <SquareCheck className={iconClass} />;
       
       // Business Operations - Time
-      if (actionId === 'time.create_entry') return <Clock className={iconClass} />;
+      if (actionId === 'time.create_entry') return <Timer className={iconClass} />;
       
       // Business Operations - CRM
       if (actionId === 'crm.create_activity_note') return <StickyNote className={iconClass} />;
@@ -3324,13 +3334,13 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     switch (item.type) {
       case 'control.if': return <GitBranch className={iconClass} />;
       case 'control.forEach': return <Repeat className={iconClass} />;
-      case 'control.tryCatch': return <Shield className={iconClass} />;
+      case 'control.tryCatch': return <ShieldAlert className={iconClass} />;
       case 'control.return': return <CornerDownRight className={iconClass} />;
       case 'control.callWorkflow': return <Workflow className={iconClass} />;
       case 'state.set': return <Database className={iconClass} />;
       case 'transform.assign': return <Settings className={iconClass} />;
       case 'event.wait': return <Clock className={iconClass} />;
-      case 'time.wait': return <Clock className={iconClass} />;
+      case 'time.wait': return <Hourglass className={iconClass} />;
       case 'human.task': return <User className={iconClass} />;
       case 'action.call': return <Zap className={iconClass} />;
       default: return <Box className={iconClass} />;
@@ -3406,6 +3416,10 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
                 scrollContainerRef={provided.innerRef}
                 scrollContainerProps={provided.droppableProps}
                 scrollContainerFooter={provided.placeholder}
+                isCollapsed={isPaletteCollapsed}
+                onToggleCollapse={() => setIsPaletteCollapsed((prev) => !prev)}
+                expandedWidth={DESIGNER_PALETTE_WIDTH}
+                collapsedWidth={DESIGNER_PALETTE_COLLAPSED_WIDTH}
                 renderItem={(item, _category, paletteIndex) => (
                   <Draggable
                     key={item.id}
@@ -4702,22 +4716,15 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
-                      <Button
-                        id="workflow-steps-view-list"
-                        variant={stepsViewMode === 'list' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setStepsViewMode('list')}
-                      >
-                        List
-                      </Button>
-                      <Button
-                        id="workflow-steps-view-graph"
-                        variant={stepsViewMode === 'graph' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setStepsViewMode('graph')}
-                      >
-                        Graph
-                      </Button>
+                      <ViewSwitcher
+                        aria-label="Workflow steps view"
+                        currentView={stepsViewMode}
+                        onChange={(v) => setStepsViewMode(v as 'list' | 'graph')}
+                        options={[
+                          { value: 'list', label: 'List' },
+                          { value: 'graph', label: 'Graph' }
+                        ]}
+                      />
                       {publishWarnings.length > 0 && (
                         <Badge variant="warning">{publishWarnings.length} warnings</Badge>
                       )}

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.module.css
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.module.css
@@ -1,0 +1,79 @@
+.container {
+  position: relative;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              min-width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.paletteToggle {
+  position: absolute;
+  top: 12px;
+  right: -12px;
+  z-index: 10;
+}
+
+/* Clips the sliding card so its translateX animation cannot bleed past
+   the palette's left edge into the app sidebar. */
+.clipper {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: stretch;
+}
+
+.card {
+  background-color: rgb(var(--color-card));
+  border: 1px solid rgb(var(--color-border-200));
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cardVisible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.cardHidden {
+  opacity: 0;
+  transform: translateX(-100%);
+  width: 0 !important;
+  min-width: 0 !important;
+  max-width: 0 !important;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+}
+
+.scrollArea {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--color-border-200)) transparent;
+}
+
+.scrollArea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollArea::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 3px;
+}
+
+.scrollArea::-webkit-scrollbar-thumb {
+  background: rgb(var(--color-border-200));
+  border-radius: 3px;
+}
+
+.scrollArea::-webkit-scrollbar-thumb:hover {
+  background: rgb(var(--color-border-300));
+}

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Search } from 'lucide-react';
 import type { DroppableProvidedProps } from '@hello-pangea/dnd';
+import { CollapseToggleButton } from '@alga-psa/ui/components/CollapseToggleButton';
+import styles from './WorkflowDesignerPalette.module.css';
 
 export type WorkflowDesignerPaletteItem = {
   id: string;
@@ -20,6 +22,10 @@ type WorkflowDesignerPaletteProps<TItem extends WorkflowDesignerPaletteItem> = {
   scrollContainerRef?: React.Ref<HTMLDivElement>;
   scrollContainerProps?: DroppableProvidedProps;
   scrollContainerFooter?: React.ReactNode;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
+  expandedWidth?: number;
+  collapsedWidth?: number;
 };
 
 export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteItem>({
@@ -34,55 +40,97 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
   scrollContainerRef,
   scrollContainerProps,
   scrollContainerFooter,
+  isCollapsed = false,
+  onToggleCollapse,
+  expandedWidth = 280,
+  collapsedWidth = 32,
 }: WorkflowDesignerPaletteProps<TItem>): React.ReactElement {
   let paletteIndex = 0;
 
+  const outerWidth = isCollapsed ? collapsedWidth : expandedWidth;
+  const containerStyle: React.CSSProperties | undefined = visible
+    ? {
+        ...(style || {}),
+        width: outerWidth,
+        minWidth: outerWidth,
+        maxWidth: outerWidth,
+      }
+    : undefined;
+
+  const cardSizingStyle: React.CSSProperties = isCollapsed
+    ? {}
+    : {
+        width: expandedWidth,
+        minWidth: expandedWidth,
+        maxWidth: expandedWidth,
+      };
+
   return (
     <aside
-      className={`pointer-events-auto w-56 max-h-[calc(100vh-220px)] bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg overflow-hidden flex flex-col min-h-0 z-40 ${visible ? '' : 'hidden'}`}
-      style={visible ? style : undefined}
+      className={`pointer-events-auto flex flex-col max-h-[calc(100vh-220px)] min-h-0 z-40 ${styles.container} ${visible ? '' : 'hidden'}`}
+      style={containerStyle}
     >
-      <div className="p-3 border-b">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <input
-            id="workflow-designer-search"
-            type="text"
-            placeholder="Search"
-            value={search}
-            disabled={registryError}
-            onChange={(event) => onSearchChange(event.target.value)}
-            className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
-          />
+      {onToggleCollapse ? (
+        <CollapseToggleButton
+          id="workflow-designer-palette-toggle"
+          isCollapsed={isCollapsed}
+          collapsedLabel="Show palette"
+          expandedLabel="Hide palette"
+          expandDirection="right"
+          className={styles.paletteToggle}
+          onClick={onToggleCollapse}
+        />
+      ) : null}
+
+      <div className={styles.clipper}>
+      <div
+        className={`${styles.card} ${isCollapsed ? styles.cardHidden : styles.cardVisible} bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur`}
+        style={cardSizingStyle}
+        aria-hidden={isCollapsed}
+      >
+        <div className="p-3 border-b">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <input
+              id="workflow-designer-search"
+              type="text"
+              placeholder="Search"
+              value={search}
+              disabled={registryError}
+              onChange={(event) => onSearchChange(event.target.value)}
+              className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+        </div>
+        {draggingFromPalette ? (
+          <div className="px-3 py-1.5 bg-primary-50 border-b text-xs text-primary-700">
+            Drop on pipeline to add
+          </div>
+        ) : null}
+        <div
+          id="workflow-designer-palette-scroll"
+          ref={scrollContainerRef}
+          {...scrollContainerProps}
+          className={`${styles.scrollArea} flex-1 min-h-0 overflow-y-auto pl-3 pr-2 py-3 space-y-4`}
+          style={{ scrollbarGutter: 'stable' }}
+        >
+          {Object.entries(groupedPaletteItems).map(([category, items]) => (
+            <div key={category}>
+              <div className="text-[10px] font-semibold uppercase text-gray-400 tracking-wider mb-2">
+                {category}
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {items.map((item) => {
+                  const currentPaletteIndex = paletteIndex;
+                  paletteIndex += 1;
+                  return renderItem(item, category, currentPaletteIndex);
+                })}
+              </div>
+            </div>
+          ))}
+          {scrollContainerFooter}
         </div>
       </div>
-      {draggingFromPalette ? (
-        <div className="px-3 py-1.5 bg-primary-50 border-b text-xs text-primary-700">
-          Drop on pipeline to add
-        </div>
-      ) : null}
-      <div
-        id="workflow-designer-palette-scroll"
-        ref={scrollContainerRef}
-        {...scrollContainerProps}
-        className="flex-1 min-h-0 overflow-y-auto pl-3 pr-5 py-3 space-y-4"
-        style={{ scrollbarGutter: 'stable' }}
-      >
-        {Object.entries(groupedPaletteItems).map(([category, items]) => (
-          <div key={category}>
-            <div className="text-[10px] font-semibold uppercase text-gray-400 tracking-wider mb-2">
-              {category}
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {items.map((item) => {
-                const currentPaletteIndex = paletteIndex;
-                paletteIndex += 1;
-                return renderItem(item, category, currentPaletteIndex);
-              })}
-            </div>
-          </div>
-        ))}
-        {scrollContainerFooter}
       </div>
     </aside>
   );

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
@@ -86,7 +86,7 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
       <div
         className={`${styles.card} ${isCollapsed ? styles.cardHidden : styles.cardVisible} bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur`}
         style={cardSizingStyle}
-        aria-hidden={isCollapsed}
+        inert={isCollapsed}
       >
         <div className="p-3 border-b">
           <div className="relative">

--- a/ee/server/src/components/workflow-graph/WorkflowGraph.tsx
+++ b/ee/server/src/components/workflow-graph/WorkflowGraph.tsx
@@ -312,7 +312,8 @@ export default function WorkflowGraph<TStep extends { id: string; type: string }
         const graph = await buildWorkflowGraph(steps as any, {
           getLabel: (step) => getLabelRef.current(step as any),
           getSubtitle: getSubtitleRef.current ? (step) => (getSubtitleRef.current?.(step as any) ?? null) : undefined,
-          getPipePathForRoot: () => rootPipePath
+          getPipePathForRoot: () => rootPipePath,
+          includeInsertions: editable
         });
         if (cancelled) return;
         setNodes(graph.nodes);
@@ -388,15 +389,42 @@ export default function WorkflowGraph<TStep extends { id: string; type: string }
   }
 
   if (steps.length === 0) {
-    return (
-      <div className={`w-full h-full flex flex-col items-center justify-center text-center ${className ?? ''}`}>
-        <div className="flex items-center justify-center w-12 h-12 rounded-full bg-success/15 border-2 border-success mb-4">
-          <Play className="h-5 w-5 text-success ml-0.5" />
+    if (!editable) {
+      return (
+        <div className={`w-full h-full flex flex-col items-center justify-center text-center ${className ?? ''}`}>
+          <div className="flex items-center justify-center w-12 h-12 rounded-full bg-success/15 border-2 border-success mb-4">
+            <Play className="h-5 w-5 text-success ml-0.5" />
+          </div>
+          <p className="text-sm text-gray-500">
+            Select a step from the panel to get started.
+          </p>
         </div>
-        <p className="text-sm text-gray-500">
-          Select a step from the panel to get started.
-        </p>
-      </div>
+      );
+    }
+    return (
+      <Droppable droppableId={`insert:${rootPipePath}:0`}>
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            className={`w-full h-full flex flex-col items-center justify-center text-center transition-colors ${
+              snapshot.isDraggingOver
+                ? 'bg-[rgb(var(--color-primary-50))] border-2 border-dashed border-[rgb(var(--color-primary-400))]'
+                : ''
+            } ${className ?? ''}`}
+          >
+            <div className="flex items-center justify-center w-12 h-12 rounded-full bg-success/15 border-2 border-success mb-4">
+              <Play className="h-5 w-5 text-success ml-0.5" />
+            </div>
+            <p className="text-sm text-gray-500">
+              {snapshot.isDraggingOver
+                ? 'Drop to add as the first step'
+                : 'Drag a step from the panel, or select one to get started.'}
+            </p>
+            <div className="hidden">{provided.placeholder}</div>
+          </div>
+        )}
+      </Droppable>
     );
   }
 

--- a/ee/server/src/components/workflow-graph/buildWorkflowGraph.ts
+++ b/ee/server/src/components/workflow-graph/buildWorkflowGraph.ts
@@ -536,24 +536,18 @@ export async function buildWorkflowGraph(
   alignStraightChains();
 
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
-  const getRenderedNodeX = (id: string) => {
+  const getLayoutNodeCenterX = (id: string) => {
     const node = nodeById.get(id);
     const pos = positions.get(id) ?? { x: 0, y: 0 };
-    return node?.type === 'workflowInsert' ? pos.x + 1 : pos.x;
-  };
-  const getRenderedNodeCenterX = (id: string) => {
-    const node = nodeById.get(id);
     const width = node?.width ?? STEP_WIDTH;
-    return getRenderedNodeX(id) + width / 2;
+    return pos.x + width / 2;
   };
 
   const laidOutNodes: Node<WorkflowGraphNodeData>[] = nodes.map((node) => {
+    const pos = positions.get(node.id) ?? { x: 0, y: 0 };
     return {
       ...node,
-      position: {
-        x: getRenderedNodeX(node.id),
-        y: positions.get(node.id)?.y ?? 0
-      }
+      position: { x: pos.x, y: pos.y }
     };
   });
 
@@ -562,8 +556,8 @@ export async function buildWorkflowGraph(
     if (edge.label) return edge;
     if ((edge.data as any)?.excludeFromLayout) return edge;
 
-    const sourceCenterX = getRenderedNodeCenterX(edge.source);
-    const targetCenterX = getRenderedNodeCenterX(edge.target);
+    const sourceCenterX = getLayoutNodeCenterX(edge.source);
+    const targetCenterX = getLayoutNodeCenterX(edge.target);
 
     if (Math.abs(sourceCenterX - targetCenterX) <= 0.75) {
       return {


### PR DESCRIPTION
## Summary
- Palette is now collapsible via a chevron toggle; expanded width bumped 224 → 280 px with a 3-column grid of shorter items. Hidden card uses `inert` so focus, clicks, and AT are all blocked while collapsed.
- The editable empty state of the graph view is now a drop target, so the first step can be added by dragging from the palette.
- Refreshed palette icons to more specific Lucide glyphs (`Ticket`, `FolderKanban`, `Handshake`, `Wand2`, `AppWindow`, `Hourglass`, `ShieldAlert`, `CalendarPlus`, `Timer`, `Contact`) and migrated the steps List/Graph toggle to the shared `ViewSwitcher`.
- Simplified `buildWorkflowGraph` layout math by dropping the +1 px render offset on insert nodes; edge-straightening now uses true layout centers.

## Test plan
- [ ] Expand/collapse palette: chevron reachable in both states, animation smooth, graph canvas re-centers.
- [ ] Collapsed palette: Tab order skips the search input and palette items; pointer clicks on the hidden area do nothing.
- [ ] Drag a step from the palette onto an empty graph — first step is inserted at index 0.
- [ ] Drag a step onto a populated graph's insert slots — existing insertion behavior unchanged.
- [ ] List ↔ Graph view switcher works and preserves selection.
- [ ] Verify palette icons match the expected action/group categories.
- [ ] Sanity-check edge routing (straight vs. stepped) after the layout-math change.