### PR TITLE
Add service request starter examples

### DIFF
--- a/docs/plans/2026-04-16-service-request-template-starter-pack-design.md
+++ b/docs/plans/2026-04-16-service-request-template-starter-pack-design.md
@@ -1,0 +1,296 @@
+# Service Request Template Starter Pack Design
+
+Date: 2026-04-16
+Slug: `service-request-template-starter-pack`
+
+## Summary
+
+Define a stronger built-in service request starter pack for common MSP portal services. The current CE starter pack contains a single `New Hire` template. This design expands the pack to six practical, high-frequency templates that work well with the current CE architecture and field builder, while remaining future-friendly for richer EE workflow variants.
+
+The selected pack is:
+
+1. New Hire Onboarding
+2. Employee Offboarding
+3. Access Request
+4. Hardware Request
+5. Software / License Request
+6. Shared Mailbox / Distribution List Request
+
+## Current-State Findings
+
+Review of the current implementation shows:
+
+1. Templates are provider-owned in-memory definitions, not database-backed entities.
+2. CE currently ships one built-in template in `server/src/lib/service-requests/providers/builtins/starterTemplateProvider.ts`.
+3. Template instantiation already creates ordinary draft definitions with no persistent template linkage.
+4. The current CE-safe basic form field types are:
+   - `short-text`
+   - `long-text`
+   - `select`
+   - `checkbox`
+   - `date`
+   - `file-upload`
+5. Built-in CE templates should remain compatible with:
+   - `ticket-only` execution
+   - `basic` form behavior
+   - `all-authenticated-client-users` visibility
+6. The original service request PRD explicitly called out demand around:
+   - new hire onboarding
+   - offboarding
+   - access requests
+   - hardware requests
+   - software/license provisioning
+
+This means the best v1 template expansion is not a new architecture. It is a content expansion within the existing provider seam.
+
+## Recommended Approach
+
+Use a **core MSP service desk starter pack**.
+
+Why:
+
+1. It matches the original PRD examples and user demand.
+2. It provides immediate value in CE with `ticket-only` execution.
+3. It avoids niche or environment-specific templates that many MSPs would delete immediately.
+4. It leaves clean room for EE variants later without changing the template contract.
+
+## Design Decisions Confirmed
+
+The approved design choices are:
+
+1. **Template set:** Option A lifecycle/service-desk pack, plus the mailbox/group request template.
+2. **Count:** Six templates.
+3. **Language:** Vendor-neutral overall, with a light Microsoft 365 bias where natural.
+4. **Field density:** Balanced forms, roughly 6-10 fields per template.
+5. **Approval-ish fields:** Lightweight only, such as justification, needed-by date, and occasional manager name.
+6. **Categories:** Use suggested grouping labels in the design, but leave built-in template `category_id` unset in v1.
+7. **Naming convention:** Prefer process-style names over uniform `Request` suffixes.
+
+## Product Rules
+
+1. All built-in templates remain ordinary starter definitions after creation.
+2. No new database tables or schema changes are required.
+3. No template should assume EE workflow execution to be useful.
+4. Each template should be publishable as-is after routing configuration, but still easy to trim or adapt.
+5. Template copy should feel polished and service-oriented rather than generic or overly technical.
+6. Built-in templates should not match or create tenant `service_categories` rows as a side effect.
+
+## Starter Pack Definition
+
+### 1. New Hire Onboarding
+
+- **Suggested grouping:** People (left unset in template metadata)
+- **Icon:** `user-plus`
+- **Portal name:** `New Hire Onboarding`
+- **Description:** `Request setup for a new employee joining your organization.`
+- **Default ticket title:** `New Hire Onboarding: {{employee_name}}`
+
+**Fields**
+- `employee_name` — short-text — required
+- `start_date` — date — required
+- `job_title` — short-text — optional
+- `department` — short-text — optional
+- `manager_name` — short-text — optional
+- `work_location` — select — required
+  - Office
+  - Remote
+  - Hybrid
+- `employment_type` — select — optional
+  - Full-time
+  - Part-time
+  - Contractor
+  - Temporary
+- `device_requirements` — long-text — optional
+- `software_access_needed` — long-text — optional
+
+### 2. Employee Offboarding
+
+- **Suggested grouping:** People (left unset in template metadata)
+- **Icon:** `user-minus`
+- **Portal name:** `Employee Offboarding`
+- **Description:** `Request account shutdown and return handling for a departing employee.`
+- **Default ticket title:** `Employee Offboarding: {{employee_name}}`
+
+**Fields**
+- `employee_name` — short-text — required
+- `last_working_date` — date — required
+- `department` — short-text — optional
+- `manager_name` — short-text — optional
+- `disable_access_immediately` — checkbox — optional
+- `recover_company_equipment` — checkbox — optional
+- `mailbox_forwarding_contact` — short-text — optional
+- `offboarding_notes` — long-text — optional
+
+### 3. Access Request
+
+- **Suggested grouping:** Access (left unset in template metadata)
+- **Icon:** `key`
+- **Portal name:** `Access Request`
+- **Description:** `Request new, changed, or removed access to a system or application.`
+- **Default ticket title:** `Access Request: {{requested_for}} - {{application_or_system}}`
+
+**Fields**
+- `requested_for` — short-text — required
+- `application_or_system` — short-text — required
+- `request_type` — select — required
+  - New access
+  - Change existing access
+  - Remove access
+- `access_level_needed` — short-text — optional
+- `needed_by_date` — date — optional
+- `business_justification` — long-text — required
+- `manager_name` — short-text — optional
+- `supporting_attachment` — file-upload — optional
+
+### 4. Hardware Request
+
+- **Suggested grouping:** Devices & Software (left unset in template metadata)
+- **Icon:** `laptop`
+- **Portal name:** `Hardware Request`
+- **Description:** `Request new equipment, replacement hardware, or accessories.`
+- **Default ticket title:** `Hardware Request: {{requested_for}} - {{hardware_type}}`
+
+**Fields**
+- `requested_for` — short-text — required
+- `hardware_type` — select — required
+  - Laptop
+  - Desktop
+  - Monitor
+  - Dock
+  - Phone
+  - Accessory
+  - Other
+- `quantity` — short-text — required
+  - default: `1`
+- `request_reason` — select — optional
+  - New equipment
+  - Replacement
+  - Upgrade
+  - Loaner
+  - Other
+- `needed_by_date` — date — optional
+- `delivery_location` — short-text — optional
+- `business_justification` — long-text — required
+- `additional_details` — long-text — optional
+
+### 5. Software / License Request
+
+- **Suggested grouping:** Devices & Software (left unset in template metadata)
+- **Icon:** `app-window`
+- **Portal name:** `Software / License Request`
+- **Description:** `Request software installation, license provisioning, or additional seats.`
+- **Default ticket title:** `Software / License Request: {{requested_for}} - {{software_name}}`
+
+**Fields**
+- `requested_for` — short-text — required
+- `software_name` — short-text — required
+- `platform` — select — optional
+  - Windows
+  - macOS
+  - Web
+  - Mobile
+  - Other
+- `license_type_or_edition` — short-text — optional
+- `needed_by_date` — date — optional
+- `business_justification` — long-text — required
+- `manager_name` — short-text — optional
+- `vendor_quote_or_screenshot` — file-upload — optional
+- `additional_details` — long-text — optional
+
+### 6. Shared Mailbox / Distribution List Request
+
+- **Suggested grouping:** Collaboration (left unset in template metadata)
+- **Icon:** `mail`
+- **Portal name:** `Shared Mailbox / Distribution List Request`
+- **Description:** `Request a shared mailbox, distribution list, or Microsoft 365 group.`
+- **Default ticket title:** `Mailbox / Group Request: {{mailbox_or_group_name}}`
+
+**Fields**
+- `request_type` — select — required
+  - Shared mailbox
+  - Distribution list
+  - Microsoft 365 group
+- `mailbox_or_group_name` — short-text — required
+- `primary_owner` — short-text — required
+- `additional_members` — long-text — optional
+- `allow_external_senders` — checkbox — optional
+- `department_or_team` — short-text — optional
+- `needed_by_date` — date — optional
+- `business_purpose` — long-text — required
+- `additional_notes` — long-text — optional
+
+## Default Provider Selections
+
+For all six templates, the initial draft should use:
+
+- **Execution provider:** `ticket-only`
+- **Form behavior provider:** `basic`
+- **Visibility provider:** `all-authenticated-client-users`
+- **Linked service:** unset
+
+This keeps the starter pack fully usable in CE and preserves the expected template-instantiation behavior.
+
+## Category Strategy
+
+Use category groupings as design guidance only, but leave built-in template category metadata unset in v1.
+
+Suggested groupings are:
+
+- **People**
+  - New Hire Onboarding
+  - Employee Offboarding
+- **Access**
+  - Access Request
+- **Devices & Software**
+  - Hardware Request
+  - Software / License Request
+- **Collaboration**
+  - Shared Mailbox / Distribution List Request
+
+This avoids coupling starter templates to tenant-specific `service_categories` rows or silently creating billing/service taxonomy records during template instantiation.
+
+## Naming Strategy
+
+Use **process-style names** in the template picker and default metadata:
+
+- `New Hire Onboarding`
+- `Employee Offboarding`
+- `Access Request`
+- `Hardware Request`
+- `Software / License Request`
+- `Shared Mailbox / Distribution List Request`
+
+This is preferable to making every item a uniform `... Request` label because it feels more service-oriented and less like raw ticket form duplication.
+
+## Implementation Shape
+
+Likely touchpoints:
+
+- `server/src/lib/service-requests/providers/builtins/starterTemplateProvider.ts`
+- any tests covering template discovery and template draft creation
+- possibly management-page tests that assert template options or template creation behavior
+
+## Testing Focus
+
+Add or update tests for:
+
+1. template provider discovery returning the expanded CE starter pack
+2. each template producing a valid draft shape
+3. select fields including valid option lists
+4. file-upload fields being accepted in template form schemas
+5. default execution, form behavior, and visibility providers remaining CE-safe
+6. null category assignment, icon, and ticket title templates being stored correctly on instantiation
+
+## Non-Goals
+
+This design does not include:
+
+1. new database entities for templates
+2. EE-only workflow-specific template variants
+3. conditional field behavior in CE templates
+4. template marketplace or tenant-installable packs
+5. service-specific routing defaults such as board/category lookup heuristics
+
+## Conclusion
+
+The right v1 move is to strengthen the built-in starter pack with six broadly useful MSP service templates, using balanced forms, light M365 bias where natural, and polished process-style naming. This improves first-run value without changing the underlying service request architecture.

--- a/ee/docs/plans/2026-04-16-service-request-template-starter-pack/PRD.md
+++ b/ee/docs/plans/2026-04-16-service-request-template-starter-pack/PRD.md
@@ -1,0 +1,80 @@
+# PRD — Service Request Template Starter Pack
+
+- Slug: `service-request-template-starter-pack`
+- Date: `2026-04-16`
+- Status: Draft
+
+## Summary
+
+Expand the CE built-in service request starter pack from a single `New Hire` template to six common MSP service templates.
+
+The starter pack should provide practical, balanced forms that are immediately useful in CE with `ticket-only` execution, `basic` form behavior, and `all-authenticated-client-users` visibility.
+
+## Problem
+
+The current built-in template set is too thin to demonstrate the service request feature well. MSP admins only see one starter template, which makes the feature feel incomplete and reduces first-run value.
+
+## Goals
+
+- Add six common MSP starter templates to the CE starter pack.
+- Keep templates compatible with the current CE field builder and execution model.
+- Use polished process-style names and realistic portal copy.
+- Keep template instantiation behavior unchanged: templates become ordinary detached drafts.
+- Avoid mutating tenant billing/service categories as part of template creation.
+
+## Non-goals
+
+- Adding request-specific category tables or a broader category refactor.
+- Auto-creating `service_categories` rows during template creation.
+- Adding EE-only workflow assumptions to the CE starter pack.
+- Changing template/provider registry architecture.
+
+## Target Templates
+
+1. New Hire Onboarding
+2. Employee Offboarding
+3. Access Request
+4. Hardware Request
+5. Software / License Request
+6. Shared Mailbox / Distribution List Request
+
+## Functional Requirements
+
+### Template content
+
+Each template must define:
+- user-facing name
+- description
+- icon
+- basic-form schema with balanced fields
+- CE-safe provider defaults
+- a default ticket title template
+
+### Provider defaults
+
+Each built-in template must use:
+- execution provider: `ticket-only`
+- form behavior provider: `basic`
+- visibility provider: `all-authenticated-client-users`
+
+### Category handling
+
+Because template metadata only supports tenant-scoped `category_id` values and current service request categories reuse `service_categories`, built-in templates must leave category unset in v1.
+
+This avoids hidden category creation or billing taxonomy coupling.
+
+### Detached draft behavior
+
+Instantiating a template must still create a normal editable draft row with no persistent template linkage.
+
+## Acceptance Criteria
+
+- The CE starter provider exposes six templates.
+- `listServiceRequestTemplateOptions()` returns all six templates.
+- Instantiating any template creates a draft definition with:
+  - expected metadata
+  - expected form schema
+  - expected CE-safe providers
+  - `category_id = null`
+- Re-instantiating the same template produces a fresh draft unaffected by edits to prior template-derived drafts.
+- Tests cover template discovery and representative instantiation behavior.

--- a/ee/docs/plans/2026-04-16-service-request-template-starter-pack/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-16-service-request-template-starter-pack/SCRATCHPAD.md
@@ -1,0 +1,48 @@
+# Scratchpad — Service Request Template Starter Pack
+
+- Plan slug: `service-request-template-starter-pack`
+- Created: `2026-04-16`
+
+## Decisions
+
+- (2026-04-16) Expand the CE starter pack to six common MSP service templates.
+- (2026-04-16) Use process-style names for the template and default definition metadata.
+- (2026-04-16) In the management UI, selecting an example should create the draft and navigate directly to its editor instead of just returning to the list.
+- (2026-04-16) Keep the pack vendor-neutral overall with a light Microsoft 365 bias where natural.
+- (2026-04-16) Use balanced forms rather than minimal or highly prescriptive forms.
+- (2026-04-16) Include only lightweight approval-ish fields such as justification, needed-by date, and occasional manager name.
+- (2026-04-16) Leave `category_id` unset for all built-in templates because category assignment currently depends on tenant-scoped `service_categories` rows.
+
+## Discoveries / Constraints
+
+- (2026-04-16) Template drafts can only prefill `metadata.categoryId`, not a portable category name.
+- (2026-04-16) Service request definitions reuse `service_categories` for category linkage and publish-time category-name snapshots.
+- (2026-04-16) Auto-creating or name-matching categories during template instantiation would couple starter templates to tenant billing/service category data.
+- (2026-04-16) The CE-safe basic field types are `short-text`, `long-text`, `select`, `checkbox`, `date`, and `file-upload`.
+- (2026-04-16) Added `app-window` to the service request icon catalog so the Software / License template has a selectable editor icon, not just a renderable stored value.
+- (2026-04-16) The service request provider registry stores built-ins in a global singleton. In a long-lived dev server, hot reload could preserve a stale `ce-starter-pack` provider instance with only one template until the registry was refreshed.
+
+## Commands / Runbooks
+
+- Inspect current starter templates:
+  - `rg -n "starterTemplateProvider|listServiceRequestTemplateOptions|createServiceRequestDefinitionFromTemplate" server/src`
+- Run focused service request tests:
+  - `cd server && set -a && source ../.env.localtest && set +a && npx vitest run src/test/unit/service-requests/providerRegistry.unit.test.ts src/test/unit/service-requests/starterTemplateProvider.unit.test.ts src/test/integration/serviceRequestDefinitionManagement.integration.test.ts src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts`
+
+## Validation
+
+- (2026-04-16) Focused service request tests passed:
+  - `src/test/unit/service-requests/providerRegistry.unit.test.ts`
+  - `src/test/unit/service-requests/starterTemplateProvider.unit.test.ts`
+  - `src/test/integration/serviceRequestDefinitionManagement.integration.test.ts`
+  - `src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts`
+- (2026-04-16) Added a provider-registry regression test to verify built-ins refresh over stale singleton state during dev-style reloads.
+- (2026-04-16) Added a management-page unit test covering example selection -> draft creation -> router navigation to the new definition.
+
+## Links / References
+
+- CE starter template provider: `server/src/lib/service-requests/providers/builtins/starterTemplateProvider.ts`
+- Template instantiation path: `server/src/lib/service-requests/definitionManagement.ts`
+- Basic form schema validation: `server/src/lib/service-requests/basicFormBuilder.ts`
+- Original service request PRD: `ee/docs/plans/2026-03-29-service-request-definitions/PRD.md`
+- Design doc: `docs/plans/2026-04-16-service-request-template-starter-pack-design.md`

--- a/ee/docs/plans/2026-04-16-service-request-template-starter-pack/features.json
+++ b/ee/docs/plans/2026-04-16-service-request-template-starter-pack/features.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "F001",
+    "description": "Expand the CE starter template provider from one template to six common MSP service templates.",
+    "implemented": true
+  },
+  {
+    "id": "F002",
+    "description": "Keep all built-in starter templates CE-safe by using ticket-only execution, basic form behavior, and all-authenticated-client-users visibility.",
+    "implemented": true
+  },
+  {
+    "id": "F003",
+    "description": "Implement the New Hire Onboarding starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F004",
+    "description": "Implement the Employee Offboarding starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F005",
+    "description": "Implement the Access Request starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F006",
+    "description": "Implement the Hardware Request starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F007",
+    "description": "Implement the Software / License Request starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F008",
+    "description": "Implement the Shared Mailbox / Distribution List Request starter template with the agreed metadata, balanced field set, and ticket title template.",
+    "implemented": true
+  },
+  {
+    "id": "F009",
+    "description": "Leave built-in template categories unset instead of matching or creating tenant service categories.",
+    "implemented": true
+  },
+  {
+    "id": "F010",
+    "description": "Update automated tests to cover expanded template discovery, CE-safe draft validity, and representative instantiation behavior.",
+    "implemented": true
+  }
+]

--- a/ee/docs/plans/2026-04-16-service-request-template-starter-pack/tests.json
+++ b/ee/docs/plans/2026-04-16-service-request-template-starter-pack/tests.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit: the CE starter template provider exposes six templates and each template builds a valid CE-safe basic-form draft.",
+    "implemented": true,
+    "featureIds": ["F001", "F002", "F003", "F004", "F005", "F006", "F007", "F008", "F009"]
+  },
+  {
+    "id": "T002",
+    "description": "Integration: listServiceRequestTemplateOptions returns all six starter templates, including the legacy new-hire template id and the new template names/descriptions.",
+    "implemented": true,
+    "featureIds": ["F001", "F003", "F004", "F005", "F006", "F007", "F008"]
+  },
+  {
+    "id": "T003",
+    "description": "Integration: instantiating representative templates creates detached editable drafts with expected metadata, expected execution config, and null category_id.",
+    "implemented": true,
+    "featureIds": ["F002", "F003", "F006", "F009", "F010"]
+  }
+]

--- a/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
+++ b/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Button } from '@alga-psa/ui/components/Button';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
+import { Switch } from '@alga-psa/ui/components/Switch';
 import type { ColumnDefinition } from '@alga-psa/types';
 import { Archive, Copy, MoreVertical, Plus, Sparkles, Undo2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -53,12 +55,25 @@ function lifecycleLabel(row: ServiceRequestDefinitionRow): string {
 }
 
 export default function ServiceRequestsManagementPage() {
+  const router = useRouter();
   const [definitions, setDefinitions] = useState<ServiceRequestDefinitionRow[]>([]);
   const [templates, setTemplates] = useState<ServiceRequestTemplateRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const hasTemplates = templates.length > 0;
+  const archivedCount = useMemo(
+    () => definitions.filter((definition) => definition.lifecycle_state === 'archived').length,
+    [definitions]
+  );
+  const visibleDefinitions = useMemo(
+    () =>
+      showArchived
+        ? definitions
+        : definitions.filter((definition) => definition.lifecycle_state !== 'archived'),
+    [definitions, showArchived]
+  );
 
   const reload = async () => {
     const [definitionsResult, templatesResult] = await Promise.all([
@@ -204,6 +219,13 @@ export default function ServiceRequestsManagementPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <Switch
+            id="service-request-show-archived-toggle"
+            checked={showArchived}
+            onCheckedChange={(checked) => setShowArchived(checked === true)}
+            disabled={loading || archivedCount === 0}
+            label={`Show archived${archivedCount > 0 ? ` (${archivedCount})` : ''}`}
+          />
           <Button
             id="service-request-create-blank"
             onClick={() =>
@@ -231,7 +253,7 @@ export default function ServiceRequestsManagementPage() {
                 disabled={!hasTemplates || isPending}
               >
                 <Sparkles className="mr-2 h-4 w-4" />
-                Create from Template
+                Start from Example
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -241,15 +263,15 @@ export default function ServiceRequestsManagementPage() {
                   onClick={() =>
                     startTransition(async () => {
                       try {
-                        await createServiceRequestDefinitionFromTemplateAction(
+                        const created = await createServiceRequestDefinitionFromTemplateAction(
                           template.providerKey,
                           template.templateId
                         );
-                        await reload();
-                        toast.success(`Draft created from ${template.templateName}`);
+                        toast.success(`Draft created from example: ${template.templateName}`);
+                        router.push(`/msp/service-requests/${created.definition_id}`);
                       } catch (error) {
                         console.error('Failed to create draft from template', error);
-                        toast.error('Failed to create from template');
+                        toast.error('Failed to create from example');
                       }
                     })
                   }
@@ -264,7 +286,7 @@ export default function ServiceRequestsManagementPage() {
 
       <DataTable
         id="service-requests-management-table"
-        data={definitions}
+        data={visibleDefinitions}
         columns={columns}
         pagination={true}
         currentPage={1}

--- a/server/src/lib/service-requests/iconCatalog.ts
+++ b/server/src/lib/service-requests/iconCatalog.ts
@@ -16,6 +16,7 @@ export const SERVICE_REQUEST_ICON_OPTIONS: ServiceRequestIconOption[] = [
   { value: 'server', label: 'Server' },
   { value: 'network', label: 'Network' },
   { value: 'wifi', label: 'Wi-Fi' },
+  { value: 'app-window', label: 'Software' },
   { value: 'mail', label: 'Email' },
   { value: 'phone', label: 'Phone' },
   { value: 'folder-open', label: 'Shared Files' },

--- a/server/src/lib/service-requests/providers/builtins/starterTemplateProvider.ts
+++ b/server/src/lib/service-requests/providers/builtins/starterTemplateProvider.ts
@@ -1,38 +1,400 @@
 import type {
   ServiceRequestTemplateDefinition,
+  ServiceRequestTemplateDraft,
   ServiceRequestTemplateProvider,
 } from '../contracts';
+import type { BasicFormField } from '../../basicFormBuilder';
+
+function buildCeStarterProviders(executionConfig: Record<string, unknown>) {
+  return {
+    executionProvider: 'ticket-only',
+    executionConfig,
+    formBehaviorProvider: 'basic',
+    formBehaviorConfig: {},
+    visibilityProvider: 'all-authenticated-client-users',
+    visibilityConfig: {},
+  };
+}
+
+function buildTemplateDraft(
+  metadata: ServiceRequestTemplateDraft['metadata'],
+  fields: BasicFormField[],
+  executionConfig: Record<string, unknown>
+): ServiceRequestTemplateDraft {
+  return {
+    metadata,
+    formSchema: {
+      fields,
+    },
+    providers: buildCeStarterProviders(executionConfig),
+  };
+}
 
 const starterTemplates: ServiceRequestTemplateDefinition[] = [
   {
     id: 'new-hire',
-    name: 'New Hire',
-    description: 'Collect baseline onboarding information for a new employee.',
-    buildDraft: () => ({
-      metadata: {
-        name: 'New Hire Request',
-        description: 'Request setup for a new team member.',
-        icon: 'user-plus',
-      },
-      formSchema: {
-        fields: [
+    name: 'New Hire Onboarding',
+    description: 'Request setup for a new employee joining your organization.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'New Hire Onboarding',
+          description: 'Request setup for a new employee joining your organization.',
+          icon: 'user-plus',
+        },
+        [
           { key: 'employee_name', type: 'short-text', label: 'Employee Name', required: true },
           { key: 'start_date', type: 'date', label: 'Start Date', required: true },
+          { key: 'job_title', type: 'short-text', label: 'Job Title', required: false },
           { key: 'department', type: 'short-text', label: 'Department', required: false },
+          { key: 'manager_name', type: 'short-text', label: 'Manager Name', required: false },
+          {
+            key: 'work_location',
+            type: 'select',
+            label: 'Work Location',
+            required: true,
+            options: [
+              { label: 'Office', value: 'Office' },
+              { label: 'Remote', value: 'Remote' },
+              { label: 'Hybrid', value: 'Hybrid' },
+            ],
+          },
+          {
+            key: 'employment_type',
+            type: 'select',
+            label: 'Employment Type',
+            required: false,
+            options: [
+              { label: 'Full-time', value: 'Full-time' },
+              { label: 'Part-time', value: 'Part-time' },
+              { label: 'Contractor', value: 'Contractor' },
+              { label: 'Temporary', value: 'Temporary' },
+            ],
+          },
+          {
+            key: 'device_requirements',
+            type: 'long-text',
+            label: 'Device Requirements',
+            required: false,
+          },
+          {
+            key: 'software_access_needed',
+            type: 'long-text',
+            label: 'Software / Access Needed',
+            required: false,
+          },
         ],
-      },
-      providers: {
-        executionProvider: 'ticket-only',
-        executionConfig: {
-          titleTemplate: 'New Hire Setup: {{employee_name}}',
+        {
+          titleTemplate: 'New Hire Onboarding: {{employee_name}}',
           includeFormResponsesInDescription: true,
+        }
+      ),
+  },
+  {
+    id: 'employee-offboarding',
+    name: 'Employee Offboarding',
+    description: 'Request account shutdown and return handling for a departing employee.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'Employee Offboarding',
+          description: 'Request account shutdown and return handling for a departing employee.',
+          icon: 'user-minus',
         },
-        formBehaviorProvider: 'basic',
-        formBehaviorConfig: {},
-        visibilityProvider: 'all-authenticated-client-users',
-        visibilityConfig: {},
-      },
-    }),
+        [
+          { key: 'employee_name', type: 'short-text', label: 'Employee Name', required: true },
+          { key: 'last_working_date', type: 'date', label: 'Last Working Date', required: true },
+          { key: 'department', type: 'short-text', label: 'Department', required: false },
+          { key: 'manager_name', type: 'short-text', label: 'Manager Name', required: false },
+          {
+            key: 'disable_access_immediately',
+            type: 'checkbox',
+            label: 'Disable Access Immediately',
+            required: false,
+          },
+          {
+            key: 'recover_company_equipment',
+            type: 'checkbox',
+            label: 'Recover Company Equipment',
+            required: false,
+          },
+          {
+            key: 'mailbox_forwarding_contact',
+            type: 'short-text',
+            label: 'Mailbox Forwarding Contact',
+            required: false,
+          },
+          {
+            key: 'offboarding_notes',
+            type: 'long-text',
+            label: 'Additional Notes',
+            required: false,
+          },
+        ],
+        {
+          titleTemplate: 'Employee Offboarding: {{employee_name}}',
+          includeFormResponsesInDescription: true,
+        }
+      ),
+  },
+  {
+    id: 'access-request',
+    name: 'Access Request',
+    description: 'Request new, changed, or removed access to a system or application.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'Access Request',
+          description: 'Request new, changed, or removed access to a system or application.',
+          icon: 'key-round',
+        },
+        [
+          { key: 'requested_for', type: 'short-text', label: 'Requested For', required: true },
+          {
+            key: 'application_or_system',
+            type: 'short-text',
+            label: 'Application or System',
+            required: true,
+          },
+          {
+            key: 'request_type',
+            type: 'select',
+            label: 'Request Type',
+            required: true,
+            options: [
+              { label: 'New access', value: 'New access' },
+              { label: 'Change existing access', value: 'Change existing access' },
+              { label: 'Remove access', value: 'Remove access' },
+            ],
+          },
+          {
+            key: 'access_level_needed',
+            type: 'short-text',
+            label: 'Access Level Needed',
+            required: false,
+          },
+          { key: 'needed_by_date', type: 'date', label: 'Needed By Date', required: false },
+          {
+            key: 'business_justification',
+            type: 'long-text',
+            label: 'Business Justification',
+            required: true,
+          },
+          { key: 'manager_name', type: 'short-text', label: 'Manager Name', required: false },
+          {
+            key: 'supporting_attachment',
+            type: 'file-upload',
+            label: 'Supporting Attachment',
+            required: false,
+          },
+        ],
+        {
+          titleTemplate: 'Access Request: {{requested_for}} - {{application_or_system}}',
+          includeFormResponsesInDescription: true,
+        }
+      ),
+  },
+  {
+    id: 'hardware-request',
+    name: 'Hardware Request',
+    description: 'Request new equipment, replacement hardware, or accessories.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'Hardware Request',
+          description: 'Request new equipment, replacement hardware, or accessories.',
+          icon: 'laptop',
+        },
+        [
+          { key: 'requested_for', type: 'short-text', label: 'Requested For', required: true },
+          {
+            key: 'hardware_type',
+            type: 'select',
+            label: 'Hardware Type',
+            required: true,
+            options: [
+              { label: 'Laptop', value: 'Laptop' },
+              { label: 'Desktop', value: 'Desktop' },
+              { label: 'Monitor', value: 'Monitor' },
+              { label: 'Dock', value: 'Dock' },
+              { label: 'Phone', value: 'Phone' },
+              { label: 'Accessory', value: 'Accessory' },
+              { label: 'Other', value: 'Other' },
+            ],
+          },
+          {
+            key: 'quantity',
+            type: 'short-text',
+            label: 'Quantity',
+            required: true,
+            defaultValue: '1',
+          },
+          {
+            key: 'request_reason',
+            type: 'select',
+            label: 'Request Reason',
+            required: false,
+            options: [
+              { label: 'New equipment', value: 'New equipment' },
+              { label: 'Replacement', value: 'Replacement' },
+              { label: 'Upgrade', value: 'Upgrade' },
+              { label: 'Loaner', value: 'Loaner' },
+              { label: 'Other', value: 'Other' },
+            ],
+          },
+          { key: 'needed_by_date', type: 'date', label: 'Needed By Date', required: false },
+          {
+            key: 'delivery_location',
+            type: 'short-text',
+            label: 'Delivery Location',
+            required: false,
+          },
+          {
+            key: 'business_justification',
+            type: 'long-text',
+            label: 'Business Justification',
+            required: true,
+          },
+          {
+            key: 'additional_details',
+            type: 'long-text',
+            label: 'Additional Details',
+            required: false,
+          },
+        ],
+        {
+          titleTemplate: 'Hardware Request: {{requested_for}} - {{hardware_type}}',
+          includeFormResponsesInDescription: true,
+        }
+      ),
+  },
+  {
+    id: 'software-license-request',
+    name: 'Software / License Request',
+    description: 'Request software installation, license provisioning, or additional seats.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'Software / License Request',
+          description: 'Request software installation, license provisioning, or additional seats.',
+          icon: 'app-window',
+        },
+        [
+          { key: 'requested_for', type: 'short-text', label: 'Requested For', required: true },
+          { key: 'software_name', type: 'short-text', label: 'Software Name', required: true },
+          {
+            key: 'platform',
+            type: 'select',
+            label: 'Platform',
+            required: false,
+            options: [
+              { label: 'Windows', value: 'Windows' },
+              { label: 'macOS', value: 'macOS' },
+              { label: 'Web', value: 'Web' },
+              { label: 'Mobile', value: 'Mobile' },
+              { label: 'Other', value: 'Other' },
+            ],
+          },
+          {
+            key: 'license_type_or_edition',
+            type: 'short-text',
+            label: 'License Type or Edition',
+            required: false,
+          },
+          { key: 'needed_by_date', type: 'date', label: 'Needed By Date', required: false },
+          {
+            key: 'business_justification',
+            type: 'long-text',
+            label: 'Business Justification',
+            required: true,
+          },
+          { key: 'manager_name', type: 'short-text', label: 'Manager Name', required: false },
+          {
+            key: 'vendor_quote_or_screenshot',
+            type: 'file-upload',
+            label: 'Vendor Quote or Screenshot',
+            required: false,
+          },
+          {
+            key: 'additional_details',
+            type: 'long-text',
+            label: 'Additional Details',
+            required: false,
+          },
+        ],
+        {
+          titleTemplate: 'Software / License Request: {{requested_for}} - {{software_name}}',
+          includeFormResponsesInDescription: true,
+        }
+      ),
+  },
+  {
+    id: 'shared-mailbox-distribution-list',
+    name: 'Shared Mailbox / Distribution List Request',
+    description: 'Request a shared mailbox, distribution list, or Microsoft 365 group.',
+    buildDraft: () =>
+      buildTemplateDraft(
+        {
+          name: 'Shared Mailbox / Distribution List Request',
+          description: 'Request a shared mailbox, distribution list, or Microsoft 365 group.',
+          icon: 'mail',
+        },
+        [
+          {
+            key: 'request_type',
+            type: 'select',
+            label: 'Request Type',
+            required: true,
+            options: [
+              { label: 'Shared mailbox', value: 'Shared mailbox' },
+              { label: 'Distribution list', value: 'Distribution list' },
+              { label: 'Microsoft 365 group', value: 'Microsoft 365 group' },
+            ],
+          },
+          {
+            key: 'mailbox_or_group_name',
+            type: 'short-text',
+            label: 'Mailbox or Group Name',
+            required: true,
+          },
+          { key: 'primary_owner', type: 'short-text', label: 'Primary Owner', required: true },
+          {
+            key: 'additional_members',
+            type: 'long-text',
+            label: 'Additional Members',
+            required: false,
+          },
+          {
+            key: 'allow_external_senders',
+            type: 'checkbox',
+            label: 'Allow External Senders',
+            required: false,
+          },
+          {
+            key: 'department_or_team',
+            type: 'short-text',
+            label: 'Department or Team',
+            required: false,
+          },
+          { key: 'needed_by_date', type: 'date', label: 'Needed By Date', required: false },
+          {
+            key: 'business_purpose',
+            type: 'long-text',
+            label: 'Business Purpose',
+            required: true,
+          },
+          {
+            key: 'additional_notes',
+            type: 'long-text',
+            label: 'Additional Notes',
+            required: false,
+          },
+        ],
+        {
+          titleTemplate: 'Mailbox / Group Request: {{mailbox_or_group_name}}',
+          includeFormResponsesInDescription: true,
+        }
+      ),
   },
 ];
 

--- a/server/src/lib/service-requests/providers/registry.ts
+++ b/server/src/lib/service-requests/providers/registry.ts
@@ -72,6 +72,10 @@ function createStoreWithBuiltIns(): ServiceRequestProviderRegistryStore {
 function getOrCreateStore(): ServiceRequestProviderRegistryStore {
   if (!globalThis.__algaServiceRequestProviderRegistry) {
     globalThis.__algaServiceRequestProviderRegistry = createStoreWithBuiltIns();
+  } else {
+    // Re-register built-ins on access so dev hot reloads refresh updated provider definitions
+    // without dropping any separately-registered enterprise providers stored in the singleton.
+    registerStoreProviders(globalThis.__algaServiceRequestProviderRegistry, builtInRegistrations);
   }
   return globalThis.__algaServiceRequestProviderRegistry;
 }

--- a/server/src/test/integration/serviceRequestDefinitionManagement.integration.test.ts
+++ b/server/src/test/integration/serviceRequestDefinitionManagement.integration.test.ts
@@ -36,6 +36,7 @@ describe('service request definition management', () => {
     });
 
     const templates = listServiceRequestTemplateOptions();
+    expect(templates).toHaveLength(6);
     const starterTemplate = templates.find(
       (template) => template.providerKey === 'ce-starter-pack' && template.templateId === 'new-hire'
     );

--- a/server/src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts
+++ b/server/src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts
@@ -33,10 +33,25 @@ describe('service request template instantiation', () => {
     });
 
     const templates = listServiceRequestTemplateOptions();
+    expect(templates).toHaveLength(6);
+    expect(templates.map((template) => template.templateName)).toEqual([
+      'New Hire Onboarding',
+      'Employee Offboarding',
+      'Access Request',
+      'Hardware Request',
+      'Software / License Request',
+      'Shared Mailbox / Distribution List Request',
+    ]);
+
     const newHireTemplate = templates.find(
       (template) => template.providerKey === 'ce-starter-pack' && template.templateId === 'new-hire'
     );
+    const hardwareTemplate = templates.find(
+      (template) =>
+        template.providerKey === 'ce-starter-pack' && template.templateId === 'hardware-request'
+    );
     expect(newHireTemplate).toBeDefined();
+    expect(hardwareTemplate).toBeDefined();
 
     const blankDraft = await createBlankServiceRequestDefinition({
       knex: db,
@@ -76,14 +91,43 @@ describe('service request template instantiation', () => {
       createdBy: actor,
     });
 
+    const hardwareDraft = await createServiceRequestDefinitionFromTemplate({
+      knex: db,
+      tenant,
+      templateProviderKey: hardwareTemplate!.providerKey,
+      templateId: hardwareTemplate!.templateId,
+      createdBy: actor,
+    });
+
     const storedB = await db('service_request_definitions')
       .where({ tenant, definition_id: templateDraftB.definition_id })
-      .first('name', 'execution_config');
+      .first('name', 'category_id', 'execution_config');
 
-    expect(storedB?.name).toBe('New Hire Request');
+    const storedHardware = await db('service_request_definitions')
+      .where({ tenant, definition_id: hardwareDraft.definition_id })
+      .first('name', 'category_id', 'form_schema', 'execution_config');
+
+    expect(storedB?.name).toBe('New Hire Onboarding');
+    expect(storedB?.category_id).toBeNull();
     expect(storedB?.execution_config).toEqual({
-      titleTemplate: 'New Hire Setup: {{employee_name}}',
+      titleTemplate: 'New Hire Onboarding: {{employee_name}}',
       includeFormResponsesInDescription: true,
+    });
+
+    expect(storedHardware?.name).toBe('Hardware Request');
+    expect(storedHardware?.category_id).toBeNull();
+    expect(storedHardware?.execution_config).toEqual({
+      titleTemplate: 'Hardware Request: {{requested_for}} - {{hardware_type}}',
+      includeFormResponsesInDescription: true,
+    });
+    expect(storedHardware?.form_schema).toMatchObject({
+      fields: expect.arrayContaining([
+        expect.objectContaining({
+          key: 'quantity',
+          type: 'short-text',
+          defaultValue: '1',
+        }),
+      ]),
     });
   });
 });

--- a/server/src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx
+++ b/server/src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+(globalThis as unknown as { React?: typeof React }).React = React;
+
+const {
+  pushMock,
+  listServiceRequestDefinitionsActionMock,
+  listServiceRequestTemplatesActionMock,
+  createServiceRequestDefinitionFromTemplateActionMock,
+  toastSuccessMock,
+  toastErrorMock,
+} = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  listServiceRequestDefinitionsActionMock: vi.fn(),
+  listServiceRequestTemplatesActionMock: vi.fn(),
+  createServiceRequestDefinitionFromTemplateActionMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('../../../../../app/msp/service-requests/actions', () => ({
+  archiveServiceRequestDefinitionAction: vi.fn(),
+  createBlankServiceRequestDefinitionAction: vi.fn(),
+  createServiceRequestDefinitionFromTemplateAction: (...args: unknown[]) =>
+    createServiceRequestDefinitionFromTemplateActionMock(...args),
+  duplicateServiceRequestDefinitionAction: vi.fn(),
+  listServiceRequestDefinitionsAction: (...args: unknown[]) =>
+    listServiceRequestDefinitionsActionMock(...args),
+  listServiceRequestTemplatesAction: (...args: unknown[]) =>
+    listServiceRequestTemplatesActionMock(...args),
+  unarchiveServiceRequestDefinitionAction: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DataTable', () => ({
+  DataTable: ({ data }: { data: Array<{ definition_id: string; name: string }> }) => (
+    <div data-testid="service-requests-table">
+      {data.map((row) => (
+        <div key={row.definition_id}>{row.name}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Switch', () => ({
+  Switch: ({
+    id,
+    checked,
+    onCheckedChange,
+    disabled,
+    label,
+  }: {
+    id?: string;
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    disabled?: boolean;
+    label?: string;
+  }) => (
+    <label htmlFor={id}>
+      <input
+        id={id}
+        type="checkbox"
+        role="switch"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onCheckedChange?.(event.target.checked)}
+      />
+      {label}
+    </label>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+}));
+
+const { default: ServiceRequestsManagementPage } = await import(
+  '../../../../../app/msp/service-requests/ServiceRequestsManagementPage'
+);
+
+describe('ServiceRequestsManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    listServiceRequestDefinitionsActionMock.mockResolvedValue([]);
+    listServiceRequestTemplatesActionMock.mockResolvedValue([
+      {
+        providerKey: 'ce-starter-pack',
+        templateId: 'new-hire',
+        templateName: 'New Hire Onboarding',
+        providerDisplayName: 'CE Starter Pack',
+      },
+    ]);
+    createServiceRequestDefinitionFromTemplateActionMock.mockResolvedValue({
+      definition_id: 'definition-123',
+    });
+  });
+
+  it('creates a draft from an example and opens the editor page immediately', async () => {
+    render(<ServiceRequestsManagementPage />);
+
+    await screen.findByText('New Hire Onboarding');
+
+    fireEvent.click(screen.getByText(/New Hire Onboarding/));
+
+    await waitFor(() => {
+      expect(createServiceRequestDefinitionFromTemplateActionMock).toHaveBeenCalledWith(
+        'ce-starter-pack',
+        'new-hire'
+      );
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Draft created from example: New Hire Onboarding'
+    );
+    expect(pushMock).toHaveBeenCalledWith('/msp/service-requests/definition-123');
+    expect(listServiceRequestDefinitionsActionMock).toHaveBeenCalledTimes(1);
+    expect(listServiceRequestTemplatesActionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides archived service requests by default and reveals them when toggled on', async () => {
+    listServiceRequestDefinitionsActionMock.mockResolvedValue([
+      {
+        definition_id: 'definition-active',
+        name: 'Active Request',
+        description: null,
+        lifecycle_state: 'draft',
+        published_at: null,
+        updated_at: '2026-04-16T00:00:00.000Z',
+      },
+      {
+        definition_id: 'definition-archived',
+        name: 'Archived Request',
+        description: null,
+        lifecycle_state: 'archived',
+        published_at: null,
+        updated_at: '2026-04-16T00:00:00.000Z',
+      },
+    ]);
+
+    render(<ServiceRequestsManagementPage />);
+
+    await screen.findByText('Active Request');
+
+    expect(screen.queryByText('Archived Request')).toBeNull();
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Show archived (1)' }));
+
+    expect(await screen.findByText('Archived Request')).toBeTruthy();
+    expect(
+      (screen.getByRole('switch', { name: 'Show archived (1)' }) as HTMLInputElement).checked
+    ).toBe(true);
+  });
+});

--- a/server/src/test/unit/service-requests/providerRegistry.unit.test.ts
+++ b/server/src/test/unit/service-requests/providerRegistry.unit.test.ts
@@ -36,6 +36,38 @@ describe('service request provider registry', () => {
     expect(getServiceRequestTemplateProvider('ce-starter-pack')).toBeDefined();
   });
 
+  it('T004: built-ins refresh over stale singleton state during dev-style reloads', () => {
+    const staleTemplateProvider = {
+      key: 'ce-starter-pack',
+      displayName: 'CE Starter Pack',
+      listTemplates: () => [
+        {
+          id: 'stale-only',
+          name: 'Stale Only',
+          description: 'stale',
+          buildDraft: () => {
+            throw new Error('Should not use stale template provider');
+          },
+        },
+      ],
+    };
+
+    globalThis.__algaServiceRequestProviderRegistry = {
+      executionProviders: new Map(),
+      formBehaviorProviders: new Map(),
+      visibilityProviders: new Map(),
+      templateProviders: new Map([['ce-starter-pack', staleTemplateProvider as any]]),
+      adminExtensionProviders: new Map(),
+    };
+
+    const templateIds = getServiceRequestTemplateProvider('ce-starter-pack')
+      ?.listTemplates()
+      .map((template) => template.id);
+
+    expect(templateIds).toContain('new-hire');
+    expect(templateIds).not.toContain('stale-only');
+  });
+
   it('T004: CE build remains coherent when enterprise provider registrations are absent', async () => {
     const registrations = await loadEnterpriseServiceRequestProviderRegistrations();
 

--- a/server/src/test/unit/service-requests/starterTemplateProvider.unit.test.ts
+++ b/server/src/test/unit/service-requests/starterTemplateProvider.unit.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getServiceRequestTemplateProvider,
+  resetServiceRequestProviderRegistry,
+  validateBasicFormSchema,
+} from '../../../lib/service-requests';
+
+describe('CE starter template provider', () => {
+  beforeEach(() => {
+    resetServiceRequestProviderRegistry();
+  });
+
+  it('T001: exposes six CE-safe starter templates with valid basic form schemas', () => {
+    const provider = getServiceRequestTemplateProvider('ce-starter-pack');
+
+    expect(provider).toBeDefined();
+
+    const templates = provider!.listTemplates();
+    expect(templates.map((template) => template.id)).toEqual([
+      'new-hire',
+      'employee-offboarding',
+      'access-request',
+      'hardware-request',
+      'software-license-request',
+      'shared-mailbox-distribution-list',
+    ]);
+
+    for (const template of templates) {
+      const draft = template.buildDraft();
+      const validation = validateBasicFormSchema(draft.formSchema);
+
+      expect(validation.isValid, `${template.id}: ${validation.errors.join(', ')}`).toBe(true);
+      expect(draft.metadata.categoryId ?? null).toBeNull();
+      expect(draft.providers).toEqual({
+        executionProvider: 'ticket-only',
+        executionConfig: draft.providers.executionConfig,
+        formBehaviorProvider: 'basic',
+        formBehaviorConfig: {},
+        visibilityProvider: 'all-authenticated-client-users',
+        visibilityConfig: {},
+      });
+      expect(draft.providers.executionConfig).toMatchObject({
+        includeFormResponsesInDescription: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expand the CE service request starter pack from one template to six built-in examples
- update the management UI to use example-oriented copy, open the new draft immediately, and add a standard switch to show archived definitions
- refresh built-in provider registrations across dev hot reloads and add focused test coverage plus plan docs

## Testing
- cd server && set -a && source ../.env.localtest && set +a && npx vitest run src/test/unit/app/msp/service-requests/ServiceRequestsManagementPage.test.tsx src/test/unit/service-requests/providerRegistry.unit.test.ts src/test/unit/service-requests/starterTemplateProvider.unit.test.ts src/test/integration/serviceRequestDefinitionManagement.integration.test.ts src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts