### PR TITLE
Add toggle to hide Budget Hours in client portal

### DIFF
--- a/packages/client-portal-composition/src/projects/ClientPortalProjectMetrics.tsx
+++ b/packages/client-portal-composition/src/projects/ClientPortalProjectMetrics.tsx
@@ -6,7 +6,12 @@ import HoursProgressBar from '@alga-psa/projects/components/HoursProgressBar';
 import { calculateProjectCompletion, type ProjectCompletionMetrics } from '@alga-psa/projects/lib/projectUtils';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
-export function ClientPortalProjectMetrics({ projectId }: { projectId: string }) {
+interface ClientPortalProjectMetricsProps {
+  projectId: string;
+  showBudgetHours?: boolean;
+}
+
+export function ClientPortalProjectMetrics({ projectId, showBudgetHours = false }: ClientPortalProjectMetricsProps) {
   const { t } = useTranslation('features/projects');
   const [metrics, setMetrics] = useState<ProjectCompletionMetrics | null>(null);
   const [loading, setLoading] = useState(true);
@@ -26,17 +31,21 @@ export function ClientPortalProjectMetrics({ projectId }: { projectId: string })
     fetchMetrics();
   }, [projectId]);
 
+  const gridClass = showBudgetHours
+    ? 'grid grid-cols-1 md:grid-cols-2 gap-6 mb-6'
+    : 'grid grid-cols-1 gap-6 mb-6';
+
   if (loading) {
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+      <div className={gridClass}>
         <div className="bg-gray-50 p-4 rounded-lg animate-pulse h-36" />
-        <div className="bg-gray-50 p-4 rounded-lg animate-pulse h-36" />
+        {showBudgetHours && <div className="bg-gray-50 p-4 rounded-lg animate-pulse h-36" />}
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+    <div className={gridClass}>
       <div className="bg-gray-50 p-4 rounded-lg">
         <h3 className="text-lg font-semibold mb-4">{t('taskCompletion', 'Task Completion')}</h3>
         <div className="flex items-center">
@@ -60,44 +69,46 @@ export function ClientPortalProjectMetrics({ projectId }: { projectId: string })
         </div>
       </div>
 
-      <div className="bg-gray-50 p-4 rounded-lg">
-        <h3 className="text-lg font-semibold mb-4">{t('budgetHours', 'Budget Hours')}</h3>
-        <div className="flex flex-col">
-          <div className="flex flex-col mb-1">
-            <p className="font-medium">
-              {t('budgetUsed', '{{percent}}% of Budget Used', { percent: Math.round(metrics?.hoursCompletionPercentage || 0) })}
-            </p>
-            <p className="text-sm text-gray-600">
-              {t('hoursUsed', '{{spent}} of {{budgeted}} hours', {
-                spent: (metrics?.spentHours || 0).toFixed(1),
-                budgeted: (metrics?.budgetedHours || 0).toFixed(1),
-              })}
-            </p>
+      {showBudgetHours && (
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h3 className="text-lg font-semibold mb-4">{t('budgetHours', 'Budget Hours')}</h3>
+          <div className="flex flex-col">
+            <div className="flex flex-col mb-1">
+              <p className="font-medium">
+                {t('budgetUsed', '{{percent}}% of Budget Used', { percent: Math.round(metrics?.hoursCompletionPercentage || 0) })}
+              </p>
+              <p className="text-sm text-gray-600">
+                {t('hoursUsed', '{{spent}} of {{budgeted}} hours', {
+                  spent: (metrics?.spentHours || 0).toFixed(1),
+                  budgeted: (metrics?.budgetedHours || 0).toFixed(1),
+                })}
+              </p>
+            </div>
+            <HoursProgressBar
+              percentage={metrics?.hoursCompletionPercentage || 0}
+              width={'100%'}
+              height={8}
+              showTooltip={true}
+              tooltipContent={
+                <div className="p-2">
+                  <p className="font-medium">{t('hoursUsage', 'Hours Usage')}</p>
+                  <p className="text-sm">
+                    {t('hoursUsedDetail', '{{spent}} of {{budgeted}} hours used', {
+                      spent: (metrics?.spentHours || 0).toFixed(1),
+                      budgeted: (metrics?.budgetedHours || 0).toFixed(1),
+                    })}
+                  </p>
+                  <p className="text-sm">
+                    {t('hoursRemaining', '{{remaining}} hours remaining', {
+                      remaining: (metrics?.remainingHours || 0).toFixed(1),
+                    })}
+                  </p>
+                </div>
+              }
+            />
           </div>
-          <HoursProgressBar
-            percentage={metrics?.hoursCompletionPercentage || 0}
-            width={'100%'}
-            height={8}
-            showTooltip={true}
-            tooltipContent={
-              <div className="p-2">
-                <p className="font-medium">{t('hoursUsage', 'Hours Usage')}</p>
-                <p className="text-sm">
-                  {t('hoursUsedDetail', '{{spent}} of {{budgeted}} hours used', {
-                    spent: (metrics?.spentHours || 0).toFixed(1),
-                    budgeted: (metrics?.budgetedHours || 0).toFixed(1),
-                  })}
-                </p>
-                <p className="text-sm">
-                  {t('hoursRemaining', '{{remaining}} hours remaining', {
-                    remaining: (metrics?.remainingHours || 0).toFixed(1),
-                  })}
-                </p>
-              </div>
-            }
-          />
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/packages/client-portal-composition/src/projects/__tests__/ClientPortalProjectMetrics.test.tsx
+++ b/packages/client-portal-composition/src/projects/__tests__/ClientPortalProjectMetrics.test.tsx
@@ -1,0 +1,151 @@
+/* @vitest-environment jsdom */
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+
+const calculateProjectCompletionMock = vi.fn();
+
+vi.mock('@alga-psa/projects/lib/projectUtils', () => ({
+  calculateProjectCompletion: (...args: unknown[]) =>
+    calculateProjectCompletionMock(...args)
+}));
+
+vi.mock('@alga-psa/projects/components/DonutChart', () => ({
+  __esModule: true,
+  default: ({ percentage }: { percentage: number }) => (
+    <div data-testid="donut-chart">{Math.round(percentage)}</div>
+  )
+}));
+
+vi.mock('@alga-psa/projects/components/HoursProgressBar', () => ({
+  __esModule: true,
+  default: ({ percentage }: { percentage: number }) => (
+    <div data-testid="hours-progress-bar">{Math.round(percentage)}</div>
+  )
+}));
+
+// `@alga-psa/ui/lib/i18n/client` is the app's i18n shim. Provide a minimal stub
+// that returns the English default (second arg) for every `t()` call.
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultOrOpts?: unknown, maybeOpts?: unknown) => {
+      const defaultValue = typeof defaultOrOpts === 'string' ? defaultOrOpts : _key;
+      const opts = (typeof defaultOrOpts === 'object' ? defaultOrOpts : maybeOpts) as
+        | Record<string, unknown>
+        | undefined;
+      if (!opts) return defaultValue;
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_m, name) =>
+        String(opts[name] ?? '')
+      );
+    }
+  })
+}));
+
+import { ClientPortalProjectMetrics } from '../ClientPortalProjectMetrics';
+
+describe('ClientPortalProjectMetrics — Budget Hours visibility', () => {
+  // Use distinctive decimal values that can't collide with task counts ("3 of 7")
+  // so substring checks for hour leakage are unambiguous.
+  const SPENT_HOURS = 12.3;         // tracked / logged time
+  const BUDGETED_HOURS = 20.7;      // budget
+  const REMAINING_HOURS = 8.4;
+  const HOURS_PCT = 59;
+
+  beforeEach(() => {
+    calculateProjectCompletionMock.mockReset();
+    calculateProjectCompletionMock.mockResolvedValue({
+      taskCompletionPercentage: 42,
+      completedTasks: 3,
+      totalTasks: 7,
+      hoursCompletionPercentage: HOURS_PCT,
+      spentHours: SPENT_HOURS,
+      budgetedHours: BUDGETED_HOURS,
+      remainingHours: REMAINING_HOURS
+    });
+  });
+
+  // Auto-cleanup between tests isn't firing reliably when this file runs
+  // alongside others in the same vitest fork, so be explicit.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Budget Hours card when showBudgetHours=true', async () => {
+    render(
+      <ClientPortalProjectMetrics projectId="p-1" showBudgetHours={true} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Task Completion')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Budget Hours')).toBeInTheDocument();
+    expect(screen.getByText(`${HOURS_PCT}% of Budget Used`)).toBeInTheDocument();
+    // Tracked time + budget are both rendered as part of the "X of Y hours" line.
+    expect(
+      screen.getByText(`${SPENT_HOURS.toFixed(1)} of ${BUDGETED_HOURS.toFixed(1)} hours`)
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT leak tracked time or budgeted hours when showBudgetHours=false', async () => {
+    render(
+      <ClientPortalProjectMetrics projectId="p-1" showBudgetHours={false} />
+    );
+
+    // Wait for data to finish loading — otherwise the loading skeleton masks
+    // the real render and the negative assertions below would pass trivially.
+    await waitFor(() => {
+      expect(calculateProjectCompletionMock).toHaveBeenCalled();
+      expect(screen.getByText('Task Completion')).toBeInTheDocument();
+    });
+
+    // Card header is gone.
+    expect(screen.queryByText('Budget Hours')).not.toBeInTheDocument();
+    // % of Budget Used line is gone.
+    expect(screen.queryByText(/of Budget Used/i)).not.toBeInTheDocument();
+
+    // CRITICAL — the actual hour numbers are absent from the DOM.
+    // Budgeted total (budget):
+    const budgetedStr = BUDGETED_HOURS.toFixed(1);
+    expect(document.body.textContent ?? '').not.toContain(budgetedStr);
+    // Tracked / logged time (spent):
+    const spentStr = SPENT_HOURS.toFixed(1);
+    expect(document.body.textContent ?? '').not.toContain(spentStr);
+    // Remaining-hours breakdown (only shown inside the card's tooltip, but also
+    // embedded in the tooltip markup via the HoursProgressBar — assert absent).
+    expect(document.body.textContent ?? '').not.toContain(REMAINING_HOURS.toFixed(1));
+
+    // Progress bar for hours is not rendered.
+    expect(screen.queryByTestId('hours-progress-bar')).not.toBeInTheDocument();
+  });
+
+  it('defaults to hiding the Budget Hours card when the prop is omitted', async () => {
+    render(<ClientPortalProjectMetrics projectId="p-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Task Completion')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Budget Hours')).not.toBeInTheDocument();
+    // Double-check raw numbers are not leaking either.
+    expect(document.body.textContent ?? '').not.toContain(BUDGETED_HOURS.toFixed(1));
+    expect(document.body.textContent ?? '').not.toContain(SPENT_HOURS.toFixed(1));
+    expect(screen.queryByTestId('hours-progress-bar')).not.toBeInTheDocument();
+  });
+
+  it('always renders the Task Completion card regardless of Budget Hours flag', async () => {
+    const { rerender } = render(
+      <ClientPortalProjectMetrics projectId="p-1" showBudgetHours={false} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Task Completion')).toBeInTheDocument();
+    });
+
+    rerender(
+      <ClientPortalProjectMetrics projectId="p-1" showBudgetHours={true} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Task Completion')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client-portal/src/components/projects/ProjectDetailView.tsx
+++ b/packages/client-portal/src/components/projects/ProjectDetailView.tsx
@@ -103,6 +103,7 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
   const config = project.client_portal_config ?? DEFAULT_CLIENT_PORTAL_CONFIG;
   const showPhases = config.show_phases ?? false;
   const showTasks = config.show_tasks ?? false;
+  const showBudgetHours = config.show_budget_hours ?? false;
 
   // Determine effective view mode - kanban only makes sense when tasks are shown
   // When only phases are enabled (no tasks), force list view
@@ -216,7 +217,7 @@ export default function ProjectDetailView({ project }: ProjectDetailViewProps) {
           {project.description || t('messages.noDescription', 'No description provided')}
         </p>
 
-        <ClientPortalProjectMetrics projectId={project.project_id} />
+        <ClientPortalProjectMetrics projectId={project.project_id} showBudgetHours={showBudgetHours} />
 
         <div>
           <h3 className="text-lg font-semibold mb-2">{t('details')}</h3>

--- a/packages/projects/src/components/ClientPortalConfigEditor.tsx
+++ b/packages/projects/src/components/ClientPortalConfigEditor.tsx
@@ -36,6 +36,10 @@ export default function ClientPortalConfigEditor({
   const getVisibilitySummary = (): string[] => {
     const summary: string[] = [t('clientPortal.summary.projectInfo', 'Project name, description, dates, and overall progress')];
 
+    if (config.show_budget_hours) {
+      summary.push(t('clientPortal.summary.budgetHours', 'Budget hours: spent vs. budgeted totals and % used'));
+    }
+
     if (config.show_phases) {
       summary.push(t('clientPortal.summary.phaseInfo', 'Phase names, descriptions, and date ranges'));
       if (config.show_phase_completion) {
@@ -85,6 +89,26 @@ export default function ClientPortalConfigEditor({
       </Alert>
 
       <div className="space-y-4 border-l-2 border-gray-200 pl-4">
+        {/* Show Budget Hours Toggle */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <label htmlFor="show-budget-hours" className="text-sm font-medium text-gray-700">
+                {t('clientPortal.showBudgetHours', 'Show Budget Hours')}
+              </label>
+              <p className="text-xs text-gray-500">
+                {t('clientPortal.showBudgetHoursDescription', 'Clients will see the project-level Budget Hours card with spent vs. budgeted hours and % of budget used.')}
+              </p>
+            </div>
+            <Switch
+              id="show-budget-hours"
+              checked={config.show_budget_hours}
+              onCheckedChange={(checked) => updateConfig({ show_budget_hours: checked })}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+
         {/* Show Phases Toggle */}
         <div className="space-y-3">
           <div className="flex items-center justify-between">

--- a/packages/projects/src/components/__tests__/ClientPortalConfigEditor.test.tsx
+++ b/packages/projects/src/components/__tests__/ClientPortalConfigEditor.test.tsx
@@ -1,0 +1,135 @@
+/* @vitest-environment jsdom */
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import ClientPortalConfigEditor from '../ClientPortalConfigEditor';
+import type { IClientPortalConfig } from '@alga-psa/types';
+import { DEFAULT_CLIENT_PORTAL_CONFIG } from '@alga-psa/types';
+
+function buildConfig(overrides: Partial<IClientPortalConfig> = {}): IClientPortalConfig {
+  return { ...DEFAULT_CLIENT_PORTAL_CONFIG, ...overrides };
+}
+
+function getBudgetHoursSwitch(): HTMLElement {
+  // Radix Switch renders a <button role="switch"> — our Switch wrapper attaches
+  // data-automation-id from the `id` prop ("show-budget-hours").
+  const el = document.querySelector('[data-automation-id="show-budget-hours"]');
+  if (!el) throw new Error('show-budget-hours switch not found');
+  return el as HTMLElement;
+}
+
+describe('ClientPortalConfigEditor — Show Budget Hours toggle', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a toggle bound to the show_budget_hours field', () => {
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig()}
+        onChange={() => {}}
+      />
+    );
+    // The toggle exists — identified by its data-automation-id, which comes
+    // from the `id="show-budget-hours"` on the Switch.
+    expect(getBudgetHoursSwitch()).toBeInTheDocument();
+  });
+
+  it('reflects show_budget_hours=false via aria-checked=false', () => {
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig({ show_budget_hours: false })}
+        onChange={() => {}}
+      />
+    );
+
+    const toggle = getBudgetHoursSwitch();
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('reflects show_budget_hours=true via aria-checked=true', () => {
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig({ show_budget_hours: true })}
+        onChange={() => {}}
+      />
+    );
+
+    const toggle = getBudgetHoursSwitch();
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('calls onChange with show_budget_hours=true when the toggle is clicked from off', () => {
+    const onChange = vi.fn();
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig({ show_budget_hours: false })}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(getBudgetHoursSwitch());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const nextConfig = onChange.mock.calls[0][0] as IClientPortalConfig;
+    expect(nextConfig.show_budget_hours).toBe(true);
+    // Unrelated flags are preserved.
+    expect(nextConfig.show_phases).toBe(false);
+    expect(nextConfig.show_tasks).toBe(false);
+  });
+
+  it('calls onChange with show_budget_hours=false when the toggle is clicked from on', () => {
+    const onChange = vi.fn();
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig({ show_budget_hours: true })}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(getBudgetHoursSwitch());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const nextConfig = onChange.mock.calls[0][0] as IClientPortalConfig;
+    expect(nextConfig.show_budget_hours).toBe(false);
+  });
+
+  it('disables the toggle when the editor is disabled', () => {
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig()}
+        onChange={() => {}}
+        disabled
+      />
+    );
+
+    const toggle = getBudgetHoursSwitch();
+    expect(toggle).toBeDisabled();
+  });
+
+  it('is independent of show_phases — does not auto-disable when phases turn off', () => {
+    const onChange = vi.fn();
+    render(
+      <ClientPortalConfigEditor
+        config={buildConfig({ show_phases: true, show_budget_hours: true })}
+        onChange={onChange}
+      />
+    );
+
+    // Toggle off show_phases — the Phases switch sits above Budget Hours visually
+    // but the two are independent state-wise.
+    const phasesToggle = document.querySelector(
+      '[data-automation-id="show-phases"]'
+    ) as HTMLElement;
+    fireEvent.click(phasesToggle);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const nextConfig = onChange.mock.calls[0][0] as IClientPortalConfig;
+    expect(nextConfig.show_phases).toBe(false);
+    // Budget Hours stays on — it's not nested under phases.
+    expect(nextConfig.show_budget_hours).toBe(true);
+  });
+});
+

--- a/packages/projects/src/schemas/__tests__/clientPortalConfigSchema.test.ts
+++ b/packages/projects/src/schemas/__tests__/clientPortalConfigSchema.test.ts
@@ -1,0 +1,53 @@
+/* @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+import { clientPortalConfigSchema } from '../project.schemas';
+import { DEFAULT_CLIENT_PORTAL_CONFIG } from '@alga-psa/types';
+
+describe('clientPortalConfigSchema — show_budget_hours', () => {
+  it('accepts show_budget_hours=true', () => {
+    const parsed = clientPortalConfigSchema.parse({
+      show_phases: false,
+      show_phase_completion: false,
+      show_tasks: false,
+      show_budget_hours: true,
+      visible_task_fields: ['task_name']
+    });
+    expect(parsed.show_budget_hours).toBe(true);
+  });
+
+  it('accepts show_budget_hours=false', () => {
+    const parsed = clientPortalConfigSchema.parse({
+      show_phases: false,
+      show_phase_completion: false,
+      show_tasks: false,
+      show_budget_hours: false,
+      visible_task_fields: ['task_name']
+    });
+    expect(parsed.show_budget_hours).toBe(false);
+  });
+
+  it('defaults show_budget_hours to false when field is omitted', () => {
+    const parsed = clientPortalConfigSchema.parse({});
+    expect(parsed.show_budget_hours).toBe(false);
+  });
+
+  it('rejects non-boolean show_budget_hours', () => {
+    expect(() =>
+      clientPortalConfigSchema.parse({ show_budget_hours: 'yes' })
+    ).toThrow();
+  });
+});
+
+describe('DEFAULT_CLIENT_PORTAL_CONFIG', () => {
+  it('has show_budget_hours set to false (hidden by default)', () => {
+    expect(DEFAULT_CLIENT_PORTAL_CONFIG.show_budget_hours).toBe(false);
+  });
+
+  it('matches the other visibility flags — all start hidden', () => {
+    expect(DEFAULT_CLIENT_PORTAL_CONFIG.show_phases).toBe(false);
+    expect(DEFAULT_CLIENT_PORTAL_CONFIG.show_tasks).toBe(false);
+    expect(DEFAULT_CLIENT_PORTAL_CONFIG.show_phase_completion).toBe(false);
+    expect(DEFAULT_CLIENT_PORTAL_CONFIG.show_budget_hours).toBe(false);
+  });
+});

--- a/packages/projects/src/schemas/project.schemas.ts
+++ b/packages/projects/src/schemas/project.schemas.ts
@@ -6,6 +6,7 @@ export const clientPortalConfigSchema = z.object({
   show_phases: z.boolean().default(false),
   show_phase_completion: z.boolean().default(false),
   show_tasks: z.boolean().default(false),
+  show_budget_hours: z.boolean().default(false),
   visible_task_fields: z.array(z.string()).default(['task_name', 'due_date', 'status'])
 });
 

--- a/packages/types/src/interfaces/project.interfaces.ts
+++ b/packages/types/src/interfaces/project.interfaces.ts
@@ -9,6 +9,7 @@ export interface IClientPortalConfig {
   show_phases?: boolean;                // Show phase breakdown
   show_phase_completion?: boolean;      // Show task completion % per phase
   show_tasks?: boolean;                 // Show individual tasks
+  show_budget_hours?: boolean;          // Show project-level budget/spent hours card
   visible_task_fields?: string[];       // Which task fields/features to show
 }
 
@@ -16,6 +17,7 @@ export const DEFAULT_CLIENT_PORTAL_CONFIG: IClientPortalConfig = {
   show_phases: false,
   show_phase_completion: false,
   show_tasks: false,
+  show_budget_hours: false,
   visible_task_fields: ['task_name', 'due_date', 'status']
 };
 

--- a/server/migrations/20260421130000_add_show_budget_hours_to_client_portal_config.cjs
+++ b/server/migrations/20260421130000_add_show_budget_hours_to_client_portal_config.cjs
@@ -1,0 +1,97 @@
+/**
+ * Add show_budget_hours flag to client_portal_config on projects and project_templates.
+ * Defaults to false (hidden) to match the rest of the client portal visibility flags.
+ */
+exports.config = { transaction: false };
+
+const NEW_DEFAULT_CLIENT_PORTAL_CONFIG = {
+  show_phases: false,
+  show_phase_completion: false,
+  show_tasks: false,
+  show_budget_hours: false,
+  visible_task_fields: ['task_name', 'due_date', 'status']
+};
+
+async function backfillTable(knex, tableName, idColumn) {
+  // CitusDB requires select-then-update with tenant in WHERE clause.
+  const rows = await knex(tableName).select(idColumn, 'tenant', 'client_portal_config');
+
+  let updated = 0;
+  for (const row of rows) {
+    const current = row.client_portal_config || {};
+    if (Object.prototype.hasOwnProperty.call(current, 'show_budget_hours')) {
+      continue;
+    }
+    const next = { ...current, show_budget_hours: false };
+    await knex(tableName)
+      .where(idColumn, row[idColumn])
+      .andWhere('tenant', row.tenant)
+      .update({ client_portal_config: JSON.stringify(next) });
+    updated += 1;
+  }
+  return updated;
+}
+
+exports.up = async function (knex) {
+  console.log('Adding show_budget_hours to client_portal_config defaults...');
+
+  await knex.schema.alterTable('projects', (table) => {
+    table.jsonb('client_portal_config').defaultTo(JSON.stringify(NEW_DEFAULT_CLIENT_PORTAL_CONFIG)).alter();
+  });
+  console.log('  ✓ Updated default for projects.client_portal_config');
+
+  await knex.schema.alterTable('project_templates', (table) => {
+    table.jsonb('client_portal_config').defaultTo(JSON.stringify(NEW_DEFAULT_CLIENT_PORTAL_CONFIG)).alter();
+  });
+  console.log('  ✓ Updated default for project_templates.client_portal_config');
+
+  const projectsUpdated = await backfillTable(knex, 'projects', 'project_id');
+  console.log(`  ✓ Backfilled show_budget_hours on ${projectsUpdated} projects`);
+
+  const templatesUpdated = await backfillTable(knex, 'project_templates', 'template_id');
+  console.log(`  ✓ Backfilled show_budget_hours on ${templatesUpdated} project_templates`);
+
+  console.log('show_budget_hours added to client_portal_config successfully');
+};
+
+const PREVIOUS_DEFAULT_CLIENT_PORTAL_CONFIG = {
+  show_phases: false,
+  show_phase_completion: false,
+  show_tasks: false,
+  visible_task_fields: ['task_name', 'due_date', 'status']
+};
+
+exports.down = async function (knex) {
+  console.log('Reverting show_budget_hours from client_portal_config defaults...');
+
+  await knex.schema.alterTable('projects', (table) => {
+    table.jsonb('client_portal_config').defaultTo(JSON.stringify(PREVIOUS_DEFAULT_CLIENT_PORTAL_CONFIG)).alter();
+  });
+  console.log('  ✓ Reverted default for projects.client_portal_config');
+
+  await knex.schema.alterTable('project_templates', (table) => {
+    table.jsonb('client_portal_config').defaultTo(JSON.stringify(PREVIOUS_DEFAULT_CLIENT_PORTAL_CONFIG)).alter();
+  });
+  console.log('  ✓ Reverted default for project_templates.client_portal_config');
+
+  // Strip show_budget_hours from existing rows.
+  async function strip(tableName, idColumn) {
+    const rows = await knex(tableName).select(idColumn, 'tenant', 'client_portal_config');
+    for (const row of rows) {
+      const current = row.client_portal_config || {};
+      if (!Object.prototype.hasOwnProperty.call(current, 'show_budget_hours')) {
+        continue;
+      }
+      const { show_budget_hours: _omit, ...rest } = current;
+      await knex(tableName)
+        .where(idColumn, row[idColumn])
+        .andWhere('tenant', row.tenant)
+        .update({ client_portal_config: JSON.stringify(rest) });
+    }
+  }
+
+  await strip('projects', 'project_id');
+  await strip('project_templates', 'template_id');
+
+  console.log('show_budget_hours reverted successfully');
+};

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Kunden werden sehen:",
+    "showBudgetHours": "Budget-Stunden anzeigen",
+    "showBudgetHoursDescription": "Kunden sehen die Karte „Budget-Stunden“ auf Projektebene mit geleisteten vs. budgetierten Stunden und % des verbrauchten Budgets.",
     "showPhases": "Phasen anzeigen",
     "showPhasesDescription": "Kunden sehen Phasenkarten mit Namen, Beschreibungen und Datumsbereichen. Sie können Phasen auswählen, um zugehörige Aufgaben anzuzeigen.",
     "showCompletion": "Fertigstellung % anzeigen",
@@ -1289,6 +1291,7 @@
     "required": "(erforderlich)",
     "summary": {
       "projectInfo": "Projektname, Beschreibung, Daten und Gesamtfortschritt",
+      "budgetHours": "Budget-Stunden: geleistete vs. budgetierte Gesamtwerte und % verbraucht",
       "phaseInfo": "Phasennamen, Beschreibungen und Datumsbereiche",
       "phaseCompletion": "Fertigstellungsprozentsatz für jede Phase",
       "taskDetails": "Aufgabendetails: {{fields}}",

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Clients will see:",
+    "showBudgetHours": "Show Budget Hours",
+    "showBudgetHoursDescription": "Clients will see the project-level Budget Hours card with spent vs. budgeted hours and % of budget used.",
     "showPhases": "Show Phases",
     "showPhasesDescription": "Clients will see phase cards with names, descriptions, and date ranges. They can select phases to view associated tasks.",
     "showCompletion": "Show Completion %",
@@ -1289,6 +1291,7 @@
     "required": "(required)",
     "summary": {
       "projectInfo": "Project name, description, dates, and overall progress",
+      "budgetHours": "Budget hours: spent vs. budgeted totals and % used",
       "phaseInfo": "Phase names, descriptions, and date ranges",
       "phaseCompletion": "Completion percentage for each phase",
       "taskDetails": "Task details: {{fields}}",

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Los clientes verán:",
+    "showBudgetHours": "Mostrar horas presupuestadas",
+    "showBudgetHoursDescription": "Los clientes verán la tarjeta de Horas presupuestadas del proyecto con horas utilizadas vs. presupuestadas y % del presupuesto consumido.",
     "showPhases": "Mostrar fases",
     "showPhasesDescription": "Los clientes verán tarjetas de fase con nombres, descripciones y rangos de fechas. Pueden seleccionar fases para ver las tareas asociadas.",
     "showCompletion": "Mostrar % de completado",
@@ -1289,6 +1291,7 @@
     "required": "(obligatorio)",
     "summary": {
       "projectInfo": "Nombre del proyecto, descripción, fechas y progreso general",
+      "budgetHours": "Horas presupuestadas: totales utilizados vs. presupuestados y % consumido",
       "phaseInfo": "Nombres de fase, descripciones y rangos de fechas",
       "phaseCompletion": "Porcentaje de completado para cada fase",
       "taskDetails": "Detalles de tareas: {{fields}}",

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Les clients verront :",
+    "showBudgetHours": "Afficher les heures budgétées",
+    "showBudgetHoursDescription": "Les clients verront la carte Heures budgétées au niveau du projet avec les heures consommées vs. budgétées et le % du budget utilisé.",
     "showPhases": "Afficher les phases",
     "showPhasesDescription": "Les clients verront des fiches de phase avec noms, descriptions et plages de dates. Ils peuvent sélectionner les phases pour voir les tâches associées.",
     "showCompletion": "Afficher le % de complétion",
@@ -1289,6 +1291,7 @@
     "required": "(requis)",
     "summary": {
       "projectInfo": "Nom du projet, description, dates et progression globale",
+      "budgetHours": "Heures budgétées : totaux consommés vs. budgétés et % utilisé",
       "phaseInfo": "Noms des phases, descriptions et plages de dates",
       "phaseCompletion": "Pourcentage de complétion pour chaque phase",
       "taskDetails": "Détails des tâches : {{fields}}",

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "I clienti vedranno:",
+    "showBudgetHours": "Mostra ore di budget",
+    "showBudgetHoursDescription": "I clienti vedranno la scheda Ore di budget a livello di progetto con ore utilizzate vs. di budget e % di budget utilizzato.",
     "showPhases": "Mostra fasi",
     "showPhasesDescription": "I clienti vedranno schede di fase con nomi, descrizioni e intervalli di date. Possono selezionare le fasi per visualizzare le attività associate.",
     "showCompletion": "Mostra % completamento",
@@ -1289,6 +1291,7 @@
     "required": "(obbligatorio)",
     "summary": {
       "projectInfo": "Nome del progetto, descrizione, date e avanzamento complessivo",
+      "budgetHours": "Ore di budget: totali utilizzati vs. di budget e % utilizzato",
       "phaseInfo": "Nomi delle fasi, descrizioni e intervalli di date",
       "phaseCompletion": "Percentuale di completamento per ogni fase",
       "taskDetails": "Dettagli attività: {{fields}}",

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Klanten zullen zien:",
+    "showBudgetHours": "Budget-uren tonen",
+    "showBudgetHoursDescription": "Klanten zien de Budget-uren-kaart op projectniveau met bestede vs. gebudgetteerde uren en % van het budget gebruikt.",
     "showPhases": "Fasen tonen",
     "showPhasesDescription": "Klanten zien fasekaarten met namen, beschrijvingen en datumbereiken. Ze kunnen fasen selecteren om bijbehorende taken te bekijken.",
     "showCompletion": "Voltooiing % tonen",
@@ -1289,6 +1291,7 @@
     "required": "(verplicht)",
     "summary": {
       "projectInfo": "Projectnaam, beschrijving, data en totale voortgang",
+      "budgetHours": "Budget-uren: bestede vs. gebudgetteerde totalen en % gebruikt",
       "phaseInfo": "Fasenamen, beschrijvingen en datumbereiken",
       "phaseCompletion": "Voltooiingspercentage voor elke fase",
       "taskDetails": "Taakdetails: {{fields}}",

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Klienci zobaczą:",
+    "showBudgetHours": "Pokaż godziny budżetowe",
+    "showBudgetHoursDescription": "Klienci zobaczą kartę Godziny budżetowe na poziomie projektu z godzinami wykorzystanymi vs. budżetowymi i % wykorzystanego budżetu.",
     "showPhases": "Pokaż fazy",
     "showPhasesDescription": "Klienci zobaczą karty faz z nazwami, opisami i zakresami dat. Mogą wybierać fazy, aby zobaczyć powiązane zadania.",
     "showCompletion": "Pokaż % ukończenia",
@@ -1289,6 +1291,7 @@
     "required": "(wymagane)",
     "summary": {
       "projectInfo": "Nazwa projektu, opis, daty i ogólny postęp",
+      "budgetHours": "Godziny budżetowe: wykorzystane vs. budżetowe wartości i % wykorzystanego budżetu",
       "phaseInfo": "Nazwy faz, opisy i zakresy dat",
       "phaseCompletion": "Procent ukończenia dla każdej fazy",
       "taskDetails": "Szczegóły zadań: {{fields}}",

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "Clients will see:",
+    "showBudgetHours": "Show Budget Hours",
+    "showBudgetHoursDescription": "Clients will see the project-level Budget Hours card with spent vs. budgeted hours and % of budget used.",
     "showPhases": "Show Phases",
     "showPhasesDescription": "Clients will see phase cards with names, descriptions, and date ranges. They can select phases to view associated tasks.",
     "showCompletion": "Show Completion %",
@@ -1289,6 +1291,7 @@
     "required": "(required)",
     "summary": {
       "projectInfo": "Project name, description, dates, and overall progress",
+      "budgetHours": "Budget hours: spent vs. budgeted totals and % used",
       "phaseInfo": "Phase names, descriptions, and date ranges",
       "phaseCompletion": "Completion percentage for each phase",
       "taskDetails": "Task details: {{fields}}",

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "11111",
+    "showBudgetHours": "11111",
+    "showBudgetHoursDescription": "11111",
     "showPhases": "11111",
     "showPhasesDescription": "11111",
     "showCompletion": "11111",
@@ -1289,6 +1291,7 @@
     "required": "11111",
     "summary": {
       "projectInfo": "11111",
+      "budgetHours": "11111",
       "phaseInfo": "11111",
       "phaseCompletion": "11111",
       "taskDetails": "11111 {{fields}} 11111",

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -1278,6 +1278,8 @@
   },
   "clientPortal": {
     "clientsWillSee": "55555",
+    "showBudgetHours": "55555",
+    "showBudgetHoursDescription": "55555",
     "showPhases": "55555",
     "showPhasesDescription": "55555",
     "showCompletion": "55555",
@@ -1289,6 +1291,7 @@
     "required": "55555",
     "summary": {
       "projectInfo": "55555",
+      "budgetHours": "55555",
       "phaseInfo": "55555",
       "phaseCompletion": "55555",
       "taskDetails": "55555 {{fields}} 55555",

--- a/server/src/interfaces/project.interfaces.ts
+++ b/server/src/interfaces/project.interfaces.ts
@@ -9,6 +9,7 @@ export interface IClientPortalConfig {
   show_phases?: boolean;                // Show phase breakdown
   show_phase_completion?: boolean;      // Show task completion % per phase
   show_tasks?: boolean;                 // Show individual tasks
+  show_budget_hours?: boolean;          // Show project-level budget/spent hours card
   visible_task_fields?: string[];       // Which task fields/features to show
 }
 
@@ -16,6 +17,7 @@ export const DEFAULT_CLIENT_PORTAL_CONFIG: IClientPortalConfig = {
   show_phases: false,
   show_phase_completion: false,
   show_tasks: false,
+  show_budget_hours: false,
   visible_task_fields: ['task_name', 'due_date', 'status']
 };
 

--- a/server/src/lib/schemas/project.schemas.ts
+++ b/server/src/lib/schemas/project.schemas.ts
@@ -6,6 +6,7 @@ export const clientPortalConfigSchema = z.object({
   show_phases: z.boolean().default(false),
   show_phase_completion: z.boolean().default(false),
   show_tasks: z.boolean().default(false),
+  show_budget_hours: z.boolean().default(false),
   visible_task_fields: z.array(z.string()).default(['task_name', 'due_date', 'status'])
 });
 


### PR DESCRIPTION
  Introduce `show_budget_hours` on IClientPortalConfig to gate the project-level Budget Hours card (spent vs. budgeted hours) in the client portal. Defaults to false — hidden — matching the sibling visibility flags. Includes admin toggle in ClientPortalConfigEditor, conditional rendering in ClientPortalProjectMetrics, DB migration with backfill across projects and project_templates, translations for 9 locales, and tests asserting tracked time and budgeted hour values never leak into the DOM when the toggle is off.

  Pay no attention to the hours behind the curtain! The Budget Hours card now waits in Oz behind a single emerald toggle, and no client shall spy a tracked minute unless an admin dares flip `show_budget_hours` from its slumber. 🎭⏱️ ✨