### PR TITLE
feat(accounting): nudge tenants toward accounting-system tax delegation

### DIFF
--- a/packages/billing/src/actions/taxSettingsActions.ts
+++ b/packages/billing/src/actions/taxSettingsActions.ts
@@ -753,3 +753,87 @@ export const updateTenantTaxSettings = withAuth(async (
     throw new Error('Failed to update tenant tax settings');
   }
 });
+
+const DELEGATION_INTEGRATION_TYPES = ['xero', 'quickbooks_online'] as const;
+const INTEGRATION_LABELS: Record<string, string> = {
+  xero: 'Xero',
+  quickbooks_online: 'QuickBooks Online',
+};
+
+/**
+ * Returns whether the in-settings "let your accounting system calculate tax" banner
+ * should appear for the current tenant, plus the label of the first delegation-capable
+ * adapter that has an active mapping. The banner appears when:
+ * - `default_tax_source` is `internal`
+ * - The tenant admin hasn't dismissed the banner
+ * - At least one live-adapter mapping (Xero / QBO Online) exists
+ */
+export const getTaxDelegationNudgeState = withAuth(async (
+  _user,
+  { tenant }
+): Promise<{ shouldShow: boolean; adapterLabel: string | null }> => {
+  if (!tenant) {
+    return { shouldShow: false, adapterLabel: null };
+  }
+
+  const { knex } = await createTenantKnex();
+
+  const settings = await knex('tenant_settings')
+    .where({ tenant })
+    .select('default_tax_source', 'tax_delegation_nudge_dismissed_at')
+    .first();
+
+  if (settings?.tax_delegation_nudge_dismissed_at) {
+    return { shouldShow: false, adapterLabel: null };
+  }
+  if ((settings?.default_tax_source ?? 'internal') !== 'internal') {
+    return { shouldShow: false, adapterLabel: null };
+  }
+
+  const mapping = await knex('tenant_external_entity_mappings')
+    .where({ tenant })
+    .whereIn('integration_type', DELEGATION_INTEGRATION_TYPES as unknown as string[])
+    .select('integration_type')
+    .first();
+
+  if (!mapping) {
+    return { shouldShow: false, adapterLabel: null };
+  }
+
+  return {
+    shouldShow: true,
+    adapterLabel: INTEGRATION_LABELS[mapping.integration_type] ?? 'your accounting system',
+  };
+});
+
+/**
+ * Marks the tax delegation banner as dismissed for the current tenant. Dismissal is
+ * tenant-wide by design — one admin's dismissal suppresses the banner for the rest
+ * of the tenant.
+ */
+export const dismissTaxDelegationNudge = withAuth(async (
+  user,
+  { tenant }
+): Promise<void> => {
+  if (!(hasPermission(user, 'billing', 'update'))) {
+    throw new Error('Permission denied: Cannot dismiss tax delegation banner');
+  }
+  if (!tenant) {
+    throw new Error('SYSTEM_ERROR: Tenant context not found');
+  }
+
+  const { knex } = await createTenantKnex();
+  const now = new Date().toISOString();
+
+  const existing = await knex('tenant_settings').where({ tenant }).first();
+  if (existing) {
+    await knex('tenant_settings')
+      .where({ tenant })
+      .update({ tax_delegation_nudge_dismissed_at: now });
+  } else {
+    await knex('tenant_settings').insert({
+      tenant,
+      tax_delegation_nudge_dismissed_at: now,
+    });
+  }
+});

--- a/packages/billing/src/components/index.ts
+++ b/packages/billing/src/components/index.ts
@@ -15,6 +15,8 @@ export { ContractWizard } from './billing-dashboard/contracts/ContractWizard';
 export { ContractDialog } from './billing-dashboard/contracts/ContractDialog';
 export { default as CreditsPage } from './credits/CreditsPage';
 export { default as TaxSettingsForm } from './tax/TaxSettingsForm';
+export { default as TaxDelegationNudge } from './tax/TaxDelegationNudge';
+export { default as TaxDelegationBanner } from './tax/TaxDelegationBanner';
 
 // Settings (billing + tax)
 export { default as BillingSettings } from './settings/billing/BillingSettings';

--- a/packages/billing/src/components/settings/billing/BillingSettings.tsx
+++ b/packages/billing/src/components/settings/billing/BillingSettings.tsx
@@ -16,6 +16,7 @@ import CreditExpirationSettings from './CreditExpirationSettings';
 import RenewalAutomationSettings from './RenewalAutomationSettings';
 import { TaxSourceSettings } from '../tax/TaxSourceSettings';
 import { TaxRegionsManager } from '../tax/TaxRegionsManager';
+import TaxDelegationBanner from '../../tax/TaxDelegationBanner';
 
 // Payment Settings Skeleton Component
 const PaymentSettingsSkeleton: React.FC = () => {
@@ -234,6 +235,7 @@ const BillingSettings: React.FC = () => {
       label: t('tabs.tax', { defaultValue: 'Tax' }),
       content: (
         <div className="space-y-6">
+          <TaxDelegationBanner />
           <TaxSourceSettings />
           <Card>
             <CardHeader>

--- a/packages/billing/src/components/tax/TaxDelegationBanner.tsx
+++ b/packages/billing/src/components/tax/TaxDelegationBanner.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React from 'react';
+import toast from 'react-hot-toast';
+import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
+import { Button } from '@alga-psa/ui/components/Button';
+import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { Cloud } from 'lucide-react';
+import {
+  dismissTaxDelegationNudge,
+  getTaxDelegationNudgeState,
+  updateTenantTaxSettings,
+} from '@alga-psa/billing/actions';
+
+export function TaxDelegationBanner(): React.JSX.Element | null {
+  const [adapterLabel, setAdapterLabel] = React.useState<string | null>(null);
+  const [shouldShow, setShouldShow] = React.useState(false);
+  const [loaded, setLoaded] = React.useState(false);
+  const [busy, setBusy] = React.useState<'enable' | 'dismiss' | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const state = await getTaxDelegationNudgeState();
+        if (cancelled) return;
+        setShouldShow(state.shouldShow);
+        setAdapterLabel(state.adapterLabel);
+      } catch (err) {
+        handleError(err, 'Unable to load tax delegation recommendation state.');
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleEnable = async () => {
+    setBusy('enable');
+    try {
+      await updateTenantTaxSettings({
+        default_tax_source: 'external',
+        allow_external_tax_override: true,
+      });
+      toast.success(
+        adapterLabel
+          ? `${adapterLabel} will calculate tax on new invoices.`
+          : 'External tax calculation enabled.',
+      );
+      setShouldShow(false);
+    } catch (err) {
+      handleError(err, 'Failed to enable external tax calculation.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleDismiss = async () => {
+    setBusy('dismiss');
+    try {
+      await dismissTaxDelegationNudge();
+      setShouldShow(false);
+    } catch (err) {
+      handleError(err, 'Failed to dismiss the banner.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (!loaded || !shouldShow) return null;
+
+  const label = adapterLabel ?? 'your accounting system';
+
+  return (
+    <Alert variant="info" id="tax-delegation-banner">
+      <Cloud className="h-4 w-4" />
+      <AlertTitle>Let {label} calculate tax?</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>
+          {label} is connected. Most customers prefer to have their accounting system
+          handle tax so the two ledgers stay aligned — Alga will post invoices without
+          tax amounts, {label} applies its tax rules, and the result syncs back to Alga.
+          Alga is not a tax package; we recommend delegating.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            id="tax-delegation-banner-enable"
+            size="sm"
+            onClick={() => void handleEnable()}
+            disabled={busy !== null}
+          >
+            {busy === 'enable' ? 'Applying…' : `Use ${label} for tax`}
+          </Button>
+          <Button
+            id="tax-delegation-banner-dismiss"
+            size="sm"
+            variant="outline"
+            onClick={() => void handleDismiss()}
+            disabled={busy !== null}
+          >
+            {busy === 'dismiss' ? 'Dismissing…' : 'Not now'}
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export default TaxDelegationBanner;

--- a/packages/billing/src/components/tax/TaxDelegationNudge.tsx
+++ b/packages/billing/src/components/tax/TaxDelegationNudge.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import React from 'react';
+import toast from 'react-hot-toast';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
+import { Button } from '@alga-psa/ui/components/Button';
+import { handleError } from '@alga-psa/ui/lib/errorHandling';
+import { Cloud } from 'lucide-react';
+import {
+  getTenantTaxSettings,
+  updateTenantTaxSettings,
+} from '@alga-psa/billing/actions';
+
+type SupportedAdapter = { key: 'xero' | 'qbo'; label: string; statusParam: string };
+
+const SUPPORTED_ADAPTERS: SupportedAdapter[] = [
+  { key: 'xero', label: 'Xero', statusParam: 'xero_status' },
+  { key: 'qbo', label: 'QuickBooks Online', statusParam: 'qbo_status' },
+];
+
+function detectJustConnectedAdapter(searchParams: URLSearchParams | null): SupportedAdapter | null {
+  if (!searchParams) return null;
+  for (const adapter of SUPPORTED_ADAPTERS) {
+    if (searchParams.get(adapter.statusParam) === 'success') {
+      return adapter;
+    }
+  }
+  return null;
+}
+
+export function TaxDelegationNudge(): React.JSX.Element | null {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const justConnected = React.useMemo(
+    () => detectJustConnectedAdapter(searchParams as URLSearchParams | null),
+    [searchParams],
+  );
+
+  const [currentSource, setCurrentSource] = React.useState<string | null>(null);
+  const [loaded, setLoaded] = React.useState(false);
+  const [dismissed, setDismissed] = React.useState(false);
+  const [applying, setApplying] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!justConnected) {
+      setLoaded(true);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await getTenantTaxSettings();
+        if (cancelled) return;
+        setCurrentSource(settings?.default_tax_source ?? 'internal');
+      } catch (err) {
+        handleError(err, 'Unable to load current tax settings.');
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [justConnected]);
+
+  const stripStatusParam = React.useCallback(() => {
+    if (!justConnected || !searchParams || !pathname) return;
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete(justConnected.statusParam);
+    const query = next.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [justConnected, pathname, router, searchParams]);
+
+  const handleEnable = async () => {
+    if (!justConnected) return;
+    setApplying(true);
+    try {
+      await updateTenantTaxSettings({
+        default_tax_source: 'external',
+        allow_external_tax_override: true,
+      });
+      toast.success(
+        `${justConnected.label} will calculate tax on new invoices. You can change this in Billing settings.`,
+      );
+      setDismissed(true);
+      stripStatusParam();
+    } catch (err) {
+      handleError(err, 'Failed to enable external tax calculation.');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleKeepInternal = () => {
+    setDismissed(true);
+    stripStatusParam();
+  };
+
+  if (!justConnected || !loaded || dismissed) return null;
+  if (currentSource && currentSource !== 'internal') return null;
+
+  return (
+    <Alert variant="info" id="tax-delegation-nudge" className="mb-4">
+      <Cloud className="h-4 w-4" />
+      <AlertTitle>Let {justConnected.label} calculate tax on future invoices?</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>
+          Recommended. New invoices will post to {justConnected.label} without tax amounts,
+          {' '}{justConnected.label} will apply its tax rules, and the calculated tax will sync back to Alga —
+          keeping your two ledgers aligned. You can change this anytime in Billing → Tax Settings.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            id="tax-delegation-nudge-enable"
+            size="sm"
+            onClick={() => void handleEnable()}
+            disabled={applying}
+          >
+            {applying ? 'Applying…' : `Yes, use ${justConnected.label}`}
+          </Button>
+          <Button
+            id="tax-delegation-nudge-dismiss"
+            size="sm"
+            variant="outline"
+            onClick={handleKeepInternal}
+            disabled={applying}
+          >
+            Keep Alga calculating tax
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export default TaxDelegationNudge;

--- a/packages/billing/src/services/accountingExportService.ts
+++ b/packages/billing/src/services/accountingExportService.ts
@@ -21,6 +21,7 @@ import {
   TaxDelegationMode
 } from '@alga-psa/types';
 import { AccountingExportValidation } from './accountingExportValidation';
+import { getExternalTaxImportService } from './externalTaxImportService';
 import { publishEvent } from '@alga-psa/event-bus/publishers';
 import { AppError } from '@alga-psa/core';
 import { getXeroCsvSettingsForTenant } from '@alga-psa/integrations/runtime';
@@ -52,7 +53,7 @@ export class AccountingExportService {
       AccountingExportRepository.create(),
       AccountingAdapterRegistry.createDefault()
     ]);
-    return new AccountingExportService(repository, registry, taxImporter);
+    return new AccountingExportService(repository, registry, taxImporter ?? getExternalTaxImportService());
   }
 
   static async createForTenant(
@@ -63,7 +64,7 @@ export class AccountingExportService {
       AccountingExportRepository.createForTenant(tenantId),
       AccountingAdapterRegistry.createDefault()
     ]);
-    return new AccountingExportService(repository, registry, taxImporter);
+    return new AccountingExportService(repository, registry, taxImporter ?? getExternalTaxImportService());
   }
 
   async createBatch(input: CreateExportBatchOptions): Promise<AccountingExportBatch> {

--- a/server/migrations/20260417130000_add_tax_delegation_nudge_dismissed.cjs
+++ b/server/migrations/20260417130000_add_tax_delegation_nudge_dismissed.cjs
@@ -1,0 +1,57 @@
+const hasColumn = async (knex, tableName, columnName) => {
+  try {
+    return await knex.schema.hasColumn(tableName, columnName);
+  } catch (error) {
+    console.warn(`Unable to check column ${columnName} on ${tableName}:`, error);
+    return false;
+  }
+};
+
+exports.up = async function up(knex) {
+  const tableName = 'tenant_settings';
+  const tableExists = await knex.schema.hasTable(tableName);
+  if (!tableExists) {
+    console.log('⊘ Skipping tax delegation nudge migration: tenant_settings table not found');
+    return;
+  }
+
+  const hasDismissedAt = await hasColumn(knex, tableName, 'tax_delegation_nudge_dismissed_at');
+  if (hasDismissedAt) {
+    console.log('⊘ tax_delegation_nudge_dismissed_at column already exists, skipping');
+    return;
+  }
+
+  await knex.schema.alterTable(tableName, (table) => {
+    table.timestamp('tax_delegation_nudge_dismissed_at', { useTz: true }).nullable();
+  });
+
+  await knex.raw(`
+    COMMENT ON COLUMN tenant_settings.tax_delegation_nudge_dismissed_at IS
+    'Set when a tenant admin dismisses the recommendation to let the accounting system calculate tax. NULL means the banner is still visible to tenant admins.'
+  `);
+
+  console.log('✓ Added tax_delegation_nudge_dismissed_at column to tenant_settings');
+};
+
+exports.down = async function down(knex) {
+  const tableName = 'tenant_settings';
+  const tableExists = await knex.schema.hasTable(tableName);
+  if (!tableExists) {
+    console.log('⊘ tenant_settings table not found, nothing to roll back');
+    return;
+  }
+
+  const hasDismissedAt = await hasColumn(knex, tableName, 'tax_delegation_nudge_dismissed_at');
+  if (!hasDismissedAt) {
+    console.log('⊘ tax_delegation_nudge_dismissed_at column already absent, nothing to roll back');
+    return;
+  }
+
+  await knex.schema.alterTable(tableName, (table) => {
+    table.dropColumn('tax_delegation_nudge_dismissed_at');
+  });
+
+  console.log('✓ Removed tax_delegation_nudge_dismissed_at column from tenant_settings');
+};
+
+exports.config = { transaction: false };

--- a/server/src/components/settings/SettingsPage.tsx
+++ b/server/src/components/settings/SettingsPage.tsx
@@ -35,7 +35,7 @@ const ExperimentalFeaturesSettings = dynamic(() => import('./general/Experimenta
 });
 import InteractionSettings from './general/InteractionSettings';
 import { TimeEntrySettings } from '@alga-psa/scheduling/components';
-import { BillingSettings } from '@alga-psa/billing/components'; // Import the new component
+import { BillingSettings, TaxDelegationNudge } from '@alga-psa/billing/components'; // Import the new component
 import NotificationsTab from './general/NotificationsTab';
 // Removed import: import IntegrationsTabLoader from './IntegrationsTabLoader';
 import { IntegrationsSettingsPage } from '@alga-psa/integrations/components';
@@ -271,7 +271,12 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
       label: t('tabs.integrations'),
       icon: Plug,
       requiredFeature: TIER_FEATURES.INTEGRATIONS,
-      content: <IntegrationsSettingsPage canUseEntraSync={canUseEntraSync} canUseCipp={canUseCipp} canUseTeams={canUseTeams} />,
+      content: (
+        <>
+          <TaxDelegationNudge />
+          <IntegrationsSettingsPage canUseEntraSync={canUseEntraSync} canUseCipp={canUseCipp} canUseTeams={canUseTeams} />
+        </>
+      ),
     }
   ];
 


### PR DESCRIPTION
## Summary

Alga PSA defaults `tenant_settings.default_tax_source` to `internal`, and that's the wrong default for the product — Alga is not a tax package, and the whole point of connecting Xero / QBO is usually to let the accounting system own the ledger (including tax). Flipping the system-wide default is a multi-phase effort (onboarding gaps, finalization gates, CSV-adapter writeback UX) — but we can capture most of the benefit today with a just-in-time nudge that surfaces at the exact moment the tenant connects an accounting system.

This PR ships three related changes:

### 1. Fix: default `taxImporter` wiring in `AccountingExportService`

Before this PR, every production caller (`accountingExportActions.ts`, `runtime.ts`, `ApiCSVAccountingController.ts`, `accountingExportInvoiceSelector.ts`, download route, audit-trail tests) called `AccountingExportService.create()` / `.createForTenant()` with **no** `taxImporter`. Inside `importExternalTaxAfterDelivery` that means `if (!this.taxImporter) return` — writeback never fired, so any invoice in `pending_external` mode would be stranded there forever and blocked from finalization.

Factories now default to the existing `getExternalTaxImportService()` singleton, matching what the existing integration test at `server/src/test/integration/accounting/externalTaxImport.integration.test.ts:188` already assumed was happening.

### 2. Post-connect nudge (`TaxDelegationNudge`)

Rendered above `<IntegrationsSettingsPage />` in the Integrations settings tab. Gated by the OAuth-callback search params (`xero_status=success` / `qbo_status=success`) **and** `default_tax_source === 'internal'`. On click of _"Yes, use Xero"_ (or QBO), calls `updateTenantTaxSettings({ default_tax_source: 'external', allow_external_tax_override: true })` and strips the status param from the URL so it doesn't re-show on refresh.

Adapter-specific copy is driven from the detected status param; adds QBO parity (shows only once the QBO UI ships — currently `disabled: true` in `AccountingIntegrationsSetup`).

### 3. Already-connected banner (`TaxDelegationBanner`)

For the population of tenants who already connected Xero / QBO before this nudge existed. Rendered above `<TaxSourceSettings />` in Billing → Tax. Visible when all three are true:
- `default_tax_source === 'internal'`
- `tax_delegation_nudge_dismissed_at IS NULL`
- At least one `xero` / `quickbooks_online` row in `tenant_external_entity_mappings`

New server actions: `getTaxDelegationNudgeState`, `dismissTaxDelegationNudge`. Dismissal is **tenant-wide** — one admin's dismissal hides the banner for the whole tenant (as we agreed; per-user dismissal would need its own UI-state table).

New migration: `20260417130000_add_tax_delegation_nudge_dismissed.cjs` adds a nullable `timestamptz tax_delegation_nudge_dismissed_at` column to `tenant_settings`. Idempotent up / down.

## Test plan
- [x] Local migration applied cleanly against the dev DB; column exists with expected shape (nullable, no default).
- [x] Banner renders on Billing → Tax with the correct adapter label ("Let Xero calculate tax?") when the conditions are met.
- [x] _"Use Xero for tax"_ flips `default_tax_source` to `external`, sets `allow_external_tax_override=true`, and hides the banner.
- [x] _"Not now"_ persists `tax_delegation_nudge_dismissed_at` and hides the banner on reload.
- [ ] Post-OAuth nudge — covered by Flow 3b of the live Xero smoke suite (next up after this PR lands).
- [ ] End-to-end external-mode cycle (create → deliver → writeback → finalize) — also Flow 3b.

## Scope notes
- This PR does **not** flip the system-wide default. That's a separate decision that depends on the wider phase-1 work (onboarding without a connected adapter, CSV writeback UX, rendering of `pending_external` invoices). The nudge gives us most of the product win with none of those blockers.
- Independent of open PRs #2337, #2339, #2340 — branches from `main`.