### PR TITLE
feat(n8n): add Project Task CRUD to community node

### DIFF
--- a/packages/n8n-nodes-alga-psa/README.md
+++ b/packages/n8n-nodes-alga-psa/README.md
@@ -11,6 +11,7 @@ This package adds one node to n8n:
 - Resources:
   - Ticket
   - Contact
+  - Project Task
   - Client
   - Board
   - Status
@@ -56,6 +57,7 @@ Create credential type `Alga PSA API` with:
 | --- | --- |
 | Ticket | Create, Get, List, List Comments, Search, Update, Add Comment, Update Status, Update Assignment, Delete |
 | Contact | Create, Get, List, Update, Delete |
+| Project Task | Create, Get, List, Update, Delete |
 | Client | List |
 | Board | List |
 | Status | List |
@@ -104,6 +106,35 @@ Contact list supports:
 `additional_email_addresses` is authored as JSON and should be an array of objects with a required `email_address` field plus optional `canonical_type`, `custom_type`, and `display_order`.
 
 Use `primary_email_canonical_type` for canonical labels such as `work`, `personal`, `billing`, or `other`. Use `primary_email_custom_type` when you need a freeform primary label instead.
+
+## Project Task Field Requirements
+
+Project Task create requires:
+
+- `task_name`
+- `Project ID` (resource locator with search or manual UUID)
+- `Phase ID` (within the selected project)
+- `Status Mapping ID` (project-specific task status mapping)
+
+Project Task create/update optional fields:
+
+- `description`
+- `assigned_to` (user UUID)
+- `estimated_hours`
+- `due_date` (ISO date/time string)
+- `priority_id`
+- `task_type_key` (server defaults to `general`)
+- `wbs_code`
+- `tags` (comma-separated)
+- Update also accepts `task_name` and `project_status_mapping_id` in its collection
+
+Project Task list requires a `Project ID` and supports `Page` and `Limit`. The server
+returns all tasks for the selected project; filter downstream if you need phase-level
+slicing. `Get`, `Update`, and `Delete` operate on a task UUID regardless of project.
+
+Status Mapping IDs are project-specific. Use the `Status Mapping ID` lookup after
+selecting a project, or fetch candidates via
+`GET /api/v1/projects/{id}/task-status-mappings`.
 
 ## Ticket Comment Operations
 

--- a/packages/n8n-nodes-alga-psa/RELEASE_NOTES.md
+++ b/packages/n8n-nodes-alga-psa/RELEASE_NOTES.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 0.4.0
+
+Feature release of the `Alga PSA` n8n community node.
+
+### Added
+
+- First-pass `Project Task` CRUD support: `Create`, `Get`, `List`, `Update`, and `Delete`
+- Project Task create required fields: `task_name`, `projectTaskProjectId`, `projectTaskPhaseId`, and `projectTaskStatusMappingId`
+- Project Task create/update optional fields: `description`, `assigned_to`, `estimated_hours`, `due_date`, `priority_id`, `task_type_key`, `wbs_code`, and comma-separated `tags` (update also accepts `task_name` and `project_status_mapping_id`)
+- Project Task list pagination (`page`, `limit`) scoped to a selected project
+- New lookup dropdowns backed by `searchProjects`, `searchProjectPhases`, and `searchProjectTaskStatusMappings` (phases and status mappings are scoped to the currently-selected project; empty selections fall back to manual UUID entry)
+
+### Notes
+
+- Checklist items, task dependencies, and ticket-task links are intentionally out of scope for the first pass and can be added in a follow-up
+- Project Task responses follow the existing node normalization rules for `{ data: ... }`, list pagination, delete success payloads, and continue-on-fail item errors
+
 ## 0.3.0
 
 Feature release of the `Alga PSA` n8n community node.

--- a/packages/n8n-nodes-alga-psa/__tests__/helpers.test.ts
+++ b/packages/n8n-nodes-alga-psa/__tests__/helpers.test.ts
@@ -3,6 +3,9 @@ import {
   buildContactCreatePayload,
   buildContactListQuery,
   buildContactUpdatePayload,
+  buildProjectTaskCreatePayload,
+  buildProjectTaskListQuery,
+  buildProjectTaskUpdatePayload,
   formatAlgaApiError,
   normalizeSuccessResponse,
   parseContactEmailAddresses,
@@ -332,5 +335,92 @@ describe('Transport and normalization helpers', () => {
         display_order: 0,
       },
     ]);
+  });
+
+  it('T070: project task create payload maps required fields and omits absent optional fields', () => {
+    const payload = buildProjectTaskCreatePayload({
+      taskName: 'Write specification',
+      statusMappingId: '00000000-0000-0000-0000-000000000301',
+      additionalFields: {},
+    });
+
+    expect(payload).toEqual({
+      task_name: 'Write specification',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000301',
+    });
+  });
+
+  it('T071: project task create payload includes scalar optional fields when present', () => {
+    const payload = buildProjectTaskCreatePayload({
+      taskName: 'Write specification',
+      statusMappingId: '00000000-0000-0000-0000-000000000301',
+      additionalFields: {
+        description: 'Draft the functional spec',
+        assigned_to: '00000000-0000-0000-0000-000000000302',
+        estimated_hours: 4.5,
+        due_date: '2026-05-01',
+        priority_id: '00000000-0000-0000-0000-000000000303',
+        task_type_key: 'design',
+        wbs_code: '1.1',
+        tags: 'backend, planning',
+      },
+    });
+
+    expect(payload).toEqual({
+      task_name: 'Write specification',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000301',
+      description: 'Draft the functional spec',
+      assigned_to: '00000000-0000-0000-0000-000000000302',
+      estimated_hours: 4.5,
+      due_date: '2026-05-01',
+      priority_id: '00000000-0000-0000-0000-000000000303',
+      task_type_key: 'design',
+      wbs_code: '1.1',
+      tags: ['backend', 'planning'],
+    });
+  });
+
+  it('T072: project task create payload rejects non-UUID assigned_to before request time', () => {
+    expect(() =>
+      buildProjectTaskCreatePayload({
+        taskName: 'Task',
+        statusMappingId: '00000000-0000-0000-0000-000000000301',
+        additionalFields: { assigned_to: 'not-a-uuid' },
+      }),
+    ).toThrow('assigned_to must be a valid UUID');
+  });
+
+  it('T073: project task create payload rejects negative estimated_hours before request time', () => {
+    expect(() =>
+      buildProjectTaskCreatePayload({
+        taskName: 'Task',
+        statusMappingId: '00000000-0000-0000-0000-000000000301',
+        additionalFields: { estimated_hours: -1 },
+      }),
+    ).toThrow('estimated_hours must be a non-negative number');
+  });
+
+  it('T074: project task update payload includes only provided update fields', () => {
+    const payload = buildProjectTaskUpdatePayload({
+      task_name: 'Renamed',
+      description: '',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000304',
+      tags: 'escalated',
+    });
+
+    expect(payload).toEqual({
+      task_name: 'Renamed',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000304',
+      tags: ['escalated'],
+    });
+  });
+
+  it('T075: project task list query serializes pagination parameters', () => {
+    expect(
+      buildProjectTaskListQuery({
+        page: 3,
+        limit: 50,
+      }),
+    ).toEqual({ page: 3, limit: 50 });
   });
 });

--- a/packages/n8n-nodes-alga-psa/__tests__/node-description-loadoptions.test.ts
+++ b/packages/n8n-nodes-alga-psa/__tests__/node-description-loadoptions.test.ts
@@ -12,12 +12,20 @@ function getProperty(node: AlgaPsa, name: string) {
 }
 
 describe('Node description and load options', () => {
-  it('T001: resource selector includes Ticket, Contact, Client, Board, Status, and Priority', () => {
+  it('T001: resource selector includes Ticket, Contact, Project Task, Client, Board, Status, and Priority', () => {
     const node = new AlgaPsa();
     const resource = getProperty(node, 'resource');
     const resourceValues = resource.options?.map((option) => option.value);
 
-    expect(resourceValues).toEqual(['ticket', 'contact', 'client', 'board', 'status', 'priority']);
+    expect(resourceValues).toEqual([
+      'ticket',
+      'contact',
+      'projectTask',
+      'client',
+      'board',
+      'status',
+      'priority',
+    ]);
   });
 
   it('T002: operation selectors expose only valid operations per resource', () => {
@@ -25,6 +33,9 @@ describe('Node description and load options', () => {
 
     const ticketOperations = getProperty(node, 'ticketOperation').options?.map((o) => o.value);
     const contactOperations = getProperty(node, 'contactOperation').options?.map((o) => o.value);
+    const projectTaskOperations = getProperty(node, 'projectTaskOperation').options?.map(
+      (o) => o.value,
+    );
     const clientOperations = getProperty(node, 'clientOperation').options?.map((o) => o.value);
     const boardOperations = getProperty(node, 'boardOperation').options?.map((o) => o.value);
     const statusOperations = getProperty(node, 'statusOperation').options?.map((o) => o.value);
@@ -43,6 +54,7 @@ describe('Node description and load options', () => {
       'delete',
     ]);
     expect(contactOperations).toEqual(['create', 'get', 'list', 'update', 'delete']);
+    expect(projectTaskOperations).toEqual(['create', 'get', 'list', 'update', 'delete']);
     expect(clientOperations).toEqual(['list']);
     expect(boardOperations).toEqual(['list']);
     expect(statusOperations).toEqual(['list']);
@@ -253,5 +265,196 @@ describe('Node description and load options', () => {
       'project_task',
       'interaction',
     ]);
+  });
+
+  it('T060: project task node subtitle includes the project task operation fallback', () => {
+    const node = new AlgaPsa();
+    expect(node.description.subtitle).toContain('$parameter["projectTaskOperation"]');
+  });
+
+  it('T061: project task create exposes required task_name, project, phase, and status mapping fields', () => {
+    const node = new AlgaPsa();
+    const taskName = getProperty(node, 'task_name');
+    const projectId = getProperty(node, 'projectTaskProjectId');
+    const phaseId = getProperty(node, 'projectTaskPhaseId');
+    const statusMappingId = getProperty(node, 'projectTaskStatusMappingId');
+
+    expect(taskName.required).toBe(true);
+    expect(taskName.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['create'],
+    });
+
+    expect(projectId.required).toBe(true);
+    expect(projectId.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['create', 'list'],
+    });
+    expect(projectId.modes?.[0].typeOptions?.searchListMethod).toBe('searchProjects');
+
+    expect(phaseId.required).toBe(true);
+    expect(phaseId.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['create'],
+    });
+    expect(phaseId.modes?.[0].typeOptions?.searchListMethod).toBe('searchProjectPhases');
+
+    expect(statusMappingId.required).toBe(true);
+    expect(statusMappingId.modes?.[0].typeOptions?.searchListMethod).toBe(
+      'searchProjectTaskStatusMappings',
+    );
+  });
+
+  it('T062: project task create/update additional fields expose the supported scalar fields', () => {
+    const node = new AlgaPsa();
+    const createAdditional = getProperty(node, 'projectTaskCreateAdditionalFields');
+    const updateAdditional = getProperty(node, 'projectTaskUpdateAdditionalFields');
+
+    const createNames = (createAdditional.options ?? []).map((field) => field.name);
+    const updateNames = (updateAdditional.options ?? []).map((field) => field.name);
+
+    expect(createNames).toEqual([
+      'description',
+      'assigned_to',
+      'estimated_hours',
+      'due_date',
+      'priority_id',
+      'task_type_key',
+      'wbs_code',
+      'tags',
+    ]);
+
+    expect(updateNames).toEqual([
+      'task_name',
+      'description',
+      'assigned_to',
+      'estimated_hours',
+      'due_date',
+      'priority_id',
+      'task_type_key',
+      'project_status_mapping_id',
+      'wbs_code',
+      'tags',
+    ]);
+  });
+
+  it('T063: project task ID field is shown only for get, update, and delete operations', () => {
+    const node = new AlgaPsa();
+    const taskId = getProperty(node, 'projectTaskId');
+
+    expect(taskId.required).toBe(true);
+    expect(taskId.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['get', 'update', 'delete'],
+    });
+  });
+
+  it('T064: project task list inputs expose project, page, and limit', () => {
+    const node = new AlgaPsa();
+    const page = getProperty(node, 'projectTaskPage');
+    const limit = getProperty(node, 'projectTaskLimit');
+
+    expect(page.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['list'],
+    });
+    expect(limit.displayOptions?.show).toEqual({
+      resource: ['projectTask'],
+      projectTaskOperation: ['list'],
+    });
+  });
+
+  it('T065: projects load-options maps API records to label/value list', async () => {
+    const node = new AlgaPsa();
+    const context = createLoadOptionsHarness({
+      requestHandler: () => ({
+        data: [{ project_id: 'proj-1', project_name: 'Website Rebuild' }],
+      }),
+    });
+
+    const result = await node.methods.listSearch.searchProjects.call(context, 'web');
+    expect(result.results).toEqual([{ name: 'Website Rebuild', value: 'proj-1' }]);
+  });
+
+  it('T066: project phases load-options scopes to the selected project via URL path', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({
+      data: [{ phase_id: 'phase-1', phase_name: 'Discovery' }],
+    }));
+
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'projectTask',
+        projectTaskOperation: 'create',
+        projectTaskProjectId: {
+          mode: 'id',
+          value: '00000000-0000-0000-0000-000000000201',
+        },
+      },
+    });
+
+    const result = await node.methods.listSearch.searchProjectPhases.call(context, 'disc');
+    expect(result.results).toEqual([{ name: 'Discovery', value: 'phase-1' }]);
+    expect(requestHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url:
+          'https://api.algapsa.test/api/v1/projects/00000000-0000-0000-0000-000000000201/phases',
+      }),
+    );
+  });
+
+  it('T067: project phases load-options returns empty list when no project is selected', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({ data: [] }));
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'projectTask',
+        projectTaskOperation: 'create',
+      },
+    });
+
+    const result = await node.methods.listSearch.searchProjectPhases.call(context, 'any');
+    expect(result.results).toEqual([]);
+    expect(requestHandler).not.toHaveBeenCalled();
+  });
+
+  it('T068: project task status mappings load-options scopes to project and maps labels', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({
+      data: [
+        {
+          project_status_mapping_id: 'mapping-1',
+          custom_name: 'In Progress',
+          status_name: 'In Progress',
+          name: 'In Progress',
+        },
+      ],
+    }));
+
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'projectTask',
+        projectTaskOperation: 'create',
+        projectTaskProjectId: {
+          mode: 'id',
+          value: '00000000-0000-0000-0000-000000000202',
+        },
+      },
+    });
+
+    const result = await node.methods.listSearch.searchProjectTaskStatusMappings.call(
+      context,
+      'progress',
+    );
+    expect(result.results).toEqual([{ name: 'In Progress', value: 'mapping-1' }]);
+    expect(requestHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url:
+          'https://api.algapsa.test/api/v1/projects/00000000-0000-0000-0000-000000000202/task-status-mappings',
+      }),
+    );
   });
 });

--- a/packages/n8n-nodes-alga-psa/__tests__/node-execute.test.ts
+++ b/packages/n8n-nodes-alga-psa/__tests__/node-execute.test.ts
@@ -1103,4 +1103,314 @@ describe('Node execute operations', () => {
       ),
     ).rejects.toBeInstanceOf(NodeOperationError);
   });
+
+  const baseProjectTaskCreateParams = {
+    resource: 'projectTask',
+    projectTaskOperation: 'create',
+    task_name: 'Draft proposal',
+    projectTaskProjectId: { mode: 'id', value: '00000000-0000-0000-0000-000000000201' },
+    projectTaskPhaseId: { mode: 'id', value: '00000000-0000-0000-0000-000000000202' },
+    projectTaskStatusMappingId: { mode: 'id', value: '00000000-0000-0000-0000-000000000203' },
+  };
+
+  it('T080: project task create sends POST /api/v1/projects/{projectId}/phases/{phaseId}/tasks', async () => {
+    const { requests } = await executeNode(
+      [
+        {
+          ...baseProjectTaskCreateParams,
+          projectTaskCreateAdditionalFields: {},
+        },
+      ],
+      () => ({ data: { task_id: '00000000-0000-0000-0000-000000000204' } }),
+    );
+
+    expect(requests[0]?.method).toBe('POST');
+    expect(requests[0]?.url).toBe(
+      'https://api.algapsa.test/api/v1/projects/00000000-0000-0000-0000-000000000201/phases/00000000-0000-0000-0000-000000000202/tasks',
+    );
+    expect(requests[0]?.body).toEqual({
+      task_name: 'Draft proposal',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000203',
+    });
+  });
+
+  it('T081: project task create includes optional fields only when provided', async () => {
+    const { requests } = await executeNode(
+      [
+        {
+          ...baseProjectTaskCreateParams,
+          projectTaskCreateAdditionalFields: {
+            description: 'Write RFC for new billing pipeline',
+            assigned_to: '00000000-0000-0000-0000-000000000205',
+            estimated_hours: 6,
+            due_date: '2026-05-15',
+            priority_id: '00000000-0000-0000-0000-000000000206',
+            task_type_key: 'design',
+            wbs_code: '2.1',
+            tags: 'billing,design',
+          },
+        },
+      ],
+      () => ({ data: { task_id: '00000000-0000-0000-0000-000000000204' } }),
+    );
+
+    expect(requests[0]?.body).toEqual({
+      task_name: 'Draft proposal',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000203',
+      description: 'Write RFC for new billing pipeline',
+      assigned_to: '00000000-0000-0000-0000-000000000205',
+      estimated_hours: 6,
+      due_date: '2026-05-15',
+      priority_id: '00000000-0000-0000-0000-000000000206',
+      task_type_key: 'design',
+      wbs_code: '2.1',
+      tags: ['billing', 'design'],
+    });
+  });
+
+  it('T082: project task create unwraps the created task object from the data wrapper', async () => {
+    const { output } = await executeNode(
+      [
+        {
+          ...baseProjectTaskCreateParams,
+          projectTaskCreateAdditionalFields: {},
+        },
+      ],
+      () => ({
+        data: {
+          task_id: '00000000-0000-0000-0000-000000000204',
+          task_name: 'Draft proposal',
+        },
+      }),
+    );
+
+    expect(output[0][0].json).toEqual({
+      task_id: '00000000-0000-0000-0000-000000000204',
+      task_name: 'Draft proposal',
+    });
+  });
+
+  it('T083: project task create rejects missing project/phase/status mapping IDs before request', async () => {
+    await expect(
+      executeNode(
+        [
+          {
+            ...baseProjectTaskCreateParams,
+            projectTaskProjectId: { mode: 'id', value: '' },
+            projectTaskCreateAdditionalFields: {},
+          },
+        ],
+        () => ({ data: {} }),
+      ),
+    ).rejects.toBeInstanceOf(NodeOperationError);
+
+    await expect(
+      executeNode(
+        [
+          {
+            ...baseProjectTaskCreateParams,
+            projectTaskPhaseId: { mode: 'id', value: '' },
+            projectTaskCreateAdditionalFields: {},
+          },
+        ],
+        () => ({ data: {} }),
+      ),
+    ).rejects.toBeInstanceOf(NodeOperationError);
+
+    await expect(
+      executeNode(
+        [
+          {
+            ...baseProjectTaskCreateParams,
+            projectTaskStatusMappingId: { mode: 'id', value: '' },
+            projectTaskCreateAdditionalFields: {},
+          },
+        ],
+        () => ({ data: {} }),
+      ),
+    ).rejects.toBeInstanceOf(NodeOperationError);
+  });
+
+  it('T084: project task get sends GET /api/v1/projects/tasks/{taskId}', async () => {
+    const { requests, output } = await executeNode(
+      [
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'get',
+          projectTaskId: '00000000-0000-0000-0000-000000000210',
+        },
+      ],
+      () => ({
+        data: {
+          task_id: '00000000-0000-0000-0000-000000000210',
+          task_name: 'Existing task',
+        },
+      }),
+    );
+
+    expect(requests[0]?.method).toBe('GET');
+    expect(requests[0]?.url).toBe(
+      'https://api.algapsa.test/api/v1/projects/tasks/00000000-0000-0000-0000-000000000210',
+    );
+    expect(output[0][0].json).toEqual({
+      task_id: '00000000-0000-0000-0000-000000000210',
+      task_name: 'Existing task',
+    });
+  });
+
+  it('T085: project task list sends GET /api/v1/projects/{projectId}/tasks with pagination', async () => {
+    const { requests, output } = await executeNode(
+      [
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'list',
+          projectTaskProjectId: {
+            mode: 'id',
+            value: '00000000-0000-0000-0000-000000000220',
+          },
+          projectTaskPage: 2,
+          projectTaskLimit: 50,
+        },
+      ],
+      () => ({
+        data: [{ task_id: '00000000-0000-0000-0000-000000000221' }],
+        pagination: { page: 2, total: 1 },
+      }),
+    );
+
+    expect(requests[0]?.method).toBe('GET');
+    expect(requests[0]?.url).toBe(
+      'https://api.algapsa.test/api/v1/projects/00000000-0000-0000-0000-000000000220/tasks',
+    );
+    expect(requests[0]?.qs).toEqual({ page: 2, limit: 50 });
+    expect(output[0][0].json).toEqual({
+      data: [{ task_id: '00000000-0000-0000-0000-000000000221' }],
+      pagination: { page: 2, total: 1 },
+    });
+  });
+
+  it('T086: project task update sends PUT with only provided fields', async () => {
+    const { requests } = await executeNode(
+      [
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'update',
+          projectTaskId: '00000000-0000-0000-0000-000000000230',
+          projectTaskUpdateAdditionalFields: {
+            task_name: 'Renamed task',
+            description: '',
+            project_status_mapping_id: '00000000-0000-0000-0000-000000000231',
+          },
+        },
+      ],
+      () => ({ data: { task_id: '00000000-0000-0000-0000-000000000230' } }),
+    );
+
+    expect(requests[0]?.method).toBe('PUT');
+    expect(requests[0]?.url).toBe(
+      'https://api.algapsa.test/api/v1/projects/tasks/00000000-0000-0000-0000-000000000230',
+    );
+    expect(requests[0]?.body).toEqual({
+      task_name: 'Renamed task',
+      project_status_mapping_id: '00000000-0000-0000-0000-000000000231',
+    });
+  });
+
+  it('T087: project task update rejects an empty update collection before request', async () => {
+    await expect(
+      executeNode(
+        [
+          {
+            resource: 'projectTask',
+            projectTaskOperation: 'update',
+            projectTaskId: '00000000-0000-0000-0000-000000000232',
+            projectTaskUpdateAdditionalFields: {},
+          },
+        ],
+        () => ({ data: {} }),
+      ),
+    ).rejects.toBeInstanceOf(NodeOperationError);
+  });
+
+  it('T088: project task delete sends DELETE and returns a success envelope', async () => {
+    const { requests, output } = await executeNode(
+      [
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'delete',
+          projectTaskId: '00000000-0000-0000-0000-000000000240',
+        },
+      ],
+      () => undefined,
+    );
+
+    expect(requests[0]?.method).toBe('DELETE');
+    expect(requests[0]?.url).toBe(
+      'https://api.algapsa.test/api/v1/projects/tasks/00000000-0000-0000-0000-000000000240',
+    );
+    expect(output[0][0].json).toEqual({
+      success: true,
+      id: '00000000-0000-0000-0000-000000000240',
+      deleted: true,
+    });
+  });
+
+  it('T089: project task get/update/delete reject invalid UUIDs before request', async () => {
+    const getResult = await executeNodeExpectFailure([
+      {
+        resource: 'projectTask',
+        projectTaskOperation: 'get',
+        projectTaskId: 'not-a-uuid',
+      },
+    ]);
+    expect(getResult.error).toBeInstanceOf(NodeOperationError);
+    expect(getResult.requests).toHaveLength(0);
+
+    const deleteResult = await executeNodeExpectFailure([
+      {
+        resource: 'projectTask',
+        projectTaskOperation: 'delete',
+        projectTaskId: '',
+      },
+    ]);
+    expect(deleteResult.error).toBeInstanceOf(NodeOperationError);
+  });
+
+  it('T090: project task continue-on-fail emits item-level errors while later items still execute', async () => {
+    const { output } = await executeNode(
+      [
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'get',
+          projectTaskId: '00000000-0000-0000-0000-000000000250',
+        },
+        {
+          resource: 'projectTask',
+          projectTaskOperation: 'get',
+          projectTaskId: '00000000-0000-0000-0000-000000000251',
+        },
+      ],
+      (_options, index) => {
+        if (index === 0) {
+          throw createApiError(404, 'NOT_FOUND', 'Task not found', { taskId: 'missing' });
+        }
+
+        return { data: { task_id: '00000000-0000-0000-0000-000000000251' } };
+      },
+      true,
+    );
+
+    expect(output[0]).toHaveLength(2);
+    expect(output[0][0].json).toEqual({
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Task not found',
+        details: { taskId: 'missing' },
+        statusCode: 404,
+      },
+    });
+    expect(output[0][1].json).toEqual({
+      task_id: '00000000-0000-0000-0000-000000000251',
+    });
+  });
 });

--- a/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/AlgaPsa.node.ts
+++ b/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/AlgaPsa.node.ts
@@ -14,6 +14,9 @@ import {
   buildContactCreatePayload,
   buildContactListQuery,
   buildContactUpdatePayload,
+  buildProjectTaskCreatePayload,
+  buildProjectTaskListQuery,
+  buildProjectTaskUpdatePayload,
   buildTicketCommentListQuery,
   buildTicketCommentPayload,
   buildTicketCreatePayload,
@@ -28,12 +31,21 @@ import {
   normalizeDeleteSuccess,
   normalizeSuccessResponse,
   parseCsvList,
+  UUID_REGEX,
 } from './helpers';
 import { algaApiRequest } from './transport';
 
-type Resource = 'ticket' | 'contact' | 'client' | 'board' | 'status' | 'priority';
+type Resource =
+  | 'ticket'
+  | 'contact'
+  | 'projectTask'
+  | 'client'
+  | 'board'
+  | 'status'
+  | 'priority';
 type StatusType = 'ticket' | 'project' | 'project_task' | 'interaction';
 type ContactOperation = 'create' | 'get' | 'list' | 'update' | 'delete';
+type ProjectTaskOperation = 'create' | 'get' | 'list' | 'update' | 'delete';
 type TicketOperation =
   | 'create'
   | 'get'
@@ -47,7 +59,7 @@ type TicketOperation =
   | 'delete';
 
 const LOOKUP_PAGE_SIZE = 100;
-type HelperResource = Exclude<Resource, 'ticket' | 'contact'>;
+type HelperResource = Exclude<Resource, 'ticket' | 'contact' | 'projectTask'>;
 
 function ensureDataArray(response: unknown): IDataObject[] {
   const normalized = normalizeSuccessResponse(response);
@@ -126,12 +138,20 @@ function getCurrentStatusLookupType(context: ILoadOptionsFunctions): StatusType 
   return undefined;
 }
 
+function getCurrentProjectLookupId(context: ILoadOptionsFunctions): string | undefined {
+  const currentParams = context.getCurrentNodeParameters?.();
+  const value = extractResourceLocatorValue(currentParams?.projectTaskProjectId);
+  return value && UUID_REGEX.test(value) ? value : undefined;
+}
+
 function getOperationParameterName(resource: Resource): string {
   switch (resource) {
     case 'ticket':
       return 'ticketOperation';
     case 'contact':
       return 'contactOperation';
+    case 'projectTask':
+      return 'projectTaskOperation';
     case 'client':
       return 'clientOperation';
     case 'board':
@@ -164,8 +184,8 @@ export class AlgaPsa implements INodeType {
     group: ['transform'],
     version: 1,
     subtitle:
-      '={{$parameter["resource"] + ": " + ($parameter["ticketOperation"] || $parameter["contactOperation"] || $parameter["clientOperation"] || $parameter["boardOperation"] || $parameter["statusOperation"] || $parameter["priorityOperation"])}}',
-    description: 'Create and manage Alga PSA tickets, contacts, and lookup resources',
+      '={{$parameter["resource"] + ": " + ($parameter["ticketOperation"] || $parameter["contactOperation"] || $parameter["projectTaskOperation"] || $parameter["clientOperation"] || $parameter["boardOperation"] || $parameter["statusOperation"] || $parameter["priorityOperation"])}}',
+    description: 'Create and manage Alga PSA tickets, contacts, project tasks, and lookup resources',
     defaults: {
       name: 'Alga PSA',
     },
@@ -186,6 +206,7 @@ export class AlgaPsa implements INodeType {
         options: [
           { name: 'Ticket', value: 'ticket' },
           { name: 'Contact', value: 'contact' },
+          { name: 'Project Task', value: 'projectTask' },
           { name: 'Client', value: 'client' },
           { name: 'Board', value: 'board' },
           { name: 'Status', value: 'status' },
@@ -249,6 +270,25 @@ export class AlgaPsa implements INodeType {
           { name: 'List', value: 'list', action: 'List contacts' },
           { name: 'Update', value: 'update', action: 'Update a contact' },
           { name: 'Delete', value: 'delete', action: 'Delete a contact' },
+        ],
+        default: 'create',
+      },
+      {
+        displayName: 'Operation',
+        name: 'projectTaskOperation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+          },
+        },
+        options: [
+          { name: 'Create', value: 'create', action: 'Create a project task' },
+          { name: 'Get', value: 'get', action: 'Get a project task' },
+          { name: 'List', value: 'list', action: 'List project tasks' },
+          { name: 'Update', value: 'update', action: 'Update a project task' },
+          { name: 'Delete', value: 'delete', action: 'Delete a project task' },
         ],
         default: 'create',
       },
@@ -1242,6 +1282,313 @@ export class AlgaPsa implements INodeType {
         },
       },
 
+      // Project Task fields
+      {
+        displayName: 'Task Name',
+        name: 'task_name',
+        type: 'string',
+        required: true,
+        default: '',
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['create'],
+          },
+        },
+      },
+      {
+        displayName: 'Project ID',
+        name: 'projectTaskProjectId',
+        type: 'resourceLocator',
+        default: { mode: 'list', value: '' },
+        required: true,
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['create', 'list'],
+          },
+        },
+        modes: [
+          {
+            displayName: 'From List',
+            name: 'list',
+            type: 'list',
+            typeOptions: {
+              searchListMethod: 'searchProjects',
+            },
+          },
+          {
+            displayName: 'By ID',
+            name: 'id',
+            type: 'string',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        description: 'Select a project or enter a project UUID manually',
+      },
+      {
+        displayName: 'Phase ID',
+        name: 'projectTaskPhaseId',
+        type: 'resourceLocator',
+        default: { mode: 'list', value: '' },
+        required: true,
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['create'],
+          },
+        },
+        modes: [
+          {
+            displayName: 'From List',
+            name: 'list',
+            type: 'list',
+            typeOptions: {
+              searchListMethod: 'searchProjectPhases',
+            },
+          },
+          {
+            displayName: 'By ID',
+            name: 'id',
+            type: 'string',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        description: 'Select a phase within the selected project, or enter a phase UUID manually',
+      },
+      {
+        displayName: 'Status Mapping ID',
+        name: 'projectTaskStatusMappingId',
+        type: 'resourceLocator',
+        default: { mode: 'list', value: '' },
+        required: true,
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['create'],
+          },
+        },
+        modes: [
+          {
+            displayName: 'From List',
+            name: 'list',
+            type: 'list',
+            typeOptions: {
+              searchListMethod: 'searchProjectTaskStatusMappings',
+            },
+          },
+          {
+            displayName: 'By ID',
+            name: 'id',
+            type: 'string',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        description:
+          'Project-specific task status mapping UUID. Use the lookup to see valid options for the selected project.',
+      },
+      {
+        displayName: 'Task ID',
+        name: 'projectTaskId',
+        type: 'string',
+        required: true,
+        default: '',
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['get', 'update', 'delete'],
+          },
+        },
+      },
+      {
+        displayName: 'Create Additional Fields',
+        name: 'projectTaskCreateAdditionalFields',
+        type: 'collection',
+        default: {},
+        placeholder: 'Add Field',
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['create'],
+          },
+        },
+        options: [
+          {
+            displayName: 'Description',
+            name: 'description',
+            type: 'string',
+            default: '',
+            typeOptions: {
+              rows: 4,
+            },
+          },
+          {
+            displayName: 'Assigned To',
+            name: 'assigned_to',
+            type: 'string',
+            default: '',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+          {
+            displayName: 'Estimated Hours',
+            name: 'estimated_hours',
+            type: 'number',
+            default: 0,
+            typeOptions: {
+              minValue: 0,
+            },
+          },
+          {
+            displayName: 'Due Date',
+            name: 'due_date',
+            type: 'string',
+            default: '',
+            placeholder: 'YYYY-MM-DD or ISO 8601 timestamp',
+          },
+          {
+            displayName: 'Priority ID',
+            name: 'priority_id',
+            type: 'string',
+            default: '',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+          {
+            displayName: 'Task Type Key',
+            name: 'task_type_key',
+            type: 'string',
+            default: '',
+            description: 'Optional task type key; server defaults to "general"',
+          },
+          {
+            displayName: 'WBS Code',
+            name: 'wbs_code',
+            type: 'string',
+            default: '',
+          },
+          {
+            displayName: 'Tags',
+            name: 'tags',
+            type: 'string',
+            default: '',
+            description: 'Comma-separated tags',
+          },
+        ],
+      },
+      {
+        displayName: 'Update Additional Fields',
+        name: 'projectTaskUpdateAdditionalFields',
+        type: 'collection',
+        default: {},
+        placeholder: 'Add Field',
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['update'],
+          },
+        },
+        options: [
+          { displayName: 'Task Name', name: 'task_name', type: 'string', default: '' },
+          {
+            displayName: 'Description',
+            name: 'description',
+            type: 'string',
+            default: '',
+            typeOptions: {
+              rows: 4,
+            },
+          },
+          {
+            displayName: 'Assigned To',
+            name: 'assigned_to',
+            type: 'string',
+            default: '',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+          {
+            displayName: 'Estimated Hours',
+            name: 'estimated_hours',
+            type: 'number',
+            default: 0,
+            typeOptions: {
+              minValue: 0,
+            },
+          },
+          {
+            displayName: 'Due Date',
+            name: 'due_date',
+            type: 'string',
+            default: '',
+            placeholder: 'YYYY-MM-DD or ISO 8601 timestamp',
+          },
+          {
+            displayName: 'Priority ID',
+            name: 'priority_id',
+            type: 'string',
+            default: '',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+          {
+            displayName: 'Task Type Key',
+            name: 'task_type_key',
+            type: 'string',
+            default: '',
+          },
+          {
+            displayName: 'Status Mapping ID',
+            name: 'project_status_mapping_id',
+            type: 'string',
+            default: '',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+          {
+            displayName: 'WBS Code',
+            name: 'wbs_code',
+            type: 'string',
+            default: '',
+          },
+          {
+            displayName: 'Tags',
+            name: 'tags',
+            type: 'string',
+            default: '',
+            description: 'Comma-separated tags',
+          },
+        ],
+      },
+      {
+        displayName: 'Page',
+        name: 'projectTaskPage',
+        type: 'number',
+        default: 1,
+        typeOptions: {
+          minValue: 1,
+          numberPrecision: 0,
+        },
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['list'],
+          },
+        },
+      },
+      {
+        displayName: 'Limit',
+        name: 'projectTaskLimit',
+        type: 'number',
+        default: 25,
+        typeOptions: {
+          minValue: 1,
+          maxValue: 100,
+          numberPrecision: 0,
+        },
+        displayOptions: {
+          show: {
+            resource: ['projectTask'],
+            projectTaskOperation: ['list'],
+          },
+        },
+      },
+
       // Helper list parameters
       {
         displayName: 'Page',
@@ -1335,6 +1682,46 @@ export class AlgaPsa implements INodeType {
           filter,
         );
       },
+      async searchProjects(this: ILoadOptionsFunctions, filter?: string): Promise<INodeListSearchResult> {
+        return loadLookup(
+          this,
+          '/api/v1/projects',
+          'project_id',
+          ['project_name', 'name'],
+          filter,
+        );
+      },
+      async searchProjectPhases(this: ILoadOptionsFunctions, filter?: string): Promise<INodeListSearchResult> {
+        const projectId = getCurrentProjectLookupId(this);
+        if (!projectId) {
+          return { results: [] };
+        }
+
+        return loadLookup(
+          this,
+          `/api/v1/projects/${projectId}/phases`,
+          'phase_id',
+          ['phase_name', 'name'],
+          filter,
+        );
+      },
+      async searchProjectTaskStatusMappings(
+        this: ILoadOptionsFunctions,
+        filter?: string,
+      ): Promise<INodeListSearchResult> {
+        const projectId = getCurrentProjectLookupId(this);
+        if (!projectId) {
+          return { results: [] };
+        }
+
+        return loadLookup(
+          this,
+          `/api/v1/projects/${projectId}/task-status-mappings`,
+          'project_status_mapping_id',
+          ['custom_name', 'status_name', 'name'],
+          filter,
+        );
+      },
     },
   };
 
@@ -1353,6 +1740,12 @@ export class AlgaPsa implements INodeType {
             ? await executeTicketOperation(this, itemIndex, operation as TicketOperation)
             : resource === 'contact'
               ? await executeContactOperation(this, itemIndex, operation as ContactOperation)
+              : resource === 'projectTask'
+                ? await executeProjectTaskOperation(
+                    this,
+                    itemIndex,
+                    operation as ProjectTaskOperation,
+                  )
             : await executeHelperOperation(
                 this,
                 resource as HelperResource,
@@ -1547,6 +1940,150 @@ async function executeContactOperation(
 
       const response = await algaApiRequest(context, 'DELETE', `/api/v1/contacts/${contactId}`);
       return normalizeDeleteSuccess(contactId, response);
+    }
+  }
+}
+
+async function executeProjectTaskOperation(
+  context: IExecuteFunctions,
+  itemIndex: number,
+  operation: ProjectTaskOperation,
+): Promise<IDataObject> {
+  switch (operation) {
+    case 'create': {
+      const taskName = requireNonEmpty(
+        context,
+        context.getNodeParameter('task_name', itemIndex) as string,
+        'task_name',
+        itemIndex,
+      );
+      const projectId = requireUuid(
+        context,
+        getResourceLocatorId(context, 'projectTaskProjectId', itemIndex),
+        'projectTaskProjectId',
+        itemIndex,
+      );
+      const phaseId = requireUuid(
+        context,
+        getResourceLocatorId(context, 'projectTaskPhaseId', itemIndex),
+        'projectTaskPhaseId',
+        itemIndex,
+      );
+      const statusMappingId = requireUuid(
+        context,
+        getResourceLocatorId(context, 'projectTaskStatusMappingId', itemIndex),
+        'projectTaskStatusMappingId',
+        itemIndex,
+      );
+
+      const additionalFields = context.getNodeParameter(
+        'projectTaskCreateAdditionalFields',
+        itemIndex,
+        {},
+      ) as IDataObject;
+
+      const payload = buildWithOperationValidation(context, itemIndex, () =>
+        buildProjectTaskCreatePayload({
+          taskName,
+          statusMappingId,
+          additionalFields,
+        }),
+      );
+
+      const response = await algaApiRequest(
+        context,
+        'POST',
+        `/api/v1/projects/${projectId}/phases/${phaseId}/tasks`,
+        undefined,
+        payload,
+      );
+      return normalizeSuccessResponse(response);
+    }
+
+    case 'get': {
+      const taskId = requireUuid(
+        context,
+        context.getNodeParameter('projectTaskId', itemIndex) as string,
+        'projectTaskId',
+        itemIndex,
+      );
+
+      const response = await algaApiRequest(
+        context,
+        'GET',
+        `/api/v1/projects/tasks/${taskId}`,
+      );
+      return normalizeSuccessResponse(response);
+    }
+
+    case 'list': {
+      const projectId = requireUuid(
+        context,
+        getResourceLocatorId(context, 'projectTaskProjectId', itemIndex),
+        'projectTaskProjectId',
+        itemIndex,
+      );
+      const page = context.getNodeParameter('projectTaskPage', itemIndex, 1) as number;
+      const limit = context.getNodeParameter('projectTaskLimit', itemIndex, 25) as number;
+
+      const query = buildProjectTaskListQuery({ page, limit });
+
+      const response = await algaApiRequest(
+        context,
+        'GET',
+        `/api/v1/projects/${projectId}/tasks`,
+        query,
+      );
+      return normalizeSuccessResponse(response);
+    }
+
+    case 'update': {
+      const taskId = requireUuid(
+        context,
+        context.getNodeParameter('projectTaskId', itemIndex) as string,
+        'projectTaskId',
+        itemIndex,
+      );
+      const additionalFields = context.getNodeParameter(
+        'projectTaskUpdateAdditionalFields',
+        itemIndex,
+        {},
+      ) as IDataObject;
+
+      const payload = buildWithOperationValidation(context, itemIndex, () =>
+        buildProjectTaskUpdatePayload(additionalFields),
+      );
+
+      if (Object.keys(payload).length === 0) {
+        throw new NodeOperationError(context.getNode(), 'At least one update field is required', {
+          itemIndex,
+        });
+      }
+
+      const response = await algaApiRequest(
+        context,
+        'PUT',
+        `/api/v1/projects/tasks/${taskId}`,
+        undefined,
+        payload,
+      );
+      return normalizeSuccessResponse(response);
+    }
+
+    case 'delete': {
+      const taskId = requireUuid(
+        context,
+        context.getNodeParameter('projectTaskId', itemIndex) as string,
+        'projectTaskId',
+        itemIndex,
+      );
+
+      const response = await algaApiRequest(
+        context,
+        'DELETE',
+        `/api/v1/projects/tasks/${taskId}`,
+      );
+      return normalizeDeleteSuccess(taskId, response);
     }
   }
 }

--- a/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/helpers.ts
+++ b/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/helpers.ts
@@ -335,6 +335,81 @@ export function buildContactUpdatePayload(additionalFields: IDataObject = {}): I
   });
 }
 
+function normalizeOptionalNumber(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${fieldName} must be a number`);
+  }
+
+  if (parsed < 0) {
+    throw new Error(`${fieldName} must be a non-negative number`);
+  }
+
+  return parsed;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const trimmed = String(value).trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+export function buildProjectTaskCreatePayload(input: {
+  taskName: string;
+  statusMappingId: string;
+  additionalFields?: IDataObject;
+}): IDataObject {
+  const additional = input.additionalFields ?? {};
+
+  return compactObject({
+    task_name: input.taskName,
+    project_status_mapping_id: input.statusMappingId,
+    description: normalizeOptionalString(additional.description),
+    assigned_to: normalizeOptionalUuid(additional.assigned_to, 'assigned_to'),
+    estimated_hours: normalizeOptionalNumber(additional.estimated_hours, 'estimated_hours'),
+    due_date: normalizeOptionalString(additional.due_date),
+    priority_id: normalizeOptionalUuid(additional.priority_id, 'priority_id'),
+    task_type_key: normalizeOptionalString(additional.task_type_key),
+    wbs_code: normalizeOptionalString(additional.wbs_code),
+    tags: parseTags(additional.tags),
+  });
+}
+
+export function buildProjectTaskUpdatePayload(additionalFields: IDataObject = {}): IDataObject {
+  return compactObject({
+    task_name: normalizeOptionalString(additionalFields.task_name),
+    description: normalizeOptionalString(additionalFields.description),
+    assigned_to: normalizeOptionalUuid(additionalFields.assigned_to, 'assigned_to'),
+    estimated_hours: normalizeOptionalNumber(additionalFields.estimated_hours, 'estimated_hours'),
+    due_date: normalizeOptionalString(additionalFields.due_date),
+    priority_id: normalizeOptionalUuid(additionalFields.priority_id, 'priority_id'),
+    task_type_key: normalizeOptionalString(additionalFields.task_type_key),
+    project_status_mapping_id: normalizeOptionalUuid(
+      additionalFields.project_status_mapping_id,
+      'project_status_mapping_id',
+    ),
+    wbs_code: normalizeOptionalString(additionalFields.wbs_code),
+    tags: parseTags(additionalFields.tags),
+  });
+}
+
+export function buildProjectTaskListQuery(input: {
+  page: number;
+  limit: number;
+}): IDataObject {
+  return compactObject({
+    page: input.page,
+    limit: input.limit,
+  });
+}
+
 export function buildContactListQuery(input: {
   page: number;
   limit: number;

--- a/packages/n8n-nodes-alga-psa/package.json
+++ b/packages/n8n-nodes-alga-psa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-alga-psa",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Alga PSA community node for n8n",
   "license": "MIT",
   "main": "dist/nodes/AlgaPsa/AlgaPsa.node.js",


### PR DESCRIPTION
## Summary
- Adds `Project Task` resource (Create, Get, List, Update, Delete) to the `n8n-nodes-alga-psa` community node, with project/phase/status-mapping lookup dropdowns scoped to the selected project and manual-UUID fallback.
- Create requires `task_name`, `projectTaskProjectId`, `projectTaskPhaseId`, `projectTaskStatusMappingId`; optional fields (description, assigned_to, estimated_hours, due_date, priority_id, task_type_key, wbs_code, tags) live under a collection. Update accepts the same set plus `task_name` and `project_status_mapping_id`. List is project-scoped with `page`/`limit`.
- Wires endpoints: `POST /api/v1/projects/{projectId}/phases/{phaseId}/tasks`, `GET/PUT/DELETE /api/v1/projects/tasks/{taskId}`, `GET /api/v1/projects/{projectId}/tasks`; new `listSearch` methods hit `/projects`, `/projects/{id}/phases`, `/projects/{id}/task-status-mappings`.
- Docs + release notes updated; package version bumped `0.3.0 -> 0.4.0`.
- 17 new tests (helpers payload/query builders, node description + load-options, execute flow incl. error paths and continue-on-fail); full suite 117/117 passing.

## Out of scope (flag if you want in this PR)
- Checklist items, task dependencies, ticket-task links
- Example workflow JSON for Project Task

## Test plan
- [x] `npm run test` in `packages/n8n-nodes-alga-psa` (117 passing)
- [x] `npm run typecheck` in `packages/n8n-nodes-alga-psa`
- [ ] Manual smoke against a live Alga PSA instance: Create -> Get -> List -> Update -> Delete against a real project
- [ ] Verify lookup dropdowns populate for Projects, Phases (after project selected), Status Mappings (after project selected)
- [ ] Confirm empty selections fall back to manual UUID entry