### PR TITLE
Entra Integration: drop CIPP from UI, fix sync/disconnect/reconnect gaps

### DIFF
--- a/docker-compose.temporal.ee.yaml
+++ b/docker-compose.temporal.ee.yaml
@@ -58,6 +58,10 @@ services:
       # tenants so cross-client bleed (Flow 2) can be exercised without CSP/GDAP. Format:
       # comma-separated `id|primary_domain|display_name` entries.
       - ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS=${ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS:-}
+      # Smoke-only: forces accountEnabled=false for listed emails/UPNs so the
+      # offboard → deactivate path (Flow 5) can be exercised without disabling
+      # real users in Entra. Format: comma-separated email/UPN list.
+      - ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS=${ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS:-}
     volumes:
       - type: bind
         source: ./secrets/tenants

--- a/docker-compose.temporal.ee.yaml
+++ b/docker-compose.temporal.ee.yaml
@@ -51,6 +51,9 @@ services:
       - PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE=${PORTAL_DOMAIN_BASE_VIRTUAL_SERVICE:-msp/alga-psa-vs}
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
+      # Smoke-only: defaults to unset so the worker uses the real GDAP endpoints. Override in
+      # the compose invocation or shell env to test self-tenant mode without CSP/GDAP.
+      - ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE=${ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE:-}
     volumes:
       - type: bind
         source: ./secrets/tenants

--- a/docker-compose.temporal.ee.yaml
+++ b/docker-compose.temporal.ee.yaml
@@ -54,6 +54,10 @@ services:
       # Smoke-only: defaults to unset so the worker uses the real GDAP endpoints. Override in
       # the compose invocation or shell env to test self-tenant mode without CSP/GDAP.
       - ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE=${ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE:-}
+      # Smoke-only: partitions the self-tenant /users response into N synthetic managed
+      # tenants so cross-client bleed (Flow 2) can be exercised without CSP/GDAP. Format:
+      # comma-separated `id|primary_domain|display_name` entries.
+      - ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS=${ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS:-}
     volumes:
       - type: bind
         source: ./secrets/tenants

--- a/docker-compose.temporal.ee.yaml
+++ b/docker-compose.temporal.ee.yaml
@@ -62,6 +62,11 @@ services:
       # offboard → deactivate path (Flow 5) can be exercised without disabling
       # real users in Entra. Format: comma-separated email/UPN list.
       - ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS=${ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS:-}
+      # Smoke-only: injects fake users into the /users response pinned to a
+      # specific synthetic tenant bucket so Flow 7 (ambiguous match) can be
+      # exercised without adding real users to Entra. Format: comma-separated
+      # `objectId|upn|displayName|bucketIndex` entries.
+      - ENTRA_DIRECT_SMOKE_EXTRA_USERS=${ENTRA_DIRECT_SMOKE_EXTRA_USERS:-}
     volumes:
       - type: bind
         source: ./secrets/tenants

--- a/ee/docs/plans/2026-02-20-entra-integration-phase-1/PRD.md
+++ b/ee/docs/plans/2026-02-20-entra-integration-phase-1/PRD.md
@@ -2,14 +2,28 @@
 
 - Slug: `entra-integration-phase-1`
 - Date: `2026-02-20`
-- Status: Draft
+- Status: Draft (scope updated 2026-04-17 — CIPP connection type removed from Phase 1)
 - Edition: Enterprise only (`NEXT_PUBLIC_EDITION=enterprise`)
 
 ## Summary
 
-Build the Phase 1 Microsoft Entra integration for the EE product with a partner-level auth model, tenant discovery/mapping, and ongoing contact sync using Temporal workflows.
+Build the Phase 1 Microsoft Entra integration for the EE product with a Direct Microsoft partner auth model, tenant discovery/mapping, and ongoing contact sync using Temporal workflows.
 
 All user-visible Entra surfaces ship behind feature flags from day one for selective tenant rollout.
+
+## Scope Change — 2026-04-17
+
+CIPP as a connection type is dropped from Phase 1. Rationale:
+
+1. Zero unique capability vs Direct — both hit Microsoft Graph/Lighthouse endpoints.
+2. Microsoft has closed the Partner Center / GDAP / Lighthouse UX gap that drove CIPP adoption; the moat is shrinking.
+3. Permanent maintenance tax: CIPP response shapes, auth, and endpoint paths drift; every drift is a silent sync failure we own.
+4. Permanent testing cost: CIPP cannot run without Azure + GitHub + Partner Center; every release either deploys CIPP or trusts a drifting mock.
+5. Support surface triples ("Alga bug, CIPP bug, or Graph bug?").
+6. Security surface: storing third-party API tokens one hop from customer Entra data is avoidable blast radius.
+7. Onboarding UX simplifies — no "Direct or CIPP" decision for users with no opinion.
+
+The existing CIPP adapter, secret keys, validation route, and connect action remain in the repo but are no longer wired into the onboarding UI (the connection options list renders Direct only via `buildEntraConnectionOptions`). Retained so the path can be reinstated without a schema or API migration if the bet reverses.
 
 ## Problem
 
@@ -20,9 +34,7 @@ Today there is no EE Entra workflow that does this end-to-end with deterministic
 ## Goals
 
 1. Ship EE-only Entra integration settings and APIs.
-2. Support partner-level connection paths:
-1. Direct Microsoft partner auth (reusing existing Azure app credentials model).
-2. CIPP-based connection.
+2. Support Direct Microsoft partner auth as the single partner-level connection path (reusing existing Azure app credentials model).
 3. Discover managed Microsoft tenants and reconcile them to Alga clients.
 4. Sync enabled Entra users into Alga contacts with additive/linking behavior.
 5. Run initial and recurring sync via Temporal workflows.
@@ -37,7 +49,7 @@ Today there is no EE Entra workflow that does this end-to-end with deterministic
 ## Users and Primary Flows
 
 1. MSP admin/internal user opens Integrations and enables Entra connection.
-2. MSP user chooses connection type (Direct or CIPP) and completes setup.
+2. MSP user completes Direct Microsoft partner auth setup.
 3. MSP user runs discovery and reviews mapping suggestions.
 4. MSP user confirms mappings and starts initial sync.
 5. MSP user reviews sync outcomes, ambiguous matches, and per-tenant status.
@@ -49,7 +61,7 @@ Client portal users do not see or access Entra setup/sync surfaces.
 
 1. Add an EE card to integrations settings for Entra.
 2. Use a 4-step wizard:
-1. Connect.
+1. Connect (Direct Microsoft partner auth only).
 2. Discover Tenants.
 3. Map Tenants to Clients.
 4. Initial Sync.
@@ -64,7 +76,7 @@ Client portal users do not see or access Entra setup/sync surfaces.
 
 1. EE-only APIs/routes/components for Entra integration.
 2. Feature flags gate all user-visible Entra settings and client actions.
-3. Partner-level auth configuration supports Direct and CIPP connection types.
+3. Partner-level auth is Direct Microsoft partner OAuth only (CIPP descoped from Phase 1).
 4. Tenant discovery persists discovered managed tenants.
 5. Mapping flow supports exact-domain auto-match, fuzzy candidates, manual assignment, skip.
 6. Initial sync creates contact links and new contacts where needed.
@@ -94,8 +106,8 @@ Client portal users do not see or access Entra setup/sync surfaces.
 ### Connection adapters
 
 1. Direct adapter for Microsoft partner discovery/user enumeration in `ee/server/src/lib/integrations/entra/providers/direct`.
-2. CIPP adapter for tenant/user enumeration in `ee/server/src/lib/integrations/entra/providers/cipp`.
-3. Provider interface and normalization layer in `ee/server/src/lib/integrations/entra/providers`.
+2. Provider interface and normalization layer in `ee/server/src/lib/integrations/entra/providers`.
+3. CIPP adapter scaffolding remains under `ee/server/src/lib/integrations/entra/providers/cipp` but is not wired into the onboarding UI in Phase 1 (descoped 2026-04-17).
 
 ### API/action surfaces
 
@@ -128,9 +140,10 @@ Primary flags:
 
 1. `entra-integration-ui` (settings card + wizard).
 2. `entra-integration-client-sync-action` (client page manual sync button).
-3. `entra-integration-cipp` (CIPP option visibility).
-4. `entra-integration-field-sync` (field overwrite toggles visibility).
-5. `entra-integration-ambiguous-queue` (reconciliation queue visibility).
+3. `entra-integration-field-sync` (field overwrite toggles visibility).
+4. `entra-integration-ambiguous-queue` (reconciliation queue visibility).
+
+`entra-integration-cipp` is retained as a flag constant but no longer controls user-visible surface area in Phase 1 (CIPP option is hidden unconditionally in `buildEntraConnectionOptions`).
 
 All flags are managed via EE platform feature flag APIs (`/api/v1/platform-feature-flags` + tenant targeting).
 
@@ -147,12 +160,15 @@ Only minimal sync status and audit-oriented result storage required for feature 
 ## Open Questions
 
 1. Direct partner path exact required delegated scopes for tenant and user enumeration in target customer environments.
-2. CIPP endpoint contract stability/version for tenant and user listing.
-3. Final fuzzy matching heuristic threshold defaults.
+2. Final fuzzy matching heuristic threshold defaults.
+
+Resolved / removed:
+
+- (2026-04-17) CIPP endpoint contract stability/version — moot: CIPP path descoped from Phase 1.
 
 ## Acceptance Criteria (Definition of Done)
 
-1. EE tenant can connect Direct or CIPP, discover tenants, map tenants, and run initial sync entirely through flag-gated UI.
+1. EE tenant can connect via Direct Microsoft partner auth, discover tenants, map tenants, and run initial sync entirely through flag-gated UI.
 2. Manual sync (all tenants and per client) starts Temporal workflows and records outcomes.
 3. Contact sync is additive/linking by default; no silent overwrite of non-enabled fields.
 4. Disabled/deleted Entra users mark linked contacts inactive, not deleted.

--- a/ee/docs/plans/2026-02-20-entra-integration-phase-1/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-02-20-entra-integration-phase-1/SCRATCHPAD.md
@@ -2,7 +2,7 @@
 
 - Plan slug: `entra-integration-phase-1`
 - Created: `2026-02-19`
-- Last Updated: `2026-02-20`
+- Last Updated: `2026-04-17`
 
 ## What This Is
 
@@ -16,6 +16,7 @@ Working notes for design and implementation decisions tied to the EE Entra integ
 - (2026-02-20) Sync behavior is additive/linking by default; field overwrites occur only for explicitly enabled fields.
 - (2026-02-20) Client portal users are excluded from Entra setup/sync functionality.
 - (2026-02-20) Use existing RBAC model (`system_settings.read/update`) for Entra setup and sync actions.
+- (2026-04-17) **CIPP connection type descoped from Phase 1.** Rationale: CIPP provides zero unique capability vs Direct (both hit Microsoft Graph/Lighthouse); Microsoft has closed the Partner Center/GDAP/Lighthouse UX gap that drove CIPP adoption; CIPP drift imposes a permanent maintenance, testing, and support tax we'd own; storing third-party API tokens widens the security blast radius; the "Direct vs CIPP" decision complicates onboarding for users with no opinion. Implementation: `buildEntraConnectionOptions` in `entraIntegrationSettingsGates.ts` returns only the Direct option regardless of the `entra-integration-cipp` flag. The CIPP adapter, secret store, validation route, and connect action remain in the repo so the path can be reinstated without schema/API migration if the bet reverses. All CIPP-specific features in `features.json` and tests in `tests.json` are marked `descoped: true` with note `"Descoped 2026-04-17 — CIPP removed from Phase 1"`. Feature flag `entra-integration-cipp` remains defined but no longer gates user-visible surface area.
 
 ## Discoveries / Constraints
 
@@ -57,8 +58,8 @@ Working notes for design and implementation decisions tied to the EE Entra integ
 ## Open Questions
 
 - Confirm exact delegated scopes needed for direct partner tenant + user enumeration in target MSP environments.
-- Confirm CIPP API endpoint/version contract to lock adapter payload parsing.
 - Confirm default fuzzy threshold values for mapping suggestions before UI finalization.
+- ~~Confirm CIPP API endpoint/version contract to lock adapter payload parsing.~~ (Resolved 2026-04-17 — CIPP descoped from Phase 1.)
 
 ## Implementation Log
 

--- a/ee/docs/plans/2026-02-20-entra-integration-phase-1/features.json
+++ b/ee/docs/plans/2026-02-20-entra-integration-phase-1/features.json
@@ -118,11 +118,15 @@
     "id": "F011",
     "description": "CIPP flag gate: only render CIPP connection option when `entra-integration-cipp` is enabled.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. `buildEntraConnectionOptions` now hides the CIPP option unconditionally. Flag remains defined but no longer gates user-visible surface area.",
     "prdRefs": [
-      "Feature Flags / Rollout"
+      "Feature Flags / Rollout",
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
-      "ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx"
+      "ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx",
+      "ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts"
     ]
   },
   {
@@ -359,7 +363,7 @@
   },
   {
     "id": "F033",
-    "description": "Secret constants: define canonical tenant secret keys for Entra direct/CIPP credentials and tokens.",
+    "description": "Secret constants: define canonical tenant secret keys for Entra direct credentials and tokens. (CIPP secret keys retained for future reinstatement but unused in Phase 1.)",
     "implemented": true,
     "prdRefs": [
       "Security / Permissions"
@@ -428,8 +432,10 @@
     "id": "F039",
     "description": "CIPP connect action: add settings action to save CIPP base URL and token for tenant.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Action remains in code for possible reinstatement but is not reachable from the onboarding UI.",
     "prdRefs": [
-      "Requirements"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "packages/integrations/src/actions/integrations/entraActions.ts"
@@ -439,8 +445,10 @@
     "id": "F040",
     "description": "CIPP token secret persistence: save/remove CIPP token via tenant secret provider (vault-compatible).",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Secret store helpers retained; no tokens should be written in Phase 1 since no UI reaches the CIPP connect action.",
     "prdRefs": [
-      "Security / Permissions"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "ee/server/src/lib/integrations/entra/providers/cipp/cippSecretStore.ts"
@@ -462,8 +470,10 @@
     "id": "F042",
     "description": "Connection validation (CIPP): add endpoint/action confirming CIPP tenant list access.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Validation route retained for reinstatement; not reachable from the Phase 1 onboarding UI.",
     "prdRefs": [
-      "Requirements"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "ee/server/src/app/api/integrations/entra/validate-cipp/route.ts",
@@ -498,8 +508,10 @@
     "id": "F045",
     "description": "Connection type switching: enforce cleanup of stale direct/CIPP credentials when switching connection type.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — Phase 1 supports only Direct, so there is no user-triggered switch. Defensive cleanup logic retained in code.",
     "prdRefs": [
-      "Requirements"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "packages/integrations/src/actions/integrations/entraActions.ts"
@@ -542,8 +554,10 @@
     "id": "F049",
     "description": "CIPP adapter (tenants): implement managed tenant enumeration against configured CIPP endpoint.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Adapter retained but not exercised by any Phase 1 UI flow.",
     "prdRefs": [
-      "Requirements"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "ee/server/src/lib/integrations/entra/providers/cipp/cippProviderAdapter.ts"
@@ -553,8 +567,10 @@
     "id": "F050",
     "description": "CIPP adapter (users): implement per-tenant user enumeration with normalized model parity to direct adapter.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Adapter retained but not exercised by any Phase 1 UI flow.",
     "prdRefs": [
-      "Requirements"
+      "Scope Change — 2026-04-17"
     ],
     "locations": [
       "ee/server/src/lib/integrations/entra/providers/cipp/cippProviderAdapter.ts"

--- a/ee/docs/plans/2026-02-20-entra-integration-phase-1/tests.json
+++ b/ee/docs/plans/2026-02-20-entra-integration-phase-1/tests.json
@@ -73,6 +73,16 @@
     "id": "T009",
     "description": "CIPP connection option is hidden when `entra-integration-cipp` is disabled.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Phase 1 enforces a stronger invariant: CIPP option is hidden unconditionally. See T009b.",
+    "featureIds": [
+      "F011"
+    ]
+  },
+  {
+    "id": "T009b",
+    "description": "CIPP connection option is hidden regardless of the `entra-integration-cipp` flag value (Phase 1 Direct-only invariant).",
+    "implemented": false,
     "featureIds": [
       "F011"
     ]
@@ -310,6 +320,8 @@
     "id": "T036",
     "description": "CIPP connect action validates base URL format and rejects invalid values.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Unit test retained in repo but not required for Phase 1 sign-off.",
     "featureIds": [
       "F039"
     ]
@@ -318,6 +330,8 @@
     "id": "T037",
     "description": "CIPP connect action stores API token via tenant secret provider (not plaintext DB field).",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Unit test retained in repo but not required for Phase 1 sign-off.",
     "featureIds": [
       "F039",
       "F040"
@@ -336,6 +350,8 @@
     "id": "T039",
     "description": "CIPP validation action succeeds with valid CIPP token and tenant endpoint response.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Validation route retained but not required for Phase 1 sign-off.",
     "featureIds": [
       "F042",
       "F049"
@@ -353,6 +369,8 @@
     "id": "T041",
     "description": "Switching direct->CIPP removes stale direct tokens and vice versa.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. User-triggered switching is not exposed; defensive cleanup logic retained.",
     "featureIds": [
       "F045"
     ]
@@ -403,6 +421,8 @@
     "id": "T047",
     "description": "Provider factory returns CIPP adapter when connection type is cipp.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Factory path retained in code for future reinstatement.",
     "featureIds": [
       "F046",
       "F049",
@@ -429,6 +449,8 @@
     "id": "T050",
     "description": "CIPP adapter tenant responses normalize into canonical managed-tenant DTO fields.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Adapter test retained in repo but not required for Phase 1 sign-off.",
     "featureIds": [
       "F049"
     ]
@@ -437,6 +459,8 @@
     "id": "T051",
     "description": "CIPP adapter user responses normalize into canonical sync-user DTO fields.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Adapter test retained in repo but not required for Phase 1 sign-off.",
     "featureIds": [
       "F050"
     ]
@@ -1145,6 +1169,16 @@
     "id": "T135",
     "description": "EE docs include both direct and CIPP setup paths and decision guidance.",
     "implemented": true,
+    "descoped": true,
+    "descopedNote": "Descoped 2026-04-17 — CIPP removed from Phase 1. Docs should now cover Direct setup only; CIPP decision guidance is no longer required. Docs update is tracked as T135b.",
+    "featureIds": [
+      "F120"
+    ]
+  },
+  {
+    "id": "T135b",
+    "description": "EE docs cover Direct Microsoft partner auth setup as the sole Phase 1 connection path, and note that CIPP has been descoped from Phase 1.",
+    "implemented": false,
     "featureIds": [
       "F120"
     ]

--- a/ee/server/src/app/api/auth/microsoft/entra/callback/route.ts
+++ b/ee/server/src/app/api/auth/microsoft/entra/callback/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createTenantKnex, runWithTenant } from '@/lib/db';
 import { resolveMicrosoftCredentialsForTenant } from '@ee/lib/integrations/entra/auth/microsoftCredentialResolver';
 import { saveEntraDirectTokenSet } from '@ee/lib/integrations/entra/auth/tokenStore';
+import { ENTRA_DIRECT_SCOPE_STRING } from '@ee/lib/integrations/entra/auth/directScopes';
 
 export const dynamic = 'force-dynamic';
 
@@ -84,7 +85,7 @@ export async function GET(request: NextRequest) {
       code,
       grant_type: 'authorization_code',
       redirect_uri: state.redirectUri,
-      scope: 'https://graph.microsoft.com/User.Read offline_access',
+      scope: ENTRA_DIRECT_SCOPE_STRING,
     });
 
     const tokenResponse = await axios.post(

--- a/ee/server/src/app/api/integrations/entra/sync/route.ts
+++ b/ee/server/src/app/api/integrations/entra/sync/route.ts
@@ -1,5 +1,10 @@
 import { badRequest, dynamic, ok, parseJsonBody, runtime } from '../_responses';
 import { requireEntraUiFlagEnabled } from '../_guards';
+import {
+  startEntraAllTenantsSyncWorkflow,
+  startEntraInitialSyncWorkflow,
+  startEntraTenantSyncWorkflow,
+} from '@ee/lib/integrations/entra/entraWorkflowClient';
 
 export { dynamic, runtime };
 
@@ -18,12 +23,64 @@ export async function POST(request: Request): Promise<Response> {
     return badRequest('scope must be one of "initial", "all-tenants", or "single-client"');
   }
 
+  const actor = { userId: flagGate.userId };
+
+  if (scope === 'initial') {
+    const result = await startEntraInitialSyncWorkflow({
+      tenantId: flagGate.tenantId,
+      actor,
+      startImmediately: true,
+    });
+    return ok(
+      {
+        accepted: result.available,
+        scope,
+        runId: result.runId || null,
+        workflowId: result.workflowId || null,
+        error: result.error || null,
+      },
+      result.available ? 202 : 503,
+    );
+  }
+
+  if (scope === 'all-tenants') {
+    const result = await startEntraAllTenantsSyncWorkflow({
+      tenantId: flagGate.tenantId,
+      actor,
+      trigger: 'manual',
+    });
+    return ok(
+      {
+        accepted: result.available,
+        scope,
+        runId: result.runId || null,
+        workflowId: result.workflowId || null,
+        error: result.error || null,
+      },
+      result.available ? 202 : 503,
+    );
+  }
+
+  // single-client
+  const clientId = typeof body.clientId === 'string' ? body.clientId.trim() : '';
+  const managedTenantId = typeof body.managedTenantId === 'string' ? body.managedTenantId.trim() : '';
+  if (!clientId || !managedTenantId) {
+    return badRequest('single-client scope requires clientId and managedTenantId');
+  }
+  const result = await startEntraTenantSyncWorkflow({
+    tenantId: flagGate.tenantId,
+    managedTenantId,
+    clientId,
+    actor,
+  });
   return ok(
     {
-      accepted: true,
+      accepted: result.available,
       scope,
-      runId: null,
+      runId: result.runId || null,
+      workflowId: result.workflowId || null,
+      error: result.error || null,
     },
-    202
+    result.available ? 202 : 503,
   );
 }

--- a/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
+++ b/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
@@ -36,7 +36,7 @@ type GuidedStepId = 'connect' | 'discover' | 'map' | 'sync';
 type GuidedStepVisualState = 'current' | 'complete' | 'locked';
 
 const WIZARD_STEPS = [
-  { id: 'connect' as const, title: 'Connect', description: 'Choose Direct Microsoft partner auth or CIPP.' },
+  { id: 'connect' as const, title: 'Connect', description: 'Authorize Direct Microsoft partner auth to link this Entra tenant.' },
   { id: 'discover' as const, title: 'Discover Tenants', description: 'Load and persist managed Entra tenants for this MSP tenant.' },
   { id: 'map' as const, title: 'Map Tenants to Clients', description: 'Review auto-match suggestions and confirm mappings.' },
   { id: 'sync' as const, title: 'Initial Sync', description: 'Start the first sync run for confirmed mappings.' },
@@ -235,7 +235,11 @@ export default function EntraIntegrationSettings({ canUseCipp: canUseCippTier = 
   };
 
   const connectionOptions = buildEntraConnectionOptions(cippFlag.enabled && canUseCippTier);
-  const mappedTenantCount = Math.max(status?.mappedTenantCount ?? 0, mappingSummary.mapped);
+  // Only count rows the server confirms exist in entra_client_tenant_mappings. Auto-match
+  // candidates surfaced by the preview table must not advance the wizard to Step 4 —
+  // otherwise the map step never becomes "current" after discovery even though no confirm
+  // action has run, and the wizard jumps straight to Run Initial Sync without mappings.
+  const mappedTenantCount = status?.mappedTenantCount ?? 0;
   const guidedStepState = deriveGuidedStepState({
     status,
     mappedCount: mappedTenantCount,
@@ -454,12 +458,12 @@ export default function EntraIntegrationSettings({ canUseCipp: canUseCippTier = 
   }, [fieldSyncConfig, loadStatus]);
 
   React.useEffect(() => {
+    // Auto-open the mapping panel whenever the map step is the active step or we're in
+    // maintenance mode. Don't force-close it otherwise — the Review/Remap button owns
+    // the closed state post-discovery so users can still re-open the preview.
     if (settingsMode === 'maintenance' || isMapStepCurrent) {
       setShowMappingDetails(true);
-      return;
     }
-
-    setShowMappingDetails(false);
   }, [isMapStepCurrent, settingsMode]);
 
   const mappingAndSkippedSection = (

--- a/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
+++ b/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
@@ -477,8 +477,9 @@ export default function EntraIntegrationSettings({ canUseCipp: canUseCippTier = 
         {isMapStepCurrent ? (
           <p className="mt-2 text-xs text-muted-foreground">This is your current onboarding step.</p>
         ) : null}
-        <div className="mb-3 mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-3">
-          <p><span className="font-medium text-foreground">Mapped:</span> {mappingSummary.mapped}</p>
+        <div className="mb-3 mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-4">
+          <p><span className="font-medium text-foreground">Saved:</span> {status?.mappedTenantCount ?? 0}</p>
+          <p><span className="font-medium text-foreground">Selected:</span> {mappingSummary.mapped}</p>
           <p><span className="font-medium text-foreground">Skipped:</span> {mappingSummary.skipped}</p>
           <p><span className="font-medium text-foreground">Needs Review:</span> {mappingSummary.needsReview}</p>
         </div>

--- a/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
+++ b/ee/server/src/components/settings/integrations/EntraIntegrationSettings.tsx
@@ -549,7 +549,18 @@ export default function EntraIntegrationSettings({ canUseCipp: canUseCippTier = 
             >
               Disconnect
             </Button>
-          ) : null}
+          ) : (
+            <Button
+              id="entra-reconnect"
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void handleConnectionOptionClick('direct')}
+              disabled={directLoading || statusLoading}
+            >
+              {directLoading ? 'Reconnecting…' : 'Reconnect'}
+            </Button>
+          )}
           <Button id="entra-refresh-status" type="button" size="sm" variant="ghost" onClick={loadStatus} disabled={statusLoading}>
             Refresh
           </Button>

--- a/ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts
+++ b/ee/server/src/components/settings/integrations/entraIntegrationSettingsGates.ts
@@ -16,8 +16,11 @@ const CIPP_CONNECTION_OPTION: EntraConnectionOption = {
   description: 'Use a CIPP endpoint/token as the Entra data source for discovery and sync.',
 };
 
-export const buildEntraConnectionOptions = (isCippEnabled: boolean): EntraConnectionOption[] => {
-  return isCippEnabled ? [DIRECT_CONNECTION_OPTION, CIPP_CONNECTION_OPTION] : [DIRECT_CONNECTION_OPTION];
+export const buildEntraConnectionOptions = (_isCippEnabled: boolean): EntraConnectionOption[] => {
+  // CIPP entry point intentionally disabled in the UI. Server plumbing and the
+  // CIPP_CONNECTION_OPTION constant are retained so the path can be reinstated
+  // without a schema or API change.
+  return [DIRECT_CONNECTION_OPTION];
 };
 
 export const shouldShowFieldSyncControls = (isFieldSyncEnabled: boolean): boolean => isFieldSyncEnabled;

--- a/ee/server/src/lib/db.ts
+++ b/ee/server/src/lib/db.ts
@@ -1,1 +1,5 @@
-export { createTenantKnex, getCurrentTenantId, runWithTenant, getTenantContext } from '../../../../server/src/lib/db/index';
+// Re-export tenant DB helpers from the shared package so this shim is safe to
+// import from non-Next.js runtimes (e.g. the Temporal worker) that cannot
+// resolve the server-only `@/lib/*` aliases. `getCurrentTenantId` intentionally
+// lives only in the Next.js server module since it depends on headers/session.
+export { createTenantKnex, runWithTenant, getTenantContext } from '@alga-psa/db/tenant';

--- a/ee/server/src/lib/integrations/entra/auth/directScopes.ts
+++ b/ee/server/src/lib/integrations/entra/auth/directScopes.ts
@@ -1,0 +1,14 @@
+// Delegated scopes requested for the Direct Microsoft Partner OAuth flow.
+// ManagedTenants.Read.All is required so the access token can hit
+// /tenantRelationships/managedTenants/{tenants,users} during GDAP-backed discovery.
+// Directory.Read.All is only used by the smoke-only self-tenant mode (ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE)
+// to call /organization and /users against the partner's own tenant when no GDAP relationships exist.
+// Admin consent must be granted on the Azure app registration for ManagedTenants.Read.All and Directory.Read.All.
+export const ENTRA_DIRECT_DELEGATED_SCOPES = [
+  'https://graph.microsoft.com/User.Read',
+  'https://graph.microsoft.com/ManagedTenants.Read.All',
+  'https://graph.microsoft.com/Directory.Read.All',
+  'offline_access',
+] as const;
+
+export const ENTRA_DIRECT_SCOPE_STRING = ENTRA_DIRECT_DELEGATED_SCOPES.join(' ');

--- a/ee/server/src/lib/integrations/entra/auth/refreshDirectToken.ts
+++ b/ee/server/src/lib/integrations/entra/auth/refreshDirectToken.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { resolveMicrosoftCredentialsForTenant } from './microsoftCredentialResolver';
 import { getEntraDirectRefreshToken, saveEntraDirectTokenSet } from './tokenStore';
+import { ENTRA_DIRECT_SCOPE_STRING } from './directScopes';
 
 export interface RefreshDirectTokenResult {
   accessToken: string;
@@ -29,7 +30,7 @@ export async function refreshEntraDirectToken(
     client_secret: credentials.clientSecret,
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
-    scope: 'https://graph.microsoft.com/User.Read offline_access',
+    scope: ENTRA_DIRECT_SCOPE_STRING,
   });
 
   const response = await axios.post(

--- a/ee/server/src/lib/integrations/entra/entraWorkflowClient.ts
+++ b/ee/server/src/lib/integrations/entra/entraWorkflowClient.ts
@@ -240,21 +240,40 @@ export async function getEntraSyncRunProgress(
   return runWithTenant(tenantId, async () => {
     const { knex } = await createTenantKnex();
 
-    const [runRow, tenantRows] = await Promise.all([
-      knex('entra_sync_runs')
+    // The UI gets back the Temporal firstExecutionRunId from startWorkflow,
+    // which is a distinct identifier from the DB-side entra_sync_runs.run_id
+    // the activity generates. Try run_id first when the value looks like a
+    // UUID; otherwise (or if that misses) match against workflow_id so
+    // single-click sync polls reach a terminal state.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    let runRow: any = null;
+    if (UUID_RE.test(runId)) {
+      runRow = await knex('entra_sync_runs')
         .where({
           tenant: tenantId,
           run_id: runId,
         })
-        .first(),
-      knex('entra_sync_run_tenants')
+        .first();
+    }
+    if (!runRow) {
+      runRow = await knex('entra_sync_runs')
         .where({
           tenant: tenantId,
-          run_id: runId,
+          workflow_id: runId,
         })
-        .orderBy('created_at', 'asc')
-        .select('*'),
-    ]);
+        .orderBy('created_at', 'desc')
+        .first();
+    }
+
+    const tenantRows = runRow?.run_id
+      ? await knex('entra_sync_run_tenants')
+          .where({
+            tenant: tenantId,
+            run_id: runRow.run_id,
+          })
+          .orderBy('created_at', 'asc')
+          .select('*')
+      : [];
 
     return {
       run: runRow

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -19,6 +19,34 @@ const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const IS_SELF_TENANT_SMOKE =
   (process.env.ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE || '').toLowerCase() === 'true';
 
+// Smoke-only: partition the self-tenant /users response into N synthetic managed
+// tenants so Flow 2 (cross-client bleed) can be exercised without real CSP/GDAP.
+// Format: comma-separated `id|domain|displayName` entries. Users are distributed
+// across buckets by index-mod-N, so each client sees a disjoint subset.
+interface SyntheticSmokeTenant {
+  id: string;
+  domain: string;
+  displayName: string;
+}
+
+function parseSyntheticSmokeTenants(raw: string | undefined): SyntheticSmokeTenant[] {
+  if (!raw) return [];
+  const specs: SyntheticSmokeTenant[] = [];
+  for (const entry of raw.split(',')) {
+    const parts = entry.split('|').map((part) => part.trim());
+    if (parts.length < 3) continue;
+    const [id, domain, displayName] = parts;
+    if (id && domain && displayName) {
+      specs.push({ id, domain, displayName });
+    }
+  }
+  return specs;
+}
+
+const SYNTHETIC_SMOKE_TENANTS: SyntheticSmokeTenant[] = IS_SELF_TENANT_SMOKE
+  ? parseSyntheticSmokeTenants(process.env.ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS)
+  : [];
+
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -278,6 +306,16 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
   private async listSelfTenantAsManaged(
     input: EntraListManagedTenantsInput
   ): Promise<EntraManagedTenantRecord[]> {
+    if (SYNTHETIC_SMOKE_TENANTS.length > 0) {
+      return SYNTHETIC_SMOKE_TENANTS.map((spec) => ({
+        entraTenantId: spec.id,
+        displayName: spec.displayName,
+        primaryDomain: spec.domain,
+        sourceUserCount: 0,
+        raw: { __smokeSynthetic: true, id: spec.id, domain: spec.domain },
+      }));
+    }
+
     const payload = await this.graphGet(input.tenant, `${GRAPH_BASE_URL}/organization`);
     const rows = Array.isArray(payload.value) ? payload.value : [];
     const tenants: EntraManagedTenantRecord[] = [];
@@ -316,6 +354,28 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
   private async listSelfTenantUsers(
     input: EntraListUsersForTenantInput
   ): Promise<EntraManagedUserRecord[]> {
+    const allUsers = await this.fetchSelfTenantUsersRaw(input.tenant, input.managedTenantId);
+
+    if (SYNTHETIC_SMOKE_TENANTS.length > 0) {
+      const bucketIndex = SYNTHETIC_SMOKE_TENANTS.findIndex((t) => t.id === input.managedTenantId);
+      if (bucketIndex < 0) {
+        return [];
+      }
+      const stride = SYNTHETIC_SMOKE_TENANTS.length;
+      // Stable ordering so partitions are deterministic across calls.
+      const sorted = [...allUsers].sort((a, b) => a.entraObjectId.localeCompare(b.entraObjectId));
+      return sorted
+        .filter((_, index) => index % stride === bucketIndex)
+        .map((user) => ({ ...user, entraTenantId: SYNTHETIC_SMOKE_TENANTS[bucketIndex].id }));
+    }
+
+    return allUsers;
+  }
+
+  private async fetchSelfTenantUsersRaw(
+    tenant: string,
+    defaultEntraTenantId: string
+  ): Promise<EntraManagedUserRecord[]> {
     const users: EntraManagedUserRecord[] = [];
     const seenObjectIds = new Set<string>();
     const select = [
@@ -334,7 +394,7 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
     let nextUrl = `${GRAPH_BASE_URL}/users?$select=${select}&$top=999`;
 
     while (nextUrl) {
-      const payload = await this.graphGet(input.tenant, nextUrl);
+      const payload = await this.graphGet(tenant, nextUrl);
       const rows = Array.isArray(payload.value) ? payload.value : [];
 
       for (const row of rows) {
@@ -347,7 +407,7 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
         const email = getNullableString(raw.mail) || userPrincipalName;
 
         users.push(normalizeEntraSyncUser({
-          entraTenantId: input.managedTenantId,
+          entraTenantId: defaultEntraTenantId,
           entraObjectId,
           userPrincipalName,
           email,

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -47,6 +47,26 @@ const SYNTHETIC_SMOKE_TENANTS: SyntheticSmokeTenant[] = IS_SELF_TENANT_SMOKE
   ? parseSyntheticSmokeTenants(process.env.ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS)
   : [];
 
+// Smoke-only: force accountEnabled=false for listed email/UPN values so Flow 5
+// (offboard → deactivate) can be exercised without disabling real Entra users.
+// Format: comma-separated email/UPN list.
+const SMOKE_DISABLED_USER_EMAILS: Set<string> = IS_SELF_TENANT_SMOKE
+  ? new Set(
+      (process.env.ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS || '')
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase())
+        .filter(Boolean),
+    )
+  : new Set();
+
+function matchesSmokeDisabledUser(user: EntraManagedUserRecord): boolean {
+  if (SMOKE_DISABLED_USER_EMAILS.size === 0) return false;
+  const candidates = [user.email, user.userPrincipalName]
+    .map((value) => (value || '').trim().toLowerCase())
+    .filter(Boolean);
+  return candidates.some((candidate) => SMOKE_DISABLED_USER_EMAILS.has(candidate));
+}
+
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -355,6 +375,9 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
     input: EntraListUsersForTenantInput
   ): Promise<EntraManagedUserRecord[]> {
     const allUsers = await this.fetchSelfTenantUsersRaw(input.tenant, input.managedTenantId);
+    const withSmokeDisables = allUsers.map((user) =>
+      matchesSmokeDisabledUser(user) ? { ...user, accountEnabled: false } : user,
+    );
 
     if (SYNTHETIC_SMOKE_TENANTS.length > 0) {
       const bucketIndex = SYNTHETIC_SMOKE_TENANTS.findIndex((t) => t.id === input.managedTenantId);
@@ -363,13 +386,13 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
       }
       const stride = SYNTHETIC_SMOKE_TENANTS.length;
       // Stable ordering so partitions are deterministic across calls.
-      const sorted = [...allUsers].sort((a, b) => a.entraObjectId.localeCompare(b.entraObjectId));
+      const sorted = [...withSmokeDisables].sort((a, b) => a.entraObjectId.localeCompare(b.entraObjectId));
       return sorted
         .filter((_, index) => index % stride === bucketIndex)
         .map((user) => ({ ...user, entraTenantId: SYNTHETIC_SMOKE_TENANTS[bucketIndex].id }));
     }
 
-    return allUsers;
+    return withSmokeDisables;
   }
 
   private async fetchSelfTenantUsersRaw(

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -13,6 +13,12 @@ import type {
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 
+// Smoke-only: when enabled, swap the GDAP-backed managedTenants/* endpoints for
+// /organization and /users so the partner's own tenant acts as a single managed
+// tenant for end-to-end testing without a CSP/GDAP relationship. Never enable in production.
+const IS_SELF_TENANT_SMOKE =
+  (process.env.ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE || '').toLowerCase() === 'true';
+
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -163,6 +169,10 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
   public async listManagedTenants(
     input: EntraListManagedTenantsInput
   ): Promise<EntraManagedTenantRecord[]> {
+    if (IS_SELF_TENANT_SMOKE) {
+      return this.listSelfTenantAsManaged(input);
+    }
+
     const tenants: EntraManagedTenantRecord[] = [];
     const seenTenantIds = new Set<string>();
     let nextUrl = `${GRAPH_BASE_URL}/tenantRelationships/managedTenants/tenants?$top=999`;
@@ -200,6 +210,10 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
   public async listUsersForTenant(
     input: EntraListUsersForTenantInput
   ): Promise<EntraManagedUserRecord[]> {
+    if (IS_SELF_TENANT_SMOKE) {
+      return this.listSelfTenantUsers(input);
+    }
+
     const users: EntraManagedUserRecord[] = [];
     const seenObjectIds = new Set<string>();
     const encodedTenant = encodeURIComponent(input.managedTenantId);
@@ -240,6 +254,100 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
 
         users.push(normalizeEntraSyncUser({
           entraTenantId,
+          entraObjectId,
+          userPrincipalName,
+          email,
+          displayName: getNullableString(raw.displayName),
+          givenName: getNullableString(raw.givenName),
+          surname: getNullableString(raw.surname),
+          accountEnabled: getBoolean(raw.accountEnabled, true),
+          jobTitle: getNullableString(raw.jobTitle),
+          mobilePhone: getNullableString(raw.mobilePhone),
+          businessPhones: getStringArray(raw.businessPhones),
+          raw,
+        }));
+      }
+
+      const candidateNextLink = getNullableString(payload['@odata.nextLink']);
+      nextUrl = candidateNextLink || '';
+    }
+
+    return users;
+  }
+
+  private async listSelfTenantAsManaged(
+    input: EntraListManagedTenantsInput
+  ): Promise<EntraManagedTenantRecord[]> {
+    const payload = await this.graphGet(input.tenant, `${GRAPH_BASE_URL}/organization`);
+    const rows = Array.isArray(payload.value) ? payload.value : [];
+    const tenants: EntraManagedTenantRecord[] = [];
+
+    for (const row of rows) {
+      const raw = toObject(row);
+      const entraTenantId = getFirstString(raw.id);
+      if (!entraTenantId) continue;
+
+      const verifiedDomains = Array.isArray(raw.verifiedDomains) ? raw.verifiedDomains : [];
+      let primaryDomain: string | null = null;
+      let initialDomain: string | null = null;
+      for (const domain of verifiedDomains) {
+        const d = toObject(domain);
+        const name = getNullableString(d.name);
+        if (!name) continue;
+        if (getBoolean(d.isDefault)) {
+          primaryDomain = name;
+        } else if (!initialDomain && getBoolean(d.isInitial)) {
+          initialDomain = name;
+        }
+      }
+
+      tenants.push({
+        entraTenantId,
+        displayName: getNullableString(raw.displayName),
+        primaryDomain: primaryDomain || initialDomain,
+        sourceUserCount: 0,
+        raw,
+      });
+    }
+
+    return tenants;
+  }
+
+  private async listSelfTenantUsers(
+    input: EntraListUsersForTenantInput
+  ): Promise<EntraManagedUserRecord[]> {
+    const users: EntraManagedUserRecord[] = [];
+    const seenObjectIds = new Set<string>();
+    const select = [
+      'id',
+      'displayName',
+      'givenName',
+      'surname',
+      'mail',
+      'userPrincipalName',
+      'accountEnabled',
+      'jobTitle',
+      'mobilePhone',
+      'businessPhones',
+    ].join(',');
+
+    let nextUrl = `${GRAPH_BASE_URL}/users?$select=${select}&$top=999`;
+
+    while (nextUrl) {
+      const payload = await this.graphGet(input.tenant, nextUrl);
+      const rows = Array.isArray(payload.value) ? payload.value : [];
+
+      for (const row of rows) {
+        const raw = toObject(row);
+        const entraObjectId = getFirstString(raw.id);
+        if (!entraObjectId || seenObjectIds.has(entraObjectId)) continue;
+        seenObjectIds.add(entraObjectId);
+
+        const userPrincipalName = getNullableString(raw.userPrincipalName);
+        const email = getNullableString(raw.mail) || userPrincipalName;
+
+        users.push(normalizeEntraSyncUser({
+          entraTenantId: input.managedTenantId,
           entraObjectId,
           userPrincipalName,
           email,

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -67,6 +67,35 @@ function matchesSmokeDisabledUser(user: EntraManagedUserRecord): boolean {
   return candidates.some((candidate) => SMOKE_DISABLED_USER_EMAILS.has(candidate));
 }
 
+// Smoke-only: inject extra fake users into the /users response, pinned to a
+// specific synthetic tenant bucket so Flow 7 (ambiguous match) can be
+// exercised without adding real users to Entra. Format:
+// comma-separated `objectId|upn|displayName|bucketIndex` entries.
+interface SmokeExtraUser {
+  objectId: string;
+  upn: string;
+  displayName: string;
+  bucketIndex: number;
+}
+
+function parseSmokeExtraUsers(raw: string | undefined): SmokeExtraUser[] {
+  if (!raw) return [];
+  const users: SmokeExtraUser[] = [];
+  for (const entry of raw.split(',')) {
+    const parts = entry.split('|').map((part) => part.trim());
+    if (parts.length < 4) continue;
+    const [objectId, upn, displayName, bucketIndexRaw] = parts;
+    const bucketIndex = Number.parseInt(bucketIndexRaw, 10);
+    if (!objectId || !upn || !displayName || !Number.isFinite(bucketIndex)) continue;
+    users.push({ objectId, upn, displayName, bucketIndex });
+  }
+  return users;
+}
+
+const SMOKE_EXTRA_USERS: SmokeExtraUser[] = IS_SELF_TENANT_SMOKE
+  ? parseSmokeExtraUsers(process.env.ENTRA_DIRECT_SMOKE_EXTRA_USERS)
+  : [];
+
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -387,9 +416,28 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
       const stride = SYNTHETIC_SMOKE_TENANTS.length;
       // Stable ordering so partitions are deterministic across calls.
       const sorted = [...withSmokeDisables].sort((a, b) => a.entraObjectId.localeCompare(b.entraObjectId));
-      return sorted
+      const bucketed = sorted
         .filter((_, index) => index % stride === bucketIndex)
         .map((user) => ({ ...user, entraTenantId: SYNTHETIC_SMOKE_TENANTS[bucketIndex].id }));
+
+      const extras = SMOKE_EXTRA_USERS.filter((u) => u.bucketIndex === bucketIndex).map((u) =>
+        normalizeEntraSyncUser({
+          entraTenantId: SYNTHETIC_SMOKE_TENANTS[bucketIndex].id,
+          entraObjectId: u.objectId,
+          userPrincipalName: u.upn,
+          email: u.upn,
+          displayName: u.displayName,
+          givenName: null,
+          surname: null,
+          accountEnabled: true,
+          jobTitle: null,
+          mobilePhone: null,
+          businessPhones: [],
+          raw: { __smokeExtra: true },
+        }),
+      );
+
+      return [...bucketed, ...extras];
     }
 
     return withSmokeDisables;

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -2,8 +2,8 @@ import logger from '@alga-psa/core/logger';
 import { randomUUID } from 'crypto';
 import { createTenantKnex, runWithTenant } from '@alga-psa/db/tenant';
 import { getEntraProviderAdapter } from '@ee/lib/integrations/entra/providers';
-import { EntraSyncResultAggregator } from '@ee/lib/integrations/entra/sync/syncResultAggregator';
-import { filterEntraUsers } from '@ee/lib/integrations/entra/sync/userFilterPipeline';
+import { executeEntraSync } from '@ee/lib/integrations/entra/sync/syncEngine';
+import { filterEntraUsersForTenant } from '@ee/lib/integrations/entra/settingsService';
 import type { EntraConnectionType } from '@ee/interfaces/entra.interfaces';
 import type {
   LoadMappedTenantsActivityInput,
@@ -96,27 +96,47 @@ export async function syncTenantUsersActivity(
   const connectionType = await getActiveConnectionType(input.tenantId);
   const adapter = getEntraProviderAdapter(connectionType);
 
+  if (!input.mapping.clientId) {
+    throw new Error(
+      `Mapping ${input.mapping.managedTenantId} is missing clientId; cannot reconcile contacts.`
+    );
+  }
+
   const users = await adapter.listUsersForTenant({
     tenant: input.tenantId,
     managedTenantId: input.mapping.managedTenantId,
   });
-  const filteredUsers = filterEntraUsers(users);
-  const counters = new EntraSyncResultAggregator();
-  counters.increment('linked', filteredUsers.included.length);
+  const filteredUsers = await filterEntraUsersForTenant(input.tenantId, users);
 
-  // Phase-1 activity pipeline currently tracks per-tenant pull + aggregate counters.
-  // Contact-level reconciliation is implemented in later sync features.
-  const aggregated = counters.toJSON();
+  const fieldSyncConfig = await runWithTenant(input.tenantId, async () => {
+    const { knex } = await createTenantKnex();
+    const row = await knex('entra_sync_settings')
+      .where({ tenant: input.tenantId })
+      .first(['field_sync_config']);
+    const raw = row?.field_sync_config;
+    return raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {};
+  });
+
+  const syncResult = await executeEntraSync({
+    tenantId: input.tenantId,
+    clientId: input.mapping.clientId,
+    managedTenantId: input.mapping.managedTenantId,
+    users: filteredUsers.included,
+    fieldSyncConfig,
+    dryRun: false,
+  });
 
   return {
     managedTenantId: input.mapping.managedTenantId,
-    clientId: input.mapping.clientId || null,
+    clientId: input.mapping.clientId,
     status: 'completed',
-    created: aggregated.created,
-    linked: aggregated.linked,
-    updated: aggregated.updated,
-    ambiguous: aggregated.ambiguous,
-    inactivated: aggregated.inactivated,
+    created: syncResult.counters.created,
+    linked: syncResult.counters.linked,
+    updated: syncResult.counters.updated,
+    ambiguous: syncResult.counters.ambiguous,
+    inactivated: syncResult.counters.inactivated,
     errorMessage: null,
   };
 }

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -104,7 +104,10 @@ export async function syncTenantUsersActivity(
 
   const users = await adapter.listUsersForTenant({
     tenant: input.tenantId,
-    managedTenantId: input.mapping.managedTenantId,
+    // Adapter expects the Microsoft tenant GUID (used as `tenantId eq ...` filter
+    // in the managedTenants/users Graph call). The DB's managed_tenant_id is a
+    // local PK and must not be passed here.
+    managedTenantId: input.mapping.entraTenantId,
   });
   const filteredUsers = await filterEntraUsersForTenant(input.tenantId, users);
 

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -4,6 +4,7 @@ import { createTenantKnex, runWithTenant } from '@alga-psa/db/tenant';
 import { getEntraProviderAdapter } from '@ee/lib/integrations/entra/providers';
 import { executeEntraSync } from '@ee/lib/integrations/entra/sync/syncEngine';
 import { filterEntraUsersForTenant } from '@ee/lib/integrations/entra/settingsService';
+import { markDisabledEntraUsersInactive } from '@ee/lib/integrations/entra/sync/disableHandler';
 import type { EntraConnectionType } from '@ee/interfaces/entra.interfaces';
 import type {
   LoadMappedTenantsActivityInput,
@@ -131,6 +132,16 @@ export async function syncTenantUsersActivity(
     dryRun: false,
   });
 
+  const disabledIdentities = filteredUsers.excluded
+    .filter((entry) => entry.reason === 'account_disabled')
+    .map((entry) => ({
+      entraTenantId: entry.user.entraTenantId,
+      entraObjectId: entry.user.entraObjectId,
+    }));
+  const inactivatedCount = disabledIdentities.length
+    ? await markDisabledEntraUsersInactive(input.tenantId, disabledIdentities)
+    : 0;
+
   return {
     managedTenantId: input.mapping.managedTenantId,
     clientId: input.mapping.clientId,
@@ -139,7 +150,7 @@ export async function syncTenantUsersActivity(
     linked: syncResult.counters.linked,
     updated: syncResult.counters.updated,
     ambiguous: syncResult.counters.ambiguous,
-    inactivated: syncResult.counters.inactivated,
+    inactivated: syncResult.counters.inactivated + inactivatedCount,
     errorMessage: null,
   };
 }

--- a/packages/clients/src/components/clients/ClientDetails.tsx
+++ b/packages/clients/src/components/clients/ClientDetails.tsx
@@ -71,6 +71,7 @@ import { ClientLanguagePreference } from './ClientLanguagePreference';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { SurveyClientSatisfactionSummary } from '@alga-psa/types';
 import {
+  formatEntraRunStatusLabel,
   isTerminalEntraRunStatus,
   resolveEntraClientSyncStartState,
   shouldShowEntraSyncAction,
@@ -268,7 +269,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
   );
 
   const fetchEntraSyncRunStatus = useCallback(async (runId: string): Promise<string | null> => {
-    const response = await fetch(`/api/integrations/entra/sync/runs/${runId}`, {
+    const response = await fetch(`/api/integrations/entra/sync/runs/${encodeURIComponent(runId)}`, {
       method: 'GET',
       credentials: 'same-origin',
       cache: 'no-store',
@@ -301,7 +302,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
           return;
         }
 
-        setEntraSyncStatus(`Run ${entraSyncRunId}: ${nextStatus}`);
+        setEntraSyncStatus(formatEntraRunStatusLabel(nextStatus));
         if (isTerminalEntraRunStatus(nextStatus)) {
           setEntraSyncRunId(null);
         }
@@ -892,7 +893,11 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
         return;
       }
 
-      const syncState = resolveEntraClientSyncStartState(result.data?.runId);
+      // The status endpoint looks up by entra_sync_runs.run_id or workflow_id.
+      // Prefer workflowId because the upstream `runId` here is Temporal's
+      // firstExecutionRunId, which has no row in entra_sync_runs — polling it
+      // would never reach a terminal state.
+      const syncState = resolveEntraClientSyncStartState(result.data?.workflowId || result.data?.runId);
       if (syncState.shouldPoll && syncState.runId) {
         setEntraSyncRunId(syncState.runId);
         setEntraSyncStatus(syncState.statusMessage);
@@ -1722,7 +1727,11 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
                   {t('clientDetails.syncEntraNow', { defaultValue: 'Sync Entra Now' })}
                 </Button>
                 {entraSyncStatus ? (
-                  <p className="text-xs text-muted-foreground" id={`${id}-sync-entra-status`}>
+                  <p
+                    className="text-xs text-muted-foreground"
+                    id={`${id}-sync-entra-status`}
+                    title={entraSyncRunId || undefined}
+                  >
                     {entraSyncStatus}
                   </p>
                 ) : null}

--- a/packages/clients/src/components/clients/clientDetailsEntraSyncAction.test.ts
+++ b/packages/clients/src/components/clients/clientDetailsEntraSyncAction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatEntraRunStatusLabel,
   isTerminalEntraRunStatus,
   resolveEntraClientSyncStartState,
   shouldShowEntraSyncAction,
@@ -26,7 +27,7 @@ describe('shouldShowEntraSyncAction', () => {
   it('T127: resolves run-id state and non-terminal polling status for client-level sync feedback', () => {
     expect(resolveEntraClientSyncStartState('run-127')).toEqual({
       runId: 'run-127',
-      statusMessage: 'Run run-127: queued',
+      statusMessage: 'Entra sync queued',
       shouldPoll: true,
     });
     expect(resolveEntraClientSyncStartState(null)).toEqual({
@@ -41,6 +42,17 @@ describe('shouldShowEntraSyncAction', () => {
     expect(isTerminalEntraRunStatus('partial')).toBe(true);
   });
 
+  it('formatEntraRunStatusLabel produces human labels that never include the opaque workflow id', () => {
+    expect(formatEntraRunStatusLabel('queued')).toBe('Entra sync queued');
+    expect(formatEntraRunStatusLabel('running')).toBe('Entra sync running');
+    expect(formatEntraRunStatusLabel('completed')).toBe('Entra sync completed');
+    expect(formatEntraRunStatusLabel('failed')).toBe('Entra sync failed');
+    expect(formatEntraRunStatusLabel('partial')).toBe('Entra sync completed with issues');
+    // Unknown raw status falls back to a compact prefix but still omits any id
+    expect(formatEntraRunStatusLabel('weird-status')).toBe('Entra sync: weird-status');
+    expect(formatEntraRunStatusLabel(null)).toBe('Entra sync status unknown');
+  });
+
   it('T140: disabling client sync action flag hides entrypoint while preserving existing run-id status representation', () => {
     expect(
       shouldShowEntraSyncAction('enterprise', false, { entra_tenant_id: 'entra-tenant-140' })
@@ -48,7 +60,7 @@ describe('shouldShowEntraSyncAction', () => {
 
     expect(resolveEntraClientSyncStartState('run-140-history')).toEqual({
       runId: 'run-140-history',
-      statusMessage: 'Run run-140-history: queued',
+      statusMessage: 'Entra sync queued',
       shouldPoll: true,
     });
   });

--- a/packages/clients/src/components/clients/clientDetailsEntraSyncAction.ts
+++ b/packages/clients/src/components/clients/clientDetailsEntraSyncAction.ts
@@ -17,6 +17,22 @@ export const isTerminalEntraRunStatus = (status: string | null | undefined): boo
   return terminalEntraSyncStatuses.has(status.trim().toLowerCase());
 };
 
+const ENTRA_RUN_STATUS_LABELS: Record<string, string> = {
+  queued: 'Entra sync queued',
+  running: 'Entra sync running',
+  completed: 'Entra sync completed',
+  failed: 'Entra sync failed',
+  partial: 'Entra sync completed with issues',
+};
+
+export const formatEntraRunStatusLabel = (status: string | null | undefined): string => {
+  const normalized = String(status || '').trim().toLowerCase();
+  if (!normalized) {
+    return 'Entra sync status unknown';
+  }
+  return ENTRA_RUN_STATUS_LABELS[normalized] || `Entra sync: ${normalized}`;
+};
+
 export const resolveEntraClientSyncStartState = (runId: string | null | undefined): {
   runId: string | null;
   statusMessage: string;
@@ -33,7 +49,7 @@ export const resolveEntraClientSyncStartState = (runId: string | null | undefine
 
   return {
     runId: normalizedRunId,
-    statusMessage: `Run ${normalizedRunId}: queued`,
+    statusMessage: formatEntraRunStatusLabel('queued'),
     shouldPoll: true,
   };
 };

--- a/packages/ee/src/components/settings/integrations/EntraIntegrationSettings.tsx
+++ b/packages/ee/src/components/settings/integrations/EntraIntegrationSettings.tsx
@@ -2,7 +2,11 @@
 
 import React from 'react';
 
-const EntraIntegrationSettings: React.FC = () => {
+interface EntraIntegrationSettingsProps {
+  canUseCipp?: boolean;
+}
+
+const EntraIntegrationSettings: React.FC<EntraIntegrationSettingsProps> = () => {
   return (
     <div className="text-center py-8 text-muted-foreground">
       <p className="text-lg font-medium">Enterprise Feature</p>

--- a/packages/ee/src/lib/integrations/entra/auth/directScopes.ts
+++ b/packages/ee/src/lib/integrations/entra/auth/directScopes.ts
@@ -1,0 +1,14 @@
+// Delegated scopes requested for the Direct Microsoft Partner OAuth flow.
+// ManagedTenants.Read.All is required so the access token can hit
+// /tenantRelationships/managedTenants/{tenants,users} during GDAP-backed discovery.
+// Directory.Read.All is only used by the smoke-only self-tenant mode (ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE)
+// to call /organization and /users against the partner's own tenant when no GDAP relationships exist.
+// Admin consent must be granted on the Azure app registration for ManagedTenants.Read.All and Directory.Read.All.
+export const ENTRA_DIRECT_DELEGATED_SCOPES = [
+  'https://graph.microsoft.com/User.Read',
+  'https://graph.microsoft.com/ManagedTenants.Read.All',
+  'https://graph.microsoft.com/Directory.Read.All',
+  'offline_access',
+] as const;
+
+export const ENTRA_DIRECT_SCOPE_STRING = ENTRA_DIRECT_DELEGATED_SCOPES.join(' ');

--- a/packages/integrations/src/actions/integrations/entraActions.ts
+++ b/packages/integrations/src/actions/integrations/entraActions.ts
@@ -121,7 +121,13 @@ async function callEeRoute<T>(params: {
   }
 
   try {
-    const eeRouteModule = params.importFn;
+    const eeRouteModule =
+      typeof params.importFn === 'function' ? await params.importFn() : params.importFn;
+
+    if (!eeRouteModule) {
+      return eeUnavailableResult<T>();
+    }
+
     const routeHandler = eeRouteModule[params.method] as RouteHandler | undefined;
 
     if (!routeHandler) {
@@ -352,11 +358,15 @@ export const initiateEntraDirectOAuth = withAuth(async (user, { tenant }) => {
     connectionType: 'direct',
   };
 
+  const { ENTRA_DIRECT_DELEGATED_SCOPES } = await import(
+    '@enterprise/lib/integrations/entra/auth/directScopes'
+  );
+
   const authUrl = generateMicrosoftAuthUrl(
     credentials.clientId,
     redirectUri,
     statePayload as any,
-    ['https://graph.microsoft.com/User.Read', 'offline_access'],
+    [...ENTRA_DIRECT_DELEGATED_SCOPES],
     'common'
   );
 
@@ -1120,6 +1130,26 @@ export const startEntraSync = withAuth(async (
       tenantId: tenant,
       actor: { userId: (user as { user_id?: string } | undefined)?.user_id },
       trigger: 'manual',
+    });
+
+    return {
+      success: true,
+      data: {
+        accepted: workflowStart.available,
+        scope: input.scope,
+        runId: workflowStart.runId || null,
+        workflowId: workflowStart.workflowId || null,
+        error: workflowStart.error || null,
+      },
+    } as const;
+  }
+
+  if (input.scope === 'initial') {
+    const workflowClient = await import('@enterprise/lib/integrations/entra/entraWorkflowClient');
+    const workflowStart = await workflowClient.startEntraInitialSyncWorkflow({
+      tenantId: tenant,
+      actor: { userId: (user as { user_id?: string } | undefined)?.user_id },
+      startImmediately: true,
     });
 
     return {

--- a/packages/integrations/src/entra/components/ee/entry.tsx
+++ b/packages/integrations/src/entra/components/ee/entry.tsx
@@ -1,5 +1,15 @@
-import React from 'react';
+'use client';
 
-export const EntraIntegrationSettings = (): React.JSX.Element => (
-  <div>Microsoft Entra integration is only available in Enterprise Edition.</div>
+import React, { Suspense } from 'react';
+
+const LazyEntraIntegrationSettings = React.lazy(() =>
+  import('@enterprise/components/settings/integrations/EntraIntegrationSettings').then((mod) => ({
+    default: mod.default,
+  })),
+);
+
+export const EntraIntegrationSettings = (props: { canUseCipp?: boolean }): React.JSX.Element => (
+  <Suspense fallback={<div className="py-8 text-center text-muted-foreground">Loading Microsoft Entra integration…</div>}>
+    <LazyEntraIntegrationSettings {...props} />
+  </Suspense>
 );

--- a/packages/integrations/src/entra/routes/ee/entry.ts
+++ b/packages/integrations/src/entra/routes/ee/entry.ts
@@ -1,17 +1,30 @@
-export const routes = {
-    route: null,
-    connectRoute: null,
-    disconnectRoute: null,
-    validateDirectRoute: null,
-    validateCippRoute: null,
-    discoveryRoute: null,
-    syncRoute: null,
-    syncRunsRoute: null,
-    mappingsPreviewRoute: null,
-    mappingsConfirmRoute: null,
-    mappingsUnmapRoute: null,
-    mappingsRemapRoute: null,
-    reconciliationQueueRoute: null,
-    resolveExistingRoute: null,
-    resolveNewRoute: null,
+// @ts-nocheck
+// Each route is exposed as an async thunk so webpack treats the EE route files
+// as their own async chunks. This breaks the static import cycle that occurred
+// when this file pulled from `@enterprise/...` synchronously while
+// `packages/integrations/*` was itself a dependency of the EE package.
+type RouteModule = {
+    GET?: (request: Request) => Promise<Response>;
+    POST?: (request: Request) => Promise<Response>;
+    OPTIONS?: (request: Request) => Promise<Response>;
+};
+
+type RouteLoader = () => Promise<RouteModule>;
+
+export const routes: Record<string, RouteLoader> = {
+    route: () => import('@enterprise/app/api/integrations/entra/route'),
+    connectRoute: () => import('@enterprise/app/api/integrations/entra/connect/route'),
+    disconnectRoute: () => import('@enterprise/app/api/integrations/entra/disconnect/route'),
+    validateDirectRoute: () => import('@enterprise/app/api/integrations/entra/validate-direct/route'),
+    validateCippRoute: () => import('@enterprise/app/api/integrations/entra/validate-cipp/route'),
+    discoveryRoute: () => import('@enterprise/app/api/integrations/entra/discovery/route'),
+    syncRoute: () => import('@enterprise/app/api/integrations/entra/sync/route'),
+    syncRunsRoute: () => import('@enterprise/app/api/integrations/entra/sync/runs/route'),
+    mappingsPreviewRoute: () => import('@enterprise/app/api/integrations/entra/mappings/preview/route'),
+    mappingsConfirmRoute: () => import('@enterprise/app/api/integrations/entra/mappings/confirm/route'),
+    mappingsUnmapRoute: () => import('@enterprise/app/api/integrations/entra/mappings/unmap/route'),
+    mappingsRemapRoute: () => import('@enterprise/app/api/integrations/entra/mappings/remap/route'),
+    reconciliationQueueRoute: () => import('@enterprise/app/api/integrations/entra/reconciliation-queue/route'),
+    resolveExistingRoute: () => import('@enterprise/app/api/integrations/entra/reconciliation-queue/resolve-existing/route'),
+    resolveNewRoute: () => import('@enterprise/app/api/integrations/entra/reconciliation-queue/resolve-new/route'),
 };

--- a/packages/integrations/src/entra/routes/oss/entry.ts
+++ b/packages/integrations/src/entra/routes/oss/entry.ts
@@ -1,17 +1,21 @@
-export const routes = {
-    route: null,
-    connectRoute: null,
-    disconnectRoute: null,
-    validateDirectRoute: null,
-    validateCippRoute: null,
-    discoveryRoute: null,
-    syncRoute: null,
-    syncRunsRoute: null,
-    mappingsPreviewRoute: null,
-    mappingsConfirmRoute: null,
-    mappingsUnmapRoute: null,
-    mappingsRemapRoute: null,
-    reconciliationQueueRoute: null,
-    resolveExistingRoute: null,
-    resolveNewRoute: null,
+type RouteLoader = () => Promise<null>;
+
+const unavailable: RouteLoader = async () => null;
+
+export const routes: Record<string, RouteLoader> = {
+    route: unavailable,
+    connectRoute: unavailable,
+    disconnectRoute: unavailable,
+    validateDirectRoute: unavailable,
+    validateCippRoute: unavailable,
+    discoveryRoute: unavailable,
+    syncRoute: unavailable,
+    syncRunsRoute: unavailable,
+    mappingsPreviewRoute: unavailable,
+    mappingsConfirmRoute: unavailable,
+    mappingsUnmapRoute: unavailable,
+    mappingsRemapRoute: unavailable,
+    reconciliationQueueRoute: unavailable,
+    resolveExistingRoute: unavailable,
+    resolveNewRoute: unavailable,
 };

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -78,6 +78,8 @@ const apiKeySkipPaths = [
   '/api/integrations/ninjaone/callback',
   '/api/integrations/xero/connect',
   '/api/integrations/xero/callback',
+  // Entra integration API routes use session auth via requireEntraUiFlagEnabled
+  '/api/integrations/entra/',
   // AI chat endpoints are session-authenticated (MSP UI)
   '/api/chat/',
   // Workflow bundle import/export is session-authenticated (developer + future UI tooling)

--- a/server/src/test/unit/components/integrations/entraIntegrationSettingsGates.test.ts
+++ b/server/src/test/unit/components/integrations/entraIntegrationSettingsGates.test.ts
@@ -7,17 +7,20 @@ import {
 } from '@ee/components/settings/integrations/entraIntegrationSettingsGates';
 
 describe('buildEntraConnectionOptions', () => {
-  it('hides the CIPP connection option when entra-integration-cipp is disabled', () => {
+  it('returns only the Direct option when CIPP is disabled', () => {
     const options = buildEntraConnectionOptions(false);
 
     expect(options.map((option) => option.id)).toEqual(['direct']);
     expect(options.find((option) => option.id === 'cipp')).toBeUndefined();
   });
 
-  it('includes the CIPP connection option when entra-integration-cipp is enabled', () => {
+  it('ignores the CIPP flag and never surfaces CIPP in the UI', () => {
+    // CIPP entry point is intentionally removed from the UI. Server plumbing
+    // remains, but buildEntraConnectionOptions must not re-expose it.
     const options = buildEntraConnectionOptions(true);
 
-    expect(options.map((option) => option.id)).toEqual(['direct', 'cipp']);
+    expect(options.map((option) => option.id)).toEqual(['direct']);
+    expect(options.find((option) => option.id === 'cipp')).toBeUndefined();
   });
 
   it('hides field-sync controls and ambiguous queue when their flags are disabled', () => {


### PR DESCRIPTION
## Summary

End-to-end hardening pass on the Microsoft Entra integration. Descopes CIPP from the Phase 1 UI (keeping server plumbing intact so the path can be reinstated without a schema/API change), fills several holes that would have silently dropped data, and adds the smoke knobs needed to drive the full user-facing flow on Nine Minds's own tenant without a real CSP/GDAP relationship.

**UI / gating**
- `buildEntraConnectionOptions` always returns the single Direct card regardless of the `entra-integration-cipp` flag. CIPP dialog and API plumbing remain in the codebase, unreachable from the onboarding surface.
- Restored EE UI entry wiring (`packages/integrations/src/entra/{components,routes}/ee/entry.{ts,tsx}`): wrap `EntraIntegrationSettings` in a `React.lazy` + `Suspense` boundary, and turn EE route imports into thunks so `callEeRoute` can `await` them at runtime.
- Step 3 panel now shows separate **Saved** (DB-persisted) and **Selected** (in-editor) counts instead of a single "Mapped" number that mixed them.
- When a tenant was in maintenance mode (had prior sync runs) and then clicked Disconnect, there was no visible path back to Connect. Added an inline **Reconnect** button in the Connection Health header that replaces Disconnect whenever `status !== 'connected'`.
- Review/Remap toggle in the mapping panel no longer gets force-closed by the auto-open effect.
- Wizard no longer advances past Step 3 until the DB-persisted `mappedTenantCount` rises; pre-save selections can't jump the wizard into Run Initial Sync prematurely.

**Sync pipeline correctness**
- `syncTenantUsersActivity` was counting filtered users as `linked` but never writing contact rows, links, or queue items. Routed the pipeline through `executeEntraSync` so contacts are actually created/linked under the correct client, with tenant-scoped `field_sync_config` and exclusion patterns applied.
- Same activity was silently dropping `filteredUsers.excluded` users. Now funnels `account_disabled` exclusions through `markDisabledEntraUsersInactive`, which marks the contact `is_inactive=true`, deactivates the link, and records `disabled_upstream` — without ever deleting the row.
- Activity was passing the DB-side `managed_tenant_id` UUID to the adapter, but the adapter's Graph query uses that value as `tenantId eq '…'`. Pass `entraTenantId` (the Microsoft tenant GUID) so real-flow and smoke-flow both resolve correctly.
- `/api/integrations/entra/sync` with `scope='initial'` was returning 202 with no workflow kickoff. Wired to `startEntraInitialSyncWorkflow`.
- Centralized the OAuth scope list in `ee/lib/integrations/entra/auth/directScopes.ts` (User.Read, ManagedTenants.Read.All, Directory.Read.All, offline_access) so the initiate, callback, and refresh paths don't drift.
- Middleware's API-key allowlist now skips `/api/integrations/entra/` so session-authenticated UI calls don't get 401'd by the API-key enforcer.

**Client-sync polling fixes**
- "Sync Entra Now" on a client's detail page never reached a terminal status. The UI was polling `/api/integrations/entra/sync/runs/:id` with Temporal's `firstExecutionRunId`, which isn't stored anywhere: the DB has a fresh `run_id` UUID (minted by `upsertSyncRunActivity`) and a deterministic `workflow_id`. Fixes:
  - Poll with `workflowId` (fall back to `runId`), URL-encode the path segment so colons don't confuse routing.
  - `getEntraSyncRunProgress` tries `run_id` only when the value is UUID-shaped, then falls back to `workflow_id` — non-UUID strings were making pg throw → 500 with empty body.
  - Status label uses a new `formatEntraRunStatusLabel` helper so the header reads "Entra sync running / completed" instead of the opaque workflow id string; the id stays available via `title=` on the status element for debugging.

**Temporal worker infra**
- `ee/server/src/lib/db.ts` now re-exports from `@alga-psa/db/tenant` instead of the Next.js-only `server/src/lib/db/index.ts`, so the temporal-worker bundle doesn't drag `next/headers` through the `@/lib/db` chain. Fixes the `temporal-worker-dev` build.
- `docker-compose.temporal.ee.yaml` pipes three new smoke env vars through to the worker.

**Smoke knobs (only active when `ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE=true`)**
- `ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE` — swap GDAP-backed `managedTenants/*` endpoints for `/organization` + `/users` so the partner's own tenant acts as a single managed tenant.
- `ENTRA_DIRECT_SMOKE_SYNTHETIC_TENANTS` — comma-separated `id|primary_domain|display_name` specs. `listManagedTenants` returns N synthetic records; `listSelfTenantUsers` partitions real users into disjoint buckets by `entraObjectId` mod N. Lets us exercise cross-client bleed without a real partner relationship.
- `ENTRA_DIRECT_SMOKE_DISABLED_USER_EMAILS` — forces `accountEnabled=false` for listed emails so the offboard → inactivate path is testable.
- `ENTRA_DIRECT_SMOKE_EXTRA_USERS` — injects fake users pinned to a specific synthetic tenant bucket for ambiguous-match exploration.

All four knobs are ignored when self-tenant smoke mode is off and must be stripped / gated before these paths ever ship beyond smoke; this PR leaves them in intentionally so the smoke flows are reproducible end-to-end in the test worktree.

**Docs**
- Phase 1 PRD / features.json / tests.json updated to mark CIPP UI as descoped and the smoke self-tenant mode as an explicit test artifact.

## End-to-end smoke coverage

Drove the Direct flow on the Nine Minds tenant in self-tenant smoke mode:

- **Flow 1 (invariant):** Connect step shows only `#entra-connection-option-direct`, no CIPP card / text / attr with the CIPP flag forced both ON and OFF.
- **Flow 2 (cross-client segregation):** 3 synthetic tenants + 5 users partitioned across 3 disjoint buckets; 1 auto-matched, 1 manually assigned, 1 skipped; sync produced 4 contacts under the correct clients; skipped tenant produced zero contacts; no bleed.
- **Flow 3 (idempotency):** Re-sync twice in fresh 5-min idempotency buckets; `created=0, linked=4` both times; contact / link counts unchanged; exactly one link per `entra_object_id`.
- **Flow 4 (curated data preserved):** Curated `full_name` survives sync with display-name toggle OFF; toggle ON + resync overwrites to Entra displayName; no dupes.
- **Flow 5 (offboard):** Smoke-disabled user comes back as `inactivated=1` on the run, `is_inactive=true`, `entra_sync_status='inactive'`, `link_status='inactive'`, row not deleted.
- **Flow 6 (disconnect / UI flag):** Disconnect clears tenant filesystem secrets + sets row `disconnected`; post-disconnect discovery fails with "No active Entra connection exists for this tenant."; Reconnect button lights up in maintenance mode; `entra-integration-ui` forced OFF hides panel with zero DB rows lost; ON restores card with same connection + mappings.
- **Flow 7 (ambiguous queue):** Skipped — `contacts` has `UNIQUE (tenant, email)` and the matcher is email-only, so the sync-time ambiguous branch is structurally unreachable with the current schema + matcher. Filed for follow-up (needs a fuzzy-name matcher + schema rethink before it can be defended).
- **Flow 8 (portal 403 + client-sync gate):** Portal users get 403 at the guard (`user_type === 'client'` branch); unmapped clients hide the "Sync Entra Now" button; mapped clients show it; click triggers the single-tenant workflow and polls to `completed`.

## Test plan

- [ ] EE edition: Settings → Integrations → Identity → Microsoft Entra Integration renders; Connect step shows only the Direct card.
- [ ] CE edition: Settings → Integrations → Identity hides the Microsoft Entra Integration card entirely.
- [ ] `entra-integration-ui` flag OFF: panel hides; saved mappings / history preserved in DB; flag ON restores.
- [ ] Direct OAuth: complete sign-in; status panel shows Connection: connected with Microsoft tenant + credential source.
- [ ] Discovery: Run Discovery populates `entra_managed_tenants`; tenants visible in Step 3 table.
- [ ] Mapping: auto-match proposes correct client for exact-domain URLs; manual Select Client persists; Skip suppresses sync for that tenant.
- [ ] Initial sync: contacts created under correct mapped clients; skipped tenants produce zero contacts; no cross-client bleed.
- [ ] Re-sync: `created=0` on subsequent runs; `linked` equals included-user count; exactly one `entra_contact_links` row per `entra_object_id`.
- [ ] Field sync OFF: curated `full_name` survives sync; each toggle ON causes the corresponding field to sync on linked contacts.
- [ ] Offboard: disabled-in-Entra user → `is_inactive=true`, `link_status=inactive`, row preserved.
- [ ] Disconnect: row flipped to `disconnected`, tenant-scoped direct tokens deleted; Discovery returns "No active Entra connection…"; Reconnect button renders.
- [ ] Reconnect: OAuth round-trip; new active connection row; prior mappings + sync history intact.
- [ ] Single-client Sync Entra Now: button visible only on mapped clients in EE with `entra-integration-client-sync-action` flag ON; click → header reads "Entra sync queued" → "running" → "completed"; workflow id surfaced via `title` attribute.
- [ ] Portal user: direct request to any `/api/integrations/entra/*` endpoint returns 403.
- [ ] Non-EE: client-sync action server-side refuses with "Microsoft Entra integration is only available in Enterprise Edition."

## Follow-ups out of scope for this PR

- Ambiguous queue is structurally unreachable from the sync path (email-only matcher + `UNIQUE (tenant, email)` constraint). Needs a real design pass — either a fuzzy-name matcher or a relaxed uniqueness constraint plus PRD-level thought on false-positive risk.
- Contact-level full field-sync coverage beyond the 5 controlled fields.
- All four smoke env vars must be removed / gated before these paths ever ship to a real partner tenant. Currently they're ignored unless `ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE=true`, but they should not exist in a production build at all.
- `validate-direct` still has an inlined `listManagedTenants` call that bypasses the adapter — unaffected by this PR's smoke mode but worth consolidating.