### PR TITLE
Surface policy simulator validation errors

### DIFF
--- a/ee/server/src/components/settings/policy/PolicyManagement.tsx
+++ b/ee/server/src/components/settings/policy/PolicyManagement.tsx
@@ -757,7 +757,11 @@ export default function PolicyManagement() {
             }
           : undefined,
       });
-      setSimulationResult(result);
+      if (result.ok === false) {
+        setError(result.error.message);
+        return;
+      }
+      setSimulationResult(result.data);
     } catch (simulationError) {
       setError(simulationError instanceof Error ? simulationError.message : 'Failed to run simulation.');
     } finally {

--- a/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
+++ b/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
@@ -105,6 +105,18 @@ export interface AuthorizationBundleSimulationPayload {
   published: AuthorizationSimulationDecision;
 }
 
+export interface AuthorizationBundleSimulationValidationError {
+  code: string;
+  message: string;
+}
+
+export type AuthorizationBundleSimulationActionResult =
+  | { ok: true; data: AuthorizationBundleSimulationPayload }
+  | {
+      ok: false;
+      error: AuthorizationBundleSimulationValidationError;
+    };
+
 const SUPPORTED_SIMULATION_ACTIONS = new Set(['read', 'approve']);
 const SUPPORTED_SIMULATION_RESOURCE_TYPES = new Set([
   'ticket',
@@ -813,26 +825,34 @@ async function loadSimulationRecord(
   throw new Error(`Unsupported simulation resource type: ${resourceType}`);
 }
 
-function assertSimulationModeSupported(input: {
+function getSimulationModeValidationError(input: {
   resourceType: string;
   action: string;
   principalUserType: 'internal' | 'client';
-}): void {
+}): AuthorizationBundleSimulationValidationError | null {
   if (!SUPPORTED_SIMULATION_ACTIONS.has(input.action)) {
-    throw new Error(
-      `Simulator only supports read/approve actions in this remediation; "${input.action}" is not currently modeled faithfully.`
-    );
+    return {
+      code: 'unsupported_simulation_action',
+      message: 'The simulator currently supports only Read and Approve checks. Choose one of those actions and try again.',
+    };
   }
 
   if (!SUPPORTED_SIMULATION_RESOURCE_TYPES.has(input.resourceType)) {
-    throw new Error(`Unsupported simulation resource type: ${input.resourceType}`);
+    return {
+      code: 'unsupported_simulation_resource_type',
+      message: 'This record type is not available in the simulator yet. Choose a supported record type and try again.',
+    };
   }
 
   if (input.resourceType === 'ticket' && input.principalUserType === 'client') {
-    throw new Error(
-      'Ticket simulation for client principals is not supported in this remediation because board-visibility builtin invariants are not modeled yet.'
-    );
+    return {
+      code: 'unsupported_ticket_client_principal_simulation',
+      message:
+        'Ticket checks for client users are not available in the simulator yet because ticket board visibility is not included. Try an internal user, or verify client ticket access in the app.',
+    };
   }
+
+  return null;
 }
 
 function applySimulationInvariantNarrowing(input: {
@@ -886,7 +906,7 @@ export const runAuthorizationBundleSimulationAction = withAuth(
         isClientVisible?: boolean;
       };
     }
-  ): Promise<AuthorizationBundleSimulationPayload> => {
+  ): Promise<AuthorizationBundleSimulationActionResult> => {
     await assertTierAccess(TIER_FEATURES.ADVANCED_AUTHORIZATION_BUNDLES);
     await assertSecuritySettingsPermission(user, 'read');
 
@@ -909,11 +929,14 @@ export const runAuthorizationBundleSimulationAction = withAuth(
       throw new Error('Principal user not found in tenant scope.');
     }
 
-    assertSimulationModeSupported({
+    const validationError = getSimulationModeValidationError({
       resourceType: input.resourceType,
       action: input.action,
       principalUserType: principal.user_type,
     });
+    if (validationError) {
+      return { ok: false, error: validationError };
+    }
 
     const canWrite = await hasPermission(user as any, 'system_settings', 'update');
 
@@ -1089,13 +1112,16 @@ export const runAuthorizationBundleSimulationAction = withAuth(
     ]);
 
     return {
-      draft: {
-        allowed: draftDecision.allowed,
-        reasonCodes: draftDecision.reasons.map((reason) => `${reason.stage}:${reason.code}`),
-      },
-      published: {
-        allowed: publishedDecision.allowed,
-        reasonCodes: publishedDecision.reasons.map((reason) => `${reason.stage}:${reason.code}`),
+      ok: true,
+      data: {
+        draft: {
+          allowed: draftDecision.allowed,
+          reasonCodes: draftDecision.reasons.map((reason) => `${reason.stage}:${reason.code}`),
+        },
+        published: {
+          allowed: publishedDecision.allowed,
+          reasonCodes: publishedDecision.reasons.map((reason) => `${reason.stage}:${reason.code}`),
+        },
       },
     };
   }

--- a/server/src/test/unit/authorization/bundleSimulatorAction.test.ts
+++ b/server/src/test/unit/authorization/bundleSimulatorAction.test.ts
@@ -225,11 +225,23 @@ vi.mock('@alga-psa/authorization/bundles/service', () => ({
 }));
 
 import {
+  type AuthorizationBundleSimulationActionResult,
+  type AuthorizationBundleSimulationPayload,
   listAuthorizationBundlesAction,
   listAuthorizationSimulationPrincipalsAction,
   listAuthorizationSimulationRecordsAction,
   runAuthorizationBundleSimulationAction,
 } from '../../../../../ee/server/src/lib/actions/auth/authorizationBundleActions';
+
+function expectSuccessfulSimulation(
+  result: AuthorizationBundleSimulationActionResult
+): AuthorizationBundleSimulationPayload {
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+  return result.data;
+}
 
 describe('runAuthorizationBundleSimulationAction', () => {
   const principalUserId = 'principal-user';
@@ -308,13 +320,13 @@ describe('runAuthorizationBundleSimulationAction', () => {
     const recordOptions = await listAuthorizationSimulationRecordsAction({ resourceType: 'ticket' });
     expect(recordOptions).toEqual([{ id: ticketId, label: 'Ticket 1' }]);
 
-    const result = await runAuthorizationBundleSimulationAction({
+    const result = expectSuccessfulSimulation(await runAuthorizationBundleSimulationAction({
       bundleId: 'bundle-1',
       principalUserId,
       resourceType: 'ticket',
       action: 'read',
       resourceId: ticketId,
-    });
+    }));
 
     expect(result.published.allowed).toBe(true);
     expect(result.draft.allowed).toBe(false);
@@ -326,7 +338,7 @@ describe('runAuthorizationBundleSimulationAction', () => {
   });
 
   it('supports synthetic scenarios without a persisted resource lookup', async () => {
-    const result = await runAuthorizationBundleSimulationAction({
+    const result = expectSuccessfulSimulation(await runAuthorizationBundleSimulationAction({
       bundleId: 'bundle-1',
       principalUserId,
       resourceType: 'ticket',
@@ -337,7 +349,7 @@ describe('runAuthorizationBundleSimulationAction', () => {
         boardId: null,
         isClientVisible: true,
       },
-    });
+    }));
 
     expect(result.published.allowed).toBe(true);
     expect(result.draft.allowed).toBe(false);
@@ -356,13 +368,13 @@ describe('runAuthorizationBundleSimulationAction', () => {
       return true;
     });
 
-    const result = await runAuthorizationBundleSimulationAction({
+    const result = expectSuccessfulSimulation(await runAuthorizationBundleSimulationAction({
       bundleId: 'bundle-1',
       principalUserId,
       resourceType: 'ticket',
       action: 'read',
       resourceId: ticketId,
-    });
+    }));
 
     expect(result.published.allowed).toBe(true);
     expect(result.draft.allowed).toBe(true);
@@ -373,13 +385,13 @@ describe('runAuthorizationBundleSimulationAction', () => {
     const recordOptions = await listAuthorizationSimulationRecordsAction({ resourceType: 'billing' });
     expect(recordOptions).toEqual([{ id: quoteId, label: 'Q-1001' }]);
 
-    const result = await runAuthorizationBundleSimulationAction({
+    const result = expectSuccessfulSimulation(await runAuthorizationBundleSimulationAction({
       bundleId: 'bundle-1',
       principalUserId,
       resourceType: 'billing',
       action: 'approve',
       resourceId: quoteId,
-    });
+    }));
 
     expect(result.published.allowed).toBe(false);
     expect(result.draft.allowed).toBe(false);
@@ -429,26 +441,32 @@ describe('runAuthorizationBundleSimulationAction', () => {
       tenant: authContext.tenant,
     });
 
-    const documentDecision = await runAuthorizationBundleSimulationAction({
+    const documentDecision = expectSuccessfulSimulation(await runAuthorizationBundleSimulationAction({
       bundleId: 'bundle-1',
       principalUserId: clientPrincipalId,
       resourceType: 'document',
       action: 'read',
       resourceId: documentId,
-    });
+    }));
 
     expect(documentDecision.published.allowed).toBe(false);
     expect(documentDecision.published.reasonCodes).toContain('builtin:document_client_visibility_denied');
 
-    await expect(
-      runAuthorizationBundleSimulationAction({
-        bundleId: 'bundle-1',
-        principalUserId,
-        resourceType: 'ticket',
-        action: 'delete',
-        resourceId: ticketId,
-      })
-    ).rejects.toThrow('Simulator only supports read/approve actions');
+    const unsupportedAction = await runAuthorizationBundleSimulationAction({
+      bundleId: 'bundle-1',
+      principalUserId,
+      resourceType: 'ticket',
+      action: 'delete',
+      resourceId: ticketId,
+    });
+
+    expect(unsupportedAction).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: 'unsupported_simulation_action',
+        message: expect.stringContaining('supports only Read and Approve checks'),
+      }),
+    });
   });
 
   it('fails closed for unsupported simulator resource types', async () => {
@@ -456,14 +474,20 @@ describe('runAuthorizationBundleSimulationAction', () => {
       listAuthorizationSimulationRecordsAction({ resourceType: 'unknown_resource' })
     ).rejects.toThrow('Unsupported simulation resource type: unknown_resource');
 
-    await expect(
-      runAuthorizationBundleSimulationAction({
-        bundleId: 'bundle-1',
-        principalUserId,
-        resourceType: 'unknown_resource',
-        action: 'read',
-        syntheticRecord: { ownerUserId: principalUserId },
-      })
-    ).rejects.toThrow('Unsupported simulation resource type: unknown_resource');
+    const unsupportedResource = await runAuthorizationBundleSimulationAction({
+      bundleId: 'bundle-1',
+      principalUserId,
+      resourceType: 'unknown_resource',
+      action: 'read',
+      syntheticRecord: { ownerUserId: principalUserId },
+    });
+
+    expect(unsupportedResource).toEqual({
+      ok: false,
+      error: {
+        code: 'unsupported_simulation_resource_type',
+        message: 'This record type is not available in the simulator yet. Choose a supported record type and try again.',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- return structured validation results for expected policy simulator limitations instead of throwing server-action errors
- show plain-language simulator messages in the policy UI
- update simulator action tests for the new result shape

## Validation
- npx nx typecheck sebastian-ee --output-style=static passed before the final copy-only tweak
- npx nx typecheck server --output-style=static passed
- npx nx typecheck @alga-psa/authorization --output-style=static passed
- targeted Vitest run is blocked locally by unresolved @alga-psa/authorization/kernel alias in the server Vitest config
- final sebastian-ee typecheck rerun was blocked by local ENOSPC disk-full error