### PR TITLE
fix(accounting): honor invoiceIds filter on export batches

### DIFF
--- a/packages/billing/src/actions/accountingExportActions.ts
+++ b/packages/billing/src/actions/accountingExportActions.ts
@@ -43,6 +43,7 @@ export interface AccountingExportPreviewFilters {
   endDate?: string;
   invoiceStatuses?: string[] | string;
   clientIds?: string[] | string;
+  invoiceIds?: string[] | string;
   clientSearch?: string;
   adapterType?: string;
   targetRealm?: string;
@@ -207,6 +208,7 @@ export const previewAccountingExport = withAuth(async (
     endDate: toOptionalString(filters.endDate),
     invoiceStatuses: toStringArray(filters.invoiceStatuses),
     clientIds: toStringArray(filters.clientIds),
+    invoiceIds: toStringArray(filters.invoiceIds),
     clientSearch: toOptionalString(filters.clientSearch),
     adapterType: toOptionalString(filters.adapterType),
     targetRealm: toOptionalString(filters.targetRealm) ?? null,
@@ -313,6 +315,11 @@ function normalizeCreateBatchFilters(
   const clientIds = toFilterStringArray(filters.client_ids ?? filters.clientIds);
   if (clientIds && clientIds.length > 0) {
     result.clientIds = clientIds;
+  }
+
+  const invoiceIds = toFilterStringArray(filters.invoice_ids ?? filters.invoiceIds);
+  if (invoiceIds && invoiceIds.length > 0) {
+    result.invoiceIds = invoiceIds;
   }
 
   const clientSearch = toFilterString(filters.client_search ?? filters.clientSearch);

--- a/packages/billing/src/services/accountingExportInvoiceSelector.ts
+++ b/packages/billing/src/services/accountingExportInvoiceSelector.ts
@@ -12,6 +12,7 @@ export interface InvoiceSelectionFilters {
   endDate?: Nullable<string>;
   invoiceStatuses?: string[];
   clientIds?: string[];
+  invoiceIds?: string[];
   clientSearch?: string;
   adapterType?: string;
   targetRealm?: Nullable<string>;
@@ -149,6 +150,10 @@ export class AccountingExportInvoiceSelector {
           );
         }
       });
+    }
+
+    if (filters.invoiceIds && filters.invoiceIds.length > 0) {
+      query.andWhere((builder) => builder.whereIn('inv.invoice_id', filters.invoiceIds!));
     }
 
     if (filters.clientIds && filters.clientIds.length > 0) {
@@ -512,6 +517,10 @@ function normalizeFilters(filters: InvoiceSelectionFilters): Record<string, unkn
 
   if (filters.clientIds && filters.clientIds.length > 0) {
     normalized.client_ids = Array.from(new Set(filters.clientIds));
+  }
+
+  if (filters.invoiceIds && filters.invoiceIds.length > 0) {
+    normalized.invoice_ids = Array.from(new Set(filters.invoiceIds));
   }
 
   if (filters.clientSearch && filters.clientSearch.trim().length > 0) {


### PR DESCRIPTION
## Summary

`normalizeCreateBatchFilters` previously only recognized `startDate`, `endDate`, `invoiceStatuses`, `clientIds`, `clientSearch`, and `excludeSyncedInvoices`. A user-supplied `invoiceIds` / `invoice_ids` filter was **silently dropped** — the batch would be created with `filters: null` and end up sweeping every unsynced invoice for the tenant rather than the caller's target set.

Surfaced while smoke-testing the live Xero adapter: a batch scoped to one invoice materialized export lines for ~10+ unrelated invoices, several of which then failed validation for unrelated mapping issues. The scoping the API docs implied didn't exist.

## Change

Thread `invoiceIds` through the three filter layers:

- `InvoiceSelectionFilters.invoiceIds?: string[]` in the selector
- `previewInvoiceLines` applies `whereIn('inv.invoice_id', ...)`
- `normalizeFilters` persists `invoice_ids` on `accounting_export_batches.filters` so the stored batch reflects the real scope
- `normalizeCreateBatchFilters` and `previewAccountingExport` accept both `invoiceIds` (camelCase) and `invoice_ids` (snake_case), consistent with the existing `clientIds`/`client_ids` handling
- `AccountingExportPreviewFilters` picks up the new field for parity

No other filter keys or behaviors touched. Unknown keys still silently drop (out of scope).

## Test plan

- [ ] POST `/api/accounting/exports/` with `filters.invoiceIds=[<one invoice uuid>]` against a tenant with multiple unsynced invoices; confirm `accounting_export_batches.filters` persists as `{"invoice_ids":[...]}` and only that invoice's charges appear in `accounting_export_lines`.
- [ ] Same with `invoice_ids` (snake) — same result.
- [ ] Omit the key — batch picks up all unsynced invoices (prior behavior preserved).
- [ ] `previewAccountingExport({ invoiceIds: [...] })` returns only the scoped lines.