### PR TITLE
[codex] Enforce global email uniqueness on user updates

### DIFF
--- a/packages/users/src/actions/user-actions/userActions.test.ts
+++ b/packages/users/src/actions/user-actions/userActions.test.ts
@@ -7,6 +7,9 @@ const hasPermissionMock = vi.hoisted(() => vi.fn());
 const hashPasswordMock = vi.hoisted(() => vi.fn());
 const revalidatePathMock = vi.hoisted(() => vi.fn());
 const upsertMock = vi.hoisted(() => vi.fn());
+const userUpdateMock = vi.hoisted(() => vi.fn());
+const getUserWithRolesMock = vi.hoisted(() => vi.fn());
+const isInReportsToChainMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@alga-psa/auth', () => ({
   withAuth: (fn: (...args: any[]) => any) => {
@@ -30,6 +33,14 @@ vi.mock('@alga-psa/db/admin', () => ({
   getAdminConnection: getAdminConnectionMock,
 }));
 
+vi.mock('@alga-psa/db/models/user', () => ({
+  default: {
+    update: userUpdateMock,
+    getUserWithRoles: getUserWithRolesMock,
+    isInReportsToChain: isInReportsToChainMock,
+  },
+}));
+
 vi.mock('@alga-psa/core/encryption', () => ({
   hashPassword: hashPasswordMock,
 }));
@@ -51,13 +62,14 @@ vi.mock('@alga-psa/db/models/userPreferences', () => ({
 
 vi.mock('@alga-psa/core/logger', () => ({
   default: {
+    debug: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
   },
 }));
 
-function createAdminDb(emailExists = false) {
+function createAdminDb(existingUserId?: string) {
   return ((table: string) => {
     if (table !== 'users') {
       throw new Error(`Unexpected admin table ${table}`);
@@ -65,7 +77,10 @@ function createAdminDb(emailExists = false) {
 
     return {
       where: (_criteria: Record<string, any>) => ({
-        first: async () => (emailExists ? { user_id: 'existing-user' } : null),
+        whereNot: (_column: string, _value: string) => ({
+          first: async () => (existingUserId ? { user_id: existingUserId } : null),
+        }),
+        first: async () => (existingUserId ? { user_id: existingUserId } : null),
       }),
     };
   }) as any;
@@ -123,19 +138,33 @@ describe('addUser', () => {
     hashPasswordMock.mockReset();
     revalidatePathMock.mockReset();
     upsertMock.mockReset();
+    userUpdateMock.mockReset();
+    getUserWithRolesMock.mockReset();
+    isInReportsToChainMock.mockReset();
 
     hasPermissionMock.mockResolvedValue(true);
     hashPasswordMock.mockResolvedValue('hashed-password');
     upsertMock.mockResolvedValue(undefined);
     revalidatePathMock.mockReturnValue(undefined);
+    userUpdateMock.mockResolvedValue(undefined);
+    getUserWithRolesMock.mockResolvedValue({
+      user_id: 'user-1',
+      email: 'updated@example.com',
+    });
+    isInReportsToChainMock.mockResolvedValue(false);
 
     withTransactionMock.mockImplementation(async (db: any, callback: (trx: any) => Promise<any>) => callback(db));
-    getAdminConnectionMock.mockResolvedValue(createAdminDb(false));
+    getAdminConnectionMock.mockResolvedValue(createAdminDb());
   });
 
   async function loadAddUser() {
     const mod = await import('./userActions');
     return mod.addUser as any;
+  }
+
+  async function loadUpdateUser() {
+    const mod = await import('./userActions');
+    return mod.updateUser as any;
   }
 
   const actingUser = { user_id: 'user-1', user_type: 'internal' } as any;
@@ -193,6 +222,44 @@ describe('addUser', () => {
       user: {
         email: 'solo@example.com',
       },
+    });
+  });
+
+  it('rejects updating an email when another tenant already uses it', async () => {
+    createTenantKnexMock.mockResolvedValue({ knex: {} });
+    getAdminConnectionMock.mockResolvedValue(createAdminDb('other-tenant-user'));
+
+    const updateUser = await loadUpdateUser();
+
+    await expect(
+      updateUser(actingUser, tenantContext, actingUser.user_id, {
+        email: 'duplicate@example.com',
+      })
+    ).rejects.toThrow('A user with this email address already exists');
+
+    expect(userUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('normalizes updated email addresses to lowercase before saving', async () => {
+    createTenantKnexMock.mockResolvedValue({ knex: {} });
+
+    const updateUser = await loadUpdateUser();
+    const result = await updateUser(actingUser, tenantContext, actingUser.user_id, {
+      email: 'Updated@Example.com',
+      first_name: 'Updated',
+    });
+
+    expect(userUpdateMock).toHaveBeenCalledWith(
+      {},
+      actingUser.user_id,
+      expect.objectContaining({
+        email: 'updated@example.com',
+        first_name: 'Updated',
+      })
+    );
+    expect(result).toEqual({
+      user_id: 'user-1',
+      email: 'updated@example.com',
     });
   });
 });

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -39,8 +39,32 @@ const ADD_USER_VALIDATION_ERRORS = new Set([
   SOLO_USER_LIMIT_MESSAGE,
 ]);
 
+const UPDATE_USER_VALIDATION_ERRORS = new Set([
+  'A user with this email address already exists',
+  'reports_to cannot reference the user itself',
+  'reports_to would create a circular reporting chain',
+]);
+
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : '';
+
+async function findExistingUserByEmailGlobally(
+  email: string,
+  options?: { excludeUserId?: string }
+): Promise<Pick<IUser, 'user_id'> | undefined> {
+  const db = await getAdminConnection();
+
+  return withTransaction(db, async (trx: Knex.Transaction) => {
+    let query = trx('users')
+      .where({ email: email.toLowerCase() });
+
+    if (options?.excludeUserId) {
+      query = query.whereNot('user_id', options.excludeUserId);
+    }
+
+    return await query.first('user_id');
+  });
+}
 
 /**
  * Check if an email exists globally across all tenants
@@ -62,8 +86,7 @@ export const checkEmailExistsGlobally = withAuth(async (
 
       const existingUser = await trx('users')
         .where({ email: email.toLowerCase() })
-        .first();
-
+        .first('user_id');
       return !!existingUser;
     });
   } catch (error) {
@@ -320,12 +343,36 @@ export const updateUser = withAuth(async (
         }
       }
 
-      await User.update(trx, userId, userData);
+      let normalizedUserData = userData;
+      if (userData.email) {
+        const normalizedEmail = userData.email.toLowerCase();
+        const existingUser = await findExistingUserByEmailGlobally(normalizedEmail, {
+          excludeUserId: userId,
+        });
+
+        if (existingUser) {
+          throw new Error('A user with this email address already exists');
+        }
+
+        normalizedUserData = {
+          ...userData,
+          email: normalizedEmail,
+        };
+      }
+
+      await User.update(trx, userId, normalizedUserData);
       const updatedUser = await User.getUserWithRoles(trx, userId);
       return updatedUser || null;
     });
   } catch (error) {
     logger.error(`Failed to update user with id ${userId}:`, error);
+    const message = getErrorMessage(error);
+    if (
+      UPDATE_USER_VALIDATION_ERRORS.has(message) ||
+      message === 'Permission denied: Cannot update user'
+    ) {
+      throw error;
+    }
     throw new Error('Failed to update user');
   }
 });


### PR DESCRIPTION
## Summary
- enforce global email uniqueness in the shared `updateUser` server action
- normalize updated email addresses to lowercase before persistence
- preserve the duplicate-email validation message instead of collapsing to a generic update failure
- add focused action tests for cross-tenant duplicate rejection and email normalization

## Why
Creating MSP users already checked email uniqueness across all tenants, but profile updates used `updateUser` without any equivalent validation. That allowed a user to change their email to one already used by another tenant, and the profile path also did not normalize email casing before save.

## Impact
- profile email changes now follow the same global uniqueness rule as MSP user creation
- duplicate-email conflicts return a specific user-facing error
- updated emails are stored consistently in lowercase

## Validation
- `pnpm vitest ../packages/users/src/actions/user-actions/userActions.test.ts` (run from `server/`)
