### PR TITLE
Fix workflow designer layout on narrow screens

### DIFF
--- a/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/PRD.md
+++ b/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/PRD.md
@@ -1,0 +1,34 @@
+# Workflow Designer Stacked Layout
+
+## Problem
+
+The workflow designer uses fixed floating panels for the action palette and properties panel. On narrow screens, the panels and the center workflow canvas compete for horizontal space, causing the center content to become cramped or obscured.
+
+## Goal
+
+When the designer does not have enough horizontal room for the palette, center content, and properties panel, switch from the three-column floating layout to a vertically stacked layout.
+
+## Non-Goals
+
+- Replace the palette or properties panel with drawers.
+- Redesign the workflow pipeline, graph view, or step configuration UI.
+- Change drag-and-drop behavior or workflow data behavior.
+
+## UX Requirements
+
+- Wide screens keep the existing floating three-panel layout.
+- Narrow screens stack the designer sections in this order:
+  1. Palette/actions panel
+  2. Main workflow content/canvas
+  3. Properties/validation panel
+- The stacked breakpoint should account for the current sidebar width and palette collapsed state instead of relying only on a hard-coded viewport breakpoint.
+- In stacked mode, the center content should not retain the large left/right padding used to avoid floating panels.
+- In stacked mode, the properties panel should be full-width and the resize handle should be hidden/disabled.
+
+## Acceptance Criteria
+
+- The workflow designer automatically switches to stacked layout when available designer width is below the required width for the floating layout.
+- The floating layout remains unchanged on sufficiently wide screens.
+- The stacked layout uses normal document flow and avoids fixed panel overlap.
+- The palette remains usable with existing drag-and-drop rendering.
+- The properties panel remains usable for selected step editing and validation messages.

--- a/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/SCRATCHPAD.md
@@ -1,0 +1,50 @@
+# Scratchpad
+
+## Decisions
+
+- Use a computed stacked breakpoint instead of a fixed CSS breakpoint.
+- Required floating width includes palette width, sidebar width, center minimum width, floating offsets, and center padding extras.
+- Preserve the existing floating layout on wide screens.
+- Stack order: palette/actions, main workflow content, properties/validation.
+- Use `display: contents` on the existing floating wrapper in stacked mode so the palette, center content, and sidebar can participate as ordered flex items without duplicating the Droppable/sidebar markup.
+- In stacked mode, force palette and sidebar flex items to `flex-none`; otherwise the palette can shrink to zero height and visually overlap the center content.
+
+## Relevant Files
+
+- `ee/server/src/components/workflow-designer/WorkflowDesigner.tsx`
+- `ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx`
+- `ee/server/src/components/workflow-designer/WorkflowDesignerPalette.module.css`
+- `ee/server/src/components/workflow-designer/workflowDesignerSidebarSizing.ts`
+
+## Implementation Notes
+
+- Added `DESIGNER_CENTER_MIN_WIDTH = 640` and derive `isStacked` from current palette width, resized sidebar width, center minimum width, and layout spacing.
+- Stacked mode switches the anchor to a single vertical scroll container.
+- Stacked mode clears center-scroll inline padding, makes the sidebar full-width, and disables the sidebar resize handle.
+- `WorkflowDesignerPalette` now accepts `layout` and `className` props so it can become full-width in stacked mode while preserving floating sizing by default.
+- Added stacked-only palette CSS so the palette card has real height in normal flow, scrolls internally to 20rem, and collapses to a compact 40px row without leaving a large blank gap.
+
+## Alga Dev Ground Truth
+
+Target browser pane: `38155ff4-221b-444a-9e4d-f06676dfb19d`, URL `http://localhost:3226/msp/workflow-editor/8dc9052e-1408-4f03-8b48-b308602489e1`.
+
+Observed viewport: `935x973`, which correctly triggers stacked mode.
+
+Screenshots captured:
+
+- `/var/folders/8g/3xyjqdpd4hx2h39h4qb2lyvm0000gn/T/ghostty-pane-ide/screenshots/workflow-stacked-cleaned-expanded.png`
+- `/var/folders/8g/3xyjqdpd4hx2h39h4qb2lyvm0000gn/T/ghostty-pane-ide/screenshots/workflow-stacked-collapsed-fixed-after-click.png`
+- `/var/folders/8g/3xyjqdpd4hx2h39h4qb2lyvm0000gn/T/ghostty-pane-ide/screenshots/workflow-stacked-sidebar-visible.png`
+
+DOM measurements after cleanup:
+
+- Expanded palette: palette rect `608x381`, center starts at palette bottom, no overlap.
+- Collapsed palette: palette row rect `608x40`, center starts below it, no large blank area.
+- Sidebar: rect `640x539`, `position: relative`, `width: 100%`, resize handle has `pointer-events: none` and `opacity: 0`.
+
+## Validation Notes
+
+- `npm --prefix ee/server run typecheck -- --pretty false` passed.
+- `npm --prefix ee/server run lint -- --file ...` failed because this repo's `next lint` command does not support `--file`.
+- `npx eslint ee/server/src/components/workflow-designer/WorkflowDesigner.tsx ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx` completed with 0 errors and existing warnings in `WorkflowDesigner.tsx`.
+- `git diff --check` passed before Alga Dev cleanup; rerun before handoff if additional edits are made.

--- a/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/features.json
+++ b/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/features.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "F001",
+    "description": "Compute whether the workflow designer has enough width for floating palette, center content, and properties panel using current panel widths.",
+    "implemented": true
+  },
+  {
+    "id": "F002",
+    "description": "Render the designer in vertically stacked normal flow when floating layout would leave the center content too narrow.",
+    "implemented": true
+  },
+  {
+    "id": "F003",
+    "description": "Remove floating-layout center padding in stacked mode so the main content can use the available width.",
+    "implemented": true
+  },
+  {
+    "id": "F004",
+    "description": "Make the properties panel full-width and disable its resize handle in stacked mode.",
+    "implemented": true
+  },
+  {
+    "id": "F005",
+    "description": "Keep existing floating behavior unchanged on wide screens.",
+    "implemented": true
+  }
+]

--- a/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/tests.json
+++ b/ee/docs/plans/2026-04-24-workflow-designer-stacked-layout/tests.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "T001",
+    "description": "Manual smoke: open the workflow designer on a wide viewport and verify the palette and properties panel still float beside the center canvas without visual overlap.",
+    "featureIds": ["F005"],
+    "implemented": false
+  },
+  {
+    "id": "T002",
+    "description": "Manual smoke: narrow the viewport until the designer stacks, then verify the order is palette, main workflow content, then properties/validation panel.",
+    "featureIds": ["F001", "F002", "F003", "F004"],
+    "implemented": false
+  },
+  {
+    "id": "T003",
+    "description": "Manual smoke: in stacked mode, select a workflow step and verify the properties panel remains editable and the resize handle is not active.",
+    "featureIds": ["F004"],
+    "implemented": false
+  }
+]

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -300,6 +300,7 @@ const DESIGNER_PALETTE_COLLAPSED_WIDTH = 32;
 const DESIGNER_PALETTE_TOGGLE_OVERHANG = 16;
 const DESIGNER_CENTER_LEFT_EXTRA_PADDING = 16;
 const DESIGNER_CENTER_RIGHT_EXTRA_PADDING = 24;
+const DESIGNER_CENTER_MIN_WIDTH = 640;
 
 type PipeSegment = {
   index: number;
@@ -1523,6 +1524,33 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     const currentPaletteWidth = isPaletteCollapsed
       ? DESIGNER_PALETTE_COLLAPSED_WIDTH
       : DESIGNER_PALETTE_WIDTH;
+    const anchorWidth = designerFloatAnchorRect.right - designerFloatAnchorRect.left;
+    const minimumFloatingWidth =
+      (DESIGNER_FLOAT_PANEL_OFFSET * 2)
+      + currentPaletteWidth
+      + DESIGNER_PALETTE_TOGGLE_OVERHANG
+      + DESIGNER_CENTER_LEFT_EXTRA_PADDING
+      + DESIGNER_CENTER_MIN_WIDTH
+      + DESIGNER_CENTER_RIGHT_EXTRA_PADDING
+      + designerSidebarWidth;
+    const isStacked = anchorWidth < minimumFloatingWidth;
+
+    if (isStacked) {
+      return {
+        isStacked,
+        paletteStyle: {
+          position: 'relative',
+          maxHeight: 'none',
+        } as React.CSSProperties,
+        sidebarStyle: {
+          position: 'relative',
+          width: '100%',
+          maxHeight: 'none',
+        } as React.CSSProperties,
+        centerScrollStyle: {} as React.CSSProperties,
+      };
+    }
+
     const paletteLeft = Math.min(
       Math.max(DESIGNER_FLOAT_EDGE_GUTTER, designerFloatAnchorRect.left + DESIGNER_FLOAT_PANEL_OFFSET),
       window.innerWidth - DESIGNER_FLOAT_EDGE_GUTTER - currentPaletteWidth
@@ -1549,6 +1577,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
     );
 
     return {
+      isStacked,
       paletteStyle: {
         position: 'fixed',
         top,
@@ -1934,10 +1963,10 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
   }, [isDesignerSidebarResizing, stopDesignerSidebarResize]);
 
   useEffect(() => {
-    if (!designerFloatAnchorRect && isDesignerSidebarResizing) {
+    if ((!designerFloatAnchorRect || designerFloatingLayout?.isStacked) && isDesignerSidebarResizing) {
       stopDesignerSidebarResize();
     }
-  }, [designerFloatAnchorRect, isDesignerSidebarResizing, stopDesignerSidebarResize]);
+  }, [designerFloatAnchorRect, designerFloatingLayout?.isStacked, isDesignerSidebarResizing, stopDesignerSidebarResize]);
 
   const handleControlPanelTabChange = useCallback((nextTabId: string) => {
     setActiveTab(nextTabId);
@@ -3483,12 +3512,17 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
   };
 
   const showInitialDesignerSkeleton = isLoading && !activeDefinition;
+  const isDesignerStacked = designerFloatingLayout?.isStacked ?? false;
+  const canResizeDesignerSidebar = canManage && !isDesignerStacked;
 
   const designerContent = (
     <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
     <div className="flex flex-col h-full min-h-0">
-	      <div ref={designerFloatAnchorRef} className="relative flex flex-col flex-1 min-h-0 overflow-hidden bg-gray-50 dark:bg-[rgb(var(--color-background))]">
-        <div className="sticky top-4 z-20 h-0 pointer-events-none">
+	      <div
+          ref={designerFloatAnchorRef}
+          className={`relative flex flex-col flex-1 min-h-0 bg-gray-50 dark:bg-[rgb(var(--color-background))] ${isDesignerStacked ? 'overflow-y-auto' : 'overflow-hidden'}`}
+        >
+        <div className={isDesignerStacked ? 'contents' : 'sticky top-4 z-20 h-0 pointer-events-none'}>
           {/* Floating Icon-Grid Palette (left) */}
           <Droppable
             droppableId="palette"
@@ -3503,6 +3537,8 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
               <WorkflowDesignerPalette
                 visible={Boolean(designerFloatAnchorRect)}
                 style={designerFloatingLayout?.paletteStyle}
+                layout={isDesignerStacked ? 'stacked' : 'floating'}
+                className={isDesignerStacked ? 'order-1 mx-4 mt-4 flex-none' : undefined}
                 search={search}
                 onSearchChange={setSearch}
                 registryError={registryError}
@@ -3532,7 +3568,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
           {/* Floating Properties (right) */}
           <aside
             id="workflow-designer-sidebar-scroll"
-            className={`pointer-events-auto relative max-h-[calc(100vh-220px)] bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg overflow-y-auto p-4 space-y-4 z-40 ${designerFloatAnchorRect ? '' : 'hidden'}`}
+            className={`pointer-events-auto relative max-h-[calc(100vh-220px)] bg-white/95 dark:bg-[rgb(var(--color-card))]/95 backdrop-blur border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg overflow-y-auto p-4 space-y-4 z-40 ${isDesignerStacked ? 'order-3 mx-4 mb-4 flex-none' : ''} ${designerFloatAnchorRect ? '' : 'hidden'}`}
             style={designerFloatingLayout?.sidebarStyle}
           >
             <div
@@ -3540,9 +3576,9 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
               role="separator"
               aria-orientation="vertical"
               aria-label="Resize properties panel"
-              className={`absolute inset-y-0 left-0 z-10 w-3 select-none ${canManage ? 'cursor-col-resize' : 'pointer-events-none opacity-0'}`}
+              className={`absolute inset-y-0 left-0 z-10 w-3 select-none ${canResizeDesignerSidebar ? 'cursor-col-resize' : 'pointer-events-none opacity-0'}`}
               onPointerDown={(event) => {
-                if (!canManage) return;
+                if (!canResizeDesignerSidebar) return;
                 event.preventDefault();
                 event.stopPropagation();
                 designerSidebarResizeRef.current = {
@@ -3722,7 +3758,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
 
 	        <div
             id="workflow-designer-center-scroll"
-            className="flex-1 min-h-0 overflow-y-auto p-6 pl-72 pr-[460px]"
+            className={isDesignerStacked ? 'order-2 flex-none min-h-0 overflow-visible p-4' : 'flex-1 min-h-0 overflow-y-auto p-6 pl-72 pr-[460px]'}
             style={designerFloatingLayout?.centerScrollStyle}
           >
           <div className="max-w-4xl mx-auto space-y-6">

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.module.css
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.module.css
@@ -12,6 +12,17 @@
   z-index: 10;
 }
 
+.stackedContainer {
+  display: block;
+  max-height: none;
+  min-height: 2.5rem;
+}
+
+.stackedContainer .paletteToggle {
+  top: 8px;
+  right: 8px;
+}
+
 /* Clips the sliding card so its translateX animation cannot bleed past
    the palette's left edge into the app sidebar. */
 .clipper {
@@ -53,6 +64,28 @@
   padding: 0;
   margin: 0;
   border-width: 0;
+}
+
+.stackedContainer .clipper {
+  display: block;
+  flex: none;
+  min-height: auto;
+  overflow: visible;
+}
+
+.stackedContainer .card {
+  flex: none;
+}
+
+.stackedContainer .cardHidden {
+  height: 0 !important;
+  min-height: 0 !important;
+  max-height: 0 !important;
+}
+
+.stackedContainer .scrollArea {
+  flex: none;
+  max-height: 20rem;
 }
 
 .scrollArea {

--- a/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx
@@ -14,6 +14,8 @@ export type WorkflowDesignerPaletteItem = {
 type WorkflowDesignerPaletteProps<TItem extends WorkflowDesignerPaletteItem> = {
   visible: boolean;
   style?: React.CSSProperties;
+  layout?: 'floating' | 'stacked';
+  className?: string;
   search: string;
   onSearchChange: (value: string) => void;
   registryError: boolean;
@@ -32,6 +34,8 @@ type WorkflowDesignerPaletteProps<TItem extends WorkflowDesignerPaletteItem> = {
 export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteItem>({
   visible,
   style,
+  layout = 'floating',
+  className,
   search,
   onSearchChange,
   registryError,
@@ -50,26 +54,40 @@ export function WorkflowDesignerPalette<TItem extends WorkflowDesignerPaletteIte
   let paletteIndex = 0;
 
   const outerWidth = isCollapsed ? collapsedWidth : expandedWidth;
+  const isStacked = layout === 'stacked';
   const containerStyle: React.CSSProperties | undefined = visible
-    ? {
-        ...(style || {}),
-        width: outerWidth,
-        minWidth: outerWidth,
-        maxWidth: outerWidth,
-      }
+    ? isStacked
+      ? {
+          ...(style || {}),
+          width: 'auto',
+          minWidth: 0,
+          maxWidth: 'none',
+        }
+      : {
+          ...(style || {}),
+          width: outerWidth,
+          minWidth: outerWidth,
+          maxWidth: outerWidth,
+        }
     : undefined;
 
   const cardSizingStyle: React.CSSProperties = isCollapsed
     ? {}
-    : {
-        width: expandedWidth,
-        minWidth: expandedWidth,
-        maxWidth: expandedWidth,
-      };
+    : isStacked
+      ? {
+          width: '100%',
+          minWidth: 0,
+          maxWidth: 'none',
+        }
+      : {
+          width: expandedWidth,
+          minWidth: expandedWidth,
+          maxWidth: expandedWidth,
+        };
 
   return (
     <aside
-      className={`pointer-events-auto flex flex-col max-h-[calc(100vh-220px)] min-h-0 z-40 ${styles.container} ${visible ? '' : 'hidden'}`}
+      className={`pointer-events-auto flex flex-col max-h-[calc(100vh-220px)] min-h-0 z-40 ${styles.container} ${isStacked ? styles.stackedContainer : ''} ${className ?? ''} ${visible ? '' : 'hidden'}`}
       style={containerStyle}
     >
       {onToggleCollapse ? (


### PR DESCRIPTION
## Summary
- stack workflow designer palette, center canvas, and properties panel when available width is too narrow
- keep the existing floating three-panel layout on wide screens
- make the stacked palette full-width/scrollable and disable properties-panel resizing in stacked mode
- add plan artifacts for the stacked layout change

## Validation
- npm --prefix ee/server run typecheck -- --pretty false
- npx eslint ee/server/src/components/workflow-designer/WorkflowDesigner.tsx ee/server/src/components/workflow-designer/WorkflowDesignerPalette.tsx (0 errors; existing warnings in WorkflowDesigner.tsx)
- git diff --check
- Alga Dev live visual/DOM inspection at 935x973 viewport
