### PR TITLE
Fix Citus appointment email template migration

### DIFF
--- a/server/migrations/20260423133000_add_teams_links_to_appointment_email_templates.cjs
+++ b/server/migrations/20260423133000_add_teams_links_to_appointment_email_templates.cjs
@@ -5,6 +5,8 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
+exports.config = { transaction: false };
+
 const ensureSequentialMode = async (knex) => {
   await knex.raw(`
     DO $$

--- a/server/migrations/20260423133000_add_teams_links_to_appointment_email_templates.cjs
+++ b/server/migrations/20260423133000_add_teams_links_to_appointment_email_templates.cjs
@@ -5,7 +5,22 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
+const ensureSequentialMode = async (knex) => {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_extension WHERE extname = 'citus'
+      ) THEN
+        EXECUTE 'SET citus.multi_shard_modify_mode TO ''sequential''';
+      END IF;
+    END $$;
+  `);
+};
+
 exports.up = async function (knex) {
+  await ensureSequentialMode(knex);
+
   const { upsertEmailTemplate } = require('./utils/templates/_shared/upsertEmailTemplates.cjs');
   const { getTemplate: getAppointmentRequestApproved } = require('./utils/templates/email/appointments/appointmentRequestApproved.cjs');
   const { getTemplate: getAppointmentAssignedTechnician } = require('./utils/templates/email/appointments/appointmentAssignedTechnician.cjs');


### PR DESCRIPTION
## Summary
- Disable the transaction wrapper for `20260423133000_add_teams_links_to_appointment_email_templates.cjs`.
- Set `citus.multi_shard_modify_mode` to sequential before the system email template upserts.

## Why
The migration reads `notification_subtypes` and then upserts `system_email_templates`. In production Citus, this can fail inside a Knex migration transaction with:

> cannot modify table "system_email_templates" because there was a parallel operation on a distributed table

Disabling the transaction and forcing sequential modify mode matches the Citus compatibility pattern used by other migrations.

## Testing
- `node -e "require('./server/migrations/20260423133000_add_teams_links_to_appointment_email_templates.cjs'); console.log('syntax ok')"`
