### PR TITLE
Fix workflow ticket tags with spaces

### DIFF
--- a/ee/server/src/components/workflow-designer/__tests__/InputMappingEditorStructuredLiterals.test.tsx
+++ b/ee/server/src/components/workflow-designer/__tests__/InputMappingEditorStructuredLiterals.test.tsx
@@ -199,6 +199,48 @@ describe('InputMappingEditor structured literals', () => {
     expect(screen.queryByPlaceholderText('[]')).not.toBeInTheDocument();
   });
 
+  it('T138: primitive array editors preserve in-progress spaces while typing multi-word values', () => {
+    const Harness = () => {
+      const [value, setValue] = React.useState<{ tags: string[] }>({ tags: [] });
+
+      return (
+        <>
+          <InputMappingEditor
+            value={value}
+            onChange={(nextValue) => setValue(nextValue as typeof value)}
+            targetFields={[
+              {
+                name: 'tags',
+                type: 'array',
+                constraints: {
+                  itemType: 'string',
+                },
+              },
+            ]}
+            fieldOptions={[]}
+            stepId="step-primitive-array-spaces"
+            positionsHandlers={positionsHandlers}
+          />
+          <div data-testid="saved-tags">{JSON.stringify(value.tags)}</div>
+        </>
+      );
+    };
+
+    render(<Harness />);
+
+    const listEditor = screen.getByPlaceholderText(
+      'Enter one value per line, or comma-separated'
+    ) as HTMLTextAreaElement;
+
+    fireEvent.focus(listEditor);
+    fireEvent.change(listEditor, { target: { value: 'Managed ' } });
+    expect(listEditor.value).toBe('Managed ');
+
+    fireEvent.change(listEditor, { target: { value: 'Managed Services' } });
+    expect(listEditor.value).toBe('Managed Services');
+    expect(screen.getByTestId('saved-tags').textContent).toBe('["Managed Services"]');
+  });
+
   it('T129/T130/T131/T132: fixed mode uses structured enum, boolean, number, and string controls', () => {
     render(
       <InputMappingEditor

--- a/ee/server/src/components/workflow-designer/mapping/InputMappingEditor.tsx
+++ b/ee/server/src/components/workflow-designer/mapping/InputMappingEditor.tsx
@@ -992,6 +992,7 @@ const LiteralValueEditor: React.FC<{
   });
   const [listError, setListError] = useState<string | null>(null);
   const [listText, setListText] = useState(() => formatPrimitiveList(value));
+  const [isEditingPrimitiveList, setIsEditingPrimitiveList] = useState(false);
 
   useEffect(() => {
     if (!supportsStructuredEditor) {
@@ -1007,11 +1008,11 @@ const LiteralValueEditor: React.FC<{
   }, [value, fieldType]);
 
   useEffect(() => {
-    if (hasStructuredPrimitiveArrayEditor) {
+    if (hasStructuredPrimitiveArrayEditor && !isEditingPrimitiveList) {
       setListText(formatPrimitiveList(value));
       setListError(null);
     }
-  }, [value, hasStructuredPrimitiveArrayEditor]);
+  }, [value, hasStructuredPrimitiveArrayEditor, isEditingPrimitiveList]);
 
   const nullableOptions: SelectOption[] = [
     { value: 'value', label: 'Use value' },
@@ -1308,6 +1309,8 @@ const LiteralValueEditor: React.FC<{
           <TextArea
             id={`${idPrefix}-literal-list`}
             value={listText}
+            onFocus={() => setIsEditingPrimitiveList(true)}
+            onBlur={() => setIsEditingPrimitiveList(false)}
             onChange={(e) => {
               const nextText = e.target.value;
               setListText(nextText);

--- a/shared/workflow/runtime/actions/__tests__/ticketWorkflowBoardStatusRuntime.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/ticketWorkflowBoardStatusRuntime.test.ts
@@ -114,6 +114,15 @@ class FakeQueryBuilder {
     return rows.length;
   }
 
+  async insert(data: Record<string, any> | Array<Record<string, any>>): Promise<any> {
+    const rows = Array.isArray(data) ? data : [data];
+    if (!this.tables[this.tableName]) {
+      this.tables[this.tableName] = [];
+    }
+    this.tables[this.tableName].push(...rows);
+    return rows;
+  }
+
   private execute(): TableRow[] {
     const rows = [...(this.tables[this.tableName] ?? [])].filter((row) =>
       Object.entries(this.conditions).every(([column, value]) => row[column] === value)
@@ -346,7 +355,64 @@ describe('ticket workflow runtime board-scoped statuses', () => {
     expect(tables.tickets[0]?.closed_at).toBe('2026-03-14T00:00:00.000Z');
   });
 
-  it("T040: tickets.create returns the selected board's default status when workflow input omits status_id", async () => {
+  it('T040: tickets.create writes real ticket tag mappings while preserving mirrored attributes.tags', async () => {
+    const tables: TableMap = { statuses: [], tag_definitions: [], tag_mappings: [] };
+    setTenantTx(tables);
+    runtimeState.createTicketMock.mockResolvedValue({
+      ticket_id: 'ticket-1',
+      ticket_number: 'T-1',
+      entered_at: '2026-03-14T00:00:00.000Z',
+      status_id: 'status-board-a-open',
+      priority_id: 'priority-1',
+    });
+
+    const action = getAction('tickets.create');
+
+    await action.handler(
+      {
+        client_id: 'client-1',
+        title: 'Workflow ticket',
+        description: 'Created from workflow',
+        board_id: 'board-a',
+        priority_id: 'priority-1',
+        tags: ['Look at the spaces'],
+      },
+      createActionContext()
+    );
+
+    expect(runtimeState.createTicketMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          tags: ['Look at the spaces'],
+        }),
+      }),
+      'tenant-1',
+      expect.any(Function),
+      {},
+      undefined,
+      undefined,
+      'user-1'
+    );
+
+    expect(tables.tag_definitions).toHaveLength(1);
+    expect(tables.tag_definitions[0]).toMatchObject({
+      tenant: 'tenant-1',
+      tag_text: 'Look at the spaces',
+      tagged_type: 'ticket',
+      text_color: '#2C3E50',
+    });
+
+    expect(tables.tag_mappings).toHaveLength(1);
+    expect(tables.tag_mappings[0]).toMatchObject({
+      tenant: 'tenant-1',
+      tag_id: tables.tag_definitions[0]?.tag_id,
+      tagged_id: 'ticket-1',
+      tagged_type: 'ticket',
+      created_by: 'user-1',
+    });
+  });
+
+  it("T041: tickets.create returns the selected board's default status when workflow input omits status_id", async () => {
     setTenantTx({
       statuses: [
         {

--- a/shared/workflow/runtime/actions/businessOperations/tickets.ts
+++ b/shared/workflow/runtime/actions/businessOperations/tickets.ts
@@ -15,7 +15,8 @@ import {
   rethrowAsStandardError,
   parseJsonMaybe,
   buildBlockNoteWithMentions,
-  attachDocumentToTicket
+  attachDocumentToTicket,
+  type TenantTxContext,
 } from './shared';
 import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
 
@@ -44,6 +45,135 @@ const withWorkflowPicker = <T extends z.ZodTypeAny>(
     'x-workflow-picker-fixed-value-hint': WORKFLOW_PICKER_HINTS[kind],
     'x-workflow-picker-allow-dynamic-reference': true,
   });
+
+const generateTagColors = (text: string): { backgroundColor: string; textColor: string } => {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = text.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const hue = Math.abs(hash) % 360;
+  const saturation = 70;
+  const lightness = 85;
+
+  const hslToHex = (h: number, s: number, l: number): string => {
+    const normalizedLightness = l / 100;
+    const a = (s * Math.min(normalizedLightness, 1 - normalizedLightness)) / 100;
+    const f = (n: number) => {
+      const k = (n + h / 30) % 12;
+      const color = normalizedLightness - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+      return Math.round(255 * color).toString(16).padStart(2, '0');
+    };
+
+    return `#${f(0)}${f(8)}${f(4)}`.toUpperCase();
+  };
+
+  return {
+    backgroundColor: hslToHex(hue, saturation, lightness),
+    textColor: '#2C3E50',
+  };
+};
+
+const normalizeTicketTags = (tags: string[] | undefined): string[] => {
+  if (!Array.isArray(tags)) return [];
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  tags.forEach((tag) => {
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  });
+
+  return normalized;
+};
+
+const ensureTicketTagMappings = async (
+  tx: TenantTxContext,
+  ticketId: string,
+  tags: string[] | undefined
+): Promise<void> => {
+  const normalizedTags = normalizeTicketTags(tags);
+  if (normalizedTags.length === 0) {
+    return;
+  }
+
+  for (const tagText of normalizedTags) {
+    const { backgroundColor, textColor } = generateTagColors(tagText);
+
+    let definition = await tx.trx('tag_definitions')
+      .where({
+        tenant: tx.tenantId,
+        tag_text: tagText,
+        tagged_type: 'ticket',
+      })
+      .first();
+
+    if (!definition) {
+      const definitionRow = {
+        tenant: tx.tenantId,
+        tag_id: uuidv4(),
+        tag_text: tagText,
+        tagged_type: 'ticket',
+        board_id: null,
+        background_color: backgroundColor,
+        text_color: textColor,
+      };
+
+      try {
+        await tx.trx('tag_definitions').insert(definitionRow);
+        definition = definitionRow;
+      } catch (error: unknown) {
+        const errorCode =
+          typeof error === 'object' && error !== null && 'code' in error
+            ? String((error as { code?: unknown }).code)
+            : undefined;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        if (errorCode === '23505' || /duplicate|unique/i.test(errorMessage)) {
+          definition = await tx.trx('tag_definitions')
+            .where({
+              tenant: tx.tenantId,
+              tag_text: tagText,
+              tagged_type: 'ticket',
+            })
+            .first();
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (!definition?.tag_id) {
+      throw new Error(`Failed to resolve ticket tag definition for "${tagText}"`);
+    }
+
+    try {
+      await tx.trx('tag_mappings').insert({
+        tenant: tx.tenantId,
+        mapping_id: uuidv4(),
+        tag_id: definition.tag_id,
+        tagged_id: ticketId,
+        tagged_type: 'ticket',
+        created_by: tx.actorUserId,
+      });
+    } catch (error: unknown) {
+      const errorCode =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : undefined;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (errorCode === '23505' || /duplicate|unique/i.test(errorMessage)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+};
 
 export function registerTicketActions(): void {
   const registry = getActionRegistryV2();
@@ -104,7 +234,7 @@ export function registerTicketActions(): void {
         'ticket-subcategory',
         ['board_id', 'category_id']
       ),
-      tags: z.array(z.string()).optional().describe('Optional tags (stored in ticket attributes)'),
+      tags: z.array(z.string()).optional().describe('Optional tags (applied to ticket tags and mirrored into ticket attributes)'),
       custom_fields: z.record(z.unknown()).optional().describe('Optional custom fields (stored in ticket attributes)'),
       attributes: z.record(z.unknown()).optional().describe('Additional attributes (merged into ticket.attributes)'),
       initial_comment: z.object({
@@ -149,7 +279,8 @@ export function registerTicketActions(): void {
       const mergedAttributes: Record<string, any> = {
         ...(input.attributes ?? {})
       };
-      if (input.tags?.length) mergedAttributes.tags = input.tags;
+      const normalizedTags = normalizeTicketTags(input.tags);
+      if (normalizedTags.length) mergedAttributes.tags = normalizedTags;
       if (input.custom_fields) mergedAttributes.custom_fields = input.custom_fields;
 
       if (input.status_id) {
@@ -227,6 +358,8 @@ export function registerTicketActions(): void {
       } catch (error) {
         rethrowAsStandardError(ctx, error);
       }
+
+      await ensureTicketTagMappings(tx, created.ticket_id, normalizedTags);
 
       if (input.assignee?.type === 'team') {
         const teamMembers = await tx.trx('team_members')


### PR DESCRIPTION
## Summary
- preserve in-progress primitive array textarea text in the workflow designer so multi-word ticket tags can be typed without losing spaces
- make `tickets.create` create real ticket tag definitions/mappings while still mirroring `attributes.tags` for backward compatibility
- add regression coverage for spaced tag entry and workflow-created ticket tag mappings

## Notes
- this change is scoped to workflow ticket creation; it does not change the separate tag update path