### PR TITLE
Require tenant ownership for workflow definitions

### DIFF
--- a/ee/packages/workflows/src/actions/workflow-event-catalog-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-event-catalog-v2-actions.ts
@@ -301,7 +301,7 @@ export const listEventCatalogWithMetricsAction = withAuth(async (user, { tenant 
       ? await knex('workflow_definitions')
         .select(knex.raw("trigger->>'eventName' as event_type"))
         .count('* as count')
-        .where({ status: 'published' })
+        .where({ status: 'published', tenant_id: tenant })
         .whereRaw("trigger->>'eventName' is not null")
         .whereIn(knex.raw("trigger->>'eventName'") as any, eventTypes)
         .groupByRaw("trigger->>'eventName'")
@@ -444,11 +444,10 @@ export const listAttachedWorkflowsByEventTypeAction = withAuth(async (user, { te
       'workflow_id',
       'name',
       'status',
-      'is_system',
       'is_paused',
       'is_visible'
     )
-    .where({ status: 'published' })
+    .where({ status: 'published', tenant_id: tenant })
     .whereRaw("trigger->>'eventName' = ?", [parsed.eventType]);
 
   // published version is max from versions table
@@ -472,7 +471,7 @@ export const listAttachedWorkflowsByEventTypeAction = withAuth(async (user, { te
       name: String(r.name),
       status: String(r.status),
       published_version: versionMap.get(String(r.workflow_id)) ?? null,
-      is_system: Boolean(r.is_system),
+      is_system: false,
       is_paused: Boolean(r.is_paused),
       is_visible: r.is_visible !== false
     }))
@@ -575,14 +574,10 @@ export const detachWorkflowTriggerFromEventAction = withAuth(async (user, { tena
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'publish', knex);
 
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!workflow) {
     throw new Error('Workflow not found');
   }
-  if (workflow.is_system) {
-    await requireWorkflowPermission(user, 'admin', knex);
-  }
-
   // Get latest published version definition.
   const versions = await WorkflowDefinitionVersionModelV2.listByWorkflow(knex, parsed.workflowId);
   const latest = versions[0];

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -1204,7 +1204,7 @@ const auditWorkflowEvent = async (
 export const listWorkflowDefinitionsAction = withAuth(async (user, { tenant }) => {
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'read', knex);
-  const records = await WorkflowDefinitionModelV2.list(knex);
+  const records = await WorkflowDefinitionModelV2.list(knex, tenant);
   const workflowIds = records.map((record) => record.workflow_id);
   const publishedVersionMap = new Map<string, number | null>();
   const scheduleStateMap = await loadWorkflowScheduleStateMap(knex, workflowIds, tenant);
@@ -1249,7 +1249,13 @@ export const listWorkflowDefinitionsPagedAction = withAuth(async (user, { tenant
   const sortBy = parsed.sortBy ?? 'updated_at';
   const sortDirection = parsed.sortDirection ?? 'desc';
 
+  const tenantId = String(tenant ?? '').trim();
+  if (!tenantId) {
+    throwHttpError(400, 'Tenant is required');
+  }
+
   const applyVisibilityFilter = (qb: any) => {
+    qb.where('wd.tenant_id', tenantId);
     if (!canAdmin) {
       qb.whereRaw('coalesce(wd.is_visible, true) = true');
     }
@@ -1370,6 +1376,11 @@ export const listWorkflowDefinitionVersionsAction = withAuth(async (user, { tena
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'read', knex);
 
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
+  if (!workflow) {
+    return throwHttpError(404, 'Not found');
+  }
+
   const rows = await knex('workflow_definition_versions')
     .select('version', 'published_at', 'created_at')
     .where({ workflow_id: parsed.workflowId })
@@ -1407,7 +1418,7 @@ export const createWorkflowDefinitionAction = withAuth(async (user, { tenant }, 
     tenant
   });
 
-  const record = await WorkflowDefinitionModelV2.create(knex, {
+  const record = await WorkflowDefinitionModelV2.create(knex, tenant, {
     workflow_id: workflowId,
     key: parsed.key?.trim() ?? null,
     name: definition.name,
@@ -1454,6 +1465,11 @@ export const getWorkflowDefinitionVersionAction = withAuth(async (user, { tenant
   const parsed = GetWorkflowDefinitionVersionInput.parse(input);
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'read', knex);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
+  if (!workflow) {
+    return throwHttpError(404, 'Not found');
+  }
+
   const record = await WorkflowDefinitionVersionModelV2.getByWorkflowAndVersion(
     knex,
     parsed.workflowId,
@@ -1471,10 +1487,7 @@ export const updateWorkflowDefinitionDraftAction = withAuth(async (user, { tenan
 
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'manage', knex);
-  const current = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
-  if (current?.is_system) {
-    await requireWorkflowPermission(user, 'admin', knex);
-  }
+  const current = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   const normalizedDraft = normalizeTimeTriggerDraftContract({
     definition: { ...parsed.definition, id: parsed.workflowId },
     payloadSchemaMode: parsed.payloadSchemaMode ?? (typeof (current as any)?.payload_schema_mode === 'string' ? (current as any).payload_schema_mode : 'pinned'),
@@ -1497,7 +1510,7 @@ export const updateWorkflowDefinitionDraftAction = withAuth(async (user, { tenan
     tenant
   });
 
-  const updated = await WorkflowDefinitionModelV2.update(knex, parsed.workflowId, {
+  const updated = await WorkflowDefinitionModelV2.update(knex, tenant, parsed.workflowId, {
     draft_definition: definition,
     draft_version: definition.version,
     updated_by: user.user_id,
@@ -1543,17 +1556,13 @@ export const updateWorkflowDefinitionMetadataAction = withAuth(async (user, { te
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'manage', knex);
 
-  const current = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const current = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!current) {
     return throwHttpError(404, 'Not found');
   }
-  if (current.is_system) {
-    await requireWorkflowPermission(user, 'admin', knex);
-  }
-
   const nextIsPaused = parsed.isPaused ?? current.is_paused ?? false;
 
-  const updated = await WorkflowDefinitionModelV2.update(knex, parsed.workflowId, {
+  const updated = await WorkflowDefinitionModelV2.update(knex, tenant, parsed.workflowId, {
     ...(parsed.key ? { key: parsed.key.trim() } : {}),
     is_visible: parsed.isVisible ?? current.is_visible ?? true,
     is_paused: nextIsPaused,
@@ -1601,19 +1610,15 @@ export const updateWorkflowDefinitionMetadataAction = withAuth(async (user, { te
 });
 
 export const preCheckWorkflowDefinitionDeletion = withAuth(async (
-  _user,
-  _ctx,
+  user,
+  { tenant },
   input: unknown
 ): Promise<DeletionValidationResult> => {
   const parsed = DeleteWorkflowDefinitionInput.parse(input);
   const { knex } = await createTenantKnex();
+  await requireWorkflowPermission(user, 'read', knex);
 
-  const base = await preCheckDeletion('workflow', parsed.workflowId);
-  if (!base.canDelete) {
-    return base;
-  }
-
-  const current = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const current = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!current) {
     return {
       canDelete: false,
@@ -1624,18 +1629,13 @@ export const preCheckWorkflowDefinitionDeletion = withAuth(async (
     };
   }
 
-  if (current.is_system) {
-    return {
-      ...base,
-      canDelete: false,
-      code: 'PERMISSION_DENIED',
-      message: 'System workflows cannot be deleted.',
-      dependencies: []
-    };
+  const base = await preCheckDeletion('workflow', parsed.workflowId);
+  if (!base.canDelete) {
+    return base;
   }
 
   const activeRuns = await knex('workflow_runs')
-    .where({ workflow_id: parsed.workflowId })
+    .where({ workflow_id: parsed.workflowId, tenant_id: tenant })
     .whereIn('status', ['RUNNING', 'WAITING'])
     .count('* as count')
     .first();
@@ -1667,13 +1667,9 @@ export const deleteWorkflowDefinitionAction = withAuth(async (
 ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
   const parsed = DeleteWorkflowDefinitionInput.parse(input);
   const { knex } = await createTenantKnex();
+  await requireWorkflowPermission(user, 'manage', knex);
 
-  const base = await preCheckDeletion('workflow', parsed.workflowId);
-  if (!base.canDelete) {
-    return { ...base, success: false };
-  }
-
-  const current = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const current = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!current) {
     return {
       success: false,
@@ -1684,19 +1680,14 @@ export const deleteWorkflowDefinitionAction = withAuth(async (
       alternatives: []
     };
   }
-  if (current.is_system) {
-    return {
-      success: false,
-      canDelete: false,
-      code: 'PERMISSION_DENIED',
-      message: 'System workflows cannot be deleted.',
-      dependencies: [],
-      alternatives: base.alternatives
-    };
+
+  const base = await preCheckDeletion('workflow', parsed.workflowId);
+  if (!base.canDelete) {
+    return { ...base, success: false };
   }
 
   const activeRuns = await knex('workflow_runs')
-    .where({ workflow_id: parsed.workflowId })
+    .where({ workflow_id: parsed.workflowId, tenant_id: tenant })
     .whereIn('status', ['RUNNING', 'WAITING'])
     .count('* as count')
     .first();
@@ -1728,7 +1719,7 @@ export const deleteWorkflowDefinitionAction = withAuth(async (
 
   const result = await deleteEntityWithValidation('workflow', parsed.workflowId, knex, tenant, async (trx) => {
     const runIds = await trx('workflow_runs')
-      .where({ workflow_id: parsed.workflowId })
+      .where({ workflow_id: parsed.workflowId, tenant_id: tenant })
       .pluck('run_id');
 
     if (runIds.length > 0) {
@@ -1745,11 +1736,11 @@ export const deleteWorkflowDefinitionAction = withAuth(async (
       .del();
 
     await trx('tenant_workflow_schedule')
-      .where({ workflow_id: parsed.workflowId })
+      .where({ workflow_id: parsed.workflowId, tenant_id: tenant })
       .del();
 
     await trx('workflow_definitions')
-      .where({ workflow_id: parsed.workflowId })
+      .where({ workflow_id: parsed.workflowId, tenant_id: tenant })
       .del();
   });
 
@@ -1783,14 +1774,10 @@ export const publishWorkflowDefinitionAction = withAuth(async (user, { tenant },
 
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'publish', knex);
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!workflow) {
     return throwHttpError(404, 'Not found');
   }
-  if (workflow.is_system) {
-    await requireWorkflowPermission(user, 'admin', knex);
-  }
-
   const maxVersionRow = await knex('workflow_definition_versions')
     .where({ workflow_id: parsed.workflowId })
     .max('version as max_version')
@@ -1876,7 +1863,7 @@ export const publishWorkflowDefinitionAction = withAuth(async (user, { tenant },
 
   const nextDraftVersion = versionToPublish + 1;
   const nextDraftDefinition = { ...definition, version: nextDraftVersion };
-  await WorkflowDefinitionModelV2.update(knex, parsed.workflowId, {
+  await WorkflowDefinitionModelV2.update(knex, tenant, parsed.workflowId, {
     status: 'published',
     draft_definition: nextDraftDefinition,
     draft_version: nextDraftVersion,
@@ -1974,15 +1961,9 @@ export const startWorkflowRunAction = withAuth(async (user, { tenant }, input: u
     return throwHttpError(413, 'Payload exceeds maximum size');
   }
 
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!workflow) {
     return throwHttpError(404, 'Workflow not found');
-  }
-  if (workflow.is_system) {
-    const canAdmin = await hasPermission(user, 'workflow', 'admin', knex);
-    if (!canAdmin) {
-      return throwHttpError(403, 'Forbidden');
-    }
   }
   if (workflow.is_paused) {
     return throwHttpError(409, 'Workflow is paused');
@@ -2196,7 +2177,7 @@ export const getWorkflowScheduleStateAction = withAuth(async (user, { tenant }, 
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'read', knex);
 
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, parsed.workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.workflowId);
   if (!workflow) {
     return throwHttpError(404, 'Not found');
   }
@@ -2555,6 +2536,19 @@ export const listWorkflowAuditLogsAction = withAuth(async (user, { tenant }, inp
   const parsed = ListWorkflowAuditLogsInput.parse(input);
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'admin', knex);
+
+  if (parsed.tableName === 'workflow_definitions') {
+    const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, parsed.recordId);
+    if (!workflow) {
+      return throwHttpError(404, 'Not found');
+    }
+  }
+  if (parsed.tableName === 'workflow_runs') {
+    const run = await WorkflowRunModelV2.getById(knex, parsed.recordId);
+    if (!run || (tenant && run.tenant_id !== tenant)) {
+      return throwHttpError(404, 'Not found');
+    }
+  }
 
   const rows = await knex('audit_logs')
     .where({ table_name: parsed.tableName, record_id: parsed.recordId })
@@ -3287,7 +3281,7 @@ export const submitWorkflowEventAction = withAuth(async (user, { tenant }, input
     }
   }
 
-  const triggered = await WorkflowDefinitionModelV2.list(knex);
+  const triggered = await WorkflowDefinitionModelV2.list(knex, tenant);
   const matching = triggered.filter((workflow) => {
     const trigger = workflow.trigger as WorkflowTrigger | null | undefined;
     return isWorkflowEventTrigger(trigger) && trigger.eventName === parsed.eventName && workflow.status === 'published';

--- a/ee/packages/workflows/src/actions/workflow-schedule-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-schedule-v2-actions.ts
@@ -283,6 +283,7 @@ const resolvePayloadSchemaRef = (
 
 const validateSchedulableWorkflow = async (
   knex: Awaited<ReturnType<typeof createTenantKnex>>['knex'],
+  tenant: string,
   workflowId: string,
   payload: Record<string, unknown>
 ): Promise<
@@ -293,7 +294,7 @@ const validateSchedulableWorkflow = async (
     }
 > => {
   ensureWorkflowPayloadSchemasRegistered();
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, workflowId);
   if (!workflow) {
     return throwHttpError(404, 'Workflow not found');
   }
@@ -343,7 +344,7 @@ const enrichScheduleRow = async (
   tenant: string,
   schedule: WorkflowScheduleStateRecord
 ) => {
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, schedule.workflow_id);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, tenant, schedule.workflow_id);
   const dayTypeFilter = normalizeWorkflowDayTypeFilter(schedule.day_type_filter);
   const resolvedBusinessDaySettings = await resolveWorkflowBusinessDaySettings(knex, {
     tenantId: tenant,
@@ -468,7 +469,7 @@ async function mutateWorkflowSchedule(
     );
   }
 
-  const schedulable = await validateSchedulableWorkflow(knex, input.workflowId, input.payload);
+  const schedulable = await validateSchedulableWorkflow(knex, tenant, input.workflowId, input.payload);
   if (isValidationFailure(schedulable)) {
     return schedulable;
   }

--- a/ee/packages/workflows/src/lib/workflowRunLauncher.ts
+++ b/ee/packages/workflows/src/lib/workflowRunLauncher.ts
@@ -129,7 +129,7 @@ export async function launchPublishedWorkflowRun(
 ): Promise<WorkflowRunLaunchResult> {
   initializeWorkflowRuntimeV2();
 
-  const workflow = await WorkflowDefinitionModelV2.getById(knex, request.workflowId);
+  const workflow = await WorkflowDefinitionModelV2.getById(knex, request.tenantId ?? '', request.workflowId);
   if (!workflow) {
     throw new Error('Workflow not found');
   }

--- a/ee/server/src/__tests__/integration/helpers/workflowSeedHelper.ts
+++ b/ee/server/src/__tests__/integration/helpers/workflowSeedHelper.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -25,24 +26,36 @@ type SystemWorkflowDefinition = {
   steps: Array<Record<string, unknown>>;
 };
 
-const loadSystemWorkflowDefinition = (): SystemWorkflowDefinition => {
-  const raw = fs.readFileSync(SYSTEM_WORKFLOW_PATH, 'utf8');
-  const parsed = JSON.parse(raw) as SystemWorkflowDefinition;
-  return { ...parsed, id: SYSTEM_WORKFLOW_ID };
+const tenantWorkflowId = (tenantId: string): string => {
+  const hex = createHash('sha256').update(`${SYSTEM_WORKFLOW_ID}:${tenantId}`).digest('hex').slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 };
 
-export async function ensureSystemEmailWorkflow(db: Knex): Promise<void> {
+const loadSystemWorkflowDefinition = (workflowId: string): SystemWorkflowDefinition => {
+  const raw = fs.readFileSync(SYSTEM_WORKFLOW_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as SystemWorkflowDefinition;
+  return { ...parsed, id: workflowId };
+};
+
+export async function ensureSystemEmailWorkflow(db: Knex, tenantId?: string): Promise<void> {
+  const resolvedTenantId = tenantId ?? (await db('tenants').select('tenant').first())?.tenant;
+  if (!resolvedTenantId) {
+    throw new Error('tenant_id is required to seed the legacy email workflow fixture');
+  }
+
+  const workflowId = tenantWorkflowId(resolvedTenantId);
   const existing = await db('workflow_definitions')
-    .where({ workflow_id: SYSTEM_WORKFLOW_ID })
+    .where({ workflow_id: workflowId, tenant_id: resolvedTenantId })
     .first();
   if (existing) {
     return;
   }
 
-  const definition = loadSystemWorkflowDefinition();
+  const definition = loadSystemWorkflowDefinition(workflowId);
   const now = new Date().toISOString();
   const record: Record<string, any> = {
-    workflow_id: SYSTEM_WORKFLOW_ID,
+    workflow_id: workflowId,
+    tenant_id: resolvedTenantId,
     name: definition.name,
     description: definition.description ?? null,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -55,7 +68,7 @@ export async function ensureSystemEmailWorkflow(db: Knex): Promise<void> {
   };
 
   if (await db.schema.hasColumn('workflow_definitions', 'is_system')) {
-    record.is_system = true;
+    record.is_system = false;
   }
   if (await db.schema.hasColumn('workflow_definitions', 'is_visible')) {
     record.is_visible = true;
@@ -69,12 +82,12 @@ export async function ensureSystemEmailWorkflow(db: Knex): Promise<void> {
   }
 
   const versionExists = await db('workflow_definition_versions')
-    .where({ workflow_id: SYSTEM_WORKFLOW_ID, version: definition.version })
+    .where({ workflow_id: workflowId, version: definition.version })
     .first();
   if (!versionExists) {
     await db('workflow_definition_versions').insert({
       version_id: uuidv4(),
-      workflow_id: SYSTEM_WORKFLOW_ID,
+      workflow_id: workflowId,
       version: definition.version,
       definition_json: definition,
       payload_schema_json: null,

--- a/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
@@ -66,7 +66,7 @@ async function setupDesigner(page: Page): Promise<{
     permissions: ADMIN_PERMISSIONS,
   });
 
-  await ensureSystemEmailWorkflow(db);
+  await ensureSystemEmailWorkflow(db, tenantData.tenant.tenantId);
 
   const workflowPage = new WorkflowDesignerPage(page);
   await workflowPage.goto(TEST_CONFIG.baseUrl);
@@ -76,6 +76,8 @@ async function setupDesigner(page: Page): Promise<{
 async function seedWorkflowDefinitions(db: Knex, count: number): Promise<{ ids: string[]; names: string[] }> {
   const ids: string[] = [];
   const names: string[] = [];
+  const tenantId = (await db('tenants').select('tenant').first())?.tenant;
+  if (!tenantId) throw new Error('tenant_id is required to seed workflow definitions');
   const now = new Date().toISOString();
   const records = Array.from({ length: count }).map((_, index) => {
     const workflowId = uuidv4();
@@ -92,6 +94,7 @@ async function seedWorkflowDefinitions(db: Knex, count: number): Promise<{ ids: 
     names.push(name);
     return {
       workflow_id: workflowId,
+      tenant_id: tenantId,
       name,
       description: null,
       payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-contract-inference.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-contract-inference.playwright.test.ts
@@ -155,7 +155,7 @@ async function setupDesigner(page: Page, permissions = ADMIN_PERMISSIONS): Promi
     });
   }
 
-  await ensureSystemEmailWorkflow(db);
+  await ensureSystemEmailWorkflow(db, tenantData.tenant.tenantId);
 
   await page.goto(`${TEST_CONFIG.baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
   await page.waitForLoadState('networkidle', { timeout: 30_000 });
@@ -167,6 +167,7 @@ async function setupDesigner(page: Page, permissions = ADMIN_PERMISSIONS): Promi
 
 async function createWorkflowWithTrigger(
   db: Knex,
+  tenantId: string,
   name: string,
   triggerEventName: string,
   payloadSchemaRef: string,
@@ -193,6 +194,7 @@ async function createWorkflowWithTrigger(
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: payloadSchemaRef,
@@ -357,6 +359,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create a workflow with a trigger event
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Inferred Test ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -399,6 +402,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create a workflow in pinned mode
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Pinned Test ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -457,6 +461,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create a workflow in pinned mode
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Mode Switch ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -501,6 +506,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
     try {
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Trigger Distinction ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -535,6 +541,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
     try {
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Preview Test ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -582,6 +589,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create inferred workflow
       workflowId1 = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Inferred Modal ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -591,6 +599,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create pinned workflow
       workflowId2 = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Pinned Modal ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -677,6 +686,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
       // Create a workflow (as admin, before logging in as read-only)
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `ReadOnly Test ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',
@@ -714,6 +724,7 @@ test.describe('Workflow Designer UI - Contract Section', () => {
     try {
       workflowId = await createWorkflowWithTrigger(
         db,
+        tenantData.tenant.tenantId,
         `Effective Preview ${uuidv4().slice(0, 6)}`,
         'INBOUND_EMAIL_RECEIVED',
         'payload.EmailWorkflowPayload.v1',

--- a/ee/server/src/__tests__/integration/workflow-designer-controls.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-controls.playwright.test.ts
@@ -73,7 +73,7 @@ async function createWorkflowTenant(
       }
     ]
   });
-  await ensureSystemEmailWorkflow(db);
+  await ensureSystemEmailWorkflow(db, tenantData.tenant.tenantId);
 
   // Warm the session on the base URL to ensure cookies apply correctly
   await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });

--- a/ee/server/src/__tests__/integration/workflow-designer-dead-letter.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-dead-letter.playwright.test.ts
@@ -57,6 +57,8 @@ type RunStepSeed = {
 
 async function createWorkflowDefinition(db: ReturnType<typeof createTestDbConnection>, name: string, version = 1): Promise<WorkflowSeed> {
   const workflowId = uuidv4();
+  const tenantId = (await db('tenants').select('tenant').first())?.tenant;
+  if (!tenantId) throw new Error('tenant_id is required to seed workflow definition');
   const now = new Date().toISOString();
   const definition = {
     id: workflowId,
@@ -69,6 +71,7 @@ async function createWorkflowDefinition(db: ReturnType<typeof createTestDbConnec
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-e2e.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-e2e.playwright.test.ts
@@ -72,6 +72,8 @@ async function setupDesigner(page: Page): Promise<{
 
 async function createWorkflowDefinition(db: Knex, name: string, steps: Record<string, unknown>[] = []): Promise<WorkflowSeed> {
   const workflowId = uuidv4();
+  const tenantId = (await db('tenants').select('tenant').first())?.tenant;
+  if (!tenantId) throw new Error('tenant_id is required to seed workflow definition');
   const now = new Date().toISOString();
   const definition = {
     id: workflowId,
@@ -84,6 +86,7 @@ async function createWorkflowDefinition(db: Knex, name: string, steps: Record<st
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-events.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-events.playwright.test.ts
@@ -73,6 +73,8 @@ type WaitSeed = {
 
 async function createWorkflowDefinition(db: Knex, name: string, version = 1): Promise<WorkflowSeed> {
   const workflowId = uuidv4();
+  const tenantId = (await db('tenants').select('tenant').first())?.tenant;
+  if (!tenantId) throw new Error('tenant_id is required to seed workflow definition');
   const now = new Date().toISOString();
   const definition = {
     id: workflowId,
@@ -85,6 +87,7 @@ async function createWorkflowDefinition(db: Knex, name: string, version = 1): Pr
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-runs.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-runs.playwright.test.ts
@@ -97,6 +97,8 @@ async function createWorkflowDefinition(
   steps: Step[] = []
 ): Promise<WorkflowSeed> {
   const workflowId = uuidv4();
+  const tenantId = (await db('tenants').select('tenant').first())?.tenant;
+  if (!tenantId) throw new Error('tenant_id is required to seed workflow definition');
   const now = new Date().toISOString();
   const definition = {
     id: workflowId,
@@ -109,6 +111,7 @@ async function createWorkflowDefinition(
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-time-triggers.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-time-triggers.playwright.test.ts
@@ -44,7 +44,7 @@ async function setupDesigner(page: Page): Promise<{
     permissions: ADMIN_PERMISSIONS
   });
 
-  await ensureSystemEmailWorkflow(db);
+  await ensureSystemEmailWorkflow(db, tenantData.tenant.tenantId);
   await page.goto(`${TEST_CONFIG.baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
   await page.waitForLoadState('networkidle', { timeout: 30_000 });
 

--- a/ee/server/src/__tests__/integration/workflow-external-schedules.actions.integration.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-external-schedules.actions.integration.test.ts
@@ -73,6 +73,7 @@ async function seedWorkflow(params?: {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: tenantId,
     name,
     description: null,
     payload_schema_ref: payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-external-schedules.migration.integration.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-external-schedules.migration.integration.test.ts
@@ -78,6 +78,7 @@ describe('Workflow external schedules migration – DB integration', () => {
     const workflowId = uuidv4();
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
+      tenant_id: 'tenant-a',
       name: 'Legacy Workflow',
       description: null,
       payload_schema_ref: 'payload.Empty.v1',

--- a/ee/server/src/__tests__/integration/workflows-ee-entry-smoke.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflows-ee-entry-smoke.playwright.test.ts
@@ -42,7 +42,7 @@ test('EE build: workflows page loads without CE/OSS stub messaging', async ({ pa
       permissions: ADMIN_PERMISSIONS,
     });
 
-    await ensureSystemEmailWorkflow(db);
+    await ensureSystemEmailWorkflow(db, tenantData.tenant.tenantId);
 
     const workflowPage = new WorkflowDesignerPage(page);
     await workflowPage.goto(TEST_CONFIG.baseUrl);

--- a/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
@@ -60,7 +60,7 @@ const TENANT_TABLES_DELETION_ORDER: string[] = [
 
   // Workflow runtime V2 (child tables first, then parent)
   'workflow_run_logs', 'workflow_runtime_events',
-  'workflow_runs', 'tenant_workflow_schedule',
+  'workflow_runs', 'tenant_workflow_schedule', 'workflow_definitions',
 
   // Task/project details
   'task_checklist_items', 'project_task_dependencies', 'task_resources',

--- a/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
+++ b/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
@@ -23,6 +23,7 @@ import {
 import { createTenantSecretProvider } from '@alga-psa/shared/workflow/secrets';
 import {
   WorkflowActionInvocationModelV2,
+  WorkflowDefinitionModelV2,
   WorkflowDefinitionVersionModelV2,
   WorkflowRunStepModelV2,
   WorkflowRunModelV2,
@@ -538,6 +539,12 @@ export async function startWorkflowRuntimeV2ChildRun(input: {
     throw new Error(`Parent workflow run not found: ${input.parentRunId}`);
   }
 
+  const childTenantId = input.tenantId ?? parentRun.tenant_id ?? null;
+  const childDefinition = await WorkflowDefinitionModelV2.getById(knex, childTenantId ?? '', input.workflowId);
+  if (!childDefinition) {
+    throw new Error(`Child workflow definition not found: ${input.workflowId}`);
+  }
+
   const definitionVersion = await WorkflowDefinitionVersionModelV2.getByWorkflowAndVersion(
     knex,
     input.workflowId,
@@ -556,7 +563,7 @@ export async function startWorkflowRuntimeV2ChildRun(input: {
     workflowId: input.workflowId,
     version: input.workflowVersion,
     payload: input.payload,
-    tenantId: input.tenantId ?? parentRun.tenant_id ?? null,
+    tenantId: childTenantId,
     triggerType: null,
     triggerMetadata: {
       parentRunId: parentRun.run_id,

--- a/ee/test-data/workflow-harness/_lib/biz-fixture.cjs
+++ b/ee/test-data/workflow-harness/_lib/biz-fixture.cjs
@@ -322,18 +322,19 @@ async function waitForFixtureRun(ctx, { startedAfter, fixtureNotifyUserId, fixtu
 }
 
 async function withWorkflowPaused(ctx, workflowId, fn) {
-  const rows = await ctx.db.query(`select is_paused from workflow_definitions where workflow_id = $1`, [workflowId]);
+  const tenantId = ctx.config.tenantId;
+  const rows = await ctx.db.query(`select is_paused from workflow_definitions where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
   const wasPaused = rows[0]?.is_paused ?? false;
 
   if (!wasPaused) {
-    await ctx.dbWrite.query(`update workflow_definitions set is_paused = true where workflow_id = $1`, [workflowId]);
+    await ctx.dbWrite.query(`update workflow_definitions set is_paused = true where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
   }
 
   try {
     return await fn();
   } finally {
     if (!wasPaused) {
-      await ctx.dbWrite.query(`update workflow_definitions set is_paused = false where workflow_id = $1`, [workflowId]);
+      await ctx.dbWrite.query(`update workflow_definitions set is_paused = false where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
     }
   }
 }

--- a/scripts/workflow-runtime-v2-compose-smoke.mjs
+++ b/scripts/workflow-runtime-v2-compose-smoke.mjs
@@ -283,6 +283,7 @@ async function runDbProjectionScenario(context) {
 
     await insertWithExistingColumns(db, 'workflow_definitions', {
       workflow_id: workflowId,
+      tenant_id: tenantId,
       name: definition.name,
       description: definition.description,
       payload_schema_ref: definition.payloadSchemaRef,

--- a/server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs
+++ b/server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs
@@ -1,0 +1,302 @@
+const { createHash, randomUUID } = require('crypto');
+
+exports.config = { transaction: false };
+
+const LEGACY_EMAIL_WORKFLOW_ID = '00000000-0000-0000-0000-00000000e001';
+const LEGACY_EMAIL_WORKFLOW_KEY = 'system.email-processing';
+
+const ensureSequentialMode = async (knex) => {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_extension WHERE extname = 'citus'
+      ) THEN
+        EXECUTE 'SET citus.multi_shard_modify_mode TO ''sequential''';
+      END IF;
+    END $$;
+  `);
+};
+
+const hasTable = async (knex, tableName) => knex.schema.hasTable(tableName);
+
+const isCitusEnabled = async (knex) => {
+  const result = await knex.raw(`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_extension WHERE extname = 'citus'
+    ) AS enabled
+  `);
+  return Boolean(result.rows?.[0]?.enabled);
+};
+
+const isWorkflowDefinitionsDistributed = async (knex) => {
+  const result = await knex.raw(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_dist_partition
+      WHERE logicalrelid = 'workflow_definitions'::regclass
+    ) AS distributed
+  `);
+  return Boolean(result.rows?.[0]?.distributed);
+};
+
+const getWorkflowDefinitionsPrimaryKey = async (knex) => {
+  const result = await knex.raw(`
+    SELECT
+      c.conname AS constraint_name,
+      array_agg(a.attname ORDER BY ord.ordinality) AS columns
+    FROM pg_constraint c
+    JOIN unnest(c.conkey) WITH ORDINALITY AS ord(attnum, ordinality) ON true
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ord.attnum
+    WHERE c.conrelid = 'workflow_definitions'::regclass
+      AND c.contype = 'p'
+    GROUP BY c.conname
+  `);
+  return result.rows?.[0] ?? null;
+};
+
+const ensureWorkflowDefinitionsCitusDistribution = async (knex) => {
+  if (!(await isCitusEnabled(knex))) {
+    return;
+  }
+
+  if (await isWorkflowDefinitionsDistributed(knex)) {
+    return;
+  }
+
+  const primaryKey = await getWorkflowDefinitionsPrimaryKey(knex);
+  const primaryKeyColumns = primaryKey?.columns ?? [];
+  const hasTenantScopedPrimaryKey =
+    primaryKeyColumns.length === 2 &&
+    primaryKeyColumns.includes('tenant_id') &&
+    primaryKeyColumns.includes('workflow_id');
+
+  if (primaryKey && !hasTenantScopedPrimaryKey) {
+    await knex.raw('ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ?? CASCADE', [
+      'workflow_definitions',
+      primaryKey.constraint_name,
+    ]);
+  }
+
+  if (!hasTenantScopedPrimaryKey) {
+    await knex.raw(`
+      ALTER TABLE workflow_definitions
+      ADD CONSTRAINT workflow_definitions_tenant_workflow_pk
+      PRIMARY KEY (tenant_id, workflow_id)
+    `);
+  }
+
+  await knex.raw(`
+    SELECT create_distributed_table('workflow_definitions', 'tenant_id', colocate_with => 'tenants')
+  `);
+};
+
+const rewriteDefinitionId = (value, workflowId) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return { ...value, id: workflowId };
+};
+
+const uniqueStrings = (values) => Array.from(new Set(
+  values
+    .map((value) => (value == null ? '' : String(value).trim()))
+    .filter(Boolean)
+));
+
+const deterministicWorkflowId = (workflowId, tenantId) => {
+  const hex = createHash('sha256').update(`${workflowId}:${tenantId}`).digest('hex').slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+const collectTenantEvidence = async (knex, workflow) => {
+  const evidence = [];
+
+  const runRows = await knex('workflow_runs')
+    .distinct('tenant_id')
+    .where({ workflow_id: workflow.workflow_id })
+    .whereNotNull('tenant_id');
+  evidence.push(...runRows.map((row) => row.tenant_id));
+
+  if (await hasTable(knex, 'tenant_workflow_schedule')) {
+    const scheduleRows = await knex('tenant_workflow_schedule')
+      .distinct('tenant_id')
+      .where({ workflow_id: workflow.workflow_id })
+      .whereNotNull('tenant_id');
+    evidence.push(...scheduleRows.map((row) => row.tenant_id));
+  }
+
+  const directEvidence = uniqueStrings(evidence);
+  if (directEvidence.length > 0) {
+    return directEvidence;
+  }
+
+  const actorIds = uniqueStrings([workflow.created_by, workflow.updated_by]);
+  if (!actorIds.length) {
+    return [];
+  }
+
+  const actorRows = await knex('users')
+    .distinct('tenant')
+    .whereIn('user_id', actorIds)
+    .whereNotNull('tenant');
+  return uniqueStrings(actorRows.map((row) => row.tenant));
+};
+
+const deleteObsoleteLegacyWorkflow = async (knex, workflow) => {
+  await knex('workflow_definition_versions').where({ workflow_id: workflow.workflow_id }).del();
+
+  if (await hasTable(knex, 'tenant_workflow_schedule')) {
+    await knex('tenant_workflow_schedule').where({ workflow_id: workflow.workflow_id }).del();
+  }
+
+  await knex('workflow_definitions').where({ workflow_id: workflow.workflow_id }).del();
+};
+
+const cloneWorkflowForTenant = async (knex, workflow, tenantId, options = {}) => {
+  const now = new Date().toISOString();
+  const existingClone = workflow.key
+    ? await knex('workflow_definitions')
+      .where({ tenant_id: tenantId, key: workflow.key })
+      .whereNot('workflow_id', workflow.workflow_id)
+      .first()
+    : null;
+  const newWorkflowId = existingClone?.workflow_id ?? deterministicWorkflowId(workflow.workflow_id, tenantId);
+
+  if (!existingClone) {
+    const clonedWorkflow = {
+      ...workflow,
+      workflow_id: newWorkflowId,
+      tenant_id: tenantId,
+      is_system: false,
+      is_visible: options.hide ? false : workflow.is_visible,
+      is_paused: options.pause ? true : workflow.is_paused,
+      draft_definition: rewriteDefinitionId(workflow.draft_definition, newWorkflowId),
+      created_at: workflow.created_at ?? now,
+      updated_at: now,
+    };
+
+    await knex('workflow_definitions')
+      .insert(clonedWorkflow)
+      .onConflict('workflow_id')
+      .ignore();
+  }
+
+  const versionRows = await knex('workflow_definition_versions')
+    .where({ workflow_id: workflow.workflow_id })
+    .orderBy('version', 'asc');
+
+  for (const version of versionRows) {
+    await knex('workflow_definition_versions')
+      .insert({
+        ...version,
+        version_id: randomUUID(),
+        workflow_id: newWorkflowId,
+        definition_json: rewriteDefinitionId(version.definition_json, newWorkflowId),
+        created_at: version.created_at ?? now,
+        updated_at: now,
+      })
+      .onConflict(['workflow_id', 'version'])
+      .ignore();
+  }
+
+  await knex('workflow_runs')
+    .where({ workflow_id: workflow.workflow_id, tenant_id: tenantId })
+    .update({ workflow_id: newWorkflowId });
+
+  if (await hasTable(knex, 'tenant_workflow_schedule')) {
+    await knex('tenant_workflow_schedule')
+      .where({ workflow_id: workflow.workflow_id, tenant_id: tenantId })
+      .update({ workflow_id: newWorkflowId });
+  }
+
+  return newWorkflowId;
+};
+
+exports.up = async function up(knex) {
+  await ensureSequentialMode(knex);
+
+  const hasTenantId = await knex.schema.hasColumn('workflow_definitions', 'tenant_id');
+  if (!hasTenantId) {
+    await knex.schema.alterTable('workflow_definitions', (table) => {
+      table.text('tenant_id');
+    });
+  }
+
+  await knex.raw('ALTER TABLE workflow_definitions DROP CONSTRAINT IF EXISTS workflow_definitions_key_unique');
+  await knex.raw('DROP INDEX IF EXISTS idx_workflow_definitions_key');
+
+  const workflows = await knex('workflow_definitions').select('*').orderBy('created_at', 'asc');
+
+  for (const workflow of workflows) {
+    const isLegacyEmailWorkflow =
+      workflow.workflow_id === LEGACY_EMAIL_WORKFLOW_ID ||
+      workflow.key === LEGACY_EMAIL_WORKFLOW_KEY;
+
+    if (workflow.tenant_id) {
+      await knex('workflow_definitions')
+        .where({ workflow_id: workflow.workflow_id })
+        .update({
+          is_system: false,
+          ...(isLegacyEmailWorkflow ? { is_visible: false, is_paused: true } : {}),
+        });
+      continue;
+    }
+
+    const tenantIds = await collectTenantEvidence(knex, workflow);
+
+    if (tenantIds.length === 0) {
+      const isObsoleteSystemWorkflow = workflow.is_system === true || isLegacyEmailWorkflow;
+
+      if (isObsoleteSystemWorkflow) {
+        await deleteObsoleteLegacyWorkflow(knex, workflow);
+        continue;
+      }
+
+      throw new Error(
+        `Unable to infer tenant_id for workflow_definitions.${workflow.workflow_id}; ` +
+        'refusing to continue with an unscoped workflow definition.'
+      );
+    }
+
+    const [primaryTenantId, ...additionalTenantIds] = tenantIds.sort();
+
+    for (const tenantId of additionalTenantIds) {
+      await cloneWorkflowForTenant(knex, workflow, tenantId, {
+        hide: isLegacyEmailWorkflow,
+        pause: isLegacyEmailWorkflow,
+      });
+    }
+
+    await knex('workflow_definitions')
+      .where({ workflow_id: workflow.workflow_id })
+      .update({
+        tenant_id: primaryTenantId,
+        is_system: false,
+        ...(isLegacyEmailWorkflow ? { is_visible: false, is_paused: true } : {}),
+        updated_at: new Date().toISOString(),
+      });
+  }
+
+  const unresolved = await knex('workflow_definitions')
+    .whereNull('tenant_id')
+    .select('workflow_id', 'key', 'name');
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Found ${unresolved.length} workflow definitions without tenant_id after backfill: ` +
+      unresolved.map((row) => `${row.workflow_id}${row.key ? ` (${row.key})` : ''}`).join(', ')
+    );
+  }
+
+  await knex.raw('ALTER TABLE workflow_definitions ALTER COLUMN tenant_id SET NOT NULL');
+  await ensureWorkflowDefinitionsCitusDistribution(knex);
+  await knex.raw('CREATE INDEX IF NOT EXISTS idx_workflow_definitions_tenant_status ON workflow_definitions(tenant_id, status)');
+  await knex.raw('CREATE INDEX IF NOT EXISTS idx_workflow_definitions_tenant_updated ON workflow_definitions(tenant_id, updated_at)');
+  await knex.raw('CREATE INDEX IF NOT EXISTS idx_workflow_definitions_tenant_name ON workflow_definitions(tenant_id, name)');
+  await knex.raw('CREATE UNIQUE INDEX IF NOT EXISTS workflow_definitions_tenant_key_unique ON workflow_definitions(tenant_id, key) WHERE key IS NOT NULL');
+};
+
+exports.down = async function down() {
+  // Deliberately no-op. The up migration may split legacy shared definitions into
+  // tenant-owned copies and reassign child rows; that data repair is not safely reversible.
+};

--- a/server/src/lib/actions/workflow-bundle-v1-actions.ts
+++ b/server/src/lib/actions/workflow-bundle-v1-actions.ts
@@ -31,12 +31,12 @@ export const exportWorkflowBundleV1Action = withAuth(async (user, { tenant }, in
   const parsed = WorkflowIdInput.parse(input);
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'admin', knex);
-  return exportWorkflowBundleV1ForWorkflowId(knex, parsed.workflowId);
+  return exportWorkflowBundleV1ForWorkflowId(knex, tenant, parsed.workflowId);
 });
 
 export const importWorkflowBundleV1Action = withAuth(async (user, { tenant }, input: unknown) => {
   const parsed = z.object({ bundle: z.unknown(), force: z.boolean().optional() }).parse(input);
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'admin', knex);
-  return importWorkflowBundleV1(knex, parsed.bundle, { force: parsed.force, actorUserId: user.user_id });
+  return importWorkflowBundleV1(knex, tenant, parsed.bundle, { force: parsed.force, actorUserId: user.user_id });
 });

--- a/server/src/lib/workflow/bundle/exportWorkflowBundleV1.ts
+++ b/server/src/lib/workflow/bundle/exportWorkflowBundleV1.ts
@@ -17,8 +17,8 @@ import type { Knex } from 'knex';
 const normalizeBoolean = (value: unknown, defaultValue: boolean): boolean =>
   typeof value === 'boolean' ? value : defaultValue;
 
-export const exportWorkflowBundleV1ForWorkflowId = async (knex: Knex, workflowId: string): Promise<WorkflowBundleV1> => {
-  const record = await WorkflowDefinitionModelV2.getById(knex, workflowId);
+export const exportWorkflowBundleV1ForWorkflowId = async (knex: Knex, tenantId: string, workflowId: string): Promise<WorkflowBundleV1> => {
+  const record = await WorkflowDefinitionModelV2.getById(knex, tenantId, workflowId);
   if (!record) {
     const error = new Error('Not found') as Error & { status?: number };
     error.status = 404;
@@ -54,7 +54,7 @@ export const exportWorkflowBundleV1ForWorkflowId = async (knex: Knex, workflowId
       pinnedPayloadSchemaRef: record.pinned_payload_schema_ref ?? null,
       trigger: (record.trigger as any) ?? null,
 
-      isSystem: normalizeBoolean(record.is_system, false),
+      isSystem: false,
       isVisible: normalizeBoolean(record.is_visible, true),
       isPaused: normalizeBoolean(record.is_paused, false),
       concurrencyLimit: record.concurrency_limit ?? null,
@@ -80,7 +80,7 @@ export const exportWorkflowBundleV1ForWorkflowId = async (knex: Knex, workflowId
   };
 };
 
-export const exportWorkflowBundleV1ForWorkflowIds = async (knex: Knex, workflowIds: string[]): Promise<WorkflowBundleV1> => {
+export const exportWorkflowBundleV1ForWorkflowIds = async (knex: Knex, tenantId: string, workflowIds: string[]): Promise<WorkflowBundleV1> => {
   const uniqueIds = Array.from(new Set(workflowIds.filter(Boolean)));
   if (!uniqueIds.length) {
     throw new Error('exportWorkflowBundleV1ForWorkflowIds requires at least one workflowId.');
@@ -88,6 +88,7 @@ export const exportWorkflowBundleV1ForWorkflowIds = async (knex: Knex, workflowI
 
   const records = await knex('workflow_definitions')
     .select('*')
+    .where({ tenant_id: tenantId })
     .whereIn('workflow_id', uniqueIds);
 
   const foundIds = new Set(records.map((r: any) => r.workflow_id));
@@ -139,7 +140,7 @@ export const exportWorkflowBundleV1ForWorkflowIds = async (knex: Knex, workflowI
         pinnedPayloadSchemaRef: record.pinned_payload_schema_ref ?? null,
         trigger: record.trigger ?? null,
 
-        isSystem: normalizeBoolean(record.is_system, false),
+        isSystem: false,
         isVisible: normalizeBoolean(record.is_visible, true),
         isPaused: normalizeBoolean(record.is_paused, false),
         concurrencyLimit: record.concurrency_limit ?? null,

--- a/server/src/lib/workflow/bundle/importWorkflowBundleV1.ts
+++ b/server/src/lib/workflow/bundle/importWorkflowBundleV1.ts
@@ -27,6 +27,7 @@ const rewriteWorkflowDefinitionId = (definition: Record<string, unknown>, workfl
 
 export const importWorkflowBundleV1 = async (
   knex: Knex,
+  tenantId: string,
   bundleJson: unknown,
   options: WorkflowBundleImportOptionsV1 = {}
 ): Promise<WorkflowBundleImportSummaryV1> => {
@@ -49,7 +50,7 @@ export const importWorkflowBundleV1 = async (
     for (const wf of bundle.workflows) {
       const existing = await trx('workflow_definitions')
         .select('workflow_id', 'key')
-        .where({ key: wf.key })
+        .where({ tenant_id: tenantId, key: wf.key })
         .first() as { workflow_id: string; key: string } | undefined;
 
       if (existing) {
@@ -73,7 +74,7 @@ export const importWorkflowBundleV1 = async (
         .sort((a, b) => a.version - b.version);
 
       if (existing) {
-        await WorkflowDefinitionModelV2.update(trx, workflowId, {
+        await WorkflowDefinitionModelV2.update(trx, tenantId, workflowId, {
           key: wf.key,
           name: wf.metadata.name,
           description: wf.metadata.description,
@@ -84,7 +85,6 @@ export const importWorkflowBundleV1 = async (
           draft_definition: draftDefinition,
           draft_version: wf.draft.draftVersion,
           status: publishedVersions.length ? 'published' : 'draft',
-          is_system: wf.metadata.isSystem,
           is_visible: wf.metadata.isVisible,
           is_paused: wf.metadata.isPaused,
           concurrency_limit: wf.metadata.concurrencyLimit,
@@ -95,7 +95,7 @@ export const importWorkflowBundleV1 = async (
           updated_by: actorUserId
         });
       } else {
-        await WorkflowDefinitionModelV2.create(trx, {
+        await WorkflowDefinitionModelV2.create(trx, tenantId, {
           workflow_id: workflowId,
           key: wf.key,
           name: wf.metadata.name,
@@ -107,7 +107,6 @@ export const importWorkflowBundleV1 = async (
           draft_definition: draftDefinition,
           draft_version: wf.draft.draftVersion,
           status: publishedVersions.length ? 'published' : 'draft',
-          is_system: wf.metadata.isSystem,
           is_visible: wf.metadata.isVisible,
           is_paused: wf.metadata.isPaused,
           concurrency_limit: wf.metadata.concurrencyLimit,

--- a/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
+++ b/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
@@ -460,6 +460,7 @@ async function seedWorkflowStatusReferences(fixture: LegacyFixture) {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: fixture.tenantId,
     name: definition.name,
     description: definition.description,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -523,6 +524,7 @@ async function seedUnresolvedWorkflowStatusReference(fixture: LegacyFixture) {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
+    tenant_id: fixture.tenantId,
     name: definition.name,
     description: definition.description,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/server/src/test/integration/workflowBundleV1.importExport.integration.test.ts
+++ b/server/src/test/integration/workflowBundleV1.importExport.integration.test.ts
@@ -139,7 +139,7 @@ afterAll(async () => {
 describe('workflow bundle v1 import/export', () => {
   it('rejects unsupported formatVersion with a clear error', async () => {
     await expect(
-      importWorkflowBundleV1(db, {
+      importWorkflowBundleV1(db, tenantId, {
         format: 'alga-psa.workflow-bundle',
         formatVersion: 999,
         exportedAt: new Date().toISOString(),
@@ -152,7 +152,7 @@ describe('workflow bundle v1 import/export', () => {
 
   it('rejects invalid bundle JSON that fails the v1 schema with a helpful error', async () => {
     await expect(
-      importWorkflowBundleV1(db, {
+      importWorkflowBundleV1(db, tenantId, {
         format: 'alga-psa.workflow-bundle',
         formatVersion: 1,
         exportedAt: new Date().toISOString(),
@@ -165,7 +165,7 @@ describe('workflow bundle v1 import/export', () => {
 
   it('fails with structured missing-dependency errors when required actions/node types/schemas are absent', async () => {
     await expect(
-      importWorkflowBundleV1(db, {
+      importWorkflowBundleV1(db, tenantId, {
         format: 'alga-psa.workflow-bundle',
         formatVersion: 1,
         exportedAt: new Date().toISOString(),
@@ -403,7 +403,7 @@ describe('workflow bundle v1 import/export', () => {
       ]
     };
 
-    const result = await importWorkflowBundleV1(db, bundle);
+    const result = await importWorkflowBundleV1(db, tenantId, bundle);
     expect(result.createdWorkflows).toHaveLength(1);
     expect(result.createdWorkflows[0].key).toBe('test.import-basic');
 
@@ -463,9 +463,9 @@ describe('workflow bundle v1 import/export', () => {
       ]
     };
 
-    await importWorkflowBundleV1(db, bundle);
+    await importWorkflowBundleV1(db, tenantId, bundle);
 
-    await expect(importWorkflowBundleV1(db, bundle)).rejects.toMatchObject({
+    await expect(importWorkflowBundleV1(db, tenantId, bundle)).rejects.toMatchObject({
       code: 'WORKFLOW_KEY_CONFLICT',
       status: 409
     });
@@ -530,10 +530,10 @@ describe('workflow bundle v1 import/export', () => {
       ]
     };
 
-    const first = await importWorkflowBundleV1(db, bundle);
+    const first = await importWorkflowBundleV1(db, tenantId, bundle);
     const firstId = first.createdWorkflows[0].workflowId;
 
-    const second = await importWorkflowBundleV1(db, bundle, { force: true });
+    const second = await importWorkflowBundleV1(db, tenantId, bundle, { force: true });
     const secondId = second.createdWorkflows[0].workflowId;
 
     expect(secondId).toBe(firstId);
@@ -616,7 +616,7 @@ describe('workflow bundle v1 import/export', () => {
       ]
     };
 
-    await expect(importWorkflowBundleV1(db, bundle)).rejects.toBeTruthy();
+    await expect(importWorkflowBundleV1(db, tenantId, bundle)).rejects.toBeTruthy();
 
     const rows = await db('workflow_definitions').where({ key: 'test.transactional' });
     expect(rows).toHaveLength(0);
@@ -634,13 +634,13 @@ describe('workflow bundle v1 import/export', () => {
     const created = await createWorkflowDefinitionAction({ key: 'test.roundtrip', definition });
     await publishWorkflowDefinitionAction({ workflowId: created.workflowId, version: 1 });
 
-    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, created.workflowId);
+    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, created.workflowId);
 
     await resetWorkflowRuntimeTables(db);
 
-    const imported = await importWorkflowBundleV1(db, exported1);
+    const imported = await importWorkflowBundleV1(db, tenantId, exported1);
     const newId = imported.createdWorkflows[0].workflowId;
-    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, newId);
+    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, newId);
 
     expect(normalizeBundleForComparison(exported2)).toEqual(normalizeBundleForComparison(exported1));
   });
@@ -744,8 +744,8 @@ describe('workflow bundle v1 import/export', () => {
       ],
     };
 
-    const imported = await importWorkflowBundleV1(db, bundle);
-    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, imported.createdWorkflows[0].workflowId);
+    const imported = await importWorkflowBundleV1(db, tenantId, bundle);
+    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, imported.createdWorkflows[0].workflowId);
     const exportedWorkflow = exported1.workflows[0];
 
     expect(exportedWorkflow?.dependencies.actions).toEqual(
@@ -779,9 +779,9 @@ describe('workflow bundle v1 import/export', () => {
 
     await resetWorkflowRuntimeTables(db);
 
-    const reimported = await importWorkflowBundleV1(db, exported1);
+    const reimported = await importWorkflowBundleV1(db, tenantId, exported1);
     const importedWorkflowId = reimported.createdWorkflows[0].workflowId;
-    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, importedWorkflowId);
+    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, importedWorkflowId);
 
     expect(normalizeBundleForComparison(exported2)).toEqual(normalizeBundleForComparison(exported1));
   });
@@ -842,7 +842,7 @@ describe('workflow bundle v1 import/export', () => {
       ]
     };
 
-    const imported = await importWorkflowBundleV1(db, bundle);
+    const imported = await importWorkflowBundleV1(db, tenantId, bundle);
     const workflowId = imported.createdWorkflows[0].workflowId;
 
     const started = await startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: {} });

--- a/server/src/test/integration/workflowDesignerGroupedPersistence.integration.test.ts
+++ b/server/src/test/integration/workflowDesignerGroupedPersistence.integration.test.ts
@@ -429,7 +429,7 @@ describe('workflow designer grouped-step persistence', () => {
       definition: invalidDefinition
     });
 
-    const recordAfterSave = await WorkflowDefinitionModelV2.getById(db, created.workflowId);
+    const recordAfterSave = await WorkflowDefinitionModelV2.getById(db, tenantId, created.workflowId);
     expect(recordAfterSave?.draft_definition).toEqual(invalidDefinition);
     expectGroupedValidationError(recordAfterSave?.validation_errors);
 
@@ -473,7 +473,7 @@ describe('workflow designer grouped-step persistence', () => {
     );
     expect(publishedVersion?.definition_json).toEqual(definition);
 
-    const rowAfterPublish = await WorkflowDefinitionModelV2.getById(db, created.workflowId);
+    const rowAfterPublish = await WorkflowDefinitionModelV2.getById(db, tenantId, created.workflowId);
     expect(rowAfterPublish?.draft_version).toBe(2);
     expect((rowAfterPublish?.draft_definition as WorkflowDefinition)?.steps).toEqual(
       definition.steps
@@ -507,7 +507,7 @@ describe('workflow designer grouped-step persistence', () => {
     expect(publishResult.ok).toBe(false);
     expectGroupedValidationError(publishResult.errors as Record<string, unknown>[] | undefined);
 
-    const rowAfterFailedPublish = await WorkflowDefinitionModelV2.getById(db, created.workflowId);
+    const rowAfterFailedPublish = await WorkflowDefinitionModelV2.getById(db, tenantId, created.workflowId);
     expectGroupedValidationError(rowAfterFailedPublish?.validation_errors);
     expect(rowAfterFailedPublish?.status).toBe('draft');
   });
@@ -528,7 +528,7 @@ describe('workflow designer grouped-step persistence', () => {
       version: 1
     });
 
-    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, created.workflowId);
+    const exported1 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, created.workflowId);
 
     expect(exported1.workflows[0]?.draft?.definition?.steps?.[0]).toMatchObject({
       type: 'action.call',
@@ -550,15 +550,15 @@ describe('workflow designer grouped-step persistence', () => {
     await resetWorkflowRuntimeTables(db);
     await ensureWorkflowScheduleStateTable(db);
 
-    const imported = await importWorkflowBundleV1(db, exported1);
+    const imported = await importWorkflowBundleV1(db, tenantId, exported1);
     const importedId = imported.createdWorkflows[0].workflowId;
-    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, importedId);
+    const exported2 = await exportWorkflowBundleV1ForWorkflowId(db, tenantId, importedId);
 
     expect(normalizeBundleForComparison(exported2)).toEqual(
       normalizeBundleForComparison(exported1)
     );
 
-    const importedRow = await WorkflowDefinitionModelV2.getById(db, importedId);
+    const importedRow = await WorkflowDefinitionModelV2.getById(db, tenantId, importedId);
     expect(importedRow?.draft_definition).toMatchObject({
       steps: [
         {

--- a/server/src/test/integration/workflowPayloadContractInference.integration.test.ts
+++ b/server/src/test/integration/workflowPayloadContractInference.integration.test.ts
@@ -82,7 +82,7 @@ describe('Workflow Payload Contract Inference - Migration Tests', () => {
     expect(result.workflowId).toBeDefined();
 
     // Verify the record was created with inferred mode
-    const record = await WorkflowDefinitionModelV2.getById(db, result.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, result.workflowId);
     expect(record?.payload_schema_mode).toBe('inferred');
   });
 
@@ -95,7 +95,7 @@ describe('Workflow Payload Contract Inference - Migration Tests', () => {
     };
 
     const result = await createWorkflowDefinitionAction({ definition });
-    const record = await WorkflowDefinitionModelV2.getById(db, result.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, result.workflowId);
 
     // Should have payload_schema_mode column
     expect(record).toHaveProperty('payload_schema_mode');
@@ -120,7 +120,7 @@ describe('Workflow Payload Contract Inference - Migration Tests', () => {
       pinnedPayloadSchemaRef: TEST_SCHEMA_REF
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, result.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, result.workflowId);
     expect(record?.payload_schema_mode).toBe('pinned');
     expect(record?.pinned_payload_schema_ref).toBe(TEST_SCHEMA_REF);
   });
@@ -141,7 +141,7 @@ describe('Workflow Payload Contract Inference - Persistence Tests', () => {
       pinnedPayloadSchemaRef: 'payload.Custom.v1'
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, result.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, result.workflowId);
     expect(record?.payload_schema_mode).toBe('pinned');
     expect(record?.pinned_payload_schema_ref).toBe('payload.Custom.v1');
   });
@@ -171,7 +171,7 @@ describe('Workflow Payload Contract Inference - Persistence Tests', () => {
       payloadSchemaMode: 'inferred'
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, result.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, result.workflowId);
     expect(record?.payload_schema_mode).toBe('inferred');
     // Pinned ref may be preserved for later toggle back, or cleared
   });
@@ -248,7 +248,7 @@ describe('Workflow Payload Contract Inference - Publish Tests', () => {
       version: 1
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
     expect(record?.payload_schema_mode).toBeDefined();
   });
 
@@ -377,7 +377,7 @@ describe('Workflow Payload Contract Inference - Publish Tests', () => {
       version: 1
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
     expect(record?.payload_schema_mode).toBe('inferred');
   });
 
@@ -400,7 +400,7 @@ describe('Workflow Payload Contract Inference - Publish Tests', () => {
       version: 1
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
     expect(record?.payload_schema_mode).toBe('pinned');
   });
 });
@@ -476,7 +476,7 @@ describe('Workflow Payload Contract Inference - API Tests', () => {
       pinnedPayloadSchemaRef: TEST_SCHEMA_REF
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
 
     expect(record?.payload_schema_mode).toBeDefined();
     expect(record?.pinned_payload_schema_ref).toBeDefined();
@@ -495,7 +495,7 @@ describe('Workflow Payload Contract Inference - API Tests', () => {
       payloadSchemaMode: 'inferred'
     });
 
-    const workflows = await WorkflowDefinitionModelV2.list(db);
+    const workflows = await WorkflowDefinitionModelV2.list(db, tenantId);
     const created = workflows.find((w) => (w.draft_definition as any)?.name === 'Test Workflow');
 
     expect(created?.payload_schema_mode).toBeDefined();
@@ -515,7 +515,7 @@ describe('Workflow Payload Contract Inference - API Tests', () => {
       pinnedPayloadSchemaRef: TEST_SCHEMA_REF
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
 
     expect(record).toHaveProperty('payload_schema_mode');
     expect(record).toHaveProperty('pinned_payload_schema_ref');
@@ -591,7 +591,7 @@ describe('Workflow Payload Contract Inference - Compatibility Tests', () => {
       pinnedPayloadSchemaRef: TEST_SCHEMA_REF
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
 
     // Should be in pinned mode with the explicit ref
     expect(record?.payload_schema_mode).toBe('pinned');
@@ -689,7 +689,7 @@ describe('Workflow Payload Contract Inference - Validation Persistence Tests', (
       version: 1
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
 
     // Validation context should be stored
     expect(record).toHaveProperty('validation_status');
@@ -710,7 +710,7 @@ describe('Workflow Payload Contract Inference - Validation Persistence Tests', (
       version: 1
     });
 
-    const record = await WorkflowDefinitionModelV2.getById(db, createResult.workflowId);
+    const record = await WorkflowDefinitionModelV2.getById(db, tenantId, createResult.workflowId);
 
     // Should have a payload schema hash for drift detection
     expect(record).toHaveProperty('validation_payload_schema_hash');

--- a/server/src/test/integration/workflowRuntimeV2.email.integration.test.ts
+++ b/server/src/test/integration/workflowRuntimeV2.email.integration.test.ts
@@ -56,7 +56,7 @@ function stubAction(actionId: string, version: number, handler: any) {
 async function seedEmailWorkflow() {
   const filePath = path.resolve(__dirname, '../../../../shared/workflow/runtime/workflows/email-processing-workflow.v2.json');
   const definition = { ...JSON.parse(fs.readFileSync(filePath, 'utf8')), id: EMAIL_WORKFLOW_ID };
-  await WorkflowDefinitionModelV2.create(db, {
+  await WorkflowDefinitionModelV2.create(db, tenantId, {
     workflow_id: definition.id,
     name: definition.name,
     description: definition.description,
@@ -402,7 +402,7 @@ describe('workflow runtime v2 email workflow integration tests', () => {
           }
         ]
       };
-      const record = await WorkflowDefinitionModelV2.create(db, {
+      const record = await WorkflowDefinitionModelV2.create(db, tenantId, {
         workflow_id: definition.id,
         name: definition.name,
         payload_schema_ref: definition.payloadSchemaRef,

--- a/server/src/test/integration/workflowRuntimeV2.publish.integration.test.ts
+++ b/server/src/test/integration/workflowRuntimeV2.publish.integration.test.ts
@@ -439,7 +439,7 @@ describe('workflow runtime v2 publish + registry + run integration tests', () =>
   it('Publish creates immutable version; later edits do not mutate published JSON. Mocks: non-target dependencies.', async () => {
     const workflowId = await createDraftWorkflow({ steps: [stateSetStep('state-1', 'READY')] });
     await publishWorkflow(workflowId, 1);
-    await WorkflowDefinitionModelV2.update(db, workflowId, {
+    await WorkflowDefinitionModelV2.update(db, tenantId, workflowId, {
       draft_definition: {
         id: workflowId,
         version: 1,

--- a/server/src/test/unit/workflowDefinitionListTriggerFilters.unit.test.ts
+++ b/server/src/test/unit/workflowDefinitionListTriggerFilters.unit.test.ts
@@ -51,6 +51,11 @@ const knexMock: any = vi.fn((table: string) => {
     }
     return next;
   }
+  if (table === 'tenant_workflow_schedule') {
+    const builder = createBuilder({ rowsResult: [] }) as any;
+    builder.then = (resolve: (rows: unknown[]) => unknown, reject?: (error: unknown) => unknown) => Promise.resolve([]).then(resolve, reject);
+    return builder;
+  }
   throw new Error(`Unexpected table ${table}`);
 });
 knexMock.raw = vi.fn((sql: string) => sql);

--- a/services/workflow-worker/src/v2/WorkflowRuntimeV2EventStreamWorker.ts
+++ b/services/workflow-worker/src/v2/WorkflowRuntimeV2EventStreamWorker.ts
@@ -279,7 +279,7 @@ export class WorkflowRuntimeV2EventStreamWorker {
 
     const schemaRegistry = getSchemaRegistry();
 
-    const workflows = await WorkflowDefinitionModelV2.list(knex);
+    const workflows = await WorkflowDefinitionModelV2.list(knex, event.tenant);
     const matching = workflows.filter(
       (workflow) => workflow.status === 'published' && (workflow.trigger as any)?.eventName === event.event_type
     );

--- a/shared/workflow/persistence/workflowDefinitionModelV2.ts
+++ b/shared/workflow/persistence/workflowDefinitionModelV2.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 
 export type WorkflowDefinitionRecord = {
   workflow_id: string;
+  tenant_id: string;
   key?: string | null;
   name: string;
   description?: string | null;
@@ -55,12 +56,23 @@ const normalizeWorkflowDefinitionWrite = (
   return out;
 };
 
+const assertTenantId = (tenantId: string | null | undefined): string => {
+  const normalized = String(tenantId ?? '').trim();
+  if (!normalized) {
+    throw new Error('tenant_id is required for workflow definition access');
+  }
+  return normalized;
+};
+
 const WorkflowDefinitionModelV2 = {
-  create: async (knex: Knex, data: Partial<WorkflowDefinitionRecord>): Promise<WorkflowDefinitionRecord> => {
+  create: async (knex: Knex, tenantId: string, data: Partial<WorkflowDefinitionRecord>): Promise<WorkflowDefinitionRecord> => {
+    const tenant = assertTenantId(tenantId);
     const normalized = normalizeWorkflowDefinitionWrite(data);
     const [record] = await knex<WorkflowDefinitionRecord>('workflow_definitions')
       .insert({
         ...normalized,
+        tenant_id: tenant,
+        is_system: false,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       })
@@ -68,27 +80,34 @@ const WorkflowDefinitionModelV2 = {
     return record;
   },
 
-  update: async (knex: Knex, workflowId: string, data: Partial<WorkflowDefinitionRecord>): Promise<WorkflowDefinitionRecord> => {
+  update: async (knex: Knex, tenantId: string, workflowId: string, data: Partial<WorkflowDefinitionRecord>): Promise<WorkflowDefinitionRecord> => {
+    const tenant = assertTenantId(tenantId);
     const normalized = normalizeWorkflowDefinitionWrite(data);
+    delete (normalized as Partial<WorkflowDefinitionRecord>).tenant_id;
     const [record] = await knex<WorkflowDefinitionRecord>('workflow_definitions')
-      .where({ workflow_id: workflowId })
+      .where({ workflow_id: workflowId, tenant_id: tenant })
       .update({
         ...normalized,
+        is_system: false,
         updated_at: new Date().toISOString()
       })
       .returning('*');
     return record;
   },
 
-  getById: async (knex: Knex, workflowId: string): Promise<WorkflowDefinitionRecord | null> => {
+  getById: async (knex: Knex, tenantId: string, workflowId: string): Promise<WorkflowDefinitionRecord | null> => {
+    const tenant = assertTenantId(tenantId);
     const record = await knex<WorkflowDefinitionRecord>('workflow_definitions')
-      .where({ workflow_id: workflowId })
+      .where({ workflow_id: workflowId, tenant_id: tenant })
       .first();
     return record || null;
   },
 
-  list: async (knex: Knex): Promise<WorkflowDefinitionRecord[]> => {
-    return knex<WorkflowDefinitionRecord>('workflow_definitions').select('*');
+  list: async (knex: Knex, tenantId: string): Promise<WorkflowDefinitionRecord[]> => {
+    const tenant = assertTenantId(tenantId);
+    return knex<WorkflowDefinitionRecord>('workflow_definitions')
+      .select('*')
+      .where({ tenant_id: tenant });
   }
 };
 

--- a/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
+++ b/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
@@ -979,7 +979,7 @@ export class WorkflowRuntimeV2 {
   }
 
   private async maybeAutoPauseWorkflow(knex: Knex, run: WorkflowRunRecord): Promise<void> {
-    const definition = await WorkflowDefinitionModelV2.getById(knex, run.workflow_id);
+    const definition = await WorkflowDefinitionModelV2.getById(knex, run.tenant_id ?? '', run.workflow_id);
     if (!definition?.auto_pause_on_failure) return;
     const minRuns = Number(definition.failure_rate_min_runs ?? 10);
     const threshold = Number(definition.failure_rate_threshold ?? 0.5);
@@ -996,7 +996,7 @@ export class WorkflowRuntimeV2 {
     const failureRate = failedCount / recentRuns.length;
 
     if (failureRate >= threshold && !definition.is_paused) {
-      await WorkflowDefinitionModelV2.update(knex, run.workflow_id, {
+      await WorkflowDefinitionModelV2.update(knex, run.tenant_id ?? '', run.workflow_id, {
         is_paused: true
       });
       await this.logRunEvent(knex, run, {

--- a/shared/workflow/secrets/tenantSecretProvider.ts
+++ b/shared/workflow/secrets/tenantSecretProvider.ts
@@ -304,14 +304,11 @@ export class TenantSecretProvider {
    * Returns a map of secret names to the workflow IDs that reference them.
    */
   async getSecretUsage(): Promise<Map<string, string[]>> {
-    // workflow_definitions / workflow_definition_versions have no tenant column,
-    // so we scope via tenant_workflow_schedule (the same linking table used elsewhere,
-    // e.g. workflow-runtime-v2-actions.ts:loadWorkflowScheduleStateMap).
-    const scheduled = await this.knex('tenant_workflow_schedule')
+    const definitions = await this.knex('workflow_definitions')
       .where({ tenant_id: this.tenantId })
       .select<{ workflow_id: string }[]>('workflow_id');
 
-    const workflowIds = scheduled.map((row) => row.workflow_id);
+    const workflowIds = definitions.map((row) => row.workflow_id);
     if (workflowIds.length === 0) {
       return new Map();
     }
@@ -322,6 +319,7 @@ export class TenantSecretProvider {
         .whereRaw("definition_json::text LIKE '%$secret%'")
         .select<{ workflow_id: string; definition_json: unknown }[]>('workflow_id', 'definition_json'),
       this.knex('workflow_definitions')
+        .where({ tenant_id: this.tenantId })
         .whereIn('workflow_id', workflowIds)
         .whereRaw("draft_definition::text LIKE '%$secret%'")
         .select<{ workflow_id: string; draft_definition: unknown }[]>('workflow_id', 'draft_definition'),

--- a/tools/workflow-harness/run.cjs
+++ b/tools/workflow-harness/run.cjs
@@ -153,8 +153,8 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
         throw new Error('--skip-import requires bundle.json to have a workflow key');
       }
       const rows = await db.query(
-        `SELECT workflow_id FROM workflow_definitions WHERE key = $1`,
-        [workflowKey]
+        `SELECT workflow_id FROM workflow_definitions WHERE tenant_id = $1 AND key = $2`,
+        [tenantId, workflowKey]
       );
       if (!rows || rows.length === 0) {
         throw new Error(`--skip-import: Workflow with key "${workflowKey}" not found in database. Import it first.`);
@@ -184,11 +184,11 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
     // This keeps event→run fanout deterministic even when many fixtures exist in the DB.
     if (workflowKey && typeof workflowKey === 'string') {
       await dbWrite.query(
-        `update workflow_definitions set is_paused = true where key like 'fixture.%' and key <> $1`,
-        [workflowKey]
+        `update workflow_definitions set is_paused = true where tenant_id = $1 and key like 'fixture.%' and key <> $2`,
+        [tenantId, workflowKey]
       );
     }
-    await dbWrite.query(`update workflow_definitions set is_paused = $2 where workflow_id = $1`, [workflowId, workflowIsPausedInBundle]);
+    await dbWrite.query(`update workflow_definitions set is_paused = $3 where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId, workflowIsPausedInBundle]);
 
     if (debug) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- add a tenant_id backfill migration for workflow_definitions, split shared legacy definitions by tenant evidence, and enforce tenant-scoped workflow keys
- require tenant context in WorkflowDefinitionModelV2 create/get/list/update paths and scope workflow runtime, schedule, event catalog, bundle import/export, worker, and secret-usage queries
- remove runtime system-workflow semantics for workflow definitions; imported/exported workflow bundles now treat isSystem as false and the legacy email workflow is hidden/paused when historical tenant evidence exists
- update workflow tests/harness fixtures for tenant-owned workflow definitions

## Validation
- npx tsc --noEmit --pretty false --project tsconfig.json
- node -e "require('./server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs')"
- npx vitest run src/test/unit/workflowDefinitionListTriggerFilters.unit.test.ts --root server