### PR TITLE
Add workflow contact mutation actions

### DIFF
--- a/ee/docs/plans/2026-04-25-workflow-contact-actions/PRD.md
+++ b/ee/docs/plans/2026-04-25-workflow-contact-actions/PRD.md
@@ -1,0 +1,357 @@
+# PRD — Workflow Contact Actions
+
+- Slug: `2026-04-25-workflow-contact-actions`
+- Date: `2026-04-25`
+- Status: Draft — product decisions resolved; ready for implementation planning
+
+## Summary
+
+Add first-class workflow designer actions in the Contact module for creating, editing, deactivating, deleting, duplicating, tagging, ticket-associating, note logging, interaction logging, and client assignment/movement of contacts.
+
+These actions should appear in the existing Contact grouped action catalog and execute through the existing `action.call` runtime path. They should follow the established business operation action conventions in `shared/workflow/runtime/actions/businessOperations/*`: Zod schemas for designer forms, tenant-scoped transactional handlers, permission checks, idempotency declarations, structured outputs for downstream workflow steps, and workflow run audit records for side-effectful mutations.
+
+## Problem
+
+Workflow authors can currently find and search contacts, but cannot perform common contact mutations without falling back to generic API/webhook workarounds or indirect actions. This leaves contact-centric automations incomplete, especially for inbound email, onboarding, ticket triage, client hygiene, and CRM follow-up flows.
+
+The requested missing operations are:
+
+1. Edit contact
+2. Create contact
+3. Deactivate contact
+4. Delete contact
+5. Duplicate contact
+6. Add tag to contact
+7. Assign contact to ticket
+8. Add note to contact
+9. Add interaction to contact
+10. Add contact to client
+11. Move contact to different client
+
+## Goals
+
+1. Register designer-visible Contact actions for each requested operation.
+2. Reuse existing contact, tag, ticket, and interaction domain behavior where practical instead of creating alternate data semantics.
+3. Keep action schemas workflow-author friendly, with picker metadata for contact, client, ticket, interaction type/status, and tag-like inputs where supported.
+4. Ensure every write is tenant-scoped, permission-checked, transactional, and fail-fast with standard workflow action errors.
+5. Return compact but useful outputs, including affected IDs, current contact summary, previous/current client IDs where relevant, and explicit status fields for idempotent operations where useful.
+6. Preserve current workflow designer grouping: all new `contacts.*` actions appear under the Contact group.
+
+## Non-goals
+
+1. Redesigning the workflow designer UI beyond schema metadata needed for pickers and structured fields.
+2. Adding new database tables or migrations unless implementation discovers a schema gap.
+3. Replacing the existing generic `crm.create_activity_note` action; `contacts.add_note` may wrap/parallel that behavior for contact-specific authoring.
+4. Adding bulk contact actions in this phase.
+5. Comprehensive contact merge/deduplication workflows beyond creating a duplicate contact from an existing contact.
+6. Changing public REST API behavior for contacts.
+
+## Users and Primary Flows
+
+### Workflow author
+
+- Builds automations from the grouped workflow action palette.
+- Selects Contact actions without needing to know REST endpoints or table names.
+- Maps values from prior steps (`contacts.find`, inbound email payloads, ticket creation outputs, form submissions) into contact action inputs.
+
+### MSP operations user
+
+- Benefits from automations that keep contacts, clients, tickets, and CRM records current.
+- Expects workflows to obey the same tenant and permission boundaries as normal MSP actions.
+
+### Primary flows
+
+1. **Inbound email creates or updates a contact**
+   - Find contact by email.
+   - If missing, create contact.
+   - Add the contact to the matched client.
+   - Assign the contact to the created ticket.
+   - Add a note/interaction documenting the source.
+
+2. **Ticket triage assigns a contact**
+   - Use client/contact search outputs.
+   - Assign selected contact to a ticket.
+   - Optionally tag the contact for follow-up.
+
+3. **Client hygiene automation moves contacts**
+   - Detect a contact associated with the wrong client.
+   - Move the contact to a target client with an expected-current-client guard.
+   - Return before/after client IDs for downstream notifications.
+
+4. **CRM follow-up logging**
+   - Add a contact note or richer interaction after a workflow milestone.
+   - Use the contact’s client automatically when possible.
+
+## UX / UI Notes
+
+1. New actions should be registered with `id` values prefixed by `contacts.` so the existing catalog builder groups them under Contact.
+2. Suggested labels:
+   - `contacts.create` → Create Contact
+   - `contacts.update` → Edit Contact
+   - `contacts.deactivate` → Deactivate Contact
+   - `contacts.delete` → Delete Contact
+   - `contacts.duplicate` → Duplicate Contact
+   - `contacts.add_tag` → Add Tag to Contact
+   - `contacts.assign_to_ticket` → Assign Contact to Ticket
+   - `contacts.add_note` → Add Note to Contact
+   - `contacts.add_interaction` → Add Interaction to Contact
+   - `contacts.add_to_client` → Add Contact to Client
+   - `contacts.move_to_client` → Move Contact to Client
+3. Picker metadata should be added where possible:
+   - `contact_id` / `source_contact_id` → contact picker
+   - `client_id` / `target_client_id` → client picker
+   - `ticket_id` → ticket picker
+   - `interaction_type_id` → interaction type picker if a picker kind exists or is added
+   - `status_id` → interaction status picker if a picker kind exists or is added
+4. Keep schemas structured and explicit. Avoid raw JSON-only fields for contact updates, phone numbers, additional emails, or interaction metadata when a typed structure is feasible.
+
+## Requirements
+
+### Functional Requirements
+
+#### Shared contact output shape
+
+All contact-mutating actions should return a compact normalized contact object, at minimum:
+
+```ts
+{
+  contact_name_id: string,
+  full_name: string | null,
+  email: string | null,
+  phone: string | null,
+  client_id: string | null,
+  is_inactive: boolean
+}
+```
+
+Actions may include richer fields where useful, but downstream mapping should not require a full `IContact` payload.
+
+#### Create contact — `contacts.create`
+
+1. Creates a contact using existing contact validation semantics.
+2. Requires `full_name` and `email`, matching `ContactModel.createContact` requirements.
+3. Accepts optional `client_id`, role, notes, inactive state, phone numbers, primary email type, additional email addresses, and optional tags.
+4. Validates referenced client exists in the tenant when provided.
+5. Fails on duplicate primary/additional email conflicts using standard workflow error categories.
+6. Returns the created contact and `created: true`.
+
+#### Edit contact — `contacts.update`
+
+1. Updates an existing contact by `contact_id`.
+2. Accepts a `patch` object with the same updateable fields as the contact API/model.
+3. Uses patch semantics: omitted fields are unchanged; explicit nullable fields clear only where the underlying model permits clearing.
+4. Preserves existing primary-email promotion rules from `ContactModel.updateContact`.
+5. Optionally supports tag replacement only if included deliberately in the update schema; otherwise tag changes stay in `contacts.add_tag`/future tag actions.
+6. Returns before/after contact summaries and list of updated fields.
+
+#### Deactivate contact — `contacts.deactivate`
+
+1. Sets `contacts.is_inactive = true` without deleting the contact record.
+2. Is idempotent: if the contact is already inactive, return `noop: true` and leave the record unchanged.
+3. Requires `contact:update`.
+4. Returns the contact ID, previous inactive state, current inactive state, `deactivated: true`, and a compact contact summary.
+5. This action is the safe default for workflow authors who want to remove a contact from active use without destroying records.
+
+#### Delete contact — `contacts.delete`
+
+1. Performs a guarded hard delete, distinct from deactivation.
+2. Requires `confirm: true` as an explicit destructive-action guard.
+3. Supports explicit missing-record behavior via `on_not_found` (`error` by default, optional `return_false`).
+4. Matches the existing UI/server delete behavior as closely as shared runtime boundaries allow.
+5. Cleans up owned child rows consistently with existing server action behavior.
+6. Fails with dependency details when associated records prevent deletion, such as tickets, interactions, documents, portal users, survey records, or asset associations.
+7. Requires `contact:delete`.
+8. Returns `{ deleted: true, contact_id }` on success and `{ deleted: false, contact_id }` only for `on_not_found: return_false`.
+9. This action should be labeled and described as destructive in the designer.
+
+#### Duplicate contact — `contacts.duplicate`
+
+1. Creates a new contact using fields copied from a source contact.
+2. Requires a new unique primary email by default because contact primary emails are tenant-unique.
+3. Allows overrides for `full_name`, `email`, `client_id`, role, notes, phone numbers, additional emails, inactive state, and whether to copy tags.
+4. Defaults target client to the source contact’s client unless `target_client_id` is supplied.
+5. Does not copy contact notes documents, tickets, interactions, portal users, invitations, external integration mappings, or other historical relationships in v1.
+6. Supports an optional external `idempotency_key` using action-provided idempotency.
+7. Returns source and duplicate contact summaries plus copied tag counts.
+
+#### Add tag to contact — `contacts.add_tag`
+
+1. Adds one or more tag mappings for a contact without replacing existing tags.
+2. Reuses the `tag_definitions` / `tag_mappings` model used by existing contact CSV import/search behavior.
+3. Is idempotent: existing mappings are returned as `existing` rather than failing or duplicating rows.
+4. Requires contact exists and tag text passes existing tag validation.
+5. Requires `contact:update`; missing tag definitions may be created under the same permission policy as `clients.add_tag`.
+6. Supports an optional external `idempotency_key` using action-provided idempotency.
+7. Returns added/existing tag summaries and counts.
+
+#### Assign contact to ticket — `contacts.assign_to_ticket`
+
+1. Sets `tickets.contact_name_id` for a ticket.
+2. Validates ticket and contact exist in the tenant.
+3. Mirrors the new client-assignment action style: a direct ticket update with relationship validation and previous/current output fields.
+4. Requires a non-null contact to belong to the ticket’s existing client when the ticket has a client.
+5. If the ticket has no client and the contact has a client, do not automatically set `tickets.client_id` unless the existing application action path does so. Current implementation discovery shows the ticket UI updates contact via `updateTicket(..., { contact_name_id })` only, so v1 should only set `tickets.contact_name_id`.
+6. Supports optional `reason` / `comment` fields for audit detail only; do not create a ticket comment in v1 unless explicitly implemented.
+7. Returns ticket ID, previous contact ID, and current contact ID. Re-running with the same contact is naturally idempotent through the same previous/current output shape.
+8. Requires `ticket:update` and `contact:read`.
+
+#### Add note to contact — `contacts.add_note`
+
+1. Appends note content to the contact’s notes document (`contacts.notes_document_id`), matching the module-specific notes-document pattern now used by `clients.add_note`.
+2. Creates the notes document when missing, links it to the contact, and appends a workflow-created note block rather than replacing existing notes.
+3. Does not create an `interactions` row; richer activity history belongs in `contacts.add_interaction` or the existing generic `crm.create_activity_note` action.
+4. Publishes or preserves existing `NOTE_CREATED` behavior when a new notes document is created, using the same best-effort/lazy event approach as the new client actions where feasible.
+5. Supports body and optional external `idempotency_key` using action-provided idempotency.
+6. Returns contact ID, document ID, whether a document was created, and updated timestamp.
+7. Requires `contact:update`.
+
+#### Add interaction to contact — `contacts.add_interaction`
+
+1. Creates a richer interaction row linked to the contact.
+2. Derives `client_id` from the contact and fails if the contact is not associated with a client.
+3. Accepts interaction type, title/subject, notes/description, status, start/end/duration or occurred-at timestamp according to existing interaction schema.
+4. Uses default interaction status when none is supplied, matching existing `addInteraction` and the new `clients.add_interaction` behavior.
+5. Uses the workflow actor as `user_id` in v1. Do not expose arbitrary user attribution until a permission-gated future version defines target-user validation and audit semantics.
+6. Validates optional ticket relationship when supplied; the ticket must belong to the derived client when it already has a client.
+7. Supports an optional external `idempotency_key` using action-provided idempotency.
+8. Publishes or preserves `INTERACTION_LOGGED` behavior using the same best-effort/lazy event approach as the new client action where feasible.
+9. Returns interaction ID, contact ID, client ID, type/status details, timestamps, duration, notes, title, ticket ID, and actor user ID.
+10. Requires `contact:update` for parity with `clients.add_interaction`.
+
+#### Add contact to client — `contacts.add_to_client`
+
+1. Sets `client_id` for a contact that currently has no client.
+2. Fails with a conflict if the contact is already assigned to a different client, directing workflow authors to `contacts.move_to_client`.
+3. Is idempotent when contact is already assigned to the target client.
+4. Returns previous and current client IDs plus `noop`.
+5. Requires `contact:update`.
+
+#### Move contact to different client — `contacts.move_to_client`
+
+1. Moves a contact from one client to another by updating `contacts.client_id`.
+2. Validates target client exists and is tenant-scoped.
+3. Supports optional `expected_current_client_id` to prevent moving from an unexpected source client.
+4. Is idempotent when already on the target client.
+5. Returns previous and current client IDs plus `noop`.
+6. Requires `contact:update`.
+
+### Non-functional Requirements
+
+1. All database operations must include tenant filters and run inside `withTenantTransaction`.
+2. Every side-effectful action must write a workflow run audit record using the existing `writeRunAudit` helper.
+3. Error handling must map validation, not-found, conflict, permission, and transient cases to standard workflow action errors.
+4. Action schemas should be versioned at `version: 1` for new action IDs.
+5. Side-effectful actions should follow the idempotency split established by the new Client actions:
+   - `actionProvided` with `actionProvidedKey` for create/duplicate/add_tag/add_note/add_interaction actions that create records or append content and need retry-safe caller semantics.
+   - `engineProvided` for update/deactivate/delete and relationship reassignment actions that are deterministic state transitions.
+
+## Data / API / Integrations
+
+### Existing code paths to reuse/reference
+
+- Contact workflow actions: `shared/workflow/runtime/actions/businessOperations/contacts.ts`
+- Registration: `shared/workflow/runtime/actions/registerBusinessOperationsActions.ts`
+- Contact model: `shared/models/contactModel.ts`
+- Contact API schema/service: `server/src/lib/api/schemas/contact.ts`, `server/src/lib/api/services/ContactService.ts`
+- Contact delete server action: `packages/clients/src/actions/contact-actions/contactActions.tsx`
+- Contact notes document action: `packages/clients/src/actions/contact-actions/contactNoteActions.ts`
+- Tag model: `shared/models/tagModel.ts`
+- Ticket assignment/update patterns: `shared/workflow/runtime/actions/businessOperations/tickets.ts`
+- Client workflow action expansion template: `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- CRM activity-note action for generic interaction-backed notes: `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- Interaction server action/model: `packages/clients/src/actions/interactionActions.ts`, `packages/clients/src/models/interactions.ts`
+
+### Known schema considerations
+
+1. `contacts` uses `contact_name_id` as the primary contact ID field.
+2. Primary contact emails are tenant-unique.
+3. Existing contact search filters tags through `tag_definitions` / `tag_mappings` with `tagged_type = 'contact'`.
+4. `ContactService.handleTags` references `contact_tags`, but no migration was found for that table during planning. Implementation should prefer `tag_mappings` unless further investigation proves otherwise.
+5. Existing delete configuration identifies contact dependencies across tickets, interactions, documents, portal users, survey records, and asset associations.
+6. Interactions have evolved over migrations; implementation must confirm the current required columns and default interaction status/type behavior before writing handlers.
+7. Contact module notes are document-backed through `contacts.notes_document_id`; do not conflate `contacts.add_note` with interaction-backed activity notes.
+
+## Security / Permissions
+
+Recommended permission checks:
+
+| Action | Permission(s) |
+| --- | --- |
+| `contacts.create` | `contact:create` |
+| `contacts.update` | `contact:update` |
+| `contacts.deactivate` | `contact:update` |
+| `contacts.delete` | `contact:delete` |
+| `contacts.duplicate` | `contact:read` + `contact:create` |
+| `contacts.add_tag` | `contact:update` (including creation of missing tag definitions, matching `clients.add_tag`) |
+| `contacts.assign_to_ticket` | `ticket:update` + `contact:read` |
+| `contacts.add_note` | `contact:update` |
+| `contacts.add_interaction` | `contact:update` for parity with `clients.add_interaction` |
+| `contacts.add_to_client` | `contact:update` |
+| `contacts.move_to_client` | `contact:update` |
+
+All permission checks must be based on the workflow actor resolved by `withTenantTransaction`.
+
+## Approaches Considered
+
+### Approach A — One designer action per requested operation, shared helpers inside `contacts.ts` (recommended)
+
+Pros:
+- Matches the user’s requested mental model and designer catalog expectations.
+- Keeps Contact group discoverable.
+- Allows focused schemas, labels, and outputs per operation.
+- Can still share validation/output/helper code internally.
+
+Cons:
+- More action definitions to maintain.
+- Some overlap between `add_to_client`, `move_to_client`, and generic update.
+
+### Approach B — Fewer generic contact actions with operation modes
+
+Pros:
+- Less registry surface area.
+- Fewer handlers.
+
+Cons:
+- Worse workflow author UX.
+- More conditional schemas and confusing designer forms.
+- Harder downstream output typing.
+
+### Approach C — Implement wrappers that call existing REST/API services directly
+
+Pros:
+- Maximizes reuse of API behavior.
+- Potentially preserves domain events without duplicating logic.
+
+Cons:
+- Workflow runtime lives in shared code and may not safely import server-only service layers.
+- Existing server action code can depend on Next/auth/revalidation concerns inappropriate for runtime actions.
+- May introduce circular package boundaries.
+
+Recommendation: Approach A, while extracting small shared helpers where repeated logic is unavoidable. Use models/shared utilities directly in runtime actions and copy only the minimal server-action delete/tag logic needed after boundary review.
+
+## Rollout / Migration
+
+1. No database migration is expected.
+2. Actions are additive; existing workflows should not break.
+3. New actions should appear automatically in the designer catalog after runtime initialization.
+4. Delete and deactivate are additive but separate actions; designer labels/descriptions must make the destructive hard-delete behavior clear.
+
+## Resolved Decisions
+
+1. `contacts.duplicate` must require a new unique primary email override; do not generate placeholder/suffix emails automatically.
+2. `contacts.assign_to_ticket` should only set `tickets.contact_name_id` in v1 unless the existing application action path also sets `tickets.client_id`. Current discovery indicates the UI contact-change path updates only `contact_name_id`.
+3. `contacts.add_tag` should create missing tag definitions exactly like `clients.add_tag`, using the same `contact:update`-style permission policy rather than a stricter separate tag-create permission.
+4. Contact create/update/deactivate actions should publish `CONTACT_CREATED` / `CONTACT_UPDATED` / `CONTACT_ARCHIVED` domain events using the same best-effort lazy import pattern used by Client actions.
+
+## Acceptance Criteria (Definition of Done)
+
+1. The Contact workflow catalog includes all eleven requested/planned actions under the Contact group, including separate Deactivate Contact and Delete Contact actions.
+2. Each action has a Zod input/output schema, UI label/description/category, side-effect metadata, and idempotency declaration.
+3. All write actions are tenant-scoped, permission-checked, transactional, and audited.
+4. Create/update/duplicate use existing contact validation for email, phone, additional email, primary email type, and client existence rules.
+5. Deactivate and delete behavior are implemented as separate actions: deactivate is idempotent and reversible via update/reactivation, while delete is guarded hard delete with blocked-dependency behavior covered by tests.
+6. Tagging uses the same storage model that contact search reads (`tag_definitions` / `tag_mappings`) unless implementation proves a different canonical path.
+7. Ticket assignment validates both entities and returns deterministic before/after output.
+8. Note and interaction actions are intentionally separate: `contacts.add_note` appends to the contact notes document, while `contacts.add_interaction` creates a valid `interactions` row linked to the contact and derived client.
+9. Add-to-client and move-to-client actions distinguish idempotent no-op, conflict, and successful move cases.
+10. Runtime tests cover the highest-risk mutations and validation failures against a real or realistically mocked tenant transaction.

--- a/ee/docs/plans/2026-04-25-workflow-contact-actions/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-25-workflow-contact-actions/SCRATCHPAD.md
@@ -1,0 +1,101 @@
+# Scratchpad — Workflow Contact Actions
+
+- Plan slug: `2026-04-25-workflow-contact-actions`
+- Created: `2026-04-25`
+
+## What This Is
+
+Working notes for adding Contact module workflow actions: create, edit, deactivate, delete, duplicate, add tag, assign to ticket, add note, add interaction, add to client, and move to client.
+
+## Decisions
+
+- 2026-04-25: Draft plan uses one workflow action per requested operation (`contacts.create`, `contacts.update`, etc.) instead of a single mode-based generic contact mutation action. Rationale: better workflow designer UX and clearer downstream output schemas.
+- 2026-04-25: Draft plan keeps actions additive under the existing `contacts.*` prefix so the current designer catalog grouping should place them under Contact.
+- 2026-04-25: Draft plan recommends requiring a new unique email for `contacts.duplicate` because contact primary emails are tenant-unique.
+- 2026-04-25: Draft plan treats `contacts.add_to_client` and `contacts.move_to_client` as separate author-facing actions even though both ultimately update `contacts.client_id`; their conflict/idempotency semantics differ.
+- 2026-04-25: User approved separating contact deactivation and hard deletion into two actions instead of using a flag. `contacts.deactivate` should be the safe idempotent action requiring `contact:update`; `contacts.delete` should remain destructive guarded hard delete requiring `contact:delete`.
+- 2026-04-25: After merging latest main with workflow Client actions, contact actions should mirror the new Client runtime conventions where applicable: action-provided idempotency for create/duplicate/add_tag/add_note/add_interaction; engine-provided idempotency for update/deactivate/delete/assignment; destructive delete requires `confirm: true`; delete supports explicit `on_not_found` behavior.
+- 2026-04-25: Updated `contacts.add_note` plan to be document-backed via `contacts.notes_document_id`, not interaction-backed. Rationale: latest `clients.add_note` establishes module-specific notes as append-only notes-document behavior, while `contacts.add_interaction` and generic `crm.create_activity_note` cover interaction rows.
+- 2026-04-25: User resolved remaining product questions: duplicate contact requires a new unique email; contact-to-ticket should not set ticket client unless the existing app action does; contact add-tag should match client add-tag behavior; contact create/update/deactivate should publish domain events with the same lazy best-effort pattern as Client actions.
+
+## Discoveries / Constraints
+
+- 2026-04-25: Existing contact workflow actions live in `shared/workflow/runtime/actions/businessOperations/contacts.ts` and currently register `contacts.find` and `contacts.search`.
+- 2026-04-25: Runtime bootstrap calls `registerBusinessOperationsActionsV2()`, which calls `registerContactActions()`, so new actions in `contacts.ts` should flow into the catalog automatically after runtime initialization.
+- 2026-04-25: `ContactModel.createContact` requires both `full_name` and `email`; it validates phone numbers, additional email addresses, primary email type, duplicate email, and client existence.
+- 2026-04-25: `ContactModel.updateContact` supports patch-like update input but has strict primary-email promotion behavior. Changing primary email requires promoting an existing/additional email path rather than blindly swapping.
+- 2026-04-25: Existing contact search in workflow uses `tag_definitions` / `tag_mappings` for contact tags (`tagged_type = 'contact'`).
+- 2026-04-25: `server/src/lib/api/services/ContactService.ts` has a private `handleTags()` that references `contact_tags`, but `rg` did not find a migration creating `contact_tags`. Implementation should verify and likely use `tag_mappings`/`TagModel` instead.
+- 2026-04-25: Existing contact delete server action in `packages/clients/src/actions/contact-actions/contactActions.tsx` uses `deleteEntityWithValidation('contact', ...)` and performs cleanup for entity tags, phone rows, comments, portal invitations, notes document content/associations, Entra reconciliation queue references, then deletes from `contacts`.
+- 2026-04-25: Contact deletion config in `packages/core/src/config/deletion/index.ts` lists dependencies: tickets, interactions, document associations, portal users, survey invitations/responses, and asset associations.
+- 2026-04-25: Generic CRM note workflow action `crm.create_activity_note` already creates rows in `interactions` using system `Note` type and supports contact targets. After reviewing new Client actions, `contacts.add_note` should not wrap this path; it should append to the contact notes document, leaving interaction rows to `contacts.add_interaction`/`crm.create_activity_note`.
+- 2026-04-25: Existing `packages/clients/src/actions/interactionActions.ts` has `addInteraction` behavior: requires either `client_id` or `contact_name_id`, derives client from contact if needed, and uses default interaction status when omitted.
+- 2026-04-25: Permission resources exist for `contact:create/read/update/delete`, `interaction:create/read/update/delete`, and `tag:create/read/update/delete` in migrations/seeds.
+- 2026-04-25: Existing ticket workflow actions define local picker metadata helpers in `tickets.ts`; contact actions may need similar helpers or shared extraction to keep schemas designer-friendly.
+- 2026-04-25: Latest `clients.assign_to_ticket` uses a direct ticket update contract with previous/current outputs and relationship validation. `contacts.assign_to_ticket` should follow that style rather than requiring an `expected_current_contact_id` guard in v1.
+- 2026-04-25: Quick app-path discovery found `packages/tickets/src/components/ticket/TicketDetails.tsx` contact-change code calls `updateTicket(ticket_id, { contact_name_id: newContactId })` only, so the workflow contact assignment plan should not auto-set `tickets.client_id` in v1.
+- 2026-04-25: Latest `clients.add_tag` avoids duplicate-insert error control flow because a caught `23505` still aborts the Postgres transaction. Contact tag implementation should pre-check mappings/definitions and return existing mappings idempotently.
+- 2026-04-25: Latest Client actions use best-effort lazy workflow event publication for create/update/archive/note/interaction paths. Contact implementation should either match this pattern where event builders exist or document any intentional gap.
+
+## Commands / Runbooks
+
+- 2026-04-25: Context discovery commands used:
+  - `find ee/docs/plans -maxdepth 2 -type f \( -name 'PRD.md' -o -name 'features.json' -o -name 'tests.json' -o -name 'SCRATCHPAD.md' \) | head -40`
+  - `git log --oneline -5 && git status --short`
+  - `rg -n "class ContactModel|createContact|updateContact|deleteContact|ContactModel\." shared server packages ee -g '*.ts' -g '*.tsx' | head -200`
+  - `rg -n "contact_name_id|contacts|interaction|tag_mappings|tag_definitions" server shared packages ee -g '*.ts' -g '*.tsx' -g '*.cjs' | head -240`
+  - `rg -n "createTable\\('contact_tags'|contact_tags" server/migrations ee/server/migrations -g '*.cjs'`
+
+## Links / References
+
+- `shared/workflow/runtime/actions/businessOperations/contacts.ts`
+- `shared/workflow/runtime/actions/businessOperations/tickets.ts`
+- `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- `shared/workflow/runtime/actions/registerBusinessOperationsActions.ts`
+- `shared/models/contactModel.ts`
+- `shared/models/tagModel.ts`
+- `server/src/lib/api/schemas/contact.ts`
+- `server/src/lib/api/services/ContactService.ts`
+- `packages/clients/src/actions/contact-actions/contactActions.tsx`
+- `packages/clients/src/actions/contact-actions/contactNoteActions.ts`
+- `packages/clients/src/actions/interactionActions.ts`
+- `packages/core/src/config/deletion/index.ts`
+- `docs/AI_coding_standards.md`
+
+## Resolved Questions
+
+- `contacts.duplicate` requires a new unique email override.
+- `contacts.assign_to_ticket` should only set `tickets.contact_name_id` in v1 unless an existing app action path is found to set `tickets.client_id` too. Current discovery indicates the app updates only `contact_name_id`.
+- `contacts.add_tag` should create missing tag definitions exactly like `clients.add_tag`, under the same update-style permission policy.
+- Contact create/update/deactivate workflow actions should publish contact domain events using the same lazy best-effort pattern as Client actions.
+
+## Implementation Log
+
+- 2026-04-26: Implemented full `contacts.*` mutation action surface in `shared/workflow/runtime/actions/businessOperations/contacts.ts`:
+  - Added registrations/schemas/handlers for `contacts.create`, `contacts.update`, `contacts.deactivate`, `contacts.delete`, `contacts.duplicate`, `contacts.add_tag`, `contacts.assign_to_ticket`, `contacts.add_note`, `contacts.add_interaction`, `contacts.add_to_client`, `contacts.move_to_client`.
+  - Added workflow picker metadata helper usage for contact/client/ticket IDs and compact normalized contact summary output schema reuse.
+  - Added tenant-scoped helper loaders and validations for contact/client/ticket lookups with standard workflow error categories.
+  - Added action-provided idempotency for create/duplicate/add_tag/add_note/add_interaction and engine-provided idempotency for update/deactivate/delete/assignment/client-move actions.
+  - Added permission checks per PRD (`contact:create/read/update/delete`, `ticket:update`) before mutation paths.
+  - Added workflow run audit writes for all side-effectful contact actions via `writeRunAudit`.
+  - Added guarded hard-delete implementation using `deleteEntityWithValidation` plus contact-owned artifact cleanup (`tag_mappings`, phone/email rows, comments, portal invitations, notes documents, enterprise queue references).
+  - Added best-effort lazy workflow domain event publishing for contact create/update/deactivate plus note/interaction events.
+- 2026-04-26: Implemented duplicate-contact constraints/behavior:
+  - Requires explicit new primary email (`input.email` required in schema).
+  - Supports field overrides and optional tag copy via canonical `tag_definitions` + `tag_mappings`.
+  - Does not copy historical relationships (tickets/interactions/notes docs/etc.).
+  - Additional emails are only copied when explicitly provided as an override. Rationale: current schema enforces tenant-unique normalized additional emails, so blind copying source additional emails can violate unique constraints.
+- 2026-04-26: Added tests:
+  - `shared/workflow/runtime/actions/__tests__/registerContactActionsMetadata.test.ts` for registration/catalog labels/idempotency and picker + compact output schema checks (T001/T002).
+  - `shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts` for DB-backed integration + permission + audit/event coverage across `contacts.*` mutations (T003-T015).
+
+## Verification
+
+- 2026-04-26: Ran targeted suites with shared Vitest config:
+  - `pnpm vitest --config shared/vitest.config.ts shared/workflow/runtime/actions/__tests__/registerContactActionsMetadata.test.ts shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts shared/workflow/runtime/actions/__tests__/businessOperations.contacts.emailSearch.test.ts`
+  - Result: pass (`3` files, `16` tests).
+
+## Gotchas
+
+- 2026-04-26: `tickets.client_id` in current schema is non-null in this test environment, so no-client ticket scenarios are not representable in DB setup. Assignment tests validate that `contacts.assign_to_ticket` only updates `tickets.contact_name_id` and preserves existing `tickets.client_id` unchanged.

--- a/ee/docs/plans/2026-04-25-workflow-contact-actions/features.json
+++ b/ee/docs/plans/2026-04-25-workflow-contact-actions/features.json
@@ -1,0 +1,338 @@
+[
+  {
+    "id": "F001",
+    "description": "Register `contacts.create` as a Contact-group workflow action with label, description, category, side-effect metadata, idempotency metadata, input schema, and output schema",
+    "implemented": true,
+    "prdRefs": [
+      "Create contact",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Implement `contacts.create` using existing contact validation for full name, primary email, client existence, phone numbers, primary email type, and additional email addresses",
+    "implemented": true,
+    "prdRefs": [
+      "Create contact",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Return a compact normalized created-contact output from `contacts.create` for downstream workflow mappings",
+    "implemented": true,
+    "prdRefs": [
+      "Shared contact output shape",
+      "Create contact"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Register `contacts.update` as a Contact-group workflow action with a typed patch schema for editable contact fields",
+    "implemented": true,
+    "prdRefs": [
+      "Edit contact",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Implement `contacts.update` patch semantics so omitted fields remain unchanged and existing primary-email promotion rules are preserved",
+    "implemented": true,
+    "prdRefs": [
+      "Edit contact"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Return before/after contact summaries and updated field names from `contacts.update`",
+    "implemented": true,
+    "prdRefs": [
+      "Edit contact",
+      "Shared contact output shape"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Register `contacts.delete` as a destructive Contact-group workflow action with guarded hard-delete label, `confirm: true`, `on_not_found`, schema, and output",
+    "implemented": true,
+    "prdRefs": [
+      "Delete contact"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Implement `contacts.delete` as tenant-scoped guarded hard delete with dependency blocking and owned-child cleanup consistent with existing contact delete behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Delete contact",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Return deterministic hard-delete status output from `contacts.delete`, including dependency conflict details and return-false behavior for missing contacts when requested",
+    "implemented": true,
+    "prdRefs": [
+      "Delete contact"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Register `contacts.duplicate` as a Contact-group workflow action with source contact picker, required new unique email override, optional field overrides, copy-tags option, and action-provided idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Duplicate contact",
+      "Resolved Decisions"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Implement `contacts.duplicate` by loading the source contact, applying overrides, validating uniqueness, excluding historical relationship copies, and creating a new contact in the target or source client",
+    "implemented": true,
+    "prdRefs": [
+      "Duplicate contact"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Implement optional tag-copy behavior for `contacts.duplicate` using the canonical contact tag mapping storage",
+    "implemented": true,
+    "prdRefs": [
+      "Duplicate contact",
+      "Add tag to contact",
+      "Known schema considerations"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Register `contacts.add_tag` as a Contact-group workflow action with contact picker, one-or-more tag text inputs, action-provided idempotency key, and added/existing tag output schema",
+    "implemented": true,
+    "prdRefs": [
+      "Add tag to contact"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "Implement `contacts.add_tag` with idempotent tag definition resolution and tag mapping creation for `tagged_type = contact`, returning existing mappings without duplicate insert error control flow",
+    "implemented": true,
+    "prdRefs": [
+      "Add tag to contact",
+      "Known schema considerations"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Use the same tag permission policy as `clients.add_tag`: `contacts.add_tag` requires `contact:update` and may create missing contact tag definitions without a separate stricter tag-create gate",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions",
+      "Resolved Decisions"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Register `contacts.assign_to_ticket` as a Contact-group workflow action with contact and ticket picker-backed inputs",
+    "implemented": true,
+    "prdRefs": [
+      "Assign contact to ticket",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "Implement `contacts.assign_to_ticket` as a direct ticket contact update that validates tenant-scoped ticket/contact existence, validates contact-client relationship, and returns previous/current contact IDs",
+    "implemented": true,
+    "prdRefs": [
+      "Assign contact to ticket"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Implement the resolved no-client-ticket policy for `contacts.assign_to_ticket`: only set `tickets.contact_name_id` unless the existing application action path is found to set `tickets.client_id` too",
+    "implemented": true,
+    "prdRefs": [
+      "Assign contact to ticket",
+      "Resolved Decisions"
+    ]
+  },
+  {
+    "id": "F019",
+    "description": "Register `contacts.add_note` as a Contact-group workflow action for document-backed contact note appends with action-provided idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Add note to contact"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "Implement `contacts.add_note` by appending to the contact notes document (`contacts.notes_document_id`), creating and linking the document when missing, and returning document metadata",
+    "implemented": true,
+    "prdRefs": [
+      "Add note to contact",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "Register `contacts.add_interaction` as a Contact-group workflow action with contact, optional ticket, interaction type/status, timing, title, notes, and action-provided idempotency fields",
+    "implemented": true,
+    "prdRefs": [
+      "Add interaction to contact",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "Implement `contacts.add_interaction` using the contact-derived client ID, workflow actor as `user_id`, default interaction status fallback, and relationship validation consistent with `clients.add_interaction`",
+    "implemented": true,
+    "prdRefs": [
+      "Add interaction to contact",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "Register `contacts.add_to_client` as a Contact-group workflow action with contact and client picker-backed inputs",
+    "implemented": true,
+    "prdRefs": [
+      "Add contact to client"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "Implement `contacts.add_to_client` to assign only unassigned contacts, no-op when already assigned to the target client, and conflict when assigned elsewhere",
+    "implemented": true,
+    "prdRefs": [
+      "Add contact to client"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Register `contacts.move_to_client` as a Contact-group workflow action with target client picker and optional expected-current-client guard",
+    "implemented": true,
+    "prdRefs": [
+      "Move contact to different client"
+    ]
+  },
+  {
+    "id": "F026",
+    "description": "Implement `contacts.move_to_client` to validate target client, move contact client_id, distinguish no-op/conflict/success, and return previous/current client IDs",
+    "implemented": true,
+    "prdRefs": [
+      "Move contact to different client"
+    ]
+  },
+  {
+    "id": "F027",
+    "description": "Add or reuse workflow JSON schema metadata helpers so contact, client, ticket, and user-facing picker hints survive designer schema serialization; use UUID fields for interaction type/status until picker support exists",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F028",
+    "description": "Create shared contact action schemas/helpers for UUIDs, contact summary output, phone number input, additional email input, and standard action result fields",
+    "implemented": true,
+    "prdRefs": [
+      "Shared contact output shape",
+      "Technical design"
+    ]
+  },
+  {
+    "id": "F029",
+    "description": "Create shared contact action helpers for loading tenant-scoped contacts/clients/tickets and throwing standard workflow not-found/validation/conflict errors",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F030",
+    "description": "Ensure every new side-effectful contact action runs through `withTenantTransaction` and uses tenant filters on all selects, inserts, updates, and deletes",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements"
+    ]
+  },
+  {
+    "id": "F031",
+    "description": "Ensure every new side-effectful contact action checks the confirmed actor permissions using `requirePermission` before mutation",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F032",
+    "description": "Ensure every new side-effectful contact action writes a workflow run audit record with action id, version, affected entity IDs, and meaningful changed data",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements"
+    ]
+  },
+  {
+    "id": "F033",
+    "description": "Map model/database errors from new contact actions into standard workflow action error categories and codes",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements"
+    ]
+  },
+  {
+    "id": "F034",
+    "description": "Update workflow designer catalog expectations so the Contact group includes all new `contacts.*` actions without disturbing existing built-in group ordering",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance Criteria",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F035",
+    "description": "Encode resolved product decisions for required duplicate email override, ticket contact-only assignment behavior, client-parity tag creation policy, and contact domain-event publication parity",
+    "implemented": true,
+    "prdRefs": [
+      "Resolved Decisions"
+    ]
+  },
+  {
+    "id": "F036",
+    "description": "Register `contacts.deactivate` as a separate Contact-group workflow action with safe deactivation label, description, schema, and output",
+    "implemented": true,
+    "prdRefs": [
+      "Deactivate contact",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F037",
+    "description": "Implement `contacts.deactivate` to set `is_inactive = true`, require `contact:update`, preserve tenant scoping, no-op when already inactive, and use engine-provided idempotency",
+    "implemented": true,
+    "prdRefs": [
+      "Deactivate contact",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F038",
+    "description": "Return previous/current inactive state, `deactivated`, `noop`, and compact contact summary from `contacts.deactivate`",
+    "implemented": true,
+    "prdRefs": [
+      "Deactivate contact",
+      "Shared contact output shape"
+    ]
+  },
+  {
+    "id": "F039",
+    "description": "Mirror the new client action runtime conventions for contact actions: action-provided idempotency for create/duplicate/add_tag/add_note/add_interaction, engine-provided idempotency for update/deactivate/delete/assignment, and best-effort lazy domain-event publication for contact create/update/deactivate plus existing note/interaction events",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements",
+      "Data / API / Integrations",
+      "Resolved Decisions"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-25-workflow-contact-actions/tests.json
+++ b/ee/docs/plans/2026-04-25-workflow-contact-actions/tests.json
@@ -1,0 +1,224 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit/catalog: registering business operations exposes all new `contacts.*` action IDs under the Contact designer catalog group with expected labels and versions",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F004",
+      "F036",
+      "F007",
+      "F010",
+      "F013",
+      "F016",
+      "F019",
+      "F021",
+      "F023",
+      "F025",
+      "F034",
+      "F039"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Unit/schema: contact action input schemas include picker metadata for contact, client, and ticket IDs and expose compact output schemas suitable for downstream mappings",
+    "implemented": true,
+    "featureIds": [
+      "F003",
+      "F016",
+      "F023",
+      "F025",
+      "F027",
+      "F028"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Integration DB: `contacts.create` creates a tenant-scoped contact with client, phone numbers, additional email addresses, compact output, action-provided idempotency metadata, and duplicate email failure as a standard conflict/validation action error",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F002",
+      "F003",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F039"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "Integration DB: `contacts.update` patches only supplied fields, preserves omitted fields, returns before/after summaries, and rejects invalid primary-email changes through existing model validation",
+    "implemented": true,
+    "featureIds": [
+      "F004",
+      "F005",
+      "F006",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "Integration DB: `contacts.add_to_client` assigns an unassigned contact, no-ops when already assigned to the target client, and conflicts when the contact belongs to a different client",
+    "implemented": true,
+    "featureIds": [
+      "F023",
+      "F024",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "Integration DB: `contacts.move_to_client` moves a contact to a new client, returns previous/current client IDs, no-ops on repeated target, and enforces `expected_current_client_id` guard",
+    "implemented": true,
+    "featureIds": [
+      "F025",
+      "F026",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "Integration DB: `contacts.assign_to_ticket` updates only `tickets.contact_name_id`, returns previous/current contact IDs, is stable when repeated, rejects cross-client assignment, and does not set `tickets.client_id` for no-client tickets unless an existing app action path is found to do so",
+    "implemented": true,
+    "featureIds": [
+      "F016",
+      "F017",
+      "F018",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "Integration DB: `contacts.add_tag` creates or reuses contact tag definitions/mappings using the same permission semantics as `clients.add_tag`, returns added/existing counts, and is idempotent on repeat calls without duplicate-insert transaction aborts",
+    "implemented": true,
+    "featureIds": [
+      "F013",
+      "F014",
+      "F015",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F039"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "Integration DB: `contacts.duplicate` requires a new unique email override, copies selected source fields, applies field/client overrides, optionally copies tags, excludes historical relationships, and fails on email conflicts",
+    "implemented": true,
+    "featureIds": [
+      "F010",
+      "F011",
+      "F012",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F035",
+      "F039"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "Integration DB: `contacts.add_note` creates a contact notes document when missing, appends note content on subsequent calls, returns document metadata, and does not create an interaction row",
+    "implemented": true,
+    "featureIds": [
+      "F019",
+      "F020",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F039"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "Integration DB: `contacts.add_interaction` inserts a valid contact-linked interaction using the contact-derived client, workflow actor as owner, supplied type/timing/details, default status fallback, and ticket relationship validation",
+    "implemented": true,
+    "featureIds": [
+      "F021",
+      "F022",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F039"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "Integration DB: `contacts.delete` requires `confirm: true`, performs guarded hard delete with owned-child cleanup for eligible contacts, supports `on_not_found: return_false`, and returns dependency conflict details when blocked",
+    "implemented": true,
+    "featureIds": [
+      "F007",
+      "F008",
+      "F009",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F035"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Unit/permission: each new contact action checks the expected permission before mutation and returns `PERMISSION_DENIED` when the workflow actor lacks access",
+    "implemented": true,
+    "featureIds": [
+      "F037",
+      "F015",
+      "F031",
+      "F035"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Unit/audit/events: each side-effectful contact action writes workflow run audit; representative action.call smoke coverage verifies saveAs output consumption; create/update/deactivate publish contact domain events with lazy best-effort event publishing",
+    "implemented": true,
+    "featureIds": [
+      "F030",
+      "F032",
+      "F039"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Integration DB: `contacts.deactivate` sets `is_inactive = true`, returns previous/current inactive state, and is idempotent when called again on an inactive contact",
+    "implemented": true,
+    "featureIds": [
+      "F036",
+      "F037",
+      "F038",
+      "F029",
+      "F030",
+      "F031",
+      "F032",
+      "F033",
+      "F039"
+    ]
+  }
+]

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -614,28 +614,51 @@ const computeValidation = async (params: {
     return base;
   };
 
+  const decodeJsonPointerSegment = (segment: string): string =>
+    segment.replace(/~1/g, '/').replace(/~0/g, '~');
+
+  const resolveLocalSchemaRef = (ref: string | undefined, rootSchema: any): any | null => {
+    if (!ref || !rootSchema || typeof rootSchema !== 'object') return null;
+    if (ref === '#') return rootSchema;
+    if (!ref.startsWith('#/')) return null;
+
+    const parts = ref.slice(2).split('/').map(decodeJsonPointerSegment);
+    let current: any = rootSchema;
+    for (const part of parts) {
+      if (!current || typeof current !== 'object') return null;
+      current = current[part];
+    }
+    return current && typeof current === 'object' ? current : null;
+  };
+
+  const resolveSchemaNode = (node: any, rootSchema: any, seenRefs = new Set<string>()): any => {
+    if (!node || typeof node !== 'object') return node;
+    if (node.anyOf && Array.isArray(node.anyOf)) {
+      const nonNull = node.anyOf.find((s: any) => s && s.type !== 'null') ?? node.anyOf[0];
+      return resolveSchemaNode(nonNull, rootSchema, seenRefs);
+    }
+    if (node.$ref && typeof node.$ref === 'string' && !seenRefs.has(node.$ref)) {
+      seenRefs.add(node.$ref);
+      const resolved = resolveLocalSchemaRef(node.$ref, rootSchema);
+      if (resolved) return resolveSchemaNode(resolved, rootSchema, seenRefs);
+    }
+    return node;
+  };
+
   const resolveSchemaAtPath = (schema: any, path: string[]): any | null => {
     if (!schema || typeof schema !== 'object') return null;
-    let current: any = schema;
+    let current: any = resolveSchemaNode(schema, schema);
     for (const seg of path) {
       if (!current) return null;
-      // Handle anyOf (nullable)
-      if (current.anyOf && Array.isArray(current.anyOf)) {
-        const nonNull = current.anyOf.find((s: any) => s && s.type !== 'null') ?? current.anyOf[0];
-        current = nonNull;
-      }
-      if (current.$ref && schema.definitions && typeof current.$ref === 'string') {
-        const key = current.$ref.replace('#/definitions/', '');
-        current = schema.definitions[key] ?? current;
-      }
+      current = resolveSchemaNode(current, schema);
       if (current.type === 'object' && current.properties && typeof current.properties === 'object') {
-        current = (current.properties as any)[seg] ?? null;
+        current = resolveSchemaNode((current.properties as any)[seg] ?? null, schema);
         continue;
       }
       if (current.type === 'array' && current.items) {
         // Only support `.items.<prop>` lookup if seg is 'items'
         if (seg === 'items') {
-          current = current.items;
+          current = resolveSchemaNode(current.items, schema);
           continue;
         }
         // Unknown array access
@@ -643,7 +666,7 @@ const computeValidation = async (params: {
       }
       return null;
     }
-    return current;
+    return resolveSchemaNode(current, schema);
   };
 
   const literalTypes = (value: unknown): Set<string> => {

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -113,6 +113,7 @@ import { WorkflowStepNameField } from './WorkflowStepNameField';
 import { WorkflowStepSaveOutputSection } from './WorkflowStepSaveOutputSection';
 import { WorkflowActionInputSection } from './WorkflowActionInputSection';
 import { WorkflowActionInputFixedPicker } from './WorkflowActionInputFixedPicker';
+import { resolveLocalJsonSchemaRef } from './jsonSchemaRefs';
 import { buildWorkflowReferenceFieldOptions } from './workflowReferenceOptions';
 import { shouldRenderWorkflowAiSchemaSection } from './workflowAiStepUtils';
 import { applyWorkflowActionPresentationHintsToList } from './workflowActionPresentation';
@@ -410,12 +411,17 @@ const mergeSchemaMetadata = (wrapper: JsonSchema, resolved: JsonSchema): JsonSch
   'x-workflow-editor': (resolved as any)['x-workflow-editor'] ?? (wrapper as any)['x-workflow-editor'],
 });
 
-const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
+const resolveSchema = (schema: JsonSchema, root?: JsonSchema, seenRefs = new Set<string>()): JsonSchema => {
+  const rootSchema = root ?? schema;
+
   // Handle $ref
-  if (schema.$ref && root?.definitions) {
-    const refKey = schema.$ref.replace('#/definitions/', '');
-    const resolved = root.definitions?.[refKey];
-    if (resolved) return resolveSchema(resolved, root);
+  if (schema.$ref) {
+    const refKey = schema.$ref;
+    if (!seenRefs.has(refKey)) {
+      seenRefs.add(refKey);
+      const resolved = resolveLocalJsonSchemaRef(refKey, rootSchema);
+      if (resolved) return resolveSchema(resolved, rootSchema, seenRefs);
+    }
   }
 
   // Handle anyOf (used for nullable types) - extract the non-null variant
@@ -425,7 +431,7 @@ const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
     );
     if (nonNullVariant) {
       // Merge nullable info back into resolved schema
-      const resolved = resolveSchema(nonNullVariant, root);
+      const resolved = resolveSchema(nonNullVariant, rootSchema, seenRefs);
       const merged = mergeSchemaMetadata(schema, resolved);
       return {
         ...merged,

--- a/ee/server/src/components/workflow-designer/__tests__/workflowDataContext.test.ts
+++ b/ee/server/src/components/workflow-designer/__tests__/workflowDataContext.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildDataContext } from '../workflowDataContext';
+import { buildWorkflowReferenceFieldOptions } from '../workflowReferenceOptions';
 import { applyCatalogActionChoiceToStep } from '../groupedActionSelection';
 import type { NodeStep, WorkflowDefinition } from '@alga-psa/workflows/runtime/client';
 import type { WorkflowDesignerCatalogAction } from '@alga-psa/workflows/runtime/designer/actionCatalog';
@@ -846,5 +847,83 @@ describe('workflow data context', () => {
         constraints: undefined,
       },
     ]);
+  });
+
+  it('T431: resolves local JSON Schema refs when browsing nested action output fields', () => {
+    const duplicateRegistry = [
+      ...actionRegistry,
+      {
+        id: 'contacts.duplicate',
+        version: 1,
+        ui: {
+          label: 'Duplicate Contact',
+          description: 'Duplicate a contact.',
+        },
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            source_contact: {
+              type: 'object',
+              properties: {
+                contact_name_id: { type: 'string', format: 'uuid' },
+                full_name: { type: ['string', 'null'] },
+                email: { type: ['string', 'null'] },
+              },
+              required: ['contact_name_id', 'full_name', 'email'],
+              additionalProperties: false,
+            },
+            duplicate_contact: {
+              $ref: '#/properties/source_contact',
+            },
+            copied_tags: { type: 'integer' },
+          },
+          required: ['source_contact', 'duplicate_contact', 'copied_tags'],
+          additionalProperties: false,
+        },
+      },
+    ];
+
+    const definition: WorkflowDefinition = {
+      id: 'wf-ref-output',
+      name: 'Ref output workflow',
+      version: 1,
+      description: '',
+      steps: [
+        {
+          id: 'duplicate-step',
+          type: 'action.call',
+          config: {
+            actionId: 'contacts.duplicate',
+            version: 1,
+            saveAs: 'duplicatedContact',
+          },
+        },
+        {
+          id: 'delete-step',
+          type: 'action.call',
+          config: {
+            actionId: 'tickets.create',
+            version: 1,
+          },
+        },
+      ],
+    };
+
+    const context = buildDataContext(definition, 'delete-step', duplicateRegistry, null);
+    const duplicateContactField = context.steps[0]?.fields.find((field) => field.name === 'duplicate_contact');
+
+    expect(duplicateContactField?.children?.map((field) => field.name)).toEqual([
+      'contact_name_id',
+      'full_name',
+      'email',
+    ]);
+
+    const referenceOptions = buildWorkflowReferenceFieldOptions(null, context).map((option) => option.value);
+
+    expect(referenceOptions).toContain('vars.duplicatedContact.duplicate_contact.contact_name_id');
   });
 });

--- a/ee/server/src/components/workflow-designer/jsonSchemaRefs.ts
+++ b/ee/server/src/components/workflow-designer/jsonSchemaRefs.ts
@@ -1,0 +1,43 @@
+export type JsonSchemaReferenceRoot = {
+  definitions?: Record<string, unknown>;
+  $defs?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+const decodeJsonPointerSegment = (segment: string): string =>
+  segment.replace(/~1/g, '/').replace(/~0/g, '~');
+
+export const resolveLocalJsonSchemaRef = <T extends object>(
+  ref: string | undefined,
+  root: T | undefined
+): T | undefined => {
+  if (!ref || !root) return undefined;
+
+  if (ref === '#') return root;
+
+  if (ref.startsWith('#/')) {
+    const parts = ref.slice(2).split('/').map(decodeJsonPointerSegment);
+    let current: unknown = root;
+
+    for (const part of parts) {
+      if (!current || typeof current !== 'object') return undefined;
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    return current && typeof current === 'object' ? (current as T) : undefined;
+  }
+
+  if (ref.startsWith('#/definitions/')) {
+    const refKey = decodeJsonPointerSegment(ref.replace('#/definitions/', ''));
+    const resolved = (root as JsonSchemaReferenceRoot).definitions?.[refKey];
+    return resolved && typeof resolved === 'object' ? (resolved as T) : undefined;
+  }
+
+  if (ref.startsWith('#/$defs/')) {
+    const refKey = decodeJsonPointerSegment(ref.replace('#/$defs/', ''));
+    const resolved = (root as JsonSchemaReferenceRoot).$defs?.[refKey];
+    return resolved && typeof resolved === 'object' ? (resolved as T) : undefined;
+  }
+
+  return undefined;
+};

--- a/ee/server/src/components/workflow-designer/workflowDataContext.ts
+++ b/ee/server/src/components/workflow-designer/workflowDataContext.ts
@@ -13,6 +13,8 @@ import {
   resolveComposeTextOutputSchemaFromConfig,
 } from '@alga-psa/workflows/authoring';
 
+import { resolveLocalJsonSchemaRef } from './jsonSchemaRefs';
+
 export type ActionRegistryItem = {
   id: string;
   version: number;
@@ -112,11 +114,16 @@ const errorGlobalSchema: JsonSchema = {
   }
 };
 
-const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
-  if (schema.$ref && root?.definitions) {
-    const refKey = schema.$ref.replace('#/definitions/', '');
-    const resolved = root.definitions?.[refKey];
-    if (resolved) return resolveSchema(resolved, root);
+const resolveSchema = (schema: JsonSchema, root?: JsonSchema, seenRefs = new Set<string>()): JsonSchema => {
+  const rootSchema = root ?? schema;
+
+  if (schema.$ref) {
+    const refKey = schema.$ref;
+    if (!seenRefs.has(refKey)) {
+      seenRefs.add(refKey);
+      const resolved = resolveLocalJsonSchemaRef(refKey, rootSchema);
+      if (resolved) return resolveSchema(resolved, rootSchema, seenRefs);
+    }
   }
 
   if (schema.anyOf?.length) {
@@ -124,7 +131,7 @@ const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
       (variant) => variant.type !== 'null' && !(Array.isArray(variant.type) && variant.type.length === 1 && variant.type[0] === 'null')
     );
     if (nonNullVariant) {
-      const resolved = resolveSchema(nonNullVariant, root);
+      const resolved = resolveSchema(nonNullVariant, rootSchema, seenRefs);
       return {
         ...resolved,
         type: Array.isArray(resolved.type) ? resolved.type : resolved.type ? [resolved.type, 'null'] : ['null']

--- a/ee/server/src/components/workflow-designer/workflowReferenceOptions.ts
+++ b/ee/server/src/components/workflow-designer/workflowReferenceOptions.ts
@@ -1,13 +1,19 @@
 import type { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 
+import { resolveLocalJsonSchemaRef } from './jsonSchemaRefs';
 import type { DataContext, JsonSchema } from './workflowDataContext';
 
-const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
-  if (schema.$ref && root?.definitions) {
-    const refKey = schema.$ref.replace('#/definitions/', '');
-    const resolved = root.definitions?.[refKey];
-    if (resolved) {
-      return resolveSchema(resolved, root);
+const resolveSchema = (schema: JsonSchema, root?: JsonSchema, seenRefs = new Set<string>()): JsonSchema => {
+  const rootSchema = root ?? schema;
+
+  if (schema.$ref) {
+    const refKey = schema.$ref;
+    if (!seenRefs.has(refKey)) {
+      seenRefs.add(refKey);
+      const resolved = resolveLocalJsonSchemaRef(refKey, rootSchema);
+      if (resolved) {
+        return resolveSchema(resolved, rootSchema, seenRefs);
+      }
     }
   }
 
@@ -18,7 +24,7 @@ const resolveSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
         !(Array.isArray(variant.type) && variant.type.length === 1 && variant.type[0] === 'null')
     );
     if (nonNullVariant) {
-      const resolved = resolveSchema(nonNullVariant, root);
+      const resolved = resolveSchema(nonNullVariant, rootSchema, seenRefs);
       return {
         ...resolved,
         type: Array.isArray(resolved.type)

--- a/ee/server/src/components/workflow-designer/workflowReferenceSelector.tsx
+++ b/ee/server/src/components/workflow-designer/workflowReferenceSelector.tsx
@@ -5,6 +5,7 @@ import { useWorkflowReferenceSectionOptions } from '@alga-psa/workflows/hooks/us
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 import type { JsonSchema } from './expression-editor';
+import { resolveLocalJsonSchemaRef } from './jsonSchemaRefs';
 import type { DataTreeContext } from './mapping/SourceDataTree';
 import {
   TypeCompatibility,
@@ -64,11 +65,16 @@ const flattenReferenceFields = (
   return flattened;
 };
 
-const resolveReferenceSchema = (schema: JsonSchema, root?: JsonSchema): JsonSchema => {
-  if (schema.$ref && root?.definitions) {
-    const refKey = schema.$ref.replace('#/definitions/', '');
-    const resolved = root.definitions?.[refKey];
-    if (resolved) return resolveReferenceSchema(resolved, root);
+const resolveReferenceSchema = (schema: JsonSchema, root?: JsonSchema, seenRefs = new Set<string>()): JsonSchema => {
+  const rootSchema = root ?? schema;
+
+  if (schema.$ref) {
+    const refKey = schema.$ref;
+    if (!seenRefs.has(refKey)) {
+      seenRefs.add(refKey);
+      const resolved = resolveLocalJsonSchemaRef(refKey, rootSchema);
+      if (resolved) return resolveReferenceSchema(resolved, rootSchema, seenRefs);
+    }
   }
 
   if (schema.anyOf?.length) {
@@ -78,7 +84,7 @@ const resolveReferenceSchema = (schema: JsonSchema, root?: JsonSchema): JsonSche
         !(Array.isArray(variant.type) && variant.type.length === 1 && variant.type[0] === 'null')
     );
     if (nonNullVariant) {
-      const resolved = resolveReferenceSchema(nonNullVariant, root);
+      const resolved = resolveReferenceSchema(nonNullVariant, rootSchema, seenRefs);
       return {
         ...resolved,
         type: Array.isArray(resolved.type)

--- a/packages/event-schemas/src/schemas/domain/crmEventSchemas.ts
+++ b/packages/event-schemas/src/schemas/domain/crmEventSchemas.ts
@@ -93,7 +93,7 @@ export type ClientArchivedEventPayload = z.infer<typeof clientArchivedEventPaylo
 
 export const contactCreatedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   fullName: z.string().min(1),
   email: z.string().email().optional(),
   primaryEmailCanonicalType: contactEmailCanonicalTypeSchema.nullable().optional(),
@@ -111,7 +111,7 @@ export type ContactCreatedEventPayload = z.infer<typeof contactCreatedEventPaylo
 
 export const contactUpdatedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   updatedByUserId: userIdSchema.optional(),
   updatedAt: z.string().datetime().optional(),
   updatedFields: updatedFieldsSchema,
@@ -132,7 +132,7 @@ export type ContactPrimarySetEventPayload = z.infer<typeof contactPrimarySetEven
 
 export const contactArchivedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   archivedByUserId: userIdSchema.optional(),
   archivedAt: z.string().datetime().optional(),
   reason: z.string().optional(),

--- a/shared/workflow/expression-authoring/__tests__/coreContracts.test.ts
+++ b/shared/workflow/expression-authoring/__tests__/coreContracts.test.ts
@@ -203,6 +203,34 @@ describe('expression authoring contracts', () => {
     expect(optionPaths.has('vars.previous.account.id')).toBe(true);
   });
 
+  it('resolves local JSON Schema refs when discovering nested workflow vars paths', () => {
+    const options = buildWorkflowExpressionPathOptions({
+      varsByName: {
+        duplicatedContact: {
+          type: 'object',
+          properties: {
+            source_contact: {
+              type: 'object',
+              properties: {
+                contact_name_id: { type: 'string' },
+                email: { type: ['string', 'null'] },
+              },
+            },
+            duplicate_contact: { $ref: '#/properties/source_contact' },
+          },
+        },
+      },
+    });
+
+    const optionByPath = new Map(options.map((option) => [option.path, option]));
+
+    expect(optionByPath.get('vars.duplicatedContact.duplicate_contact')?.isLeaf).toBe(false);
+    expect(optionByPath.get('vars.duplicatedContact.duplicate_contact.contact_name_id')).toMatchObject({
+      valueType: 'string',
+      isLeaf: true,
+    });
+  });
+
   it('returns informational diagnostics for unresolved schema-aware paths', () => {
     const options = buildWorkflowExpressionPathOptions({
       payloadSchema: {

--- a/shared/workflow/expression-authoring/pathDiscovery.ts
+++ b/shared/workflow/expression-authoring/pathDiscovery.ts
@@ -27,33 +27,58 @@ const normalizeSchemaType = (schema: SharedExpressionSchemaNode | undefined): Sh
   return 'unknown';
 };
 
+const decodeJsonPointerSegment = (segment: string): string =>
+  segment.replace(/~1/g, '/').replace(/~0/g, '~');
+
+const resolveLocalSchemaRef = (
+  ref: string | undefined,
+  rootSchema: SharedExpressionSchemaNode | undefined
+): SharedExpressionSchemaNode | undefined => {
+  if (!ref || !rootSchema) return undefined;
+  if (ref === '#') return rootSchema;
+  if (!ref.startsWith('#/')) return undefined;
+
+  const parts = ref.slice(2).split('/').map(decodeJsonPointerSegment);
+  let current: unknown = rootSchema;
+  for (const part of parts) {
+    if (!current || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current && typeof current === 'object'
+    ? (current as SharedExpressionSchemaNode)
+    : undefined;
+};
+
 const resolveSchema = (
   schema: SharedExpressionSchemaNode | undefined,
-  rootSchema?: SharedExpressionSchemaNode
+  rootSchema?: SharedExpressionSchemaNode,
+  seenRefs = new Set<string>()
 ): SharedExpressionSchemaNode | undefined => {
   if (!schema) return undefined;
+  const root = rootSchema ?? schema;
 
-  if (schema.$ref && rootSchema?.definitions) {
-    const refKey = schema.$ref.replace('#/definitions/', '');
-    const referenced = rootSchema.definitions[refKey];
+  if (schema.$ref && !seenRefs.has(schema.$ref)) {
+    seenRefs.add(schema.$ref);
+    const referenced = resolveLocalSchemaRef(schema.$ref, root);
     if (referenced) {
-      return resolveSchema(referenced, rootSchema);
+      return resolveSchema(referenced, root, seenRefs);
     }
   }
 
   if (schema.anyOf?.length) {
     const nonNull = schema.anyOf.find((variant) => normalizeSchemaType(variant) !== 'null');
     if (nonNull) {
-      return resolveSchema(nonNull, rootSchema);
+      return resolveSchema(nonNull, root, seenRefs);
     }
   }
 
   if (schema.oneOf?.length) {
-    return resolveSchema(schema.oneOf[0], rootSchema);
+    return resolveSchema(schema.oneOf[0], root, seenRefs);
   }
 
   if (schema.allOf?.length) {
-    return resolveSchema(schema.allOf[0], rootSchema);
+    return resolveSchema(schema.allOf[0], root, seenRefs);
   }
 
   return schema;
@@ -75,10 +100,11 @@ const hasChildNodes = (schema: SharedExpressionSchemaNode | undefined): boolean 
 const createOption = (
   root: SharedExpressionContextRoot,
   segments: string[],
-  schema: SharedExpressionSchemaNode | undefined
+  schema: SharedExpressionSchemaNode | undefined,
+  rootSchema: SharedExpressionSchemaNode | undefined = root.schema
 ): SharedExpressionPathOption => {
   const path = joinPath(root.key, segments);
-  const resolvedSchema = resolveSchema(schema, root.schema);
+  const resolvedSchema = resolveSchema(schema, rootSchema);
 
   return {
     root: root.key,
@@ -102,8 +128,12 @@ const pushObjectPropertyOptions = (
   const propertyEntries = Object.entries(schema.properties ?? {}).sort(([a], [b]) => a.localeCompare(b));
   for (const [propertyName, propertySchema] of propertyEntries) {
     const nextSegments = [...parentSegments, propertyName];
-    options.push(createOption(root, nextSegments, propertySchema));
-    pushNestedOptions(options, root, nextSegments, propertySchema, rootSchema);
+    const nextRootSchema =
+      root.key === 'vars' && parentSegments.length === 0 && propertySchema && typeof propertySchema === 'object'
+        ? propertySchema
+        : rootSchema;
+    options.push(createOption(root, nextSegments, propertySchema, nextRootSchema));
+    pushNestedOptions(options, root, nextSegments, propertySchema, nextRootSchema);
   }
 };
 

--- a/shared/workflow/runtime/__tests__/workflowDesignerContactCatalogRuntime.test.ts
+++ b/shared/workflow/runtime/__tests__/workflowDesignerContactCatalogRuntime.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { zodToWorkflowJsonSchema } from '../jsonSchemaMetadata';
+import { registerBusinessOperationsActionsV2 } from '../actions/registerBusinessOperationsActions';
+import { getActionRegistryV2 } from '../registries/actionRegistry';
+import { buildWorkflowDesignerActionCatalog, type WorkflowDesignerCatalogSourceAction } from '../designer/actionCatalog';
+
+const EXPECTED_CONTACT_ACTION_IDS = [
+  'contacts.find',
+  'contacts.search',
+  'contacts.create',
+  'contacts.update',
+  'contacts.deactivate',
+  'contacts.delete',
+  'contacts.duplicate',
+  'contacts.add_tag',
+  'contacts.assign_to_ticket',
+  'contacts.add_note',
+  'contacts.add_interaction',
+  'contacts.add_to_client',
+  'contacts.move_to_client',
+] as const;
+
+describe('workflow designer contact catalog grouping from runtime registrations', () => {
+  beforeAll(() => {
+    const registry = getActionRegistryV2();
+    if (!registry.get('contacts.move_to_client', 1)) {
+      registerBusinessOperationsActionsV2();
+    }
+  });
+
+  it('T001: groups runtime-registered contacts.* actions under built-in Contact group without catalog seed changes', () => {
+    const registry = getActionRegistryV2();
+    const allRuntimeActions = registry.list();
+
+    const sourceActions: WorkflowDesignerCatalogSourceAction[] = allRuntimeActions.map((action) => ({
+      id: action.id,
+      version: action.version,
+      ui: action.ui,
+      inputSchema: zodToWorkflowJsonSchema(action.inputSchema),
+      outputSchema: zodToWorkflowJsonSchema(action.outputSchema),
+    }));
+
+    const catalog = buildWorkflowDesignerActionCatalog(sourceActions);
+    const contactRecord = catalog.find((record) => record.groupKey === 'contact');
+
+    expect(contactRecord).toBeDefined();
+    expect(contactRecord?.label).toBe('Contact');
+
+    expect(contactRecord?.allowedActionIds).toEqual(expect.arrayContaining([...EXPECTED_CONTACT_ACTION_IDS]));
+    expect(contactRecord?.allowedActionIds.length).toBeGreaterThanOrEqual(EXPECTED_CONTACT_ACTION_IDS.length);
+
+    const contactActionIdsFromGroup = new Set(contactRecord?.actions.map((action) => action.id));
+    for (const actionId of EXPECTED_CONTACT_ACTION_IDS) {
+      expect(contactActionIdsFromGroup.has(actionId)).toBe(true);
+    }
+  });
+});

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts
@@ -1,0 +1,937 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { knex, type Knex } from 'knex';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+import { getSecret } from '@alga-psa/core/secrets';
+import { v4 as uuidv4 } from 'uuid';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../../..');
+const TEST_DB_NAME = 'test_database';
+const PRODUCTION_DB_NAMES = new Set(['sebastian_prod', 'production', 'prod', 'server']);
+
+function verifyTestDatabase(dbName: string): void {
+  if (PRODUCTION_DB_NAMES.has(dbName.toLowerCase())) {
+    throw new Error(`Attempting to use production database (${dbName}) for testing`);
+  }
+}
+
+async function recreateDatabase(
+  databaseName: string,
+  dbHost: string,
+  dbPort: number,
+  adminUser: string,
+  adminPassword: string,
+  appUser: string,
+  appPassword: string
+): Promise<void> {
+  const adminConnection = knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: adminUser,
+      password: adminPassword,
+      database: 'postgres',
+    },
+    pool: { min: 1, max: 2 },
+  });
+
+  try {
+    const safeDbName = databaseName.replace(/"/g, '""');
+    await adminConnection.raw(
+      'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ? AND pid <> pg_backend_pid()',
+      [databaseName]
+    );
+    await adminConnection.raw(`DROP DATABASE IF EXISTS "${safeDbName}"`);
+    await adminConnection.raw(`CREATE DATABASE "${safeDbName}"`);
+    await adminConnection.raw(`DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${appUser}') THEN
+          CREATE ROLE ${appUser} WITH LOGIN PASSWORD '${appPassword}';
+        ELSE
+          ALTER ROLE ${appUser} WITH LOGIN PASSWORD '${appPassword}';
+        END IF;
+      END;
+    $$;`);
+    await adminConnection.raw(`ALTER DATABASE "${safeDbName}" OWNER TO ${appUser}`);
+    await adminConnection.raw(`GRANT ALL PRIVILEGES ON DATABASE "${safeDbName}" TO ${appUser}`);
+  } finally {
+    await adminConnection.destroy().catch(() => undefined);
+  }
+}
+
+async function createTestDbConnection(): Promise<Knex> {
+  const databaseName = process.env.DB_NAME_SERVER || TEST_DB_NAME;
+  verifyTestDatabase(databaseName);
+
+  const dbHost = process.env.DB_HOST || 'localhost';
+  const dbPort = Number.parseInt(process.env.DB_PORT || '5432', 10);
+  const adminUser = process.env.DB_USER_ADMIN || 'postgres';
+  const adminPassword = await getSecret('postgres_password', 'DB_PASSWORD_ADMIN', 'postpass123');
+  const appUser = process.env.DB_USER_SERVER || 'app_user';
+  const appPassword = await getSecret('db_password_server', 'DB_PASSWORD_SERVER', 'postpass123');
+
+  await recreateDatabase(databaseName, dbHost, dbPort, adminUser, adminPassword, appUser, appPassword);
+
+  process.env.DB_HOST = dbHost;
+  process.env.DB_PORT = String(dbPort);
+  process.env.DB_NAME_SERVER = databaseName;
+  process.env.DB_USER_SERVER = appUser;
+  process.env.DB_USER_ADMIN = adminUser;
+
+  const adminKnex = knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: adminUser,
+      password: adminPassword,
+      database: databaseName,
+    },
+    migrations: { directory: path.join(repoRoot, 'server', 'migrations') },
+    seeds: { directory: path.join(repoRoot, 'server', 'seeds', 'dev') },
+  });
+
+  await adminKnex.migrate.latest();
+  await adminKnex.seed.run();
+  await adminKnex.destroy();
+
+  return knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: appUser,
+      password: appPassword,
+      database: databaseName,
+    },
+    asyncStackTraces: true,
+    pool: { min: 2, max: 20 },
+  });
+}
+
+async function createTenant(db: Knex, name = 'Test Tenant'): Promise<string> {
+  const tenantId = uuidv4();
+  const now = new Date().toISOString();
+
+  await db('tenants').insert({
+    tenant: tenantId,
+    client_name: name,
+    phone_number: '555-0100',
+    email: `test-${tenantId.substring(0, 8)}@example.com`,
+    created_at: now,
+    updated_at: now,
+    payment_platform_id: `test-platform-${tenantId.substring(0, 8)}`,
+    payment_method_id: `test-method-${tenantId.substring(0, 8)}`,
+    auth_service_id: `test-auth-${tenantId.substring(0, 8)}`,
+    plan: 'pro',
+  });
+
+  return tenantId;
+}
+
+async function createUser(
+  db: Knex,
+  tenantId: string,
+  options: {
+    email?: string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+    user_type?: 'client' | 'internal';
+    is_inactive?: boolean;
+    contact_id?: string;
+  } = {}
+): Promise<string> {
+  const userId = uuidv4();
+
+  await db('users').insert({
+    user_id: userId,
+    tenant: tenantId,
+    username: options.username || `test.user.${userId}`,
+    first_name: options.first_name || 'Test',
+    last_name: options.last_name || 'User',
+    email: options.email || `test.user.${userId}@example.com`,
+    hashed_password: 'hashed_password_here',
+    created_at: new Date(),
+    two_factor_enabled: false,
+    is_google_user: false,
+    is_inactive: options.is_inactive ?? false,
+    user_type: options.user_type || 'internal',
+    contact_id: options.contact_id,
+  });
+
+  return userId;
+}
+
+async function createClient(db: Knex, tenantId: string, name = 'Test Client'): Promise<string> {
+  const clientId = uuidv4();
+  const now = new Date().toISOString();
+
+  await db('clients').insert({
+    client_id: clientId,
+    client_name: name,
+    tenant: tenantId,
+    billing_cycle: 'monthly',
+    is_tax_exempt: false,
+    url: '',
+    created_at: now,
+    updated_at: now,
+    is_inactive: false,
+    credit_balance: 0,
+  });
+
+  return clientId;
+}
+
+async function createContactRaw(
+  db: Knex,
+  tenantId: string,
+  options: {
+    full_name?: string;
+    email?: string;
+    client_id?: string | null;
+    is_inactive?: boolean;
+    notes_document_id?: string | null;
+  } = {}
+): Promise<string> {
+  const contactId = uuidv4();
+  const now = new Date().toISOString();
+
+  await db('contacts').insert({
+    tenant: tenantId,
+    contact_name_id: contactId,
+    full_name: options.full_name ?? `Contact ${contactId.slice(0, 6)}`,
+    email: options.email ?? `${contactId.slice(0, 8)}@example.com`,
+    client_id: options.client_id ?? null,
+    is_inactive: options.is_inactive ?? false,
+    notes_document_id: options.notes_document_id ?? null,
+    primary_email_canonical_type: 'work',
+    created_at: now,
+    updated_at: now,
+  });
+
+  return contactId;
+}
+
+async function createTicketStatusId(db: Knex, tenantId: string, actorUserId: string): Promise<string> {
+  const existing = await db('statuses')
+    .where({ tenant: tenantId, status_type: 'ticket' })
+    .orderBy('order_number', 'asc')
+    .first();
+  if (existing?.status_id) return existing.status_id;
+
+  const [inserted] = await db('statuses')
+    .insert({
+      tenant: tenantId,
+      name: 'Open',
+      status_type: 'ticket',
+      order_number: 1,
+      created_by: actorUserId,
+      is_closed: false,
+      is_default: true,
+    })
+    .returning('status_id');
+
+  return inserted.status_id;
+}
+
+async function createTicket(
+  db: Knex,
+  params: {
+    tenantId: string;
+    actorUserId: string;
+    clientId?: string | null;
+    contactId?: string | null;
+    title?: string;
+  }
+): Promise<string> {
+  const ticketId = uuidv4();
+  const statusId = await createTicketStatusId(db, params.tenantId, params.actorUserId);
+
+  await db('tickets').insert({
+    ticket_id: ticketId,
+    tenant: params.tenantId,
+    ticket_number: `WF-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+    title: params.title ?? 'Workflow Test Ticket',
+    status_id: statusId,
+    client_id: params.clientId ?? null,
+    entered_by: params.actorUserId,
+    contact_name_id: params.contactId ?? null,
+  });
+
+  return ticketId;
+}
+
+async function getDefaultInteractionStatusId(db: Knex, tenantId: string, actorUserId: string): Promise<string> {
+  const existing = await db('statuses').where({ tenant: tenantId, status_type: 'interaction', is_default: true }).first();
+  if (existing?.status_id) return existing.status_id;
+
+  const [created] = await db('statuses')
+    .insert({
+      tenant: tenantId,
+      name: 'Logged',
+      status_type: 'interaction',
+      order_number: 1,
+      created_by: actorUserId,
+      is_closed: false,
+      is_default: true,
+    })
+    .returning('status_id');
+
+  return created.status_id;
+}
+
+async function getAnyInteractionTypeId(db: Knex, tenantId: string): Promise<string> {
+  const tenantType = await db('interaction_types').where({ tenant: tenantId }).first();
+  if (tenantType?.type_id) return tenantType.type_id;
+
+  const systemType = await db('system_interaction_types').first();
+  if (!systemType?.type_id) {
+    throw new Error('Expected at least one system_interaction_types row in seeded DB');
+  }
+  return systemType.type_id;
+}
+
+const runtimeState = vi.hoisted(() => ({
+  db: null as Knex | null,
+  tenantId: '',
+  actorUserId: '',
+  deniedPermissions: new Set<string>(),
+  publishedEvents: [] as Array<{ eventType: string; payload: Record<string, unknown>; idempotencyKey: string }>,
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(async (event: { eventType: string; payload: Record<string, unknown>; idempotencyKey: string }) => {
+    runtimeState.publishedEvents.push(event);
+  }),
+}));
+
+vi.mock('../businessOperations/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../businessOperations/shared')>();
+
+  return {
+    ...actual,
+    withTenantTransaction: async (_ctx: any, fn: any) => {
+      if (!runtimeState.db) {
+        throw new Error('DB unavailable for test runtime state');
+      }
+
+      return runtimeState.db.transaction(async (trx) => {
+        await trx.raw(`select set_config('app.current_tenant', ?, true)`, [runtimeState.tenantId]);
+        return fn({
+          tenantId: runtimeState.tenantId,
+          actorUserId: runtimeState.actorUserId,
+          trx,
+        });
+      });
+    },
+    requirePermission: async (ctx: any, _tx: any, permission: { resource: string; action: string }) => {
+      const key = `${permission.resource}:${permission.action}`;
+      if (!runtimeState.deniedPermissions.has(key)) return;
+      throw {
+        category: 'ActionError',
+        code: 'PERMISSION_DENIED',
+        message: `Missing permission ${key}`,
+        details: { permission: key },
+        nodePath: ctx?.stepPath ?? 'steps.contact-action',
+        at: new Date().toISOString(),
+      };
+    },
+  };
+});
+
+import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { registerContactActions } from '../businessOperations/contacts';
+
+function getAction(actionId: string) {
+  const action = getActionRegistryV2().get(actionId, 1);
+  if (!action) throw new Error(`Missing action ${actionId}@1`);
+  return action;
+}
+
+function actionCtx(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    runId: uuidv4(),
+    stepPath: 'steps.contact-action',
+    idempotencyKey: uuidv4(),
+    attempt: 1,
+    nowIso: () => new Date().toISOString(),
+    env: {},
+    tenantId: runtimeState.tenantId,
+    ...overrides,
+  };
+}
+
+async function invokeAction(actionId: string, input: Record<string, unknown>, ctxOverrides: Record<string, unknown> = {}) {
+  const action = getAction(actionId);
+  const parsedInput = action.inputSchema.parse(input);
+  return action.handler(parsedInput, actionCtx(ctxOverrides) as any);
+}
+
+describe('contact workflow runtime DB-backed action handlers', () => {
+  let db: Knex;
+
+  beforeAll(async () => {
+    if (!getActionRegistryV2().get('contacts.move_to_client', 1)) {
+      registerContactActions();
+    }
+
+    db = await createTestDbConnection();
+    runtimeState.db = db;
+  }, 180000);
+
+  beforeEach(async () => {
+    const tenantId = await createTenant(db, `Workflow Contact Runtime Test ${Date.now()}`);
+    const actorUserId = await createUser(db, tenantId, {
+      user_type: 'internal',
+      first_name: 'Workflow',
+      last_name: 'Actor',
+    });
+
+    runtimeState.tenantId = tenantId;
+    runtimeState.actorUserId = actorUserId;
+    runtimeState.deniedPermissions.clear();
+    runtimeState.publishedEvents.length = 0;
+  });
+
+  afterAll(async () => {
+    await db?.destroy();
+    runtimeState.db = null;
+  });
+
+  it('T003: contacts.create creates scoped contact rows and returns compact output; duplicate email conflicts', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Create Client');
+    const action = getAction('contacts.create');
+    const keyFromContext = action.idempotency.mode === 'actionProvided'
+      ? action.idempotency.key({}, actionCtx({ runId: 'run-fixed', stepPath: 'steps.fixed' }) as any)
+      : '';
+
+    expect(action.idempotency.mode).toBe('actionProvided');
+    expect(keyFromContext).toBe('run:run-fixed:steps.fixed');
+
+    const created = await invokeAction('contacts.create', {
+      full_name: 'Created Contact',
+      email: 'created.contact@example.com',
+      client_id: clientId,
+      role: 'Manager',
+      notes: 'Created by workflow',
+      phone_numbers: [{ phone_number: '555-0101', canonical_type: 'work', is_default: true }],
+      additional_email_addresses: [{ email_address: 'created.contact+alt@example.com', canonical_type: 'personal' }],
+    });
+
+    expect(created.created).toBe(true);
+    expect(created.contact.full_name).toBe('Created Contact');
+    expect(created.contact.email).toBe('created.contact@example.com');
+    expect(created.contact.client_id).toBe(clientId);
+
+    const dbContact = await db('contacts')
+      .where({ tenant: runtimeState.tenantId, contact_name_id: created.contact.contact_name_id })
+      .first();
+    expect(dbContact).toBeTruthy();
+
+    const phones = await db('contact_phone_numbers')
+      .where({ tenant: runtimeState.tenantId, contact_name_id: created.contact.contact_name_id });
+    expect(phones.length).toBe(1);
+
+    const additionalEmails = await db('contact_additional_email_addresses')
+      .where({ tenant: runtimeState.tenantId, contact_name_id: created.contact.contact_name_id });
+    expect(additionalEmails.length).toBe(1);
+
+    await expect(
+      invokeAction('contacts.create', {
+        full_name: 'Duplicate Contact',
+        email: 'created.contact@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('T004: contacts.update patches supplied fields, preserves omitted fields, returns before/after and enforces model email rules', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Update Client');
+    const contactId = await invokeAction('contacts.create', {
+      full_name: 'Update Target',
+      email: 'update.target@example.com',
+      client_id: clientId,
+      role: 'Initial',
+      phone_numbers: [{ phone_number: '555-0102', canonical_type: 'work', is_default: true }],
+      additional_email_addresses: [{ email_address: 'update.target+alt@example.com', canonical_type: 'personal' }],
+    }).then((result) => result.contact.contact_name_id as string);
+
+    const updated = await invokeAction('contacts.update', {
+      contact_id: contactId,
+      patch: {
+        full_name: 'Updated Name',
+        role: 'Updated Role',
+      },
+    });
+
+    expect(updated.contact_before.contact_name_id).toBe(contactId);
+    expect(updated.contact_after.full_name).toBe('Updated Name');
+    expect(updated.changed_fields).toEqual(expect.arrayContaining(['full_name', 'role']));
+
+    const stored = await db('contacts').where({ tenant: runtimeState.tenantId, contact_name_id: contactId }).first();
+    expect(stored.email).toBe('update.target@example.com');
+
+    await expect(
+      invokeAction('contacts.update', {
+        contact_id: contactId,
+        patch: {
+          email: 'new.primary@example.com',
+        },
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('T005: contacts.add_to_client assigns unassigned contacts, no-ops on same client, and conflicts on other client', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Client A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Client B');
+    const contactId = await createContactRaw(db, runtimeState.tenantId, { client_id: null });
+
+    const assigned = await invokeAction('contacts.add_to_client', {
+      contact_id: contactId,
+      client_id: clientA,
+    });
+
+    expect(assigned.previous_client_id).toBeNull();
+    expect(assigned.current_client_id).toBe(clientA);
+    expect(assigned.noop).toBe(false);
+
+    const noop = await invokeAction('contacts.add_to_client', {
+      contact_id: contactId,
+      client_id: clientA,
+    });
+    expect(noop.noop).toBe(true);
+
+    await expect(
+      invokeAction('contacts.add_to_client', {
+        contact_id: contactId,
+        client_id: clientB,
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('T006: contacts.move_to_client moves contact, no-ops when repeated, and enforces expected_current_client_id', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Client A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Client B');
+    const contactId = await createContactRaw(db, runtimeState.tenantId, { client_id: clientA });
+
+    const moved = await invokeAction('contacts.move_to_client', {
+      contact_id: contactId,
+      target_client_id: clientB,
+      expected_current_client_id: clientA,
+    });
+    expect(moved.previous_client_id).toBe(clientA);
+    expect(moved.current_client_id).toBe(clientB);
+    expect(moved.noop).toBe(false);
+
+    const noop = await invokeAction('contacts.move_to_client', {
+      contact_id: contactId,
+      target_client_id: clientB,
+    });
+    expect(noop.noop).toBe(true);
+
+    await expect(
+      invokeAction('contacts.move_to_client', {
+        contact_id: contactId,
+        target_client_id: clientA,
+        expected_current_client_id: clientA,
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('T007: contacts.assign_to_ticket updates only contact_name_id and enforces client relationship', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Ticket Client A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Ticket Client B');
+
+    const contactA = await createContactRaw(db, runtimeState.tenantId, { client_id: clientA });
+    const contactB = await createContactRaw(db, runtimeState.tenantId, { client_id: clientB });
+
+    const ticketWithClient = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: clientA,
+      contactId: null,
+    });
+
+    const assigned = await invokeAction('contacts.assign_to_ticket', {
+      ticket_id: ticketWithClient,
+      contact_id: contactA,
+    });
+    expect(assigned.previous_contact_id).toBeNull();
+    expect(assigned.current_contact_id).toBe(contactA);
+
+    await expect(
+      invokeAction('contacts.assign_to_ticket', {
+        ticket_id: ticketWithClient,
+        contact_id: contactB,
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const ticketAfter = await db('tickets').where({ tenant: runtimeState.tenantId, ticket_id: ticketWithClient }).first();
+    expect(ticketAfter.contact_name_id).toBe(contactA);
+    expect(ticketAfter.client_id).toBe(clientA);
+  });
+
+  it('T008: contacts.add_tag creates/reuses definitions and mappings and remains idempotent', async () => {
+    const contactId = await createContactRaw(db, runtimeState.tenantId, { client_id: null });
+
+    const first = await invokeAction('contacts.add_tag', {
+      contact_id: contactId,
+      tags: ['priority', 'managed'],
+    });
+    expect(first.added_count).toBe(2);
+    expect(first.existing_count).toBe(0);
+
+    const second = await invokeAction('contacts.add_tag', {
+      contact_id: contactId,
+      tags: ['priority'],
+    });
+    expect(second.added_count).toBe(0);
+    expect(second.existing_count).toBe(1);
+
+    const mappings = await db('tag_mappings as tm')
+      .join('tag_definitions as td', function joinTagDefs() {
+        this.on('tm.tenant', 'td.tenant').andOn('tm.tag_id', 'td.tag_id');
+      })
+      .where({
+        'tm.tenant': runtimeState.tenantId,
+        'tm.tagged_type': 'contact',
+        'tm.tagged_id': contactId,
+      })
+      .select('td.tag_text');
+
+    expect(mappings.map((row: { tag_text: string }) => row.tag_text).sort()).toEqual(['managed', 'priority']);
+    expect(mappings.length).toBe(2);
+  });
+
+  it('T009: contacts.duplicate requires new email, supports overrides and tag copy, and excludes historical relationships', async () => {
+    const sourceClient = await createClient(db, runtimeState.tenantId, 'Source Client');
+    const targetClient = await createClient(db, runtimeState.tenantId, 'Target Client');
+    const sourceContact = await invokeAction('contacts.create', {
+      full_name: 'Source Contact',
+      email: 'source.contact@example.com',
+      client_id: sourceClient,
+      role: 'Source Role',
+      notes: 'Source Notes',
+      phone_numbers: [{ phone_number: '555-0110', canonical_type: 'work', is_default: true }],
+      additional_email_addresses: [{ email_address: 'source.contact+alt@example.com', canonical_type: 'personal' }],
+    }).then((result) => result.contact.contact_name_id as string);
+
+    await invokeAction('contacts.add_tag', {
+      contact_id: sourceContact,
+      tags: ['vip', 'imported'],
+    });
+
+    const sourceTicket = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: sourceClient,
+      contactId: sourceContact,
+    });
+
+    await db('interactions').insert({
+      tenant: runtimeState.tenantId,
+      interaction_id: uuidv4(),
+      type_id: await getAnyInteractionTypeId(db, runtimeState.tenantId),
+      contact_name_id: sourceContact,
+      client_id: sourceClient,
+      user_id: runtimeState.actorUserId,
+      ticket_id: sourceTicket,
+      title: 'Source Interaction',
+      notes: 'Source interaction notes',
+      interaction_date: new Date().toISOString(),
+      start_time: new Date().toISOString(),
+      end_time: new Date().toISOString(),
+      duration: 0,
+      status_id: await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId),
+    });
+
+    const duplicate = await invokeAction('contacts.duplicate', {
+      source_contact_id: sourceContact,
+      email: 'duplicate.contact@example.com',
+      full_name: 'Duplicate Contact',
+      target_client_id: targetClient,
+      copy_tags: true,
+    });
+
+    expect(duplicate.source_contact.contact_name_id).toBe(sourceContact);
+    expect(duplicate.duplicate_contact.full_name).toBe('Duplicate Contact');
+    expect(duplicate.duplicate_contact.client_id).toBe(targetClient);
+    expect(duplicate.copied_tags).toBeGreaterThanOrEqual(2);
+
+    const duplicatedId = duplicate.duplicate_contact.contact_name_id;
+    const duplicatedTickets = await db('tickets').where({ tenant: runtimeState.tenantId, contact_name_id: duplicatedId });
+    const duplicatedInteractions = await db('interactions').where({ tenant: runtimeState.tenantId, contact_name_id: duplicatedId });
+    expect(duplicatedTickets.length).toBe(0);
+    expect(duplicatedInteractions.length).toBe(0);
+
+    await expect(
+      invokeAction('contacts.duplicate', {
+        source_contact_id: sourceContact,
+        email: 'source.contact@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('T010: contacts.add_note creates and appends notes document without creating interaction rows', async () => {
+    const contactId = await createContactRaw(db, runtimeState.tenantId, { client_id: null });
+
+    const first = await invokeAction('contacts.add_note', {
+      contact_id: contactId,
+      body: 'First workflow note',
+    });
+    expect(first.created_document).toBe(true);
+
+    const second = await invokeAction('contacts.add_note', {
+      contact_id: contactId,
+      body: 'Second workflow note',
+    });
+    expect(second.created_document).toBe(false);
+    expect(second.document_id).toBe(first.document_id);
+
+    const contentRow = await db('document_block_content')
+      .where({ tenant: runtimeState.tenantId, document_id: first.document_id })
+      .first();
+    const blocks = typeof contentRow?.block_data === 'string' ? JSON.parse(contentRow.block_data) : contentRow?.block_data;
+    expect(Array.isArray(blocks)).toBe(true);
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+
+    const interactions = await db('interactions')
+      .where({ tenant: runtimeState.tenantId, contact_name_id: contactId })
+      .select('interaction_id');
+    expect(interactions.length).toBe(0);
+  });
+
+  it('T011: contacts.add_interaction uses contact-derived client, default status, actor ownership, and ticket validation', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Interaction A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Interaction B');
+    const contact = await createContactRaw(db, runtimeState.tenantId, { client_id: clientA });
+
+    const ticketA = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: clientA,
+      contactId: contact,
+    });
+    const ticketB = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: clientB,
+    });
+
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const defaultStatusId = await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+
+    const result = await invokeAction('contacts.add_interaction', {
+      contact_id: contact,
+      interaction_type_id: typeId,
+      title: 'Workflow Interaction',
+      ticket_id: ticketA,
+      notes: 'Logged from workflow',
+    });
+
+    expect(result.contact_id).toBe(contact);
+    expect(result.client_id).toBe(clientA);
+    expect(result.ticket_id).toBe(ticketA);
+    expect(result.status_id).toBe(defaultStatusId);
+    expect(result.user_id).toBe(runtimeState.actorUserId);
+
+    await expect(
+      invokeAction('contacts.add_interaction', {
+        contact_id: contact,
+        interaction_type_id: typeId,
+        title: 'Invalid Ticket',
+        ticket_id: ticketB,
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('T012: contacts.delete requires confirm, supports return_false, hard-deletes eligible contacts, and returns dependency conflicts', async () => {
+    const deletableContact = await createContactRaw(db, runtimeState.tenantId, { client_id: null });
+
+    await expect(
+      invokeAction('contacts.delete', {
+        contact_id: deletableContact,
+        confirm: false,
+      })
+    ).rejects.toThrow();
+
+    const deleted = await invokeAction('contacts.delete', {
+      contact_id: deletableContact,
+      confirm: true,
+    });
+    expect(deleted).toEqual({ deleted: true, contact_id: deletableContact });
+
+    const deletedRow = await db('contacts').where({ tenant: runtimeState.tenantId, contact_name_id: deletableContact }).first();
+    expect(deletedRow).toBeFalsy();
+
+    const missingResult = await invokeAction('contacts.delete', {
+      contact_id: uuidv4(),
+      confirm: true,
+      on_not_found: 'return_false',
+    });
+    expect(missingResult.deleted).toBe(false);
+
+    const blockedClient = await createClient(db, runtimeState.tenantId, 'Blocked Client');
+    const blockedContact = await createContactRaw(db, runtimeState.tenantId, { client_id: blockedClient });
+    await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: blockedClient,
+      contactId: blockedContact,
+    });
+
+    await expect(
+      invokeAction('contacts.delete', {
+        contact_id: blockedContact,
+        confirm: true,
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('T013: each mutating contacts action enforces required permissions', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Perm Client A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Perm Client B');
+    const contactA = await createContactRaw(db, runtimeState.tenantId, { client_id: clientA });
+    const ticketA = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: clientA,
+      contactId: contactA,
+    });
+    const interactionTypeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+
+    const checks: Array<{ actionId: string; denied: string; input: Record<string, unknown> }> = [
+      { actionId: 'contacts.create', denied: 'contact:create', input: { full_name: 'Denied', email: 'denied@example.com' } },
+      { actionId: 'contacts.update', denied: 'contact:update', input: { contact_id: contactA, patch: { full_name: 'Denied' } } },
+      { actionId: 'contacts.deactivate', denied: 'contact:update', input: { contact_id: contactA } },
+      { actionId: 'contacts.delete', denied: 'contact:delete', input: { contact_id: contactA, confirm: true } },
+      {
+        actionId: 'contacts.duplicate',
+        denied: 'contact:read',
+        input: { source_contact_id: contactA, email: 'dup.denied@example.com' },
+      },
+      { actionId: 'contacts.add_tag', denied: 'contact:update', input: { contact_id: contactA, tags: ['x'] } },
+      {
+        actionId: 'contacts.assign_to_ticket',
+        denied: 'ticket:update',
+        input: { contact_id: contactA, ticket_id: ticketA },
+      },
+      { actionId: 'contacts.add_note', denied: 'contact:update', input: { contact_id: contactA, body: 'Denied note' } },
+      {
+        actionId: 'contacts.add_interaction',
+        denied: 'contact:update',
+        input: { contact_id: contactA, interaction_type_id: interactionTypeId, title: 'Denied interaction' },
+      },
+      {
+        actionId: 'contacts.add_to_client',
+        denied: 'contact:update',
+        input: { contact_id: contactA, client_id: clientB },
+      },
+      {
+        actionId: 'contacts.move_to_client',
+        denied: 'contact:update',
+        input: { contact_id: contactA, target_client_id: clientB },
+      },
+    ];
+
+    for (const check of checks) {
+      runtimeState.deniedPermissions.clear();
+      runtimeState.deniedPermissions.add(check.denied);
+      await expect(invokeAction(check.actionId, check.input)).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    }
+
+    runtimeState.deniedPermissions.clear();
+  });
+
+  it('T014: side-effectful contacts actions write audits and create/update/deactivate publish contact events', async () => {
+    const clientA = await createClient(db, runtimeState.tenantId, 'Audit Client A');
+    const clientB = await createClient(db, runtimeState.tenantId, 'Audit Client B');
+
+    const created = await invokeAction('contacts.create', {
+      full_name: 'Audit Contact',
+      email: 'audit.contact@example.com',
+      client_id: clientA,
+    });
+
+    const contactId = created.contact.contact_name_id as string;
+
+    await invokeAction('contacts.update', {
+      contact_id: contactId,
+      patch: { full_name: 'Audit Contact Updated' },
+    });
+
+    await invokeAction('contacts.add_tag', { contact_id: contactId, tags: ['audit-tag'] });
+
+    const ticket = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId: clientA,
+      contactId: null,
+    });
+
+    await invokeAction('contacts.assign_to_ticket', { contact_id: contactId, ticket_id: ticket });
+    await invokeAction('contacts.add_note', { contact_id: contactId, body: 'Audit note body' });
+
+    await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+
+    await invokeAction('contacts.add_interaction', {
+      contact_id: contactId,
+      interaction_type_id: await getAnyInteractionTypeId(db, runtimeState.tenantId),
+      title: 'Audit interaction',
+    });
+
+    await invokeAction('contacts.move_to_client', {
+      contact_id: contactId,
+      target_client_id: clientB,
+      expected_current_client_id: clientA,
+    });
+
+    await invokeAction('contacts.deactivate', { contact_id: contactId });
+
+    const auditRows = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, table_name: 'workflow_runs', user_id: runtimeState.actorUserId })
+      .whereIn('operation', [
+        'workflow_action:contacts.create',
+        'workflow_action:contacts.update',
+        'workflow_action:contacts.add_tag',
+        'workflow_action:contacts.assign_to_ticket',
+        'workflow_action:contacts.add_note',
+        'workflow_action:contacts.add_interaction',
+        'workflow_action:contacts.move_to_client',
+        'workflow_action:contacts.deactivate',
+      ]);
+
+    const operations = new Set(auditRows.map((row: { operation: string }) => row.operation));
+    expect(operations.has('workflow_action:contacts.create')).toBe(true);
+    expect(operations.has('workflow_action:contacts.update')).toBe(true);
+    expect(operations.has('workflow_action:contacts.deactivate')).toBe(true);
+
+    const eventTypes = runtimeState.publishedEvents.map((event) => event.eventType);
+    expect(eventTypes).toContain('CONTACT_CREATED');
+    expect(eventTypes).toContain('CONTACT_UPDATED');
+    expect(eventTypes).toContain('CONTACT_ARCHIVED');
+  });
+
+  it('T015: contacts.deactivate sets inactive and is idempotent on repeated calls', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Deactivate Client');
+    const contactId = await createContactRaw(db, runtimeState.tenantId, { client_id: clientId, is_inactive: false });
+
+    const first = await invokeAction('contacts.deactivate', { contact_id: contactId });
+    expect(first.deactivated).toBe(true);
+    expect(first.noop).toBe(false);
+    expect(first.previous_is_inactive).toBe(false);
+    expect(first.current_is_inactive).toBe(true);
+
+    const second = await invokeAction('contacts.deactivate', { contact_id: contactId });
+    expect(second.deactivated).toBe(false);
+    expect(second.noop).toBe(true);
+    expect(second.previous_is_inactive).toBe(true);
+    expect(second.current_is_inactive).toBe(true);
+  });
+});

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.contacts.db.test.ts
@@ -458,6 +458,7 @@ describe('contact workflow runtime DB-backed action handlers', () => {
       email: 'update.target@example.com',
       client_id: clientId,
       role: 'Initial',
+      notes: 'Initial Notes',
       phone_numbers: [{ phone_number: '555-0102', canonical_type: 'work', is_default: true }],
       additional_email_addresses: [{ email_address: 'update.target+alt@example.com', canonical_type: 'personal' }],
     }).then((result) => result.contact.contact_name_id as string);
@@ -476,6 +477,29 @@ describe('contact workflow runtime DB-backed action handlers', () => {
 
     const stored = await db('contacts').where({ tenant: runtimeState.tenantId, contact_name_id: contactId }).first();
     expect(stored.email).toBe('update.target@example.com');
+    expect(stored.notes).toBe('Initial Notes');
+
+    const cleared = await invokeAction('contacts.update', {
+      contact_id: contactId,
+      patch: {
+        role: null,
+        notes: null,
+      },
+    });
+    expect(cleared.changed_fields).toEqual(expect.arrayContaining(['role', 'notes']));
+
+    const clearedStored = await db('contacts').where({ tenant: runtimeState.tenantId, contact_name_id: contactId }).first();
+    expect(clearedStored.role).toBeNull();
+    expect(clearedStored.notes).toBeNull();
+
+    await expect(
+      invokeAction('contacts.update', {
+        contact_id: contactId,
+        patch: {
+          email: null,
+        },
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
 
     await expect(
       invokeAction('contacts.update', {
@@ -916,6 +940,34 @@ describe('contact workflow runtime DB-backed action handlers', () => {
     expect(eventTypes).toContain('CONTACT_CREATED');
     expect(eventTypes).toContain('CONTACT_UPDATED');
     expect(eventTypes).toContain('CONTACT_ARCHIVED');
+  });
+
+  it('T014b: contact create/update/deactivate events are published for unassigned contacts', async () => {
+    const created = await invokeAction('contacts.create', {
+      full_name: 'Unassigned Event Contact',
+      email: 'unassigned.event@example.com',
+    });
+
+    const contactId = created.contact.contact_name_id as string;
+    await invokeAction('contacts.update', {
+      contact_id: contactId,
+      patch: { full_name: 'Unassigned Event Contact Updated' },
+    });
+    await invokeAction('contacts.deactivate', { contact_id: contactId });
+
+    const contactEvents = runtimeState.publishedEvents.filter((event) =>
+      ['CONTACT_CREATED', 'CONTACT_UPDATED', 'CONTACT_ARCHIVED'].includes(event.eventType)
+    );
+
+    expect(contactEvents.map((event) => event.eventType)).toEqual([
+      'CONTACT_CREATED',
+      'CONTACT_UPDATED',
+      'CONTACT_ARCHIVED',
+    ]);
+    for (const event of contactEvents) {
+      expect(event.payload.contactId).toBe(contactId);
+      expect(event.payload).not.toHaveProperty('clientId');
+    }
   });
 
   it('T015: contacts.deactivate sets inactive and is idempotent on repeated calls', async () => {

--- a/shared/workflow/runtime/actions/__tests__/registerContactActionsMetadata.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/registerContactActionsMetadata.test.ts
@@ -1,0 +1,122 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { zodToWorkflowJsonSchema } from '../../jsonSchemaMetadata';
+import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { registerContactActions } from '../businessOperations/contacts';
+
+const EXPECTED_CONTACT_ACTION_IDS = [
+  'contacts.find',
+  'contacts.search',
+  'contacts.create',
+  'contacts.update',
+  'contacts.deactivate',
+  'contacts.delete',
+  'contacts.duplicate',
+  'contacts.add_tag',
+  'contacts.assign_to_ticket',
+  'contacts.add_note',
+  'contacts.add_interaction',
+  'contacts.add_to_client',
+  'contacts.move_to_client',
+] as const;
+
+describe('contact workflow action registration metadata', () => {
+  beforeAll(() => {
+    const registry = getActionRegistryV2();
+    if (!registry.get('contacts.move_to_client', 1)) {
+      registerContactActions();
+    }
+  });
+
+  it('T001: registers all new contacts.* actions with expected labels and idempotency metadata', () => {
+    const registry = getActionRegistryV2();
+
+    const actions = EXPECTED_CONTACT_ACTION_IDS.map((id) => {
+      const action = registry.get(id, 1);
+      expect(action, `${id}@1 should be registered`).toBeDefined();
+      return action!;
+    });
+
+    const byId = new Map(actions.map((action) => [action.id, action]));
+
+    expect(byId.get('contacts.find')?.ui?.label).toBe('Find Contact');
+    expect(byId.get('contacts.search')?.ui?.label).toBe('Search Contacts');
+    expect(byId.get('contacts.create')?.ui?.label).toBe('Create Contact');
+    expect(byId.get('contacts.update')?.ui?.label).toBe('Edit Contact');
+    expect(byId.get('contacts.deactivate')?.ui?.label).toBe('Deactivate Contact');
+    expect(byId.get('contacts.delete')?.ui?.label).toBe('Delete Contact');
+    expect(byId.get('contacts.duplicate')?.ui?.label).toBe('Duplicate Contact');
+    expect(byId.get('contacts.add_tag')?.ui?.label).toBe('Add Tag to Contact');
+    expect(byId.get('contacts.assign_to_ticket')?.ui?.label).toBe('Assign Contact to Ticket');
+    expect(byId.get('contacts.add_note')?.ui?.label).toBe('Add Note to Contact');
+    expect(byId.get('contacts.add_interaction')?.ui?.label).toBe('Add Interaction to Contact');
+    expect(byId.get('contacts.add_to_client')?.ui?.label).toBe('Add Contact to Client');
+    expect(byId.get('contacts.move_to_client')?.ui?.label).toBe('Move Contact to Client');
+
+    expect(byId.get('contacts.find')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.search')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.create')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('contacts.update')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.deactivate')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.delete')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.duplicate')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('contacts.add_tag')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('contacts.assign_to_ticket')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.add_note')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('contacts.add_interaction')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('contacts.add_to_client')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('contacts.move_to_client')?.idempotency.mode).toBe('engineProvided');
+
+    for (const id of EXPECTED_CONTACT_ACTION_IDS) {
+      expect(byId.get(id)?.ui?.category).toBe('Business Operations');
+    }
+  });
+
+  it('T002: contact action schemas include picker metadata and compact contact output shape', () => {
+    const registry = getActionRegistryV2();
+
+    const create = registry.get('contacts.create', 1);
+    const assign = registry.get('contacts.assign_to_ticket', 1);
+    const addToClient = registry.get('contacts.add_to_client', 1);
+    const moveToClient = registry.get('contacts.move_to_client', 1);
+
+    expect(create).toBeDefined();
+    expect(assign).toBeDefined();
+    expect(addToClient).toBeDefined();
+    expect(moveToClient).toBeDefined();
+
+    if (!create || !assign || !addToClient || !moveToClient) {
+      throw new Error('Missing expected contact actions');
+    }
+
+    const createInputSchema = zodToWorkflowJsonSchema(create.inputSchema);
+    const assignInputSchema = zodToWorkflowJsonSchema(assign.inputSchema);
+    const addToClientInputSchema = zodToWorkflowJsonSchema(addToClient.inputSchema);
+    const moveToClientInputSchema = zodToWorkflowJsonSchema(moveToClient.inputSchema);
+    const createOutputSchema = zodToWorkflowJsonSchema(create.outputSchema);
+
+    const createInputProps = createInputSchema.properties as Record<string, Record<string, unknown>>;
+    const assignInputProps = assignInputSchema.properties as Record<string, Record<string, unknown>>;
+    const addToClientInputProps = addToClientInputSchema.properties as Record<string, Record<string, unknown>>;
+    const moveToClientInputProps = moveToClientInputSchema.properties as Record<string, Record<string, unknown>>;
+
+    expect(createInputProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(assignInputProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(assignInputProps.ticket_id?.['x-workflow-picker-kind']).toBe('ticket');
+    expect(addToClientInputProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(addToClientInputProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(moveToClientInputProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(moveToClientInputProps.target_client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(moveToClientInputProps.expected_current_client_id?.['x-workflow-picker-kind']).toBe('client');
+
+    const outputProps = createOutputSchema.properties as Record<string, any>;
+    const contactShape = outputProps.contact?.properties as Record<string, any>;
+    expect(contactShape).toBeTruthy();
+    expect(contactShape.contact_name_id).toBeTruthy();
+    expect(contactShape.full_name).toBeTruthy();
+    expect(contactShape.email).toBeTruthy();
+    expect(contactShape.phone).toBeTruthy();
+    expect(contactShape.client_id).toBeTruthy();
+    expect(contactShape.is_inactive).toBeTruthy();
+  });
+});

--- a/shared/workflow/runtime/actions/businessOperations/contacts.ts
+++ b/shared/workflow/runtime/actions/businessOperations/contacts.ts
@@ -1,25 +1,657 @@
 import { z } from 'zod';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { deleteEntityWithValidation, isEnterprise } from '@alga-psa/core';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
 import { ContactModel } from '../../../../models/contactModel';
+import { buildContactArchivedPayload, buildContactCreatedPayload, buildContactUpdatedPayload } from '../../../streams/domainEventBuilders/contactEventBuilders';
+import { buildInteractionLoggedPayload, buildNoteCreatedPayload } from '../../../streams/domainEventBuilders/crmInteractionNoteEventBuilders';
 import {
   uuidSchema,
   isoDateTimeSchema,
+  actionProvidedKey,
   withTenantTransaction,
   requirePermission,
-  throwActionError
+  writeRunAudit,
+  throwActionError,
+  rethrowAsStandardError,
+  parseJsonMaybe,
+  type TenantTxContext,
 } from './shared';
+
+const WORKFLOW_PICKER_HINTS = {
+  client: 'Search clients',
+  ticket: 'Search tickets',
+  contact: 'Search contacts',
+} as const;
+
+const withWorkflowPicker = <T extends z.ZodTypeAny>(
+  schema: T,
+  description: string,
+  kind: keyof typeof WORKFLOW_PICKER_HINTS,
+  dependencies?: string[]
+): T =>
+  withWorkflowJsonSchemaMetadata(schema, description, {
+    'x-workflow-picker-kind': kind,
+    'x-workflow-picker-dependencies': dependencies,
+    'x-workflow-picker-fixed-value-hint': WORKFLOW_PICKER_HINTS[kind],
+    'x-workflow-picker-allow-dynamic-reference': true,
+  });
+
+const contactSummarySchema = z.object({
+  contact_name_id: uuidSchema,
+  full_name: z.string().nullable(),
+  email: z.string().nullable(),
+  phone: z.string().nullable(),
+  client_id: uuidSchema.nullable(),
+  is_inactive: z.boolean(),
+});
+
+const tagResultSchema = z.object({
+  tag_id: uuidSchema,
+  tag_text: z.string(),
+  mapping_id: uuidSchema.optional(),
+});
+
+const nullableUuidSchema = z.union([uuidSchema, z.null()]);
+
+const contactPhoneInputSchema = z.object({
+  contact_phone_number_id: uuidSchema.optional(),
+  phone_number: z.string().min(1),
+  canonical_type: z.enum(['work', 'mobile', 'home', 'fax', 'other']).nullable().optional(),
+  custom_type: z.string().nullable().optional(),
+  is_default: z.boolean().optional(),
+  display_order: z.number().int().min(0).optional(),
+});
+
+const contactAdditionalEmailInputSchema = z.object({
+  contact_additional_email_address_id: uuidSchema.optional(),
+  email_address: z.string().email(),
+  canonical_type: z.enum(['work', 'personal', 'billing', 'other']).nullable().optional(),
+  custom_type: z.string().nullable().optional(),
+  display_order: z.number().int().min(0).optional(),
+});
+
+const contactCreateInputSchema = z.object({
+  full_name: z.string().min(1),
+  email: z.string().email(),
+  client_id: withWorkflowPicker(nullableUuidSchema.optional(), 'Optional client id', 'client'),
+  role: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  is_inactive: z.boolean().optional(),
+  primary_email_canonical_type: z.enum(['work', 'personal', 'billing', 'other']).nullable().optional(),
+  primary_email_custom_type: z.string().nullable().optional(),
+  phone_numbers: z.array(contactPhoneInputSchema).optional(),
+  additional_email_addresses: z.array(contactAdditionalEmailInputSchema).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+});
+
+const contactUpdatePatchSchema = z
+  .object({
+    full_name: z.string().min(1).optional(),
+    email: z.string().email().nullable().optional(),
+    client_id: nullableUuidSchema.optional(),
+    role: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    is_inactive: z.boolean().optional(),
+    primary_email_canonical_type: z.enum(['work', 'personal', 'billing', 'other']).nullable().optional(),
+    primary_email_custom_type: z.string().nullable().optional(),
+    primary_email_custom_type_id: uuidSchema.nullable().optional(),
+    phone_numbers: z.array(contactPhoneInputSchema).optional(),
+    additional_email_addresses: z.array(contactAdditionalEmailInputSchema).optional(),
+  })
+  .superRefine((value, refinementCtx) => {
+    const keys = Object.keys(value);
+    if (keys.length === 0) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'patch must include at least one editable field',
+      });
+      return;
+    }
+
+    const hasDefinedValue = keys.some((key) => (value as Record<string, unknown>)[key] !== undefined);
+    if (!hasDefinedValue) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'patch must include at least one defined value',
+      });
+    }
+  });
+
+const contactDuplicateInputSchema = z.object({
+  source_contact_id: withWorkflowPicker(uuidSchema, 'Source contact id', 'contact'),
+  email: z.string().email().describe('New unique primary email for duplicated contact'),
+  full_name: z.string().min(1).optional(),
+  target_client_id: withWorkflowPicker(nullableUuidSchema.optional(), 'Target client id', 'client'),
+  role: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  is_inactive: z.boolean().optional(),
+  primary_email_canonical_type: z.enum(['work', 'personal', 'billing', 'other']).nullable().optional(),
+  primary_email_custom_type: z.string().nullable().optional(),
+  phone_numbers: z.array(contactPhoneInputSchema).optional(),
+  additional_email_addresses: z.array(contactAdditionalEmailInputSchema).optional(),
+  copy_tags: z.boolean().default(true),
+  idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+});
+
+const normalizeTagText = (value: string): string => value.trim();
+
+const uniqueNormalizedTags = (tags: string[] | undefined): string[] => {
+  if (!Array.isArray(tags)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const value of tags) {
+    const normalized = normalizeTagText(String(value));
+    if (!normalized) continue;
+    const lower = normalized.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(normalized);
+  }
+
+  return out;
+};
+
+const generateTagColors = (text: string): { backgroundColor: string; textColor: string } => {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = text.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const hue = Math.abs(hash) % 360;
+  const saturation = 70;
+  const lightness = 85;
+
+  const hslToHex = (h: number, s: number, l: number): string => {
+    const normalizedLightness = l / 100;
+    const a = (s * Math.min(normalizedLightness, 1 - normalizedLightness)) / 100;
+    const f = (n: number) => {
+      const k = (n + h / 30) % 12;
+      const color = normalizedLightness - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+      return Math.round(255 * color)
+        .toString(16)
+        .padStart(2, '0');
+    };
+
+    return `#${f(0)}${f(8)}${f(4)}`.toUpperCase();
+  };
+
+  return {
+    backgroundColor: hslToHex(hue, saturation, lightness),
+    textColor: '#2C3E50',
+  };
+};
+
+const contactToSummary = (row: Record<string, unknown>) =>
+  contactSummarySchema.parse({
+    contact_name_id: row.contact_name_id,
+    full_name: (row.full_name as string | null | undefined) ?? null,
+    email: (row.email as string | null | undefined) ?? null,
+    phone: (row.default_phone_number as string | null | undefined) ?? (row.phone as string | null | undefined) ?? null,
+    client_id: (row.client_id as string | null | undefined) ?? null,
+    is_inactive: Boolean(row.is_inactive),
+  });
+
+async function ensureContactExists(ctx: any, tx: TenantTxContext, contactId: string): Promise<Record<string, any>> {
+  const contact = await ContactModel.getContactById(contactId, tx.tenantId, tx.trx);
+  if (!contact) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Contact not found',
+      details: { contact_id: contactId },
+    });
+  }
+  return contact;
+}
+
+async function ensureClientExists(ctx: any, tx: TenantTxContext, clientId: string): Promise<Record<string, any>> {
+  const client = await tx.trx('clients').where({ tenant: tx.tenantId, client_id: clientId }).first();
+  if (!client) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Client not found',
+      details: { client_id: clientId },
+    });
+  }
+  return client;
+}
+
+async function ensureTicketExists(ctx: any, tx: TenantTxContext, ticketId: string): Promise<Record<string, any>> {
+  const ticket = await tx.trx('tickets').where({ tenant: tx.tenantId, ticket_id: ticketId }).first();
+  if (!ticket) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Ticket not found',
+      details: { ticket_id: ticketId },
+    });
+  }
+  return ticket;
+}
+
+function rethrowContactModelError(ctx: any, error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (/^VALIDATION_ERROR:/i.test(message) || /^FOREIGN_KEY_ERROR:/i.test(message)) {
+    throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message });
+  }
+  if (/^NOT_FOUND:/i.test(message)) {
+    throwActionError(ctx, { category: 'ActionError', code: 'NOT_FOUND', message });
+  }
+  if (/^EMAIL_EXISTS:/i.test(message)) {
+    throwActionError(ctx, { category: 'ActionError', code: 'CONFLICT', message });
+  }
+  if (/^SYSTEM_ERROR:/i.test(message)) {
+    throwActionError(ctx, { category: 'ActionError', code: 'INTERNAL_ERROR', message });
+  }
+
+  rethrowAsStandardError(ctx, error);
+}
+
+async function getTableColumns(tx: TenantTxContext, tableName: string): Promise<Set<string>> {
+  const rows = await tx.trx('information_schema.columns')
+    .select('column_name')
+    .where({ table_schema: 'public', table_name: tableName });
+
+  return new Set(rows.map((row: { column_name: string }) => row.column_name));
+}
+
+function pickExistingFields(
+  data: Record<string, unknown>,
+  availableColumns: Set<string>,
+  allowedFields: Set<string>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    if (!allowedFields.has(key)) continue;
+    if (!availableColumns.has(key)) continue;
+    if (value === undefined) continue;
+    out[key] = value;
+  }
+
+  return out;
+}
+
+async function ensureContactTagMappings(
+  tx: TenantTxContext,
+  contactId: string,
+  tags: string[]
+): Promise<{
+  added: Array<z.infer<typeof tagResultSchema>>;
+  existing: Array<z.infer<typeof tagResultSchema>>;
+}> {
+  const normalizedTags = uniqueNormalizedTags(tags);
+  if (normalizedTags.length === 0) {
+    return { added: [], existing: [] };
+  }
+
+  const added: Array<z.infer<typeof tagResultSchema>> = [];
+  const existing: Array<z.infer<typeof tagResultSchema>> = [];
+  const tagDefinitionColumns = await getTableColumns(tx, 'tag_definitions');
+  const tagMappingColumns = await getTableColumns(tx, 'tag_mappings');
+
+  for (const tagText of normalizedTags) {
+    const { backgroundColor, textColor } = generateTagColors(tagText);
+
+    const definitionRow = pickExistingFields(
+      {
+        tenant: tx.tenantId,
+        tag_id: uuidv4(),
+        tag_text: tagText,
+        tagged_type: 'contact',
+        background_color: backgroundColor,
+        text_color: textColor,
+        created_at: new Date().toISOString(),
+      },
+      tagDefinitionColumns,
+      new Set([
+        'tenant',
+        'tag_id',
+        'tag_text',
+        'tagged_type',
+        'background_color',
+        'text_color',
+        'created_at',
+      ])
+    );
+
+    await tx.trx('tag_definitions')
+      .insert(definitionRow)
+      .onConflict(['tenant', 'tag_text', 'tagged_type'])
+      .ignore();
+
+    const definition = await tx.trx('tag_definitions')
+      .where({
+        tenant: tx.tenantId,
+        tag_text: tagText,
+        tagged_type: 'contact',
+      })
+      .first();
+
+    if (!definition?.tag_id) {
+      throw new Error(`Failed to resolve tag definition for "${tagText}"`);
+    }
+
+    const mappingId = uuidv4();
+    const mappingRow = pickExistingFields(
+      {
+        tenant: tx.tenantId,
+        mapping_id: mappingId,
+        tag_id: definition.tag_id,
+        tagged_id: contactId,
+        tagged_type: 'contact',
+        created_by: tx.actorUserId,
+        created_at: new Date().toISOString(),
+      },
+      tagMappingColumns,
+      new Set(['tenant', 'mapping_id', 'tag_id', 'tagged_id', 'tagged_type', 'created_by', 'created_at'])
+    );
+
+    const insertedMappings = await tx.trx('tag_mappings')
+      .insert(mappingRow)
+      .onConflict(['tenant', 'tag_id', 'tagged_id'])
+      .ignore()
+      .returning('mapping_id');
+
+    if (insertedMappings.length > 0) {
+      added.push(
+        tagResultSchema.parse({
+          tag_id: definition.tag_id,
+          tag_text: definition.tag_text,
+          mapping_id: typeof mappingRow.mapping_id === 'string' ? mappingRow.mapping_id : undefined,
+        })
+      );
+      continue;
+    }
+
+    const mapping = await tx.trx('tag_mappings')
+      .where({
+        tenant: tx.tenantId,
+        tag_id: definition.tag_id,
+        tagged_id: contactId,
+        tagged_type: 'contact',
+      })
+      .first();
+
+    existing.push(
+      tagResultSchema.parse({
+        tag_id: definition.tag_id,
+        tag_text: definition.tag_text,
+        mapping_id: typeof mapping?.mapping_id === 'string' ? mapping.mapping_id : undefined,
+      })
+    );
+  }
+
+  return { added, existing };
+}
+
+async function deleteFromTableIfExists(
+  trx: Knex.Transaction,
+  tableName: string,
+  where: Record<string, unknown>
+): Promise<void> {
+  const exists = await trx.schema.hasTable(tableName);
+  if (!exists) return;
+  await trx(tableName).where(where).delete();
+}
+
+async function getExistingPublicTables(
+  trx: Knex.Transaction,
+  tableNames: string[]
+): Promise<Set<string>> {
+  const rows = await trx('information_schema.tables')
+    .select('table_name')
+    .where({ table_schema: 'public' })
+    .whereIn('table_name', tableNames);
+
+  return new Set((rows as Array<{ table_name: string }>).map((row) => row.table_name));
+}
+
+async function cleanupEntraReferencesBeforeContactDelete(
+  trx: Knex.Transaction,
+  tenantId: string,
+  contactId: string
+): Promise<void> {
+  if (!isEnterprise) {
+    return;
+  }
+
+  const queueTableExists = await trx('information_schema.tables')
+    .where({ table_schema: 'public', table_name: 'entra_contact_reconciliation_queue' })
+    .first('table_name');
+
+  if (!queueTableExists) {
+    return;
+  }
+
+  await trx('entra_contact_reconciliation_queue')
+    .where({ tenant: tenantId, resolved_contact_id: contactId })
+    .update({
+      resolved_contact_id: null,
+      updated_at: trx.fn.now(),
+    });
+}
+
+async function cleanupContactDeleteArtifacts(
+  trx: Knex.Transaction,
+  tenant: string,
+  contactId: string
+): Promise<void> {
+  await deleteFromTableIfExists(trx, 'tag_mappings', {
+    tenant,
+    tagged_type: 'contact',
+    tagged_id: contactId,
+  });
+  await deleteFromTableIfExists(trx, 'contact_phone_numbers', { tenant, contact_name_id: contactId });
+  await deleteFromTableIfExists(trx, 'contact_additional_email_addresses', { tenant, contact_name_id: contactId });
+  await deleteFromTableIfExists(trx, 'comments', { tenant, contact_id: contactId });
+  await deleteFromTableIfExists(trx, 'portal_invitations', { tenant, contact_id: contactId });
+}
+
+async function cleanupContactNotesDocument(
+  trx: Knex.Transaction,
+  tenant: string,
+  contactId: string
+): Promise<void> {
+  const contactRecord = await trx('contacts')
+    .where({ contact_name_id: contactId, tenant })
+    .select('notes_document_id')
+    .first();
+
+  if (!contactRecord?.notes_document_id) {
+    return;
+  }
+
+  await deleteFromTableIfExists(trx, 'document_block_content', {
+    tenant,
+    document_id: contactRecord.notes_document_id,
+  });
+  await deleteFromTableIfExists(trx, 'document_associations', {
+    tenant,
+    document_id: contactRecord.notes_document_id,
+  });
+  await deleteFromTableIfExists(trx, 'documents', {
+    tenant,
+    document_id: contactRecord.notes_document_id,
+  });
+}
+
+async function getDefaultInteractionStatusId(ctx: any, tx: TenantTxContext): Promise<string> {
+  const status = await tx.trx('statuses')
+    .where({
+      tenant: tx.tenantId,
+      status_type: 'interaction',
+      is_default: true,
+    })
+    .first();
+
+  if (!status?.status_id) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'INTERNAL_ERROR',
+      message: 'No default interaction status found',
+    });
+  }
+
+  return status.status_id;
+}
+
+async function appendContactNoteBlock(
+  tx: TenantTxContext,
+  contact: Record<string, any>,
+  body: string
+): Promise<{ document_id: string; created_document: boolean; updated_at: string }> {
+  const nowIso = new Date().toISOString();
+  const contentBlock = {
+    type: 'paragraph',
+    content: [{ type: 'text', text: body }],
+  };
+
+  if (contact.notes_document_id) {
+    const existing = await tx.trx('document_block_content')
+      .where({ tenant: tx.tenantId, document_id: contact.notes_document_id })
+      .first();
+
+    const existingBlocks = Array.isArray(existing?.block_data)
+      ? existing.block_data
+      : parseJsonMaybe(existing?.block_data) ?? [];
+
+    const nextBlocks = [...(Array.isArray(existingBlocks) ? existingBlocks : []), contentBlock];
+
+    if (existing) {
+      await tx.trx('document_block_content')
+        .where({ tenant: tx.tenantId, document_id: contact.notes_document_id })
+        .update({ block_data: JSON.stringify(nextBlocks), updated_at: nowIso });
+    } else {
+      await tx.trx('document_block_content').insert({
+        content_id: uuidv4(),
+        tenant: tx.tenantId,
+        document_id: contact.notes_document_id,
+        block_data: JSON.stringify(nextBlocks),
+        created_at: nowIso,
+        updated_at: nowIso,
+      });
+    }
+
+    await tx.trx('documents')
+      .where({ tenant: tx.tenantId, document_id: contact.notes_document_id })
+      .update({ updated_at: nowIso, edited_by: tx.actorUserId });
+
+    return {
+      document_id: contact.notes_document_id,
+      created_document: false,
+      updated_at: nowIso,
+    };
+  }
+
+  const documentId = uuidv4();
+  const documentType = await tx.trx('document_types')
+    .where({ tenant: tx.tenantId })
+    .orderBy('type_name', 'asc')
+    .first();
+
+  const documentInsert: Record<string, unknown> = {
+    tenant: tx.tenantId,
+    document_id: documentId,
+    document_name: `${contact.full_name ?? 'Contact'} Notes`,
+    created_by: tx.actorUserId,
+    user_id: tx.actorUserId,
+    updated_at: nowIso,
+    entered_at: nowIso,
+  };
+
+  const documentColumns = await getTableColumns(tx, 'documents');
+  if (documentColumns.has('type_id')) {
+    documentInsert.type_id = documentType?.type_id ?? null;
+  }
+  if (documentColumns.has('shared_type_id')) {
+    documentInsert.shared_type_id = null;
+  }
+
+  await tx.trx('documents').insert(documentInsert);
+
+  await tx.trx('document_block_content').insert({
+    content_id: uuidv4(),
+    tenant: tx.tenantId,
+    document_id: documentId,
+    block_data: JSON.stringify([contentBlock]),
+    created_at: nowIso,
+    updated_at: nowIso,
+  });
+
+  await tx.trx('document_associations')
+    .insert({
+      association_id: uuidv4(),
+      tenant: tx.tenantId,
+      document_id: documentId,
+      entity_id: contact.contact_name_id,
+      entity_type: 'contact',
+      created_at: nowIso,
+    })
+    .onConflict(['tenant', 'document_id', 'entity_id', 'entity_type'])
+    .ignore();
+
+  await tx.trx('contacts')
+    .where({ tenant: tx.tenantId, contact_name_id: contact.contact_name_id })
+    .update({ notes_document_id: documentId, updated_at: nowIso });
+
+  return {
+    document_id: documentId,
+    created_document: true,
+    updated_at: nowIso,
+  };
+}
+
+const maybeWorkflowActor = (userId: string): { actorType: 'USER'; actorUserId: string } =>
+  ({ actorType: 'USER', actorUserId: userId });
+
+async function publishWorkflowDomainEvent(params: {
+  eventType: string;
+  payload: Record<string, unknown>;
+  tenantId: string;
+  occurredAt: string;
+  actorUserId: string;
+  idempotencyKey: string;
+}): Promise<void> {
+  try {
+    const publishers = (await import('@alga-psa/event-bus/publishers')) as unknown as {
+      publishWorkflowEvent?: (value: {
+        eventType: string;
+        payload: Record<string, unknown>;
+        ctx: {
+          tenantId: string;
+          occurredAt: string;
+          actor: { actorType: 'USER'; actorUserId: string };
+        };
+        idempotencyKey: string;
+      }) => Promise<unknown>;
+    };
+    if (!publishers.publishWorkflowEvent) return;
+
+    await publishers.publishWorkflowEvent({
+      eventType: params.eventType,
+      payload: params.payload,
+      ctx: {
+        tenantId: params.tenantId,
+        occurredAt: params.occurredAt,
+        actor: maybeWorkflowActor(params.actorUserId),
+      },
+      idempotencyKey: params.idempotencyKey,
+    });
+  } catch {
+    // Best-effort publication; action persistence/audit remains source of truth.
+  }
+}
 
 export function registerContactActions(): void {
   const registry = getActionRegistryV2();
-
-  const contactDetailsSchema = z.object({
-    contact_name_id: uuidSchema,
-    full_name: z.string().nullable(),
-    email: z.string().nullable(),
-    phone: z.string().nullable(),
-    client_id: uuidSchema.nullable(),
-    is_inactive: z.boolean()
-  });
 
   // ---------------------------------------------------------------------------
   // A11 — contacts.find
@@ -27,80 +659,92 @@ export function registerContactActions(): void {
   registry.register({
     id: 'contacts.find',
     version: 1,
-    inputSchema: z.object({
-      contact_id: uuidSchema.optional(),
-      email: z.string().email().optional(),
-      phone: z.string().optional().describe('Phone number (normalized digits match)'),
-      client_id: uuidSchema.optional().describe('Optional client scope'),
-      on_not_found: z.enum(['return_null', 'error']).default('return_null'),
-      match_strategy: z.enum(['first_created', 'most_recent']).default('first_created').describe('Deterministic ordering when multiple matches exist')
-    }).refine((val) => Boolean(val.contact_id || val.email || val.phone), { message: 'contact_id, email, or phone required' }),
+    inputSchema: z
+      .object({
+        contact_id: withWorkflowPicker(uuidSchema.optional(), 'Contact id', 'contact'),
+        email: z.string().email().optional(),
+        phone: z.string().optional().describe('Phone number (normalized digits match)'),
+        client_id: withWorkflowPicker(uuidSchema.optional(), 'Optional client scope', 'client'),
+        on_not_found: z.enum(['return_null', 'error']).default('return_null'),
+        match_strategy: z
+          .enum(['first_created', 'most_recent'])
+          .default('first_created')
+          .describe('Deterministic ordering when multiple matches exist'),
+      })
+      .refine((val) => Boolean(val.contact_id || val.email || val.phone), {
+        message: 'contact_id, email, or phone required',
+      }),
     outputSchema: z.object({
-      contact: contactDetailsSchema.nullable()
+      contact: contactSummarySchema.nullable(),
     }),
     sideEffectful: false,
     idempotency: { mode: 'engineProvided' },
     ui: { label: 'Find Contact', category: 'Business Operations', description: 'Find a contact by id or email' },
-    handler: async (input, ctx) => withTenantTransaction(ctx, async (tx) => {
-      await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
-      const startedAt = Date.now();
-      let matchedBy: 'contact_id' | 'email' | 'phone' | null = null;
-      let contacts: any[] = [];
-      if (input.contact_id) {
-        const contact = await ContactModel.getContactById(input.contact_id, tx.tenantId, tx.trx);
-        if (contact) contacts = [contact];
-        matchedBy = 'contact_id';
-      } else if (input.email) {
-        const email = input.email.toLowerCase().trim();
-        matchedBy = 'email';
-        const contact = await ContactModel.getContactByEmail(email, tx.tenantId, tx.trx);
-        if (contact) {
-          contacts = [contact];
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
+        const startedAt = Date.now();
+        let matchedBy: 'contact_id' | 'email' | 'phone' | null = null;
+        let contacts: any[] = [];
+        if (input.contact_id) {
+          const contact = await ContactModel.getContactById(input.contact_id, tx.tenantId, tx.trx);
+          if (contact) contacts = [contact];
+          matchedBy = 'contact_id';
+        } else if (input.email) {
+          const email = input.email.toLowerCase().trim();
+          matchedBy = 'email';
+          const contact = await ContactModel.getContactByEmail(email, tx.tenantId, tx.trx);
+          if (contact) {
+            contacts = [contact];
+          }
+        } else if (input.phone) {
+          const digits = String(input.phone).replace(/\D/g, '');
+          if (digits.length < 7) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'phone is invalid',
+            });
+          }
+          matchedBy = 'phone';
+          contacts = await tx.trx('contacts')
+            .where({ tenant: tx.tenantId })
+            .andWhereRaw(`regexp_replace(coalesce(phone,''), '\\\\D', '', 'g') = ?`, [digits])
+            .orderBy('is_inactive', 'asc')
+            .orderBy(
+              input.match_strategy === 'most_recent' ? 'created_at' : 'created_at',
+              input.match_strategy === 'most_recent' ? 'desc' : 'asc'
+            )
+            .limit(5);
         }
-      } else if (input.phone) {
-        const digits = String(input.phone).replace(/\D/g, '');
-        if (digits.length < 7) {
-          throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: 'phone is invalid' });
+
+        if (input.client_id) {
+          contacts = contacts.filter((c) => c?.client_id === input.client_id);
         }
-        matchedBy = 'phone';
-        contacts = await tx.trx('contacts')
-          .where({ tenant: tx.tenantId })
-          .andWhereRaw(`regexp_replace(coalesce(phone,''), '\\\\D', '', 'g') = ?`, [digits])
-          .orderBy('is_inactive', 'asc')
-          .orderBy(input.match_strategy === 'most_recent' ? 'created_at' : 'created_at', input.match_strategy === 'most_recent' ? 'desc' : 'asc')
-          .limit(5);
-      }
 
-      // Apply client scope filter and choose first match deterministically.
-      if (input.client_id) {
-        contacts = contacts.filter((c) => c?.client_id === input.client_id);
-      }
-
-      const contact = contacts[0] ?? null;
-      if (!contact) {
-        if (input.on_not_found === 'error') {
-          throwActionError(ctx, { category: 'ActionError', code: 'NOT_FOUND', message: 'Contact not found', details: { matched_by: matchedBy } });
+        const contact = contacts[0] ?? null;
+        if (!contact) {
+          if (input.on_not_found === 'error') {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Contact not found',
+              details: { matched_by: matchedBy },
+            });
+          }
+          return { contact: null };
         }
-        return { contact: null };
-      }
 
-      const parsed = contactDetailsSchema.parse({
-        contact_name_id: contact.contact_name_id,
-        full_name: contact.full_name ?? null,
-        email: contact.email ?? null,
-        phone: contact.phone ?? null,
-        client_id: contact.client_id ?? null,
-        is_inactive: Boolean(contact.is_inactive)
-      });
+        const parsed = contactToSummary(contact);
 
-      ctx.logger?.info('workflow_action:contacts.find', {
-        duration_ms: Date.now() - startedAt,
-        matched_by: matchedBy,
-        match_count: contacts.length
-      });
+        ctx.logger?.info('workflow_action:contacts.find', {
+          duration_ms: Date.now() - startedAt,
+          matched_by: matchedBy,
+          match_count: contacts.length,
+        });
 
-      return { contact: parsed };
-    })
+        return { contact: parsed };
+      }),
   });
 
   // ---------------------------------------------------------------------------
@@ -111,45 +755,50 @@ export function registerContactActions(): void {
     version: 1,
     inputSchema: z.object({
       query: z.string().min(1).describe('Search query (name/email/phone)'),
-      client_id: uuidSchema.optional().describe('Optional client scope'),
-      filters: z.object({
-        tags: z.array(z.string()).optional(),
-        sort_by: z.enum(['name', 'updated_at']).optional(),
-        sort_order: z.enum(['asc', 'desc']).optional()
-      }).optional(),
+      client_id: withWorkflowPicker(uuidSchema.optional(), 'Optional client scope', 'client'),
+      filters: z
+        .object({
+          tags: z.array(z.string()).optional(),
+          sort_by: z.enum(['name', 'updated_at']).optional(),
+          sort_order: z.enum(['asc', 'desc']).optional(),
+        })
+        .optional(),
       page: z.number().int().positive().default(1),
-      page_size: z.number().int().positive().max(100).default(25)
+      page_size: z.number().int().positive().max(100).default(25),
     }),
     outputSchema: z.object({
-      contacts: z.array(contactDetailsSchema),
-      first_contact: contactDetailsSchema.nullable(),
+      contacts: z.array(contactSummarySchema),
+      first_contact: contactSummarySchema.nullable(),
       page: z.number().int(),
       page_size: z.number().int(),
-      total: z.number().int()
+      total: z.number().int(),
     }),
     sideEffectful: false,
     idempotency: { mode: 'engineProvided' },
     ui: { label: 'Search Contacts', category: 'Business Operations', description: 'Search contacts by name or email' },
-    handler: async (input, ctx) => withTenantTransaction(ctx, async (tx) => {
-      await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
 
-      const startedAt = Date.now();
-      const minQueryLen = Number(process.env.WORKFLOW_CONTACT_SEARCH_MIN_QUERY_LEN ?? 2);
-      const rawQuery = String(input.query ?? '').trim();
-      if (rawQuery.length < minQueryLen) {
-        throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: `query must be at least ${minQueryLen} characters` });
-      }
-      const escaped = rawQuery.replace(/[%_\\]/g, (m) => `\\${m}`);
-      const pattern = `%${escaped}%`;
+        const startedAt = Date.now();
+        const minQueryLen = Number(process.env.WORKFLOW_CONTACT_SEARCH_MIN_QUERY_LEN ?? 2);
+        const rawQuery = String(input.query ?? '').trim();
+        if (rawQuery.length < minQueryLen) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: `query must be at least ${minQueryLen} characters`,
+          });
+        }
+        const escaped = rawQuery.replace(/[%_\\]/g, (m) => `\\${m}`);
+        const pattern = `%${escaped}%`;
 
-      const page = input.page ?? 1;
-      const pageSize = input.page_size ?? 25;
-      const offset = (page - 1) * pageSize;
-      const filters = input.filters ?? {};
+        const page = input.page ?? 1;
+        const pageSize = input.page_size ?? 25;
+        const offset = (page - 1) * pageSize;
+        const filters = input.filters ?? {};
 
-      let base = tx.trx('contacts')
-        .where({ tenant: tx.tenantId })
-        .where(function q() {
+        let base = tx.trx('contacts').where({ tenant: tx.tenantId }).where(function q() {
           this.whereRaw(`full_name ILIKE ? ESCAPE '\\\\'`, [pattern])
             .orWhereRaw(`email ILIKE ? ESCAPE '\\\\'`, [pattern])
             .orWhereExists(function additionalEmailSearch() {
@@ -161,56 +810,1093 @@ export function registerContactActions(): void {
             })
             .orWhereRaw(`phone ILIKE ? ESCAPE '\\\\'`, [pattern]);
         });
-      if (input.client_id) base = base.andWhere('client_id', input.client_id);
 
-      if (filters.tags?.length) {
-        base = base
-          .join('tag_mappings as tm', function joinTagMappings() {
-            this.on('tm.tenant', 'contacts.tenant').andOn('tm.tagged_id', 'contacts.contact_name_id');
-          })
-          .join('tag_definitions as td', function joinTagDefs() {
-            this.on('td.tenant', 'tm.tenant').andOn('td.tag_id', 'tm.tag_id');
-          })
-          .where('tm.tagged_type', 'contact')
-          .whereIn('td.tag_text', filters.tags);
-      }
+        if (input.client_id) base = base.andWhere('client_id', input.client_id);
 
-      const countRow = await base.clone().clearSelect().clearOrder().countDistinct({ count: 'contact_name_id' }).first();
-      const total = parseInt(String((countRow as any)?.count ?? 0), 10);
+        if (filters.tags?.length) {
+          base = base
+            .join('tag_mappings as tm', function joinTagMappings() {
+              this.on('tm.tenant', 'contacts.tenant').andOn('tm.tagged_id', 'contacts.contact_name_id');
+            })
+            .join('tag_definitions as td', function joinTagDefs() {
+              this.on('td.tenant', 'tm.tenant').andOn('td.tag_id', 'tm.tag_id');
+            })
+            .where('tm.tagged_type', 'contact')
+            .whereIn('td.tag_text', filters.tags);
+        }
 
-      const sortBy = filters.sort_by ?? 'name';
-      const sortOrder = filters.sort_order ?? 'asc';
+        const countRow = await base.clone().clearSelect().clearOrder().countDistinct({ count: 'contact_name_id' }).first();
+        const total = parseInt(String((countRow as any)?.count ?? 0), 10);
 
-      const rows = await base
-        .clone()
-        .clearSelect()
-        .select('*')
-        .orderBy(sortBy === 'updated_at' ? 'updated_at' : 'full_name', sortOrder)
-        .orderBy('contact_name_id', 'asc')
-        .limit(pageSize)
-        .offset(offset);
+        const sortBy = filters.sort_by ?? 'name';
+        const sortOrder = filters.sort_order ?? 'asc';
 
-      const contacts = rows.map((row: any) => contactDetailsSchema.parse({
-        contact_name_id: row.contact_name_id,
-        full_name: row.full_name ?? null,
-        email: row.email ?? null,
-        phone: row.phone ?? null,
-        client_id: row.client_id ?? null,
-        is_inactive: Boolean(row.is_inactive)
-      }));
+        const rows = await base
+          .clone()
+          .clearSelect()
+          .select('*')
+          .orderBy(sortBy === 'updated_at' ? 'updated_at' : 'full_name', sortOrder)
+          .orderBy('contact_name_id', 'asc')
+          .limit(pageSize)
+          .offset(offset);
 
-      ctx.logger?.info('workflow_action:contacts.search', {
-        duration_ms: Date.now() - startedAt,
-        query_len: rawQuery.length,
-        client_scope: input.client_id ?? null,
-        filters: { tags_count: Array.isArray(filters.tags) ? filters.tags.length : 0, sort_by: sortBy, sort_order: sortOrder },
-        result_count: contacts.length,
-        page,
-        page_size: pageSize,
-        total
-      });
+        const contacts = rows.map((row: any) => contactToSummary(row));
 
-      return { contacts, first_contact: contacts[0] ?? null, page, page_size: pageSize, total };
-    })
+        ctx.logger?.info('workflow_action:contacts.search', {
+          duration_ms: Date.now() - startedAt,
+          query_len: rawQuery.length,
+          client_scope: input.client_id ?? null,
+          filters: {
+            tags_count: Array.isArray(filters.tags) ? filters.tags.length : 0,
+            sort_by: sortBy,
+            sort_order: sortOrder,
+          },
+          result_count: contacts.length,
+          page,
+          page_size: pageSize,
+          total,
+        });
+
+        return { contacts, first_contact: contacts[0] ?? null, page, page_size: pageSize, total };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A13 — contacts.create
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.create',
+    version: 1,
+    inputSchema: contactCreateInputSchema,
+    outputSchema: z.object({
+      created: z.boolean(),
+      contact: contactSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Create Contact',
+      category: 'Business Operations',
+      description: 'Create a contact with optional client assignment, details, and initial tags',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'create' });
+
+        if (input.client_id) {
+          await ensureClientExists(ctx, tx, input.client_id);
+        }
+
+        let createdContact: Record<string, any>;
+        try {
+          createdContact = await ContactModel.createContact(
+            {
+              full_name: input.full_name,
+              email: input.email,
+              client_id: input.client_id ?? undefined,
+              role: input.role ?? undefined,
+              notes: input.notes ?? undefined,
+              is_inactive: input.is_inactive,
+              primary_email_canonical_type: input.primary_email_canonical_type ?? undefined,
+              primary_email_custom_type: input.primary_email_custom_type ?? undefined,
+              phone_numbers: input.phone_numbers ?? undefined,
+              additional_email_addresses: input.additional_email_addresses ?? undefined,
+            },
+            tx.tenantId,
+            tx.trx
+          ) as unknown as Record<string, any>;
+        } catch (error) {
+          rethrowContactModelError(ctx, error);
+        }
+
+        if (input.tags?.length) {
+          await ensureContactTagMappings(tx, createdContact.contact_name_id, input.tags);
+        }
+
+        const after = await ensureContactExists(ctx, tx, createdContact.contact_name_id);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.create',
+          changedData: {
+            contact_id: after.contact_name_id,
+            full_name: after.full_name,
+            client_id: after.client_id ?? null,
+          },
+          details: { action_id: 'contacts.create', action_version: 1, contact_id: after.contact_name_id },
+        });
+
+        if (typeof after.client_id === 'string' && after.client_id) {
+          const occurredAt = (after.created_at as string | undefined) ?? new Date().toISOString();
+          await publishWorkflowDomainEvent({
+            eventType: 'CONTACT_CREATED',
+            payload: buildContactCreatedPayload({
+              contactId: after.contact_name_id,
+              clientId: after.client_id,
+              fullName: after.full_name,
+              email: after.email ?? undefined,
+              primaryEmailCanonicalType: after.primary_email_canonical_type ?? null,
+              primaryEmailCustomTypeId: after.primary_email_custom_type_id ?? null,
+              primaryEmailType: after.primary_email_type ?? null,
+              additionalEmailAddresses: after.additional_email_addresses ?? [],
+              phoneNumbers: after.phone_numbers ?? [],
+              defaultPhoneNumber: after.default_phone_number ?? undefined,
+              defaultPhoneType: after.default_phone_type ?? undefined,
+              createdByUserId: tx.actorUserId,
+              createdAt: occurredAt,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `contact_created:${after.contact_name_id}`,
+          });
+        }
+
+        return {
+          created: true,
+          contact: contactToSummary(after),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A14 — contacts.update
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.update',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      patch: contactUpdatePatchSchema,
+    }),
+    outputSchema: z.object({
+      contact_before: contactSummarySchema,
+      contact_after: contactSummarySchema,
+      changed_fields: z.array(z.string()),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Edit Contact',
+      category: 'Business Operations',
+      description: 'Patch editable fields on an existing contact',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        const before = await ensureContactExists(ctx, tx, input.contact_id);
+        const patch = input.patch;
+        const changedFields = Object.keys(patch).filter((key) => (patch as Record<string, unknown>)[key] !== undefined);
+
+        if (patch.client_id && patch.client_id !== before.client_id) {
+          await ensureClientExists(ctx, tx, patch.client_id);
+        }
+
+        let after: Record<string, any>;
+        try {
+          after = await ContactModel.updateContact(
+            input.contact_id,
+            {
+              full_name: patch.full_name,
+              email: patch.email ?? undefined,
+              client_id: patch.client_id === null ? null as unknown as string : patch.client_id ?? undefined,
+              role: patch.role ?? undefined,
+              notes: patch.notes ?? undefined,
+              is_inactive: patch.is_inactive,
+              primary_email_canonical_type: patch.primary_email_canonical_type ?? undefined,
+              primary_email_custom_type: patch.primary_email_custom_type ?? undefined,
+              primary_email_custom_type_id: patch.primary_email_custom_type_id ?? undefined,
+              phone_numbers: patch.phone_numbers ?? undefined,
+              additional_email_addresses: patch.additional_email_addresses ?? undefined,
+            } as any,
+            tx.tenantId,
+            tx.trx
+          ) as unknown as Record<string, any>;
+        } catch (error) {
+          rethrowContactModelError(ctx, error);
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.update',
+          changedData: {
+            contact_id: input.contact_id,
+            changed_fields: changedFields,
+          },
+          details: { action_id: 'contacts.update', action_version: 1, contact_id: input.contact_id },
+        });
+
+        const eventClientId = (after.client_id ?? before.client_id) as string | null;
+        const occurredAt = (after.updated_at as string | undefined) ?? new Date().toISOString();
+
+        if (typeof eventClientId === 'string' && eventClientId) {
+          const updatedPayload = buildContactUpdatedPayload({
+            contactId: input.contact_id,
+            clientId: eventClientId,
+            before,
+            after,
+            updatedFieldKeys: changedFields,
+            updatedByUserId: tx.actorUserId,
+            updatedAt: occurredAt,
+          });
+          const updatedFields = (updatedPayload as { updatedFields?: string[] }).updatedFields ?? [];
+          if (updatedFields.length > 0) {
+            await publishWorkflowDomainEvent({
+              eventType: 'CONTACT_UPDATED',
+              payload: updatedPayload,
+              tenantId: tx.tenantId,
+              occurredAt,
+              actorUserId: tx.actorUserId,
+              idempotencyKey: `contact_updated:${input.contact_id}:${occurredAt}`,
+            });
+          }
+        }
+
+        const wasInactive = Boolean(before.is_inactive);
+        const isInactive = Boolean(after.is_inactive);
+        if (!wasInactive && isInactive && typeof eventClientId === 'string' && eventClientId) {
+          await publishWorkflowDomainEvent({
+            eventType: 'CONTACT_ARCHIVED',
+            payload: buildContactArchivedPayload({
+              contactId: input.contact_id,
+              clientId: eventClientId,
+              archivedByUserId: tx.actorUserId,
+              archivedAt: occurredAt,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `contact_archived:${input.contact_id}:${occurredAt}`,
+          });
+        }
+
+        return {
+          contact_before: contactToSummary(before),
+          contact_after: contactToSummary(after),
+          changed_fields: changedFields,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A15 — contacts.deactivate
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.deactivate',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      reason: z.string().optional().describe('Optional reason/audit detail for deactivation'),
+    }),
+    outputSchema: z.object({
+      contact_id: uuidSchema,
+      deactivated: z.boolean(),
+      noop: z.boolean(),
+      previous_is_inactive: z.boolean(),
+      current_is_inactive: z.boolean(),
+      contact: contactSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Deactivate Contact',
+      category: 'Business Operations',
+      description: 'Set a contact inactive without deleting records',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        const before = await ensureContactExists(ctx, tx, input.contact_id);
+        const previousInactive = Boolean(before.is_inactive);
+        let currentInactive = previousInactive;
+        let after = before;
+
+        if (!previousInactive) {
+          const nowIso = new Date().toISOString();
+          await tx.trx('contacts')
+            .where({ tenant: tx.tenantId, contact_name_id: input.contact_id })
+            .update({ is_inactive: true, updated_at: nowIso });
+          after = await ensureContactExists(ctx, tx, input.contact_id);
+          currentInactive = Boolean(after.is_inactive);
+
+          if (typeof after.client_id === 'string' && after.client_id) {
+            await publishWorkflowDomainEvent({
+              eventType: 'CONTACT_ARCHIVED',
+              payload: buildContactArchivedPayload({
+                contactId: input.contact_id,
+                clientId: after.client_id,
+                archivedByUserId: tx.actorUserId,
+                archivedAt: nowIso,
+                reason: input.reason,
+              }),
+              tenantId: tx.tenantId,
+              occurredAt: nowIso,
+              actorUserId: tx.actorUserId,
+              idempotencyKey: `contact_archived:${input.contact_id}:${nowIso}`,
+            });
+          }
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.deactivate',
+          changedData: {
+            contact_id: input.contact_id,
+            previous_is_inactive: previousInactive,
+            current_is_inactive: currentInactive,
+            noop: previousInactive,
+          },
+          details: {
+            action_id: 'contacts.deactivate',
+            action_version: 1,
+            contact_id: input.contact_id,
+            reason: input.reason ?? null,
+          },
+        });
+
+        return {
+          contact_id: input.contact_id,
+          deactivated: !previousInactive,
+          noop: previousInactive,
+          previous_is_inactive: previousInactive,
+          current_is_inactive: currentInactive,
+          contact: contactToSummary(after),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A16 — contacts.delete
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.delete',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      confirm: z.boolean().refine((value) => value === true, { message: 'confirm must be true to delete a contact' }),
+      on_not_found: z.enum(['error', 'return_false']).default('error'),
+    }),
+    outputSchema: z.object({
+      deleted: z.boolean(),
+      contact_id: uuidSchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Delete Contact',
+      category: 'Business Operations',
+      description: 'Destructive hard-delete for a contact with dependency validation',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'delete' });
+
+        const existing = await tx.trx('contacts')
+          .where({ tenant: tx.tenantId, contact_name_id: input.contact_id })
+          .first();
+
+        if (!existing) {
+          if (input.on_not_found === 'return_false') {
+            return { deleted: false, contact_id: input.contact_id };
+          }
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Contact not found',
+            details: { contact_id: input.contact_id },
+          });
+        }
+
+        const result = await deleteEntityWithValidation(
+          'contact',
+          input.contact_id,
+          tx.trx,
+          tx.tenantId,
+          async (trx: Knex.Transaction, tenantId: string) => {
+            await cleanupContactDeleteArtifacts(trx, tenantId, input.contact_id);
+            await cleanupContactNotesDocument(trx, tenantId, input.contact_id);
+            await cleanupEntraReferencesBeforeContactDelete(trx, tenantId, input.contact_id);
+            await trx('contacts').where({ tenant: tenantId, contact_name_id: input.contact_id }).delete();
+          }
+        );
+
+        if (!result?.deleted) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'CONFLICT',
+            message: result?.message ?? 'Unable to delete contact due to dependencies',
+            details: {
+              dependencies: result?.dependencies ?? [],
+              alternatives: result?.alternatives ?? [],
+            },
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.delete',
+          changedData: { contact_id: input.contact_id, deleted: true },
+          details: { action_id: 'contacts.delete', action_version: 1, contact_id: input.contact_id },
+        });
+
+        return { deleted: true, contact_id: input.contact_id };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A17 — contacts.duplicate
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.duplicate',
+    version: 1,
+    inputSchema: contactDuplicateInputSchema,
+    outputSchema: z.object({
+      source_contact: contactSummarySchema,
+      duplicate_contact: contactSummarySchema,
+      copied_tags: z.number().int(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Duplicate Contact',
+      category: 'Business Operations',
+      description: 'Create a new contact from a source contact with explicit email override',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'create' });
+
+        const source = await ensureContactExists(ctx, tx, input.source_contact_id);
+
+        const targetClientId = Object.prototype.hasOwnProperty.call(input, 'target_client_id')
+          ? input.target_client_id
+          : source.client_id ?? null;
+
+        if (typeof targetClientId === 'string' && targetClientId) {
+          await ensureClientExists(ctx, tx, targetClientId);
+        }
+
+        let duplicate: Record<string, any>;
+        const sourcePhoneNumbers = Array.isArray(source.phone_numbers)
+          ? source.phone_numbers.map((phone: Record<string, unknown>, index: number) => ({
+              phone_number: phone.phone_number as string,
+              canonical_type: (phone.canonical_type as string | null | undefined) ?? undefined,
+              custom_type: (phone.custom_type as string | null | undefined) ?? undefined,
+              is_default: Boolean(phone.is_default),
+              display_order: typeof phone.display_order === 'number' ? phone.display_order : index,
+            }))
+          : [];
+        try {
+          duplicate = await ContactModel.createContact(
+            {
+              full_name: input.full_name ?? source.full_name,
+              email: input.email,
+              client_id: targetClientId ?? undefined,
+              role: Object.prototype.hasOwnProperty.call(input, 'role') ? (input.role ?? undefined) : (source.role ?? undefined),
+              notes: Object.prototype.hasOwnProperty.call(input, 'notes') ? (input.notes ?? undefined) : (source.notes ?? undefined),
+              is_inactive: input.is_inactive ?? Boolean(source.is_inactive),
+              primary_email_canonical_type:
+                input.primary_email_canonical_type ?? source.primary_email_canonical_type ?? undefined,
+              primary_email_custom_type: input.primary_email_custom_type ?? undefined,
+              phone_numbers: input.phone_numbers ?? sourcePhoneNumbers,
+              additional_email_addresses: input.additional_email_addresses ?? [],
+            },
+            tx.tenantId,
+            tx.trx
+          ) as unknown as Record<string, any>;
+        } catch (error) {
+          rethrowContactModelError(ctx, error);
+        }
+
+        let copiedTags = 0;
+        if (input.copy_tags) {
+          const sourceTags = await tx.trx('tag_mappings as tm')
+            .join('tag_definitions as td', function joinTagDefs() {
+              this.on('tm.tenant', 'td.tenant').andOn('tm.tag_id', 'td.tag_id');
+            })
+            .where({
+              'tm.tenant': tx.tenantId,
+              'tm.tagged_type': 'contact',
+              'tm.tagged_id': input.source_contact_id,
+              'td.tagged_type': 'contact',
+            })
+            .select('td.tag_text');
+
+          const tagResult = await ensureContactTagMappings(
+            tx,
+            duplicate.contact_name_id,
+            sourceTags.map((row: { tag_text: string }) => row.tag_text)
+          );
+          copiedTags = tagResult.added.length + tagResult.existing.length;
+        }
+
+        const duplicateLoaded = await ensureContactExists(ctx, tx, duplicate.contact_name_id);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.duplicate',
+          changedData: {
+            source_contact_id: input.source_contact_id,
+            duplicate_contact_id: duplicateLoaded.contact_name_id,
+            copied_tags: copiedTags,
+          },
+          details: {
+            action_id: 'contacts.duplicate',
+            action_version: 1,
+            contact_id: duplicateLoaded.contact_name_id,
+          },
+        });
+
+        return {
+          source_contact: contactToSummary(source),
+          duplicate_contact: contactToSummary(duplicateLoaded),
+          copied_tags: copiedTags,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A18 — contacts.add_tag
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.add_tag',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      tags: z.array(z.string().min(1)).min(1).describe('One or more tags to attach to the contact'),
+      idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+    }),
+    outputSchema: z.object({
+      contact_id: uuidSchema,
+      added: z.array(tagResultSchema),
+      existing: z.array(tagResultSchema),
+      added_count: z.number().int(),
+      existing_count: z.number().int(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Add Tag to Contact',
+      category: 'Business Operations',
+      description: 'Attach one or more tags to a contact with idempotent behavior',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        await ensureContactExists(ctx, tx, input.contact_id);
+        const tagResult = await ensureContactTagMappings(tx, input.contact_id, input.tags);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.add_tag',
+          changedData: {
+            contact_id: input.contact_id,
+            added_count: tagResult.added.length,
+            existing_count: tagResult.existing.length,
+          },
+          details: { action_id: 'contacts.add_tag', action_version: 1, contact_id: input.contact_id },
+        });
+
+        return {
+          contact_id: input.contact_id,
+          added: tagResult.added,
+          existing: tagResult.existing,
+          added_count: tagResult.added.length,
+          existing_count: tagResult.existing.length,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A19 — contacts.assign_to_ticket
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.assign_to_ticket',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      ticket_id: withWorkflowPicker(uuidSchema, 'Ticket id', 'ticket'),
+      reason: z.string().optional().describe('Optional reason/audit detail for assignment'),
+      comment: z.string().optional().describe('Optional internal comment/audit detail for assignment'),
+    }),
+    outputSchema: z.object({
+      ticket_id: uuidSchema,
+      previous_contact_id: nullableUuidSchema,
+      current_contact_id: nullableUuidSchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Assign Contact to Ticket',
+      category: 'Business Operations',
+      description: 'Set a ticket contact with tenant/client relationship validation',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'ticket', action: 'update' });
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
+
+        const ticket = await ensureTicketExists(ctx, tx, input.ticket_id);
+        const contact = await ensureContactExists(ctx, tx, input.contact_id);
+
+        if (ticket.client_id && contact.client_id !== ticket.client_id) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Contact must belong to the ticket client',
+            details: {
+              contact_id: input.contact_id,
+              contact_client_id: contact.client_id ?? null,
+              ticket_id: input.ticket_id,
+              ticket_client_id: ticket.client_id,
+            },
+          });
+        }
+
+        const previousContactId = ticket.contact_name_id ?? null;
+        await tx.trx('tickets')
+          .where({ tenant: tx.tenantId, ticket_id: input.ticket_id })
+          .update({ contact_name_id: input.contact_id, updated_at: new Date().toISOString() });
+
+        const after = await ensureTicketExists(ctx, tx, input.ticket_id);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.assign_to_ticket',
+          changedData: {
+            ticket_id: input.ticket_id,
+            previous_contact_id: previousContactId,
+            current_contact_id: after.contact_name_id ?? null,
+          },
+          details: {
+            action_id: 'contacts.assign_to_ticket',
+            action_version: 1,
+            contact_id: input.contact_id,
+            reason: input.reason ?? null,
+            comment: input.comment ?? null,
+          },
+        });
+
+        return {
+          ticket_id: input.ticket_id,
+          previous_contact_id: previousContactId,
+          current_contact_id: after.contact_name_id ?? null,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A20 — contacts.add_note
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.add_note',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      body: z.string().min(1).describe('Note content to append to the contact notes document'),
+      idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+    }),
+    outputSchema: z.object({
+      contact_id: uuidSchema,
+      document_id: uuidSchema,
+      created_document: z.boolean(),
+      updated_at: isoDateTimeSchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Add Note to Contact',
+      category: 'Business Operations',
+      description: 'Append a note block to the contact notes document',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        const contact = await ensureContactExists(ctx, tx, input.contact_id);
+        const result = await appendContactNoteBlock(tx, contact, input.body);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.add_note',
+          changedData: {
+            contact_id: input.contact_id,
+            document_id: result.document_id,
+            created_document: result.created_document,
+          },
+          details: { action_id: 'contacts.add_note', action_version: 1, contact_id: input.contact_id },
+        });
+
+        if (result.created_document) {
+          await publishWorkflowDomainEvent({
+            eventType: 'NOTE_CREATED',
+            payload: buildNoteCreatedPayload({
+              noteId: result.document_id,
+              entityType: 'contact',
+              entityId: input.contact_id,
+              createdByUserId: tx.actorUserId,
+              createdAt: result.updated_at,
+              visibility: 'internal',
+              bodyPreview: input.body,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt: result.updated_at,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `note_created:contact:${input.contact_id}:${result.document_id}`,
+          });
+        }
+
+        return {
+          contact_id: input.contact_id,
+          document_id: result.document_id,
+          created_document: result.created_document,
+          updated_at: result.updated_at,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A21 — contacts.add_interaction
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.add_interaction',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      interaction_type_id: uuidSchema.describe('Interaction type id'),
+      title: z.string().min(1),
+      ticket_id: withWorkflowPicker(uuidSchema.optional(), 'Optional ticket id', 'ticket'),
+      notes: z.string().optional(),
+      start_time: isoDateTimeSchema.optional(),
+      end_time: isoDateTimeSchema.optional(),
+      duration: z.number().int().nonnegative().optional(),
+      status_id: uuidSchema.optional(),
+      interaction_date: isoDateTimeSchema.optional(),
+      idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+    }),
+    outputSchema: z.object({
+      interaction_id: uuidSchema,
+      contact_id: uuidSchema,
+      client_id: uuidSchema,
+      ticket_id: nullableUuidSchema,
+      interaction_type_id: uuidSchema,
+      status_id: nullableUuidSchema,
+      title: z.string(),
+      notes: z.string().nullable(),
+      interaction_date: isoDateTimeSchema,
+      start_time: isoDateTimeSchema.nullable(),
+      end_time: isoDateTimeSchema.nullable(),
+      duration: z.number().int().nullable(),
+      user_id: uuidSchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Add Interaction to Contact',
+      category: 'Business Operations',
+      description: 'Log an interaction for a contact using the workflow actor as owner',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        const contact = await ensureContactExists(ctx, tx, input.contact_id);
+        if (!contact.client_id) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Contact must be assigned to a client before logging interactions',
+            details: { contact_id: input.contact_id },
+          });
+        }
+
+        if (input.ticket_id) {
+          const ticket = await ensureTicketExists(ctx, tx, input.ticket_id);
+          if (ticket.client_id && ticket.client_id !== contact.client_id) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'ticket_id must belong to the contact client',
+              details: {
+                ticket_id: input.ticket_id,
+                ticket_client_id: ticket.client_id,
+                contact_client_id: contact.client_id,
+              },
+            });
+          }
+        }
+
+        if (input.status_id) {
+          const status = await tx.trx('statuses')
+            .where({ tenant: tx.tenantId, status_id: input.status_id, status_type: 'interaction' })
+            .first();
+          if (!status) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Interaction status not found',
+              details: { status_id: input.status_id },
+            });
+          }
+        }
+
+        const statusId = input.status_id ?? (await getDefaultInteractionStatusId(ctx, tx));
+        const interactionDate = input.interaction_date ?? new Date().toISOString();
+
+        const insertRow = {
+          tenant: tx.tenantId,
+          interaction_id: uuidv4(),
+          type_id: input.interaction_type_id,
+          contact_name_id: input.contact_id,
+          client_id: contact.client_id,
+          user_id: tx.actorUserId,
+          ticket_id: input.ticket_id ?? null,
+          title: input.title,
+          notes: input.notes ?? null,
+          interaction_date: interactionDate,
+          start_time: input.start_time ?? interactionDate,
+          end_time: input.end_time ?? interactionDate,
+          duration: input.duration ?? 0,
+          status_id: statusId,
+        };
+
+        let created: any;
+        try {
+          [created] = await tx.trx('interactions').insert(insertRow).returning('*');
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.add_interaction',
+          changedData: {
+            interaction_id: created.interaction_id,
+            contact_id: created.contact_name_id,
+            client_id: created.client_id,
+            ticket_id: created.ticket_id ?? null,
+            type_id: created.type_id,
+          },
+          details: {
+            action_id: 'contacts.add_interaction',
+            action_version: 1,
+            contact_id: input.contact_id,
+            interaction_id: created.interaction_id,
+          },
+        });
+
+        await publishWorkflowDomainEvent({
+          eventType: 'INTERACTION_LOGGED',
+          payload: buildInteractionLoggedPayload({
+            interactionId: created.interaction_id,
+            clientId: created.client_id,
+            contactId: created.contact_name_id ?? undefined,
+            interactionType: String(created.type_name ?? created.type_id ?? 'interaction'),
+            interactionOccurredAt:
+              created.interaction_date instanceof Date
+                ? created.interaction_date.toISOString()
+                : String(created.interaction_date),
+            loggedByUserId: created.user_id,
+            subject: created.title ?? undefined,
+            outcome: created.status_name ?? undefined,
+          }),
+          tenantId: tx.tenantId,
+          occurredAt:
+            created.interaction_date instanceof Date
+              ? created.interaction_date.toISOString()
+              : String(created.interaction_date),
+          actorUserId: tx.actorUserId,
+          idempotencyKey: `interaction_logged:${created.interaction_id}`,
+        });
+
+        return {
+          interaction_id: created.interaction_id,
+          contact_id: created.contact_name_id,
+          client_id: created.client_id,
+          ticket_id: created.ticket_id ?? null,
+          interaction_type_id: created.type_id,
+          status_id: created.status_id ?? null,
+          title: created.title,
+          notes: created.notes ?? null,
+          interaction_date:
+            created.interaction_date instanceof Date
+              ? created.interaction_date.toISOString()
+              : String(created.interaction_date),
+          start_time:
+            created.start_time instanceof Date
+              ? created.start_time.toISOString()
+              : created.start_time
+                ? String(created.start_time)
+                : null,
+          end_time:
+            created.end_time instanceof Date
+              ? created.end_time.toISOString()
+              : created.end_time
+                ? String(created.end_time)
+                : null,
+          duration:
+            typeof created.duration === 'number' ? created.duration : created.duration ? Number(created.duration) : null,
+          user_id: created.user_id,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A22 — contacts.add_to_client
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.add_to_client',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      client_id: withWorkflowPicker(uuidSchema, 'Client id', 'client'),
+    }),
+    outputSchema: z.object({
+      contact_id: uuidSchema,
+      previous_client_id: nullableUuidSchema,
+      current_client_id: nullableUuidSchema,
+      noop: z.boolean(),
+      contact: contactSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Add Contact to Client',
+      category: 'Business Operations',
+      description: 'Assign an unassigned contact to a client with idempotent semantics',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        await ensureClientExists(ctx, tx, input.client_id);
+        const before = await ensureContactExists(ctx, tx, input.contact_id);
+
+        const previousClientId = before.client_id ?? null;
+        if (previousClientId && previousClientId !== input.client_id) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'CONFLICT',
+            message: 'Contact is already assigned to a different client; use contacts.move_to_client',
+            details: {
+              contact_id: input.contact_id,
+              previous_client_id: previousClientId,
+              requested_client_id: input.client_id,
+            },
+          });
+        }
+
+        let after = before;
+        const noop = previousClientId === input.client_id;
+        if (!noop) {
+          await tx.trx('contacts')
+            .where({ tenant: tx.tenantId, contact_name_id: input.contact_id })
+            .update({ client_id: input.client_id, updated_at: new Date().toISOString() });
+          after = await ensureContactExists(ctx, tx, input.contact_id);
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.add_to_client',
+          changedData: {
+            contact_id: input.contact_id,
+            previous_client_id: previousClientId,
+            current_client_id: after.client_id ?? null,
+            noop,
+          },
+          details: {
+            action_id: 'contacts.add_to_client',
+            action_version: 1,
+            contact_id: input.contact_id,
+          },
+        });
+
+        return {
+          contact_id: input.contact_id,
+          previous_client_id: previousClientId,
+          current_client_id: after.client_id ?? null,
+          noop,
+          contact: contactToSummary(after),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // A23 — contacts.move_to_client
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'contacts.move_to_client',
+    version: 1,
+    inputSchema: z.object({
+      contact_id: withWorkflowPicker(uuidSchema, 'Contact id', 'contact'),
+      target_client_id: withWorkflowPicker(uuidSchema, 'Target client id', 'client'),
+      expected_current_client_id: withWorkflowPicker(nullableUuidSchema.optional(), 'Optional expected current client id', 'client'),
+    }),
+    outputSchema: z.object({
+      contact_id: uuidSchema,
+      previous_client_id: nullableUuidSchema,
+      current_client_id: nullableUuidSchema,
+      noop: z.boolean(),
+      contact: contactSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Move Contact to Client',
+      category: 'Business Operations',
+      description: 'Move a contact to another client with optional source-client guard',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'contact', action: 'update' });
+
+        await ensureClientExists(ctx, tx, input.target_client_id);
+        const before = await ensureContactExists(ctx, tx, input.contact_id);
+        const previousClientId = before.client_id ?? null;
+
+        if (Object.prototype.hasOwnProperty.call(input, 'expected_current_client_id')) {
+          const expected = input.expected_current_client_id ?? null;
+          if (expected !== previousClientId) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'CONFLICT',
+              message: 'Contact current client did not match expected_current_client_id',
+              details: {
+                contact_id: input.contact_id,
+                expected_current_client_id: expected,
+                actual_current_client_id: previousClientId,
+              },
+            });
+          }
+        }
+
+        let after = before;
+        const noop = previousClientId === input.target_client_id;
+
+        if (!noop) {
+          await tx.trx('contacts')
+            .where({ tenant: tx.tenantId, contact_name_id: input.contact_id })
+            .update({ client_id: input.target_client_id, updated_at: new Date().toISOString() });
+          after = await ensureContactExists(ctx, tx, input.contact_id);
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:contacts.move_to_client',
+          changedData: {
+            contact_id: input.contact_id,
+            previous_client_id: previousClientId,
+            current_client_id: after.client_id ?? null,
+            noop,
+          },
+          details: {
+            action_id: 'contacts.move_to_client',
+            action_version: 1,
+            contact_id: input.contact_id,
+            expected_current_client_id: input.expected_current_client_id ?? null,
+          },
+        });
+
+        return {
+          contact_id: input.contact_id,
+          previous_client_id: previousClientId,
+          current_client_id: after.client_id ?? null,
+          noop,
+          contact: contactToSummary(after),
+        };
+      }),
   });
 }

--- a/shared/workflow/runtime/actions/businessOperations/contacts.ts
+++ b/shared/workflow/runtime/actions/businessOperations/contacts.ts
@@ -5,6 +5,10 @@ import { deleteEntityWithValidation, isEnterprise } from '@alga-psa/core';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
 import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
 import { ContactModel } from '../../../../models/contactModel';
+import type {
+  ContactEmailAddressInput as ContactModelEmailInput,
+  ContactPhoneNumberInput as ContactModelPhoneInput,
+} from '../../../../interfaces/contact.interfaces';
 import { buildContactArchivedPayload, buildContactCreatedPayload, buildContactUpdatedPayload } from '../../../streams/domainEventBuilders/contactEventBuilders';
 import { buildInteractionLoggedPayload, buildNoteCreatedPayload } from '../../../streams/domainEventBuilders/crmInteractionNoteEventBuilders';
 import {
@@ -56,14 +60,21 @@ const tagResultSchema = z.object({
 
 const nullableUuidSchema = z.union([uuidSchema, z.null()]);
 
+const CONTACT_PHONE_CANONICAL_TYPES = ['work', 'mobile', 'home', 'fax', 'other'] as const;
+
 const contactPhoneInputSchema = z.object({
   contact_phone_number_id: uuidSchema.optional(),
   phone_number: z.string().min(1),
-  canonical_type: z.enum(['work', 'mobile', 'home', 'fax', 'other']).nullable().optional(),
+  canonical_type: z.enum(CONTACT_PHONE_CANONICAL_TYPES).nullable().optional(),
   custom_type: z.string().nullable().optional(),
   is_default: z.boolean().optional(),
   display_order: z.number().int().min(0).optional(),
 });
+
+type ContactPhoneInput = z.infer<typeof contactPhoneInputSchema>;
+
+const isContactPhoneCanonicalType = (value: unknown): value is ContactPhoneInput['canonical_type'] =>
+  value === null || CONTACT_PHONE_CANONICAL_TYPES.includes(value as (typeof CONTACT_PHONE_CANONICAL_TYPES)[number]);
 
 const contactAdditionalEmailInputSchema = z.object({
   contact_additional_email_address_id: uuidSchema.optional(),
@@ -899,8 +910,8 @@ export function registerContactActions(): void {
               is_inactive: input.is_inactive,
               primary_email_canonical_type: input.primary_email_canonical_type ?? undefined,
               primary_email_custom_type: input.primary_email_custom_type ?? undefined,
-              phone_numbers: input.phone_numbers ?? undefined,
-              additional_email_addresses: input.additional_email_addresses ?? undefined,
+              phone_numbers: input.phone_numbers as ContactModelPhoneInput[] | undefined,
+              additional_email_addresses: input.additional_email_addresses as ContactModelEmailInput[] | undefined,
             },
             tx.tenantId,
             tx.trx
@@ -925,31 +936,29 @@ export function registerContactActions(): void {
           details: { action_id: 'contacts.create', action_version: 1, contact_id: after.contact_name_id },
         });
 
-        if (typeof after.client_id === 'string' && after.client_id) {
-          const occurredAt = (after.created_at as string | undefined) ?? new Date().toISOString();
-          await publishWorkflowDomainEvent({
-            eventType: 'CONTACT_CREATED',
-            payload: buildContactCreatedPayload({
-              contactId: after.contact_name_id,
-              clientId: after.client_id,
-              fullName: after.full_name,
-              email: after.email ?? undefined,
-              primaryEmailCanonicalType: after.primary_email_canonical_type ?? null,
-              primaryEmailCustomTypeId: after.primary_email_custom_type_id ?? null,
-              primaryEmailType: after.primary_email_type ?? null,
-              additionalEmailAddresses: after.additional_email_addresses ?? [],
-              phoneNumbers: after.phone_numbers ?? [],
-              defaultPhoneNumber: after.default_phone_number ?? undefined,
-              defaultPhoneType: after.default_phone_type ?? undefined,
-              createdByUserId: tx.actorUserId,
-              createdAt: occurredAt,
-            }),
-            tenantId: tx.tenantId,
-            occurredAt,
-            actorUserId: tx.actorUserId,
-            idempotencyKey: `contact_created:${after.contact_name_id}`,
-          });
-        }
+        const occurredAt = (after.created_at as string | undefined) ?? new Date().toISOString();
+        await publishWorkflowDomainEvent({
+          eventType: 'CONTACT_CREATED',
+          payload: buildContactCreatedPayload({
+            contactId: after.contact_name_id,
+            clientId: after.client_id ?? null,
+            fullName: after.full_name,
+            email: after.email ?? undefined,
+            primaryEmailCanonicalType: after.primary_email_canonical_type ?? null,
+            primaryEmailCustomTypeId: after.primary_email_custom_type_id ?? null,
+            primaryEmailType: after.primary_email_type ?? null,
+            additionalEmailAddresses: after.additional_email_addresses ?? [],
+            phoneNumbers: after.phone_numbers ?? [],
+            defaultPhoneNumber: after.default_phone_number ?? undefined,
+            defaultPhoneType: after.default_phone_type ?? undefined,
+            createdByUserId: tx.actorUserId,
+            createdAt: occurredAt,
+          }),
+          tenantId: tx.tenantId,
+          occurredAt,
+          actorUserId: tx.actorUserId,
+          idempotencyKey: `contact_created:${after.contact_name_id}`,
+        });
 
         return {
           created: true,
@@ -992,23 +1001,16 @@ export function registerContactActions(): void {
           await ensureClientExists(ctx, tx, patch.client_id);
         }
 
+        const updatePayload: Record<string, unknown> = {};
+        for (const key of changedFields) {
+          updatePayload[key] = (patch as Record<string, unknown>)[key];
+        }
+
         let after: Record<string, any>;
         try {
           after = await ContactModel.updateContact(
             input.contact_id,
-            {
-              full_name: patch.full_name,
-              email: patch.email ?? undefined,
-              client_id: patch.client_id === null ? null as unknown as string : patch.client_id ?? undefined,
-              role: patch.role ?? undefined,
-              notes: patch.notes ?? undefined,
-              is_inactive: patch.is_inactive,
-              primary_email_canonical_type: patch.primary_email_canonical_type ?? undefined,
-              primary_email_custom_type: patch.primary_email_custom_type ?? undefined,
-              primary_email_custom_type_id: patch.primary_email_custom_type_id ?? undefined,
-              phone_numbers: patch.phone_numbers ?? undefined,
-              additional_email_addresses: patch.additional_email_addresses ?? undefined,
-            } as any,
+            updatePayload as any,
             tx.tenantId,
             tx.trx
           ) as unknown as Record<string, any>;
@@ -1028,32 +1030,36 @@ export function registerContactActions(): void {
         const eventClientId = (after.client_id ?? before.client_id) as string | null;
         const occurredAt = (after.updated_at as string | undefined) ?? new Date().toISOString();
 
-        if (typeof eventClientId === 'string' && eventClientId) {
-          const updatedPayload = buildContactUpdatedPayload({
-            contactId: input.contact_id,
-            clientId: eventClientId,
-            before,
-            after,
-            updatedFieldKeys: changedFields,
-            updatedByUserId: tx.actorUserId,
-            updatedAt: occurredAt,
+        const updatedPayload = buildContactUpdatedPayload({
+          contactId: input.contact_id,
+          clientId: eventClientId,
+          before: {
+            ...before,
+            contact_name_id: String(before.contact_name_id ?? input.contact_id),
+          },
+          after: {
+            ...after,
+            contact_name_id: String(after.contact_name_id ?? input.contact_id),
+          },
+          updatedFieldKeys: changedFields,
+          updatedByUserId: tx.actorUserId,
+          updatedAt: occurredAt,
+        });
+        const updatedFields = (updatedPayload as { updatedFields?: string[] }).updatedFields ?? [];
+        if (updatedFields.length > 0) {
+          await publishWorkflowDomainEvent({
+            eventType: 'CONTACT_UPDATED',
+            payload: updatedPayload,
+            tenantId: tx.tenantId,
+            occurredAt,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `contact_updated:${input.contact_id}:${occurredAt}`,
           });
-          const updatedFields = (updatedPayload as { updatedFields?: string[] }).updatedFields ?? [];
-          if (updatedFields.length > 0) {
-            await publishWorkflowDomainEvent({
-              eventType: 'CONTACT_UPDATED',
-              payload: updatedPayload,
-              tenantId: tx.tenantId,
-              occurredAt,
-              actorUserId: tx.actorUserId,
-              idempotencyKey: `contact_updated:${input.contact_id}:${occurredAt}`,
-            });
-          }
         }
 
         const wasInactive = Boolean(before.is_inactive);
         const isInactive = Boolean(after.is_inactive);
-        if (!wasInactive && isInactive && typeof eventClientId === 'string' && eventClientId) {
+        if (!wasInactive && isInactive) {
           await publishWorkflowDomainEvent({
             eventType: 'CONTACT_ARCHIVED',
             payload: buildContactArchivedPayload({
@@ -1119,22 +1125,20 @@ export function registerContactActions(): void {
           after = await ensureContactExists(ctx, tx, input.contact_id);
           currentInactive = Boolean(after.is_inactive);
 
-          if (typeof after.client_id === 'string' && after.client_id) {
-            await publishWorkflowDomainEvent({
-              eventType: 'CONTACT_ARCHIVED',
-              payload: buildContactArchivedPayload({
-                contactId: input.contact_id,
-                clientId: after.client_id,
-                archivedByUserId: tx.actorUserId,
-                archivedAt: nowIso,
-                reason: input.reason,
-              }),
-              tenantId: tx.tenantId,
-              occurredAt: nowIso,
-              actorUserId: tx.actorUserId,
-              idempotencyKey: `contact_archived:${input.contact_id}:${nowIso}`,
-            });
-          }
+          await publishWorkflowDomainEvent({
+            eventType: 'CONTACT_ARCHIVED',
+            payload: buildContactArchivedPayload({
+              contactId: input.contact_id,
+              clientId: after.client_id ?? null,
+              archivedByUserId: tx.actorUserId,
+              archivedAt: nowIso,
+              reason: input.reason,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt: nowIso,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `contact_archived:${input.contact_id}:${nowIso}`,
+          });
         }
 
         await writeRunAudit(ctx, tx, {
@@ -1276,10 +1280,10 @@ export function registerContactActions(): void {
         }
 
         let duplicate: Record<string, any>;
-        const sourcePhoneNumbers = Array.isArray(source.phone_numbers)
+        const sourcePhoneNumbers: ContactModelPhoneInput[] = Array.isArray(source.phone_numbers)
           ? source.phone_numbers.map((phone: Record<string, unknown>, index: number) => ({
               phone_number: phone.phone_number as string,
-              canonical_type: (phone.canonical_type as string | null | undefined) ?? undefined,
+              canonical_type: isContactPhoneCanonicalType(phone.canonical_type) ? phone.canonical_type : undefined,
               custom_type: (phone.custom_type as string | null | undefined) ?? undefined,
               is_default: Boolean(phone.is_default),
               display_order: typeof phone.display_order === 'number' ? phone.display_order : index,
@@ -1297,8 +1301,8 @@ export function registerContactActions(): void {
               primary_email_canonical_type:
                 input.primary_email_canonical_type ?? source.primary_email_canonical_type ?? undefined,
               primary_email_custom_type: input.primary_email_custom_type ?? undefined,
-              phone_numbers: input.phone_numbers ?? sourcePhoneNumbers,
-              additional_email_addresses: input.additional_email_addresses ?? [],
+              phone_numbers: (input.phone_numbers as ContactModelPhoneInput[] | undefined) ?? sourcePhoneNumbers,
+              additional_email_addresses: (input.additional_email_addresses as ContactModelEmailInput[] | undefined) ?? [],
             },
             tx.tenantId,
             tx.trx

--- a/shared/workflow/runtime/schemas/crmEventSchemas.ts
+++ b/shared/workflow/runtime/schemas/crmEventSchemas.ts
@@ -95,7 +95,7 @@ export type ClientArchivedEventPayload = z.infer<typeof clientArchivedEventPaylo
 
 export const contactCreatedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   fullName: z.string().min(1),
   email: z.string().email().optional(),
   primaryEmailCanonicalType: contactEmailCanonicalTypeSchema.nullable().optional(),
@@ -113,7 +113,7 @@ export type ContactCreatedEventPayload = z.infer<typeof contactCreatedEventPaylo
 
 export const contactUpdatedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   updatedByUserId: userIdSchema.optional(),
   updatedAt: z.string().datetime().optional(),
   updatedFields: updatedFieldsSchema,
@@ -134,7 +134,7 @@ export type ContactPrimarySetEventPayload = z.infer<typeof contactPrimarySetEven
 
 export const contactArchivedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
   contactId: contactIdSchema,
-  clientId: clientIdSchema,
+  clientId: clientIdSchema.optional(),
   archivedByUserId: userIdSchema.optional(),
   archivedAt: z.string().datetime().optional(),
   reason: z.string().optional(),

--- a/shared/workflow/streams/domainEventBuilders/__tests__/contactEventBuilders.test.ts
+++ b/shared/workflow/streams/domainEventBuilders/__tests__/contactEventBuilders.test.ts
@@ -101,6 +101,45 @@ describe('contactEventBuilders', () => {
     });
   });
 
+  it('builds contact lifecycle payloads for unassigned contacts without clientId', () => {
+    const createdPayload = buildWorkflowPayload(
+      buildContactCreatedPayload({
+        contactId,
+        fullName: 'Unassigned Contact',
+        email: 'unassigned@example.com',
+        createdByUserId: actorUserId,
+        createdAt: occurredAt,
+      }),
+      ctx
+    );
+    const updatedPayload = buildWorkflowPayload(
+      buildContactUpdatedPayload({
+        contactId,
+        before: { contact_name_id: contactId, full_name: 'Before' },
+        after: { contact_name_id: contactId, full_name: 'After' },
+        updatedFieldKeys: ['full_name'],
+        updatedByUserId: actorUserId,
+        updatedAt: occurredAt,
+      }),
+      ctx
+    );
+    const archivedPayload = buildWorkflowPayload(
+      buildContactArchivedPayload({
+        contactId,
+        archivedByUserId: actorUserId,
+        archivedAt: occurredAt,
+      }),
+      ctx
+    );
+
+    expect(contactCreatedEventPayloadSchema.safeParse(createdPayload).success).toBe(true);
+    expect(contactUpdatedEventPayloadSchema.safeParse(updatedPayload).success).toBe(true);
+    expect(contactArchivedEventPayloadSchema.safeParse(archivedPayload).success).toBe(true);
+    expect(createdPayload).not.toHaveProperty('clientId');
+    expect(updatedPayload).not.toHaveProperty('clientId');
+    expect(archivedPayload).not.toHaveProperty('clientId');
+  });
+
   it('T017: builds CONTACT_UPDATED payloads with email metadata diffs compatible with schema', () => {
     const before = {
       contact_name_id: contactId,

--- a/shared/workflow/streams/domainEventBuilders/contactEventBuilders.ts
+++ b/shared/workflow/streams/domainEventBuilders/contactEventBuilders.ts
@@ -40,7 +40,7 @@ function areValuesEqual(a: unknown, b: unknown): boolean {
 
 export function buildContactCreatedPayload(params: {
   contactId: string;
-  clientId: string;
+  clientId?: string | null;
   fullName: string;
   email?: string;
   primaryEmailCanonicalType?: string | null;
@@ -55,7 +55,7 @@ export function buildContactCreatedPayload(params: {
 }): Record<string, unknown> {
   return {
     contactId: params.contactId,
-    clientId: params.clientId,
+    ...(params.clientId ? { clientId: params.clientId } : {}),
     fullName: params.fullName,
     ...(params.email ? { email: params.email } : {}),
     ...(params.primaryEmailCanonicalType !== undefined ? { primaryEmailCanonicalType: params.primaryEmailCanonicalType } : {}),
@@ -72,7 +72,7 @@ export function buildContactCreatedPayload(params: {
 
 export function buildContactUpdatedPayload(params: {
   contactId: string;
-  clientId: string;
+  clientId?: string | null;
   before: ContactLike;
   after: ContactLike;
   updatedFieldKeys: string[];
@@ -107,7 +107,7 @@ export function buildContactUpdatedPayload(params: {
 
   return {
     contactId: params.contactId,
-    clientId: params.clientId,
+    ...(params.clientId ? { clientId: params.clientId } : {}),
     ...(params.updatedByUserId ? { updatedByUserId: params.updatedByUserId } : {}),
     ...(params.updatedAt ? { updatedAt: normalizeChangeValue(params.updatedAt) } : {}),
     ...(updatedFields.length ? { updatedFields } : {}),
@@ -133,14 +133,14 @@ export function buildContactPrimarySetPayload(params: {
 
 export function buildContactArchivedPayload(params: {
   contactId: string;
-  clientId: string;
+  clientId?: string | null;
   archivedByUserId?: string;
   archivedAt?: Date | string;
   reason?: string;
 }): Record<string, unknown> {
   return {
     contactId: params.contactId,
-    clientId: params.clientId,
+    ...(params.clientId ? { clientId: params.clientId } : {}),
     ...(params.archivedByUserId ? { archivedByUserId: params.archivedByUserId } : {}),
     ...(params.archivedAt ? { archivedAt: normalizeChangeValue(params.archivedAt) } : {}),
     ...(params.reason ? { reason: params.reason } : {}),


### PR DESCRIPTION
## Summary
- add workflow contact mutation actions for create/update/tag/note/assign/client move/deactivate/duplicate/delete flows
- add CRM contact runtime event payload support and regression coverage
- fix workflow designer/schema path resolution for nested local JSON Schema refs such as contacts.duplicate -> duplicate_contact.contact_name_id

## Validation
- cd ee/server && pnpm typecheck
- cd ee/server && pnpm vitest --config vitest.config.ts src/components/workflow-designer/__tests__/workflowDataContext.test.ts
- pnpm vitest --config shared/vitest.config.ts shared/workflow/expression-authoring/__tests__/coreContracts.test.ts
- backend/runtime contact action tests: 3 files / 17 tests passed
- live workflow smoke: catalog, create/tag/note/assign, add/move/deactivate, duplicate/delete guard, edit nullable/validation

## Smoke highlights
- branch-current Temporal worker ran contact workflows successfully
- Duplicate Contact -> Delete Contact no longer shows MAPPING_TYPE_UNKNOWN for duplicate_contact.contact_name_id
- Edit Contact supports explicit null for notes and rejects patch.email = null without clearing primary email
