### PR TITLE
fix(auth): prefer id_token oid/sub for OAuth provider_account_id

### DIFF
--- a/packages/auth/src/lib/nextAuthOptions.ts
+++ b/packages/auth/src/lib/nextAuthOptions.ts
@@ -870,6 +870,24 @@ function extractProviderAccountId(
     account: Record<string, unknown> | null | undefined,
     metadata: OAuthAccountMetadata,
 ): string | undefined {
+    const claims = metadata.idTokenClaims as Record<string, unknown> | undefined;
+
+    // Microsoft: oid is the Azure AD object ID — the value Bot Framework sends
+    // as activity.from.aadObjectId. Azure AD's sub is pairwise per app and does
+    // not match what Teams bots receive, so prefer oid.
+    if (claims && typeof claims.oid === 'string' && claims.oid.length > 0) {
+        return claims.oid;
+    }
+
+    // Generic OIDC subject (Google and others).
+    if (claims && typeof claims.sub === 'string' && claims.sub.length > 0) {
+        return claims.sub;
+    }
+
+    // Fallbacks: account.providerAccountId is populated by NextAuth from the
+    // profile() callback's returned id, which in this codebase is the Alga
+    // user_id — not a stable provider identifier. Use it only if the ID token
+    // is unavailable.
     const direct = toOptionalString(account?.providerAccountId);
     if (direct) {
         return direct;
@@ -878,11 +896,6 @@ function extractProviderAccountId(
     const legacyId = toOptionalString(account?.id);
     if (legacyId) {
         return legacyId;
-    }
-
-    const claims = metadata.idTokenClaims as Record<string, unknown> | undefined;
-    if (claims && typeof claims.sub === 'string' && claims.sub.length > 0) {
-        return claims.sub;
     }
 
     return undefined;


### PR DESCRIPTION
  The profile() callback returns Alga user_id as `id`, which NextAuth v5
  copies into account.providerAccountId. That polluted value was being
  written to user_auth_accounts.provider_account_id, breaking the Teams
  bot's lookup (which keys on Bot Framework's aadObjectId = Azure AD oid).

  Reorder extractProviderAccountId to prefer idTokenClaims.oid (Microsoft)
  and idTokenClaims.sub (generic OIDC) before the polluted fallbacks.

  "Curiouser and curiouser!" cried the Azure oid, tumbling down the
  rabbit-hole of id_token claims, only to discover that sub was
  pairwise all along and providerAccountId had been wearing a user_id
  costume to the Mad Hatter's tea party. 🎩🐇✨