### PR TITLE
Fix hosted Microsoft email OAuth fallback

### DIFF
--- a/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/PRD.md
+++ b/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/PRD.md
@@ -1,0 +1,33 @@
+# Microsoft Email Hosted OAuth Fallback
+
+## Problem
+
+Microsoft 365 inbound email OAuth currently requires a tenant Microsoft profile bound to the `email` consumer. Tenants that only configure or revoke MSP SSO login domains cannot use the included Nine Minds hosted Microsoft OAuth application, even though inbound email historically supported hosted/app-level credentials.
+
+## Goals
+
+- Restore the hosted Nine Minds Microsoft OAuth path for inbound email when no explicit Email Microsoft profile binding exists.
+- Preserve explicit tenant-owned Microsoft email bindings when configured and ready.
+- Keep MSP SSO login-domain claim state independent from inbound email OAuth behavior.
+- Avoid falling back silently when an explicit Email binding exists but points to an invalid or incomplete profile.
+
+## Non-goals
+
+- Add/delete UI for MSP SSO login-domain claims.
+- Change MSP SSO discovery behavior.
+- Change calendar or Teams Microsoft profile resolution.
+- Migrate existing Microsoft profiles or consumer bindings.
+
+## Desired Behavior
+
+1. Microsoft inbound email OAuth resolves credentials from the tenant's ready `email` Microsoft profile binding when present.
+2. If no `email` binding exists, the resolver uses app-level hosted Microsoft email credentials from `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, and optional `MICROSOFT_TENANT_ID` app secrets or environment variables.
+3. If an explicit binding exists but is invalid/archived/missing required secrets, the resolver fails with the binding error instead of hiding the misconfiguration.
+4. Existing OAuth initiation, callback token exchange, and refresh-token flows all use the same resolver behavior.
+
+## Acceptance Criteria
+
+- A tenant without an Email Microsoft profile binding can initiate Microsoft inbound email OAuth when app-level hosted credentials are configured.
+- A tenant with a ready Email Microsoft profile binding still uses that bound profile.
+- A tenant with an invalid Email binding gets an invalid-profile error rather than fallback.
+- Existing contract tests continue to prove runtime callers use the shared resolver and do not read Microsoft env vars directly.

--- a/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/SCRATCHPAD.md
@@ -1,0 +1,26 @@
+# Scratchpad
+
+## 2026-04-24
+
+- Confirmed MSP SSO domain revocation is not the right fix for Microsoft 365 inbound email OAuth.
+- `revokeMspSsoDomainClaim` sets `claim_status = 'revoked'` but leaves `is_active = true`; MSP SSO discovery still treats revoked EE claims as ineligible and falls back to app-level SSO providers.
+- Microsoft inbound email uses `resolveMicrosoftConsumerProfileConfig(tenant, 'email')` in OAuth initiation, callback, and token refresh.
+- Current resolver returns `not_configured` when no Email binding exists, so the included hosted/Nine Minds Microsoft email OAuth app is never used by the active server-action path.
+- Decision: add hosted app-level fallback inside the shared integrations resolver for `consumerType === 'email'` only when no explicit binding exists. Do not fallback for invalid explicit bindings.
+- Additional discovery: `initiateEmailOAuth` validates a provider after the form creates the `email_providers` row. The legacy binding migration could interpret that just-created row as legacy usage and auto-bind Email to the tenant's only Microsoft profile. To avoid forcing tenants onto an SSO-oriented app, Email binding migration now requires legacy tenant Microsoft client credentials, not just a Microsoft email provider row.
+
+Key files:
+- `packages/integrations/src/lib/microsoftConsumerProfileResolution.ts`
+- `packages/integrations/src/actions/integrations/microsoftActions.ts`
+- `packages/integrations/src/actions/email-actions/oauthActions.ts`
+- `server/src/app/api/auth/microsoft/callback/route.ts`
+- `server/src/services/email/providers/MicrosoftGraphAdapter.ts`
+- `packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts`
+- `server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts`
+
+Validation:
+- PASS: `cd server && npx vitest run --coverage.enabled=false ../packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts`
+- PASS with warnings only: `npx eslint packages/integrations/src/lib/microsoftConsumerProfileResolution.ts packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts packages/integrations/src/actions/integrations/microsoftActions.ts`
+- Existing unrelated failures observed when running broader suites:
+  - `server/src/test/unit/microsoft/microsoftConsumerRuntimeResolution.contract.test.ts` expects calendar EE action implementation in `packages/ee/src/lib/actions/integrations/calendarActions.ts`, but this branch currently has a CE stub export there.
+  - `packages/integrations/src/actions/integrations/microsoftActions.test.ts` has edition-visibility failures in this environment where `isEnterprise` is statically resolved rather than following per-test `NEXT_PUBLIC_EDITION` changes.

--- a/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/features.json
+++ b/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/features.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "F001",
+    "description": "Microsoft email credential resolution falls back to hosted app-level credentials when no explicit Email binding exists.",
+    "implemented": true,
+    "prdRefs": ["Goals", "Desired Behavior #2"]
+  },
+  {
+    "id": "F002",
+    "description": "Ready explicit Email Microsoft profile bindings continue to take precedence over hosted app-level credentials.",
+    "implemented": true,
+    "prdRefs": ["Desired Behavior #1"]
+  },
+  {
+    "id": "F003",
+    "description": "Invalid explicit Email bindings fail closed instead of silently falling back to hosted app-level credentials.",
+    "implemented": true,
+    "prdRefs": ["Desired Behavior #3"]
+  },
+  {
+    "id": "F004",
+    "description": "OAuth initiation, callback, and token refresh continue to resolve Microsoft email credentials through the shared resolver.",
+    "implemented": true,
+    "prdRefs": ["Desired Behavior #4"]
+  }
+]

--- a/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/tests.json
+++ b/ee/docs/plans/2026-04-24-microsoft-email-hosted-oauth-fallback/tests.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "T001",
+    "description": "Resolver returns hosted app-level Microsoft email credentials when no Email binding exists and hosted credentials are configured.",
+    "implemented": true,
+    "featureIds": ["F001"]
+  },
+  {
+    "id": "T002",
+    "description": "Resolver prefers a ready explicit Email binding over hosted app-level Microsoft credentials.",
+    "implemented": true,
+    "featureIds": ["F002"]
+  },
+  {
+    "id": "T003",
+    "description": "Resolver returns invalid_profile for an invalid explicit Email binding even when hosted app-level credentials exist.",
+    "implemented": true,
+    "featureIds": ["F003"]
+  },
+  {
+    "id": "T004",
+    "description": "Resolver does not implicitly bind Email to an unrelated single Microsoft profile before hosted fallback.",
+    "implemented": true,
+    "featureIds": ["F001", "F003"]
+  },
+  {
+    "id": "T005",
+    "description": "Runtime contract confirms email OAuth initiation, callback, and token refresh use the shared resolver instead of direct Microsoft env reads.",
+    "implemented": true,
+    "featureIds": ["F004"]
+  }
+]

--- a/packages/integrations/src/actions/integrations/microsoftActions.ts
+++ b/packages/integrations/src/actions/integrations/microsoftActions.ts
@@ -462,6 +462,18 @@ async function tenantHasLegacyMicrosoftEmailUsage(knex: any, tenant: string): Pr
   return Boolean(provider);
 }
 
+async function tenantHasLegacyMicrosoftEmailClientCredentials(
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  tenant: string
+): Promise<boolean> {
+  const [clientId, clientSecret] = await Promise.all([
+    secretProvider.getTenantSecret(tenant, MICROSOFT_CLIENT_ID_SECRET),
+    secretProvider.getTenantSecret(tenant, MICROSOFT_CLIENT_SECRET_SECRET),
+  ]);
+
+  return Boolean((clientId || '').trim() && (clientSecret || '').trim());
+}
+
 async function tenantHasLegacyMicrosoftCalendarUsage(knex: any, tenant: string): Promise<boolean> {
   const provider = await knex('calendar_providers')
     .where({ tenant, provider_type: 'microsoft' })
@@ -498,11 +510,13 @@ async function ensureMicrosoftConsumerBindingMigration(
     return existingBindings;
   }
 
-  const [shouldBackfillMspSso, shouldBackfillEmail, shouldBackfillCalendar] = await Promise.all([
+  const [shouldBackfillMspSso, hasLegacyEmailUsage, hasLegacyEmailClientCredentials, shouldBackfillCalendar] = await Promise.all([
     missingConsumers.has('msp_sso') ? tenantHasLegacyMspSsoUsage(knex, tenant) : false,
     missingConsumers.has('email') ? tenantHasLegacyMicrosoftEmailUsage(knex, tenant) : false,
+    missingConsumers.has('email') ? tenantHasLegacyMicrosoftEmailClientCredentials(secretProvider, tenant) : false,
     missingConsumers.has('calendar') ? tenantHasLegacyMicrosoftCalendarUsage(knex, tenant) : false,
   ]);
+  const shouldBackfillEmail = hasLegacyEmailUsage && hasLegacyEmailClientCredentials;
 
   const consumersToBackfill: MicrosoftProfileConsumer[] = [];
 

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts
@@ -36,6 +36,7 @@ const hoisted = vi.hoisted(() => {
 
   const state = {
     tenantSecrets: new Map<string, string>(),
+    appSecrets: new Map<string, string>(),
     microsoftProfiles: [] as MicrosoftProfileRow[],
     microsoftConsumerBindings: [] as MicrosoftConsumerBindingRow[],
     emailProviders: [] as LegacyUsageRow[],
@@ -93,6 +94,7 @@ const hoisted = vi.hoisted(() => {
   return {
     state,
     getTenantSecretMock: vi.fn(async (tenant: string, key: string) => state.tenantSecrets.get(`${tenant}:${key}`) || null),
+    getAppSecretMock: vi.fn(async (key: string) => state.appSecrets.get(key) || null),
     setTenantSecretMock: vi.fn(async (tenant: string, key: string, value: string | null) => {
       if (value === null) {
         state.tenantSecrets.delete(`${tenant}:${key}`);
@@ -107,6 +109,7 @@ const hoisted = vi.hoisted(() => {
 vi.mock('@alga-psa/core/secrets', () => ({
   getSecretProviderInstance: async () => ({
     getTenantSecret: hoisted.getTenantSecretMock,
+    getAppSecret: hoisted.getAppSecretMock,
     setTenantSecret: hoisted.setTenantSecretMock,
   }),
 }));
@@ -120,6 +123,7 @@ import { resolveMicrosoftConsumerProfileConfig } from './microsoftConsumerProfil
 describe('resolveMicrosoftConsumerProfileConfig', () => {
   beforeEach(() => {
     hoisted.state.tenantSecrets.clear();
+    hoisted.state.appSecrets.clear();
     hoisted.state.microsoftProfiles.length = 0;
     hoisted.state.microsoftConsumerBindings.length = 0;
     hoisted.state.emailProviders.length = 0;
@@ -172,10 +176,106 @@ describe('resolveMicrosoftConsumerProfileConfig', () => {
       clientId: 'bound-client-id',
       clientSecret: 'bound-secret',
       microsoftTenantId: 'bound-tenant-id',
+      credentialSource: 'binding',
     });
     expect(result.clientId).not.toBe(process.env.MICROSOFT_CLIENT_ID);
     expect(result.clientSecret).not.toBe(process.env.MICROSOFT_CLIENT_SECRET);
     expect(result.microsoftTenantId).not.toBe(process.env.MICROSOFT_TENANT_ID);
+  });
+
+  it('T401: falls back to hosted app-level Microsoft email credentials when no Email binding exists', async () => {
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_ID', 'hosted-client-id');
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_SECRET', 'hosted-client-secret');
+    hoisted.state.appSecrets.set('MICROSOFT_TENANT_ID', 'hosted-tenant-id');
+
+    const result = await resolveMicrosoftConsumerProfileConfig('tenant-hosted', 'email');
+
+    expect(result).toEqual({
+      status: 'ready',
+      tenantId: 'tenant-hosted',
+      consumerType: 'email',
+      clientId: 'hosted-client-id',
+      clientSecret: 'hosted-client-secret',
+      microsoftTenantId: 'hosted-tenant-id',
+      credentialSource: 'app',
+    });
+  });
+
+  it('T402: uses hosted Microsoft email env credentials when app secrets are unavailable', async () => {
+    process.env.MICROSOFT_CLIENT_ID = 'env-hosted-client-id';
+    process.env.MICROSOFT_CLIENT_SECRET = 'env-hosted-client-secret';
+    process.env.MICROSOFT_TENANT_ID = 'env-hosted-tenant-id';
+
+    const result = await resolveMicrosoftConsumerProfileConfig('tenant-env-hosted', 'email');
+
+    expect(result).toEqual({
+      status: 'ready',
+      tenantId: 'tenant-env-hosted',
+      consumerType: 'email',
+      clientId: 'env-hosted-client-id',
+      clientSecret: 'env-hosted-client-secret',
+      microsoftTenantId: 'env-hosted-tenant-id',
+      credentialSource: 'app',
+    });
+  });
+
+  it('T403: does not implicitly bind Email to an unrelated single Microsoft profile before hosted fallback', async () => {
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_ID', 'hosted-client-id');
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_SECRET', 'hosted-client-secret');
+    hoisted.state.microsoftProfiles.push({
+      tenant: 'tenant-with-sso-profile',
+      profile_id: 'profile-sso-only',
+      display_name: 'SSO Profile',
+      display_name_normalized: 'sso profile',
+      client_id: 'sso-client-id',
+      tenant_id: 'sso-tenant-id',
+      client_secret_ref: 'sso-secret-ref',
+      is_default: true,
+      is_archived: false,
+      archived_at: null,
+      created_by: null,
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    hoisted.state.tenantSecrets.set('tenant-with-sso-profile:sso-secret-ref', 'sso-secret');
+    hoisted.state.emailProviders.push({
+      tenant: 'tenant-with-sso-profile',
+      provider_type: 'microsoft',
+    });
+
+    await expect(resolveMicrosoftConsumerProfileConfig('tenant-with-sso-profile', 'email')).resolves.toEqual({
+      status: 'ready',
+      tenantId: 'tenant-with-sso-profile',
+      consumerType: 'email',
+      clientId: 'hosted-client-id',
+      clientSecret: 'hosted-client-secret',
+      microsoftTenantId: 'common',
+      credentialSource: 'app',
+    });
+    expect(hoisted.state.microsoftConsumerBindings).toHaveLength(0);
+  });
+
+  it('T404: does not fall back to hosted credentials when an explicit Email binding is invalid', async () => {
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_ID', 'hosted-client-id');
+    hoisted.state.appSecrets.set('MICROSOFT_CLIENT_SECRET', 'hosted-client-secret');
+    hoisted.state.microsoftConsumerBindings.push({
+      tenant: 'tenant-invalid-binding',
+      consumer_type: 'email',
+      profile_id: 'missing-profile',
+      created_by: null,
+      updated_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    await expect(resolveMicrosoftConsumerProfileConfig('tenant-invalid-binding', 'email')).resolves.toEqual({
+      status: 'invalid_profile',
+      tenantId: 'tenant-invalid-binding',
+      consumerType: 'email',
+      profileId: 'missing-profile',
+      message: 'Selected Email Microsoft profile is missing or archived',
+    });
   });
 
   it('T325/T326: materializes the calendar binding only from concrete legacy calendar usage and otherwise fails closed', async () => {
@@ -231,6 +331,7 @@ describe('resolveMicrosoftConsumerProfileConfig', () => {
       clientId: 'legacy-client',
       clientSecret: 'legacy-secret',
       microsoftTenantId: 'legacy-tenant',
+      credentialSource: 'binding',
     });
     expect(hoisted.state.microsoftConsumerBindings).toEqual([
       expect.objectContaining({

--- a/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
+++ b/packages/integrations/src/lib/microsoftConsumerProfileResolution.ts
@@ -9,6 +9,9 @@ import {
 const LEGACY_MICROSOFT_CLIENT_ID_SECRET = 'microsoft_client_id';
 const LEGACY_MICROSOFT_CLIENT_SECRET_SECRET = 'microsoft_client_secret';
 const LEGACY_MICROSOFT_TENANT_ID_SECRET = 'microsoft_tenant_id';
+const HOSTED_MICROSOFT_CLIENT_ID_SECRET = 'MICROSOFT_CLIENT_ID';
+const HOSTED_MICROSOFT_CLIENT_SECRET_SECRET = 'MICROSOFT_CLIENT_SECRET';
+const HOSTED_MICROSOFT_TENANT_ID_SECRET = 'MICROSOFT_TENANT_ID';
 const DEFAULT_MICROSOFT_PROFILE_NAME = 'Default Microsoft Profile';
 
 interface MicrosoftProfileRow {
@@ -48,6 +51,7 @@ export interface MicrosoftBindingCandidateProfile {
 }
 
 type ResolverStatus = 'ready' | 'not_configured' | 'invalid_profile';
+type MicrosoftCredentialSource = 'binding' | 'app';
 
 export interface MicrosoftConsumerProfileResolution {
   status: ResolverStatus;
@@ -57,6 +61,7 @@ export interface MicrosoftConsumerProfileResolution {
   clientId?: string;
   clientSecret?: string;
   microsoftTenantId?: string;
+  credentialSource?: MicrosoftCredentialSource;
   message?: string;
 }
 
@@ -102,6 +107,35 @@ async function getLegacyMicrosoftConfig(
     clientId: (clientId || '').trim(),
     clientSecret: (clientSecret || '').trim(),
     tenantId: normalizeTenantId(tenantId),
+  };
+}
+
+async function resolveHostedMicrosoftEmailConfig(
+  tenantId: string,
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>
+): Promise<MicrosoftConsumerProfileResolution | null> {
+  const [appClientId, appClientSecret, appTenantId] = await Promise.all([
+    secretProvider.getAppSecret(HOSTED_MICROSOFT_CLIENT_ID_SECRET),
+    secretProvider.getAppSecret(HOSTED_MICROSOFT_CLIENT_SECRET_SECRET),
+    secretProvider.getAppSecret(HOSTED_MICROSOFT_TENANT_ID_SECRET),
+  ]);
+
+  const clientId = (appClientId || process.env.MICROSOFT_CLIENT_ID || '').trim();
+  const clientSecret = (appClientSecret || process.env.MICROSOFT_CLIENT_SECRET || '').trim();
+  const microsoftTenantId = normalizeTenantId(appTenantId || process.env.MICROSOFT_TENANT_ID);
+
+  if (!isConfigured(clientId) || !isConfigured(clientSecret)) {
+    return null;
+  }
+
+  return {
+    status: 'ready',
+    tenantId,
+    consumerType: 'email',
+    clientId,
+    clientSecret,
+    microsoftTenantId,
+    credentialSource: 'app',
   };
 }
 
@@ -286,6 +320,14 @@ async function tenantHasLegacyUsage(
   return false;
 }
 
+async function hasLegacyMicrosoftEmailClientCredentials(
+  secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>>,
+  tenant: string
+): Promise<boolean> {
+  const legacyConfig = await getLegacyMicrosoftConfig(secretProvider, tenant);
+  return isConfigured(legacyConfig.clientId) && isConfigured(legacyConfig.clientSecret);
+}
+
 async function ensureMicrosoftConsumerBindingMigration(
   db: any,
   tenant: string,
@@ -310,6 +352,13 @@ async function ensureMicrosoftConsumerBindingMigration(
 
   const shouldBackfill = await tenantHasLegacyUsage(db, tenant, consumerType);
   if (!shouldBackfill) {
+    return undefined;
+  }
+
+  if (
+    consumerType === 'email' &&
+    !(await hasLegacyMicrosoftEmailClientCredentials(secretProvider, tenant))
+  ) {
     return undefined;
   }
 
@@ -345,6 +394,13 @@ export async function resolveMicrosoftConsumerProfileConfig(
   const binding = await ensureMicrosoftConsumerBindingMigration(db, tenantId, consumerType, secretProvider);
 
   if (!binding) {
+    if (consumerType === 'email') {
+      const hostedEmailConfig = await resolveHostedMicrosoftEmailConfig(tenantId, secretProvider);
+      if (hostedEmailConfig) {
+        return hostedEmailConfig;
+      }
+    }
+
     return {
       status: 'not_configured',
       tenantId,
@@ -383,5 +439,6 @@ export async function resolveMicrosoftConsumerProfileConfig(
     clientId: profile.client_id,
     clientSecret: clientSecret || undefined,
     microsoftTenantId: normalizeTenantId(profile.tenant_id),
+    credentialSource: 'binding',
   };
 }


### PR DESCRIPTION
## Summary
- Restore hosted/Nine Minds Microsoft OAuth fallback for inbound email when no explicit Email Microsoft profile binding exists
- Preserve explicit Email profile bindings when configured and fail closed for invalid explicit bindings
- Prevent transient/new Microsoft email provider rows from implicitly binding Email to an unrelated tenant Microsoft profile
- Add plan artifacts and resolver tests for hosted fallback behavior

## Validation
- `cd server && npx vitest run --coverage.enabled=false ../packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts`
- `npx eslint packages/integrations/src/lib/microsoftConsumerProfileResolution.ts packages/integrations/src/lib/microsoftConsumerProfileResolution.test.ts packages/integrations/src/actions/integrations/microsoftActions.ts` (warnings only, existing style/no-undef warnings)

## Notes
- Broader Microsoft runtime contract test currently fails on this branch because the calendar action path resolves to a CE stub; noted in the plan scratchpad as unrelated to this fix.