### PR TITLE
fix(ui): disable formatting toolbar in RichTextViewer to remove stray image download icon

### DIFF
--- a/packages/ui/src/editor/RichTextViewer.tsx
+++ b/packages/ui/src/editor/RichTextViewer.tsx
@@ -584,6 +584,7 @@ function RichTextViewerInternal({
           key={shouldRemount ? contentKey : 'stable'}
           editor={editor}
           editable={false}
+          formattingToolbar={false}
           theme={blockNoteTheme}
           className="w-full min-w-0"
           style={{


### PR DESCRIPTION
BlockNote's formatting toolbar was rendering a download action icon when an image block inside a comment was focused, causing it to appear at the top-left corner of the screen. Since RichTextViewer is always read-only, the toolbar serves no purpose; disabling it removes the icon entirely.