### PR TITLE
fix(billing/invoice-templates): enable pagination on layouts table

### DIFF
--- a/packages/billing/src/components/billing-dashboard/InvoiceTemplates.tsx
+++ b/packages/billing/src/components/billing-dashboard/InvoiceTemplates.tsx
@@ -314,7 +314,6 @@ return (
               id="invoice-templates-table"
               data={invoiceTemplates}
               columns={templateColumns}
-              pagination={false}
               onRowClick={(record) => {
                 if (record.isStandard) {
                   void handleCloneAndEdit(record);


### PR DESCRIPTION
## Summary
- The invoice layouts table in the billing dashboard previously passed `pagination={false}` to `DataTable`, capping the visible list at the first 10 layouts with no way to reach the rest.
- Removing the prop restores `DataTable`'s default client-side pagination (page controls + items-per-page selector).

## Test plan
- [ ] Open Billing → Invoice Layouts with more than 10 layouts and confirm pagination controls appear and navigate correctly.
- [ ] With ≤10 layouts, confirm the table renders normally without pagination controls.