### PR TITLE
Resolve project tree statuses per phase

### DIFF
--- a/packages/projects/src/actions/projectActions.ts
+++ b/packages/projects/src/actions/projectActions.ts
@@ -293,13 +293,20 @@ export const getProjectTreeData = withAuth(async (user, { tenant }, projectId?: 
             ));
           }
 
-          const statuses = await getProjectTaskStatusesInternal(trx, tenant, project.project_id, user);
+          // Resolve effective statuses per phase (phase-specific overrides when present,
+          // else project-level defaults) so the status IDs surfaced in the tree match the
+          // IDs the kanban will render for each phase.
+          const phaseStatuses = await Promise.all(
+            phases.map((phase) =>
+              getProjectTaskStatusesInternal(trx, tenant, project.project_id, user, phase.phase_id)
+            )
+          );
 
         return {
           label: project.project_name,
           value: project.project_id,
           type: 'project' as const,
-          children: phases.map((phase): {
+          children: phases.map((phase, phaseIndex): {
             label: string;
             value: string;
             type: 'phase';
@@ -312,7 +319,7 @@ export const getProjectTreeData = withAuth(async (user, { tenant }, projectId?: 
             label: phase.phase_name,
             value: phase.phase_id,
             type: 'phase' as const,
-            children: statuses.map((status): {
+            children: phaseStatuses[phaseIndex].map((status): {
                 label: string;
                 value: string;
                 type: 'status';


### PR DESCRIPTION
  getProjectTreeData surfaced project-level status mappings under every
  phase, so when a phase had its own overrides the IDs in the tree did
  not match the kanban columns. Duplicated tasks routed through the
  dialog landed on valid rows with invisible statuses. Fetch effective
  mappings per phase instead, falling back to project-level when the
  phase has no overrides.

  And so the Cheshire task grinned its way into the garden, only to find
  its status had evaporated — leaving nothing behind but a phase_id and
  a faint suggestion of a kanban column. 🐈‍⬛🌳🃏