### PR TITLE
Improve invoice field alignment controls and recurring preview samples

### DIFF
--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -949,6 +949,14 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
 
   const draggablePointerDown = listeners?.onPointerDown;
   const previewContent = useMemo(() => getPreviewContent(node, previewData), [node, previewData]);
+  const fieldNodeStyle = isFieldNode ? getNodeStyle(node) : undefined;
+  const fieldLayoutStyle = isFieldNode
+    ? {
+        justifyContent: fieldNodeStyle?.justifyContent ?? 'space-between',
+        alignItems: fieldNodeStyle?.alignItems ?? (previewContent.singleLine ? 'center' : 'flex-start'),
+        gap: fieldNodeStyle?.gap,
+      }
+    : undefined;
   const pointerDownPositionRef = useRef<{ x: number; y: number } | null>(null);
   const pointerDownSelectedRef = useRef(false);
   const pointerMovedRef = useRef(false);
@@ -1150,6 +1158,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
                 previewContent.singleLine ? 'whitespace-nowrap overflow-hidden' : 'items-start',
                 previewContent.isPlaceholder && 'text-slate-400'
               )}
+              style={fieldLayoutStyle}
             >
               {fieldDisplayLabel && (
                 <span

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.integration.test.tsx
@@ -362,4 +362,58 @@ describe('DesignerSchemaInspector (schema-driven integration)', () => {
 
     expect((useInvoiceDesignerStore.getState().nodesById['field-1'].props as any)?.metadata?.label).toBe('PO');
   });
+
+  it('renders reusable icon-enum controls for field alignment and updates justifyContent', () => {
+    act(() => {
+      const store = useInvoiceDesignerStore.getState();
+      store.loadWorkspace({
+        rootId: 'doc-1',
+        nodesById: {
+          'doc-1': { id: 'doc-1', type: 'document', props: { name: 'Document' }, children: ['page-1'] },
+          'page-1': { id: 'page-1', type: 'page', props: { name: 'Page 1' }, children: ['field-1'] },
+          'field-1': {
+            id: 'field-1',
+            type: 'field',
+            props: {
+              name: 'Period Field',
+              metadata: {
+                label: 'Period',
+                bindingKey: 'invoice.recurringServicePeriodLabel',
+                format: 'text',
+              },
+              style: {},
+            },
+            children: [],
+          },
+        },
+        snapToGrid: false,
+        gridSize: 8,
+        showGuides: false,
+        showRulers: false,
+        canvasScale: 1,
+      });
+      store.selectNode('field-1');
+    });
+
+    const Wrapper: React.FC = () => {
+      const nodes = useInvoiceDesignerStore((state) => state.nodes);
+      const selectedNodeId = useInvoiceDesignerStore((state) => state.selectedNodeId);
+      const node = useInvoiceDesignerStore((state) =>
+        selectedNodeId ? (state.nodesById[selectedNodeId] as DesignerNode | undefined) : undefined
+      );
+      const nodesById = useMemo(() => new Map(nodes.map((n) => [n.id, n] as const)), [nodes]);
+      if (!node) return null;
+      return <DesignerSchemaInspector node={node} nodesById={nodesById} />;
+    };
+
+    render(<Wrapper />);
+
+    const defaultButton = screen.getByLabelText('Label / Value Alignment: Space Between');
+    expect(defaultButton.getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByLabelText('Label / Value Alignment: Start'));
+
+    const updated = useInvoiceDesignerStore.getState().nodesById['field-1'];
+    expect((updated.props as any)?.style?.justifyContent).toBe('flex-start');
+  });
 });

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Input } from '@alga-psa/ui/components/Input';
 import ColorPicker from '@alga-psa/ui/components/ColorPicker';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
+import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import {
   buildInvoiceExpressionPathOptions,
   type SharedExpressionPathOption,
@@ -699,6 +700,42 @@ export const DesignerSchemaInspector: React.FC<Props> = ({ node, nodesById }) =>
             onValueChange={(value: string) => setNodeProp(node.id, field.path, value, true)}
             size="sm"
           />
+        </div>
+      );
+    }
+
+    if (field.kind === 'icon-enum') {
+      const value = resolveValue(field);
+      const valueAsString = typeof value === 'string' ? value : field.options[0]?.value ?? '';
+      const columns = field.columns ?? Math.min(field.options.length, 3);
+      return (
+        <div key={field.id}>
+          <p className="text-xs text-slate-500 block mb-1">{field.label}</p>
+          <div id={domId} className="grid gap-1" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+            {field.options.map((option) => {
+              const Icon = option.icon;
+              const isSelected = option.value === valueAsString;
+              return (
+                <Tooltip key={option.value} content={option.tooltip ?? option.label}>
+                  <button
+                    type="button"
+                    onClick={() => setNodeProp(node.id, field.path, option.value, true)}
+                    className={[
+                      'h-8 rounded border transition-colors inline-flex items-center justify-center',
+                      isSelected
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+                        : 'border-slate-200 dark:border-[rgb(var(--color-border-200))] text-slate-600 dark:text-slate-400 hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800'
+                    ].join(' ')}
+                    aria-pressed={isSelected}
+                    aria-label={`${field.label}: ${option.label}`}
+                    data-automation-id={`designer-inspector-icon-enum-${field.id}-${option.value}`}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </button>
+                </Tooltip>
+              );
+            })}
+          </div>
         </div>
       );
     }

--- a/packages/billing/src/components/invoice-designer/preview/sampleScenarios.ts
+++ b/packages/billing/src/components/invoice-designer/preview/sampleScenarios.ts
@@ -45,6 +45,9 @@ export const INVOICE_PREVIEW_SAMPLE_SCENARIOS: InvoicePreviewSampleScenario[] = 
       invoiceNumber: 'INV-2026-0147',
       issueDate: '2026-02-06',
       dueDate: '2026-02-20',
+      recurringServicePeriodStart: '2026-01-01',
+      recurringServicePeriodEnd: '2026-03-01',
+      recurringServicePeriodLabel: 'Jan 1, 2026 - Mar 1, 2026',
       customer: {
         name: 'Blue Harbor Dental',
         address: '901 Harbor Ave, Seattle, WA 98104',
@@ -106,6 +109,9 @@ export const INVOICE_PREVIEW_SAMPLE_SCENARIOS: InvoicePreviewSampleScenario[] = 
       invoiceNumber: 'INV-2026-0192',
       issueDate: '2026-02-03',
       dueDate: '2026-02-17',
+      recurringServicePeriodStart: '2026-01-01',
+      recurringServicePeriodEnd: '2026-03-01',
+      recurringServicePeriodLabel: 'Jan 1, 2026 - Mar 1, 2026',
       poNumber: 'PO-8831',
       customer: {
         name: 'Evergreen Animal Hospital',
@@ -179,6 +185,9 @@ export const INVOICE_PREVIEW_SAMPLE_SCENARIOS: InvoicePreviewSampleScenario[] = 
       invoiceNumber: 'INV-2026-0205',
       issueDate: '2026-02-05',
       dueDate: '2026-02-19',
+      recurringServicePeriodStart: '2026-02-01',
+      recurringServicePeriodEnd: '2026-03-01',
+      recurringServicePeriodLabel: 'Feb 1, 2026 - Mar 1, 2026',
       poNumber: 'PO-9942',
       customer: {
         name: 'Summit Physical Therapy',
@@ -227,6 +236,9 @@ export const INVOICE_PREVIEW_SAMPLE_SCENARIOS: InvoicePreviewSampleScenario[] = 
       invoiceNumber: 'INV-2026-0227',
       issueDate: '2026-02-08',
       dueDate: '2026-02-28',
+      recurringServicePeriodStart: '2026-01-01',
+      recurringServicePeriodEnd: '2026-02-01',
+      recurringServicePeriodLabel: 'Jan 1, 2026 - Feb 1, 2026',
       poNumber: null,
       customer: {
         name: 'Helios Logistics Group',

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.test.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.test.ts
@@ -70,5 +70,6 @@ describe('componentSchema', () => {
     expect(paths).toContain('metadata.bindingKey');
     expect(paths).toContain('metadata.format');
     expect(paths).toContain('metadata.emptyValue');
+    expect(paths).toContain('style.justifyContent');
   });
 });

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
@@ -1,4 +1,12 @@
 import { DEFAULT_INVOICE_PRINT_SETTINGS, resolveTemplatePrintSettings } from '@alga-psa/types';
+import {
+  AlignCenter,
+  AlignHorizontalDistributeCenter,
+  AlignHorizontalSpaceAround,
+  AlignHorizontalSpaceBetween,
+  AlignLeft,
+  AlignRight,
+} from 'lucide-react';
 import type {
   DesignerComponentType,
   DesignerContainerLayout,
@@ -336,6 +344,58 @@ const FIELD_INSPECTOR: DesignerInspectorSchema = {
             { value: 'underline', label: 'Underline' },
             { value: 'box', label: 'Box' },
             { value: 'none', label: 'None' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'field-layout',
+      title: 'Field Layout',
+      fields: [
+        {
+          kind: 'icon-enum',
+          id: 'fieldJustifyContent',
+          domId: 'designer-field-justify-content',
+          label: 'Label / Value Alignment',
+          path: 'style.justifyContent',
+          columns: 3,
+          options: [
+            {
+              value: 'space-between',
+              label: 'Space Between',
+              tooltip: 'Push label and value to opposite edges',
+              icon: AlignHorizontalSpaceBetween,
+            },
+            {
+              value: 'flex-start',
+              label: 'Start',
+              tooltip: 'Keep label and value packed at the start',
+              icon: AlignLeft,
+            },
+            {
+              value: 'center',
+              label: 'Center',
+              tooltip: 'Center label and value together',
+              icon: AlignCenter,
+            },
+            {
+              value: 'flex-end',
+              label: 'End',
+              tooltip: 'Pack label and value at the end',
+              icon: AlignRight,
+            },
+            {
+              value: 'space-around',
+              label: 'Space Around',
+              tooltip: 'Distribute label and value with space around each',
+              icon: AlignHorizontalSpaceAround,
+            },
+            {
+              value: 'space-evenly',
+              label: 'Space Evenly',
+              tooltip: 'Distribute label and value with even spacing',
+              icon: AlignHorizontalDistributeCenter,
+            },
           ],
         },
       ],
@@ -793,6 +853,7 @@ export const DESIGNER_COMPONENT_SCHEMAS: Record<DesignerComponentType, DesignerC
       style: {
         width: 'auto',
         height: 'auto',
+        justifyContent: 'space-between',
       },
       metadata: {
         bindingKey: 'invoice.number',

--- a/packages/billing/src/components/invoice-designer/schema/inspectorSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/inspectorSchema.ts
@@ -1,3 +1,5 @@
+import type { LucideIcon } from 'lucide-react';
+
 export type DesignerInspectorSchema = {
   panels: DesignerInspectorPanel[];
 };
@@ -52,6 +54,16 @@ export type DesignerInspectorField =
       path: string;
       domId?: string;
       options: Array<{ value: string; label: string }>;
+      visibleWhen?: DesignerInspectorVisibleWhen;
+    }
+  | {
+      kind: 'icon-enum';
+      id: string;
+      label: string;
+      path: string;
+      domId?: string;
+      options: Array<{ value: string; label: string; icon: LucideIcon; tooltip?: string }>;
+      columns?: number;
       visibleWhen?: DesignerInspectorVisibleWhen;
     }
   | {

--- a/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.addNodeFromPalette.test.ts
@@ -85,6 +85,7 @@ describe('designerStore addNodeFromPalette', () => {
     expect(field.props.style).toMatchObject({
       width: 'auto',
       height: 'auto',
+      justifyContent: 'space-between',
     });
     expect(field.props.metadata).toMatchObject({
       fieldBorderStyle: 'none',

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -188,6 +188,7 @@ describe('renderEvaluatedTemplateAst', () => {
     expect(rendered.html).toContain('border-bottom:1px solid #cbd5e1');
     expect(rendered.html).toContain('padding:0');
     expect(rendered.html).toContain('border:0');
+    expect(rendered.html).toContain('justify-content:space-between');
   });
 
   it('renders multiline plain fields without single-line inset chrome', async () => {

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -142,6 +142,7 @@ const resolveFieldBorderStyle = (
       border: '0',
       backgroundColor: 'transparent',
       display: 'flex',
+      justifyContent: 'space-between',
       alignItems: 'flex-start',
     };
   }
@@ -152,6 +153,7 @@ const resolveFieldBorderStyle = (
       borderRadius: '4px',
       backgroundColor: 'transparent',
       display: 'flex',
+      justifyContent: 'space-between',
       alignItems: 'center',
     };
   }
@@ -162,6 +164,7 @@ const resolveFieldBorderStyle = (
     borderRadius: '0',
     backgroundColor: 'transparent',
     display: 'flex',
+    justifyContent: 'space-between',
     alignItems: 'center',
   };
 };


### PR DESCRIPTION
## Summary
- add invoice-level recurring service period fields to recurring-focused invoice preview samples
- add a reusable `icon-enum` inspector control type for Lucide-based property-pane toggles
- expose field-level label/value alignment in the invoice designer property pane
- default field alignment to `space-between` for new and existing field nodes in both design canvas and authoritative preview rendering

## Why
The invoice Period field was rendering differently from other metadata rows like Invoice # because field alignment was controlled by inline field style, but that behavior was not editable in the field property pane. This makes the control explicit and consistent with the icon-based alignment affordances used elsewhere in the designer.

## Validation
- targeted Vitest coverage for:
  - field inspector schema exposure
  - icon-enum field alignment control behavior
  - new field default style expectations
  - AST/react renderer field alignment output

## Notes
- I did not change unrelated broad test failures already present in the targeted schema suite.
