### PR TITLE
fix(xero): make invoice re-export idempotent via InvoiceID + LineItemID threading

### DIFF
--- a/packages/billing/src/adapters/accounting/xeroAdapter.ts
+++ b/packages/billing/src/adapters/accounting/xeroAdapter.ts
@@ -151,6 +151,7 @@ export class XeroAdapter implements AccountingExportAdapter {
       adapterFactory: (adapterType) => (adapterType === XeroAdapter.TYPE ? this.companyAdapter : null)
     });
     const resolver = await AccountingMappingResolver.create({ companySyncService });
+    const invoiceMappingRepository = new KnexInvoiceMappingRepository(knex);
 
     const invoicesById = await this.loadInvoices(knex, tenantId, context);
     const chargesById = await this.loadCharges(knex, tenantId, context);
@@ -163,6 +164,32 @@ export class XeroAdapter implements AccountingExportAdapter {
       const invoice = invoicesById.get(invoiceId);
       if (!invoice) {
         throw new AppError('XERO_INVOICE_NOT_FOUND', `Invoice ${invoiceId} not found for tenant ${tenantId}`);
+      }
+
+      // If this invoice was already exported to Xero, look up the Xero InvoiceID
+      // and the per-charge LineItemIDs so we can send them back on this export.
+      // Xero upserts invoices by InvoiceNumber; without an InvoiceID on an update
+      // it rematches by number and then rejects any LineItemID it doesn't already
+      // have in that draft. Threading the known IDs makes the retry idempotent.
+      const existingMapping = await invoiceMappingRepository.findInvoiceMapping({
+        tenantId,
+        adapterType: this.type,
+        invoiceId,
+        targetRealm: context.batch.target_realm ?? null
+      });
+      const storedChargeLineMappings = Array.isArray(
+        (existingMapping?.metadata as any)?.chargeLineMappings
+      )
+        ? ((existingMapping!.metadata as any).chargeLineMappings as Array<{
+            chargeId: string;
+            xeroLineItemId: string;
+          }>)
+        : [];
+      const knownChargeToXeroLineItemId = new Map<string, string>();
+      for (const entry of storedChargeLineMappings) {
+        if (entry?.chargeId && entry?.xeroLineItemId) {
+          knownChargeToXeroLineItemId.set(entry.chargeId, entry.xeroLineItemId);
+        }
       }
 
       const clientId =
@@ -303,6 +330,7 @@ export class XeroAdapter implements AccountingExportAdapter {
 
         const payload: XeroInvoiceLinePayload = {
           lineId: line.line_id,
+          externalLineItemId: knownChargeToXeroLineItemId.get(line.invoice_charge_id) ?? null,
           amountCents: Math.round(line.amount_cents),
           description,
           quantity: typeof charge.quantity === 'number' ? charge.quantity : 1,
@@ -339,6 +367,7 @@ export class XeroAdapter implements AccountingExportAdapter {
 
       const invoicePayload: XeroInvoicePayload = {
         invoiceId,
+        externalInvoiceId: existingMapping?.externalInvoiceId ?? null,
         contactId: clientMapping.external_entity_id,
         currency: invoice.currency_code ?? exportLines[0]?.currency_code ?? null,
         reference,

--- a/packages/integrations/src/lib/xero/xeroClientService.ts
+++ b/packages/integrations/src/lib/xero/xeroClientService.ts
@@ -162,6 +162,15 @@ export interface XeroTaxComponentPayload {
 
 export interface XeroInvoiceLinePayload {
   lineId: string;
+  /**
+   * Xero-assigned LineItemID from a prior export of the same invoice, when known.
+   * Omit on a fresh create — Xero will generate and return one, which we then
+   * persist on the invoice mapping for future updates. On a retry / update we
+   * MUST send the Xero LineItemID for every previously-posted line, otherwise
+   * Xero's upsert-by-InvoiceNumber rejects the line with "Could not find line
+   * item(s) with the following id(s)".
+   */
+  externalLineItemId?: string | null;
   amountCents: number;
   description?: string | null;
   quantity?: number | null;
@@ -178,6 +187,12 @@ export interface XeroInvoiceLinePayload {
 
 export interface XeroInvoicePayload {
   invoiceId: string;
+  /**
+   * Xero-assigned InvoiceID from a prior export of the same Alga invoice, when known.
+   * Setting this turns the POST into an explicit update rather than an
+   * upsert-by-InvoiceNumber, which is what makes retries idempotent.
+   */
+  externalInvoiceId?: string | null;
   contactId: string;
   currency?: string | null;
   reference?: string | null;
@@ -948,6 +963,7 @@ function mapInvoicePayload(payload: XeroInvoicePayload): Record<string, unknown>
 
   const invoice: Record<string, unknown> = {
     Type: 'ACCREC',
+    InvoiceID: payload.externalInvoiceId ?? undefined,
     InvoiceNumber: invoiceNumber,
     Reference: payload.reference ?? undefined,
     Date: formatDate(payload.invoiceDate),
@@ -971,7 +987,11 @@ function mapInvoiceLine(line: XeroInvoiceLinePayload): Record<string, unknown> {
   const tracking = normalizeTracking(line.tracking);
 
   const payload: Record<string, unknown> = {
-    LineItemID: line.lineId,
+    // Only send LineItemID for lines we know Xero already has (from a prior export).
+    // Sending our Alga UUID as LineItemID tricks Xero into treating the line as
+    // one it already knows and, on retry, triggers a validation error because
+    // the ID doesn't match any line in the existing draft.
+    LineItemID: line.externalLineItemId ?? undefined,
     Description: buildLineDescription(line),
     Quantity: quantity,
     UnitAmount: unitAmount ?? (quantity !== 0 ? Number((lineAmount ?? 0) / quantity) : undefined),


### PR DESCRIPTION
## Summary
Xero upserts invoices by \`InvoiceNumber\`. Our adapter never threaded the Xero-assigned \`InvoiceID\` or per-line \`LineItemID\`s back on subsequent exports, so every retry looked like a fresh POST to Xero: Xero matched the existing draft by \`InvoiceNumber\`, then rejected the brand-new \`LineItemID\`s with

> \`"Could not find line item(s) with the following id(s): <Alga UUID>"\`

The trigger was a second fault — \`mapInvoiceLine\` was sending Alga's export-line UUID as \`LineItemID\`. Xero never saw those UUIDs on the first export either (it assigned its own and returned them in the response), so what we were sending has always been meaningless. It just happened to be harmless on a create and fatal on an upsert.

## Changes
- \`packages/integrations/src/lib/xero/xeroClientService.ts\`
  - Add \`externalInvoiceId\` to \`XeroInvoicePayload\` and \`externalLineItemId\` to \`XeroInvoiceLinePayload\`.
  - Map both to \`InvoiceID\` / \`LineItemID\` on the Xero wire payload only when set. Absent on a fresh create — Xero generates and returns them, which the deliver step already persists via \`chargeLineMappings\` metadata.
- \`packages/billing/src/adapters/accounting/xeroAdapter.ts\`
  - In \`transform\`, look up the existing invoice mapping (using the realm-aware \`KnexInvoiceMappingRepository.findInvoiceMapping\` that already exists), grab the Xero \`InvoiceID\` and the stored \`chargeLineMappings\`, and stamp each line's \`externalLineItemId\` onto the payload before handing off to the client. On a fresh first-time export the mapping is absent and both IDs stay undefined — behavior is unchanged.

## Scope
- Xero only for now. QBO has a similar update model, but its integration UI is still disabled in \`AccountingIntegrationsSetup\`, so parity there can follow when QBO ships.
- No change to internal-mode tax export behavior. No change to the writeback path — this PR only affects how the outbound invoice payload identifies itself to Xero.
- Branches off \`main\`, independent of the other open PRs in this series (\`#2341\`, \`#2342\`, etc.).

## Test plan
- [x] Code review of the payload threading in both files.
- [ ] Live smoke: exercise retry-same-\`invoice_id\` path once the invoice-selector's \"already-synced\" filter can be bypassed for retries (currently it blocks re-export at preview, so this PR's code path only fires after manual mapping reset or a future retry-from-failed-state flow). Planned follow-up.
- [ ] Unit coverage for \`XeroAdapter.transform\` with and without an existing mapping (stubbed repo).

## Follow-ups referenced but not in this PR
- Charge-level divergence on retry (added / removed / reordered charges between exports) needs a merge policy on \`chargeLineMappings\` — today the deliver step overwrites the whole array from the current payload. Fine for same-charge retries; lossy if a charge was dropped then re-added. Tracked separately.