### PR TITLE
fix: suppress duplicate Xero connection alert when disconnected

### DIFF
--- a/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/XeroIntegrationSettings.tsx
@@ -331,7 +331,7 @@ export default function XeroIntegrationSettings() {
             </Alert>
           )}
 
-          {status?.error ? (
+          {status?.error && defaultConnection ? (
             <Alert variant={status.connected ? 'info' : 'destructive'}>
               <AlertDescription>{status.error}</AlertDescription>
             </Alert>


### PR DESCRIPTION
## Summary
- The Xero settings panel was rendering two stacked alerts with the same "No live Xero organisation is connected yet…" message — one info alert hard-coded in the component and one destructive alert sourced from `status.error`.
- Only render the `status.error` alert when a `defaultConnection` exists, so it surfaces real token/refresh failures instead of duplicating the disconnected-state message.

## Test plan
- [ ] Open Settings → Integrations → Accounting → Xero with no Xero connection: verify only the single info alert is shown above the Connect Xero button.
- [ ] With a connected Xero org whose tokens are expired/invalid, verify the destructive `status.error` alert still renders.