### PR TITLE
fix(ui): prevent ClientPicker click-through and focus theft in dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43438,7 +43438,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.20-rc5",
+      "version": "1.0.27-rc5",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -43794,7 +43794,7 @@
       }
     },
     "packages/n8n-nodes-alga-psa": {
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "n8n-workflow": "^1.90.0"
@@ -44465,6 +44465,7 @@
         "@emoji-mart/react": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
+        "@radix-ui/react-focus-scope": "^1.1.7",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-progress": "^1.1.1",
@@ -44616,11 +44617,7 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -48358,7 +48355,7 @@
       }
     },
     "server": {
-      "version": "1.0.20-rc5",
+      "version": "1.0.27-rc5",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/workflow-streams": "*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -85,6 +85,7 @@
     "@blocknote/react": "^0.47.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
+    "@radix-ui/react-focus-scope": "^1.1.7",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-progress": "^1.1.1",

--- a/packages/ui/src/components/ClientPicker.tsx
+++ b/packages/ui/src/components/ClientPicker.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import { FocusScope } from '@radix-ui/react-focus-scope';
 import { ChevronDown, Plus } from 'lucide-react';
 import type { VariantProps } from 'class-variance-authority';
 import type { IClient } from '@alga-psa/types';
@@ -280,10 +281,22 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
   }, [mappedOptions, placeholder, selectedClientId, updateMetadata]);
 
   const dropdown = (
+    <FocusScope
+      asChild
+      loop
+      trapped
+      onMountAutoFocus={(event) => {
+        event.preventDefault();
+      }}
+      onUnmountAutoFocus={(event) => {
+        event.preventDefault();
+        triggerRef.current?.querySelector('button')?.focus();
+      }}
+    >
     <div
       ref={dropdownRef}
       className="fixed z-[10000] bg-white border border-gray-200 rounded-md shadow-lg overflow-hidden"
-      style={{ top: dropdownCoords.top, left: dropdownCoords.left, width: dropdownCoords.width }}
+      style={{ top: dropdownCoords.top, left: dropdownCoords.left, width: dropdownCoords.width, pointerEvents: 'auto' }}
       onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
@@ -368,6 +381,7 @@ export const ClientPicker: React.FC<ClientPickerProps & AutomationProps> = ({
         </>
       )}
     </div>
+    </FocusScope>
   );
 
   return (


### PR DESCRIPTION
## Summary
- The portaled `ClientPicker` dropdown inherited `pointer-events: none` from the Radix Dialog backdrop on `<body>`, so clicking the "Search clients..." box passed through and selected the work item below it (visible on the time entry screen's Add Work Item dialog when the filters panel is open).
- Once pointer events were re-enabled on the dropdown, the Dialog's FocusScope stole focus back from the portaled input. Wrapping the dropdown in a nested `@radix-ui/react-focus-scope` pauses the Dialog's trap so the search input can keep focus — the same mechanism Radix Popover/Select use when nested inside a Dialog.
- `onUnmountAutoFocus` returns focus to the trigger button when the dropdown closes.

## Test plan
- [x] Open Add Work Item dialog on the timesheet → expand Filters → click "Select Client" → click the Search clients box. Verify input focuses, keystrokes land in it, and work items below do not get selected.
- [x] Click outside the dropdown → dropdown closes and focus returns to the `#client-picker-trigger` button.
- [ ] Regression: ClientPicker usage outside a Dialog (e.g. filter bars) still opens, filters, selects, and closes as before.