### PR TITLE
Deliver Teams bot replies via BF connector

### DIFF
--- a/ee/packages/microsoft-teams/package.json
+++ b/ee/packages/microsoft-teams/package.json
@@ -50,6 +50,7 @@
     "@alga-psa/workflow-streams": "*",
     "@alga-psa/workflows": "*",
     "@microsoft/teams-js": "^2.28.0",
+    "jose": "^5.9.6",
     "lucide-react": "^0.428.0"
   },
   "peerDependencies": {

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotConnector.ts
@@ -1,0 +1,181 @@
+import type { TeamsBotResponseActivity } from './teamsBotHandler';
+
+interface CachedToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+interface BotCredentials {
+  appId: string;
+  tenantId: string;
+  password: string;
+}
+
+// Bot Framework service URLs are issued by Microsoft and all live under a
+// small set of trusted hostname suffixes. Before sending a bearer token to a
+// serviceUrl we got out of an inbound activity, sanity-check that it looks
+// like a real Bot Framework endpoint so we never leak the token to an
+// attacker-controlled URL even if inbound validation is bypassed somehow.
+const TRUSTED_SERVICE_URL_SUFFIXES = [
+  '.botframework.com',
+  '.trafficmanager.net',
+  '.botplatform.cloudes.microsoft.com',
+];
+
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+let cachedToken: CachedToken | null = null;
+let inFlightTokenRequest: Promise<string> | null = null;
+
+export function readBotCredentialsFromEnv(): BotCredentials | null {
+  const appId = process.env.TEAMS_BOT_APP_ID?.trim();
+  const tenantId = process.env.TEAMS_BOT_APP_TENANT_ID?.trim();
+  const password = process.env.TEAMS_BOT_APP_PASSWORD?.trim();
+  if (!appId || !tenantId || !password) {
+    return null;
+  }
+  return { appId, tenantId, password };
+}
+
+export function isBotConnectorConfigured(): boolean {
+  return readBotCredentialsFromEnv() !== null;
+}
+
+export function isTrustedServiceUrl(serviceUrl: string): boolean {
+  try {
+    const url = new URL(serviceUrl);
+    if (url.protocol !== 'https:') {
+      return false;
+    }
+    const host = url.hostname.toLowerCase();
+    return TRUSTED_SERVICE_URL_SUFFIXES.some((suffix) => host.endsWith(suffix));
+  } catch {
+    return false;
+  }
+}
+
+async function fetchAccessToken(credentials: BotCredentials): Promise<string> {
+  const tokenUrl = `https://login.microsoftonline.com/${encodeURIComponent(
+    credentials.tenantId
+  )}/oauth2/v2.0/token`;
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: credentials.appId,
+    client_secret: credentials.password,
+    scope: 'https://api.botframework.com/.default',
+  });
+
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `Failed to acquire Bot Framework token (${response.status} ${response.statusText}): ${detail.slice(0, 200)}`
+    );
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+
+  if (!payload.access_token) {
+    throw new Error('Bot Framework token response did not include access_token.');
+  }
+
+  const lifetimeMs = (payload.expires_in ?? 3600) * 1000;
+  cachedToken = {
+    accessToken: payload.access_token,
+    expiresAt: Date.now() + lifetimeMs - TOKEN_EXPIRY_BUFFER_MS,
+  };
+  return payload.access_token;
+}
+
+async function getAccessToken(credentials: BotCredentials): Promise<string> {
+  if (cachedToken && cachedToken.expiresAt > Date.now()) {
+    return cachedToken.accessToken;
+  }
+  if (inFlightTokenRequest) {
+    return inFlightTokenRequest;
+  }
+  inFlightTokenRequest = fetchAccessToken(credentials).finally(() => {
+    inFlightTokenRequest = null;
+  });
+  return inFlightTokenRequest;
+}
+
+export interface SendBotActivityInput {
+  serviceUrl: string;
+  conversationId: string;
+  replyToId?: string | null;
+  activity: TeamsBotResponseActivity;
+}
+
+export interface SendBotActivityResult {
+  status: 'sent' | 'skipped';
+  reason?: string;
+}
+
+export async function sendBotActivity(input: SendBotActivityInput): Promise<SendBotActivityResult> {
+  const credentials = readBotCredentialsFromEnv();
+  if (!credentials) {
+    return {
+      status: 'skipped',
+      reason: 'teams_bot_credentials_not_configured',
+    };
+  }
+
+  if (!input.serviceUrl || !input.conversationId) {
+    return {
+      status: 'skipped',
+      reason: 'missing_service_url_or_conversation_id',
+    };
+  }
+
+  if (!isTrustedServiceUrl(input.serviceUrl)) {
+    return {
+      status: 'skipped',
+      reason: 'untrusted_service_url',
+    };
+  }
+
+  const token = await getAccessToken(credentials);
+
+  const base = input.serviceUrl.endsWith('/') ? input.serviceUrl.slice(0, -1) : input.serviceUrl;
+  const conversation = encodeURIComponent(input.conversationId);
+  const url = input.replyToId
+    ? `${base}/v3/conversations/${conversation}/activities/${encodeURIComponent(input.replyToId)}`
+    : `${base}/v3/conversations/${conversation}/activities`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input.activity),
+  });
+
+  if (response.status === 401) {
+    // Token likely expired between cache check and request. Clear the cache
+    // so the next send forces a fresh token, then surface the error.
+    cachedToken = null;
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `Failed to send Bot Framework activity (${response.status} ${response.statusText}): ${detail.slice(0, 200)}`
+    );
+  }
+
+  return { status: 'sent' };
+}

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotHandler.ts
@@ -4,6 +4,8 @@ import { NextResponse } from 'next/server';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { getTeamsRuntimeAvailability } from '../getTeamsRuntimeAvailability';
 import { buildTeamsAvailabilityJsonResponse } from '../teamsAvailabilityResponses';
+import { sendBotActivity, isBotConnectorConfigured } from './teamsBotConnector';
+import { verifyTeamsBotRequest } from './teamsBotJwtVerifier';
 import {
   executeTeamsAction,
   listAvailableTeamsActions,
@@ -19,10 +21,16 @@ import { resolveTeamsTenantContext } from '../resolveTeamsTenantContext';
 
 export interface TeamsBotActivity {
   type?: string;
+  id?: string | null;
+  serviceUrl?: string | null;
   text?: string | null;
   from?: {
     id?: string | null;
     aadObjectId?: string | null;
+    name?: string | null;
+  } | null;
+  recipient?: {
+    id?: string | null;
     name?: string | null;
   } | null;
   conversation?: {
@@ -1118,6 +1126,19 @@ export async function handleTeamsBotActivity(
 export async function handleTeamsBotActivityRequest(
   request: Request
 ): Promise<NextResponse> {
+  // Verify inbound JWT before we read the body so attackers can't blast
+  // payloads at the action registry. In unconfigured environments (no bot
+  // credentials in env) verification is skipped, in which case the handler
+  // still runs but sendBotActivity becomes a no-op and no reply is produced.
+  const verification = await verifyTeamsBotRequest(request.headers.get('authorization'));
+  if (verification.status === 'rejected') {
+    console.warn('[teams-bot] rejected inbound request', { reason: verification.reason });
+    return NextResponse.json(
+      { error: 'unauthorized', message: 'Bot Framework request verification failed.' },
+      { status: 401 }
+    );
+  }
+
   let activity: TeamsBotActivity;
   try {
     activity = (await request.json()) as TeamsBotActivity;
@@ -1143,10 +1164,38 @@ export async function handleTeamsBotActivityRequest(
   }
 
   const response = await handleTeamsBotActivity(activity, { tenantIdHint });
-  return NextResponse.json(response, {
-    status: 200,
-    headers: {
-      'Cache-Control': 'no-store',
-    },
-  });
+
+  // Deliver the reply back to Teams via the Bot Framework connector. For a
+  // normal `message` activity Teams ignores the HTTP response body entirely
+  // and only sees what arrives via the connector POST. If credentials are
+  // not configured we skip sending and return 200 so Teams doesn't retry.
+  const serviceUrl = normalizeOptionalString(activity.serviceUrl);
+  const conversationId = normalizeOptionalString(activity.conversation?.id);
+  const replyToId = normalizeOptionalString(activity.id);
+
+  if (serviceUrl && conversationId && isBotConnectorConfigured()) {
+    try {
+      const result = await sendBotActivity({
+        serviceUrl,
+        conversationId,
+        replyToId,
+        activity: response,
+      });
+      if (result.status === 'skipped' && result.reason) {
+        console.warn('[teams-bot] reply skipped', { reason: result.reason });
+      }
+    } catch (err) {
+      console.error('[teams-bot] failed to send reply', err);
+    }
+  }
+
+  return NextResponse.json(
+    { status: 'ok' },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    }
+  );
 }

--- a/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/bot/teamsBotJwtVerifier.ts
@@ -1,0 +1,109 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { readBotCredentialsFromEnv } from './teamsBotConnector';
+
+const BOT_FRAMEWORK_OPENID_URL =
+  'https://login.botframework.com/v1/.well-known/openidconfiguration';
+const BOT_FRAMEWORK_ISSUER = 'https://api.botframework.com';
+
+interface OpenIdConfig {
+  jwks_uri?: string;
+  issuer?: string;
+}
+
+interface CachedJwksContext {
+  jwks: ReturnType<typeof createRemoteJWKSet>;
+  issuer: string;
+  refreshedAt: number;
+}
+
+const JWKS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+
+let cachedContext: CachedJwksContext | null = null;
+let inFlightConfigFetch: Promise<CachedJwksContext> | null = null;
+
+async function loadJwksContext(): Promise<CachedJwksContext> {
+  if (cachedContext && Date.now() - cachedContext.refreshedAt < JWKS_CACHE_TTL_MS) {
+    return cachedContext;
+  }
+
+  if (inFlightConfigFetch) {
+    return inFlightConfigFetch;
+  }
+
+  inFlightConfigFetch = (async () => {
+    const response = await fetch(BOT_FRAMEWORK_OPENID_URL);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch Bot Framework OpenID config (${response.status} ${response.statusText})`
+      );
+    }
+    const config = (await response.json()) as OpenIdConfig;
+    if (!config.jwks_uri) {
+      throw new Error('Bot Framework OpenID config did not include jwks_uri.');
+    }
+    const jwks = createRemoteJWKSet(new URL(config.jwks_uri));
+    const next: CachedJwksContext = {
+      jwks,
+      issuer: config.issuer || BOT_FRAMEWORK_ISSUER,
+      refreshedAt: Date.now(),
+    };
+    cachedContext = next;
+    return next;
+  })().finally(() => {
+    inFlightConfigFetch = null;
+  });
+
+  return inFlightConfigFetch;
+}
+
+export type TeamsBotVerificationResult =
+  | { status: 'verified'; payload: JWTPayload }
+  | { status: 'unconfigured' }
+  | { status: 'rejected'; reason: string };
+
+function extractBearer(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  return match ? match[1].trim() : null;
+}
+
+export async function verifyTeamsBotRequest(
+  authHeader: string | null
+): Promise<TeamsBotVerificationResult> {
+  const credentials = readBotCredentialsFromEnv();
+  if (!credentials) {
+    // Without bot credentials configured, outbound replies can't be sent
+    // either, so strict inbound verification would only serve to block the
+    // handler from logging/parsing the activity. Degrade to "unconfigured"
+    // and let the caller decide what to do.
+    return { status: 'unconfigured' };
+  }
+
+  const token = extractBearer(authHeader);
+  if (!token) {
+    return { status: 'rejected', reason: 'missing_bearer_token' };
+  }
+
+  let context: CachedJwksContext;
+  try {
+    context = await loadJwksContext();
+  } catch (err) {
+    return {
+      status: 'rejected',
+      reason: `openid_config_fetch_failed: ${err instanceof Error ? err.message : 'unknown'}`,
+    };
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, context.jwks, {
+      issuer: context.issuer,
+      audience: credentials.appId,
+    });
+    return { status: 'verified', payload };
+  } catch (err) {
+    return {
+      status: 'rejected',
+      reason: err instanceof Error ? err.message : 'invalid_token',
+    };
+  }
+}

--- a/ee/packages/microsoft-teams/src/lib/teams/buildTeamsFullPsaUrl.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/buildTeamsFullPsaUrl.ts
@@ -19,6 +19,7 @@ export function buildTeamsFullPsaUrl(destination: TeamsTabDestination): string |
     case 'contact':
       return `/msp/contacts/${destination.contactId}`;
     case 'my_work':
+      return '/msp/dashboard';
     default:
       return null;
   }

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -789,6 +789,29 @@ spec:
                 key: IPINFO_API_TOKEN
           {{- end }}
 
+          # ----------- MICROSOFT TEAMS BOT ----------------
+          {{- if .Values.secrets.TEAMS_BOT_APP_ID }}
+          - name: TEAMS_BOT_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: TEAMS_BOT_APP_ID
+          {{- end }}
+          {{- if .Values.secrets.TEAMS_BOT_APP_TENANT_ID }}
+          - name: TEAMS_BOT_APP_TENANT_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: TEAMS_BOT_APP_TENANT_ID
+          {{- end }}
+          {{- if .Values.secrets.TEAMS_BOT_APP_PASSWORD }}
+          - name: TEAMS_BOT_APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: TEAMS_BOT_APP_PASSWORD
+          {{- end }}
+
           # ----------- SECRET PROVIDER ----------------
           # Composite secret provider configuration
           - name: SECRET_READ_CHAIN

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -40,6 +40,21 @@ data:
   {{- else if index $existing.data "IPINFO_API_TOKEN" }}
   IPINFO_API_TOKEN: {{ index $existing.data "IPINFO_API_TOKEN" }}
   {{- end }}
+  {{- if and .Values.secrets .Values.secrets.TEAMS_BOT_APP_ID }}
+  TEAMS_BOT_APP_ID: {{ .Values.secrets.TEAMS_BOT_APP_ID | b64enc | quote }}
+  {{- else if index $existing.data "TEAMS_BOT_APP_ID" }}
+  TEAMS_BOT_APP_ID: {{ index $existing.data "TEAMS_BOT_APP_ID" }}
+  {{- end }}
+  {{- if and .Values.secrets .Values.secrets.TEAMS_BOT_APP_TENANT_ID }}
+  TEAMS_BOT_APP_TENANT_ID: {{ .Values.secrets.TEAMS_BOT_APP_TENANT_ID | b64enc | quote }}
+  {{- else if index $existing.data "TEAMS_BOT_APP_TENANT_ID" }}
+  TEAMS_BOT_APP_TENANT_ID: {{ index $existing.data "TEAMS_BOT_APP_TENANT_ID" }}
+  {{- end }}
+  {{- if and .Values.secrets .Values.secrets.TEAMS_BOT_APP_PASSWORD }}
+  TEAMS_BOT_APP_PASSWORD: {{ .Values.secrets.TEAMS_BOT_APP_PASSWORD | b64enc | quote }}
+  {{- else if index $existing.data "TEAMS_BOT_APP_PASSWORD" }}
+  TEAMS_BOT_APP_PASSWORD: {{ index $existing.data "TEAMS_BOT_APP_PASSWORD" }}
+  {{- end }}
 {{- else }}
   {{- /* First install — generate or use explicit values */}}
   {{- if .Values.secrets }}
@@ -59,6 +74,15 @@ data:
   {{- end }}
   {{- if .Values.secrets.IPINFO_API_TOKEN }}
   IPINFO_API_TOKEN: {{ .Values.secrets.IPINFO_API_TOKEN | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.TEAMS_BOT_APP_ID }}
+  TEAMS_BOT_APP_ID: {{ .Values.secrets.TEAMS_BOT_APP_ID | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.TEAMS_BOT_APP_TENANT_ID }}
+  TEAMS_BOT_APP_TENANT_ID: {{ .Values.secrets.TEAMS_BOT_APP_TENANT_ID | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.TEAMS_BOT_APP_PASSWORD }}
+  TEAMS_BOT_APP_PASSWORD: {{ .Values.secrets.TEAMS_BOT_APP_PASSWORD | b64enc | quote }}
   {{- end }}
   {{- else }}
   NEXTAUTH_SECRET: {{ randAlphaNum 32 | b64enc | quote }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,6 +288,7 @@
         "@alga-psa/workflow-streams": "*",
         "@alga-psa/workflows": "*",
         "@microsoft/teams-js": "^2.28.0",
+        "jose": "^5.9.6",
         "lucide-react": "^0.428.0"
       },
       "devDependencies": {
@@ -298,6 +299,15 @@
         "next": "^16.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "ee/packages/microsoft-teams/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "ee/packages/workflows": {


### PR DESCRIPTION
  The bot messaging endpoint was returning TeamsBotResponseActivity inline in the HTTP response, which Teams ignores for `message` activities — replies must be POSTed separately to {serviceUrl}/v3/conversations/{id}/activities with an acquired OAuth  token. This adds a single-tenant token cache + sendActivity connector, inbound JWT verification against the Bot Framework JWKS, and wires TEAMS_BOT_APP_ID / TENANT_ID / PASSWORD through the helm chart and values-driven secret. TeamsBotActivity now carries serviceUrl, id, and recipient so the route can address the outbound reply.
  Also: buildTeamsFullPsaUrl returns /msp/dashboard for the default my_work destination so the Teams personal tab embeds the dashboard instead of rendering a dead-end "Signed in as…" card.

  And lo — Teams, like the Wizard behind the emerald curtain, pays no attention to the NextResponse.json shouting from the messaging endpoint. Only a Bearer-wielding POST trudging the yellow-brick  /v3/conversations/ road is ever truly heard. 🎩🌪️ ✨