### PR TITLE
fix(accounting): return 409 for idempotent export retries

### DIFF
--- a/server/src/lib/api/controllers/ApiAccountingExportController.ts
+++ b/server/src/lib/api/controllers/ApiAccountingExportController.ts
@@ -122,6 +122,16 @@ export class ApiAccountingExportController extends ApiBaseController {
               { status: 409 }
             );
           }
+          if (error instanceof AppError && error.code === 'ACCOUNTING_EXPORT_EMPTY_BATCH') {
+            return NextResponse.json(
+              {
+                error: error.code,
+                message: error.message,
+                filters: error.details?.filters
+              },
+              { status: 409 }
+            );
+          }
           throw error;
         }
       });


### PR DESCRIPTION
## Summary
- Adds an `ACCOUNTING_EXPORT_EMPTY_BATCH` handler to the `createBatch` controller so that an export whose filters match only already-synced invoices returns **409 Conflict** instead of the previous **500 Internal Server Error**.
- Matches the existing 409 convention used for `ACCOUNTING_EXPORT_DUPLICATE`.
- Surfaces the normalized filter payload on the response so the UI / API consumer can explain the outcome.

## Why
Flow 2 of the live Xero smoke test (immediate retry of the same invoice export) was surfacing as a generic 500 even though the underlying guard was doing the right thing — the preview came back empty because the only matching invoice was already mapped. Mapping this to 409 makes the idempotency trip observable to clients without treating it as a server error.

## Test plan
- [x] Live smoke: re-ran `POST /api/accounting/exports/` with the same `invoice_ids` filter while the dev server was running. Response went from `500 INTERNAL_ERROR` to `409` with body `{"error":"ACCOUNTING_EXPORT_EMPTY_BATCH","message":"No invoices match the selected filters (or all matching invoices have already been exported).","filters":{"invoice_ids":["…"]}}`.
- [ ] Add controller-level unit coverage for the new branch (follow-up).

## Scope notes
- `execute` and `downloadFile` handlers still return 400 for the same error code — left untouched here to keep this PR narrow. They can be aligned to 409 in a follow-up if desired; no consumer currently asserts on those codes in-tree.
- Independent of PRs #2337 and #2339; branches from `main`.