### PR TITLE
fix(n8n): scope ticket status lookups to board_id

### DIFF
--- a/packages/n8n-nodes-alga-psa/README.md
+++ b/packages/n8n-nodes-alga-psa/README.md
@@ -151,6 +151,15 @@ For ticket `client_id`, `board_id`, `status_id`, and `priority_id`, plus contact
 - Use dynamic list lookups (`From List`) when available.
 - Use manual UUID input (`By ID`) if lookups fail or if you already know the ID.
 
+## Board-Scoped Ticket Statuses
+
+Ticket statuses in Alga PSA are owned by a board. This changes how ticket status lookups work:
+
+- `Ticket -> Create`: the `Status ID` dropdown is filtered by the selected `Board ID`. Pick the board first.
+- `Ticket -> Update`: when changing `status_id` inside the update fields, also include `board_id` (destination board) so the status dropdown can list valid options. A status is only valid for the ticket's current or updated board.
+- `Ticket -> Update Status`: use the optional `Board ID (for Status Picker)` field to filter the `Status ID` dropdown to the ticket's board. The value is not sent in the request — the server validates against the ticket's existing board. Manual UUID entry still works without this helper.
+- `Status -> List` with type `Ticket` requires a `Board ID`. Use type `Project`, `Project Task`, or `Interaction` for tenant-wide (non-board-owned) statuses.
+
 ## Output and Error Behavior
 
 - API responses unwrap `{ data: ... }` for easier downstream use.

--- a/packages/n8n-nodes-alga-psa/RELEASE_NOTES.md
+++ b/packages/n8n-nodes-alga-psa/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## 0.4.1
+
+Patch release of the `Alga PSA` n8n community node.
+
+### Fixes
+
+- Ticket status lookups now pass `board_id` to `GET /api/v1/statuses`, restoring compatibility with Alga PSA's per-board ticket statuses (generic `type=ticket` calls without a board now return an HTTP 400 from the server)
+- `Ticket -> Create` and `Ticket -> Update` status dropdowns read the board from the current form state (top-level `board_id` for create, `updateAdditionalFields.board_id` for update) and filter accordingly
+- `Status -> List` with `Ticket` type now requires and forwards a `Board ID`
+
+### Added
+
+- New optional `Board ID (for Status Picker)` field on `Ticket -> Update Status` that scopes the status dropdown to one board. The value is not sent in the request payload; the server still validates the new status against the ticket's existing board
+- `Status -> List` exposes a `Board ID` selector that is shown and required when the status type is `Ticket`
+
+### Notes
+
+- Manual UUID entry for `status_id` continues to work unchanged on all ticket operations
+- Existing `updateStatus` workflows that pass a known `status_id` by manual UUID are unaffected
+
 ## 0.4.0
 
 Feature release of the `Alga PSA` n8n community node.

--- a/packages/n8n-nodes-alga-psa/__tests__/node-description-loadoptions.test.ts
+++ b/packages/n8n-nodes-alga-psa/__tests__/node-description-loadoptions.test.ts
@@ -98,6 +98,7 @@ describe('Node description and load options', () => {
       currentNodeParameters: {
         resource: 'ticket',
         ticketOperation: 'create',
+        board_id: { mode: 'id', value: '00000000-0000-0000-0000-000000000200' },
       },
     });
 
@@ -109,9 +110,98 @@ describe('Node description and load options', () => {
         qs: expect.objectContaining({
           type: 'ticket',
           search: 'new',
+          board_id: '00000000-0000-0000-0000-000000000200',
         }),
       }),
     );
+  });
+
+  it('T038b: ticket status load-options without a board_id returns an empty list without hitting the API', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({ data: [{ status_id: 'status-1', name: 'New' }] }));
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'ticket',
+        ticketOperation: 'create',
+      },
+    });
+
+    const result = await node.methods.listSearch.searchStatuses.call(context, 'new');
+    expect(result.results).toEqual([]);
+    expect(requestHandler).not.toHaveBeenCalled();
+  });
+
+  it('T038c: ticket update status load-options reads board_id from updateAdditionalFields', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({ data: [{ status_id: 'status-2', name: 'Resolved' }] }));
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'ticket',
+        ticketOperation: 'update',
+        updateAdditionalFields: {
+          board_id: { mode: 'id', value: '00000000-0000-0000-0000-000000000201' },
+        },
+      },
+    });
+
+    const result = await node.methods.listSearch.searchStatuses.call(context);
+    expect(result.results).toEqual([{ name: 'Resolved', value: 'status-2' }]);
+    expect(requestHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qs: expect.objectContaining({
+          type: 'ticket',
+          board_id: '00000000-0000-0000-0000-000000000201',
+        }),
+      }),
+    );
+  });
+
+  it('T038d: ticket updateStatus load-options reads board_id from statusFilterBoardId', async () => {
+    const node = new AlgaPsa();
+    const requestHandler = vi.fn(() => ({ data: [{ status_id: 'status-3', name: 'In Progress' }] }));
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'ticket',
+        ticketOperation: 'updateStatus',
+        statusFilterBoardId: { mode: 'id', value: '00000000-0000-0000-0000-000000000202' },
+      },
+    });
+
+    const result = await node.methods.listSearch.searchStatuses.call(context);
+    expect(result.results).toEqual([{ name: 'In Progress', value: 'status-3' }]);
+    expect(requestHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qs: expect.objectContaining({
+          type: 'ticket',
+          board_id: '00000000-0000-0000-0000-000000000202',
+        }),
+      }),
+    );
+  });
+
+  it('T038e: non-ticket status load-options omits board_id', async () => {
+    const node = new AlgaPsa();
+    let capturedQs: Record<string, unknown> | undefined;
+    const requestHandler = vi.fn((options: { qs?: Record<string, unknown> }) => {
+      capturedQs = options.qs;
+      return { data: [{ status_id: 'status-4', name: 'Planned' }] };
+    });
+    const context = createLoadOptionsHarness({
+      requestHandler,
+      currentNodeParameters: {
+        resource: 'status',
+        statusOperation: 'list',
+        helperStatusType: 'project',
+      },
+    });
+
+    const result = await node.methods.listSearch.searchStatuses.call(context);
+    expect(result.results).toEqual([{ name: 'Planned', value: 'status-4' }]);
+    expect(capturedQs).toMatchObject({ type: 'project' });
+    expect(capturedQs).not.toHaveProperty('board_id');
   });
 
   it('T039: priority load-options maps API records to label/value list', async () => {

--- a/packages/n8n-nodes-alga-psa/__tests__/node-execute.test.ts
+++ b/packages/n8n-nodes-alga-psa/__tests__/node-execute.test.ts
@@ -1032,7 +1032,53 @@ describe('Node execute operations', () => {
       limit: 25,
       type: 'project_task',
     });
+    expect(requests[0]?.qs).not.toHaveProperty('board_id');
     expect(output[0][0].json).toEqual({ data: [{ status_id: '1', name: 'New' }] });
+  });
+
+  it('T034b: Status helper list with ticket type requires board_id and passes it to the API', async () => {
+    const { requests, output } = await executeNode(
+      [
+        {
+          resource: 'status',
+          statusOperation: 'list',
+          helperStatusType: 'ticket',
+          helperBoardId: { mode: 'id', value: '00000000-0000-0000-0000-000000000200' },
+          helperPage: 1,
+          helperLimit: 25,
+          helperSearch: '',
+        },
+      ],
+      () => ({ data: [{ status_id: 'status-1', name: 'Open', board_id: '00000000-0000-0000-0000-000000000200' }] }),
+    );
+
+    expect(requests[0]?.url).toBe('https://api.algapsa.test/api/v1/statuses');
+    expect(requests[0]?.qs).toMatchObject({
+      page: 1,
+      limit: 25,
+      type: 'ticket',
+      board_id: '00000000-0000-0000-0000-000000000200',
+    });
+    expect(output[0][0].json).toEqual({
+      data: [{ status_id: 'status-1', name: 'Open', board_id: '00000000-0000-0000-0000-000000000200' }],
+    });
+  });
+
+  it('T034c: Status helper list with ticket type rejects missing board_id before the API call', async () => {
+    const result = await executeNodeExpectFailure([
+      {
+        resource: 'status',
+        statusOperation: 'list',
+        helperStatusType: 'ticket',
+        helperBoardId: { mode: 'id', value: '' },
+        helperPage: 1,
+        helperLimit: 25,
+        helperSearch: '',
+      },
+    ]);
+
+    expect(result.error).toBeInstanceOf(NodeOperationError);
+    expect(result.requests).toHaveLength(0);
   });
 
   it('T035: Priority helper list maps to GET /api/v1/priorities and returns list output', async () => {

--- a/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/AlgaPsa.node.ts
+++ b/packages/n8n-nodes-alga-psa/nodes/AlgaPsa/AlgaPsa.node.ts
@@ -144,6 +144,40 @@ function getCurrentProjectLookupId(context: ILoadOptionsFunctions): string | und
   return value && UUID_REGEX.test(value) ? value : undefined;
 }
 
+function getCurrentStatusBoardId(context: ILoadOptionsFunctions): string | undefined {
+  const currentParams = context.getCurrentNodeParameters?.();
+  if (!currentParams) {
+    return undefined;
+  }
+
+  const resource = currentParams.resource as Resource | undefined;
+
+  if (resource === 'ticket') {
+    const ticketOperation = currentParams.ticketOperation as TicketOperation | undefined;
+
+    if (ticketOperation === 'create') {
+      return extractResourceLocatorValue(currentParams.board_id) || undefined;
+    }
+
+    if (ticketOperation === 'update') {
+      const updateAdditional = currentParams.updateAdditionalFields as IDataObject | undefined;
+      return extractResourceLocatorValue(updateAdditional?.board_id) || undefined;
+    }
+
+    if (ticketOperation === 'updateStatus') {
+      return extractResourceLocatorValue(currentParams.statusFilterBoardId) || undefined;
+    }
+
+    return undefined;
+  }
+
+  if (resource === 'status') {
+    return extractResourceLocatorValue(currentParams.helperBoardId) || undefined;
+  }
+
+  return undefined;
+}
+
 function getOperationParameterName(resource: Resource): string {
   switch (resource) {
     case 'ticket':
@@ -420,6 +454,36 @@ export class AlgaPsa implements INodeType {
         description: 'Select a board or enter a board UUID manually',
       },
       {
+        displayName: 'Board ID (for Status Picker)',
+        name: 'statusFilterBoardId',
+        type: 'resourceLocator',
+        default: { mode: 'list', value: '' },
+        displayOptions: {
+          show: {
+            resource: ['ticket'],
+            ticketOperation: ['updateStatus'],
+          },
+        },
+        modes: [
+          {
+            displayName: 'From List',
+            name: 'list',
+            type: 'list',
+            typeOptions: {
+              searchListMethod: 'searchBoards',
+            },
+          },
+          {
+            displayName: 'By ID',
+            name: 'id',
+            type: 'string',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        description:
+          "Optional — scopes the Status ID dropdown to one board. Ticket statuses are board-owned, so the picker needs a board to list options. Not sent in the request; the server validates against the ticket's existing board.",
+      },
+      {
         displayName: 'Status ID',
         name: 'status_id',
         type: 'resourceLocator',
@@ -447,7 +511,8 @@ export class AlgaPsa implements INodeType {
             placeholder: '00000000-0000-0000-0000-000000000000',
           },
         ],
-        description: 'Select a status or enter a status UUID manually',
+        description:
+          'Select a status or enter a status UUID manually. Ticket statuses are board-owned, so the dropdown is filtered by the selected board',
       },
       {
         displayName: 'Priority ID',
@@ -1651,6 +1716,38 @@ export class AlgaPsa implements INodeType {
         },
         description: 'Filter statuses by entity type',
       },
+      {
+        displayName: 'Board ID',
+        name: 'helperBoardId',
+        type: 'resourceLocator',
+        default: { mode: 'list', value: '' },
+        required: true,
+        displayOptions: {
+          show: {
+            resource: ['status'],
+            statusOperation: ['list'],
+            helperStatusType: ['ticket'],
+          },
+        },
+        modes: [
+          {
+            displayName: 'From List',
+            name: 'list',
+            type: 'list',
+            typeOptions: {
+              searchListMethod: 'searchBoards',
+            },
+          },
+          {
+            displayName: 'By ID',
+            name: 'id',
+            type: 'string',
+            placeholder: '00000000-0000-0000-0000-000000000000',
+          },
+        ],
+        description:
+          'Required — ticket statuses are board-owned, so listing them requires a board_id',
+      },
     ],
   };
 
@@ -1664,13 +1761,21 @@ export class AlgaPsa implements INodeType {
       },
       async searchStatuses(this: ILoadOptionsFunctions, filter?: string): Promise<INodeListSearchResult> {
         const type = getCurrentStatusLookupType(this);
+        const boardId = getCurrentStatusBoardId(this);
+
+        // Ticket statuses are board-scoped; without a board_id the server returns 400.
+        // Return an empty list so the user can fall back to manual UUID entry.
+        if (type === 'ticket' && !boardId) {
+          return { results: [] };
+        }
+
         return loadLookup(
           this,
           '/api/v1/statuses',
           'status_id',
           ['name', 'status_name'],
           filter,
-          compactObject({ type }),
+          compactObject({ type, board_id: boardId }),
         );
       },
       async searchPriorities(this: ILoadOptionsFunctions, filter?: string): Promise<INodeListSearchResult> {
@@ -1819,11 +1924,23 @@ async function executeHelperOperation(
       ? (context.getNodeParameter('helperStatusType', itemIndex, 'ticket') as StatusType)
       : undefined;
 
+  let statusBoardId: string | undefined;
+  if (resource === 'status' && statusType === 'ticket') {
+    const rawHelperBoard = context.getNodeParameter('helperBoardId', itemIndex, {}) as unknown;
+    statusBoardId = requireUuid(
+      context,
+      extractResourceLocatorValue(rawHelperBoard),
+      'helperBoardId',
+      itemIndex,
+    );
+  }
+
   const query = compactObject({
     page,
     limit,
     search,
     type: statusType,
+    board_id: statusBoardId,
   });
 
   const response = await algaApiRequest(context, 'GET', endpoint, query);

--- a/packages/n8n-nodes-alga-psa/package.json
+++ b/packages/n8n-nodes-alga-psa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-alga-psa",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Alga PSA community node for n8n",
   "license": "MIT",
   "main": "dist/nodes/AlgaPsa/AlgaPsa.node.js",


### PR DESCRIPTION
## Summary

- Ticket status dropdowns and the `Status → List` helper in the n8n community node now pass `board_id` to `GET /api/v1/statuses`, restoring compatibility with the per-board ticket statuses change. Without it the server returns HTTP 400 (`board_id is required when querying ticket statuses`).
- `searchStatuses` reads the current form state: top-level `board_id` for `Ticket → Create`, `updateAdditionalFields.board_id` for `Ticket → Update`, and a new optional `Board ID (for Status Picker)` (`statusFilterBoardId`) for `Ticket → Update Status` (used only to filter the dropdown; not sent in the payload).
- `Status → List` now shows and requires a `Board ID` (`helperBoardId`) when the status type is `ticket`; non-ticket types are unchanged.
- Manual UUID entry for `status_id` continues to work on every ticket operation; when no board is selected, the dropdown falls back to an empty list rather than hitting the server.

Package bumped to `0.4.1` with matching release notes and README guidance.

## Test plan
- [x] `npm run test` in `packages/n8n-nodes-alga-psa` (123 passed, incl. new board-scoped status cases)
- [x] `npm run typecheck` in `packages/n8n-nodes-alga-psa`
- [ ] Manual smoke against a tenant: Ticket → Create/Update/Update Status with dropdowns respects selected board; Status helper with type `Ticket` requires board
- [ ] Manual smoke that `Status → List` with `Project` / `Project Task` / `Interaction` still works without a board