### PR TITLE
fix(accounting): make external-mode tax writeback actually complete

### DIFF
--- a/packages/billing/src/adapters/accounting/quickBooksOnlineAdapter.ts
+++ b/packages/billing/src/adapters/accounting/quickBooksOnlineAdapter.ts
@@ -609,8 +609,11 @@ export class QuickBooksOnlineAdapter implements AccountingExportAdapter {
     targetRealm?: string
   ): Promise<ExternalInvoiceFetchResult> {
     try {
-      const { knex } = await createTenantKnex();
-      const tenantId = await this.getTenantFromContext(knex);
+      const { knex, tenant } = await createTenantKnex();
+      if (!tenant) {
+        throw new AppError('QBO_TENANT_REQUIRED', 'Unable to determine tenant from context');
+      }
+      const tenantId = tenant;
 
       if (!targetRealm) {
         return {

--- a/packages/billing/src/adapters/accounting/xeroAdapter.ts
+++ b/packages/billing/src/adapters/accounting/xeroAdapter.ts
@@ -605,8 +605,11 @@ export class XeroAdapter implements AccountingExportAdapter {
     targetRealm?: string
   ): Promise<ExternalInvoiceFetchResult> {
     try {
-      const { knex } = await createTenantKnex();
-      const tenantId = await this.getTenantFromContext(knex);
+      const { knex, tenant } = await createTenantKnex();
+      if (!tenant) {
+        throw new AppError('XERO_TENANT_REQUIRED', 'Unable to determine tenant from context');
+      }
+      const tenantId = tenant;
 
       const client = await XeroClientService.create(tenantId, targetRealm ?? null);
       const xeroInvoice = await client.getInvoice(externalInvoiceRef);
@@ -875,6 +878,13 @@ function normalizeTaxComponents(input: unknown): XeroTaxComponentPayload[] | und
 
 function defaultLineAmountType(lines: XeroInvoiceLinePayload[]): LineAmountType {
   if (lines.some((line) => typeof line.taxAmountCents === 'number' && line.taxAmountCents !== 0)) {
+    return 'Exclusive';
+  }
+  // When we delegate tax calculation to Xero we still send a TaxType per line so
+  // Xero knows which rate to apply. Those TaxType codes are only valid on
+  // Exclusive/Inclusive invoices — on a NoTax invoice Xero overrides TaxType to
+  // NONE and charges no tax, which silently breaks writeback.
+  if (lines.some((line) => Boolean(line.taxType))) {
     return 'Exclusive';
   }
   return 'NoTax';

--- a/packages/billing/src/services/externalTaxImportService.ts
+++ b/packages/billing/src/services/externalTaxImportService.ts
@@ -229,11 +229,15 @@ export class ExternalTaxImportService {
         .first();
 
       const newTotalsRow = newTotals as unknown as { subtotal?: number | string; tax?: number | string } | undefined;
-      const newTotal = Number(newTotalsRow?.subtotal ?? 0) + Number(newTotalsRow?.tax ?? 0);
+      const newSubtotal = Number(newTotalsRow?.subtotal ?? 0);
+      const newTax = Number(newTotalsRow?.tax ?? 0);
+      const newTotal = newSubtotal + newTax;
 
       await knex('invoices')
         .where({ invoice_id: invoiceId, tenant })
         .update({
+          subtotal: newSubtotal,
+          tax: newTax,
           total_amount: newTotal,
           updated_at: knex.fn.now()
         });


### PR DESCRIPTION
## Summary
Three independent bugs were each silently breaking the external-tax writeback pipeline. Together they meant that an invoice created with `tax_source='pending_external'` and exported to Xero/QBO would post to the accounting system with **\$0 tax** and stay stuck in `pending_external` in Alga — blocking finalization. Fixed on the external-mode path end-to-end.

### 1. Adapter tenant lookup fails outside a transaction
`XeroAdapter.fetchExternalInvoice` and `QuickBooksOnlineAdapter.fetchExternalInvoice` resolved the tenant via `SELECT current_setting('app.current_tenant', …)`, which is only set when a transaction has called `SET LOCAL`. The post-delivery writeback runs outside a transaction, so every auto-import threw `XERO_TENANT_REQUIRED: Unable to determine tenant from context`. `createTenantKnex()` already returns the tenant from AsyncLocalStorage — use that directly.

### 2. `defaultLineAmountType` silently picks \`NoTax\` under delegation
When \`shouldExcludeTax=true\` (Alga is delegating tax to Xero), the adapter omits \`TaxAmount\` but still sends a \`TaxType\` per line so Xero knows which rate to apply. With no tax amounts, \`defaultLineAmountType\` fell through to \`'NoTax'\`. Xero then overrides any TaxType to \`NONE\` on a \`NoTax\` invoice, the draft is created with \$0 tax, writeback imports \$0, and the Alga ledger diverges from Xero's. If any line has a TaxType, the invoice must be \`'Exclusive'\`.

### 3. \`invoices.tax\` / \`invoices.subtotal\` not updated on writeback
\`externalTaxImportService.importTaxForInvoice\` recomputed the correct \`subtotal\` and \`tax\` from the charges but only wrote \`total_amount\` back to the invoice header. Downstream reports that still read \`invoices.tax\` silently understated tax. Persist all three columns.

## Test plan
- [x] Live smoke against Xero Demo Company (US). With the fixes in place, the full cycle \`create (pending_external) → deliver → auto-writeback → finalize\` completes. External tax imported at Xero's Demo rate (9.25% OUTPUT = \$18.50 on a \$200 line), \`invoices.tax_source\` flipped to \`external\`, \`invoices.tax=1850\`, \`total_amount=21850\`, and the finalize gate released.
- [ ] Unit coverage for (1) at the adapter level and (2) on \`defaultLineAmountType\` — follow-up.

## Context / dependencies
- Composes with PR #2341 (the taxImporter auto-wire + tax-delegation UI nudge). #2341 made the writeback actually fire; this PR makes that firing actually succeed. Either alone is insufficient; both together turn on end-to-end external-mode.
- Branches off \`main\`, independent of the other open PRs in this series.
- Does not change behavior when Alga is the tax authority (\`tax_source='internal'\`) — \`defaultLineAmountType\` still picks \`Exclusive\` when \`TaxAmount\` is non-zero, so existing internal-mode invoices keep posting with authoritative tax amounts as before.

## Smoke findings surfaced but not in this PR
- Xero matches existing drafts by \`InvoiceNumber\` on re-export; retrying the same \`invoice_id\` with the same number trips a \`"Could not find line item(s) with the following id(s)"\` error because a freshly generated \`LineItemID\` doesn't exist in the pre-existing draft. Separate PR to address — likely needs idempotent upsert via the existing external mapping.