### PR TITLE
Fix inbound email layout table parsing

### DIFF
--- a/shared/lib/utils/__tests__/contentConversion.test.ts
+++ b/shared/lib/utils/__tests__/contentConversion.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { convertHtmlToBlockNote } from '../contentConversion';
+
+function textFromBlock(block: any): string {
+  const content = Array.isArray(block.content) ? block.content : [];
+  return content.map((item: any) => item.text ?? '').join('');
+}
+
+describe('convertHtmlToBlockNote email table handling', () => {
+  it('preserves table blocks by default', async () => {
+    const result = await convertHtmlToBlockNote(`
+      <table>
+        <tr><td>Name</td><td>Ada Lovelace</td></tr>
+        <tr><td>Business Email Address</td><td>ada@example.com</td></tr>
+      </table>
+    `);
+
+    expect(result.some((block) => block.type === 'table')).toBe(true);
+  });
+
+  it('preserves normal data tables as BlockNote table blocks even when email table cleanup is enabled', async () => {
+    const result = await convertHtmlToBlockNote(`
+      <table>
+        <tr><th>Name</th><th>Email</th></tr>
+        <tr><td>Ada Lovelace</td><td>ada@example.com</td></tr>
+        <tr><td>Grace Hopper</td><td>grace@example.com</td></tr>
+      </table>
+    `, { flattenTables: true });
+
+    const tableBlock = result.find((block) => block.type === 'table');
+    expect(tableBlock).toBeDefined();
+    expect((tableBlock?.content as any)?.rows).toHaveLength(3);
+    expect((tableBlock?.content as any)?.rows[0].cells).toHaveLength(2);
+  });
+
+  it('splits collapsed nested layout-table content into label/value paragraphs', async () => {
+    const result = await convertHtmlToBlockNote(`
+      <table>
+        <tr><td>
+          <h2>Entry Details</h2>
+          <table><tr><td>
+            <h2>Tools &amp; Resources</h2>
+            <table>
+              <tr><td><p><b>Name</b></p></td><td><p>Ada Lovelace</p></td></tr>
+              <tr><td><p><b>Business Email Address</b></p></td><td><p>ada@example.com</p></td></tr>
+              <tr><td><p><b>Description of Issue</b></p></td><td><p>Requesting a call back.</p></td></tr>
+            </table>
+          </td></tr></table>
+        </td></tr>
+      </table>
+    `, { flattenTables: true });
+
+    expect(result.every((block) => block.type === 'paragraph')).toBe(true);
+    expect(result.map(textFromBlock)).toContain('Name Ada Lovelace');
+    expect(result.map(textFromBlock)).toContain('Business Email Address ada@example.com');
+    expect(result.map(textFromBlock)).toContain('Description of Issue Requesting a call back.');
+  });
+});

--- a/shared/lib/utils/contentConversion.ts
+++ b/shared/lib/utils/contentConversion.ts
@@ -4,6 +4,16 @@ import { convertMarkdownToBlocks, type BlockNoteBlock } from './markdownToBlocks
 export { convertMarkdownToBlocks };
 export type { BlockNoteBlock };
 
+export interface HtmlToBlockNoteOptions {
+  /**
+   * Email clients and form tools often use HTML tables for layout. BlockNote
+   * preserves those as table blocks, which can render as bunched-up text in the
+   * ticket detail view. Enable this for inbound email bodies to convert table
+   * rows into plain paragraph blocks while keeping native parsing elsewhere.
+   */
+  flattenTables?: boolean;
+}
+
 // Lazy singleton — avoids re-creating jsdom + Tiptap extensions per call.
 let _serverEditor: ReturnType<typeof ServerBlockNoteEditor.create> | null = null;
 function getServerEditor() {
@@ -46,6 +56,166 @@ function extractRawMarkdownFromBlocks(blocks: BlockNoteBlock[]): string | null {
   return MARKDOWN_SIGNAL_PATTERN.test(text) ? text : null;
 }
 
+function defaultParagraphProps() {
+  return {
+    textAlignment: 'left',
+    backgroundColor: 'default',
+    textColor: 'default',
+  };
+}
+
+function paragraphBlock(text: string): BlockNoteBlock {
+  return {
+    type: 'paragraph',
+    props: defaultParagraphProps(),
+    content: [{ type: 'text', text, styles: {} }],
+  };
+}
+
+function extractTextFromBlockNoteContent(value: unknown): string {
+  if (!value) return '';
+
+  if (typeof value === 'string') return value;
+
+  if (Array.isArray(value)) {
+    return value
+      .map(extractTextFromBlockNoteContent)
+      .filter(Boolean)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  if (typeof value !== 'object') return '';
+
+  const record = value as Record<string, any>;
+  if (typeof record.text === 'string') return record.text;
+  if (record.type === 'link') return extractTextFromBlockNoteContent(record.content);
+  if (record.type === 'tableCell') return extractTextFromBlockNoteContent(record.content);
+  if (record.content) return extractTextFromBlockNoteContent(record.content);
+  if (record.children) return extractTextFromBlockNoteContent(record.children);
+
+  return '';
+}
+
+function isLikelyLabelInlineContent(item: any): boolean {
+  if (!item || typeof item !== 'object') return false;
+  if (item.styles?.bold === true) return true;
+  if (item.type === 'link' && Array.isArray(item.content)) {
+    return item.content.some(isLikelyLabelInlineContent);
+  }
+  return false;
+}
+
+function normalizeCellText(value: string): string[] {
+  return value
+    .replace(/\u00a0/g, ' ')
+    .split(/\n+/)
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+}
+
+/**
+ * Break a collapsed one-cell email-layout table into semantic text segments.
+ *
+ * The inbound failure case is not a normal data table. The source email has many
+ * nested presentation tables, but BlockNote's HTML parser flattens that whole
+ * nest into a single table cell whose inline content alternates like:
+ *
+ *   bold label, plain value, bold label, plain value, ...
+ *
+ * Example: `Name` (bold), `Ada Lovelace`, `Business Email Address` (bold), ...
+ * That shape renders as one bunched-up table cell in the ticket viewer. To
+ * recover readable content, keep each text run and mark whether it came from a
+ * likely field label. Bold inline content is the strongest signal because the
+ * form-like emails style labels in bold/uppercase while values are plain text.
+ *
+ * We do not use this for multi-row/multi-column tables; those remain BlockNote
+ * table blocks and are handled by `flattenTableBlock`'s shape checks.
+ */
+function getSingleCellContentSegments(cell: any): Array<{ text: string; isLabel: boolean }> {
+  const content = Array.isArray(cell?.content) ? cell.content : [];
+  return content.flatMap((item: any) => {
+    const text = extractTextFromBlockNoteContent(item);
+    const isLabel = isLikelyLabelInlineContent(item);
+    return normalizeCellText(text).map((line) => ({ text: line, isLabel }));
+  });
+}
+
+/**
+ * Convert recovered label/value segments to paragraphs.
+ *
+ * A label followed by a non-label value becomes one line (`Label Value`). Any
+ * unpaired labels/values are kept as their own paragraphs so we do not discard
+ * content when an email field is blank or the parser emits an unexpected run.
+ */
+function singleCellSegmentsToParagraphBlocks(
+  segments: Array<{ text: string; isLabel: boolean }>
+): BlockNoteBlock[] {
+  if (segments.length === 0) return [];
+
+  const lines: string[] = [];
+  for (let i = 0; i < segments.length; i += 1) {
+    const current = segments[i];
+    const next = segments[i + 1];
+
+    if (current.isLabel && next && !next.isLabel) {
+      lines.push(`${current.text} ${next.text}`.trim());
+      i += 1;
+      continue;
+    }
+
+    lines.push(current.text);
+  }
+
+  return lines.map(paragraphBlock);
+}
+
+/**
+ * Decide whether a parsed table is an email layout artifact and, if so, flatten
+ * it into readable paragraphs.
+ *
+ * Target only the narrow problematic shape:
+ * 1. BlockNote parsed the table as exactly one row.
+ * 2. That row has exactly one cell.
+ * 3. The cell contains more than one text segment, with at least one segment
+ *    styled like a label (currently bold inline content).
+ *
+ * This protects normal data tables. A real table such as a 3x2 status grid has
+ * multiple rows/cells and is returned unchanged as a BlockNote `table` block.
+ * The one-cell + label/value pattern, however, is almost always a presentation
+ * table from email/form tooling that BlockNote collapsed during HTML parsing.
+ */
+function flattenTableBlock(block: BlockNoteBlock): BlockNoteBlock[] {
+  const rows = (block.content as any)?.rows;
+  if (!Array.isArray(rows)) return [block];
+
+  if (rows.length !== 1) return [block];
+
+  const cells = Array.isArray(rows[0]?.cells) ? rows[0].cells : [];
+  if (cells.length !== 1) return [block];
+
+  const segments = getSingleCellContentSegments(cells[0]);
+  const hasLabelValueRuns = segments.some((segment) => segment.isLabel) && segments.length > 1;
+  if (!hasLabelValueRuns) return [block];
+
+  return singleCellSegmentsToParagraphBlocks(segments);
+}
+
+function flattenTableBlocks(blocks: BlockNoteBlock[]): BlockNoteBlock[] {
+  return blocks.flatMap((block) => {
+    if (block.type === 'table') {
+      return flattenTableBlock(block);
+    }
+
+    if (Array.isArray(block.children) && block.children.length > 0) {
+      return [{ ...block, children: flattenTableBlocks(block.children) }];
+    }
+
+    return [block];
+  });
+}
+
 /**
  * Convert HTML to BlockNote blocks using BlockNote's own parser.
  * Handles Outlook CSS, HTML comments, `<style>` blocks, etc. natively.
@@ -54,7 +224,10 @@ function extractRawMarkdownFromBlocks(blocks: BlockNoteBlock[]): string | null {
  * Outlook), the result is re-parsed through the markdown parser to produce
  * properly structured blocks (headings, lists, bold, etc.).
  */
-export async function convertHtmlToBlockNote(html: string): Promise<BlockNoteBlock[]> {
+export async function convertHtmlToBlockNote(
+  html: string,
+  options: HtmlToBlockNoteOptions = {},
+): Promise<BlockNoteBlock[]> {
   if (!html) return [];
 
   // Strip non-content markup that ServerBlockNoteEditor may pass through as
@@ -77,7 +250,11 @@ export async function convertHtmlToBlockNote(html: string): Promise<BlockNoteBlo
     .replace(/<\/?\w+:[^>]*>/g, '');
 
   const editor = getServerEditor();
-  const blocks = await editor.tryParseHTMLToBlocks(cleanHtml);
+  let blocks = await editor.tryParseHTMLToBlocks(cleanHtml) as BlockNoteBlock[];
+
+  if (options.flattenTables) {
+    blocks = flattenTableBlocks(blocks);
+  }
 
   // Detect raw-markdown-in-paragraphs (Outlook wrapping markdown lines in <p>)
   const rawMarkdown = extractRawMarkdownFromBlocks(blocks as BlockNoteBlock[]);

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -476,7 +476,7 @@ async function blocksFromEmailBody(params: {
 
   if (html) {
     try {
-      const blocks = await convertHtmlToBlockNote(html);
+      const blocks = await convertHtmlToBlockNote(html, { flattenTables: true });
       return blocks.length ? blocks : blocksFallbackFromText(text ?? '');
     } catch {
       return blocksFallbackFromText(text ?? '');


### PR DESCRIPTION
## Summary
- Add targeted inbound-email table cleanup for collapsed one-cell layout tables from HTML email/form tooling
- Preserve normal multi-row/multi-column HTML tables as BlockNote table blocks
- Enable the cleanup only for inbound email body conversion
- Add focused tests for default table preservation, inbound cleanup preservation of normal tables, and collapsed layout-table flattening

## Validation
- cd shared && npx vitest run --config vitest.config.ts lib/utils/__tests__/contentConversion.test.ts --reporter=dot
- cd shared && npm run typecheck
- Ran the production EML sample through the local inbound pipeline for tenant 2313304f-0253-48fb-8a34-af237f9d1111 and verified the stored content no longer contains a table block for the problematic layout-table area
- Ran a simple 3x2 table sanity check and verified it remains a BlockNote table block