### PR TITLE
preserve HTML tables in inbound email tickets

### DIFF
--- a/shared/lib/utils/contentConversion.test.ts
+++ b/shared/lib/utils/contentConversion.test.ts
@@ -103,6 +103,89 @@ describe('convertHtmlToBlockNote', () => {
     expect(allText).not.toContain('MsoNormal');
     expect(allText).not.toContain('@font-face');
   });
+
+  it('should strip Outlook conditional comments with CSS inside style tags', async () => {
+    // Outlook/Word emails wrap CSS in <!--[if ...]> ... <![endif]--> and
+    // also use <!-- ... --> inside <style> tags
+    const html = `
+      <html><head>
+      <!--[if gte mso 9]><xml><o:OfficeDocumentSettings><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]-->
+      <!--[if !mso]><style>v\\:* {behavior:url(#default#VML);}</style><![endif]-->
+      <style>
+      <!--
+       /* Font Definitions */
+       @font-face {font-family:"Cambria Math"; panose-1:2 4 5 3 5 4 6 3 2 4;}
+       @font-face {font-family:Calibri; panose-1:2 15 5 2 2 2 4 3 2 4;}
+       /* Style Definitions */
+       p.MsoNormal, li.MsoNormal, div.MsoNormal {margin:0in; font-size:11.0pt; font-family:"Calibri",sans-serif; color:windowtext;}
+       span.EmailStyle17 {mso-style-type:personal-compose; font-family:"Calibri",sans-serif;}
+      -->
+      </style>
+      </head><body>
+      <div class=WordSection1>
+      <p class=MsoNormal>Hello from Outlook</p>
+      </div>
+      </body></html>
+    `;
+    const result = await convertHtmlToBlockNote(html);
+
+    const allText = result
+      .flatMap(b => (b.content || []))
+      .filter((c: any) => c.type === 'text')
+      .map((c: any) => c.text)
+      .join(' ');
+    expect(allText).toContain('Hello from Outlook');
+    expect(allText).not.toContain('font-family');
+    expect(allText).not.toContain('@font-face');
+    expect(allText).not.toContain('Cambria Math');
+    expect(allText).not.toContain('MsoNormal');
+    expect(allText).not.toContain('OfficeDocumentSettings');
+  });
+
+  it('should strip Outlook conditional PIs without comment markers', async () => {
+    // Some Outlook emails use <![if ...]>...<![endif]> without -- prefix
+    const html = `
+      <html><head>
+      <![if !supportMisalignedColumns]>
+      <style>
+       .MsoTableGrid { border-collapse:collapse; }
+      </style>
+      <![endif]>
+      </head><body>
+      <p>Content after PI</p>
+      </body></html>
+    `;
+    const result = await convertHtmlToBlockNote(html);
+
+    const allText = result
+      .flatMap(b => (b.content || []))
+      .filter((c: any) => c.type === 'text')
+      .map((c: any) => c.text)
+      .join(' ');
+    expect(allText).toContain('Content after PI');
+    expect(allText).not.toContain('MsoTableGrid');
+    expect(allText).not.toContain('border-collapse');
+  });
+
+  it('should parse HTML tables into table blocks', async () => {
+    const html = `
+      <table border="1">
+        <tr><th></th><th>Column 1</th><th>Column 2</th><th>Column3</th></tr>
+        <tr><td>Row 1</td><td>some</td><td>text</td><td>to</td></tr>
+        <tr><td>Row 2</td><td>fill</td><td>in</td><td>cells</td></tr>
+      </table>
+    `;
+    const result = await convertHtmlToBlockNote(html);
+
+    const tableBlock = result.find(b => b.type === 'table');
+    expect(tableBlock).toBeDefined();
+
+    // Table should have structured content, not flat text
+    const content = tableBlock?.content as any;
+    expect(content).toBeDefined();
+    expect(content.rows).toBeDefined();
+    expect(content.rows.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe('convertMarkdownToBlocks', () => {

--- a/shared/lib/utils/contentConversion.ts
+++ b/shared/lib/utils/contentConversion.ts
@@ -58,12 +58,23 @@ export async function convertHtmlToBlockNote(html: string): Promise<BlockNoteBlo
   if (!html) return [];
 
   // Strip non-content markup that ServerBlockNoteEditor may pass through as
-  // text: HTML/conditional comments (Outlook CSS), <style>, <script>, <head>.
+  // text: HTML/conditional comments (Outlook CSS), <style>, <script>, <head>,
+  // and Outlook/Word-specific conditional constructs & XML blocks.
   const cleanHtml = html
+    // Outlook downlevel-hidden conditional comments: <!--[if ...]>...<![endif]-->
+    .replace(/<!--\[if[^\]]*\]>[\s\S]*?<!\[endif\]-->/gi, '')
+    // Standard HTML comments (including CSS-hiding <!-- ... --> inside <style>)
     .replace(/<!--[\s\S]*?-->/g, '')
+    // Outlook conditional processing instructions without -- prefix:
+    // <![if ...]>...<![endif]> (not wrapped in HTML comments)
+    .replace(/<!\[if[^\]]*\]>[\s\S]*?<!\[endif\]>/gi, '')
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
     .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<head[^>]*>[\s\S]*?<\/head>/gi, '');
+    .replace(/<head[^>]*>[\s\S]*?<\/head>/gi, '')
+    // Outlook/Word <xml> blocks (e.g. <xml><o:OfficeDocumentSettings>...)
+    .replace(/<xml[^>]*>[\s\S]*?<\/xml>/gi, '')
+    // Office-namespace elements that may appear in <body> (e.g. <o:p>, <w:Sdt>)
+    .replace(/<\/?\w+:[^>]*>/g, '');
 
   const editor = getServerEditor();
   const blocks = await editor.tryParseHTMLToBlocks(cleanHtml);

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -1329,7 +1329,7 @@ export async function processInboundEmailInApp(
   const ticketResult = await createTicketFromEmail(
     {
       title: emailData.subject || '(no subject)',
-      description: parsedEmail?.sanitizedText ?? emailData.body?.text ?? '',
+      description: serializedBlocks,
       client_id: targetClientId,
       contact_id: targetContactId,
       source: 'email',


### PR DESCRIPTION
And so the MsoNormal scarecrows were marched out of Emerald City,
  the @font-face hedgehogs tucked back into Wonderland's rabbit hole,
  and the Column1/Row2 teacups finally took their proper seats at
  the ticket's mad tea-party — all in neat rows, never again spilling
  across the description like unrsvp'd guests. 🎩☕🌪️