### PR TITLE
fix(billing): anchor invoice due date to invoice_date, not cycle end

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -1460,7 +1460,7 @@ export const getDueDate = withAuth(async (
     user,
     { tenant },
     clientId: string,
-    billingEndDate: ISO8601String
+    invoiceDate: ISO8601String
 ): Promise<ISO8601String> => {
     const { knex } = await createTenantKnex();
     const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -1474,12 +1474,10 @@ export const getDueDate = withAuth(async (
     });
 
     const paymentTerms = client?.payment_terms || 'net_30';
-    const days = await getPaymentTermDays(paymentTerms); // Await the async function
-    console.log('paymentTerms', paymentTerms, 'days', days);
+    const days = await getPaymentTermDays(paymentTerms);
 
-    // Convert billingEndDate string to a Temporal.PlainDate before adding days
-    const plainEndDate = toPlainDate(billingEndDate);
-    const dueDate = plainEndDate.add({ days });
+    const plainInvoiceDate = toPlainDate(invoiceDate);
+    const dueDate = plainInvoiceDate.add({ days });
     return toISODate(dueDate);
 });
 

--- a/packages/billing/src/actions/billingCycleActions.ts
+++ b/packages/billing/src/actions/billingCycleActions.ts
@@ -702,6 +702,9 @@ async function fetchRecurringInvoiceHistoryPage(
         'c.client_name',
         trx.raw(`coalesce(rsp_summary.service_period_start, (${detailServicePeriodStartSql})) as service_period_start`),
         trx.raw(`coalesce(rsp_summary.service_period_end, (${detailServicePeriodEndSql})) as service_period_end`),
+        // `i.billing_period_start/end` is the legacy misnamed invoice window; newer rows have the
+        // canonical window in `recurring_service_periods`. Coalesce both into `invoice_window_*`.
+        // Column rename on `invoices` to `invoice_window_*` is pending.
         trx.raw(`coalesce(rsp_summary.invoice_window_start, i.billing_period_start) as invoice_window_start`),
         trx.raw(`coalesce(rsp_summary.invoice_window_end, i.billing_period_end) as invoice_window_end`),
         trx.raw(`coalesce(rsp_summary.cadence_owner, 'client') as cadence_owner`),

--- a/packages/billing/src/actions/creditActions.ts
+++ b/packages/billing/src/actions/creditActions.ts
@@ -499,9 +499,9 @@ export const createPrepaymentInvoice = withAuth(async (
                 total_amount: amount,
                 status: 'draft',
                 invoice_number: await generateInvoiceNumber(),
-                // Prepayments remain non-service financial artifacts. These
-                // header dates track the immediate financial issuance window;
-                // canonical recurring service periods stay null/absent.
+                // `billing_period_start/end` stores the invoice window, not the service period.
+                // Prepayments are not service-backed, so we set the window to "now" — there is no
+                // recurring_service_periods row for this invoice. Column rename to `invoice_window_*` is pending.
                 billing_period_start: new Date().toISOString(),
                 billing_period_end: new Date().toISOString(),
                 credit_applied: 0,

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -1222,7 +1222,8 @@ async function buildPreviewInvoiceForSelectionInputs(params: {
   }
 
   const client = await getClientDetails(knex, tenant, client_id);
-  const due_date = await getDueDate(client_id, cycleEnd);
+  const previewInvoiceDate = Temporal.Now.plainDateISO().toString();
+  const due_date = await getDueDate(client_id, previewInvoiceDate);
   const chargesByContractGroup: { [key: string]: IBillingCharge[] } = {};
   const nonContractAssociatedCharges: IBillingCharge[] = [];
 
@@ -1990,7 +1991,7 @@ export const createInvoiceFromBillingResult = withAuth(async (
     throw new Error(`Client '${client.client_name}' does not have a default tax region configured. Please set one before generating invoices.`);
   }
   const currentDate = Temporal.Now.plainDateISO().toString();
-  const due_date = await getDueDate(clientId, cycleEnd); // Uses temporary import
+  const due_date = await getDueDate(clientId, currentDate);
   // taxService initialized above
   // let subtotal = 0; // Subtotal will be calculated by persistInvoiceCharges
 
@@ -2020,7 +2021,9 @@ export const createInvoiceFromBillingResult = withAuth(async (
     tenant,
     currency_code: billingResult.currency_code || 'USD',
     is_manual: false,
-    // Add billing period dates to ensure validation works correctly
+    // `billing_period_start/end` stores the INVOICE WINDOW (when this cycle may be cut),
+    // not the service period. Service periods live in `recurring_service_periods`.
+    // Column rename to `invoice_window_*` is pending — do not treat these as customer-facing dates.
     billing_period_start: toPlainDate(cycleStart),
     billing_period_end: toPlainDate(cycleEnd),
     // Tax source: 'internal', 'pending_external', or 'external'

--- a/packages/billing/src/actions/manualInvoiceActions.ts
+++ b/packages/billing/src/actions/manualInvoiceActions.ts
@@ -13,6 +13,7 @@ import { getSession } from '@alga-psa/auth';
 import { getAnalyticsAsync } from '../lib/authHelpers';
 
 import { getInitialInvoiceTaxSource } from './taxSourceActions';
+import { getDueDate } from './billingAndTax';
 
 export interface ManualInvoiceItem { // Add export
   service_id: string;
@@ -57,6 +58,7 @@ export const generateManualInvoice = withAuth(async (
   }
 
   const currentDate = Temporal.Now.plainDateISO().toString();
+  const dueDate = await getDueDate(clientId, currentDate);
 
   // Generate invoice number and create invoice record
   const invoiceNumber = await generateInvoiceNumber();
@@ -71,7 +73,7 @@ export const generateManualInvoice = withAuth(async (
     tenant,
     client_id: clientId,
     invoice_date: currentDate,
-    due_date: currentDate, // You may want to calculate this based on payment terms
+    due_date: dueDate,
     invoice_number: invoiceNumber,
     status: 'draft',
     currency_code: request.currency_code || client.default_currency_code || 'USD',

--- a/packages/billing/src/services/accountingExportInvoiceSelector.ts
+++ b/packages/billing/src/services/accountingExportInvoiceSelector.ts
@@ -55,6 +55,9 @@ type InvoicePreviewSelectionRow = {
   client_name?: string | null;
   currency_code?: string | null;
   invoice_is_manual?: boolean | null;
+  // `billing_period_start/end` stores the invoice window, not the service period.
+  // Canonical service periods are in `detail_service_period_*` below / `recurring_service_periods`.
+  // Column rename to `invoice_window_*` is pending.
   billing_period_start?: string | Date | null;
   billing_period_end?: string | Date | null;
   total_amount?: number | string | null;

--- a/packages/billing/src/services/invoiceService.ts
+++ b/packages/billing/src/services/invoiceService.ts
@@ -98,6 +98,9 @@ async function linkRecurringServicePeriodToInvoiceDetail(params: {
     return 0;
   }
 
+  // `invoices.billing_period_start/end` is misleadingly named — it actually stores the
+  // invoice window (when this cycle may be cut), not a service period. That's why we read
+  // it into `invoiceWindow*` locals here. Column rename to `invoice_window_*` is pending.
   const invoiceWindow = await invoiceBuilder
     .where({ invoice_id: invoiceId, tenant })
     .first(['billing_period_start', 'billing_period_end']);

--- a/packages/clients/src/actions/clientContractLineActions.ts
+++ b/packages/clients/src/actions/clientContractLineActions.ts
@@ -124,7 +124,10 @@ async function getLatestHistoricalInvoicedEndDate(db: any, tenant: string, clien
 
   // If we found an invoice, determine the appropriate date to return
   if (latestInvoice) {
-    // If billing_period_end exists, use it
+    // NOTE: `billing_period_end` is the INVOICE WINDOW end (when the cycle could be cut),
+    // not the service period end. For arrears billing this over-reports "billed through" by
+    // roughly one cycle. Acceptable here only because this is the legacy-flat-invoice fallback;
+    // the canonical path reads `recurring_service_periods`. Column rename to `invoice_window_*` is pending.
     if (latestInvoice.billing_period_end) {
       return new Date(latestInvoice.billing_period_end);
     }

--- a/server/src/lib/api/schemas/invoiceSchemas.ts
+++ b/server/src/lib/api/schemas/invoiceSchemas.ts
@@ -167,6 +167,9 @@ const baseInvoiceSchema = z.object({
   billing_cycle_id: uuidSchema.nullable().optional(),
   is_manual: z.boolean().default(false),
   is_prepayment: z.boolean().default(false),
+  // NOTE: these fields store the INVOICE WINDOW (when the cycle may be cut), not the service
+  // period. Service periods live in `recurring_service_periods`. Column rename to
+  // `invoice_window_*` is pending. Do not surface these as customer-facing "billing period" dates.
   billing_period_start: invoiceDateSchema.optional(),
   billing_period_end: invoiceDateSchema.optional(),
   recurring_execution_window_kind: recurringExecutionWindowKindSchema.nullable().optional(),

--- a/server/src/lib/api/services/FinancialService.ts
+++ b/server/src/lib/api/services/FinancialService.ts
@@ -698,6 +698,8 @@ export class FinancialService extends BaseService<ITransaction> {
           total_amount: request.amount,
           status: 'draft',
           invoice_number: invoiceNumber,
+          // `billing_period_start/end` stores the invoice window, not a service period.
+          // Prepayment credits are not service-backed, so window = "now". Rename pending.
           billing_period_start: now,
           billing_period_end: now,
           credit_applied: 0,

--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -32,6 +32,7 @@ import {
   generateInvoiceNumber,
   previewInvoiceForSelectionInput,
 } from '@alga-psa/billing/actions/invoiceGeneration';
+import { getDueDate } from '@alga-psa/billing/actions/billingAndTax';
 import { BillingEngine } from '@alga-psa/billing/services';
 import { TaxService } from '@alga-psa/billing/services/taxService';
 import { NumberingService } from '@shared/services/numberingService';
@@ -400,6 +401,8 @@ export class InvoiceService extends BaseService<IInvoice> {
         subtotal: data.subtotal || 0,
         tax: taxCalculation?.tax_amount || 0,
         total_amount: data.total_amount || 0,
+        // `billing_period_start/end` stores the invoice window, not the service period.
+        // This generic create endpoint trusts the caller; rename to `invoice_window_*` is pending.
         billing_period_start: data.billing_period_start,
         billing_period_end: data.billing_period_end,
         is_manual: data.is_manual || false,
@@ -1650,6 +1653,7 @@ export class InvoiceService extends BaseService<IInvoice> {
     const numberingService = new NumberingService({ knex, tenant });
     const invoiceNumber = await numberingService.getNextNumber('INVOICE');
     const currentDate = Temporal.Now.plainDateISO().toString();
+    const computedDueDate = await getDueDate(data.clientId, currentDate);
     const sessionLike = { user: { id: context.userId } } as { user: { id: string } };
 
     let createdInvoice: InvoiceViewModel | null = null;
@@ -1663,7 +1667,7 @@ export class InvoiceService extends BaseService<IInvoice> {
         client_id: data.clientId,
         invoice_number: invoiceNumber,
         invoice_date: currentDate,
-        due_date: currentDate,
+        due_date: computedDueDate,
         status: 'draft',
         subtotal: 0,
         tax: 0,


### PR DESCRIPTION
## Summary

- **Due-date bug**: `getDueDate` anchored payment terms to `cycleEnd` (the invoice window end). For monthly billing with net_30, this overshot the customer's expected due date by ~30 days. Example from production: invoice `0001842` (ConnectWise LLC) — `invoice_date=2026-04-15`, `cycleEnd=2026-05-08`, net_30 → stored `due_date=2026-06-07` instead of the expected `2026-05-15`. Fix anchors to invoice date.
- **Manual invoices**: both `generateManualInvoice` paths (`packages/billing/src/actions/manualInvoiceActions.ts` and `server/src/lib/api/services/InvoiceService.ts`) previously set `due_date = invoice_date`, ignoring `clients.payment_terms`. Now respect payment terms via `getDueDate`.
- **Documentation**: `invoices.billing_period_start/end` is misleadingly named — it stores the *invoice window* (when this cycle may be cut), not the *service period*. Canonical service periods live in `recurring_service_periods`. Added clarifying comments at 9 natural sites (producers, readers, schema, exports, the legacy "billed through" fallback) flagging the pending rename to `invoice_window_*`.

## Test plan

- [ ] Generate a recurring invoice for a client on net_30; verify `due_date = invoice_date + 30`, not `cycleEnd + 30`.
- [ ] Generate a manual invoice for a client on net_15 via the UI and via the API; verify `due_date = invoice_date + 15` in both paths.
- [ ] Generate a prepayment credit invoice; verify it still reports `due_date = invoice_date` (intentional, no terms math).
- [ ] Generate an advance-billed invoice (cycle end > invoice date); verify due date is no longer compounded with the full cycle length.
- [ ] Generate a monthly arrears invoice after the cycle ends; verify due date matches net terms from the invoice date (standard "Net 30 from Issue Date").
- [ ] Run existing `server/src/test/infrastructure/billing/invoices/invoiceDueDate.test.ts`; the pure date-math assertions still pass (parameter is now `invoiceDate`, but the math is unchanged).
- [ ] Smoke the invoice preview UI: "Period" on the PDF should still show the service period from `recurring_service_periods` (unchanged).