### PR TITLE
fix(migrations): drop ON UPDATE CASCADE from location FK migrations

### DIFF
--- a/server/migrations/20260415120000_add_location_to_quote_items.cjs
+++ b/server/migrations/20260415120000_add_location_to_quote_items.cjs
@@ -67,12 +67,13 @@ exports.up = async function up(knex) {
       'quote_items and client_locations are compatible for FK - adding foreign key constraint'
     );
     await knex.schema.alterTable('quote_items', (table) => {
+      // ON UPDATE CASCADE is not supported by Citus when the distribution
+      // key (tenant) is part of the FK, so we only set ON DELETE.
       table
         .foreign(['location_id', 'tenant'])
         .references(['location_id', 'tenant'])
         .inTable('client_locations')
-        .onDelete('RESTRICT')
-        .onUpdate('CASCADE');
+        .onDelete('RESTRICT');
     });
   } else {
     console.log(

--- a/server/migrations/20260415120100_add_location_to_invoice_charges.cjs
+++ b/server/migrations/20260415120100_add_location_to_invoice_charges.cjs
@@ -67,12 +67,13 @@ exports.up = async function up(knex) {
       'invoice_charges and client_locations are compatible for FK - adding foreign key constraint'
     );
     await knex.schema.alterTable('invoice_charges', (table) => {
+      // ON UPDATE CASCADE is not supported by Citus when the distribution
+      // key (tenant) is part of the FK, so we only set ON DELETE.
       table
         .foreign(['location_id', 'tenant'])
         .references(['location_id', 'tenant'])
         .inTable('client_locations')
-        .onDelete('RESTRICT')
-        .onUpdate('CASCADE');
+        .onDelete('RESTRICT');
     });
   } else {
     console.log(

--- a/server/migrations/20260415120200_add_location_to_contract_lines.cjs
+++ b/server/migrations/20260415120200_add_location_to_contract_lines.cjs
@@ -66,12 +66,13 @@ exports.up = async function up(knex) {
       'contract_lines and client_locations are compatible for FK - adding foreign key constraint'
     );
     await knex.schema.alterTable('contract_lines', (table) => {
+      // ON UPDATE CASCADE is not supported by Citus when the distribution
+      // key (tenant) is part of the FK, so we only set ON DELETE.
       table
         .foreign(['location_id', 'tenant'])
         .references(['location_id', 'tenant'])
         .inTable('client_locations')
-        .onDelete('RESTRICT')
-        .onUpdate('CASCADE');
+        .onDelete('RESTRICT');
     });
   } else {
     console.log(

--- a/server/migrations/20260415120300_recreate_tickets_location_fk.cjs
+++ b/server/migrations/20260415120300_recreate_tickets_location_fk.cjs
@@ -80,12 +80,13 @@ exports.up = async function up(knex) {
       'tickets and client_locations are compatible for FK - adding foreign key constraint'
     );
     await knex.schema.alterTable('tickets', (table) => {
+      // ON UPDATE CASCADE is not supported by Citus when the distribution
+      // key (tenant) is part of the FK, so we only set ON DELETE.
       table
         .foreign(['location_id', 'tenant'])
         .references(['location_id', 'tenant'])
         .inTable('client_locations')
-        .onDelete('RESTRICT')
-        .onUpdate('CASCADE');
+        .onDelete('RESTRICT');
     });
   } else {
     console.log(


### PR DESCRIPTION
## Summary
- Citus rejects `ON UPDATE CASCADE` on foreign keys that include the distribution key (`tenant`), causing the `invoice_charges` migration to fail during Argo deploys with: `SET NULL, SET DEFAULT or CASCADE is not supported in ON UPDATE operation when distribution key included in the foreign constraint`.
- The fix aligns the three new location FK migrations (`quote_items`, `invoice_charges`, `contract_lines` — all dated 2026-04-15, from #2347) with the pre-existing `tickets` location migration (`20250613190110_add_location_to_tickets.cjs`), which only sets `ON DELETE RESTRICT`.
- `quote_items` and `contract_lines` happened to hit the skip-FK path in the failing environment due to mismatched distribution, but they would fail identically in any environment where both tables are distributed — fixing all three prevents recurrence.

## Test plan
- [ ] Re-run the Argo deploy and confirm all three migrations succeed on the Citus-enabled environment that previously failed
- [ ] Verify the `invoice_charges_location_id_tenant_foreign` constraint is created with `ON DELETE RESTRICT` and no `ON UPDATE` clause
- [ ] Confirm a fresh non-Citus dev database also runs the three migrations cleanly