### PR TITLE
Return coded errors from addUser/updateUser

### DIFF
--- a/packages/client-portal/src/components/profile/ClientProfile.tsx
+++ b/packages/client-portal/src/components/profile/ClientProfile.tsx
@@ -122,7 +122,7 @@ export function ClientProfile() {
 
     try {
       // Update user profile
-      await updateUser(user.user_id, {
+      const result = await updateUser(user.user_id, {
         first_name: firstName,
         last_name: lastName,
         email: email,
@@ -130,16 +130,21 @@ export function ClientProfile() {
         timezone: timezone
       });
 
+      if (!result.success) {
+        const errorKeys: Record<typeof result.code, string> = {
+          EMAIL_ALREADY_EXISTS: 'profile.messages.emailAlreadyExists',
+          REPORTS_TO_SELF: 'profile.messages.reportsToSelf',
+          REPORTS_TO_CYCLE: 'profile.messages.reportsToCycle',
+        };
+        toast.error(tProfile(errorKeys[result.code], { defaultValue: result.error }));
+        return;
+      }
+
       // Show success toast
       toast.success(tProfile('profile.messages.updateSuccess'));
 
-      // Note: Notification preferences are managed separately through their own UI components:
-      // - InternalNotificationPreferences handles internal notification settings
-      // - Email notification preferences should be managed through their dedicated section
-
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : tProfile('profile.messages.updateError', 'Failed to save profile');
-      setError(errorMessage);
+      toast.error(tProfile('profile.messages.updateError', 'Failed to save profile'));
       handleError(err, tProfile('profile.messages.updateError', 'Failed to save profile'));
     }
   };

--- a/packages/client-portal/src/components/settings/UserManagementSettings.tsx
+++ b/packages/client-portal/src/components/settings/UserManagementSettings.tsx
@@ -245,9 +245,19 @@ export function UserManagementSettings() {
 
     setIsDeleteProcessing(true);
     try {
-      const updatedUser = await updateUser(userToDelete.user_id, { is_inactive: true });
-      if (updatedUser) {
-        setUsers(prev => prev.map(user => user.user_id === updatedUser.user_id ? updatedUser : user));
+      const result = await updateUser(userToDelete.user_id, { is_inactive: true });
+      if (!result.success) {
+        const errorKeys: Record<typeof result.code, string> = {
+          EMAIL_ALREADY_EXISTS: 'clientSettings.users.emailAlreadyExists',
+          REPORTS_TO_SELF: 'clientSettings.users.reportsToSelf',
+          REPORTS_TO_CYCLE: 'clientSettings.users.reportsToCycle',
+        };
+        setError(tProfile(errorKeys[result.code], { defaultValue: result.error }));
+        return;
+      }
+      if (result.user) {
+        const updated = result.user;
+        setUsers(prev => prev.map(user => user.user_id === updated.user_id ? updated : user));
       }
       resetDeleteState();
     } catch (error) {

--- a/packages/users/src/actions/user-actions/userActions.test.ts
+++ b/packages/users/src/actions/user-actions/userActions.test.ts
@@ -188,6 +188,7 @@ describe('addUser', () => {
 
     expect(result).toEqual({
       success: false,
+      code: 'SOLO_PLAN_LIMIT',
       error: 'Solo plan is limited to 1 user. Upgrade to Pro to add more users.',
     });
   });
@@ -231,12 +232,15 @@ describe('addUser', () => {
 
     const updateUser = await loadUpdateUser();
 
-    await expect(
-      updateUser(actingUser, tenantContext, actingUser.user_id, {
-        email: 'duplicate@example.com',
-      })
-    ).rejects.toThrow('A user with this email address already exists');
+    const result = await updateUser(actingUser, tenantContext, actingUser.user_id, {
+      email: 'duplicate@example.com',
+    });
 
+    expect(result).toEqual({
+      success: false,
+      code: 'EMAIL_ALREADY_EXISTS',
+      error: 'A user with this email address already exists',
+    });
     expect(userUpdateMock).not.toHaveBeenCalled();
   });
 
@@ -258,8 +262,11 @@ describe('addUser', () => {
       })
     );
     expect(result).toEqual({
-      user_id: 'user-1',
-      email: 'updated@example.com',
+      success: true,
+      user: {
+        user_id: 'user-1',
+        email: 'updated@example.com',
+      },
     });
   });
 });

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -23,27 +23,27 @@ interface ActionResult {
   error?: string;
 }
 
+export type AddUserErrorCode =
+  | 'ROLE_REQUIRED'
+  | 'INVALID_ROLE'
+  | 'ROLE_MSP_NOT_ALLOWED_FOR_CLIENT'
+  | 'ROLE_CLIENT_NOT_ALLOWED_FOR_MSP'
+  | 'EMAIL_ALREADY_EXISTS'
+  | 'LICENSE_LIMIT_REACHED'
+  | 'SOLO_PLAN_LIMIT';
+
 type AddUserResult =
   | { success: true; user: IUser }
-  | { success: false; error: string };
+  | { success: false; code: AddUserErrorCode; error: string };
 
-const SOLO_USER_LIMIT_MESSAGE = 'Solo plan is limited to 1 user. Upgrade to Pro to add more users.';
+export type UpdateUserErrorCode =
+  | 'EMAIL_ALREADY_EXISTS'
+  | 'REPORTS_TO_SELF'
+  | 'REPORTS_TO_CYCLE';
 
-const ADD_USER_VALIDATION_ERRORS = new Set([
-  'Role is required',
-  'Invalid role',
-  'Cannot assign MSP role to client portal user',
-  'Cannot assign client portal role to MSP user',
-  'A user with this email address already exists',
-  "You've reached your MSP user license limit.",
-  SOLO_USER_LIMIT_MESSAGE,
-]);
-
-const UPDATE_USER_VALIDATION_ERRORS = new Set([
-  'A user with this email address already exists',
-  'reports_to cannot reference the user itself',
-  'reports_to would create a circular reporting chain',
-]);
+export type UpdateUserResult =
+  | { success: true; user: IUserWithRoles | null }
+  | { success: false; code: UpdateUserErrorCode; error: string };
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : '';
@@ -118,7 +118,7 @@ export const addUser = withAuth(async (
       }
 
       if (!userData.roleId) {
-        return { success: false, error: 'Role is required' };
+        return { success: false, code: 'ROLE_REQUIRED', error: 'Role is required' };
       }
 
       // Validate that the role exists
@@ -127,22 +127,34 @@ export const addUser = withAuth(async (
         .first();
 
       if (!role) {
-        return { success: false, error: 'Invalid role' };
+        return { success: false, code: 'INVALID_ROLE', error: 'Invalid role' };
       }
 
       // Validate role matches user type
       const isClientUser = userData.userType === 'client';
       if (isClientUser && !role.client) {
-        return { success: false, error: 'Cannot assign MSP role to client portal user' };
+        return {
+          success: false,
+          code: 'ROLE_MSP_NOT_ALLOWED_FOR_CLIENT',
+          error: 'Cannot assign MSP role to client portal user',
+        };
       }
       if (!isClientUser && !role.msp) {
-        return { success: false, error: 'Cannot assign client portal role to MSP user' };
+        return {
+          success: false,
+          code: 'ROLE_CLIENT_NOT_ALLOWED_FOR_MSP',
+          error: 'Cannot assign client portal role to MSP user',
+        };
       }
 
       // Check if email already exists globally
       const emailExists = await checkEmailExistsGlobally(userData.email);
       if (emailExists) {
-        return { success: false, error: 'A user with this email address already exists' };
+        return {
+          success: false,
+          code: 'EMAIL_ALREADY_EXISTS',
+          error: 'A user with this email address already exists',
+        };
       }
 
       // Check license limits for  MSP (internal) users
@@ -168,11 +180,19 @@ export const addUser = withAuth(async (
         const plan = tenantRow.plan as string | null | undefined;
 
         if (plan === 'solo' && used >= 1) {
-          return { success: false, error: SOLO_USER_LIMIT_MESSAGE };
+          return {
+            success: false,
+            code: 'SOLO_PLAN_LIMIT',
+            error: 'Solo plan is limited to 1 user. Upgrade to Pro to add more users.',
+          };
         }
 
         if (limit !== null && used >= limit) {
-          return { success: false, error: "You've reached your MSP user license limit." };
+          return {
+            success: false,
+            code: 'LICENSE_LIMIT_REACHED',
+            error: "You've reached your MSP user license limit.",
+          };
         }
 
       }
@@ -211,9 +231,6 @@ export const addUser = withAuth(async (
   } catch (error: unknown) {
     logger.error('Error adding user:', error);
     const message = getErrorMessage(error);
-    if (ADD_USER_VALIDATION_ERRORS.has(message)) {
-      return { success: false, error: message };
-    }
     if (message === 'Permission denied: Cannot create user') {
       throw error;
     }
@@ -310,10 +327,10 @@ export const updateUser = withAuth(async (
   { tenant },
   userId: string,
   userData: Partial<IUser>
-): Promise<IUserWithRoles | null> => {
+): Promise<UpdateUserResult> => {
   try {
     const { knex } = await createTenantKnex();
-    return await withTransaction(knex, async (trx) => {
+    return await withTransaction(knex, async (trx): Promise<UpdateUserResult> => {
       // Permission Check: User can update their own profile OR have user:update permission
       const isOwnProfile = currentUser.user_id === userId;
 
@@ -332,13 +349,21 @@ export const updateUser = withAuth(async (
 
       if (userData.reports_to !== undefined) {
         if (userData.reports_to === userId) {
-          throw new Error('reports_to cannot reference the user itself');
+          return {
+            success: false,
+            code: 'REPORTS_TO_SELF',
+            error: 'reports_to cannot reference the user itself',
+          };
         }
 
         if (userData.reports_to) {
           const wouldCreateCycle = await User.isInReportsToChain(trx, userId, userData.reports_to);
           if (wouldCreateCycle) {
-            throw new Error('reports_to would create a circular reporting chain');
+            return {
+              success: false,
+              code: 'REPORTS_TO_CYCLE',
+              error: 'reports_to would create a circular reporting chain',
+            };
           }
         }
       }
@@ -351,7 +376,11 @@ export const updateUser = withAuth(async (
         });
 
         if (existingUser) {
-          throw new Error('A user with this email address already exists');
+          return {
+            success: false,
+            code: 'EMAIL_ALREADY_EXISTS',
+            error: 'A user with this email address already exists',
+          };
         }
 
         normalizedUserData = {
@@ -362,15 +391,12 @@ export const updateUser = withAuth(async (
 
       await User.update(trx, userId, normalizedUserData);
       const updatedUser = await User.getUserWithRoles(trx, userId);
-      return updatedUser || null;
+      return { success: true, user: updatedUser || null };
     });
   } catch (error) {
     logger.error(`Failed to update user with id ${userId}:`, error);
     const message = getErrorMessage(error);
-    if (
-      UPDATE_USER_VALIDATION_ERRORS.has(message) ||
-      message === 'Permission denied: Cannot update user'
-    ) {
+    if (message === 'Permission denied: Cannot update user') {
       throw error;
     }
     throw new Error('Failed to update user');

--- a/server/public/locales/de/client-portal.json
+++ b/server/public/locales/de/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Benutzer nicht gefunden",
       "loadError": "Profil konnte nicht geladen werden",
       "loading": "Profil wird geladen...",
-      "avatarDescription": "Dieses Avatar wird dem MSP-Team angezeigt, wenn es deine Kontaktinformationen ansieht."
+      "avatarDescription": "Dieses Avatar wird dem MSP-Team angezeigt, wenn es deine Kontaktinformationen ansieht.",
+      "emailAlreadyExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits",
+      "reportsToSelf": "Ein Benutzer kann sich nicht selbst als Vorgesetzten zuweisen",
+      "reportsToCycle": "Dies würde eine zirkuläre Berichtskette erzeugen"
     },
     "imageUpload": {
       "uploadAvatar": "Avatar hochladen",
@@ -447,7 +450,10 @@
       "loadError": "Benutzer konnten nicht geladen werden",
       "emailExists": "Ein Kontakt mit dieser E-Mail-Adresse existiert bereits",
       "createError": "Benutzer konnte nicht erstellt werden",
-      "deleteError": "Benutzer konnte nicht gelöscht werden"
+      "deleteError": "Benutzer konnte nicht gelöscht werden",
+      "emailAlreadyExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits",
+      "reportsToSelf": "Ein Benutzer kann sich nicht selbst als Vorgesetzten zuweisen",
+      "reportsToCycle": "Dies würde eine zirkuläre Berichtskette erzeugen"
     },
     "visibilityGroups": {
       "title": "Sichtbarkeitsgruppen",

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "Der Standard-Client muss einen Standard-Standort konfiguriert haben, um Portaleinladungen zu senden.",
         "noLocationEmail": "Der Standort des Standard-Clients muss eine Kontakt-E-Mail-Adresse konfiguriert haben.",
         "noBaseUrl": "Die Basis-URL ist nicht für Portaleinladungen konfiguriert.",
-        "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein."
+        "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein.",
+        "roleRequired": "Rolle ist erforderlich",
+        "invalidRole": "Ausgewählte Rolle ist ungültig",
+        "licenseLimitReached": "Sie haben Ihr MSP-Benutzerlizenzlimit erreicht.",
+        "soloPlanLimit": "Der Solo-Tarif ist auf 1 Benutzer begrenzt. Führen Sie ein Upgrade auf Pro durch, um weitere Benutzer hinzuzufügen."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Benutzer konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
         "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein",
         "passwordChangeFailed": "Passwort konnte nicht geändert werden",
-        "passwordChangeError": "Beim Ändern des Passworts ist ein Fehler aufgetreten"
+        "passwordChangeError": "Beim Ändern des Passworts ist ein Fehler aufgetreten",
+        "emailAlreadyExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits",
+        "reportsToSelf": "Ein Benutzer kann sich nicht selbst als Vorgesetzten zuweisen",
+        "reportsToCycle": "Dies würde eine zirkuläre Berichtskette erzeugen"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Benutzer nicht gefunden",
-        "fillRequiredFields": "Bitte füllen Sie alle Pflichtfelder aus"
+        "fillRequiredFields": "Bitte füllen Sie alle Pflichtfelder aus",
+        "saveFailed": "Profil konnte nicht gespeichert werden",
+        "emailAlreadyExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits",
+        "reportsToSelf": "Ein Benutzer kann sich nicht selbst als Vorgesetzten zuweisen",
+        "reportsToCycle": "Dies würde eine zirkuläre Berichtskette erzeugen"
       }
     },
     "validation": {

--- a/server/public/locales/en/client-portal.json
+++ b/server/public/locales/en/client-portal.json
@@ -341,6 +341,9 @@
     "messages": {
       "updateSuccess": "Profile updated successfully",
       "updateError": "Failed to update profile",
+      "emailAlreadyExists": "A user with this email address already exists",
+      "reportsToSelf": "A user cannot report to themselves",
+      "reportsToCycle": "This would create a circular reporting chain",
       "photoUploaded": "Photo uploaded successfully",
       "photoRemoved": "Photo removed successfully",
       "userNotFound": "User not found",
@@ -446,6 +449,9 @@
       "permissionError": "You do not have permission to manage users",
       "loadError": "Failed to load users",
       "emailExists": "A contact with this email address already exists",
+      "emailAlreadyExists": "A user with this email address already exists",
+      "reportsToSelf": "A user cannot report to themselves",
+      "reportsToCycle": "This would create a circular reporting chain",
       "createError": "Failed to create user",
       "deleteError": "Failed to delete user"
     },

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "Default client must have a default location configured to send portal invitations.",
         "noLocationEmail": "Default client's location must have a contact email configured.",
         "noBaseUrl": "Base URL is not configured for portal invitations.",
-        "passwordTooShort": "Password must be at least 8 characters long."
+        "passwordTooShort": "Password must be at least 8 characters long.",
+        "roleRequired": "Role is required",
+        "invalidRole": "Selected role is invalid",
+        "licenseLimitReached": "You've reached your MSP user license limit.",
+        "soloPlanLimit": "Solo plan is limited to 1 user. Upgrade to Pro to add more users."
       }
     }
   },
@@ -293,6 +297,9 @@
         "removeRoleFailed": "Failed to remove role. Please try again.",
         "updateUserNotFound": "Failed to update user. User not found.",
         "updateFailed": "Failed to update user. Please try again.",
+        "emailAlreadyExists": "A user with this email address already exists",
+        "reportsToSelf": "A user cannot report to themselves",
+        "reportsToCycle": "This would create a circular reporting chain",
         "passwordTooShort": "Password must be at least 8 characters long",
         "passwordChangeFailed": "Failed to change password",
         "passwordChangeError": "An error occurred while changing password"
@@ -1360,7 +1367,11 @@
       },
       "error": {
         "userNotFound": "User not found",
-        "fillRequiredFields": "Please fill in all required fields"
+        "fillRequiredFields": "Please fill in all required fields",
+        "saveFailed": "Failed to save profile",
+        "emailAlreadyExists": "A user with this email address already exists",
+        "reportsToSelf": "A user cannot report to themselves",
+        "reportsToCycle": "This would create a circular reporting chain"
       }
     },
     "validation": {

--- a/server/public/locales/es/client-portal.json
+++ b/server/public/locales/es/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Usuario no encontrado",
       "loadError": "No se pudo cargar el perfil",
       "loading": "Cargando perfil...",
-      "avatarDescription": "Este avatar se muestra al personal del MSP cuando consultan tu información de contacto."
+      "avatarDescription": "Este avatar se muestra al personal del MSP cuando consultan tu información de contacto.",
+      "emailAlreadyExists": "Ya existe un usuario con esta dirección de correo electrónico",
+      "reportsToSelf": "Un usuario no puede reportarse a sí mismo",
+      "reportsToCycle": "Esto crearía una cadena de reporte circular"
     },
     "imageUpload": {
       "uploadAvatar": "Subir avatar",
@@ -447,7 +450,10 @@
       "loadError": "No se pudieron cargar los usuarios",
       "emailExists": "Ya existe un contacto con esta dirección de correo electrónico",
       "createError": "No se pudo crear el usuario",
-      "deleteError": "No se pudo eliminar el usuario"
+      "deleteError": "No se pudo eliminar el usuario",
+      "emailAlreadyExists": "Ya existe un usuario con esta dirección de correo electrónico",
+      "reportsToSelf": "Un usuario no puede reportarse a sí mismo",
+      "reportsToCycle": "Esto crearía una cadena de reporte circular"
     },
     "visibilityGroups": {
       "title": "Grupos de visibilidad",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "El cliente predeterminado debe tener una ubicación predeterminada configurada para enviar invitaciones al portal.",
         "noLocationEmail": "La ubicación del cliente predeterminado debe tener un correo electrónico de contacto configurado.",
         "noBaseUrl": "La URL base no está configurada para las invitaciones al portal.",
-        "passwordTooShort": "La contraseña debe tener al menos 8 caracteres."
+        "passwordTooShort": "La contraseña debe tener al menos 8 caracteres.",
+        "roleRequired": "Se requiere un rol",
+        "invalidRole": "El rol seleccionado no es válido",
+        "licenseLimitReached": "Ha alcanzado el límite de licencias de usuario MSP.",
+        "soloPlanLimit": "El plan Solo está limitado a 1 usuario. Actualice a Pro para agregar más usuarios."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Error al actualizar el usuario. Inténtelo de nuevo.",
         "passwordTooShort": "La contraseña debe tener al menos 8 caracteres",
         "passwordChangeFailed": "Error al cambiar la contraseña",
-        "passwordChangeError": "Se produjo un error al cambiar la contraseña"
+        "passwordChangeError": "Se produjo un error al cambiar la contraseña",
+        "emailAlreadyExists": "Ya existe un usuario con esta dirección de correo electrónico",
+        "reportsToSelf": "Un usuario no puede reportarse a sí mismo",
+        "reportsToCycle": "Esto crearía una cadena de reporte circular"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Usuario no encontrado",
-        "fillRequiredFields": "Complete todos los campos obligatorios"
+        "fillRequiredFields": "Complete todos los campos obligatorios",
+        "saveFailed": "No se pudo guardar el perfil",
+        "emailAlreadyExists": "Ya existe un usuario con esta dirección de correo electrónico",
+        "reportsToSelf": "Un usuario no puede reportarse a sí mismo",
+        "reportsToCycle": "Esto crearía una cadena de reporte circular"
       }
     },
     "validation": {

--- a/server/public/locales/fr/client-portal.json
+++ b/server/public/locales/fr/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Utilisateur introuvable",
       "loadError": "Échec du chargement du profil",
       "loading": "Chargement du profil...",
-      "avatarDescription": "Cet avatar est affiché au personnel MSP lorsqu'il consulte vos informations de contact."
+      "avatarDescription": "Cet avatar est affiché au personnel MSP lorsqu'il consulte vos informations de contact.",
+      "emailAlreadyExists": "Un utilisateur avec cette adresse e-mail existe déjà",
+      "reportsToSelf": "Un utilisateur ne peut pas être son propre responsable",
+      "reportsToCycle": "Cela créerait une chaîne hiérarchique circulaire"
     },
     "imageUpload": {
       "uploadAvatar": "Téléverser un avatar",
@@ -447,7 +450,10 @@
       "loadError": "Échec du chargement des utilisateurs",
       "emailExists": "Un contact avec cette adresse e-mail existe déjà",
       "createError": "Échec de la création de l'utilisateur",
-      "deleteError": "Échec de la suppression de l'utilisateur"
+      "deleteError": "Échec de la suppression de l'utilisateur",
+      "emailAlreadyExists": "Un utilisateur avec cette adresse e-mail existe déjà",
+      "reportsToSelf": "Un utilisateur ne peut pas être son propre responsable",
+      "reportsToCycle": "Cela créerait une chaîne hiérarchique circulaire"
     },
     "visibilityGroups": {
       "title": "Groupes de visibilité",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "Le client par défaut doit avoir un emplacement par défaut configuré pour envoyer des invitations au portail.",
         "noLocationEmail": "L'emplacement du client par défaut doit avoir une adresse e-mail de contact configurée.",
         "noBaseUrl": "L'URL de base n'est pas configurée pour les invitations au portail.",
-        "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères."
+        "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
+        "roleRequired": "Le rôle est requis",
+        "invalidRole": "Le rôle sélectionné est invalide",
+        "licenseLimitReached": "Vous avez atteint la limite de licences utilisateur MSP.",
+        "soloPlanLimit": "Le plan Solo est limité à 1 utilisateur. Passez à Pro pour ajouter d'autres utilisateurs."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Échec de la mise à jour de l'utilisateur. Veuillez réessayer.",
         "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères",
         "passwordChangeFailed": "Échec de la modification du mot de passe",
-        "passwordChangeError": "Une erreur est survenue lors de la modification du mot de passe"
+        "passwordChangeError": "Une erreur est survenue lors de la modification du mot de passe",
+        "emailAlreadyExists": "Un utilisateur avec cette adresse e-mail existe déjà",
+        "reportsToSelf": "Un utilisateur ne peut pas être son propre responsable",
+        "reportsToCycle": "Cela créerait une chaîne hiérarchique circulaire"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Utilisateur introuvable",
-        "fillRequiredFields": "Veuillez remplir tous les champs obligatoires"
+        "fillRequiredFields": "Veuillez remplir tous les champs obligatoires",
+        "saveFailed": "Échec de l'enregistrement du profil",
+        "emailAlreadyExists": "Un utilisateur avec cette adresse e-mail existe déjà",
+        "reportsToSelf": "Un utilisateur ne peut pas être son propre responsable",
+        "reportsToCycle": "Cela créerait une chaîne hiérarchique circulaire"
       }
     },
     "validation": {

--- a/server/public/locales/it/client-portal.json
+++ b/server/public/locales/it/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Utente non trovato",
       "loadError": "Impossibile caricare il profilo",
       "loading": "Caricamento profilo...",
-      "avatarDescription": "Questo avatar viene mostrato al personale MSP quando consulta le tue informazioni di contatto."
+      "avatarDescription": "Questo avatar viene mostrato al personale MSP quando consulta le tue informazioni di contatto.",
+      "emailAlreadyExists": "Esiste già un utente con questo indirizzo e-mail",
+      "reportsToSelf": "Un utente non può riferire a se stesso",
+      "reportsToCycle": "Questo creerebbe una catena di riporto circolare"
     },
     "imageUpload": {
       "uploadAvatar": "Carica avatar",
@@ -447,7 +450,10 @@
       "loadError": "Impossibile caricare gli utenti",
       "emailExists": "Esiste già un contatto con questo indirizzo email",
       "createError": "Impossibile creare l'utente",
-      "deleteError": "Impossibile eliminare l'utente"
+      "deleteError": "Impossibile eliminare l'utente",
+      "emailAlreadyExists": "Esiste già un utente con questo indirizzo e-mail",
+      "reportsToSelf": "Un utente non può riferire a se stesso",
+      "reportsToCycle": "Questo creerebbe una catena di riporto circolare"
     },
     "visibilityGroups": {
       "title": "Gruppi di visibilità",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "Il client predefinito deve avere una sede predefinita configurata per inviare inviti al portale.",
         "noLocationEmail": "La sede del client predefinito deve avere un indirizzo e-mail di contatto configurato.",
         "noBaseUrl": "L'URL di base non è configurato per gli inviti al portale.",
-        "passwordTooShort": "La password deve contenere almeno 8 caratteri."
+        "passwordTooShort": "La password deve contenere almeno 8 caratteri.",
+        "roleRequired": "Il ruolo è obbligatorio",
+        "invalidRole": "Il ruolo selezionato non è valido",
+        "licenseLimitReached": "Hai raggiunto il limite di licenze utente MSP.",
+        "soloPlanLimit": "Il piano Solo è limitato a 1 utente. Passa a Pro per aggiungere altri utenti."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Impossibile aggiornare l'utente. Riprovi.",
         "passwordTooShort": "La password deve contenere almeno 8 caratteri",
         "passwordChangeFailed": "Impossibile modificare la password",
-        "passwordChangeError": "Si e verificato un errore durante la modifica della password"
+        "passwordChangeError": "Si e verificato un errore durante la modifica della password",
+        "emailAlreadyExists": "Esiste già un utente con questo indirizzo e-mail",
+        "reportsToSelf": "Un utente non può riferire a se stesso",
+        "reportsToCycle": "Questo creerebbe una catena di riporto circolare"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Utente non trovato",
-        "fillRequiredFields": "Compili tutti i campi obbligatori"
+        "fillRequiredFields": "Compili tutti i campi obbligatori",
+        "saveFailed": "Impossibile salvare il profilo",
+        "emailAlreadyExists": "Esiste già un utente con questo indirizzo e-mail",
+        "reportsToSelf": "Un utente non può riferire a se stesso",
+        "reportsToCycle": "Questo creerebbe una catena di riporto circolare"
       }
     },
     "validation": {

--- a/server/public/locales/nl/client-portal.json
+++ b/server/public/locales/nl/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Gebruiker niet gevonden",
       "loadError": "Profiel laden is mislukt",
       "loading": "Profiel wordt geladen...",
-      "avatarDescription": "Deze avatar wordt getoond aan het MSP-team wanneer zij je contactgegevens bekijken."
+      "avatarDescription": "Deze avatar wordt getoond aan het MSP-team wanneer zij je contactgegevens bekijken.",
+      "emailAlreadyExists": "Er bestaat al een gebruiker met dit e-mailadres",
+      "reportsToSelf": "Een gebruiker kan niet aan zichzelf rapporteren",
+      "reportsToCycle": "Dit zou een circulaire rapportagelijn creëren"
     },
     "imageUpload": {
       "uploadAvatar": "Avatar uploaden",
@@ -447,7 +450,10 @@
       "loadError": "Gebruikers konden niet worden geladen",
       "emailExists": "Er bestaat al een contact met dit e-mailadres",
       "createError": "Gebruiker kon niet worden aangemaakt",
-      "deleteError": "Gebruiker kon niet worden verwijderd"
+      "deleteError": "Gebruiker kon niet worden verwijderd",
+      "emailAlreadyExists": "Er bestaat al een gebruiker met dit e-mailadres",
+      "reportsToSelf": "Een gebruiker kan niet aan zichzelf rapporteren",
+      "reportsToCycle": "Dit zou een circulaire rapportagelijn creëren"
     },
     "visibilityGroups": {
       "title": "Zichtbaarheidsgroepen",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "De standaardklant moet een standaardlocatie hebben om portaluitnodigingen te versturen.",
         "noLocationEmail": "De locatie van de standaardklant moet een contact-e-mailadres hebben geconfigureerd.",
         "noBaseUrl": "Basis-URL is niet geconfigureerd voor portaluitnodigingen.",
-        "passwordTooShort": "Wachtwoord moet minstens 8 tekens lang zijn."
+        "passwordTooShort": "Wachtwoord moet minstens 8 tekens lang zijn.",
+        "roleRequired": "Rol is vereist",
+        "invalidRole": "Geselecteerde rol is ongeldig",
+        "licenseLimitReached": "U heeft uw MSP-gebruikerslicentielimiet bereikt.",
+        "soloPlanLimit": "Het Solo-abonnement is beperkt tot 1 gebruiker. Upgrade naar Pro om meer gebruikers toe te voegen."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Kan gebruiker niet bijwerken. Probeer het opnieuw.",
         "passwordTooShort": "Wachtwoord moet minimaal 8 tekens lang zijn",
         "passwordChangeFailed": "Kan wachtwoord niet wijzigen",
-        "passwordChangeError": "Er is een fout opgetreden bij het wijzigen van het wachtwoord"
+        "passwordChangeError": "Er is een fout opgetreden bij het wijzigen van het wachtwoord",
+        "emailAlreadyExists": "Er bestaat al een gebruiker met dit e-mailadres",
+        "reportsToSelf": "Een gebruiker kan niet aan zichzelf rapporteren",
+        "reportsToCycle": "Dit zou een circulaire rapportagelijn creëren"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Gebruiker niet gevonden",
-        "fillRequiredFields": "Vul alle verplichte velden in"
+        "fillRequiredFields": "Vul alle verplichte velden in",
+        "saveFailed": "Profiel kon niet worden opgeslagen",
+        "emailAlreadyExists": "Er bestaat al een gebruiker met dit e-mailadres",
+        "reportsToSelf": "Een gebruiker kan niet aan zichzelf rapporteren",
+        "reportsToCycle": "Dit zou een circulaire rapportagelijn creëren"
       }
     },
     "validation": {

--- a/server/public/locales/pl/client-portal.json
+++ b/server/public/locales/pl/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "Nie znaleziono użytkownika",
       "loadError": "Nie udało się wczytać profilu",
       "loading": "Ładowanie profilu...",
-      "avatarDescription": "Ten awatar jest widoczny dla personelu MSP podczas przeglądania danych kontaktowych."
+      "avatarDescription": "Ten awatar jest widoczny dla personelu MSP podczas przeglądania danych kontaktowych.",
+      "emailAlreadyExists": "Użytkownik o tym adresie e-mail już istnieje",
+      "reportsToSelf": "Użytkownik nie może podlegać samemu sobie",
+      "reportsToCycle": "Spowodowałoby to cykliczną strukturę podległości"
     },
     "imageUpload": {
       "uploadAvatar": "Prześlij awatar",
@@ -447,7 +450,10 @@
       "loadError": "Nie udało się wczytać użytkowników",
       "emailExists": "Kontakt z tym adresem e-mail już istnieje",
       "createError": "Nie udało się utworzyć użytkownika",
-      "deleteError": "Nie udało się usunąć użytkownika"
+      "deleteError": "Nie udało się usunąć użytkownika",
+      "emailAlreadyExists": "Użytkownik o tym adresie e-mail już istnieje",
+      "reportsToSelf": "Użytkownik nie może podlegać samemu sobie",
+      "reportsToCycle": "Spowodowałoby to cykliczną strukturę podległości"
     },
     "visibilityGroups": {
       "title": "Grupy widoczności",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "Domyślny klient musi mieć skonfigurowaną domyślną lokalizację, aby wysyłać zaproszenia do portalu.",
         "noLocationEmail": "Lokalizacja domyślnego klienta musi mieć skonfigurowany kontaktowy adres e-mail.",
         "noBaseUrl": "Podstawowy adres URL nie jest skonfigurowany dla zaproszeń do portalu.",
-        "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków."
+        "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków.",
+        "roleRequired": "Rola jest wymagana",
+        "invalidRole": "Wybrana rola jest nieprawidłowa",
+        "licenseLimitReached": "Osiągnięto limit licencji użytkowników MSP.",
+        "soloPlanLimit": "Plan Solo jest ograniczony do 1 użytkownika. Przejdź na Pro, aby dodać więcej użytkowników."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Nie udało się zaktualizować użytkownika. Proszę spróbować ponownie.",
         "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków",
         "passwordChangeFailed": "Nie udało się zmienić hasła",
-        "passwordChangeError": "Wystąpił błąd podczas zmiany hasła"
+        "passwordChangeError": "Wystąpił błąd podczas zmiany hasła",
+        "emailAlreadyExists": "Użytkownik o tym adresie e-mail już istnieje",
+        "reportsToSelf": "Użytkownik nie może podlegać samemu sobie",
+        "reportsToCycle": "Spowodowałoby to cykliczną strukturę podległości"
       }
     }
   },
@@ -1359,7 +1366,11 @@
       },
       "error": {
         "userNotFound": "Nie znaleziono użytkownika",
-        "fillRequiredFields": "Proszę wypełnić wszystkie wymagane pola"
+        "fillRequiredFields": "Proszę wypełnić wszystkie wymagane pola",
+        "saveFailed": "Nie udało się zapisać profilu",
+        "emailAlreadyExists": "Użytkownik o tym adresie e-mail już istnieje",
+        "reportsToSelf": "Użytkownik nie może podlegać samemu sobie",
+        "reportsToCycle": "Spowodowałoby to cykliczną strukturę podległości"
       }
     },
     "validation": {

--- a/server/public/locales/pt/client-portal.json
+++ b/server/public/locales/pt/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "User not found",
       "loadError": "Failed to load profile",
       "loading": "Loading profile...",
-      "avatarDescription": "This avatar is shown to MSP staff when they view your contact information."
+      "avatarDescription": "This avatar is shown to MSP staff when they view your contact information.",
+      "emailAlreadyExists": "Já existe um utilizador com este endereço de e-mail",
+      "reportsToSelf": "Um utilizador não pode reportar a si próprio",
+      "reportsToCycle": "Isto criaria uma cadeia de reporte circular"
     },
     "imageUpload": {
       "uploadAvatar": "Upload Avatar",
@@ -447,7 +450,10 @@
       "loadError": "Failed to load users",
       "emailExists": "A contact with this email address already exists",
       "createError": "Failed to create user",
-      "deleteError": "Failed to delete user"
+      "deleteError": "Failed to delete user",
+      "emailAlreadyExists": "Já existe um utilizador com este endereço de e-mail",
+      "reportsToSelf": "Um utilizador não pode reportar a si próprio",
+      "reportsToCycle": "Isto criaria uma cadeia de reporte circular"
     },
     "messages": {
       "saveChanges": "Save Changes",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "O cliente predefinido deve ter uma localização predefinida configurada para enviar convites do portal.",
         "noLocationEmail": "A localização do cliente predefinido deve ter um e-mail de contacto configurado.",
         "noBaseUrl": "O URL base não está configurado para convites do portal.",
-        "passwordTooShort": "A palavra-passe deve ter pelo menos 8 caracteres."
+        "passwordTooShort": "A palavra-passe deve ter pelo menos 8 caracteres.",
+        "roleRequired": "A função é obrigatória",
+        "invalidRole": "A função selecionada é inválida",
+        "licenseLimitReached": "Atingiu o limite de licenças de utilizador MSP.",
+        "soloPlanLimit": "O plano Solo está limitado a 1 utilizador. Atualize para Pro para adicionar mais utilizadores."
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "Failed to update user. Please try again.",
         "passwordTooShort": "Password must be at least 8 characters long",
         "passwordChangeFailed": "Failed to change password",
-        "passwordChangeError": "An error occurred while changing password"
+        "passwordChangeError": "An error occurred while changing password",
+        "emailAlreadyExists": "Já existe um utilizador com este endereço de e-mail",
+        "reportsToSelf": "Um utilizador não pode reportar a si próprio",
+        "reportsToCycle": "Isto criaria uma cadeia de reporte circular"
       }
     }
   },
@@ -1360,7 +1367,11 @@
       },
       "error": {
         "userNotFound": "User not found",
-        "fillRequiredFields": "Please fill in all required fields"
+        "fillRequiredFields": "Please fill in all required fields",
+        "saveFailed": "Falha ao guardar o perfil",
+        "emailAlreadyExists": "Já existe um utilizador com este endereço de e-mail",
+        "reportsToSelf": "Um utilizador não pode reportar a si próprio",
+        "reportsToCycle": "Isto criaria uma cadeia de reporte circular"
       }
     },
     "validation": {

--- a/server/public/locales/xx/client-portal.json
+++ b/server/public/locales/xx/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "11111",
       "loadError": "11111",
       "loading": "11111",
-      "avatarDescription": "11111"
+      "avatarDescription": "11111",
+      "emailAlreadyExists": "11111",
+      "reportsToSelf": "11111",
+      "reportsToCycle": "11111"
     },
     "imageUpload": {
       "uploadAvatar": "11111",
@@ -447,7 +450,10 @@
       "loadError": "11111",
       "emailExists": "11111",
       "createError": "11111",
-      "deleteError": "11111"
+      "deleteError": "11111",
+      "emailAlreadyExists": "11111",
+      "reportsToSelf": "11111",
+      "reportsToCycle": "11111"
     },
     "messages": {
       "saveChanges": "11111",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "11111",
         "noLocationEmail": "11111",
         "noBaseUrl": "11111",
-        "passwordTooShort": "11111"
+        "passwordTooShort": "11111",
+        "roleRequired": "11111",
+        "invalidRole": "11111",
+        "licenseLimitReached": "11111",
+        "soloPlanLimit": "11111"
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "11111",
         "passwordTooShort": "11111",
         "passwordChangeFailed": "11111",
-        "passwordChangeError": "11111"
+        "passwordChangeError": "11111",
+        "emailAlreadyExists": "11111",
+        "reportsToSelf": "11111",
+        "reportsToCycle": "11111"
       }
     }
   },
@@ -1360,7 +1367,11 @@
       },
       "error": {
         "userNotFound": "11111",
-        "fillRequiredFields": "11111"
+        "fillRequiredFields": "11111",
+        "saveFailed": "11111",
+        "emailAlreadyExists": "11111",
+        "reportsToSelf": "11111",
+        "reportsToCycle": "11111"
       }
     },
     "validation": {

--- a/server/public/locales/yy/client-portal.json
+++ b/server/public/locales/yy/client-portal.json
@@ -346,7 +346,10 @@
       "userNotFound": "55555",
       "loadError": "55555",
       "loading": "55555",
-      "avatarDescription": "55555"
+      "avatarDescription": "55555",
+      "emailAlreadyExists": "55555",
+      "reportsToSelf": "55555",
+      "reportsToCycle": "55555"
     },
     "imageUpload": {
       "uploadAvatar": "55555",
@@ -447,7 +450,10 @@
       "loadError": "55555",
       "emailExists": "55555",
       "createError": "55555",
-      "deleteError": "55555"
+      "deleteError": "55555",
+      "emailAlreadyExists": "55555",
+      "reportsToSelf": "55555",
+      "reportsToCycle": "55555"
     },
     "messages": {
       "saveChanges": "55555",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -234,7 +234,11 @@
         "noDefaultLocation": "55555",
         "noLocationEmail": "55555",
         "noBaseUrl": "55555",
-        "passwordTooShort": "55555"
+        "passwordTooShort": "55555",
+        "roleRequired": "55555",
+        "invalidRole": "55555",
+        "licenseLimitReached": "55555",
+        "soloPlanLimit": "55555"
       }
     }
   },
@@ -295,7 +299,10 @@
         "updateFailed": "55555",
         "passwordTooShort": "55555",
         "passwordChangeFailed": "55555",
-        "passwordChangeError": "55555"
+        "passwordChangeError": "55555",
+        "emailAlreadyExists": "55555",
+        "reportsToSelf": "55555",
+        "reportsToCycle": "55555"
       }
     }
   },
@@ -1360,7 +1367,11 @@
       },
       "error": {
         "userNotFound": "55555",
-        "fillRequiredFields": "55555"
+        "fillRequiredFields": "55555",
+        "saveFailed": "55555",
+        "emailAlreadyExists": "55555",
+        "reportsToSelf": "55555",
+        "reportsToCycle": "55555"
       }
     },
     "validation": {

--- a/server/src/components/settings/general/UserDetails.tsx
+++ b/server/src/components/settings/general/UserDetails.tsx
@@ -237,9 +237,18 @@ const UserDetails: React.FC<UserDetailsProps> = ({ userId, onUpdate }) => {
           updatedUserData.reports_to = reportsTo || null;
         }
         
-        const updatedUser = await updateUser(user.user_id, updatedUserData);
-        if (updatedUser) {
-          setUser(updatedUser);
+        const result = await updateUser(user.user_id, updatedUserData);
+        if (!result.success) {
+          const errorKeys: Record<typeof result.code, string> = {
+            EMAIL_ALREADY_EXISTS: 'userDetails.messages.error.emailAlreadyExists',
+            REPORTS_TO_SELF: 'userDetails.messages.error.reportsToSelf',
+            REPORTS_TO_CYCLE: 'userDetails.messages.error.reportsToCycle',
+          };
+          toast.error(t(errorKeys[result.code], { defaultValue: result.error }));
+          return;
+        }
+        if (result.user) {
+          setUser(result.user);
           onUpdate();
           closeDrawer();
           toast.success(t('userDetails.messages.success.userUpdated'));

--- a/server/src/components/settings/general/UserManagement.tsx
+++ b/server/src/components/settings/general/UserManagement.tsx
@@ -508,7 +508,18 @@ const fetchContacts = async (): Promise<void> => {
         });
 
         if (!result.success) {
-          reportCreateUserError(result.error);
+          const keysByCode: Record<typeof result.code, string> = {
+            ROLE_REQUIRED: 'users.messages.error.roleRequired',
+            INVALID_ROLE: 'users.messages.error.invalidRole',
+            ROLE_MSP_NOT_ALLOWED_FOR_CLIENT: 'users.messages.error.selectAppropriateRole',
+            ROLE_CLIENT_NOT_ALLOWED_FOR_MSP: 'users.messages.error.selectAppropriateRole',
+            EMAIL_ALREADY_EXISTS: 'users.messages.error.emailAlreadyInUse',
+            LICENSE_LIMIT_REACHED: 'users.messages.error.licenseLimitReached',
+            SOLO_PLAN_LIMIT: 'users.messages.error.soloPlanLimit',
+          };
+          const message = t(keysByCode[result.code], { defaultValue: result.error });
+          toast.error(message);
+          setError(message);
           return;
         }
 

--- a/server/src/components/settings/profile/UserProfile.tsx
+++ b/server/src/components/settings/profile/UserProfile.tsx
@@ -281,7 +281,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
 
     try {
       // Update user profile
-      await updateUser(user.user_id, {
+      const result = await updateUser(user.user_id, {
         first_name: firstName,
         last_name: lastName,
         email: email,
@@ -289,9 +289,15 @@ export default function UserProfile({ userId }: UserProfileProps) {
         timezone: timezone
       });
 
-      // Note: Notification preferences are managed separately through their own UI components:
-      // - InternalNotificationPreferences handles internal notification settings
-      // - Email notification preferences should be managed through their dedicated section
+      if (!result.success) {
+        const errorKeys: Record<typeof result.code, string> = {
+          EMAIL_ALREADY_EXISTS: 'profile.messages.error.emailAlreadyExists',
+          REPORTS_TO_SELF: 'profile.messages.error.reportsToSelf',
+          REPORTS_TO_CYCLE: 'profile.messages.error.reportsToCycle',
+        };
+        toast.error(t(errorKeys[result.code], { defaultValue: result.error }));
+        return;
+      }
 
       // Show success confirmation
       setHasAttemptedSubmit(false);
@@ -299,7 +305,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
 
     } catch (err) {
       console.error('Error saving profile:', err);
-      setError(err instanceof Error ? err.message : t('profile.messages.error.saveFailed', {
+      toast.error(t('profile.messages.error.saveFailed', {
         defaultValue: 'Failed to save profile',
       }));
     }


### PR DESCRIPTION
  Server actions threw raw English messages, which Next.js sanitizes in
  production — leaving users staring at "An error occurred in the Server
  Components render." Both actions now return a discriminated `{ success,
  code, error }` result, callers map the stable code to an i18n key with
  the English string as fallback, and translations ship in all ten
  locales. UserProfile no longer replaces the whole page on save errors;
  it just toasts.

  "Curiouser and curiouser!" cried Alice, for the looking-glass had taken
  her email and replied only with a digest. But lo — each spurned Error
  now carried a proper CODE, and the Queen of Hearts declared: "No more
  shall my subjects read 'An error occurred in the Server Components
  render' — off with its SANITIZED HEAD!" 🫖 ✉️ 👑