### PR TITLE
Fix workflow permissions for new tenants

### DIFF
--- a/ee/server/seeds/onboarding/02_permissions.cjs
+++ b/ee/server/seeds/onboarding/02_permissions.cjs
@@ -56,6 +56,13 @@ exports.seed = async function(knex, tenantId) {
         { resource: 'extension', action: 'read', msp: true, client: false, description: 'Read extension APIs and storage' },
         { resource: 'extension', action: 'write', msp: true, client: false, description: 'Write extension APIs and storage' },
 
+        // Workflow permissions
+        { resource: 'workflow', action: 'read', msp: true, client: false, description: 'Read workflows' },
+        { resource: 'workflow', action: 'view', msp: true, client: false, description: 'View workflows' },
+        { resource: 'workflow', action: 'manage', msp: true, client: false, description: 'Manage workflows' },
+        { resource: 'workflow', action: 'publish', msp: true, client: false, description: 'Publish workflows' },
+        { resource: 'workflow', action: 'admin', msp: true, client: false, description: 'Administer workflows' },
+
         // Service permissions
         { resource: 'service', action: 'create', msp: true, client: false, description: 'Create services' },
         { resource: 'service', action: 'read', msp: true, client: false, description: 'View services' },

--- a/server/migrations/20260424200000_ensure_workflow_permissions_for_newer_tenants.cjs
+++ b/server/migrations/20260424200000_ensure_workflow_permissions_for_newer_tenants.cjs
@@ -1,0 +1,77 @@
+const WORKFLOW_PERMISSIONS = [
+  { resource: 'workflow', action: 'read', msp: true, client: false, description: 'Read workflows' },
+  { resource: 'workflow', action: 'view', msp: true, client: false, description: 'View workflows' },
+  { resource: 'workflow', action: 'manage', msp: true, client: false, description: 'Manage workflows' },
+  { resource: 'workflow', action: 'publish', msp: true, client: false, description: 'Publish workflows' },
+  { resource: 'workflow', action: 'admin', msp: true, client: false, description: 'Administer workflows' },
+];
+
+exports.up = async function up(knex) {
+  const tenants = await knex('tenants').select('tenant');
+  if (!tenants.length) return;
+
+  for (const { tenant } of tenants) {
+    const existingPerms = await knex('permissions')
+      .where({ tenant, resource: 'workflow' })
+      .select('permission_id', 'action');
+
+    const existingActions = new Set(existingPerms.map((permission) => permission.action));
+    const permissionsToInsert = WORKFLOW_PERMISSIONS
+      .filter((permission) => !existingActions.has(permission.action))
+      .map((permission) => ({
+        tenant,
+        permission_id: knex.raw('gen_random_uuid()'),
+        created_at: new Date(),
+        ...permission,
+      }));
+
+    if (permissionsToInsert.length > 0) {
+      await knex('permissions').insert(permissionsToInsert);
+    }
+
+    // Keep pre-existing rows aligned with the current MSP-only workflow permission contract.
+    await knex('permissions')
+      .where({ tenant, resource: 'workflow' })
+      .whereIn('action', WORKFLOW_PERMISSIONS.map((permission) => permission.action))
+      .update({ msp: true, client: false });
+
+    const adminRole = await knex('roles')
+      .where({ tenant, msp: true })
+      .whereRaw('LOWER(role_name) = ?', ['admin'])
+      .first('role_id');
+
+    if (!adminRole) continue;
+
+    const workflowPermissionRows = await knex('permissions')
+      .where({ tenant, resource: 'workflow', msp: true })
+      .whereIn('action', WORKFLOW_PERMISSIONS.map((permission) => permission.action))
+      .select('permission_id');
+
+    if (!workflowPermissionRows.length) continue;
+
+    const existingRolePerms = await knex('role_permissions')
+      .where({ tenant, role_id: adminRole.role_id })
+      .whereIn('permission_id', workflowPermissionRows.map((permission) => permission.permission_id))
+      .select('permission_id');
+
+    const existingRolePermIds = new Set(existingRolePerms.map((rolePermission) => rolePermission.permission_id));
+    const rolePermissionsToInsert = workflowPermissionRows
+      .filter((permission) => !existingRolePermIds.has(permission.permission_id))
+      .map((permission) => ({
+        tenant,
+        role_id: adminRole.role_id,
+        permission_id: permission.permission_id,
+      }));
+
+    if (rolePermissionsToInsert.length > 0) {
+      await knex('role_permissions').insert(rolePermissionsToInsert);
+    }
+  }
+};
+
+exports.down = async function down() {
+  // Deliberately no-op: workflow permissions are a baseline entitlement also
+  // created by earlier migrations. This migration repairs tenants created after
+  // those migrations ran, so rollback cannot safely distinguish repaired rows
+  // from rows that predated this migration.
+};


### PR DESCRIPTION
## Summary
- Add baseline workflow permissions to EE onboarding permissions seed so newly-created tenants get workflow access.
- Add an idempotent migration to repair existing tenants missing workflow permissions and assign them to MSP Admin.
- Keep workflow permissions MSP-only and do not depend on ABAC bundle configuration.

## Production evidence
- Failing tenant `2ac4adb7-853a-41a2-84b5-098af3d2fa11` had zero `workflow:*` permission rows, causing workflow server actions to throw 403.
- Known-good tenant `55f6a1b8-8ad9-42c7-ba39-a508dcaecd37` had `workflow:read/view/manage/publish/admin` assigned to MSP Admin.
- Failing tenant had zero authorization bundles/assignments, so ABAC was not the direct cause.

## Testing
- `node -e "require('./server/migrations/20260424200000_ensure_workflow_permissions_for_newer_tenants.cjs'); require('./ee/server/seeds/onboarding/02_permissions.cjs'); console.log('syntax ok')"`
