### PR TITLE
fix(workflow-worker): restore /health endpoint for kubelet probes

### DIFF
--- a/services/workflow-worker/src/healthServer.ts
+++ b/services/workflow-worker/src/healthServer.ts
@@ -1,0 +1,76 @@
+import http from 'node:http';
+import logger from '@alga-psa/core/logger';
+
+export interface HealthSnapshot {
+  ready: boolean;
+  startedAt: string;
+  workers: Record<string, boolean>;
+}
+
+/**
+ * Minimal HTTP server that answers the /health probe Istio rewrites
+ * kubelet's liveness/readiness checks to. Returns 200 once markReady()
+ * has been called and 503 before that so kubelet sees an honest state
+ * during startup.
+ */
+export class HealthServer {
+  private server: http.Server | null = null;
+  private readonly port: number;
+  private state: HealthSnapshot;
+
+  constructor(port?: number) {
+    this.port = Number(port ?? process.env.PORT ?? 4000);
+    this.state = {
+      ready: false,
+      startedAt: new Date().toISOString(),
+      workers: {},
+    };
+  }
+
+  setWorker(name: string, ready: boolean): void {
+    this.state.workers[name] = ready;
+  }
+
+  markReady(): void {
+    this.state.ready = true;
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        if (req.method !== 'GET') {
+          res.statusCode = 405;
+          res.end();
+          return;
+        }
+        const path = (req.url ?? '/').split('?')[0];
+        if (path === '/health' || path === '/livez' || path === '/readyz') {
+          res.statusCode = this.state.ready ? 200 : 503;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(this.state));
+          return;
+        }
+        res.statusCode = 404;
+        res.end();
+      });
+
+      server.once('error', (err) => {
+        logger.error('[HealthServer] Failed to listen', { err });
+        reject(err);
+      });
+
+      server.listen(this.port, () => {
+        logger.info('[HealthServer] Listening', { port: this.port });
+        this.server = server;
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}

--- a/services/workflow-worker/src/index.ts
+++ b/services/workflow-worker/src/index.ts
@@ -16,10 +16,17 @@ import { WorkflowRuntimeV2EventStreamWorker } from './v2/WorkflowRuntimeV2EventS
 import { WorkflowRuntimeV2TemporalWorker } from './v2/WorkflowRuntimeV2TemporalWorker.js';
 import logger from '@alga-psa/core/logger';
 import { TenantEmailService, StaticTemplateProcessor, EmailProviderManager } from '@alga-psa/email';
+import { HealthServer } from './healthServer.js';
 import { registerEnterpriseStorageProviders } from './registerEnterpriseStorageProviders.js';
 
 async function startServices() {
+  const healthServer = new HealthServer();
   try {
+    // Start the health HTTP server before anything else so kubelet probes
+    // (rewritten by the Istio sidecar to hit localhost:PORT/health) get a
+    // response — 503 until the workers finish starting, 200 after.
+    await healthServer.start();
+
     logger.info('[WorkflowWorker] Initializing services');
     const verbose =
       process.env.WORKFLOW_WORKER_VERBOSE === 'true' ||
@@ -71,33 +78,39 @@ async function startServices() {
     });
     if (enableTemporalPolling) {
       await runtimeV2TemporalWorker.start();
+      healthServer.setWorker('temporal', true);
     } else {
       logger.info('[WorkflowWorker] Authored Temporal polling disabled for this environment');
     }
     await runtimeV2EventWorker.start();
+    healthServer.setWorker('eventStream', true);
     if (enableDbPollingWorker) {
       await runtimeV2Worker.start();
+      healthServer.setWorker('dbPolling', true);
     } else {
       logger.info('[WorkflowWorker] DB polling runtime worker disabled; Temporal-native runtime is authoritative for new runs');
     }
-    
+
+    healthServer.markReady();
     logger.info('[WorkflowWorker] All services started successfully');
-    
+
     // Handle graceful shutdown
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
-    
+
     async function shutdown() {
       logger.info('[WorkflowWorker] Shutting down services...');
       await Promise.all([
         enableTemporalPolling ? runtimeV2TemporalWorker.stop() : Promise.resolve(),
         runtimeV2EventWorker.stop(),
-        enableDbPollingWorker ? runtimeV2Worker.stop() : Promise.resolve()
+        enableDbPollingWorker ? runtimeV2Worker.stop() : Promise.resolve(),
+        healthServer.stop(),
       ]);
       process.exit(0);
     }
   } catch (error) {
     logger.error('[WorkflowWorker] Failed to start services:', error);
+    await healthServer.stop().catch(() => undefined);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Reintroduce a minimal `node:http` health server on `PORT` (default 4000) so Istio's `ISTIO_KUBE_APP_PROBERS` (which rewrites kubelet liveness/readiness probes to `http://localhost:PORT/health`) gets a real response instead of 500.
- The legacy `WorkerServer` was removed during the Temporal cutover, but the Helm chart's probe wiring still expects `/health` — which made every rollout fail `helm --wait` and left the new image unable to take traffic. Observed in prod today: pod `workflow-worker-9cdb496d6-gmvjs` had readiness/liveness 500s with no process listening on 4000.
- Server returns 503 during startup and flips to 200 after the Temporal + event-stream workers (and optional DB poller) report started. Worker states are included in the JSON body for debuggability. Shutdown is wired to SIGINT/SIGTERM.

## Test plan
- [ ] Build image via Argo (`workflow-worker-ci-cd` with `branch=fix/workflows-not-working`) — helm deploy should pass `--wait` within the 10m timeout.
- [ ] After rollout: `kubectl -n msp exec <pod> -c workflow-worker -- curl -s localhost:4000/health` returns 200 with `{"ready":true,...}`.
- [ ] `kubectl -n msp describe pod <pod>` shows no `Readiness probe failed` events.
- [ ] Confirm workflow-worker pods finish rolling (3/3 Ready on the new ReplicaSet, old `7456d9f6c5` pods scaled down).
- [ ] Verify `workflow:events:global` stream is being drained and new workflows actually execute — smoke by triggering a ticket event in the app.

Pairs with the memory bump in `nm-kube-config@360fa44` (workflow-worker hosted/sebastian values → 2Gi limit) that was needed to keep the new image from OOMing at the 1Gi limit.