### PR TITLE
feat(workflows): add CRM workflow actions

### DIFF
--- a/ee/docs/plans/2026-04-25-workflow-crm-actions/PRD.md
+++ b/ee/docs/plans/2026-04-25-workflow-crm-actions/PRD.md
@@ -1,0 +1,340 @@
+# PRD — CRM Workflow Actions
+
+- Slug: `workflow-crm-actions`
+- Date: `2026-04-25`
+- Status: Draft
+
+## Summary
+
+Expand the Workflow Runtime V2 CRM action module beyond its single existing action, `crm.create_activity_note`, so workflow authors can query and update CRM activities, schedule follow-up activities, and automate quote sending from workflow logic.
+
+This plan treats the user-proposed CRM action list as a phased roadmap. The first implementation pass focuses on the four highest-value actions:
+
+1. `crm.find_activities`
+2. `crm.update_activity`
+3. `crm.schedule_activity`
+4. `crm.send_quote`
+
+The remaining recommended actions are documented as follow-on scope so their naming, dependencies, and overlap with newly merged Client workflow actions are explicit before implementation begins.
+
+## Problem
+
+The CRM workflow module is sparse. Today it registers exactly one action in `shared/workflow/runtime/actions/businessOperations/crm.ts`:
+
+- `crm.create_activity_note`
+
+That leaves workflow authors unable to automate common CRM loops:
+
+- Look up recent sales/account interactions before choosing an onboarding path.
+- Update an activity after a ticket, quote, or project milestone changes.
+- Schedule a follow-up call or meeting after work is completed.
+- Send a prepared quote when a workflow reaches a business-ready state.
+
+By comparison, Tickets and Clients now have much richer workflow action coverage. Recent main-branch updates added extensive Client workflow actions and established implementation conventions that CRM should follow.
+
+## Goals
+
+- Add first-pass CRM workflow actions for activity lookup, activity update, follow-up scheduling, and quote sending.
+- Keep actions grouped under the existing Workflow Designer CRM tile via `crm.*` action IDs.
+- Preserve current shared workflow runtime architecture: Zod schemas, registry registration, `action.call`, tenant transaction helpers, permission checks, audit logs, and schema-derived designer forms.
+- Reuse existing data models/services where safe, but do not import server-only `withAuth` actions into shared runtime code.
+- Follow recent main-branch workflow-action conventions:
+  - picker metadata with `withWorkflowJsonSchemaMetadata`
+  - lazy workflow event publisher imports from shared runtime action handlers
+  - deterministic event idempotency keys
+  - DB-backed shared-root action tests
+- Clearly separate CRM activity/interactions from Client-module notes/interactions that now exist in `clients.*` workflow actions.
+
+## Non-goals
+
+- Replacing `crm.create_activity_note` or changing its persisted contract.
+- Implementing every recommended CRM action in the first pass.
+- Building new Workflow Designer UI controls beyond existing schema metadata and picker conventions.
+- Calling Next.js server actions or `withAuth` action wrappers directly from shared workflow runtime code.
+- Reworking quote lifecycle, quote PDF rendering, email templates, or approval logic outside the workflow-action wrappers.
+- Duplicating `clients.add_note` or `clients.add_interaction` semantics under CRM without a clear CRM-wide abstraction.
+- Adding new event schemas unless implementation discovers a hard gap that cannot be solved with existing CRM/tag/quote events.
+
+## Users and Primary Flows
+
+### Users
+
+- MSP admin building workflow automations.
+- Account manager or dispatcher whose CRM follow-up tasks are triggered by tickets, projects, or quote state.
+- Internal Alga PSA engineer extending Workflow Runtime V2 business operations.
+
+### Primary flows
+
+1. **Find recent CRM activity before branching**
+   - Workflow receives a client/contact/ticket event.
+   - Workflow runs `crm.find_activities` with client/contact/date/type/status filters.
+   - Workflow branches based on whether there were recent sales, QBR, onboarding, or support interactions.
+
+2. **Update an existing CRM activity**
+   - Workflow has an interaction ID from a trigger or prior lookup.
+   - Workflow runs `crm.update_activity` to update status, notes, tags, visibility, or outcome-related fields.
+   - The action returns before/after summaries and changed fields.
+
+3. **Schedule a follow-up activity**
+   - Workflow closes a ticket or completes onboarding.
+   - Workflow runs `crm.schedule_activity` to create a future-dated interaction linked to a client/contact/ticket.
+   - The activity appears as a CRM interaction/follow-up record and emits interaction logging events where appropriate.
+
+4. **Send a quote from workflow**
+   - Workflow identifies an existing quote that is ready to send.
+   - Workflow runs `crm.send_quote` with optional recipients, subject, and message.
+   - Existing quote send logic publishes the quote to the portal, stores/generates PDF best-effort, and sends email best-effort.
+
+## UX / UI Notes
+
+- New actions should appear under the existing Workflow Designer CRM group. No catalog seed change should be needed because `crm.*` action IDs map to the built-in CRM group.
+- First-pass labels:
+  - `crm.find_activities` → Find CRM Activities
+  - `crm.update_activity` → Update CRM Activity
+  - `crm.schedule_activity` → Schedule CRM Activity
+  - `crm.send_quote` → Send Quote
+- Schema descriptions should use MSP language: activity, interaction, follow-up, client, contact, quote.
+- Picker-backed fields should use current metadata conventions where supported:
+  - `client_id` → `client`
+  - `contact_id` → `contact` with `client_id` dependency when applicable
+  - `ticket_id` → `ticket`
+  - `user_id`/owner fields → `user`
+  - `quote_id` can remain UUID in v1 unless a quote picker already exists or is introduced separately
+  - interaction type/status can remain UUID fields in v1 unless a supported picker kind exists
+- Output schemas should be rich enough for downstream branches: found counts, activity summaries, quote status, email sent flag where available, and changed fields.
+
+## Requirements
+
+### Functional Requirements — First Pass
+
+#### `crm.find_activities`
+
+- Register action ID `crm.find_activities`, version `1`.
+- Side-effect-free.
+- Inputs:
+  - optional `client_id`
+  - optional `contact_id`
+  - optional `ticket_id`
+  - optional `user_id`
+  - optional `type_id`
+  - optional `status_id`
+  - optional `date_from`
+  - optional `date_to`
+  - optional `limit` defaulted and capped
+  - optional `on_empty`: `return_empty` or `error`
+- Require at least one meaningful filter or date range to avoid unbounded CRM scans.
+- Enforce `client:read`, `contact:read`, or a CRM/read-equivalent permission decision documented before implementation. If no CRM-specific permission exists, use the safest existing resource permission based on supplied filters.
+- Return:
+  - `activities`: array of normalized activity summaries
+  - `count`
+  - `matched_filters`
+- Summaries should include interaction ID, type, status, client/contact/ticket IDs and names where available, title, notes preview, interaction date, start/end time, user ID/name, visibility, category, and tags where available.
+
+#### `crm.update_activity`
+
+- Register action ID `crm.update_activity`, version `1`.
+- Inputs:
+  - `activity_id`
+  - `patch` object for editable fields:
+    - `title`
+    - `notes`
+    - `status_id`
+    - `visibility`
+    - `category`
+    - `tags`
+    - `interaction_date`
+    - `start_time`
+    - `end_time`
+    - `duration`
+    - optionally `type_id` if changing type is product-safe
+  - optional `reason`
+- Reject empty patches.
+- Validate activity exists in tenant.
+- Validate status IDs are tenant statuses with `status_type = 'interaction'`.
+- Validate interaction type IDs against tenant `interaction_types` or `system_interaction_types`.
+- Preserve immutable fields such as `tenant`, `interaction_id`, and workflow actor attribution unless explicitly designed otherwise.
+- Write run audit with before/after summary and changed fields.
+- Return before/after summaries and changed fields.
+
+#### `crm.schedule_activity`
+
+- Register action ID `crm.schedule_activity`, version `1`.
+- Inputs:
+  - `client_id` or `contact_id` (at least one required; resolve client from contact when omitted)
+  - optional `ticket_id`
+  - `type_id`
+  - `title`
+  - optional `notes`
+  - optional `status_id` (default to tenant default interaction status)
+  - `start_time`
+  - optional `end_time`
+  - optional `duration`
+  - optional `visibility`
+  - optional `category`
+  - optional `tags`
+  - optional `assigned_user_id`/`owner_user_id`; default workflow actor in v1
+  - optional `idempotency_key`
+- Validate linked client/contact/ticket relationships.
+- Validate `start_time <= end_time` when both are supplied.
+- If duration is omitted and start/end are supplied, derive duration consistently with current interaction behavior.
+- If status is omitted, use the tenant default `interaction` status or fail with a clear setup error if missing.
+- Insert into `interactions` as a future-dated interaction/follow-up.
+- Emit `INTERACTION_LOGGED` using existing payload builders through a lazy event publisher helper and deterministic idempotency key.
+- Write run audit.
+- Return created activity summary.
+
+#### `crm.send_quote`
+
+- Register action ID `crm.send_quote`, version `1`.
+- Inputs:
+  - `quote_id`
+  - optional `email_addresses`
+  - optional `subject`
+  - optional `message`
+  - optional `no_op_if_already_sent` default `true`
+- Validate quote exists in tenant and is not a template.
+- Enforce billing update/read authorization equivalent to existing quote send behavior.
+- Respect existing approval settings and quote status rules:
+  - if approval is required, only approved quotes can be sent
+  - otherwise only draft or approved quotes can be sent
+- Prefer shared-safe reuse of underlying billing quote send services/models. Do not import `withAuth` server action wrappers directly into shared runtime. If direct package import is unsafe, extract a shared-safe quote send helper first.
+- Preserve existing send behavior: transition quote to `sent`, set `sent_at`, store quote PDF best-effort, send quote email best-effort, record quote activity.
+- Return quote summary plus send metadata such as previous status, new status, sent timestamp, recipients, email_sent, and message ID where available.
+- Write run audit with quote ID, previous/new status, and email metadata.
+
+### Functional Requirements — Roadmap / Follow-on Scope
+
+These are explicitly useful but not required for the first implementation pass unless scope is expanded.
+
+- `crm.create_interaction_type`: create tenant-specific CRM activity types such as QBR, Site Visit, or Upsell Call.
+- `crm.update_activity_status`: dedicated status-transition wrapper around `crm.update_activity` for simple “mark completed/closed” workflows.
+- `crm.create_quote`: create a quote from workflow, including template-based creation where safe.
+- `crm.convert_quote`: convert quote to draft contract, invoice, or both using existing quote conversion services.
+- `crm.find_quotes`: search quotes by client, status, date range, template flag, and pagination options.
+- `crm.submit_quote_for_approval`: move eligible draft quotes into quote approval flow.
+- `crm.tag_entity`: apply tags to client, contact, or interaction using existing tag definitions/mappings and TAG events.
+- `crm.create_client_note`: only if a CRM-wide note action is still needed after the newly merged `clients.add_note` action; otherwise prefer Client/Contact module note actions.
+
+### Cross-cutting Requirements
+
+- Register all first-pass actions in `shared/workflow/runtime/actions/businessOperations/crm.ts` via existing `registerCrmActions()` and `registerBusinessOperationsActionsV2()` wiring.
+- Use `withTenantTransaction`, `requirePermission`, `writeRunAudit`, `throwActionError`, and `rethrowAsStandardError` from `businessOperations/shared.ts`.
+- Use `withWorkflowJsonSchemaMetadata` from `shared/workflow/runtime/jsonSchemaMetadata.ts` for supported picker fields.
+- Use action-provided idempotency for create/send operations where retry duplicates are possible; use engine-provided idempotency for reads and deterministic updates.
+- Use lazy dynamic import for workflow event publication from shared runtime action handlers, mirroring the new Client workflow actions.
+- Use deterministic event idempotency keys for emitted workflow events.
+- Keep implementation additive and backward compatible with existing workflows.
+
+## Data / API / Integrations
+
+### Current workflow files
+
+- `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- `shared/workflow/runtime/actions/businessOperations/tickets.ts`
+- `shared/workflow/runtime/actions/registerBusinessOperationsActions.ts`
+- `shared/workflow/runtime/designer/actionCatalog.ts`
+- `shared/workflow/runtime/jsonSchemaMetadata.ts`
+- `shared/workflow/runtime/actions/businessOperations/shared.ts`
+
+### Existing CRM/client files and patterns
+
+- `packages/clients/src/actions/interactionActions.ts`
+  - `getInteractionsForEntity`
+  - `getRecentInteractions`
+  - `updateInteraction`
+  - `addInteraction`
+- `packages/clients/src/models/interactions.ts`
+  - `getForEntity`
+  - `getRecentInteractions`
+  - `updateInteraction`
+  - `getById`
+- `packages/clients/src/actions/interactionTypeActions.ts`
+  - `createInteractionType`
+- `shared/workflow/streams/domainEventBuilders/crmInteractionNoteEventBuilders.ts`
+  - `buildInteractionLoggedPayload`
+  - `buildNoteCreatedPayload`
+
+### Existing quote files and patterns
+
+- `packages/billing/src/actions/quoteActions.ts`
+  - `createQuote`
+  - `sendQuote`
+  - `submitQuoteForApproval`
+  - `convertQuoteToContract`
+  - `convertQuoteToInvoice`
+  - `convertQuoteToBoth`
+- `packages/billing/src/models/quote.ts`
+  - `getById`
+  - `getByNumber`
+  - `listByTenant`
+  - `listByClient`
+- `packages/billing/src/services/quoteConversionService.ts`
+  - `convertQuoteToDraftContract`
+  - `convertQuoteToDraftInvoice`
+  - `convertQuoteToDraftContractAndInvoice`
+
+### Existing tag/event files
+
+- `packages/tags/src/actions/tagActions.ts`
+- `shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`
+- `shared/workflow/runtime/schemas/crmEventSchemas.ts`
+
+### Existing tables likely touched
+
+- `interactions`
+- `interaction_types`
+- `system_interaction_types`
+- `statuses` where `status_type = 'interaction'`
+- `clients`
+- `contacts`
+- `tickets`
+- `quotes`
+- quote activity/document/email-related tables used by existing quote send behavior
+- `audit_logs`
+
+## Security / Permissions
+
+- All queries and mutations must filter by tenant.
+- Activity reads must require a safe read permission. Exact permission mapping must be documented before implementation if no CRM-specific permission exists.
+- Activity updates and scheduling must require update/create permissions for the relevant CRM resource or safest existing client/contact permission.
+- Quote send must require the same effective billing read/update authorization as existing quote send behavior, including authorization-kernel checks where applicable.
+- Workflow actor should remain the actor for audit/event attribution unless a future action version explicitly supports permission-gated actor override.
+- Do not allow workflow inputs to set `tenant`, `interaction_id`, quote ownership, or other system-managed fields.
+
+## Observability
+
+- Write `audit_logs` rows with `writeRunAudit` for all side-effectful actions.
+- Include action ID/version, target IDs, changed fields, before/after status where relevant, and event/send metadata.
+- Use existing workflow event builders and lazy publication helpers for `INTERACTION_LOGGED` where new interactions are created.
+- Do not add new metrics in this plan.
+
+## Rollout / Migration
+
+- No database migration is expected for the first pass.
+- Runtime/catalog additions are additive and should not break existing workflow definitions.
+- Existing `crm.create_activity_note` remains available and unchanged.
+- Designer catalog should expose the new CRM actions automatically after runtime initialization.
+- If implementation discovers missing status/type constraints or missing quote-safe helper boundaries, update the plan before adding migrations or package refactors.
+
+## Open Questions
+
+1. What is the correct permission resource/action for CRM interactions? Candidate mappings: `client:read/update`, `contact:read/update`, or a CRM/activity-specific permission if one exists.
+2. Should `crm.update_activity` emit a workflow event? There is `INTERACTION_LOGGED` for creation, but no obvious `INTERACTION_UPDATED` schema in current CRM event schemas.
+3. Should `crm.schedule_activity` be considered a normal `INTERACTION_LOGGED` event even when the interaction date is in the future?
+4. Is quote send safe to extract into a shared helper callable from `shared/workflow/runtime`, or should the workflow action perform equivalent persistence while avoiding server-only action imports?
+5. Should `crm.send_quote` no-op for already sent quotes, or should it support resend semantics in a later `crm.resend_quote` action?
+6. Should `crm.create_client_note` be dropped from the CRM roadmap because `clients.add_note` now exists, or retained as a cross-entity CRM note wrapper?
+
+## Acceptance Criteria (Definition of Done)
+
+- Runtime initialization registers `crm.find_activities`, `crm.update_activity`, `crm.schedule_activity`, and `crm.send_quote` at version `1`.
+- Designer catalog shows the new actions under the CRM group with meaningful labels, descriptions, input schemas, output schemas, and supported picker metadata.
+- `crm.find_activities` returns tenant-scoped filtered interaction summaries and rejects unsafe unbounded queries.
+- `crm.update_activity` validates editable fields, status/type IDs, and tenant ownership, then returns before/after summaries and changed fields.
+- `crm.schedule_activity` creates a future-dated interaction linked to valid client/contact/ticket records, audits the change, and emits `INTERACTION_LOGGED` through the shared-runtime-safe event publishing pattern.
+- `crm.send_quote` sends/publishes an eligible quote using existing quote send semantics or a shared-safe extraction of that logic, audits the result, and returns send metadata.
+- All side-effectful actions enforce permissions and write run audit rows.
+- DB-backed tests cover representative success and guard/failure paths for activity update/schedule and quote send eligibility.
+- Unit tests cover action registration, designer CRM grouping, picker metadata, and event payload compatibility.
+- No existing workflow runtime, Client workflow action, Ticket workflow action, or CRM activity note tests regress.

--- a/ee/docs/plans/2026-04-25-workflow-crm-actions/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-25-workflow-crm-actions/SCRATCHPAD.md
@@ -1,0 +1,122 @@
+# Scratchpad — CRM Workflow Actions
+
+- Plan slug: `workflow-crm-actions`
+- Created: `2026-04-25`
+
+## What This Is
+
+Rolling notes for expanding Workflow Runtime V2 CRM actions beyond `crm.create_activity_note`.
+
+## Decisions
+
+- (2026-04-25) First implementation pass is scoped to `crm.find_activities`, `crm.update_activity`, `crm.schedule_activity`, and `crm.send_quote`. Rationale: these match the user's recommended high-value first pass and unlock CRM lookup/update/follow-up/quote-send workflows without committing to the entire roadmap at once.
+- (2026-04-25) Keep all first-pass actions under `crm.*` so existing designer catalog grouping places them under the built-in CRM group.
+- (2026-04-25) Do not call `withAuth` Next.js server action wrappers directly from `shared/workflow/runtime`. Reuse underlying models/services only when package-boundary safe, or extract shared-safe helpers first.
+- (2026-04-25) Mirror latest Client workflow action patterns: picker metadata via `withWorkflowJsonSchemaMetadata`, lazy event-bus imports, deterministic event idempotency keys, and DB-backed shared-root tests.
+- (2026-04-25) Treat `crm.create_client_note` as roadmap-only until we decide whether newly merged `clients.add_note` already satisfies the intended user need.
+
+## Discoveries / Constraints
+
+- (2026-04-25) Current CRM workflow action file is `shared/workflow/runtime/actions/businessOperations/crm.ts` and only registers `crm.create_activity_note`.
+- (2026-04-25) Latest main added substantial Client workflow action coverage in `shared/workflow/runtime/actions/businessOperations/clients.ts`, including `clients.add_note` and `clients.add_interaction`; CRM plan must avoid duplicating those module-specific semantics by accident.
+- (2026-04-25) Client workflow actions introduced a local `withWorkflowPicker` helper using `withWorkflowJsonSchemaMetadata` and `x-workflow-picker-kind`; CRM should use the same convention for supported fields.
+- (2026-04-25) Client workflow actions publish events using a lazy dynamic import helper (`publishWorkflowDomainEvent`) so shared-root tests do not fail when `@alga-psa/event-bus` is not resolvable. CRM should copy that pattern.
+- (2026-04-25) Existing interaction server actions are in `packages/clients/src/actions/interactionActions.ts`: `addInteraction`, `getInteractionsForEntity`, `getRecentInteractions`, `updateInteraction`, `getInteractionStatuses`, and `deleteInteraction`.
+- (2026-04-25) Existing interaction model is in `packages/clients/src/models/interactions.ts` and supports `getForEntity`, `getRecentInteractions`, `addInteraction`, `updateInteraction`, and `getById`, but those model methods call `createTenantKnex` internally; direct use from a workflow transaction may require careful adaptation or local query implementation.
+- (2026-04-25) Existing interaction type server action is `createInteractionType` in `packages/clients/src/actions/interactionTypeActions.ts` and writes to `interaction_types` with `created_by`.
+- (2026-04-25) Existing quote server actions are in `packages/billing/src/actions/quoteActions.ts`: `createQuote`, `sendQuote`, `submitQuoteForApproval`, conversion wrappers, and related helpers. These are `withAuth` server actions and should not be imported directly into shared runtime handlers.
+- (2026-04-25) Existing quote model in `packages/billing/src/models/quote.ts` supports `getById`, `getByNumber`, `listByTenant`, `listByClient`, `create`, and update/status transition behavior.
+- (2026-04-25) Quote conversion services in `packages/billing/src/services/quoteConversionService.ts` expose `convertQuoteToDraftContract`, `convertQuoteToDraftInvoice`, and `convertQuoteToDraftContractAndInvoice` for later roadmap actions.
+- (2026-04-25) CRM event schemas/builders currently include `INTERACTION_LOGGED`, `NOTE_CREATED`, `TAG_DEFINITION_CREATED`, `TAG_APPLIED`, and `TAG_REMOVED`; no obvious `INTERACTION_UPDATED` event was found in initial search.
+- (2026-04-25) Tag event builders exist in `shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`; tag action implementation can follow ticket/client tag patterns later.
+
+## Commands / Runbooks
+
+- (2026-04-25) Initial discovery commands:
+  - `rg -n "export async function (updateInteraction|getRecentInteractions|getInteractionsForEntity|createInteractionType)|function (updateInteraction|getRecentInteractions|getInteractionsForEntity|createInteractionType)|createInteractionType|updateInteraction|getRecentInteractions|getInteractionsForEntity" packages server shared ee -g'*.ts' | head -160`
+  - `rg -n "createQuote|sendQuote|convertQuoteToDraft|submit.*approval|find.*Quote|Quote" packages/billing server/src ee packages -g'*.ts' | head -220`
+  - `rg -n "TAG_APPLIED|TAG_REMOVED|TAG_DEFINITION_CREATED|buildNoteCreatedPayload|buildInteractionLoggedPayload|NOTE_CREATED|INTERACTION_LOGGED" shared packages server ee -g'*.ts' | head -180`
+  - `rg -n "export (async function|const) (createQuote|sendQuote|submitQuote|.*approval|find|getQuote|updateQuote|convertQuote)|function (createQuote|sendQuote|submitQuote)|const (createQuote|sendQuote|submitQuote)" packages/billing/src/actions/quoteActions.ts server/src -g'*.ts' | head -160`
+  - `rg -n "list\\(|QuoteListOptions|getAll|page|filters|status|client_id" packages/billing/src/models/quote.ts | head -180`
+
+## Links / References
+
+- `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- `shared/workflow/runtime/actions/businessOperations/tickets.ts`
+- `shared/workflow/runtime/actions/businessOperations/shared.ts`
+- `shared/workflow/runtime/actions/registerBusinessOperationsActions.ts`
+- `shared/workflow/runtime/designer/actionCatalog.ts`
+- `shared/workflow/runtime/jsonSchemaMetadata.ts`
+- `packages/clients/src/actions/interactionActions.ts`
+- `packages/clients/src/models/interactions.ts`
+- `packages/clients/src/actions/interactionTypeActions.ts`
+- `packages/billing/src/actions/quoteActions.ts`
+- `packages/billing/src/models/quote.ts`
+- `packages/billing/src/services/quoteConversionService.ts`
+- `shared/workflow/streams/domainEventBuilders/crmInteractionNoteEventBuilders.ts`
+- `shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`
+- `shared/workflow/runtime/schemas/crmEventSchemas.ts`
+
+## Open Questions
+
+- What permission resource/action should govern CRM interaction reads and mutations? Candidate mappings are `client`, `contact`, or an existing CRM/activity-specific permission if present.
+- Should `crm.update_activity` emit any workflow event, or should it only audit because there is no current `INTERACTION_UPDATED` schema?
+- Should `crm.schedule_activity` emit `INTERACTION_LOGGED` even though it creates a future-dated interaction/follow-up?
+- What is the safest package boundary for quote send logic from shared workflow runtime? Can we extract reusable quote send logic from `packages/billing/src/actions/quoteActions.ts`, or should workflow runtime implement an equivalent helper locally?
+- Should `crm.send_quote` no-op on already sent quotes when `no_op_if_already_sent` is true, or should resend be explicitly out of scope until a `crm.resend_quote` action exists?
+- Should `crm.create_client_note` remain on the CRM roadmap now that `clients.add_note` exists?
+
+## Implementation Log (2026-04-26)
+
+- Implemented all first-pass CRM runtime actions in `shared/workflow/runtime/actions/businessOperations/crm.ts`:
+  - `crm.find_activities`
+  - `crm.update_activity`
+  - `crm.schedule_activity`
+  - `crm.send_quote`
+- Preserved existing `crm.create_activity_note` behavior and registration.
+- Added shared CRM runtime helper patterns to match current V2 conventions:
+  - `withWorkflowPicker` + `withWorkflowJsonSchemaMetadata`
+  - lazy event publication helper for workflow domain events
+  - tenant-scoped detail joins and summary normalization for interactions
+  - standardized validation + `throwActionError`/`rethrowAsStandardError` error mapping
+
+## Open Question Resolutions (2026-04-26)
+
+- Permission mapping for CRM interactions:
+  - `crm.find_activities` now requires `client:read`, and additionally requires `contact:read` / `ticket:read` when those filters are supplied.
+  - `crm.update_activity` and `crm.schedule_activity` require `client:update`; `crm.schedule_activity` additionally requires `ticket:read` when `ticket_id` is provided.
+  - Rationale: interactions are CRM records anchored to client relationships; supplemental resource permissions are enforced when filters/links depend on those resources.
+- `crm.update_activity` event emission:
+  - Decision: do not emit a CRM update domain event in v1; rely on run audit + returned before/after diff.
+  - Rationale: no `INTERACTION_UPDATED` schema currently exists; avoided introducing new event schema in first pass.
+- Future-dated schedule event semantics:
+  - Decision: `crm.schedule_activity` emits `INTERACTION_LOGGED` with scheduled `interaction_date` and deterministic idempotency key.
+  - Rationale: creation of the interaction record is the durable event; consumers can branch on time fields.
+- Quote helper boundary:
+  - Decision: `crm.send_quote` uses shared-runtime-safe DB/model helpers and best-effort internal helpers; it does not import `withAuth` server action wrappers.
+  - Rationale: satisfies shared runtime boundary and keeps quote send semantics in workflow runtime.
+- Already-sent quote behavior:
+  - Decision: `crm.send_quote` no-ops by default when quote is already `sent` (`no_op_if_already_sent=true`), and returns metadata with `no_op=true`.
+  - Decision: if `no_op_if_already_sent=false`, action raises validation error (resend out of scope for v1 action).
+- `crm.create_client_note` roadmap decision:
+  - Decision: remains roadmap-only; no implementation added in this pass.
+  - Rationale: overlaps with existing `clients.add_note` behavior.
+
+## Test Coverage Added (2026-04-26)
+
+- Added runtime/unit tests:
+  - `shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts`
+  - `shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts`
+  - `shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts`
+- Added DB-backed action tests:
+  - `shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts`
+  - Covers: find/update/schedule/send success, guard/failure paths, permission denials, `INTERACTION_LOGGED` publish path, and `crm.create_activity_note` regression.
+
+## Commands / Runbooks (2026-04-26)
+
+- Runtime/unit tests:
+  - `cd shared && npx vitest workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts --run`
+- DB-backed CRM tests:
+  - `cd shared && npx vitest workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts --run`
+

--- a/ee/docs/plans/2026-04-25-workflow-crm-actions/features.json
+++ b/ee/docs/plans/2026-04-25-workflow-crm-actions/features.json
@@ -1,0 +1,289 @@
+[
+  {
+    "id": "F001",
+    "description": "Register crm.find_activities version 1 as a side-effect-free workflow action",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.find_activities"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Define crm.find_activities input schema with client/contact/ticket/user/type/status/date/limit filters and on_empty behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.find_activities"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Reject unsafe unbounded crm.find_activities queries that lack meaningful filters or date range",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.find_activities"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Implement tenant-scoped interaction query joins for crm.find_activities with normalized activity summaries",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.find_activities",
+      "Data / API / Integrations > Existing CRM/client files and patterns"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Enforce documented read permission mapping for crm.find_activities",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Register crm.update_activity version 1 with editable patch schema and before/after output schema",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Reject empty crm.update_activity patches and prevent mutation of tenant, interaction_id, and system-managed fields",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Validate crm.update_activity target activity exists in the current tenant",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Validate interaction status IDs for crm.update_activity against tenant statuses with status_type interaction",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Validate interaction type IDs for crm.update_activity against tenant interaction_types or system_interaction_types",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Implement crm.update_activity mutation, changed-field calculation, before/after summaries, and run audit",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.update_activity",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Enforce documented update permission mapping for crm.update_activity",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Register crm.schedule_activity version 1 with follow-up activity input schema and created activity output schema",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "Require crm.schedule_activity to resolve a client from client_id or contact_id and validate contact belongs to client when both are provided",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Validate optional crm.schedule_activity ticket_id belongs to the resolved client/contact context where applicable",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Validate crm.schedule_activity type_id and default/explicit interaction status_id",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "Validate crm.schedule_activity time inputs and derive duration from start/end when needed",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Insert crm.schedule_activity records into interactions as future-dated follow-up activities using workflow actor ownership by default",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F019",
+    "description": "Emit INTERACTION_LOGGED for crm.schedule_activity with existing payload builder, lazy publisher import, and deterministic idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.schedule_activity",
+      "Cross-cutting Requirements"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "Write run audit for crm.schedule_activity with created activity, links, and schedule metadata",
+    "implemented": true,
+    "prdRefs": [
+      "Observability"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "Register crm.send_quote version 1 with quote_id, recipient, subject, message, and no_op_if_already_sent schema",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "Validate crm.send_quote quote exists in tenant, is not a template, and satisfies existing quote send status and approval rules",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "Enforce crm.send_quote billing read/update authorization equivalent to existing quote send behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "Resolve or extract a shared-runtime-safe quote send helper instead of importing withAuth server action wrappers directly",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote",
+      "Non-goals",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Implement crm.send_quote status transition to sent, sent_at update, quote activity recording, PDF store best-effort, and email send best-effort according to existing quote send semantics",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote",
+      "Data / API / Integrations > Existing quote files and patterns"
+    ]
+  },
+  {
+    "id": "F026",
+    "description": "Return crm.send_quote quote summary and send metadata including previous/new status, sent timestamp, recipients, email_sent, and message ID where available",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — First Pass > crm.send_quote"
+    ]
+  },
+  {
+    "id": "F027",
+    "description": "Write run audit for crm.send_quote with quote ID, status transition, and email metadata",
+    "implemented": true,
+    "prdRefs": [
+      "Observability"
+    ]
+  },
+  {
+    "id": "F028",
+    "description": "Add workflow picker metadata to supported CRM action UUID fields using current x-workflow-picker-kind conventions",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Cross-cutting Requirements"
+    ]
+  },
+  {
+    "id": "F029",
+    "description": "Expose new CRM actions through existing registerCrmActions and registerBusinessOperationsActionsV2 wiring without designer catalog seed changes",
+    "implemented": true,
+    "prdRefs": [
+      "Cross-cutting Requirements",
+      "Acceptance Criteria (Definition of Done)"
+    ]
+  },
+  {
+    "id": "F030",
+    "description": "Confirm designer catalog serialization includes new CRM action labels, schemas, output schemas, and picker metadata under CRM group",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Acceptance Criteria (Definition of Done)"
+    ]
+  },
+  {
+    "id": "F031",
+    "description": "Use shared workflow action transaction, permission, audit, throwActionError, and rethrowAsStandardError helpers consistently across CRM handlers",
+    "implemented": true,
+    "prdRefs": [
+      "Cross-cutting Requirements"
+    ]
+  },
+  {
+    "id": "F032",
+    "description": "Document resolved permission mapping, interaction update event decision, future interaction event semantics, quote helper boundary, already-sent quote behavior, and create_client_note roadmap decision in the scratchpad",
+    "implemented": true,
+    "prdRefs": [
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F033",
+    "description": "Preserve crm.create_activity_note registration and behavior while adding the new CRM actions",
+    "implemented": true,
+    "prdRefs": [
+      "Non-goals",
+      "Rollout / Migration"
+    ]
+  },
+  {
+    "id": "F034",
+    "description": "Keep follow-on CRM action roadmap documented for create_interaction_type, update_activity_status, quote create/find/convert/approval, tag_entity, and create_client_note",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements — Roadmap / Follow-on Scope"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-25-workflow-crm-actions/tests.json
+++ b/ee/docs/plans/2026-04-25-workflow-crm-actions/tests.json
@@ -1,0 +1,172 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit: runtime registration exposes crm.find_activities, crm.update_activity, crm.schedule_activity, and crm.send_quote at version 1 while preserving crm.create_activity_note",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F006",
+      "F013",
+      "F021",
+      "F029",
+      "F033"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Unit: Workflow Designer catalog groups the new crm.* actions under the built-in CRM group with expected labels and schema metadata",
+    "implemented": true,
+    "featureIds": [
+      "F028",
+      "F030"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Unit: CRM action schemas expose supported picker metadata for client, contact, ticket, and user UUID fields without requiring new quote/activity pickers",
+    "implemented": true,
+    "featureIds": [
+      "F028"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "DB-backed integration: crm.find_activities returns tenant-scoped filtered activity summaries and rejects unbounded searches",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F002",
+      "F003",
+      "F004",
+      "F005",
+      "F031"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "DB-backed integration: crm.update_activity applies allowed patch fields, validates status/type IDs, records audit, and returns before/after changed fields",
+    "implemented": true,
+    "featureIds": [
+      "F006",
+      "F007",
+      "F008",
+      "F009",
+      "F010",
+      "F011",
+      "F012",
+      "F031"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "DB-backed integration: crm.update_activity rejects cross-tenant activity IDs, empty patches, invalid statuses, and invalid interaction types",
+    "implemented": true,
+    "featureIds": [
+      "F007",
+      "F008",
+      "F009",
+      "F010",
+      "F012",
+      "F031"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "DB-backed integration: crm.schedule_activity resolves client/contact context, validates ticket relationship, creates a future-dated interaction, records audit, and returns created summary",
+    "implemented": true,
+    "featureIds": [
+      "F013",
+      "F014",
+      "F015",
+      "F016",
+      "F017",
+      "F018",
+      "F020",
+      "F031"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "Unit or DB-backed integration: crm.schedule_activity publishes INTERACTION_LOGGED through lazy event publisher with deterministic idempotency key and schema-compatible payload",
+    "implemented": true,
+    "featureIds": [
+      "F019"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "DB-backed integration: crm.schedule_activity rejects missing client/contact, mismatched contact/client, mismatched ticket/client, invalid status/type, and invalid time windows",
+    "implemented": true,
+    "featureIds": [
+      "F014",
+      "F015",
+      "F016",
+      "F017",
+      "F031"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "DB-backed integration: crm.send_quote sends an eligible quote using shared-safe quote send behavior, transitions status to sent, records quote activity/audit, and returns send metadata",
+    "implemented": true,
+    "featureIds": [
+      "F021",
+      "F022",
+      "F023",
+      "F024",
+      "F025",
+      "F026",
+      "F027",
+      "F031"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "DB-backed integration: crm.send_quote rejects quote templates, missing/cross-tenant quotes, ineligible statuses, and quotes blocked by approval settings",
+    "implemented": true,
+    "featureIds": [
+      "F022",
+      "F023",
+      "F024",
+      "F031"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "DB-backed integration: permission-denied paths are covered for CRM read, CRM mutation, and quote send actions according to the resolved permission mapping",
+    "implemented": true,
+    "featureIds": [
+      "F005",
+      "F012",
+      "F023",
+      "F031",
+      "F032"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Runtime smoke: representative CRM action.call step saves output with saveAs and downstream expression assignment can consume it",
+    "implemented": true,
+    "featureIds": [
+      "F029",
+      "F030"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Regression: existing crm.create_activity_note behavior and existing Client/Ticket workflow action tests continue to pass",
+    "implemented": true,
+    "featureIds": [
+      "F033"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Plan hygiene: scratchpad records final decisions for all open questions before implementation is marked complete",
+    "implemented": true,
+    "featureIds": [
+      "F032",
+      "F034"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/PRD.md
+++ b/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/PRD.md
@@ -1,0 +1,413 @@
+# PRD — CRM Workflow Follow-up Actions
+
+- Slug: `workflow-crm-followup-actions`
+- Date: `2026-04-25`
+- Status: Draft
+
+## Summary
+
+Add the remaining CRM workflow actions after the first-pass CRM plan (`workflow-crm-actions`) lands. This follow-up plan covers interaction taxonomy, simple activity status transitions, quote creation/search/conversion/approval, and CRM activity tagging.
+
+Planned actions:
+
+1. `crm.create_interaction_type`
+2. `crm.update_activity_status`
+3. `crm.create_quote`
+4. `crm.add_quote_item`
+5. `crm.create_quote_from_template`
+6. `crm.find_quotes`
+7. `crm.submit_quote_for_approval`
+8. `crm.convert_quote`
+9. `crm.tag_activity`
+
+Explicitly out of scope: `crm.create_client_note`. Use `clients.add_note` for client notes and add a future `contacts.add_note` action under the Contact module if contact note automation is needed.
+
+This plan intentionally builds on discoveries from the recent workflow updates and the first CRM plan: shared runtime actions must not import `withAuth` server action wrappers directly, picker metadata should follow current Workflow Designer conventions, event publication should use lazy shared-runtime-safe helpers, and DB-backed tests should validate real migrated schema behavior.
+
+## Problem
+
+The first-pass CRM plan unlocks activity lookup/update/scheduling and quote sending, but it leaves several high-value CRM automation gaps:
+
+- MSPs cannot create their own CRM activity taxonomy from workflows.
+- Workflows need a simple “mark this activity completed/closed/won” action without constructing a full patch object.
+- Quote automation remains incomplete without create/search/item/approval/conversion actions.
+- CRM activity tagging is not available for interactions/activities.
+
+These gaps matter because MSP automations often span support, account management, and billing: identify a client state, tag/account-classify it, create or submit a quote, and convert accepted quote value along the way.
+
+## Goals
+
+- Complete the next CRM workflow action layer after first-pass activity and send-quote support.
+- Keep action IDs under `crm.*` so the existing Designer CRM group continues to work.
+- Provide quote pipeline actions that are safe, permission-checked, and consistent with existing quote lifecycle rules.
+- Provide CRM taxonomy and status helpers that simplify common workflow authoring.
+- Provide a dedicated tag action for CRM activities/interactions.
+- Keep note creation on module-specific actions: existing `clients.add_note` and a future `contacts.add_note` if needed.
+- Reuse existing model/service behavior where safe, extracting shared-safe helpers where necessary.
+
+## Non-goals
+
+- Replacing first-pass CRM actions (`crm.find_activities`, `crm.update_activity`, `crm.schedule_activity`, `crm.send_quote`).
+- Replacing Client module workflow actions such as `clients.add_note` or `clients.add_interaction`.
+- Adding a CRM-scoped client/contact note wrapper; note automation should use module-specific actions (`clients.add_note`, future `contacts.add_note`).
+- Replacing quote UI/API behavior or adding new quote lifecycle states.
+- Introducing a generic arbitrary-table patch action.
+- Calling `withAuth` server actions directly from `shared/workflow/runtime`.
+- Building new Workflow Designer controls beyond metadata-driven picker support.
+- Adding broad quote item editing beyond the create-quote input scope described here.
+
+## Prerequisites / Dependencies
+
+- First-pass CRM plan should be implemented or at least its shared helper decisions should be resolved:
+  - lazy workflow event publisher helper for CRM actions
+  - CRM permission mapping
+  - quote shared-helper/package-boundary approach
+  - common CRM activity summary schemas
+- Recent Client workflow action patterns remain the model for picker metadata, event publication, idempotency, and DB-backed tests.
+- Quote actions must respect existing quote status transitions from `packages/billing/src/schemas/quoteSchemas.ts`.
+
+## Users and Primary Flows
+
+### Users
+
+- MSP admin building cross-functional workflows.
+- Account manager automating CRM follow-ups and QBR/upsell workflows.
+- Sales/finance operator automating quote pipeline steps.
+- Internal Alga PSA engineer maintaining Workflow Runtime V2 business operations.
+
+### Primary flows
+
+1. **Create CRM taxonomy automatically**
+   - Workflow detects a new MSP process or onboarding template.
+   - Workflow creates a custom interaction type such as `QBR`, `Site Visit`, or `Upsell Call` if it does not exist.
+
+2. **Mark an activity status without a full patch**
+   - Workflow finds or creates an activity.
+   - Workflow runs `crm.update_activity_status` with a target status ID or status name.
+   - The action validates the interaction status and returns the previous/current status.
+
+3. **Create and build a quote**
+   - Workflow creates a quote header for a client/contact after a qualifying ticket or opportunity event.
+   - Workflow either creates a blank quote header with `crm.create_quote` and adds items with `crm.add_quote_item`, or creates a populated quote from a template with `crm.create_quote_from_template`.
+   - Workflow optionally submits the quote for approval when tenant settings or business rules require it.
+
+4. **Find quotes before branching**
+   - Workflow checks whether the client already has open quotes.
+   - If none exist, it creates one; if one exists, it updates/sends/submits it through existing CRM quote actions.
+
+5. **Convert an accepted quote**
+   - Workflow receives a quote accepted event or polls/fetches accepted quote state.
+   - Workflow converts quote content to a draft contract, draft invoice, or both based on selected items.
+
+6. **Tag CRM activities**
+   - Workflow applies tags like `Needs QBR`, `Upsell Candidate`, or `Onboarding Risk` to interactions/activities.
+   - Client and contact tagging stay in their own module actions.
+   - Tag definition creation and tag application events are emitted consistently.
+
+## UX / UI Notes
+
+- All actions should appear under the existing Workflow Designer CRM group via the `crm.*` prefix.
+- Suggested labels:
+  - `crm.create_interaction_type` → Create Activity Type
+  - `crm.update_activity_status` → Update Activity Status
+  - `crm.create_quote` → Create Quote
+  - `crm.add_quote_item` → Add Quote Item
+  - `crm.create_quote_from_template` → Create Quote from Template
+  - `crm.find_quotes` → Find Quotes
+  - `crm.submit_quote_for_approval` → Submit Quote for Approval
+  - `crm.convert_quote` → Convert Quote
+  - `crm.tag_activity` → Tag CRM Activity
+- Use picker metadata where supported:
+  - `client_id` → `client`
+  - `contact_id` → `contact`, dependent on `client_id` where appropriate
+  - `ticket_id` → `ticket`
+  - `user_id` → `user`
+  - `quote_id`, `interaction_id`, `interaction_type_id`, and `interaction_status_id` remain UUID fields in v1 unless picker support already exists or is separately introduced.
+- Quote action outputs should include enough summary fields for branching: quote ID, number, status, client ID, totals, conversion target IDs, and approval/send state.
+
+## Requirements
+
+### `crm.create_interaction_type`
+
+- Register action ID `crm.create_interaction_type`, version `1`.
+- Inputs:
+  - `type_name`
+  - optional `icon`
+  - optional `display_order`
+  - optional `idempotency_key`
+  - optional `if_exists`: `return_existing` or `error` (default `return_existing`)
+- Validate non-empty type name and reasonable length.
+- Enforce tenant uniqueness by normalized type name where possible.
+- If `display_order` is omitted, assign next display order using existing `interaction_types` max order behavior.
+- Set `created_by` to workflow actor.
+- Require `settings:update` because activity types are tenant CRM taxonomy/configuration.
+- Return interaction type summary and `created` boolean.
+- Use action-provided idempotency.
+- Write run audit.
+
+### `crm.update_activity_status`
+
+- Register action ID `crm.update_activity_status`, version `1`.
+- Inputs:
+  - `activity_id`
+  - either `status_id` or `status_name`
+  - optional `reason`
+  - optional `no_op_if_already_status` default `true`
+- Validate activity exists in tenant.
+- Resolve/validate target status from `statuses` where `status_type = 'interaction'`.
+- If already in target status and no-op is true, return no-op without duplicate audit/event noise.
+- Update only `status_id` and timestamp/audit metadata as available.
+- Return activity ID, previous/current status IDs/names, `no_op`, and updated activity summary.
+- Implement as a dedicated wrapper around the same safe update path used by `crm.update_activity`.
+
+### `crm.create_quote`
+
+- Register action ID `crm.create_quote`, version `1`.
+- Scope v1 to quote header creation only. Quote item creation is handled by `crm.add_quote_item`.
+- Inputs should support a constrained, workflow-friendly subset of quote header creation:
+  - `client_id`
+  - optional `contact_id`
+  - `title`
+  - optional `description`
+  - `quote_date`
+  - `valid_until`
+  - optional `po_number`
+  - optional `internal_notes`
+  - optional `client_notes`
+  - optional `terms_and_conditions`
+  - optional `currency_code` default `USD`
+  - optional `idempotency_key`
+- Validate non-template quotes require client ID.
+- Validate `valid_until >= quote_date`.
+- Validate contact belongs to client when provided.
+- Use existing quote model/schema behavior where package-boundary safe.
+- Return quote summary.
+- Require billing create authorization and quote read authorization decisions equivalent to existing quote actions.
+- Use action-provided idempotency and run audit.
+
+### `crm.add_quote_item`
+
+- Register action ID `crm.add_quote_item`, version `1`.
+- Inputs:
+  - `quote_id`
+  - `description`
+  - `quantity`
+  - optional `unit_price`
+  - optional `unit_of_measure`
+  - optional `display_order`
+  - optional `phase`
+  - optional `is_optional` default `false`
+  - optional `is_selected` default `true`
+  - optional `is_recurring` default `false`
+  - optional `billing_frequency`
+  - optional `billing_method`: `fixed`, `hourly`, or `usage`
+  - optional `is_discount` default `false`
+  - optional `discount_type`: `percentage` or `fixed`
+  - optional `discount_percentage`
+  - optional `applies_to_item_id`
+  - optional `applies_to_service_id`
+  - optional `is_taxable` default `true`
+  - optional `tax_region`
+  - optional `tax_rate`
+  - optional `location_id`
+  - optional `cost`
+  - optional `cost_currency`
+  - optional `idempotency_key`
+- Validate quote exists in tenant and is editable.
+- Reject adding items to quote templates in v1 unless template support is explicitly resolved later.
+- Validate line item fields using existing quote item schema rules where package-boundary safe:
+  - recurring items require billing frequency.
+  - discount items require discount type.
+  - percentage discounts require discount percentage.
+- Assign `display_order` deterministically when omitted.
+- Persist item through shared-safe quote item model/helper behavior.
+- Recalculate quote financials after insertion.
+- Return quote item summary plus refreshed quote summary/totals.
+- Require billing update/read authorization equivalent to existing quote item behavior.
+- Use action-provided idempotency and run audit.
+
+### `crm.create_quote_from_template`
+
+- Register action ID `crm.create_quote_from_template`, version `1`.
+- Inputs:
+  - `template_id`
+  - `client_id`
+  - optional `contact_id`
+  - optional `title` override
+  - optional `quote_date` override
+  - optional `valid_until` override
+  - optional `po_number`
+  - optional `internal_notes` override/append decision if supported safely
+  - optional `client_notes` override/append decision if supported safely
+  - optional `currency_code` override if supported safely
+  - optional `idempotency_key`
+- Validate `template_id` points to a tenant quote template (`is_template = true`).
+- Validate target client exists and contact belongs to that client when supplied.
+- Reuse/extract shared-safe behavior from existing quote template creation logic; do not import `withAuth` server action wrappers directly into shared runtime.
+- Copy safe template header fields and template items to the new quote.
+- Apply supplied overrides after template defaults.
+- Recalculate quote financials after copying items.
+- Return created quote summary and created item summaries.
+- Require billing create/read authorization equivalent to existing quote template creation behavior.
+- Use action-provided idempotency and run audit.
+
+### `crm.find_quotes`
+
+- Register action ID `crm.find_quotes`, version `1`.
+- Side-effect-free.
+- Inputs:
+  - optional `quote_id`
+  - optional `quote_number`
+  - optional `client_id`
+  - optional `status`
+  - optional `date_from`
+  - optional `date_to`
+  - optional `is_template` default `false`
+  - pagination and sorting fields aligned with `Quote.listByTenant`
+  - optional `on_empty`: `return_empty` or `error`
+- Require at least one meaningful filter or an explicit bounded date range unless a small page size is enforced.
+- Enforce billing read authorization and quote authorization-kernel filtering equivalent to existing quote list/read behavior.
+- Return paginated quote summaries and first quote.
+
+### `crm.submit_quote_for_approval`
+
+- Register action ID `crm.submit_quote_for_approval`, version `1`.
+- Inputs:
+  - `quote_id`
+  - optional `comment` or `reason`
+  - optional `no_op_if_already_pending` default `true`
+- Validate quote exists, is readable/updatable by workflow actor, is not a template, and is in draft status unless no-op applies.
+- Transition status to `pending_approval` using existing quote status rules.
+- Record quote activity if existing behavior does or if a shared helper is extracted.
+- Return quote summary, previous status, new status, and no-op flag.
+- Write run audit.
+
+### `crm.convert_quote`
+
+- Register action ID `crm.convert_quote`, version `1`.
+- Inputs:
+  - `quote_id`
+  - `target`: `contract`, `invoice`, or `contract_and_invoice`
+  - optional `no_op_if_already_converted` default `true`
+- Validate quote exists, is not a template, and is eligible for conversion.
+- Enforce billing create + update authorization equivalent to existing conversion actions.
+- Reuse shared-safe conversion services:
+  - `convertQuoteToDraftContract`
+  - `convertQuoteToDraftInvoice`
+  - `convertQuoteToDraftContractAndInvoice`
+- Validate selected quote items support the requested target and return clear errors from conversion service as workflow action errors.
+- Return quote summary plus created contract ID and/or invoice ID.
+- Write run audit.
+
+### `crm.tag_activity`
+
+- Register action ID `crm.tag_activity`, version `1`.
+- Scope v1 to interactions/activities only. Client and contact tagging stay in their own module actions.
+- Inputs:
+  - `activity_id`
+  - `tags`: non-empty array of tag text values
+  - optional `if_exists`: `no_op` or `error` (default `no_op`)
+  - optional `idempotency_key`
+- Validate target interaction/activity exists in tenant.
+- Validate tag text using current tag validation rules.
+- Create missing tag definitions and insert missing tag mappings idempotently.
+- Require CRM interaction/activity update permission and tag create permission when creating new tag definitions, matching existing tag behavior where possible.
+- Emit `TAG_DEFINITION_CREATED` for newly created definitions and `TAG_APPLIED` for newly applied mappings through lazy event publishing with deterministic keys.
+- Return added/existing tag summaries and counts.
+- Use action-provided idempotency and run audit.
+
+### Explicitly dropped: `crm.create_client_note`
+
+- Do not implement `crm.create_client_note` in this follow-up plan.
+- Use `clients.add_note` for client note automation.
+- Add a future `contacts.add_note` Contact-module action if workflows need contact note automation.
+- Rationale: module-specific note actions keep ownership clearer and avoid duplicating the newly merged Client workflow note behavior under CRM.
+
+### Cross-cutting Requirements
+
+- Implement in `shared/workflow/runtime/actions/businessOperations/crm.ts` or extracted shared-safe helper modules.
+- Do not directly import `packages/*/src/actions/*` server action wrappers into shared runtime action code.
+- Use `withTenantTransaction`, `requirePermission`, `writeRunAudit`, `throwActionError`, and `rethrowAsStandardError`.
+- Use `withWorkflowJsonSchemaMetadata` for picker-backed fields.
+- Use deterministic idempotency and no-op behavior for retry-sensitive mutations.
+- Keep all actions tenant-scoped and actor-attributed.
+- Preserve `crm.create_activity_note` and first-pass CRM actions.
+
+## Data / API / Integrations
+
+### Key files
+
+- `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- `shared/workflow/runtime/actions/businessOperations/tickets.ts`
+- `shared/workflow/runtime/actions/businessOperations/shared.ts`
+- `shared/workflow/runtime/jsonSchemaMetadata.ts`
+- `packages/clients/src/actions/interactionTypeActions.ts`
+- `packages/clients/src/actions/clientNoteActions.ts` (reference only; CRM note wrapper dropped)
+- `packages/clients/src/actions/contact-actions/contactNoteActions.ts` (reference for future `contacts.add_note`, not this plan)
+- `packages/tags/src/actions/tagActions.ts`
+- `packages/billing/src/actions/quoteActions.ts`
+- `packages/billing/src/models/quote.ts`
+- `packages/billing/src/models/quoteItem.ts`
+- `packages/billing/src/actions/quoteActions.ts` (`createQuoteFromTemplate` as behavior reference; do not import wrapper directly)
+- `packages/billing/src/schemas/quoteSchemas.ts`
+- `packages/billing/src/services/quoteConversionService.ts`
+- `shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`
+- `shared/workflow/streams/domainEventBuilders/crmInteractionNoteEventBuilders.ts`
+
+### Tables likely touched
+
+- `interaction_types`
+- `interactions`
+- `statuses`
+- `quotes`
+- `quote_items`
+- `quote_activities`
+- quote conversion target tables for contracts/invoices
+- `tag_definitions`
+- `tag_mappings`
+- `clients`
+- `contacts`
+- `audit_logs`
+
+## Security / Permissions
+
+- `crm.create_interaction_type` requires `settings:update` because activity types are tenant CRM taxonomy/configuration.
+- Resolve and document CRM interaction mutation permission for `crm.update_activity_status`.
+- Quote actions, including `crm.add_quote_item`, must enforce billing create/read/update and quote authorization-kernel decisions equivalent to existing quote actions.
+- `crm.tag_activity` must enforce CRM interaction/activity update permission and tag create permission when creating new definitions.
+- Workflow actor remains the created_by/performed_by/audit actor unless a future version explicitly supports override.
+
+## Observability
+
+- Write run audit for all side-effectful actions.
+- Emit existing events where supported:
+  - `TAG_DEFINITION_CREATED`
+  - `TAG_APPLIED`
+- Quote pipeline actions should emit quote-specific workflow events only when matching `QUOTE_*` event schemas/builders already exist. If no matching quote event contract exists, remain audit-only plus existing quote activity records.
+- Do not invent new `QUOTE_*` or `INTERACTION_UPDATED` events in this plan; new event contracts require a separate event-schema plan.
+- Capture no-op outcomes in action outputs and audit where useful.
+
+## Rollout / Migration
+
+- No database migration is expected by default.
+- All actions are additive.
+- If quote helper extraction changes package exports, keep it backward compatible and covered by existing quote tests.
+- `crm.create_client_note` is dropped in favor of module-specific actions; no migration or runtime registration is needed for it.
+
+## Open Questions
+
+All planning decisions for this follow-up scope are resolved. Implementation may still discover package-boundary details that need scratchpad updates.
+
+## Acceptance Criteria (Definition of Done)
+
+- Runtime initialization registers the selected follow-up actions at version `1`.
+- Designer catalog shows the selected actions under CRM with labels, schema metadata, and output schemas.
+- Interaction type creation is idempotent and permission-checked.
+- Activity status update provides a simple validated transition/no-op wrapper.
+- Quote create/add-item/template/find/submit/convert actions respect quote lifecycle, billing permissions, and authorization-kernel behavior.
+- Quote pipeline actions emit only already-defined quote workflow events; when no matching quote event schema/builder exists, they remain audit-only plus quote activity records.
+- CRM activity tagging creates definitions/mappings idempotently for interactions and emits tag events for new changes.
+- `crm.create_client_note` remains absent; client note automation uses `clients.add_note`, and contact note automation is deferred to a future Contact-module action.
+- DB-backed tests cover representative happy paths and high-risk guard cases.
+- Existing first-pass CRM, Client, Ticket, and quote tests do not regress.

--- a/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/SCRATCHPAD.md
@@ -1,0 +1,118 @@
+# Scratchpad — CRM Workflow Follow-up Actions
+
+- Plan slug: `workflow-crm-followup-actions`
+- Created: `2026-04-25`
+
+## What This Is
+
+Rolling notes for the second CRM workflow action wave after first-pass CRM activity lookup/update/scheduling and quote send actions.
+
+## Decisions
+
+- (2026-04-25) This follow-up plan covers the remaining recommended actions: `crm.create_interaction_type`, `crm.update_activity_status`, `crm.create_quote`, `crm.add_quote_item`, `crm.create_quote_from_template`, `crm.find_quotes`, `crm.submit_quote_for_approval`, `crm.convert_quote`, and `crm.tag_activity`.
+- (2026-04-25) Keep actions under `crm.*` so existing designer grouping places them in CRM without catalog seed changes.
+- (2026-04-25) Do not directly import `withAuth` server actions from `packages/*/src/actions/*` into shared workflow runtime code. Extract or use shared-safe model/service helpers instead.
+- (2026-04-25) Resolved: drop `crm.create_client_note` from CRM follow-up scope. Use `clients.add_note` for client notes and add a future `contacts.add_note` action if contact note workflow automation is needed. Rationale: module-specific note actions keep ownership clear and avoid duplicating newly merged Client workflow behavior under CRM.
+- (2026-04-25) Use current Client workflow action conventions for picker metadata, lazy event publication, deterministic event idempotency keys, action idempotency, and DB-backed tests.
+- (2026-04-25) Resolved: `crm.create_quote` creates the quote header only; quote item creation is a separate action named `crm.add_quote_item`. Rationale: keeps header creation simple while still supporting full quote-building workflows in this plan.
+- (2026-04-25) Resolved: include a separate `crm.create_quote_from_template` action in this plan. Rationale: templates are important for standardized quote automation, but a dedicated action keeps semantics cleaner than overloading `crm.create_quote`.
+- (2026-04-25) Resolved: `crm.create_interaction_type` requires `settings:update`. Rationale: activity types are tenant CRM taxonomy/configuration, so this should be admin-controlled rather than available to all CRM editors.
+- (2026-04-25) Resolved: `crm.tag_activity` is interaction/activity-specific only. Client and contact tagging stay in their own module actions. Rationale: keeps CRM tag action focused and avoids turning it into a generic tag action.
+- (2026-04-25) Resolved: quote pipeline actions emit quote-specific workflow events only if matching `QUOTE_*` schemas/builders already exist. Otherwise they remain audit-only plus existing quote activity records. Rationale: avoids inventing event contracts inside this plan while preserving event parity if contracts already exist.
+
+## Discoveries / Constraints
+
+- (2026-04-25) `packages/clients/src/actions/interactionTypeActions.ts` has `createInteractionType`, but it is a `withAuth` server action. Underlying behavior is simple: insert `interaction_types` with `type_name`, `icon`, `display_order`, tenant, and `created_by`.
+- (2026-04-25) `packages/billing/src/schemas/quoteSchemas.ts` defines quote statuses and allowed transitions. Follow-up quote actions must respect these transitions.
+- (2026-04-25) `packages/billing/src/models/quote.ts` exposes shared-looking model methods such as `getById`, `getByNumber`, `listByTenant`, `listByClient`, `create`, and `update`, but import safety from shared workflow runtime must still be confirmed.
+- (2026-04-25) `packages/billing/src/models/quoteItem.ts` and quote item schema rules should be used or mirrored for `crm.add_quote_item`; shared runtime import safety must be confirmed.
+- (2026-04-25) `packages/billing/src/services/quoteConversionService.ts` exposes conversion services for draft contracts/invoices/both. These are promising for `crm.convert_quote`, but package-boundary safety still needs confirmation.
+- (2026-04-25) `packages/tags/src/actions/tagActions.ts` shows desired tag semantics: entity update permission, tag create permission for new definitions, tag definition creation, tag mapping insertion, and TAG event publication. It is a server action file and should be used as a behavior reference, not directly imported.
+- (2026-04-25) `packages/clients/src/actions/clientNoteActions.ts` and `packages/clients/src/actions/contact-actions/contactNoteActions.ts` show client/contact notes document behavior and NOTE_CREATED publication. They remain useful references for a future Contact-module note action, but CRM follow-up will not implement a note wrapper.
+- (2026-04-25) `shared/workflow/runtime/actions/businessOperations/clients.ts` already implements `clients.add_note` for client notes. Do not duplicate that implementation in CRM.
+
+## Commands / Runbooks
+
+- (2026-04-25) Discovery commands:
+  - `rg -n "export const createInteractionType|updateInteractionType" packages/clients/src/actions/interactionTypeActions.ts`
+  - `rg -n "export const createQuote|sendQuote|submitQuoteForApproval|convertQuote" packages/billing/src/actions/quoteActions.ts`
+  - `rg -n "quoteStatusSchema|QUOTE_ALLOWED_STATUS_TRANSITIONS|canTransitionQuoteStatus" packages/billing/src/schemas/quoteSchemas.ts`
+  - `rg -n "list\\(|QuoteListOptions|getByNumber|getById" packages/billing/src/models/quote.ts`
+  - `rg -n "TAG_DEFINITION_CREATED|TAG_APPLIED|buildTagAppliedPayload" packages/tags/src/actions/tagActions.ts shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`
+  - `rg -n "notes_document_id|saveClientNote|saveContactNote|NOTE_CREATED" packages/clients/src/actions shared/workflow/runtime/actions/businessOperations/clients.ts`
+
+## Links / References
+
+- First-pass CRM plan: `ee/docs/plans/2026-04-25-workflow-crm-actions/`
+- `shared/workflow/runtime/actions/businessOperations/crm.ts`
+- `shared/workflow/runtime/actions/businessOperations/clients.ts`
+- `shared/workflow/runtime/actions/businessOperations/shared.ts`
+- `shared/workflow/runtime/jsonSchemaMetadata.ts`
+- `packages/clients/src/actions/interactionTypeActions.ts`
+- `packages/billing/src/actions/quoteActions.ts`
+- `packages/billing/src/models/quote.ts`
+- `packages/billing/src/schemas/quoteSchemas.ts`
+- `packages/billing/src/services/quoteConversionService.ts`
+- `packages/tags/src/actions/tagActions.ts`
+- `shared/workflow/streams/domainEventBuilders/tagEventBuilders.ts`
+- `packages/clients/src/actions/clientNoteActions.ts`
+- `packages/clients/src/actions/contact-actions/contactNoteActions.ts`
+- `shared/workflow/streams/domainEventBuilders/crmInteractionNoteEventBuilders.ts`
+
+## Open Questions
+
+- Resolved: drop `crm.create_client_note`; use module-specific note actions instead.
+- Resolved: `crm.create_quote` is header-only and quote item creation is handled by separate `crm.add_quote_item`.
+- Resolved: template-based quote creation is included as separate `crm.create_quote_from_template`.
+- Resolved: interaction type creation requires `settings:update`.
+- Resolved: `crm.tag_activity` is interaction/activity-specific only; clients/contacts use their own module tag actions.
+- Resolved: quote pipeline actions emit existing quote events only if matching schemas/builders already exist; otherwise audit-only plus quote activities.
+
+## Implementation Log — 2026-04-26
+
+- Implemented follow-up CRM workflow actions in `shared/workflow/runtime/actions/businessOperations/crm.ts`:
+  - `crm.create_interaction_type`
+  - `crm.update_activity_status`
+  - `crm.create_quote`
+  - `crm.add_quote_item`
+  - `crm.create_quote_from_template`
+  - `crm.find_quotes`
+  - `crm.submit_quote_for_approval`
+  - `crm.convert_quote`
+  - `crm.tag_activity`
+- Confirmed these actions are all registered at version `1`, side-effect metadata is set, and action-provided idempotency is used for retry-sensitive create/tag/item/template mutations.
+- Added picker metadata for follow-up quote fields:
+  - `crm.create_quote.client_id` / `contact_id`
+  - `crm.create_quote_from_template.client_id` / `contact_id`
+- Kept first-pass actions intact (`crm.create_activity_note`, `crm.find_activities`, `crm.update_activity`, `crm.schedule_activity`, `crm.send_quote`) and did not remove/rename existing IDs.
+- Quote pipeline event stance preserved: no new quote event schema contracts were added; quote follow-up actions are audit-driven (plus existing quote model/service activity behavior).
+- `crm.tag_activity` remains interaction/activity scoped; client/contact tagging remains module-specific.
+
+## Test and Runtime Updates — 2026-04-26
+
+- Updated unit/runtime metadata tests:
+  - `shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts`
+  - `shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts`
+  - `shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts` (switched representative runtime smoke to follow-up action `crm.find_quotes`)
+- Expanded DB-backed CRM action suite with follow-up tests in:
+  - `shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts`
+  - Added helper `createQuoteItemRecord` for conversion/template/add-item test setup.
+
+## Vitest Aliasing Discovery — 2026-04-26
+
+- Shared-runtime tests importing billing/authorization modules required additional aliases in `shared/vitest.config.ts`:
+  - `@shared/*`
+  - `@alga-psa/core/*`
+  - `@alga-psa/db/*`
+- Without these aliases, `crm.ts` imports of billing models/services failed test resolution due unresolved package paths.
+
+## Commands Run — 2026-04-26
+
+- `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts`
+- `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts`
+- `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts`
+
+## Test Environment Gotcha
+
+- DB-backed CRM suite currently aborts before execution in this shell because `businessOperations.crm.db.test.ts` guards against production DB names and detects `DB_NAME_SERVER=server` from environment bootstrap.
+- Command-level overrides (`DB_NAME_SERVER=test_database ...`) did not take effect in this run context; follow-up is to run the DB suite in a sanitized env where `DB_NAME_SERVER` resolves to a safe test DB before release sign-off.

--- a/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/features.json
+++ b/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/features.json
@@ -1,0 +1,370 @@
+[
+  {
+    "id": "F001",
+    "description": "Register crm.create_interaction_type version 1 with type_name, icon, display_order, if_exists, and idempotency inputs",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_interaction_type"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Implement idempotent tenant-scoped interaction type creation with next display_order fallback and created_by attribution",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_interaction_type"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Enforce settings:update permission for crm.create_interaction_type because activity types are tenant CRM taxonomy configuration",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_interaction_type",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Register crm.update_activity_status version 1 with activity_id, status_id/status_name, reason, and no-op inputs",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.update_activity_status"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Implement crm.update_activity_status target activity validation and interaction status resolution",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.update_activity_status"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Implement crm.update_activity_status mutation/no-op behavior with before/current status output and audit",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.update_activity_status",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Register crm.create_quote version 1 with constrained quote creation schema and optional idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Validate crm.create_quote client/contact/date/currency inputs using existing quote schema rules where safe",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Scope crm.create_quote v1 to quote header creation only; quote items use crm.add_quote_item and template creation uses crm.create_quote_from_template",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote",
+      "Requirements > crm.add_quote_item",
+      "Requirements > crm.create_quote_from_template",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Implement shared-runtime-safe crm.create_quote header persistence, output summary, and audit without inline quote item creation",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Enforce billing create/read authorization for crm.create_quote equivalent to existing quote actions",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Register crm.find_quotes version 1 with quote_id, quote_number, client_id, status, date, template, pagination, and on_empty filters",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.find_quotes"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Implement crm.find_quotes tenant-scoped quote lookup/search with pagination and safe bounded-query behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.find_quotes"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "Enforce billing read and quote authorization-kernel filtering for crm.find_quotes",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.find_quotes",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Register crm.submit_quote_for_approval version 1 with quote_id, optional comment/reason, and no-op input",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.submit_quote_for_approval"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Implement crm.submit_quote_for_approval draft-only status transition, template guard, no-op behavior, quote activity/audit, and output summary",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.submit_quote_for_approval"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "Enforce billing update/read authorization for crm.submit_quote_for_approval equivalent to existing quote actions",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Register crm.convert_quote version 1 with quote_id, target, and no-op input",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.convert_quote"
+    ]
+  },
+  {
+    "id": "F019",
+    "description": "Implement crm.convert_quote validation for quote existence, non-template status, conversion eligibility, and no-op behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.convert_quote"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "Call shared-safe quote conversion services for contract, invoice, and contract_and_invoice targets and return target IDs",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.convert_quote",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "Enforce billing create/update/read authorization for crm.convert_quote equivalent to existing quote conversion actions",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "Register crm.tag_activity version 1 with activity_id, tags, if_exists, and idempotency inputs",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.tag_activity"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "Validate crm.tag_activity target interaction exists in tenant; v1 scope is interaction-only because clients/contacts use their own module tag actions",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.tag_activity"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "Implement tag text validation, tag definition creation, and idempotent tag mapping insertion for crm.tag_activity",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.tag_activity"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Enforce interaction update and tag create permissions for crm.tag_activity",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.tag_activity",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F026",
+    "description": "Emit TAG_DEFINITION_CREATED and TAG_APPLIED for new crm.tag_activity changes through lazy event publication with deterministic keys",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.tag_activity",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F027",
+    "description": "Drop crm.create_client_note from follow-up implementation scope in favor of clients.add_note and a future contacts.add_note action",
+    "implemented": true,
+    "prdRefs": [
+      "Non-goals",
+      "Rollout / Migration",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F031",
+    "description": "Add workflow picker metadata to supported follow-up CRM action UUID fields",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Cross-cutting Requirements"
+    ]
+  },
+  {
+    "id": "F032",
+    "description": "Expose selected follow-up CRM actions through registerCrmActions and designer catalog without new catalog seed changes",
+    "implemented": true,
+    "prdRefs": [
+      "Cross-cutting Requirements",
+      "Acceptance Criteria (Definition of Done)"
+    ]
+  },
+  {
+    "id": "F033",
+    "description": "Use shared workflow action helpers for tenant transaction, permissions, audit, action errors, and standard error rethrowing",
+    "implemented": true,
+    "prdRefs": [
+      "Cross-cutting Requirements"
+    ]
+  },
+  {
+    "id": "F034",
+    "description": "Preserve crm.create_activity_note and first-pass CRM action behavior while adding follow-up actions",
+    "implemented": true,
+    "prdRefs": [
+      "Cross-cutting Requirements",
+      "Rollout / Migration"
+    ]
+  },
+  {
+    "id": "F035",
+    "description": "Document resolved scope and package-boundary decisions in the scratchpad before implementation completion, including interaction-only crm.tag_activity scope and quote event stance",
+    "implemented": true,
+    "prdRefs": [
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F036",
+    "description": "Register crm.add_quote_item version 1 with quote_id, line item fields, and optional idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.add_quote_item"
+    ]
+  },
+  {
+    "id": "F037",
+    "description": "Validate crm.add_quote_item target quote exists, belongs to tenant, is editable, and is not a template unless explicitly allowed",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.add_quote_item"
+    ]
+  },
+  {
+    "id": "F038",
+    "description": "Validate crm.add_quote_item line item fields using existing quote item schema rules for quantity, price, discounts, recurring billing, optional selection, and tax fields",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.add_quote_item",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F039",
+    "description": "Implement shared-runtime-safe crm.add_quote_item persistence, display_order assignment, financial recalculation, output summary, and audit",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.add_quote_item",
+      "Data / API / Integrations",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F040",
+    "description": "Enforce billing update/read authorization for crm.add_quote_item equivalent to existing quote item update/create behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.add_quote_item",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F041",
+    "description": "Register crm.create_quote_from_template version 1 with template_id, client/contact/date override fields, and optional idempotency key",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote_from_template"
+    ]
+  },
+  {
+    "id": "F042",
+    "description": "Validate crm.create_quote_from_template template quote exists in tenant, is marked as template, and target client/contact overrides are valid",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote_from_template"
+    ]
+  },
+  {
+    "id": "F043",
+    "description": "Implement shared-runtime-safe crm.create_quote_from_template behavior by extracting or reusing existing template creation logic without importing withAuth server actions",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote_from_template",
+      "Cross-cutting Requirements",
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F044",
+    "description": "Copy template quote header and item data safely for crm.create_quote_from_template, recalculate totals, return created quote/item summaries, and write audit",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote_from_template",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F045",
+    "description": "Enforce billing create/read authorization for crm.create_quote_from_template equivalent to existing quote template creation behavior",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > crm.create_quote_from_template",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F046",
+    "description": "For quote pipeline actions, emit existing quote workflow events only if schemas/builders already exist; otherwise rely on audit logs and quote activities without adding new event schemas",
+    "implemented": true,
+    "prdRefs": [
+      "Observability",
+      "Open Questions"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/tests.json
+++ b/ee/docs/plans/2026-04-25-workflow-crm-followup-actions/tests.json
@@ -1,0 +1,190 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit: selected follow-up crm.* actions register at version 1, preserve existing CRM actions, and appear under the CRM designer catalog group, including quote item/template actions",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F004",
+      "F007",
+      "F012",
+      "F015",
+      "F018",
+      "F022",
+      "F032",
+      "F034",
+      "F036",
+      "F041"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Unit: follow-up CRM action schemas expose supported picker metadata for client, contact, ticket, and user fields without requiring quote/activity pickers",
+    "implemented": true,
+    "featureIds": [
+      "F031"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "DB-backed integration: crm.create_interaction_type creates a tenant type with display_order fallback, returns existing on duplicate when configured, records audit, and requires settings:update",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F002",
+      "F003",
+      "F033"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "DB-backed integration: crm.update_activity_status transitions a tenant activity to a valid interaction status, no-ops when already set, records audit, and rejects invalid statuses/cross-tenant activities",
+    "implemented": true,
+    "featureIds": [
+      "F004",
+      "F005",
+      "F006",
+      "F033"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "DB-backed integration: crm.create_quote creates a tenant quote header for a valid client/contact, applies date/schema validation, and records audit without inline quote item creation",
+    "implemented": true,
+    "featureIds": [
+      "F007",
+      "F008",
+      "F010",
+      "F011",
+      "F033"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "DB-backed integration: crm.find_quotes returns tenant-scoped authorized quote summaries by quote ID/number/client/status and rejects unsafe unbounded searches",
+    "implemented": true,
+    "featureIds": [
+      "F012",
+      "F013",
+      "F014",
+      "F033"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "DB-backed integration: crm.submit_quote_for_approval transitions draft quotes to pending_approval, rejects templates/non-draft quotes, handles no-op pending quotes, and records audit",
+    "implemented": true,
+    "featureIds": [
+      "F015",
+      "F016",
+      "F017",
+      "F033"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "DB-backed integration: crm.convert_quote converts eligible accepted quotes to contract, invoice, and both targets through shared-safe services and returns created target IDs",
+    "implemented": true,
+    "featureIds": [
+      "F018",
+      "F019",
+      "F020",
+      "F021",
+      "F033"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "DB-backed integration: crm.convert_quote rejects ineligible statuses, templates, missing selected item classes, cross-tenant quote IDs, and permission-denied actors",
+    "implemented": true,
+    "featureIds": [
+      "F019",
+      "F020",
+      "F021",
+      "F033"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "DB-backed integration: crm.tag_activity validates interaction targets, creates missing tag definitions/mappings idempotently, enforces permissions, records audit, and returns added/existing counts",
+    "implemented": true,
+    "featureIds": [
+      "F022",
+      "F023",
+      "F024",
+      "F025",
+      "F033"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "Unit or DB-backed integration: crm.tag_activity publishes TAG_DEFINITION_CREATED and TAG_APPLIED only for new changes with deterministic idempotency keys and schema-compatible payloads",
+    "implemented": true,
+    "featureIds": [
+      "F026"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Runtime smoke: representative follow-up CRM action.call step saves output with saveAs and downstream expression assignment can consume it",
+    "implemented": true,
+    "featureIds": [
+      "F032"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Regression: existing crm.create_activity_note, first-pass CRM actions, Client workflow actions, Ticket workflow actions, and quote model/action tests continue to pass",
+    "implemented": true,
+    "featureIds": [
+      "F034"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Plan hygiene: scratchpad records final decisions for quote header/item/template split, interaction type permission, interaction-only tag scope, quote event stance, and dropped create_client_note scope",
+    "implemented": true,
+    "featureIds": [
+      "F009",
+      "F027",
+      "F035",
+      "F036",
+      "F041",
+      "F046"
+    ]
+  },
+  {
+    "id": "T016",
+    "description": "DB-backed integration: crm.add_quote_item adds valid one-time and recurring quote items to editable quotes, assigns display order, recalculates totals, returns item/quote summary, and records audit",
+    "implemented": true,
+    "featureIds": [
+      "F036",
+      "F037",
+      "F038",
+      "F039",
+      "F040",
+      "F033"
+    ]
+  },
+  {
+    "id": "T017",
+    "description": "DB-backed integration: crm.create_quote_from_template creates a client quote from a template quote, copies safe header/item data, applies overrides, recalculates totals, records audit, and rejects non-template/cross-tenant templates",
+    "implemented": true,
+    "featureIds": [
+      "F041",
+      "F042",
+      "F043",
+      "F044",
+      "F045",
+      "F033"
+    ]
+  },
+  {
+    "id": "T018",
+    "description": "Unit: quote pipeline actions do not introduce new quote event schemas; they emit only pre-existing quote events if available and otherwise remain audit/quote-activity only",
+    "implemented": true,
+    "featureIds": [
+      "F046"
+    ]
+  }
+]

--- a/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
+++ b/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
@@ -12,8 +12,8 @@ import {
   type RelationshipTemplateKey,
   BuiltinAuthorizationKernelProvider,
   BundleAuthorizationKernelProvider,
-  createAuthorizationKernel,
 } from '@alga-psa/authorization/kernel';
+import { createAuthorizationKernelWithDefaultRbac } from '@alga-psa/authorization/adapters/rbac';
 import {
   archiveBundle,
   cloneAuthorizationBundle,
@@ -1005,7 +1005,7 @@ export const runAuthorizationBundleSimulationAction = withAuth(
       : [];
 
     const createKernelWithRules = (rules: BundleNarrowingRule[]) =>
-      createAuthorizationKernel({
+      createAuthorizationKernelWithDefaultRbac({
         builtinProvider: new BuiltinAuthorizationKernelProvider({
           relationshipRules:
             input.resourceType === 'document' && principal.user_type === 'client' && input.action === 'read'

--- a/ee/server/src/lib/authorization/kernel.ts
+++ b/ee/server/src/lib/authorization/kernel.ts
@@ -1,10 +1,10 @@
 import {
   type AuthorizationEvaluationInput,
   type AuthorizationKernel,
-  createAuthorizationKernel,
   BuiltinAuthorizationKernelProvider,
   BundleAuthorizationKernelProvider,
 } from '@alga-psa/authorization/kernel';
+import { createAuthorizationKernelWithDefaultRbac } from '@alga-psa/authorization/adapters/rbac';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
 
 async function resolveBundleNarrowingRules(input: AuthorizationEvaluationInput) {
@@ -27,7 +27,7 @@ async function resolveBundleNarrowingRules(input: AuthorizationEvaluationInput) 
 }
 
 export function createEnterpriseAuthorizationKernel(): AuthorizationKernel {
-  return createAuthorizationKernel({
+  return createAuthorizationKernelWithDefaultRbac({
     builtinProvider: new BuiltinAuthorizationKernelProvider(),
     bundleProvider: new BundleAuthorizationKernelProvider({
       resolveRules: resolveBundleNarrowingRules,

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -7,35 +7,39 @@
   "types": "./src/index.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
+      "import": "./dist/index.js",
       "types": "./src/index.ts"
     },
     "./kernel": {
-      "import": "./src/kernel/index.ts",
+      "import": "./dist/kernel/index.js",
       "types": "./src/kernel/index.ts"
     },
     "./kernel/*": {
-      "import": "./src/kernel/*",
+      "import": "./dist/kernel/*.js",
       "types": "./src/kernel/*"
     },
     "./bundles/catalog": {
-      "import": "./src/bundles/catalog.ts",
+      "import": "./dist/bundles/catalog.js",
       "types": "./src/bundles/catalog.ts"
     },
     "./bundles/service": {
-      "import": "./src/bundles/service.ts",
+      "import": "./dist/bundles/service.js",
       "types": "./src/bundles/service.ts"
     },
     "./bundles/starterBundles": {
-      "import": "./src/bundles/starterBundles.ts",
+      "import": "./dist/bundles/starterBundles.js",
       "types": "./src/bundles/starterBundles.ts"
     },
+    "./adapters/rbac": {
+      "import": "./dist/adapters/rbacAdapter.js",
+      "types": "./src/adapters/rbacAdapter.ts"
+    },
     "./pagination": {
-      "import": "./src/pagination/index.ts",
+      "import": "./dist/pagination/index.js",
       "types": "./src/pagination/index.ts"
     },
     "./pagination/authorizationAwarePagination": {
-      "import": "./src/pagination/authorizationAwarePagination.ts",
+      "import": "./dist/pagination/authorizationAwarePagination.js",
       "types": "./src/pagination/authorizationAwarePagination.ts"
     }
   },

--- a/packages/authorization/src/adapters/rbacAdapter.ts
+++ b/packages/authorization/src/adapters/rbacAdapter.ts
@@ -1,0 +1,27 @@
+import type {
+  AuthorizationKernel,
+  AuthorizationKernelFactoryInput,
+  RbacEvaluator,
+} from '../kernel/contracts';
+import { createAuthorizationKernel } from '../kernel/engine';
+import { hasPermission } from '../rbac';
+
+export const defaultRbacEvaluator: RbacEvaluator = async (input) => hasPermission(
+  {
+    tenant: input.subject.tenant,
+    user_id: input.subject.userId,
+    user_type: input.subject.userType,
+  },
+  input.resource.type,
+  input.resource.action,
+  input.knex
+);
+
+export function createAuthorizationKernelWithDefaultRbac(
+  input: Omit<AuthorizationKernelFactoryInput, 'rbacEvaluator'> & Partial<Pick<AuthorizationKernelFactoryInput, 'rbacEvaluator'>>
+): AuthorizationKernel {
+  return createAuthorizationKernel({
+    ...input,
+    rbacEvaluator: input.rbacEvaluator ?? defaultRbacEvaluator,
+  });
+}

--- a/packages/authorization/src/kernel/engine.ts
+++ b/packages/authorization/src/kernel/engine.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from '../rbac';
 import type {
   AuthorizationDecision,
   AuthorizationEvaluationInput,
@@ -11,19 +10,6 @@ import type {
 } from './contracts';
 import { getRequestCache } from './requestCache';
 import { intersectAuthorizationScopes } from './scope';
-
-async function defaultRbacEvaluator(input: AuthorizationEvaluationInput): Promise<boolean> {
-  return hasPermission(
-    {
-      tenant: input.subject.tenant,
-      user_id: input.subject.userId,
-      user_type: input.subject.userType,
-    },
-    input.resource.type,
-    input.resource.action,
-    input.knex
-  );
-}
 
 function createRbacDeniedReasons(input: AuthorizationEvaluationInput): AuthorizationReason[] {
   return [
@@ -176,10 +162,6 @@ class DefaultAuthorizationKernel implements AuthorizationKernel {
   }
 }
 
-export function createAuthorizationKernel(input: Partial<AuthorizationKernelFactoryInput> & Pick<AuthorizationKernelFactoryInput, 'builtinProvider'>): AuthorizationKernel {
-  return new DefaultAuthorizationKernel({
-    builtinProvider: input.builtinProvider,
-    bundleProvider: input.bundleProvider,
-    rbacEvaluator: input.rbacEvaluator ?? defaultRbacEvaluator,
-  });
+export function createAuthorizationKernel(input: AuthorizationKernelFactoryInput): AuthorizationKernel {
+  return new DefaultAuthorizationKernel(input);
 }

--- a/packages/authorization/tsup.config.ts
+++ b/packages/authorization/tsup.config.ts
@@ -3,4 +3,5 @@ import { makeConfig } from '../build-tools/tsup-preset';
 
 export default defineConfig(makeConfig({
   external: ['knex'],
+  addJsExtensions: true,
 }));

--- a/packages/billing/src/services/quoteCalculationService.ts
+++ b/packages/billing/src/services/quoteCalculationService.ts
@@ -1,6 +1,4 @@
 import type { Knex } from 'knex';
-import { runWithTenant } from '@alga-psa/db';
-import { TaxService } from './taxService';
 
 interface QuoteCalculationContext {
   quote_id: string;
@@ -59,6 +57,191 @@ function calculateDiscountAmount(item: QuoteItemRow, baseAmount: number): number
   return Math.abs(toNumber(item.quantity || 1) * toNumber(item.unit_price));
 }
 
+function isDateApplicable(row: { start_date?: string | Date | null; end_date?: string | Date | null }, date: string): boolean {
+  const currentDate = new Date(date);
+  if (row.start_date && new Date(row.start_date) > currentDate) return false;
+  if (row.end_date && new Date(row.end_date) < currentDate) return false;
+  return true;
+}
+
+function calculateThresholdBasedTax(
+  thresholds: Array<{ min_amount: number | string; max_amount?: number | string | null; rate: number | string }>,
+  netAmount: number
+): { taxAmount: number; taxRate: number } {
+  let taxAmount = 0;
+  let remainingAmount = netAmount;
+
+  for (const threshold of thresholds) {
+    if (remainingAmount <= 0) break;
+
+    const minAmount = toNumber(threshold.min_amount);
+    const maxAmount = threshold.max_amount == null ? null : toNumber(threshold.max_amount);
+    const taxableAmount = maxAmount == null
+      ? remainingAmount
+      : Math.min(remainingAmount, Math.max(maxAmount - minAmount, 0));
+
+    taxAmount += Math.ceil((taxableAmount * toNumber(threshold.rate)) / 100);
+    remainingAmount -= taxableAmount;
+  }
+
+  return {
+    taxAmount,
+    taxRate: netAmount > 0 ? (taxAmount / netAmount) * 100 : 0,
+  };
+}
+
+async function getApplicableTaxHoliday(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  taxRateId: string,
+  date: string
+): Promise<Record<string, unknown> | undefined> {
+  const currentDate = new Date(date);
+  const holidays = await knexOrTrx('tax_holidays')
+    .where({ tenant, tax_rate_id: taxRateId })
+    .orderBy('start_date');
+
+  return holidays.find((holiday) =>
+    new Date(holiday.start_date) <= currentDate && new Date(holiday.end_date) >= currentDate
+  );
+}
+
+async function calculateComponentTax(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  component: Record<string, unknown>,
+  amount: number,
+  date: string
+): Promise<number> {
+  const holiday = await getApplicableTaxHoliday(knexOrTrx, tenant, String(component.tax_rate_id), date);
+  if (holiday) return 0;
+  return Math.ceil((amount * toNumber(component.rate)) / 100);
+}
+
+async function calculateTaxWithConnection(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  netAmount: number,
+  date: string,
+  regionCode: string | undefined,
+  isTaxable: boolean,
+  currencyCode?: string | null
+): Promise<{ taxAmount: number; taxRate: number }> {
+  const client = await knexOrTrx('clients')
+    .where({ tenant, client_id: clientId })
+    .select('is_tax_exempt')
+    .first();
+
+  if (!client) {
+    throw new Error(`Client ${clientId} not found in tenant ${tenant}`);
+  }
+
+  if (client.is_tax_exempt || !isTaxable) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  const taxSettings = await knexOrTrx('client_tax_settings')
+    .where({ tenant, client_id: clientId })
+    .select('is_reverse_charge_applicable')
+    .first();
+  if (taxSettings?.is_reverse_charge_applicable) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  if (regionCode) {
+    const applicableRates = await knexOrTrx('tax_rates')
+      .where({ tenant, region_code: regionCode, is_active: true })
+      .andWhere('start_date', '<=', date)
+      .andWhere(function dateRange() {
+        this.whereNull('end_date').orWhere('end_date', '>', date);
+      })
+      .andWhere(function currencyRange() {
+        this.whereNull('currency_code');
+        if (currencyCode) this.orWhere('currency_code', currencyCode);
+      })
+      .select('tax_percentage');
+
+    const combinedTaxRate = applicableRates.reduce((sum, rate) => sum + toNumber(rate.tax_percentage), 0);
+    return {
+      taxAmount: netAmount > 0 ? Math.ceil((netAmount * combinedTaxRate) / 100) : 0,
+      taxRate: combinedTaxRate,
+    };
+  }
+
+  const defaultRateAssoc = await knexOrTrx('client_tax_rates')
+    .where({ tenant, client_id: clientId, is_default: true })
+    .whereNull('location_id')
+    .select('tax_rate_id')
+    .first();
+
+  if (!defaultRateAssoc) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  const taxRate = await knexOrTrx('tax_rates')
+    .where({ tenant, tax_rate_id: defaultRateAssoc.tax_rate_id, is_active: true })
+    .andWhere('start_date', '<=', date)
+    .andWhere(function dateRange() {
+      this.whereNull('end_date').orWhere('end_date', '>', date);
+    })
+    .andWhere(function currencyRange() {
+      this.whereNull('currency_code');
+      if (currencyCode) this.orWhere('currency_code', currencyCode);
+    })
+    .first();
+
+  if (!taxRate) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  if (taxRate.is_composite) {
+    const components = await knexOrTrx('tax_components')
+      .join('composite_tax_mappings', function joinMappings() {
+        this.on('tax_components.tax_component_id', '=', 'composite_tax_mappings.tax_component_id')
+          .andOn('tax_components.tenant', '=', 'composite_tax_mappings.tenant');
+      })
+      .where({
+        'tax_components.tenant': tenant,
+        'composite_tax_mappings.composite_tax_id': taxRate.tax_rate_id,
+      })
+      .orderBy('composite_tax_mappings.sequence')
+      .select('tax_components.*');
+
+    let totalTaxAmount = 0;
+    let taxableAmount = netAmount;
+    for (const component of components) {
+      if (!isDateApplicable(component, date)) continue;
+      const componentTax = await calculateComponentTax(knexOrTrx, tenant, component, taxableAmount, date);
+      totalTaxAmount += componentTax;
+      if (component.is_compound) taxableAmount += componentTax;
+    }
+
+    return {
+      taxAmount: totalTaxAmount,
+      taxRate: netAmount > 0 ? (totalTaxAmount / netAmount) * 100 : 0,
+    };
+  }
+
+  const thresholds = await knexOrTrx('tax_rate_thresholds')
+    .where({ tenant, tax_rate_id: taxRate.tax_rate_id })
+    .orderBy('min_amount');
+
+  if (thresholds.length > 0) {
+    return calculateThresholdBasedTax(thresholds, netAmount);
+  }
+
+  if (netAmount <= 0) {
+    return { taxAmount: 0, taxRate: toNumber(taxRate.tax_percentage) };
+  }
+
+  const taxRatePercentage = toNumber(taxRate.tax_percentage);
+  return {
+    taxAmount: Math.ceil((netAmount * taxRatePercentage) / 100),
+    taxRate: taxRatePercentage,
+  };
+}
+
 export async function recalculateQuoteFinancials(
   knexOrTrx: Knex | Knex.Transaction,
   tenant: string,
@@ -105,7 +288,6 @@ export async function recalculateQuoteFinancials(
     }
   }
 
-  const taxService = quote.client_id ? new TaxService() : null;
   const quoteDate = toQuoteDate(quote.quote_date);
   const currencyCode = quote.currency_code ?? 'USD';
   const taxSource = quote.tax_source ?? 'internal';
@@ -156,17 +338,17 @@ export async function recalculateQuoteFinancials(
     } else {
       subtotal += isIncludedInTotals ? resolvedTotalPrice : 0;
 
-      if (isIncludedInTotals && quote.client_id && taxService && taxSource === 'internal') {
-        const taxResult = await runWithTenant(tenant, async () => {
-          return taxService.calculateTax(
-            quote.client_id!,
-            netAmount,
-            quoteDate,
-            taxRegion ?? undefined,
-            item.is_taxable !== false,
-            currencyCode
-          );
-        });
+      if (isIncludedInTotals && quote.client_id && taxSource === 'internal') {
+        const taxResult = await calculateTaxWithConnection(
+          knexOrTrx,
+          tenant,
+          quote.client_id,
+          netAmount,
+          quoteDate,
+          taxRegion ?? undefined,
+          item.is_taxable !== false,
+          currencyCode
+        );
 
         taxAmount = taxResult.taxAmount;
         taxRate = Math.round(Number(taxResult.taxRate ?? 0));

--- a/packages/billing/src/services/quoteConversionService.ts
+++ b/packages/billing/src/services/quoteConversionService.ts
@@ -356,19 +356,15 @@ export async function convertQuoteToDraftContract(
     }))
   );
 
-  const configRows = contractLineMappings.map(({ item, contractLineId, contractLineType }) => {
-    if (!item.service_id) {
-      throw new Error('Recurring quote items must be linked to a catalog service before converting to a contract');
-    }
-
-    return {
+  const configRows = contractLineMappings
+    .filter(({ item }) => Boolean(item.service_id))
+    .map(({ item, contractLineId, contractLineType }) => ({
       item,
       contractLineId,
       contractLineType,
       configId: uuidv4(),
-      serviceId: item.service_id,
-    };
-  });
+      serviceId: item.service_id as string,
+    }));
 
   await insertRowsUsingExistingColumns(
     knexOrTrx,
@@ -384,19 +380,21 @@ export async function convertQuoteToDraftContract(
     }))
   );
 
-  await knexOrTrx('contract_line_service_configuration').insert(
-    configRows.map(({ configId, contractLineId, contractLineType, serviceId, item }) => ({
-      tenant,
-      config_id: configId,
-      contract_line_id: contractLineId,
-      service_id: serviceId,
-      configuration_type: contractLineType,
-      custom_rate: item.unit_price,
-      quantity: item.quantity,
-      created_at: nowIso,
-      updated_at: nowIso,
-    }))
-  );
+  if (configRows.length > 0) {
+    await knexOrTrx('contract_line_service_configuration').insert(
+      configRows.map(({ configId, contractLineId, contractLineType, serviceId, item }) => ({
+        tenant,
+        config_id: configId,
+        contract_line_id: contractLineId,
+        service_id: serviceId,
+        configuration_type: contractLineType,
+        custom_rate: item.unit_price,
+        quantity: item.quantity,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+  }
 
   const fixedConfigRows = configRows.filter((row) => row.contractLineType === 'Fixed');
   if (fixedConfigRows.length > 0) {

--- a/packages/core/src/config/deletion.ts
+++ b/packages/core/src/config/deletion.ts
@@ -1,0 +1,1 @@
+export * from './deletion/index';

--- a/packages/tickets/src/actions/ticketActions.authorizationNarrowing.test.ts
+++ b/packages/tickets/src/actions/ticketActions.authorizationNarrowing.test.ts
@@ -437,6 +437,7 @@ describe('ticket authorization narrowing for migrated list/detail paths', () => 
       bundleProvider: new BundleAuthorizationKernelProvider({
         resolveRules: (input) => resolveBundleNarrowingRulesForEvaluation(trx as any, input),
       }),
+      rbacEvaluator: async () => true,
     });
 
     const uiAllowedIds = (await getTicketsForList({ boardFilterState: 'all' } as any)).map((ticket) => ticket.ticket_id).sort();

--- a/server/src/lib/authorization/kernel/engine.ts
+++ b/server/src/lib/authorization/kernel/engine.ts
@@ -1,4 +1,3 @@
-import { hasPermission } from '../../auth/rbac';
 import type {
   AuthorizationDecision,
   AuthorizationEvaluationInput,
@@ -11,18 +10,6 @@ import type {
 } from './contracts';
 import { getRequestCache } from './requestCache';
 import { intersectAuthorizationScopes } from './scope';
-
-async function defaultRbacEvaluator(input: AuthorizationEvaluationInput): Promise<boolean> {
-  return hasPermission(
-    {
-      user_id: input.subject.userId,
-      user_type: input.subject.userType,
-    },
-    input.resource.type,
-    input.resource.action,
-    input.knex
-  );
-}
 
 function createRbacDeniedReasons(input: AuthorizationEvaluationInput): AuthorizationReason[] {
   return [
@@ -175,10 +162,6 @@ class DefaultAuthorizationKernel implements AuthorizationKernel {
   }
 }
 
-export function createAuthorizationKernel(input: Partial<AuthorizationKernelFactoryInput> & Pick<AuthorizationKernelFactoryInput, 'builtinProvider'>): AuthorizationKernel {
-  return new DefaultAuthorizationKernel({
-    builtinProvider: input.builtinProvider,
-    bundleProvider: input.bundleProvider,
-    rbacEvaluator: input.rbacEvaluator ?? defaultRbacEvaluator,
-  });
+export function createAuthorizationKernel(input: AuthorizationKernelFactoryInput): AuthorizationKernel {
+  return new DefaultAuthorizationKernel(input);
 }

--- a/server/src/lib/authorization/kernel/index.ts
+++ b/server/src/lib/authorization/kernel/index.ts
@@ -1,8 +1,6 @@
 import type { AuthorizationKernel } from '@alga-psa/authorization/kernel';
-import {
-  BuiltinAuthorizationKernelProvider,
-  createAuthorizationKernel,
-} from '@alga-psa/authorization/kernel';
+import { BuiltinAuthorizationKernelProvider } from '@alga-psa/authorization/kernel';
+import { createAuthorizationKernelWithDefaultRbac } from '@alga-psa/authorization/adapters/rbac';
 import { loadEnterpriseAuthorizationKernelFactory } from './enterpriseEntry';
 
 declare global {
@@ -11,7 +9,7 @@ declare global {
 }
 
 export function createBuiltinAuthorizationKernel(): AuthorizationKernel {
-  return createAuthorizationKernel({
+  return createAuthorizationKernelWithDefaultRbac({
     builtinProvider: new BuiltinAuthorizationKernelProvider(),
   });
 }

--- a/services/workflow-worker/Dockerfile
+++ b/services/workflow-worker/Dockerfile
@@ -26,6 +26,7 @@ COPY shared/package.json ./shared/
 COPY services/workflow-worker/package.json ./services/workflow-worker/
 COPY server/package.json ./server/
 COPY packages/core/package.json ./packages/core/
+COPY packages/authorization/package.json ./packages/authorization/
 COPY packages/db/package.json ./packages/db/
 COPY packages/event-bus/package.json ./packages/event-bus/
 COPY packages/event-schemas/package.json ./packages/event-schemas/
@@ -45,6 +46,7 @@ RUN npm config set legacy-peer-deps true && PUPPETEER_SKIP_DOWNLOAD=true npm ins
   --workspace=workflow-worker \
   --workspace=server \
   --workspace=@alga-psa/core \
+  --workspace=@alga-psa/authorization \
   --workspace=@alga-psa/db \
   --workspace=@alga-psa/event-bus \
   --workspace=@alga-psa/event-schemas \
@@ -73,6 +75,9 @@ WORKDIR /app/packages/types
 RUN npm run build
 
 WORKDIR /app/packages/db
+RUN npm run build
+
+WORKDIR /app/packages/authorization
 RUN npm run build
 
 WORKDIR /app/packages/formatting

--- a/services/workflow-worker/scripts/validate-runtime-imports.mjs
+++ b/services/workflow-worker/scripts/validate-runtime-imports.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SERVICE_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(SERVICE_ROOT, '../..');
 const DIST_ROOT = path.resolve(
   process.env.WORKFLOW_WORKER_VALIDATE_DIST_ROOT || path.join(SERVICE_ROOT, 'dist'),
 );
@@ -14,6 +15,14 @@ const DIST_ROOT = path.resolve(
 const ENTRY_CANDIDATES = [
   path.join(DIST_ROOT, 'services/workflow-worker/src/index.js'),
   path.join(DIST_ROOT, 'src/index.js'),
+];
+
+const EXTRA_ENTRY_CANDIDATES = [
+  // The worker imports @alga-psa/workflows/runtime/worker as a package export.
+  // That package dist is outside services/workflow-worker/dist, so scan it
+  // explicitly to catch bundled alias/server/UI leaks before Docker runtime.
+  path.join(REPO_ROOT, 'ee/packages/workflows/dist/runtime/worker.mjs'),
+  path.join(REPO_ROOT, 'ee/packages/workflows/dist/runtime/core.mjs'),
 ];
 
 const FORBIDDEN_ROOT_IMPORTS = new Set([
@@ -103,7 +112,10 @@ function validate() {
     throw new Error('Unable to locate workflow-worker dist entrypoint');
   }
 
-  const queue = [entry];
+  const queue = [
+    entry,
+    ...EXTRA_ENTRY_CANDIDATES.filter((candidate) => fs.existsSync(candidate)),
+  ];
   const visited = new Set();
   const violations = [];
 

--- a/services/workflow-worker/src/v2/WorkflowRuntimeV2EventStreamWorker.ts
+++ b/services/workflow-worker/src/v2/WorkflowRuntimeV2EventStreamWorker.ts
@@ -2,7 +2,7 @@ import logger from '@shared/core/logger.js';
 import {
   RedisStreamClient,
   WorkflowEventBaseSchema,
-} from '@alga-psa/workflow-streams';
+} from '@alga-psa/shared/workflow/streams/index.js';
 import {
   createSecretResolverFromProvider,
   getSchemaRegistry,

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
         find: /^@alga-psa\/db\/connection$/,
         replacement: path.resolve(__dirname, '../packages/db/src/lib/connection.ts'),
       },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/db/src/$1'),
+      },
       { find: /^@alga-psa\/core$/, replacement: path.resolve(__dirname, '../packages/core/src/index.ts') },
       {
         find: /^@alga-psa\/core\/logger$/,
@@ -45,6 +49,10 @@ export default defineConfig({
       {
         find: /^@alga-psa\/core\/secrets$/,
         replacement: path.resolve(__dirname, '../packages/core/src/lib/secrets/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/core/src/$1'),
       },
       {
         find: /^@shared\/workflow\/secrets$/,
@@ -61,6 +69,10 @@ export default defineConfig({
       {
         find: /^@shared\/workflow\/streams\/(.*)$/,
         replacement: path.resolve(__dirname, './workflow/streams/$1'),
+      },
+      {
+        find: /^@shared\/(.*)$/,
+        replacement: path.resolve(__dirname, './$1'),
       },
     ],
   },

--- a/shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts
+++ b/shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { zodToWorkflowJsonSchema } from '../jsonSchemaMetadata';
+import { registerBusinessOperationsActionsV2 } from '../actions/registerBusinessOperationsActions';
+import { getActionRegistryV2 } from '../registries/actionRegistry';
+import { buildWorkflowDesignerActionCatalog, type WorkflowDesignerCatalogSourceAction } from '../designer/actionCatalog';
+
+const EXPECTED_CRM_ACTION_IDS = [
+  'crm.create_activity_note',
+  'crm.find_activities',
+  'crm.update_activity',
+  'crm.schedule_activity',
+  'crm.send_quote',
+] as const;
+
+describe('workflow designer crm catalog grouping from runtime registrations', () => {
+  beforeAll(() => {
+    const registry = getActionRegistryV2();
+    if (!registry.get('crm.send_quote', 1)) {
+      registerBusinessOperationsActionsV2();
+    }
+  });
+
+  it('T002: groups runtime-registered crm.* actions under built-in CRM group without catalog seed changes', () => {
+    const registry = getActionRegistryV2();
+    const sourceActions: WorkflowDesignerCatalogSourceAction[] = registry.list().map((action) => ({
+      id: action.id,
+      version: action.version,
+      ui: action.ui,
+      inputSchema: zodToWorkflowJsonSchema(action.inputSchema),
+      outputSchema: zodToWorkflowJsonSchema(action.outputSchema),
+    }));
+
+    const catalog = buildWorkflowDesignerActionCatalog(sourceActions);
+    const crmRecord = catalog.find((record) => record.groupKey === 'crm');
+
+    expect(crmRecord).toBeDefined();
+    expect(crmRecord?.label).toBe('CRM');
+    expect(crmRecord?.allowedActionIds).toEqual(expect.arrayContaining([...EXPECTED_CRM_ACTION_IDS]));
+
+    const crmActionsById = new Map(crmRecord?.actions.map((action) => [action.id, action]));
+    expect(crmActionsById.get('crm.find_activities')?.label).toBe('Find CRM Activities');
+    expect(crmActionsById.get('crm.update_activity')?.label).toBe('Update CRM Activity');
+    expect(crmActionsById.get('crm.schedule_activity')?.label).toBe('Schedule CRM Activity');
+    expect(crmActionsById.get('crm.send_quote')?.label).toBe('Send Quote');
+  });
+});

--- a/shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts
+++ b/shared/workflow/runtime/__tests__/workflowDesignerCrmCatalogRuntime.test.ts
@@ -11,17 +11,26 @@ const EXPECTED_CRM_ACTION_IDS = [
   'crm.update_activity',
   'crm.schedule_activity',
   'crm.send_quote',
+  'crm.create_interaction_type',
+  'crm.update_activity_status',
+  'crm.create_quote',
+  'crm.add_quote_item',
+  'crm.create_quote_from_template',
+  'crm.find_quotes',
+  'crm.submit_quote_for_approval',
+  'crm.convert_quote',
+  'crm.tag_activity',
 ] as const;
 
 describe('workflow designer crm catalog grouping from runtime registrations', () => {
   beforeAll(() => {
     const registry = getActionRegistryV2();
-    if (!registry.get('crm.send_quote', 1)) {
+    if (!registry.get('crm.tag_activity', 1)) {
       registerBusinessOperationsActionsV2();
     }
   });
 
-  it('T002: groups runtime-registered crm.* actions under built-in CRM group without catalog seed changes', () => {
+  it('T001: groups runtime-registered crm.* actions under built-in CRM group without catalog seed changes', () => {
     const registry = getActionRegistryV2();
     const sourceActions: WorkflowDesignerCatalogSourceAction[] = registry.list().map((action) => ({
       id: action.id,
@@ -40,8 +49,14 @@ describe('workflow designer crm catalog grouping from runtime registrations', ()
 
     const crmActionsById = new Map(crmRecord?.actions.map((action) => [action.id, action]));
     expect(crmActionsById.get('crm.find_activities')?.label).toBe('Find CRM Activities');
-    expect(crmActionsById.get('crm.update_activity')?.label).toBe('Update CRM Activity');
-    expect(crmActionsById.get('crm.schedule_activity')?.label).toBe('Schedule CRM Activity');
-    expect(crmActionsById.get('crm.send_quote')?.label).toBe('Send Quote');
+    expect(crmActionsById.get('crm.create_interaction_type')?.label).toBe('Create Activity Type');
+    expect(crmActionsById.get('crm.update_activity_status')?.label).toBe('Update Activity Status');
+    expect(crmActionsById.get('crm.create_quote')?.label).toBe('Create Quote');
+    expect(crmActionsById.get('crm.add_quote_item')?.label).toBe('Add Quote Item');
+    expect(crmActionsById.get('crm.create_quote_from_template')?.label).toBe('Create Quote from Template');
+    expect(crmActionsById.get('crm.find_quotes')?.label).toBe('Find Quotes');
+    expect(crmActionsById.get('crm.submit_quote_for_approval')?.label).toBe('Submit Quote for Approval');
+    expect(crmActionsById.get('crm.convert_quote')?.label).toBe('Convert Quote');
+    expect(crmActionsById.get('crm.tag_activity')?.label).toBe('Tag CRM Activity');
   });
 });

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
@@ -18,10 +18,18 @@ const repoRoot = path.resolve(__dirname, '../../../../..');
 const TEST_DB_NAME = 'test_database';
 const PRODUCTION_DB_NAMES = new Set(['sebastian_prod', 'production', 'prod', 'server']);
 
-const publishWorkflowEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+type PublishedWorkflowEvent = {
+  eventType?: string;
+  idempotencyKey?: string;
+  [key: string]: unknown;
+};
+
+const publishWorkflowEventMock = vi.hoisted(() =>
+  vi.fn(async (_event: PublishedWorkflowEvent) => undefined)
+);
 
 vi.mock('@alga-psa/event-bus/publishers', () => ({
-  publishWorkflowEvent: (...args: any[]) => publishWorkflowEventMock(...args),
+  publishWorkflowEvent: (event: PublishedWorkflowEvent) => publishWorkflowEventMock(event),
 }));
 
 function verifyTestDatabase(dbName: string): void {

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
@@ -375,6 +375,50 @@ async function createQuote(
   return quoteId;
 }
 
+async function createQuoteItemRecord(
+  db: Knex,
+  params: {
+    tenantId: string;
+    actorUserId: string;
+    quoteId: string;
+    description: string;
+    quantity?: number;
+    unitPrice?: number;
+    isRecurring?: boolean;
+    billingFrequency?: string | null;
+    isOptional?: boolean;
+    isSelected?: boolean;
+    displayOrder?: number;
+  }
+): Promise<string> {
+  const quoteItemId = uuidv4();
+  const quantity = params.quantity ?? 1;
+  const unitPrice = params.unitPrice ?? 1000;
+  const displayOrder = params.displayOrder ?? 0;
+  const total = quantity * unitPrice;
+  await db('quote_items').insert({
+    tenant: params.tenantId,
+    quote_item_id: quoteItemId,
+    quote_id: params.quoteId,
+    description: params.description,
+    quantity,
+    unit_price: unitPrice,
+    total_price: total,
+    net_amount: total,
+    tax_amount: 0,
+    display_order: displayOrder,
+    is_optional: params.isOptional ?? false,
+    is_selected: params.isSelected ?? true,
+    is_recurring: params.isRecurring ?? false,
+    billing_frequency: params.billingFrequency ?? null,
+    created_by: params.actorUserId,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  });
+
+  return quoteItemId;
+}
+
 const runtimeState = vi.hoisted(() => ({
   db: null as Knex | null,
   tenantId: '',
@@ -504,6 +548,346 @@ describe('crm workflow runtime DB-backed action handlers', () => {
     resetWorkflowEmailProvider();
     await db?.destroy();
     runtimeState.db = null;
+  });
+
+  it('T003: crm.create_interaction_type creates tenant type, handles duplicates, audits, and requires settings:update', async () => {
+    const created = await invokeAction('crm.create_interaction_type', {
+      type_name: 'QBR Follow-up',
+      icon: 'phone',
+    });
+
+    expect(created.interaction_type.created).toBe(true);
+    expect(created.interaction_type.type_name).toBe('QBR Follow-up');
+    expect(created.interaction_type.display_order).toBeGreaterThanOrEqual(0);
+
+    const duplicate = await invokeAction('crm.create_interaction_type', {
+      type_name: '  qbr follow-up  ',
+      if_exists: 'return_existing',
+    });
+    expect(duplicate.interaction_type.created).toBe(false);
+    expect(duplicate.interaction_type.type_id).toBe(created.interaction_type.type_id);
+
+    await expect(
+      invokeAction('crm.create_interaction_type', {
+        type_name: 'QBR Follow-up',
+        if_exists: 'error',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    const audit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.create_interaction_type' })
+      .first();
+    expect(audit).toBeTruthy();
+
+    runtimeState.deniedPermissions.add('settings:update');
+    await expect(
+      invokeAction('crm.create_interaction_type', { type_name: 'Blocked Type' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    runtimeState.deniedPermissions.clear();
+  });
+
+  it('T004: crm.update_activity_status transitions statuses, no-ops, audits, and rejects invalid status/activity', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Status Client');
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const initialStatusId = await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+    const nextStatusId = await createInteractionStatus(db, runtimeState.tenantId, runtimeState.actorUserId, 'Completed');
+
+    const activityId = await createInteraction(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      typeId,
+      statusId: initialStatusId,
+    });
+
+    const changed = await invokeAction('crm.update_activity_status', {
+      activity_id: activityId,
+      status_id: nextStatusId,
+    });
+    expect(changed.no_op).toBe(false);
+    expect(changed.previous_status_id).toBe(initialStatusId);
+    expect(changed.current_status_id).toBe(nextStatusId);
+
+    const noOp = await invokeAction('crm.update_activity_status', {
+      activity_id: activityId,
+      status_name: 'completed',
+      no_op_if_already_status: true,
+    });
+    expect(noOp.no_op).toBe(true);
+    expect(noOp.current_status_id).toBe(nextStatusId);
+
+    await expect(
+      invokeAction('crm.update_activity_status', {
+        activity_id: activityId,
+        status_name: 'not-a-real-status',
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const otherTenantId = await createTenant(db, 'Other Activity Tenant');
+    const otherUserId = await createUser(db, otherTenantId);
+    const otherClientId = await createClient(db, otherTenantId, 'Other Activity Client');
+    const otherTypeId = await getAnyInteractionTypeId(db, otherTenantId);
+    const otherActivityId = await createInteraction(db, {
+      tenantId: otherTenantId,
+      actorUserId: otherUserId,
+      clientId: otherClientId,
+      typeId: otherTypeId,
+    });
+
+    await expect(
+      invokeAction('crm.update_activity_status', {
+        activity_id: otherActivityId,
+        status_id: nextStatusId,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('T005/T006/T007/T016/T017: quote creation/find/approval/item/template follow-up actions enforce tenant guards and audit', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Quote Flow Client');
+    const contactId = await createContact(db, runtimeState.tenantId, clientId, 'Quote Flow Contact');
+    const templateId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      contactId,
+      title: 'Template Quote',
+      status: null as any,
+      isTemplate: true,
+    });
+
+    await createQuoteItemRecord(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      quoteId: templateId,
+      description: 'Template Item',
+      unitPrice: 1500,
+      displayOrder: 0,
+    });
+
+    const createdQuote = await invokeAction('crm.create_quote', {
+      client_id: clientId,
+      contact_id: contactId,
+      title: 'Workflow Created Quote',
+      quote_date: new Date('2026-01-01').toISOString(),
+      valid_until: new Date('2026-02-01').toISOString(),
+      currency_code: 'USD',
+    });
+    expect(createdQuote.quote.quote_id).toBeTruthy();
+
+    const addItem = await invokeAction('crm.add_quote_item', {
+      quote_id: createdQuote.quote.quote_id,
+      description: 'Managed Service',
+      quantity: 2,
+      unit_price: 2000,
+      display_order: 0,
+    });
+    expect(addItem.quote_item.quote_id).toBe(createdQuote.quote.quote_id);
+    expect(addItem.quote.quote_id).toBe(createdQuote.quote.quote_id);
+
+    const foundQuotes = await invokeAction('crm.find_quotes', {
+      quote_id: createdQuote.quote.quote_id,
+      on_empty: 'error',
+      pageSize: 25,
+    });
+    expect(foundQuotes.count).toBe(1);
+    expect(foundQuotes.first_quote?.quote_id).toBe(createdQuote.quote.quote_id);
+
+    const submitted = await invokeAction('crm.submit_quote_for_approval', {
+      quote_id: createdQuote.quote.quote_id,
+      reason: 'auto-submit',
+    });
+    expect(submitted.previous_status).toBe('draft');
+    expect(submitted.new_status).toBe('pending_approval');
+
+    const noOpPending = await invokeAction('crm.submit_quote_for_approval', {
+      quote_id: createdQuote.quote.quote_id,
+      no_op_if_already_pending: true,
+    });
+    expect(noOpPending.no_op).toBe(true);
+
+    const fromTemplate = await invokeAction('crm.create_quote_from_template', {
+      template_id: templateId,
+      client_id: clientId,
+      contact_id: contactId,
+      title: 'Templated Quote',
+      quote_date: new Date('2026-03-01').toISOString(),
+      valid_until: new Date('2026-03-30').toISOString(),
+    });
+    expect(fromTemplate.quote.quote_id).toBeTruthy();
+    expect(fromTemplate.quote_items.length).toBeGreaterThan(0);
+
+    await expect(
+      invokeAction('crm.create_quote', {
+        client_id: clientId,
+        contact_id: contactId,
+        title: 'Bad Dates',
+        quote_date: new Date('2026-04-02').toISOString(),
+        valid_until: new Date('2026-04-01').toISOString(),
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      invokeAction('crm.find_quotes', {
+        on_empty: 'return_empty',
+        pageSize: 100,
+      })
+    ).rejects.toThrow();
+
+    const quoteAudit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.create_quote' })
+      .first();
+    expect(quoteAudit).toBeTruthy();
+  });
+
+  it('T008/T009: crm.convert_quote converts accepted quotes and rejects ineligible/template/cross-tenant/permission cases', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Convert Client');
+    const quoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      title: 'Convert Me',
+      status: 'accepted',
+    });
+
+    await createQuoteItemRecord(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      quoteId,
+      description: 'Recurring Contract Line',
+      unitPrice: 5000,
+      isRecurring: true,
+      billingFrequency: 'monthly',
+      displayOrder: 0,
+    });
+    await createQuoteItemRecord(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      quoteId,
+      description: 'One-time Setup',
+      unitPrice: 2000,
+      isRecurring: false,
+      displayOrder: 1,
+    });
+
+    const converted = await invokeAction('crm.convert_quote', {
+      quote_id: quoteId,
+      target: 'contract_and_invoice',
+    });
+    expect(converted.no_op).toBe(false);
+    expect(converted.contract_id).toBeTruthy();
+    expect(converted.invoice_id).toBeTruthy();
+
+    const noOp = await invokeAction('crm.convert_quote', {
+      quote_id: quoteId,
+      target: 'contract',
+      no_op_if_already_converted: true,
+    });
+    expect(noOp.no_op).toBe(true);
+
+    const draftQuoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: 'draft',
+    });
+    await expect(
+      invokeAction('crm.convert_quote', {
+        quote_id: draftQuoteId,
+        target: 'contract',
+      })
+    ).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+
+    const templateQuoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: null as any,
+      isTemplate: true,
+    });
+    await expect(
+      invokeAction('crm.convert_quote', {
+        quote_id: templateQuoteId,
+        target: 'invoice',
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const otherTenant = await createTenant(db, 'Other Convert Tenant');
+    const otherUser = await createUser(db, otherTenant);
+    const otherClient = await createClient(db, otherTenant, 'Other Convert Client');
+    const otherQuote = await createQuote(db, {
+      tenantId: otherTenant,
+      actorUserId: otherUser,
+      clientId: otherClient,
+      status: 'accepted',
+    });
+    await expect(
+      invokeAction('crm.convert_quote', {
+        quote_id: otherQuote,
+        target: 'contract',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    runtimeState.deniedPermissions.add('billing:create');
+    await expect(
+      invokeAction('crm.convert_quote', {
+        quote_id: quoteId,
+        target: 'contract',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    runtimeState.deniedPermissions.clear();
+  });
+
+  it('T010/T011: crm.tag_activity validates interactions, applies tags idempotently, enforces tag:create, audits, and emits tag events', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Tag Client');
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const activityId = await createInteraction(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      typeId,
+    });
+
+    const tagged = await invokeAction('crm.tag_activity', {
+      activity_id: activityId,
+      tags: ['Needs QBR', 'Upsell Candidate'],
+    });
+
+    expect(tagged.added_count).toBe(2);
+    expect(tagged.existing_count).toBe(0);
+    expect(publishWorkflowEventMock).toHaveBeenCalled();
+    const publishedTypes = publishWorkflowEventMock.mock.calls.map((call) => call[0]?.eventType);
+    expect(publishedTypes).toContain('TAG_DEFINITION_CREATED');
+    expect(publishedTypes).toContain('TAG_APPLIED');
+
+    const idempotent = await invokeAction('crm.tag_activity', {
+      activity_id: activityId,
+      tags: ['Needs QBR'],
+      if_exists: 'no_op',
+    });
+    expect(idempotent.added_count).toBe(0);
+    expect(idempotent.existing_count).toBe(1);
+
+    await expect(
+      invokeAction('crm.tag_activity', {
+        activity_id: activityId,
+        tags: ['Needs QBR'],
+        if_exists: 'error',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    runtimeState.deniedPermissions.add('tag:create');
+    await expect(
+      invokeAction('crm.tag_activity', {
+        activity_id: activityId,
+        tags: ['Brand New Tag'],
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    runtimeState.deniedPermissions.clear();
+
+    const audit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.tag_activity' })
+      .first();
+    expect(audit).toBeTruthy();
   });
 
   it('T004: crm.find_activities returns tenant-scoped filtered summaries and rejects unbounded searches', async () => {

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
@@ -852,8 +852,18 @@ describe('crm workflow runtime DB-backed action handlers', () => {
       tags: ['Needs QBR', 'Upsell Candidate'],
     });
 
+    expect(tagged.tagged_entity).toEqual({ type: 'client', id: clientId });
     expect(tagged.added_count).toBe(2);
     expect(tagged.existing_count).toBe(0);
+
+    const unsupportedInteractionMappings = await db('tag_mappings')
+      .where({ tenant: runtimeState.tenantId, tagged_id: activityId, tagged_type: 'interaction' });
+    expect(unsupportedInteractionMappings).toHaveLength(0);
+
+    const clientMappings = await db('tag_mappings')
+      .where({ tenant: runtimeState.tenantId, tagged_id: clientId, tagged_type: 'client' });
+    expect(clientMappings).toHaveLength(2);
+
     expect(publishWorkflowEventMock).toHaveBeenCalled();
     const publishedTypes = publishWorkflowEventMock.mock.calls.map((call) => call[0]?.eventType);
     expect(publishedTypes).toContain('TAG_DEFINITION_CREATED');

--- a/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/businessOperations.crm.db.test.ts
@@ -1,0 +1,932 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { knex, type Knex } from 'knex';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+import { getSecret } from '@alga-psa/core/secrets';
+import { v4 as uuidv4 } from 'uuid';
+
+import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { registerCrmActions } from '../businessOperations/crm';
+import { registerWorkflowEmailProvider, resetWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../../..');
+const TEST_DB_NAME = 'test_database';
+const PRODUCTION_DB_NAMES = new Set(['sebastian_prod', 'production', 'prod', 'server']);
+
+const publishWorkflowEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: (...args: any[]) => publishWorkflowEventMock(...args),
+}));
+
+function verifyTestDatabase(dbName: string): void {
+  if (PRODUCTION_DB_NAMES.has(dbName.toLowerCase())) {
+    throw new Error(`Attempting to use production database (${dbName}) for testing`);
+  }
+}
+
+async function recreateDatabase(
+  databaseName: string,
+  dbHost: string,
+  dbPort: number,
+  adminUser: string,
+  adminPassword: string,
+  appUser: string,
+  appPassword: string
+): Promise<void> {
+  const adminConnection = knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: adminUser,
+      password: adminPassword,
+      database: 'postgres',
+    },
+    pool: { min: 1, max: 2 },
+  });
+
+  try {
+    const safeDbName = databaseName.replace(/"/g, '""');
+    await adminConnection.raw(
+      'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ? AND pid <> pg_backend_pid()',
+      [databaseName]
+    );
+    await adminConnection.raw(`DROP DATABASE IF EXISTS "${safeDbName}"`);
+    await adminConnection.raw(`CREATE DATABASE "${safeDbName}"`);
+    await adminConnection.raw(`DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${appUser}') THEN
+          CREATE ROLE ${appUser} WITH LOGIN PASSWORD '${appPassword}';
+        ELSE
+          ALTER ROLE ${appUser} WITH LOGIN PASSWORD '${appPassword}';
+        END IF;
+      END;
+    $$;`);
+    await adminConnection.raw(`ALTER DATABASE "${safeDbName}" OWNER TO ${appUser}`);
+    await adminConnection.raw(`GRANT ALL PRIVILEGES ON DATABASE "${safeDbName}" TO ${appUser}`);
+  } finally {
+    await adminConnection.destroy().catch(() => undefined);
+  }
+}
+
+async function createTestDbConnection(): Promise<Knex> {
+  const databaseName = process.env.DB_NAME_SERVER || TEST_DB_NAME;
+  verifyTestDatabase(databaseName);
+
+  const dbHost = process.env.DB_HOST || 'localhost';
+  const dbPort = Number.parseInt(process.env.DB_PORT || '5432', 10);
+  const adminUser = process.env.DB_USER_ADMIN || 'postgres';
+  const adminPassword = await getSecret('postgres_password', 'DB_PASSWORD_ADMIN', 'postpass123');
+  const appUser = process.env.DB_USER_SERVER || 'app_user';
+  const appPassword = await getSecret('db_password_server', 'DB_PASSWORD_SERVER', 'postpass123');
+
+  await recreateDatabase(databaseName, dbHost, dbPort, adminUser, adminPassword, appUser, appPassword);
+
+  process.env.DB_HOST = dbHost;
+  process.env.DB_PORT = String(dbPort);
+  process.env.DB_NAME_SERVER = databaseName;
+  process.env.DB_USER_SERVER = appUser;
+  process.env.DB_USER_ADMIN = adminUser;
+
+  const adminKnex = knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: adminUser,
+      password: adminPassword,
+      database: databaseName,
+    },
+    migrations: { directory: path.join(repoRoot, 'server', 'migrations') },
+    seeds: { directory: path.join(repoRoot, 'server', 'seeds', 'dev') },
+  });
+
+  await adminKnex.migrate.latest();
+  await adminKnex.seed.run();
+  await adminKnex.destroy();
+
+  return knex({
+    client: 'pg',
+    connection: {
+      host: dbHost,
+      port: dbPort,
+      user: appUser,
+      password: appPassword,
+      database: databaseName,
+    },
+    asyncStackTraces: true,
+    pool: { min: 2, max: 20 },
+  });
+}
+
+async function createTenant(db: Knex, name = 'Test Tenant'): Promise<string> {
+  const tenantId = uuidv4();
+  const now = new Date().toISOString();
+
+  await db('tenants').insert({
+    tenant: tenantId,
+    client_name: name,
+    phone_number: '555-0100',
+    email: `test-${tenantId.substring(0, 8)}@example.com`,
+    created_at: now,
+    updated_at: now,
+    payment_platform_id: `test-platform-${tenantId.substring(0, 8)}`,
+    payment_method_id: `test-method-${tenantId.substring(0, 8)}`,
+    auth_service_id: `test-auth-${tenantId.substring(0, 8)}`,
+    plan: 'pro',
+  });
+
+  return tenantId;
+}
+
+async function createUser(db: Knex, tenantId: string, options: { email?: string; first_name?: string; last_name?: string } = {}): Promise<string> {
+  const userId = uuidv4();
+
+  await db('users').insert({
+    user_id: userId,
+    tenant: tenantId,
+    username: `test.user.${userId}`,
+    first_name: options.first_name || 'Test',
+    last_name: options.last_name || 'User',
+    email: options.email || `test.user.${userId}@example.com`,
+    hashed_password: 'hashed_password_here',
+    created_at: new Date(),
+    two_factor_enabled: false,
+    is_google_user: false,
+    is_inactive: false,
+    user_type: 'internal',
+  });
+
+  return userId;
+}
+
+async function createClient(db: Knex, tenantId: string, name = 'Test Client'): Promise<string> {
+  const clientId = uuidv4();
+  const now = new Date().toISOString();
+
+  await db('clients').insert({
+    client_id: clientId,
+    client_name: name,
+    tenant: tenantId,
+    billing_cycle: 'monthly',
+    is_tax_exempt: false,
+    created_at: now,
+    updated_at: now,
+    is_inactive: false,
+    credit_balance: 0,
+  });
+
+  return clientId;
+}
+
+async function createContact(db: Knex, tenantId: string, clientId: string, name: string): Promise<string> {
+  const contactId = uuidv4();
+  await db('contacts').insert({
+    tenant: tenantId,
+    contact_name_id: contactId,
+    full_name: name,
+    client_id: clientId,
+    email: `${contactId.slice(0, 8)}@example.com`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    is_inactive: false,
+  });
+  return contactId;
+}
+
+async function getTicketStatusId(db: Knex, tenantId: string, actorUserId: string): Promise<string> {
+  const existing = await db('statuses')
+    .where({ tenant: tenantId, status_type: 'ticket' })
+    .orderBy('order_number', 'asc')
+    .first();
+  if (existing?.status_id) return existing.status_id;
+
+  const [inserted] = await db('statuses')
+    .insert({
+      tenant: tenantId,
+      name: 'Open',
+      status_type: 'ticket',
+      order_number: 1,
+      created_by: actorUserId,
+      is_closed: false,
+      is_default: true,
+    })
+    .returning('status_id');
+  return inserted.status_id;
+}
+
+async function createTicket(db: Knex, params: { tenantId: string; actorUserId: string; clientId: string; contactId?: string | null }): Promise<string> {
+  const ticketId = uuidv4();
+  const statusId = await getTicketStatusId(db, params.tenantId, params.actorUserId);
+
+  await db('tickets').insert({
+    ticket_id: ticketId,
+    tenant: params.tenantId,
+    ticket_number: `WF-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+    title: 'Workflow Ticket',
+    status_id: statusId,
+    client_id: params.clientId,
+    entered_by: params.actorUserId,
+    contact_name_id: params.contactId ?? null,
+  });
+
+  return ticketId;
+}
+
+async function getDefaultInteractionStatusId(db: Knex, tenantId: string, actorUserId: string): Promise<string> {
+  const existing = await db('statuses').where({ tenant: tenantId, status_type: 'interaction', is_default: true }).first();
+  if (existing?.status_id) return existing.status_id;
+
+  const [created] = await db('statuses')
+    .insert({
+      tenant: tenantId,
+      name: 'Logged',
+      status_type: 'interaction',
+      order_number: 1,
+      created_by: actorUserId,
+      is_closed: false,
+      is_default: true,
+    })
+    .returning('status_id');
+
+  return created.status_id;
+}
+
+async function createInteractionStatus(db: Knex, tenantId: string, actorUserId: string, name: string): Promise<string> {
+  const [status] = await db('statuses')
+    .insert({
+      tenant: tenantId,
+      name,
+      status_type: 'interaction',
+      order_number: Math.floor(Math.random() * 1000) + 2,
+      created_by: actorUserId,
+      is_closed: false,
+      is_default: false,
+    })
+    .returning('status_id');
+  return status.status_id;
+}
+
+async function getAnyInteractionTypeId(db: Knex, tenantId: string): Promise<string> {
+  const tenantType = await db('interaction_types').where({ tenant: tenantId }).first();
+  if (tenantType?.type_id) return tenantType.type_id;
+
+  const systemType = await db('system_interaction_types').first();
+  if (!systemType?.type_id) {
+    throw new Error('Expected at least one system_interaction_types row in seeded DB');
+  }
+  return systemType.type_id;
+}
+
+async function createInteractionType(db: Knex, tenantId: string, name: string): Promise<string> {
+  const typeId = uuidv4();
+  await db('interaction_types').insert({
+    tenant: tenantId,
+    type_id: typeId,
+    type_name: name,
+    icon: 'phone',
+  });
+  return typeId;
+}
+
+async function createInteraction(
+  db: Knex,
+  params: {
+    tenantId: string;
+    actorUserId: string;
+    clientId: string;
+    contactId?: string | null;
+    ticketId?: string | null;
+    typeId: string;
+    statusId?: string | null;
+    title?: string;
+    notes?: string;
+    interactionDate?: string;
+  }
+): Promise<string> {
+  const interactionId = uuidv4();
+  const interactionDate = params.interactionDate ?? new Date().toISOString();
+
+  await db('interactions').insert({
+    tenant: params.tenantId,
+    interaction_id: interactionId,
+    type_id: params.typeId,
+    contact_name_id: params.contactId ?? null,
+    client_id: params.clientId,
+    ticket_id: params.ticketId ?? null,
+    user_id: params.actorUserId,
+    title: params.title ?? 'Interaction',
+    notes: params.notes ?? null,
+    interaction_date: interactionDate,
+    start_time: interactionDate,
+    end_time: interactionDate,
+    duration: 0,
+    status_id: params.statusId ?? null,
+    visibility: 'internal',
+    category: 'general',
+    tags: ['seed'],
+  });
+
+  return interactionId;
+}
+
+async function createQuote(
+  db: Knex,
+  params: {
+    tenantId: string;
+    actorUserId: string;
+    clientId: string;
+    contactId?: string | null;
+    title?: string;
+    status?: string;
+    isTemplate?: boolean;
+  }
+): Promise<string> {
+  const quoteId = uuidv4();
+  await db('quotes').insert({
+    tenant: params.tenantId,
+    quote_id: quoteId,
+    quote_number: `Q-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+    client_id: params.clientId,
+    contact_id: params.contactId ?? null,
+    title: params.title ?? 'Workflow Quote',
+    description: 'Quote description',
+    quote_date: new Date().toISOString(),
+    status: params.status ?? 'draft',
+    version: 1,
+    subtotal: 10000,
+    discount_total: 0,
+    tax: 0,
+    total_amount: 10000,
+    currency_code: 'USD',
+    is_template: params.isTemplate ?? false,
+    created_by: params.actorUserId,
+    updated_by: params.actorUserId,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  });
+
+  return quoteId;
+}
+
+const runtimeState = vi.hoisted(() => ({
+  db: null as Knex | null,
+  tenantId: '',
+  actorUserId: '',
+  deniedPermissions: new Set<string>(),
+}));
+
+vi.mock('../businessOperations/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../businessOperations/shared')>();
+
+  return {
+    ...actual,
+    withTenantTransaction: async (_ctx: any, fn: any) => {
+      if (!runtimeState.db) {
+        throw new Error('DB unavailable for test runtime state');
+      }
+
+      return runtimeState.db.transaction(async (trx) => {
+        await trx.raw('select set_config(\'app.current_tenant\', ?, true)', [runtimeState.tenantId]);
+        return fn({
+          tenantId: runtimeState.tenantId,
+          actorUserId: runtimeState.actorUserId,
+          trx,
+        });
+      });
+    },
+    requirePermission: async (ctx: any, _tx: any, permission: { resource: string; action: string }) => {
+      const key = `${permission.resource}:${permission.action}`;
+      if (!runtimeState.deniedPermissions.has(key)) return;
+      throw {
+        category: 'ActionError',
+        code: 'PERMISSION_DENIED',
+        message: `Missing permission ${key}`,
+        details: { permission: key },
+        nodePath: ctx?.stepPath ?? 'steps.crm-action',
+        at: new Date().toISOString(),
+      };
+    },
+  };
+});
+
+function getAction(actionId: string) {
+  const action = getActionRegistryV2().get(actionId, 1);
+  if (!action) throw new Error(`Missing action ${actionId}@1`);
+  return action;
+}
+
+function actionCtx(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    runId: uuidv4(),
+    stepPath: 'steps.crm-action',
+    idempotencyKey: uuidv4(),
+    attempt: 1,
+    nowIso: () => new Date().toISOString(),
+    env: {},
+    tenantId: runtimeState.tenantId,
+    ...overrides,
+  };
+}
+
+async function invokeAction(actionId: string, input: Record<string, unknown>, ctxOverrides: Record<string, unknown> = {}) {
+  const action = getAction(actionId);
+  const parsedInput = action.inputSchema.parse(input);
+  return action.handler(parsedInput, actionCtx(ctxOverrides) as any);
+}
+
+describe('crm workflow runtime DB-backed action handlers', () => {
+  let db: Knex;
+
+  beforeAll(async () => {
+    if (!getActionRegistryV2().get('crm.send_quote', 1)) {
+      registerCrmActions();
+    }
+
+    db = await createTestDbConnection();
+    runtimeState.db = db;
+  }, 180000);
+
+  beforeEach(async () => {
+    publishWorkflowEventMock.mockClear();
+
+    const tenantId = await createTenant(db, `Workflow CRM Runtime Test ${Date.now()}`);
+    const actorUserId = await createUser(db, tenantId, {
+      first_name: 'Workflow',
+      last_name: 'Actor',
+    });
+
+    runtimeState.tenantId = tenantId;
+    runtimeState.actorUserId = actorUserId;
+    runtimeState.deniedPermissions.clear();
+
+    registerWorkflowEmailProvider({
+      TenantEmailService: {
+        getInstance: () => ({
+          sendEmail: async () => ({ success: true, messageId: 'msg-test-1' }),
+        }),
+        getTenantEmailSettings: async () => ({ providerConfigs: [] }),
+      },
+      StaticTemplateProcessor: class {
+        subject: string;
+        html: string;
+        text?: string;
+
+        constructor(subject: string, html: string, text?: string) {
+          this.subject = subject;
+          this.html = html;
+          this.text = text;
+        }
+
+        async process() {
+          return { subject: this.subject, html: this.html, text: this.text };
+        }
+      } as any,
+      EmailProviderManager: class {
+        async initialize() {}
+        async getAvailableProviders() {
+          return [];
+        }
+        async sendEmail() {
+          return { success: true };
+        }
+      } as any,
+    });
+  });
+
+  afterAll(async () => {
+    resetWorkflowEmailProvider();
+    await db?.destroy();
+    runtimeState.db = null;
+  });
+
+  it('T004: crm.find_activities returns tenant-scoped filtered summaries and rejects unbounded searches', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Activity Client');
+    const contactId = await createContact(db, runtimeState.tenantId, clientId, 'Activity Contact');
+    const ticketId = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      contactId,
+    });
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const statusId = await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+
+    await createInteraction(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      contactId,
+      ticketId,
+      typeId,
+      statusId,
+      title: 'Keep me',
+      notes: 'Interaction details for preview behavior',
+    });
+
+    const otherTenant = await createTenant(db, 'Other CRM Tenant');
+    const otherUser = await createUser(db, otherTenant);
+    const otherClient = await createClient(db, otherTenant, 'Other Client');
+    const otherTypeId = await getAnyInteractionTypeId(db, otherTenant);
+    await createInteraction(db, {
+      tenantId: otherTenant,
+      actorUserId: otherUser,
+      clientId: otherClient,
+      typeId: otherTypeId,
+      title: 'Other tenant interaction',
+    });
+
+    const result = await invokeAction('crm.find_activities', {
+      client_id: clientId,
+      limit: 10,
+      on_empty: 'return_empty',
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.activities[0].client_id).toBe(clientId);
+    expect(result.activities[0].title).toBe('Keep me');
+    expect(result.activities[0].notes_preview).toContain('Interaction details');
+
+    await expect(
+      invokeAction('crm.find_activities', {
+        limit: 10,
+        on_empty: 'return_empty',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('T005/T006: crm.update_activity updates allowed fields, validates status/type ids, and writes audit', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Update Client');
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const statusId = await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+    const nextStatusId = await createInteractionStatus(db, runtimeState.tenantId, runtimeState.actorUserId, 'Follow-up Complete');
+    const nextTypeId = await createInteractionType(db, runtimeState.tenantId, 'QBR');
+
+    const activityId = await createInteraction(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      typeId,
+      statusId,
+      title: 'Original Title',
+      notes: 'Original notes',
+    });
+
+    const updated = await invokeAction('crm.update_activity', {
+      activity_id: activityId,
+      patch: {
+        title: 'Updated Title',
+        notes: 'Updated notes',
+        status_id: nextStatusId,
+        type_id: nextTypeId,
+        visibility: 'client_visible',
+        category: 'outcome',
+        tags: ['completed', 'followup'],
+      },
+      reason: 'workflow update test',
+    });
+
+    expect(updated.activity_before.title).toBe('Original Title');
+    expect(updated.activity_after.title).toBe('Updated Title');
+    expect(updated.activity_after.status_id).toBe(nextStatusId);
+    expect(updated.activity_after.type_id).toBe(nextTypeId);
+    expect(updated.changed_fields).toEqual(expect.arrayContaining(['title', 'notes', 'status_id', 'type_id', 'visibility', 'category', 'tags']));
+
+    const audit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.update_activity' })
+      .orderBy('timestamp', 'desc')
+      .first();
+
+    expect(audit).toBeTruthy();
+
+    const otherTenantId = await createTenant(db, `Other Tenant ${Date.now()}`);
+    const otherUserId = await createUser(db, otherTenantId);
+    const otherClientId = await createClient(db, otherTenantId, 'Other Client');
+    const otherTypeId = await getAnyInteractionTypeId(db, otherTenantId);
+    const otherActivityId = await createInteraction(db, {
+      tenantId: otherTenantId,
+      actorUserId: otherUserId,
+      clientId: otherClientId,
+      typeId: otherTypeId,
+    });
+
+    await expect(
+      invokeAction('crm.update_activity', {
+        activity_id: otherActivityId,
+        patch: { title: 'Should fail' },
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(
+      invokeAction('crm.update_activity', {
+        activity_id: activityId,
+        patch: {},
+      })
+    ).rejects.toThrow();
+
+    await expect(
+      invokeAction('crm.update_activity', {
+        activity_id: activityId,
+        patch: { status_id: uuidv4() },
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      invokeAction('crm.update_activity', {
+        activity_id: activityId,
+        patch: { type_id: uuidv4() },
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('T007/T008/T009: crm.schedule_activity validates context, creates follow-up, audits, and publishes INTERACTION_LOGGED', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Schedule Client');
+    const contactId = await createContact(db, runtimeState.tenantId, clientId, 'Schedule Contact');
+    const ticketId = await createTicket(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      contactId,
+    });
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    await getDefaultInteractionStatusId(db, runtimeState.tenantId, runtimeState.actorUserId);
+
+    const now = new Date();
+    const startTime = new Date(now.getTime() + 60 * 60 * 1000).toISOString();
+    const endTime = new Date(now.getTime() + 2 * 60 * 60 * 1000).toISOString();
+
+    const scheduled = await invokeAction('crm.schedule_activity', {
+      contact_id: contactId,
+      ticket_id: ticketId,
+      type_id: typeId,
+      title: 'Schedule follow-up call',
+      notes: 'Discuss deployment',
+      start_time: startTime,
+      end_time: endTime,
+      visibility: 'internal',
+      category: 'follow-up',
+      tags: ['qbr'],
+    });
+
+    expect(scheduled.activity.client_id).toBe(clientId);
+    expect(scheduled.activity.contact_id).toBe(contactId);
+    expect(scheduled.activity.ticket_id).toBe(ticketId);
+    expect(scheduled.activity.duration).toBe(60);
+
+    const stored = await db('interactions')
+      .where({ tenant: runtimeState.tenantId, interaction_id: scheduled.activity.activity_id })
+      .first();
+
+    expect(stored).toBeTruthy();
+
+    const audit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.schedule_activity' })
+      .orderBy('timestamp', 'desc')
+      .first();
+
+    expect(audit).toBeTruthy();
+    expect(publishWorkflowEventMock).toHaveBeenCalledTimes(1);
+    expect(publishWorkflowEventMock.mock.calls[0]?.[0]).toMatchObject({
+      eventType: 'INTERACTION_LOGGED',
+      idempotencyKey: `interaction_logged:${scheduled.activity.activity_id}`,
+    });
+
+    await expect(
+      invokeAction('crm.schedule_activity', {
+        type_id: typeId,
+        title: 'Missing context',
+        start_time: startTime,
+      })
+    ).rejects.toThrow();
+
+    const otherClientId = await createClient(db, runtimeState.tenantId, 'Other Client');
+    const wrongContactId = await createContact(db, runtimeState.tenantId, otherClientId, 'Wrong Contact');
+
+    await expect(
+      invokeAction('crm.schedule_activity', {
+        client_id: clientId,
+        contact_id: wrongContactId,
+        type_id: typeId,
+        title: 'Mismatched contact',
+        start_time: startTime,
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      invokeAction('crm.schedule_activity', {
+        client_id: clientId,
+        ticket_id: ticketId,
+        type_id: uuidv4(),
+        title: 'Invalid type',
+        start_time: startTime,
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      invokeAction('crm.schedule_activity', {
+        client_id: clientId,
+        type_id: typeId,
+        status_id: uuidv4(),
+        title: 'Invalid status',
+        start_time: startTime,
+      })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await expect(
+      invokeAction('crm.schedule_activity', {
+        client_id: clientId,
+        type_id: typeId,
+        title: 'Invalid window',
+        start_time: endTime,
+        end_time: startTime,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('T010/T011: crm.send_quote sends eligible quotes, writes activity/audit, and rejects ineligible cases', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Quote Client');
+    const contactId = await createContact(db, runtimeState.tenantId, clientId, 'Quote Contact');
+
+    const quoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      contactId,
+      status: 'draft',
+      isTemplate: false,
+    });
+
+    const sent = await invokeAction('crm.send_quote', {
+      quote_id: quoteId,
+      email_addresses: ['custom@example.com'],
+      subject: 'Workflow quote send',
+      message: 'Please review this quote',
+      no_op_if_already_sent: true,
+    });
+
+    expect(sent.previous_status).toBe('draft');
+    expect(sent.new_status).toBe('sent');
+    expect(sent.email_sent).toBe(true);
+    expect(sent.recipients).toEqual(expect.arrayContaining(['custom@example.com']));
+    expect(sent.message_id).toBe('msg-test-1');
+
+    const updated = await db('quotes').where({ tenant: runtimeState.tenantId, quote_id: quoteId }).first();
+    expect(updated.status).toBe('sent');
+    expect(updated.sent_at).toBeTruthy();
+
+    const sentActivity = await db('quote_activities')
+      .where({ tenant: runtimeState.tenantId, quote_id: quoteId, activity_type: 'sent' })
+      .first();
+    expect(sentActivity).toBeTruthy();
+
+    const sendAudit = await db('audit_logs')
+      .where({ tenant: runtimeState.tenantId, operation: 'workflow_action:crm.send_quote' })
+      .orderBy('timestamp', 'desc')
+      .first();
+
+    expect(sendAudit).toBeTruthy();
+
+    const templateQuoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: 'draft',
+      isTemplate: true,
+    });
+
+    await expect(
+      invokeAction('crm.send_quote', { quote_id: templateQuoteId })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const rejectedQuoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: 'rejected',
+      isTemplate: false,
+    });
+
+    await expect(
+      invokeAction('crm.send_quote', { quote_id: rejectedQuoteId })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    await db('tenant_settings')
+      .insert({
+        tenant: runtimeState.tenantId,
+        settings: JSON.stringify({ billing: { quotes: { approvalRequired: true } } }),
+      })
+      .onConflict('tenant')
+      .merge({ settings: JSON.stringify({ billing: { quotes: { approvalRequired: true } } }) });
+
+    const pendingQuoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: 'draft',
+      isTemplate: false,
+    });
+
+    await expect(
+      invokeAction('crm.send_quote', { quote_id: pendingQuoteId })
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+    const otherTenantId = await createTenant(db, 'Other Quote Tenant');
+    const otherUser = await createUser(db, otherTenantId);
+    const otherClient = await createClient(db, otherTenantId, 'Other Quote Client');
+    const otherQuoteId = await createQuote(db, {
+      tenantId: otherTenantId,
+      actorUserId: otherUser,
+      clientId: otherClient,
+      status: 'draft',
+    });
+
+    await expect(
+      invokeAction('crm.send_quote', { quote_id: otherQuoteId })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('T012: CRM read/mutation/send actions return PERMISSION_DENIED based on mapped permissions', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Permission Client');
+    const typeId = await getAnyInteractionTypeId(db, runtimeState.tenantId);
+    const quoteId = await createQuote(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      status: 'draft',
+    });
+
+    const activityId = await createInteraction(db, {
+      tenantId: runtimeState.tenantId,
+      actorUserId: runtimeState.actorUserId,
+      clientId,
+      typeId,
+    });
+
+    const checks: Array<{ actionId: string; denied: string; input: Record<string, unknown> }> = [
+      {
+        actionId: 'crm.find_activities',
+        denied: 'client:read',
+        input: { client_id: clientId, on_empty: 'return_empty' },
+      },
+      {
+        actionId: 'crm.update_activity',
+        denied: 'client:update',
+        input: { activity_id: activityId, patch: { title: 'Denied' } },
+      },
+      {
+        actionId: 'crm.schedule_activity',
+        denied: 'client:update',
+        input: { client_id: clientId, type_id: typeId, title: 'Denied', start_time: new Date().toISOString() },
+      },
+      {
+        actionId: 'crm.send_quote',
+        denied: 'billing:update',
+        input: { quote_id: quoteId },
+      },
+      {
+        actionId: 'crm.send_quote',
+        denied: 'billing:read',
+        input: { quote_id: quoteId },
+      },
+    ];
+
+    for (const check of checks) {
+      runtimeState.deniedPermissions.clear();
+      runtimeState.deniedPermissions.add(check.denied);
+      await expect(invokeAction(check.actionId, check.input)).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    }
+
+    runtimeState.deniedPermissions.clear();
+  });
+
+  it('T014: crm.create_activity_note remains functional after CRM action expansion', async () => {
+    const clientId = await createClient(db, runtimeState.tenantId, 'Legacy Note Client');
+
+    const note = await invokeAction('crm.create_activity_note', {
+      target: {
+        type: 'client',
+        id: clientId,
+      },
+      body: 'Legacy note preserved',
+      visibility: 'internal',
+      category: 'note',
+      tags: ['legacy'],
+    });
+
+    expect(note.note_id).toBeTruthy();
+
+    const stored = await db('interactions')
+      .where({ tenant: runtimeState.tenantId, interaction_id: note.note_id })
+      .first();
+
+    expect(stored).toBeTruthy();
+    expect(stored.client_id).toBe(clientId);
+    expect(stored.notes).toBe('Legacy note preserved');
+  });
+});

--- a/shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { zodToWorkflowJsonSchema } from '../../jsonSchemaMetadata';
+import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { registerCrmActions } from '../businessOperations/crm';
+
+const EXPECTED_CRM_ACTION_IDS = [
+  'crm.create_activity_note',
+  'crm.find_activities',
+  'crm.update_activity',
+  'crm.schedule_activity',
+  'crm.send_quote',
+] as const;
+
+describe('crm workflow action registration metadata', () => {
+  beforeAll(() => {
+    const registry = getActionRegistryV2();
+    if (!registry.get('crm.send_quote', 1)) {
+      registerCrmActions();
+    }
+  });
+
+  it('T001: registers new crm.* actions at version 1 while preserving crm.create_activity_note', () => {
+    const registry = getActionRegistryV2();
+
+    const actions = EXPECTED_CRM_ACTION_IDS.map((id) => {
+      const action = registry.get(id, 1);
+      expect(action, `${id}@1 should be registered`).toBeDefined();
+      return action!;
+    });
+
+    const byId = new Map(actions.map((action) => [action.id, action]));
+
+    expect(byId.get('crm.create_activity_note')?.ui?.label).toBe('Create Activity Note');
+    expect(byId.get('crm.find_activities')?.ui?.label).toBe('Find CRM Activities');
+    expect(byId.get('crm.update_activity')?.ui?.label).toBe('Update CRM Activity');
+    expect(byId.get('crm.schedule_activity')?.ui?.label).toBe('Schedule CRM Activity');
+    expect(byId.get('crm.send_quote')?.ui?.label).toBe('Send Quote');
+
+    expect(byId.get('crm.find_activities')?.sideEffectful).toBe(false);
+    expect(byId.get('crm.update_activity')?.sideEffectful).toBe(true);
+    expect(byId.get('crm.schedule_activity')?.sideEffectful).toBe(true);
+    expect(byId.get('crm.send_quote')?.sideEffectful).toBe(true);
+
+    expect(byId.get('crm.find_activities')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('crm.update_activity')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('crm.schedule_activity')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('crm.send_quote')?.idempotency.mode).toBe('engineProvided');
+  });
+
+  it('T003: crm action schemas expose picker metadata for supported uuid fields only', () => {
+    const registry = getActionRegistryV2();
+
+    const findActivities = registry.get('crm.find_activities', 1);
+    const scheduleActivity = registry.get('crm.schedule_activity', 1);
+
+    expect(findActivities).toBeDefined();
+    expect(scheduleActivity).toBeDefined();
+
+    if (!findActivities || !scheduleActivity) {
+      throw new Error('Missing expected CRM workflow actions');
+    }
+
+    const findSchema = zodToWorkflowJsonSchema(findActivities.inputSchema);
+    const scheduleSchema = zodToWorkflowJsonSchema(scheduleActivity.inputSchema);
+
+    const findProps = findSchema.properties as Record<string, Record<string, unknown>>;
+    const scheduleProps = scheduleSchema.properties as Record<string, Record<string, unknown>>;
+
+    expect(findProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(findProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(findProps.contact_id?.['x-workflow-picker-dependencies']).toEqual(['client_id']);
+    expect(findProps.ticket_id?.['x-workflow-picker-kind']).toBe('ticket');
+    expect(findProps.user_id?.['x-workflow-picker-kind']).toBe('user');
+
+    expect(scheduleProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(scheduleProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(scheduleProps.contact_id?.['x-workflow-picker-dependencies']).toEqual(['client_id']);
+    expect(scheduleProps.ticket_id?.['x-workflow-picker-kind']).toBe('ticket');
+    expect(scheduleProps.assigned_user_id?.['x-workflow-picker-kind']).toBe('user');
+    expect(scheduleProps.owner_user_id?.['x-workflow-picker-kind']).toBe('user');
+
+    expect(scheduleProps.type_id?.['x-workflow-picker-kind']).toBeUndefined();
+    expect(scheduleProps.status_id?.['x-workflow-picker-kind']).toBeUndefined();
+  });
+});

--- a/shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts
+++ b/shared/workflow/runtime/actions/__tests__/registerCrmActionsMetadata.test.ts
@@ -10,17 +10,26 @@ const EXPECTED_CRM_ACTION_IDS = [
   'crm.update_activity',
   'crm.schedule_activity',
   'crm.send_quote',
+  'crm.create_interaction_type',
+  'crm.update_activity_status',
+  'crm.create_quote',
+  'crm.add_quote_item',
+  'crm.create_quote_from_template',
+  'crm.find_quotes',
+  'crm.submit_quote_for_approval',
+  'crm.convert_quote',
+  'crm.tag_activity',
 ] as const;
 
 describe('crm workflow action registration metadata', () => {
   beforeAll(() => {
     const registry = getActionRegistryV2();
-    if (!registry.get('crm.send_quote', 1)) {
+    if (!registry.get('crm.tag_activity', 1)) {
       registerCrmActions();
     }
   });
 
-  it('T001: registers new crm.* actions at version 1 while preserving crm.create_activity_note', () => {
+  it('T001: registers follow-up crm.* actions at version 1 while preserving first-pass actions', () => {
     const registry = getActionRegistryV2();
 
     const actions = EXPECTED_CRM_ACTION_IDS.map((id) => {
@@ -37,35 +46,52 @@ describe('crm workflow action registration metadata', () => {
     expect(byId.get('crm.schedule_activity')?.ui?.label).toBe('Schedule CRM Activity');
     expect(byId.get('crm.send_quote')?.ui?.label).toBe('Send Quote');
 
-    expect(byId.get('crm.find_activities')?.sideEffectful).toBe(false);
-    expect(byId.get('crm.update_activity')?.sideEffectful).toBe(true);
-    expect(byId.get('crm.schedule_activity')?.sideEffectful).toBe(true);
-    expect(byId.get('crm.send_quote')?.sideEffectful).toBe(true);
+    expect(byId.get('crm.create_interaction_type')?.ui?.label).toBe('Create Activity Type');
+    expect(byId.get('crm.update_activity_status')?.ui?.label).toBe('Update Activity Status');
+    expect(byId.get('crm.create_quote')?.ui?.label).toBe('Create Quote');
+    expect(byId.get('crm.add_quote_item')?.ui?.label).toBe('Add Quote Item');
+    expect(byId.get('crm.create_quote_from_template')?.ui?.label).toBe('Create Quote from Template');
+    expect(byId.get('crm.find_quotes')?.ui?.label).toBe('Find Quotes');
+    expect(byId.get('crm.submit_quote_for_approval')?.ui?.label).toBe('Submit Quote for Approval');
+    expect(byId.get('crm.convert_quote')?.ui?.label).toBe('Convert Quote');
+    expect(byId.get('crm.tag_activity')?.ui?.label).toBe('Tag CRM Activity');
 
-    expect(byId.get('crm.find_activities')?.idempotency.mode).toBe('engineProvided');
-    expect(byId.get('crm.update_activity')?.idempotency.mode).toBe('engineProvided');
-    expect(byId.get('crm.schedule_activity')?.idempotency.mode).toBe('actionProvided');
-    expect(byId.get('crm.send_quote')?.idempotency.mode).toBe('engineProvided');
+    expect(byId.get('crm.find_activities')?.sideEffectful).toBe(false);
+    expect(byId.get('crm.find_quotes')?.sideEffectful).toBe(false);
+    expect(byId.get('crm.create_quote')?.sideEffectful).toBe(true);
+
+    expect(byId.get('crm.create_interaction_type')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('crm.add_quote_item')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('crm.create_quote_from_template')?.idempotency.mode).toBe('actionProvided');
+    expect(byId.get('crm.find_quotes')?.idempotency.mode).toBe('engineProvided');
   });
 
-  it('T003: crm action schemas expose picker metadata for supported uuid fields only', () => {
+  it('T002: follow-up crm action schemas expose picker metadata for supported uuid fields only', () => {
     const registry = getActionRegistryV2();
 
     const findActivities = registry.get('crm.find_activities', 1);
     const scheduleActivity = registry.get('crm.schedule_activity', 1);
+    const createQuote = registry.get('crm.create_quote', 1);
+    const createQuoteFromTemplate = registry.get('crm.create_quote_from_template', 1);
 
     expect(findActivities).toBeDefined();
     expect(scheduleActivity).toBeDefined();
+    expect(createQuote).toBeDefined();
+    expect(createQuoteFromTemplate).toBeDefined();
 
-    if (!findActivities || !scheduleActivity) {
+    if (!findActivities || !scheduleActivity || !createQuote || !createQuoteFromTemplate) {
       throw new Error('Missing expected CRM workflow actions');
     }
 
     const findSchema = zodToWorkflowJsonSchema(findActivities.inputSchema);
     const scheduleSchema = zodToWorkflowJsonSchema(scheduleActivity.inputSchema);
+    const createQuoteSchema = zodToWorkflowJsonSchema(createQuote.inputSchema);
+    const createQuoteFromTemplateSchema = zodToWorkflowJsonSchema(createQuoteFromTemplate.inputSchema);
 
     const findProps = findSchema.properties as Record<string, Record<string, unknown>>;
     const scheduleProps = scheduleSchema.properties as Record<string, Record<string, unknown>>;
+    const createQuoteProps = createQuoteSchema.properties as Record<string, Record<string, unknown>>;
+    const createQuoteFromTemplateProps = createQuoteFromTemplateSchema.properties as Record<string, Record<string, unknown>>;
 
     expect(findProps.client_id?.['x-workflow-picker-kind']).toBe('client');
     expect(findProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
@@ -80,6 +106,15 @@ describe('crm workflow action registration metadata', () => {
     expect(scheduleProps.assigned_user_id?.['x-workflow-picker-kind']).toBe('user');
     expect(scheduleProps.owner_user_id?.['x-workflow-picker-kind']).toBe('user');
 
+    expect(createQuoteProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(createQuoteProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(createQuoteProps.contact_id?.['x-workflow-picker-dependencies']).toEqual(['client_id']);
+
+    expect(createQuoteFromTemplateProps.client_id?.['x-workflow-picker-kind']).toBe('client');
+    expect(createQuoteFromTemplateProps.contact_id?.['x-workflow-picker-kind']).toBe('contact');
+    expect(createQuoteFromTemplateProps.contact_id?.['x-workflow-picker-dependencies']).toEqual(['client_id']);
+
+    expect(createQuoteProps.quote_id?.['x-workflow-picker-kind']).toBeUndefined();
     expect(scheduleProps.type_id?.['x-workflow-picker-kind']).toBeUndefined();
     expect(scheduleProps.status_id?.['x-workflow-picker-kind']).toBeUndefined();
   });

--- a/shared/workflow/runtime/actions/businessOperations/crm.ts
+++ b/shared/workflow/runtime/actions/businessOperations/crm.ts
@@ -4,8 +4,18 @@ import type { Knex } from 'knex';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
 import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
 import { getWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
+import Quote from '../../../../../packages/billing/src/models/quote';
+import QuoteItem from '../../../../../packages/billing/src/models/quoteItem';
 import QuoteActivity from '../../../../../packages/billing/src/models/quoteActivity';
 import { getQuoteApprovalWorkflowSettings } from '../../../../../packages/billing/src/lib/quoteApprovalSettings';
+import { createQuoteItemSchema, createQuoteSchema, quoteStatusSchema } from '../../../../../packages/billing/src/schemas/quoteSchemas';
+import {
+  convertQuoteToDraftContract,
+  convertQuoteToDraftContractAndInvoice,
+  convertQuoteToDraftInvoice,
+} from '../../../../../packages/billing/src/services/quoteConversionService';
+import TagDefinition from '../../../../../packages/tags/src/models/tagDefinition';
+import TagMapping from '../../../../../packages/tags/src/models/tagMapping';
 import {
   uuidSchema,
   isoDateTimeSchema,
@@ -18,6 +28,15 @@ import {
   type TenantTxContext,
 } from './shared';
 import { buildInteractionLoggedPayload } from '../../../streams/domainEventBuilders/crmInteractionNoteEventBuilders';
+import { buildTagAppliedPayload, buildTagDefinitionCreatedPayload } from '../../../streams/domainEventBuilders/tagEventBuilders';
+import {
+  BuiltinAuthorizationKernelProvider,
+  BundleAuthorizationKernelProvider,
+  RequestLocalAuthorizationCache,
+  createAuthorizationKernel,
+  type AuthorizationSubject,
+} from '@alga-psa/authorization/kernel';
+import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
 
 const WORKFLOW_PICKER_HINTS = {
   client: 'Search clients',
@@ -190,6 +209,211 @@ const sendQuoteInputSchema = z.object({
   subject: z.string().optional(),
   message: z.string().optional(),
   no_op_if_already_sent: z.boolean().default(true),
+});
+
+const createInteractionTypeInputSchema = z.object({
+  type_name: z.string().trim().min(1).max(120),
+  icon: z.string().trim().max(120).optional(),
+  display_order: z.number().int().nonnegative().optional(),
+  if_exists: z.enum(['return_existing', 'error']).default('return_existing'),
+  idempotency_key: z.string().optional(),
+});
+
+const interactionTypeSummarySchema = z.object({
+  type_id: uuidSchema,
+  type_name: z.string(),
+  icon: z.string().nullable(),
+  display_order: z.number().int().nullable(),
+  created_by: nullableUuidSchema,
+  created: z.boolean(),
+});
+
+const updateActivityStatusInputSchema = z
+  .object({
+    activity_id: uuidSchema,
+    status_id: uuidSchema.optional(),
+    status_name: z.string().trim().min(1).max(255).optional(),
+    reason: z.string().optional(),
+    no_op_if_already_status: z.boolean().default(true),
+  })
+  .superRefine((value, refinementCtx) => {
+    if (!value.status_id && !value.status_name) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Either status_id or status_name is required',
+      });
+    }
+    if (value.status_id && value.status_name) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide either status_id or status_name, not both',
+      });
+    }
+  });
+
+const createQuoteInputSchema = z.object({
+  client_id: withWorkflowPicker(uuidSchema, 'Client id', 'client'),
+  contact_id: withWorkflowPicker(uuidSchema.optional(), 'Optional contact id linked to client', 'contact', ['client_id']),
+  title: z.string().trim().min(1),
+  description: z.string().optional().nullable(),
+  quote_date: z.coerce.date(),
+  valid_until: z.coerce.date(),
+  po_number: z.string().trim().max(255).optional().nullable(),
+  internal_notes: z.string().optional().nullable(),
+  client_notes: z.string().optional().nullable(),
+  terms_and_conditions: z.string().optional().nullable(),
+  currency_code: z.string().trim().length(3).default('USD'),
+  idempotency_key: z.string().optional(),
+}).superRefine((value, refinementCtx) => {
+  if (value.valid_until.getTime() < value.quote_date.getTime()) {
+    refinementCtx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'valid_until must be on or after quote_date',
+      path: ['valid_until'],
+    });
+  }
+});
+
+const addQuoteItemInputSchema = z.object({
+  quote_id: uuidSchema,
+  description: z.string().trim().min(1),
+  quantity: z.number().int().positive(),
+  unit_price: z.number().int().min(0).optional(),
+  unit_of_measure: z.string().trim().optional().nullable(),
+  display_order: z.number().int().nonnegative().optional(),
+  phase: z.string().trim().optional().nullable(),
+  is_optional: z.boolean().default(false),
+  is_selected: z.boolean().default(true),
+  is_recurring: z.boolean().default(false),
+  billing_frequency: z.string().trim().optional().nullable(),
+  billing_method: z.enum(['fixed', 'hourly', 'usage']).optional().nullable(),
+  is_discount: z.boolean().default(false),
+  discount_type: z.enum(['percentage', 'fixed']).optional().nullable(),
+  discount_percentage: z.number().int().min(0).max(100).optional().nullable(),
+  applies_to_item_id: uuidSchema.optional().nullable(),
+  applies_to_service_id: uuidSchema.optional().nullable(),
+  is_taxable: z.boolean().default(true),
+  tax_region: z.string().trim().optional().nullable(),
+  tax_rate: z.number().int().min(0).optional().nullable(),
+  location_id: uuidSchema.optional().nullable(),
+  cost: z.number().int().min(0).optional().nullable(),
+  cost_currency: z.string().trim().length(3).optional().nullable(),
+  idempotency_key: z.string().optional(),
+});
+
+const createQuoteFromTemplateInputSchema = z.object({
+  template_id: uuidSchema,
+  client_id: withWorkflowPicker(uuidSchema, 'Client id', 'client'),
+  contact_id: withWorkflowPicker(uuidSchema.optional(), 'Optional contact id linked to client', 'contact', ['client_id']),
+  title: z.string().trim().min(1).optional(),
+  quote_date: z.coerce.date().optional(),
+  valid_until: z.coerce.date().optional(),
+  po_number: z.string().trim().max(255).optional().nullable(),
+  internal_notes: z.string().optional().nullable(),
+  client_notes: z.string().optional().nullable(),
+  currency_code: z.string().trim().length(3).optional(),
+  idempotency_key: z.string().optional(),
+});
+
+const findQuotesInputSchema = z
+  .object({
+    quote_id: uuidSchema.optional(),
+    quote_number: z.string().trim().min(1).max(120).optional(),
+    client_id: withWorkflowPicker(uuidSchema.optional(), 'Optional client id filter', 'client'),
+    status: quoteStatusSchema.optional(),
+    date_from: z.coerce.date().optional(),
+    date_to: z.coerce.date().optional(),
+    is_template: z.boolean().default(false),
+    page: z.number().int().positive().default(1),
+    pageSize: z.number().int().positive().max(200).default(25),
+    sortBy: z.enum(['quote_date', 'total_amount', 'status', 'created_at']).default('quote_date'),
+    sortOrder: z.enum(['asc', 'desc']).default('desc'),
+    on_empty: onEmptySchema.default('return_empty'),
+  })
+  .superRefine((value, refinementCtx) => {
+    if (value.date_from && value.date_to && value.date_from.getTime() > value.date_to.getTime()) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'date_from must be less than or equal to date_to',
+      });
+      return;
+    }
+
+    const hasFilter = Boolean(
+      value.quote_id ||
+      value.quote_number ||
+      value.client_id ||
+      value.status ||
+      value.date_from ||
+      value.date_to
+    );
+    const hasBoundedDateRange = Boolean(value.date_from && value.date_to);
+    const smallPage = value.pageSize <= 25;
+
+    if (!hasFilter && !hasBoundedDateRange && !smallPage) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide at least one filter, a bounded date range, or use pageSize <= 25',
+      });
+    }
+  });
+
+const submitQuoteForApprovalInputSchema = z.object({
+  quote_id: uuidSchema,
+  comment: z.string().optional(),
+  reason: z.string().optional(),
+  no_op_if_already_pending: z.boolean().default(true),
+});
+
+const convertQuoteInputSchema = z.object({
+  quote_id: uuidSchema,
+  target: z.enum(['contract', 'invoice', 'contract_and_invoice']),
+  no_op_if_already_converted: z.boolean().default(true),
+});
+
+const tagActivityInputSchema = z.object({
+  activity_id: uuidSchema,
+  tags: z.array(z.string().trim().min(1)).min(1),
+  if_exists: z.enum(['no_op', 'error']).default('no_op'),
+  idempotency_key: z.string().optional(),
+});
+
+const quoteDetailSummarySchema = z.object({
+  quote_id: uuidSchema,
+  quote_number: z.string().nullable(),
+  status: z.string().nullable(),
+  client_id: nullableUuidSchema,
+  contact_id: nullableUuidSchema,
+  title: z.string(),
+  quote_date: isoDateTimeSchema.nullable(),
+  valid_until: isoDateTimeSchema.nullable(),
+  currency_code: z.string().nullable(),
+  subtotal: z.number().nullable(),
+  discount_total: z.number().nullable(),
+  tax: z.number().nullable(),
+  total_amount: z.number().nullable(),
+  sent_at: isoDateTimeSchema.nullable(),
+  converted_contract_id: nullableUuidSchema,
+  converted_invoice_id: nullableUuidSchema,
+  is_template: z.boolean(),
+});
+
+const quoteItemSummarySchema = z.object({
+  quote_item_id: uuidSchema,
+  quote_id: uuidSchema,
+  description: z.string(),
+  quantity: z.number().int(),
+  unit_price: z.number(),
+  total_price: z.number(),
+  display_order: z.number().int(),
+  is_optional: z.boolean(),
+  is_selected: z.boolean(),
+  is_recurring: z.boolean(),
+  is_discount: z.boolean(),
+  billing_frequency: z.string().nullable(),
+  discount_type: z.string().nullable(),
+  discount_percentage: z.number().nullable(),
+  created_at: isoDateTimeSchema.nullable(),
 });
 
 function asIsoString(value: unknown): string | null {
@@ -648,8 +872,1269 @@ function toQuoteSummary(quote: Record<string, unknown>) {
   });
 }
 
+function toQuoteDetailSummary(quote: Record<string, unknown>) {
+  return quoteDetailSummarySchema.parse({
+    quote_id: quote.quote_id,
+    quote_number: quote.quote_number == null ? null : String(quote.quote_number),
+    status: quote.status == null ? null : String(quote.status),
+    client_id: quote.client_id ?? null,
+    contact_id: quote.contact_id ?? null,
+    title: String(quote.title ?? ''),
+    quote_date: asIsoString(quote.quote_date),
+    valid_until: asIsoString(quote.valid_until),
+    currency_code: quote.currency_code == null ? null : String(quote.currency_code),
+    subtotal: quote.subtotal == null ? null : Number(quote.subtotal),
+    discount_total: quote.discount_total == null ? null : Number(quote.discount_total),
+    tax: quote.tax == null ? null : Number(quote.tax),
+    total_amount: quote.total_amount == null ? null : Number(quote.total_amount),
+    sent_at: asIsoString(quote.sent_at),
+    converted_contract_id: quote.converted_contract_id ?? null,
+    converted_invoice_id: quote.converted_invoice_id ?? null,
+    is_template: Boolean(quote.is_template),
+  });
+}
+
+function toQuoteItemSummary(item: Record<string, unknown>) {
+  return quoteItemSummarySchema.parse({
+    quote_item_id: item.quote_item_id,
+    quote_id: item.quote_id,
+    description: String(item.description ?? ''),
+    quantity: Number(item.quantity ?? 0),
+    unit_price: Number(item.unit_price ?? 0),
+    total_price: Number(item.total_price ?? 0),
+    display_order: Number(item.display_order ?? 0),
+    is_optional: Boolean(item.is_optional),
+    is_selected: Boolean(item.is_selected),
+    is_recurring: Boolean(item.is_recurring),
+    is_discount: Boolean(item.is_discount),
+    billing_frequency: item.billing_frequency == null ? null : String(item.billing_frequency),
+    discount_type: item.discount_type == null ? null : String(item.discount_type),
+    discount_percentage: item.discount_percentage == null ? null : Number(item.discount_percentage),
+    created_at: asIsoString(item.created_at),
+  });
+}
+
+function normalizeInteractionTypeName(typeName: string): string {
+  return typeName.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function normalizeQuoteDates<T extends Record<string, unknown>>(value: T): T {
+  const normalized = { ...value };
+  for (const field of ['quote_date', 'valid_until'] as const) {
+    if (normalized[field] instanceof Date) {
+      normalized[field] = (normalized[field] as Date).toISOString();
+    }
+  }
+  return normalized;
+}
+
+async function ensureQuoteContactBelongsToClient(
+  ctx: any,
+  tx: TenantTxContext,
+  clientId: string,
+  contactId: string | undefined
+): Promise<void> {
+  if (!contactId) return;
+
+  const contact = await tx.trx('contacts')
+    .where({ tenant: tx.tenantId, contact_name_id: contactId })
+    .first();
+
+  if (!contact) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Contact not found',
+      details: { contact_id: contactId },
+    });
+  }
+
+  if (contact.client_id !== clientId) {
+    throwActionError(ctx, {
+      category: 'ValidationError',
+      code: 'VALIDATION_ERROR',
+      message: 'contact_id must belong to client_id',
+      details: { contact_id: contactId, client_id: clientId },
+    });
+  }
+}
+
+type QuoteAuthorizationRecord = {
+  quote_id: string | null;
+  client_id: string | null;
+  created_by: string | null;
+};
+
+function createQuoteAuthorizationKernel(knexOrTrx: Knex | Knex.Transaction) {
+  return createAuthorizationKernel({
+    builtinProvider: new BuiltinAuthorizationKernelProvider({ mutationGuards: [] }),
+    bundleProvider: new BundleAuthorizationKernelProvider({
+      resolveRules: async (input) => {
+        try {
+          return await resolveBundleNarrowingRulesForEvaluation(knexOrTrx, input);
+        } catch {
+          return [];
+        }
+      },
+    }),
+    rbacEvaluator: async () => true,
+  });
+}
+
+async function resolveQuoteAuthorizationSubject(
+  trx: Knex.Transaction,
+  tenantId: string,
+  actorUserId: string
+): Promise<AuthorizationSubject> {
+  const [roleRows, teamRows, managedRows, userRow] = await Promise.all([
+    trx('user_roles').where({ tenant: tenantId, user_id: actorUserId }).select<{ role_id: string }[]>('role_id').catch(() => []),
+    trx('team_members').where({ tenant: tenantId, user_id: actorUserId }).select<{ team_id: string }[]>('team_id').catch(() => []),
+    trx('users').where({ tenant: tenantId, reports_to: actorUserId }).select<{ user_id: string }[]>('user_id').catch(() => []),
+    trx('users')
+      .where({ tenant: tenantId, user_id: actorUserId })
+      .select<{ user_type?: string | null; contact_id?: string | null; client_id?: string | null }>('user_type', 'contact_id', 'client_id')
+      .first()
+      .catch(() => null),
+  ]);
+
+  const clientId = userRow?.client_id ?? null;
+  return {
+    tenant: tenantId,
+    userId: actorUserId,
+    userType: userRow?.user_type === 'client' ? 'client' : 'internal',
+    roleIds: roleRows.map((row) => row.role_id),
+    teamIds: teamRows.map((row) => row.team_id),
+    managedUserIds: managedRows.map((row) => row.user_id),
+    clientId,
+    portfolioClientIds: clientId ? [clientId] : [],
+  };
+}
+
+function toQuoteAuthorizationRecord(quote: Record<string, unknown>): QuoteAuthorizationRecord {
+  return {
+    quote_id: quote.quote_id == null ? null : String(quote.quote_id),
+    client_id: quote.client_id == null ? null : String(quote.client_id),
+    created_by: quote.created_by == null ? null : String(quote.created_by),
+  };
+}
+
+async function authorizeQuoteRead(
+  trx: Knex.Transaction,
+  tenantId: string,
+  actorUserId: string,
+  quote: Record<string, unknown>
+): Promise<boolean> {
+  const subject = await resolveQuoteAuthorizationSubject(trx, tenantId, actorUserId);
+  const kernel = createQuoteAuthorizationKernel(trx);
+  const decision = await kernel.authorizeResource({
+    subject,
+    resource: {
+      type: 'billing',
+      action: 'read',
+      id: quote.quote_id == null ? null : String(quote.quote_id),
+    },
+    record: {
+      id: toQuoteAuthorizationRecord(quote).quote_id,
+      ownerUserId: toQuoteAuthorizationRecord(quote).created_by,
+      clientId: toQuoteAuthorizationRecord(quote).client_id,
+    },
+    requestCache: new RequestLocalAuthorizationCache(),
+    knex: trx,
+  });
+  return decision.allowed;
+}
+
+async function getAuthorizedQuoteForMutation(
+  ctx: any,
+  tx: TenantTxContext,
+  quoteId: string,
+  deniedMessage: string
+): Promise<Record<string, unknown>> {
+  const quote = await tx.trx('quotes').where({ tenant: tx.tenantId, quote_id: quoteId }).first();
+  if (!quote) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Quote not found',
+      details: { quote_id: quoteId },
+    });
+  }
+
+  const allowed = await authorizeQuoteRead(tx.trx, tx.tenantId, tx.actorUserId, quote);
+  if (!allowed) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'PERMISSION_DENIED',
+      message: deniedMessage,
+      details: { quote_id: quoteId },
+    });
+  }
+
+  return quote;
+}
+
+async function resolveInteractionStatus(
+  ctx: any,
+  tx: TenantTxContext,
+  params: { statusId?: string; statusName?: string }
+): Promise<{ status_id: string; status_name: string }> {
+  let statusRow: Record<string, unknown> | undefined;
+  if (params.statusId) {
+    statusRow = await tx.trx('statuses')
+      .where({ tenant: tx.tenantId, status_type: 'interaction', status_id: params.statusId })
+      .first();
+  } else if (params.statusName) {
+    statusRow = await tx.trx('statuses')
+      .where({ tenant: tx.tenantId, status_type: 'interaction' })
+      .whereRaw('lower(trim(name)) = lower(trim(?))', [params.statusName])
+      .first();
+  }
+
+  if (!statusRow?.status_id) {
+    throwActionError(ctx, {
+      category: 'ValidationError',
+      code: 'VALIDATION_ERROR',
+      message: 'Target interaction status was not found',
+      details: { status_id: params.statusId ?? null, status_name: params.statusName ?? null },
+    });
+  }
+
+  return {
+    status_id: String(statusRow.status_id),
+    status_name: String(statusRow.name ?? ''),
+  };
+}
+
+function validateTagText(value: string): string {
+  const tagText = value.trim();
+  if (!tagText) {
+    throw new Error('Tag text is required');
+  }
+  if (tagText.length > 50) {
+    throw new Error('Tag text too long (max 50 characters)');
+  }
+  if (!/^[a-zA-Z0-9\-_\s!@#$%^&*()+=\][{};':",./<>?]+$/.test(tagText)) {
+    throw new Error('Tag text contains invalid characters');
+  }
+  return tagText;
+}
+
 export function registerCrmActions(): void {
   const registry = getActionRegistryV2();
+
+  // ---------------------------------------------------------------------------
+  // crm.create_interaction_type
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.create_interaction_type',
+    version: 1,
+    inputSchema: createInteractionTypeInputSchema,
+    outputSchema: z.object({
+      interaction_type: interactionTypeSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Create Activity Type',
+      category: 'Business Operations',
+      description: 'Create a tenant CRM interaction type with idempotent duplicate handling',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'settings', action: 'update' });
+
+        const normalizedTypeName = normalizeInteractionTypeName(input.type_name);
+        const existing = await tx.trx('interaction_types')
+          .where({ tenant: tx.tenantId })
+          .whereRaw('lower(trim(type_name)) = ?', [normalizedTypeName])
+          .first();
+
+        if (existing) {
+          if (input.if_exists === 'error') {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'CONFLICT',
+              message: 'Interaction type already exists',
+              details: { type_name: input.type_name },
+            });
+          }
+
+          return {
+            interaction_type: interactionTypeSummarySchema.parse({
+              type_id: existing.type_id,
+              type_name: String(existing.type_name),
+              icon: existing.icon == null ? null : String(existing.icon),
+              display_order: existing.display_order == null ? null : Number(existing.display_order),
+              created_by: existing.created_by ?? null,
+              created: false,
+            }),
+          };
+        }
+
+        const nowIso = new Date().toISOString();
+        const typeId = uuidv4();
+
+        const displayOrder = input.display_order ?? await (async () => {
+          const row = await tx.trx('interaction_types')
+            .where({ tenant: tx.tenantId })
+            .max<{ max?: number | string }>('display_order as max')
+            .first();
+          return Number(row?.max ?? -1) + 1;
+        })();
+
+        try {
+          await tx.trx('interaction_types').insert({
+            tenant: tx.tenantId,
+            type_id: typeId,
+            type_name: input.type_name.trim(),
+            icon: input.icon?.trim() || null,
+            display_order: displayOrder,
+            created_by: tx.actorUserId,
+            created_at: nowIso,
+          });
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.create_interaction_type',
+          changedData: {
+            type_id: typeId,
+            type_name: input.type_name.trim(),
+            display_order: displayOrder,
+            created: true,
+          },
+          details: {
+            action_id: 'crm.create_interaction_type',
+            action_version: 1,
+            type_id: typeId,
+          },
+        });
+
+        return {
+          interaction_type: interactionTypeSummarySchema.parse({
+            type_id: typeId,
+            type_name: input.type_name.trim(),
+            icon: input.icon?.trim() || null,
+            display_order: displayOrder,
+            created_by: tx.actorUserId,
+            created: true,
+          }),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.update_activity_status
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.update_activity_status',
+    version: 1,
+    inputSchema: updateActivityStatusInputSchema,
+    outputSchema: z.object({
+      activity_id: uuidSchema,
+      previous_status_id: nullableUuidSchema,
+      previous_status_name: z.string().nullable(),
+      current_status_id: nullableUuidSchema,
+      current_status_name: z.string().nullable(),
+      no_op: z.boolean(),
+      activity: activitySummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Update Activity Status',
+      category: 'Business Operations',
+      description: 'Update only the status for an existing CRM activity',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'client', action: 'update' });
+
+        const before = await fetchActivitySummary(ctx, tx, input.activity_id);
+        const targetStatus = await resolveInteractionStatus(ctx, tx, {
+          statusId: input.status_id,
+          statusName: input.status_name,
+        });
+
+        if (before.status_id === targetStatus.status_id && input.no_op_if_already_status) {
+          return {
+            activity_id: input.activity_id,
+            previous_status_id: before.status_id,
+            previous_status_name: before.status_name,
+            current_status_id: before.status_id,
+            current_status_name: before.status_name,
+            no_op: true,
+            activity: before,
+          };
+        }
+
+        try {
+          const updatedCount = await tx.trx('interactions')
+            .where({ tenant: tx.tenantId, interaction_id: input.activity_id })
+            .update({ status_id: targetStatus.status_id });
+          if (!updatedCount) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Activity not found',
+              details: { activity_id: input.activity_id },
+            });
+          }
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const after = await fetchActivitySummary(ctx, tx, input.activity_id);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.update_activity_status',
+          changedData: {
+            activity_id: input.activity_id,
+            previous_status_id: before.status_id,
+            current_status_id: after.status_id,
+            reason: input.reason ?? null,
+          },
+          details: {
+            action_id: 'crm.update_activity_status',
+            action_version: 1,
+            activity_id: input.activity_id,
+          },
+        });
+
+        return {
+          activity_id: input.activity_id,
+          previous_status_id: before.status_id,
+          previous_status_name: before.status_name,
+          current_status_id: after.status_id,
+          current_status_name: after.status_name,
+          no_op: false,
+          activity: after,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.create_quote
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.create_quote',
+    version: 1,
+    inputSchema: createQuoteInputSchema,
+    outputSchema: z.object({
+      quote: quoteDetailSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Create Quote',
+      category: 'Business Operations',
+      description: 'Create a draft quote header for a client/contact',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'create' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+
+        const client = await tx.trx('clients').where({ tenant: tx.tenantId, client_id: input.client_id }).first();
+        if (!client) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Client not found',
+            details: { client_id: input.client_id },
+          });
+        }
+
+        await ensureQuoteContactBelongsToClient(ctx, tx, input.client_id, input.contact_id);
+
+        let parsedInput: Record<string, unknown>;
+        try {
+          parsedInput = normalizeQuoteDates(createQuoteSchema.parse({
+            client_id: input.client_id,
+            contact_id: input.contact_id ?? null,
+            title: input.title,
+            description: input.description ?? null,
+            quote_date: input.quote_date,
+            valid_until: input.valid_until,
+            po_number: input.po_number ?? null,
+            internal_notes: input.internal_notes ?? null,
+            client_notes: input.client_notes ?? null,
+            terms_and_conditions: input.terms_and_conditions ?? null,
+            currency_code: input.currency_code,
+            tax_source: 'internal',
+            is_template: false,
+            created_by: tx.actorUserId,
+          }));
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const createdQuote = await Quote.create(tx.trx, tx.tenantId, {
+          ...(parsedInput as any),
+          subtotal: 0,
+          discount_total: 0,
+          tax: 0,
+          total_amount: 0,
+        } as any);
+
+        const authorized = await authorizeQuoteRead(tx.trx, tx.tenantId, tx.actorUserId, createdQuote as any);
+        if (!authorized) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied: Cannot read created quote',
+          });
+        }
+
+        const fullQuote = await Quote.getById(tx.trx, tx.tenantId, createdQuote.quote_id);
+        if (!fullQuote) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Quote not found after creation',
+            details: { quote_id: createdQuote.quote_id },
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.create_quote',
+          changedData: {
+            quote_id: createdQuote.quote_id,
+            client_id: input.client_id,
+            contact_id: input.contact_id ?? null,
+            status: createdQuote.status ?? null,
+          },
+          details: {
+            action_id: 'crm.create_quote',
+            action_version: 1,
+            quote_id: createdQuote.quote_id,
+          },
+        });
+
+        return { quote: toQuoteDetailSummary(fullQuote as any) };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.add_quote_item
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.add_quote_item',
+    version: 1,
+    inputSchema: addQuoteItemInputSchema,
+    outputSchema: z.object({
+      quote_item: quoteItemSummarySchema,
+      quote: quoteDetailSummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Add Quote Item',
+      category: 'Business Operations',
+      description: 'Add an item to an editable quote and return refreshed totals',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'update' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+
+        const quote = await getAuthorizedQuoteForMutation(
+          ctx,
+          tx,
+          input.quote_id,
+          'Permission denied: Cannot update quote'
+        );
+
+        if (quote.is_template) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Cannot add items to quote templates',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        if (String(quote.status ?? 'draft') !== 'draft') {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Only draft quotes are editable',
+            details: { quote_id: input.quote_id, status: quote.status ?? null },
+          });
+        }
+
+        let parsedInput: Record<string, unknown>;
+        try {
+          parsedInput = createQuoteItemSchema.parse({
+            ...input,
+            created_by: tx.actorUserId,
+          }) as Record<string, unknown>;
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const createdItem = await QuoteItem.create(tx.trx, tx.tenantId, parsedInput as any);
+        const refreshedQuote = await Quote.getById(tx.trx, tx.tenantId, input.quote_id);
+        if (!refreshedQuote) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Quote not found after item creation',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.add_quote_item',
+          changedData: {
+            quote_id: input.quote_id,
+            quote_item_id: createdItem.quote_item_id,
+            display_order: createdItem.display_order,
+            total_price: createdItem.total_price,
+          },
+          details: {
+            action_id: 'crm.add_quote_item',
+            action_version: 1,
+            quote_id: input.quote_id,
+            quote_item_id: createdItem.quote_item_id,
+          },
+        });
+
+        return {
+          quote_item: toQuoteItemSummary(createdItem as any),
+          quote: toQuoteDetailSummary(refreshedQuote as any),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.create_quote_from_template
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.create_quote_from_template',
+    version: 1,
+    inputSchema: createQuoteFromTemplateInputSchema,
+    outputSchema: z.object({
+      quote: quoteDetailSummarySchema,
+      quote_items: z.array(quoteItemSummarySchema),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Create Quote from Template',
+      category: 'Business Operations',
+      description: 'Create a client quote from a quote template with optional overrides',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'create' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+
+        const templateQuote = await getAuthorizedQuoteForMutation(
+          ctx,
+          tx,
+          input.template_id,
+          'Permission denied: Cannot read quote template'
+        );
+
+        if (!templateQuote.is_template) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'template_id must reference a quote template',
+            details: { template_id: input.template_id },
+          });
+        }
+
+        const templateWithItems = await Quote.getById(tx.trx, tx.tenantId, input.template_id);
+        if (!templateWithItems) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Template quote not found',
+            details: { template_id: input.template_id },
+          });
+        }
+
+        const client = await tx.trx('clients').where({ tenant: tx.tenantId, client_id: input.client_id }).first();
+        if (!client) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Client not found',
+            details: { client_id: input.client_id },
+          });
+        }
+        await ensureQuoteContactBelongsToClient(ctx, tx, input.client_id, input.contact_id);
+
+        const resolvedQuoteDate = input.quote_date ?? (templateWithItems.quote_date ? new Date(templateWithItems.quote_date) : undefined);
+        const resolvedValidUntil = input.valid_until ?? (templateWithItems.valid_until ? new Date(templateWithItems.valid_until) : undefined);
+
+        if (!resolvedQuoteDate || !resolvedValidUntil) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'quote_date and valid_until must be resolvable from input or template',
+          });
+        }
+
+        let parsedQuote: Record<string, unknown>;
+        try {
+          parsedQuote = normalizeQuoteDates(createQuoteSchema.parse({
+            client_id: input.client_id,
+            contact_id: input.contact_id ?? null,
+            title: input.title ?? templateWithItems.title,
+            description: templateWithItems.description ?? null,
+            quote_date: resolvedQuoteDate,
+            valid_until: resolvedValidUntil,
+            po_number: input.po_number ?? null,
+            internal_notes: input.internal_notes ?? templateWithItems.internal_notes ?? null,
+            client_notes: input.client_notes ?? templateWithItems.client_notes ?? null,
+            terms_and_conditions: templateWithItems.terms_and_conditions ?? null,
+            currency_code: input.currency_code ?? templateWithItems.currency_code,
+            tax_source: templateWithItems.tax_source ?? 'internal',
+            is_template: false,
+            created_by: tx.actorUserId,
+          }));
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const createdQuote = await Quote.create(tx.trx, tx.tenantId, {
+          ...(parsedQuote as any),
+          subtotal: 0,
+          discount_total: 0,
+          tax: 0,
+          total_amount: 0,
+        } as any);
+
+        for (const item of templateWithItems.quote_items ?? []) {
+          await QuoteItem.create(tx.trx, tx.tenantId, {
+            quote_id: createdQuote.quote_id,
+            service_id: item.service_id ?? null,
+            service_item_kind: item.service_item_kind ?? null,
+            service_name: item.service_name ?? null,
+            service_sku: item.service_sku ?? null,
+            billing_method: item.billing_method ?? null,
+            description: item.description,
+            quantity: item.quantity,
+            unit_price: item.unit_price,
+            unit_of_measure: item.unit_of_measure ?? null,
+            display_order: item.display_order,
+            phase: item.phase ?? null,
+            is_optional: item.is_optional,
+            is_selected: item.is_selected,
+            is_recurring: item.is_recurring,
+            billing_frequency: item.billing_frequency ?? null,
+            is_discount: item.is_discount ?? false,
+            discount_type: item.discount_type ?? null,
+            discount_percentage: item.discount_percentage ?? null,
+            applies_to_item_id: item.applies_to_item_id ?? null,
+            applies_to_service_id: item.applies_to_service_id ?? null,
+            is_taxable: item.is_taxable ?? true,
+            tax_region: item.tax_region ?? null,
+            tax_rate: item.tax_rate ?? null,
+            location_id: item.location_id ?? null,
+            cost: item.cost ?? null,
+            cost_currency: item.cost_currency ?? null,
+            created_by: tx.actorUserId,
+          } as any);
+        }
+
+        const createdQuoteWithItems = await Quote.getById(tx.trx, tx.tenantId, createdQuote.quote_id);
+        if (!createdQuoteWithItems) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Created quote not found',
+            details: { quote_id: createdQuote.quote_id },
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.create_quote_from_template',
+          changedData: {
+            quote_id: createdQuote.quote_id,
+            template_id: input.template_id,
+            item_count: createdQuoteWithItems.quote_items?.length ?? 0,
+          },
+          details: {
+            action_id: 'crm.create_quote_from_template',
+            action_version: 1,
+            quote_id: createdQuote.quote_id,
+          },
+        });
+
+        return {
+          quote: toQuoteDetailSummary(createdQuoteWithItems as any),
+          quote_items: (createdQuoteWithItems.quote_items ?? []).map((item) => toQuoteItemSummary(item as any)),
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.find_quotes
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.find_quotes',
+    version: 1,
+    inputSchema: findQuotesInputSchema,
+    outputSchema: z.object({
+      quotes: z.array(quoteDetailSummarySchema),
+      first_quote: quoteDetailSummarySchema.nullable(),
+      count: z.number().int(),
+      pagination: z.object({
+        page: z.number().int(),
+        page_size: z.number().int(),
+      }),
+    }),
+    sideEffectful: false,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Find Quotes',
+      category: 'Business Operations',
+      description: 'Find tenant quotes with safe filters and pagination',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+
+        const query = tx.trx('quotes')
+          .where({ tenant: tx.tenantId, is_template: input.is_template });
+
+        if (input.quote_id) query.andWhere('quote_id', input.quote_id);
+        if (input.quote_number) query.andWhere('quote_number', input.quote_number);
+        if (input.client_id) query.andWhere('client_id', input.client_id);
+        if (input.status) query.andWhere('status', input.status);
+        if (input.date_from) query.andWhere('quote_date', '>=', input.date_from.toISOString());
+        if (input.date_to) query.andWhere('quote_date', '<=', input.date_to.toISOString());
+
+        query.orderBy(input.sortBy, input.sortOrder);
+        query.limit(input.pageSize).offset((input.page - 1) * input.pageSize);
+
+        const rows = await query;
+        const authorizedRows: Array<Record<string, unknown>> = [];
+        for (const row of rows) {
+          if (await authorizeQuoteRead(tx.trx, tx.tenantId, tx.actorUserId, row)) {
+            authorizedRows.push(row as Record<string, unknown>);
+          }
+        }
+
+        if (authorizedRows.length === 0 && input.on_empty === 'error') {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'No quotes matched the supplied filters',
+          });
+        }
+
+        const summaries = authorizedRows.map((row) => toQuoteDetailSummary(row));
+        return {
+          quotes: summaries,
+          first_quote: summaries[0] ?? null,
+          count: summaries.length,
+          pagination: {
+            page: input.page,
+            page_size: input.pageSize,
+          },
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.submit_quote_for_approval
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.submit_quote_for_approval',
+    version: 1,
+    inputSchema: submitQuoteForApprovalInputSchema,
+    outputSchema: z.object({
+      quote: quoteDetailSummarySchema,
+      previous_status: z.string().nullable(),
+      new_status: z.string().nullable(),
+      no_op: z.boolean(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Submit Quote for Approval',
+      category: 'Business Operations',
+      description: 'Submit a draft quote to pending_approval',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'update' });
+
+        const quote = await getAuthorizedQuoteForMutation(
+          ctx,
+          tx,
+          input.quote_id,
+          'Permission denied: Cannot update quote'
+        );
+
+        if (quote.is_template) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Quote templates cannot be submitted for approval',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        const previousStatus = quote.status == null ? null : String(quote.status);
+        if (previousStatus === 'pending_approval' && input.no_op_if_already_pending) {
+          return {
+            quote: toQuoteDetailSummary(quote),
+            previous_status: previousStatus,
+            new_status: previousStatus,
+            no_op: true,
+          };
+        }
+
+        if (previousStatus !== 'draft') {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Only draft quotes can be submitted for approval',
+            details: { quote_id: input.quote_id, status: previousStatus },
+          });
+        }
+
+        const updatedQuote = await Quote.update(tx.trx, tx.tenantId, input.quote_id, {
+          status: 'pending_approval' as any,
+          updated_by: tx.actorUserId,
+        });
+
+        const comment = input.comment?.trim() || input.reason?.trim() || null;
+        if (comment) {
+          await QuoteActivity.create(tx.trx, tx.tenantId, {
+            quote_id: input.quote_id,
+            activity_type: 'approval_submitted',
+            description: `Quote submitted for approval: ${comment}`,
+            performed_by: tx.actorUserId,
+            metadata: { comment },
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.submit_quote_for_approval',
+          changedData: {
+            quote_id: input.quote_id,
+            previous_status: previousStatus,
+            new_status: updatedQuote.status ?? null,
+            comment,
+          },
+          details: {
+            action_id: 'crm.submit_quote_for_approval',
+            action_version: 1,
+            quote_id: input.quote_id,
+          },
+        });
+
+        return {
+          quote: toQuoteDetailSummary(updatedQuote as any),
+          previous_status: previousStatus,
+          new_status: updatedQuote.status == null ? null : String(updatedQuote.status),
+          no_op: false,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.convert_quote
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.convert_quote',
+    version: 1,
+    inputSchema: convertQuoteInputSchema,
+    outputSchema: z.object({
+      quote: quoteDetailSummarySchema,
+      contract_id: nullableUuidSchema,
+      invoice_id: nullableUuidSchema,
+      no_op: z.boolean(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Convert Quote',
+      category: 'Business Operations',
+      description: 'Convert an accepted quote to draft contract/invoice targets',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'create' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'update' });
+
+        const quote = await getAuthorizedQuoteForMutation(
+          ctx,
+          tx,
+          input.quote_id,
+          'Permission denied: Cannot convert quote'
+        );
+
+        if (quote.is_template) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Quote templates cannot be converted',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        const alreadyConverted = Boolean(quote.converted_contract_id || quote.converted_invoice_id || quote.status === 'converted');
+        if (alreadyConverted && input.no_op_if_already_converted) {
+          return {
+            quote: toQuoteDetailSummary(quote),
+            contract_id: quote.converted_contract_id ?? null,
+            invoice_id: quote.converted_invoice_id ?? null,
+            no_op: true,
+          };
+        }
+
+        try {
+          if (input.target === 'contract') {
+            const result = await convertQuoteToDraftContract(tx.trx, tx.tenantId, input.quote_id, tx.actorUserId);
+            await writeRunAudit(ctx, tx, {
+              operation: 'workflow_action:crm.convert_quote',
+              changedData: {
+                quote_id: input.quote_id,
+                target: input.target,
+                contract_id: result.contract.contract_id,
+              },
+              details: {
+                action_id: 'crm.convert_quote',
+                action_version: 1,
+                quote_id: input.quote_id,
+              },
+            });
+            return {
+              quote: toQuoteDetailSummary(result.quote as any),
+              contract_id: result.contract.contract_id,
+              invoice_id: result.quote.converted_invoice_id ?? null,
+              no_op: false,
+            };
+          }
+
+          if (input.target === 'invoice') {
+            const result = await convertQuoteToDraftInvoice(tx.trx, tx.tenantId, input.quote_id, tx.actorUserId);
+            await writeRunAudit(ctx, tx, {
+              operation: 'workflow_action:crm.convert_quote',
+              changedData: {
+                quote_id: input.quote_id,
+                target: input.target,
+                invoice_id: result.invoice.invoice_id,
+              },
+              details: {
+                action_id: 'crm.convert_quote',
+                action_version: 1,
+                quote_id: input.quote_id,
+              },
+            });
+            return {
+              quote: toQuoteDetailSummary(result.quote as any),
+              contract_id: result.quote.converted_contract_id ?? null,
+              invoice_id: result.invoice.invoice_id,
+              no_op: false,
+            };
+          }
+
+          const result = await convertQuoteToDraftContractAndInvoice(tx.trx, tx.tenantId, input.quote_id, tx.actorUserId);
+          await writeRunAudit(ctx, tx, {
+            operation: 'workflow_action:crm.convert_quote',
+            changedData: {
+              quote_id: input.quote_id,
+              target: input.target,
+              contract_id: result.contract.contract_id,
+              invoice_id: result.invoice.invoice_id,
+            },
+            details: {
+              action_id: 'crm.convert_quote',
+              action_version: 1,
+              quote_id: input.quote_id,
+            },
+          });
+          return {
+            quote: toQuoteDetailSummary(result.quote as any),
+            contract_id: result.contract.contract_id,
+            invoice_id: result.invoice.invoice_id,
+            no_op: false,
+          };
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.tag_activity
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.tag_activity',
+    version: 1,
+    inputSchema: tagActivityInputSchema,
+    outputSchema: z.object({
+      activity_id: uuidSchema,
+      added_tags: z.array(z.object({ tag_id: uuidSchema, tag_text: z.string(), mapping_id: uuidSchema })),
+      existing_tags: z.array(z.object({ tag_id: uuidSchema, tag_text: z.string(), mapping_id: uuidSchema })),
+      added_count: z.number().int(),
+      existing_count: z.number().int(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Tag CRM Activity',
+      category: 'Business Operations',
+      description: 'Apply existing/new tags to a CRM interaction activity',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'client', action: 'update' });
+
+        const interaction = await tx.trx('interactions')
+          .where({ tenant: tx.tenantId, interaction_id: input.activity_id })
+          .first();
+        if (!interaction) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Activity not found',
+            details: { activity_id: input.activity_id },
+          });
+        }
+
+        const normalizedTags = Array.from(new Set(input.tags.map((tag) => validateTagText(tag))));
+        const addedTags: Array<{ tag_id: string; tag_text: string; mapping_id: string }> = [];
+        const existingTags: Array<{ tag_id: string; tag_text: string; mapping_id: string }> = [];
+        const createdDefinitions: Array<{ tag_id: string; tag_text: string; created_at?: Date }> = [];
+        const createdMappings: Array<{ tag_id: string; tagged_id: string; created_at?: Date }> = [];
+
+        for (const tagText of normalizedTags) {
+          const maybeExistingDefinition = await TagDefinition.findByTextAndType(tx.trx, tx.tenantId, tagText, 'interaction');
+          if (!maybeExistingDefinition) {
+            await requirePermission(ctx, tx, { resource: 'tag', action: 'create' });
+          }
+
+          const { definition, created } = await TagDefinition.getOrCreateWithStatus(
+            tx.trx,
+            tx.tenantId,
+            tagText,
+            'interaction',
+            {}
+          );
+
+          const existingMapping = await tx.trx('tag_mappings')
+            .where({
+              tenant: tx.tenantId,
+              tag_id: definition.tag_id,
+              tagged_id: input.activity_id,
+              tagged_type: 'interaction',
+            })
+            .first();
+
+          if (existingMapping) {
+            if (input.if_exists === 'error') {
+              throwActionError(ctx, {
+                category: 'ActionError',
+                code: 'CONFLICT',
+                message: 'Tag is already applied to this activity',
+                details: { activity_id: input.activity_id, tag_text: tagText },
+              });
+            }
+            existingTags.push({
+              tag_id: definition.tag_id,
+              tag_text: definition.tag_text,
+              mapping_id: String(existingMapping.mapping_id),
+            });
+            continue;
+          }
+
+          const mapping = await TagMapping.insert(tx.trx, tx.tenantId, {
+            tag_id: definition.tag_id,
+            tagged_id: input.activity_id,
+            tagged_type: 'interaction',
+            created_by: tx.actorUserId,
+          }, tx.actorUserId);
+
+          if (created) {
+            createdDefinitions.push({
+              tag_id: definition.tag_id,
+              tag_text: definition.tag_text,
+              created_at: definition.created_at,
+            });
+          }
+          createdMappings.push({
+            tag_id: definition.tag_id,
+            tagged_id: input.activity_id,
+            created_at: mapping.created_at,
+          });
+          addedTags.push({
+            tag_id: definition.tag_id,
+            tag_text: definition.tag_text,
+            mapping_id: mapping.mapping_id,
+          });
+        }
+
+        const occurredAt = new Date().toISOString();
+        for (const definition of createdDefinitions) {
+          await publishWorkflowDomainEvent({
+            eventType: 'TAG_DEFINITION_CREATED',
+            payload: buildTagDefinitionCreatedPayload({
+              tagId: definition.tag_id,
+              tagName: definition.tag_text,
+              createdByUserId: tx.actorUserId,
+              createdAt: definition.created_at ?? occurredAt,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `tag_definition_created:${definition.tag_id}`,
+          });
+        }
+
+        for (const mapping of createdMappings) {
+          await publishWorkflowDomainEvent({
+            eventType: 'TAG_APPLIED',
+            payload: buildTagAppliedPayload({
+              tagId: mapping.tag_id,
+              entityType: 'interaction',
+              entityId: mapping.tagged_id,
+              appliedByUserId: tx.actorUserId,
+              appliedAt: mapping.created_at ?? occurredAt,
+            }),
+            tenantId: tx.tenantId,
+            occurredAt,
+            actorUserId: tx.actorUserId,
+            idempotencyKey: `tag_applied:${mapping.tagged_id}:${mapping.tag_id}`,
+          });
+        }
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.tag_activity',
+          changedData: {
+            activity_id: input.activity_id,
+            tags: normalizedTags,
+            added_count: addedTags.length,
+            existing_count: existingTags.length,
+          },
+          details: {
+            action_id: 'crm.tag_activity',
+            action_version: 1,
+            activity_id: input.activity_id,
+          },
+        });
+
+        return {
+          activity_id: input.activity_id,
+          added_tags: addedTags,
+          existing_tags: existingTags,
+          added_count: addedTags.length,
+          existing_count: existingTags.length,
+        };
+      }),
+  });
 
   // ---------------------------------------------------------------------------
   // A18 — crm.create_activity_note

--- a/shared/workflow/runtime/actions/businessOperations/crm.ts
+++ b/shared/workflow/runtime/actions/businessOperations/crm.ts
@@ -1,14 +1,652 @@
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
+import { getWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
+import QuoteActivity from '../../../../../packages/billing/src/models/quoteActivity';
+import { getQuoteApprovalWorkflowSettings } from '../../../../../packages/billing/src/lib/quoteApprovalSettings';
 import {
   uuidSchema,
   isoDateTimeSchema,
+  actionProvidedKey,
   withTenantTransaction,
   requirePermission,
   writeRunAudit,
-  throwActionError
+  throwActionError,
+  rethrowAsStandardError,
+  type TenantTxContext,
 } from './shared';
+import { buildInteractionLoggedPayload } from '../../../streams/domainEventBuilders/crmInteractionNoteEventBuilders';
+
+const WORKFLOW_PICKER_HINTS = {
+  client: 'Search clients',
+  contact: 'Search contacts',
+  ticket: 'Search tickets',
+  user: 'Search users',
+} as const;
+
+const withWorkflowPicker = <T extends z.ZodTypeAny>(
+  schema: T,
+  description: string,
+  kind: keyof typeof WORKFLOW_PICKER_HINTS,
+  dependencies?: string[]
+): T =>
+  withWorkflowJsonSchemaMetadata(schema, description, {
+    'x-workflow-picker-kind': kind,
+    'x-workflow-picker-dependencies': dependencies,
+    'x-workflow-picker-fixed-value-hint': WORKFLOW_PICKER_HINTS[kind],
+    'x-workflow-picker-allow-dynamic-reference': true,
+  });
+
+const nullableUuidSchema = z.union([uuidSchema, z.null()]);
+const visibilitySchema = z.enum(['internal', 'client_visible']);
+const onEmptySchema = z.enum(['return_empty', 'error']);
+
+const activitySummarySchema = z.object({
+  activity_id: uuidSchema,
+  type_id: uuidSchema,
+  type_name: z.string().nullable(),
+  status_id: nullableUuidSchema,
+  status_name: z.string().nullable(),
+  client_id: nullableUuidSchema,
+  client_name: z.string().nullable(),
+  contact_id: nullableUuidSchema,
+  contact_name: z.string().nullable(),
+  ticket_id: nullableUuidSchema,
+  ticket_number: z.string().nullable(),
+  title: z.string().nullable(),
+  notes_preview: z.string().nullable(),
+  interaction_date: isoDateTimeSchema,
+  start_time: isoDateTimeSchema.nullable(),
+  end_time: isoDateTimeSchema.nullable(),
+  duration: z.number().int().nullable(),
+  user_id: nullableUuidSchema,
+  user_name: z.string().nullable(),
+  visibility: z.string().nullable(),
+  category: z.string().nullable(),
+  tags: z.array(z.string()).nullable(),
+});
+
+const quoteSummarySchema = z.object({
+  quote_id: uuidSchema,
+  quote_number: z.string().nullable(),
+  status: z.string().nullable(),
+  client_id: nullableUuidSchema,
+  title: z.string(),
+});
+
+const findActivitiesInputSchema = z
+  .object({
+    client_id: withWorkflowPicker(uuidSchema.optional(), 'Optional client id filter', 'client'),
+    contact_id: withWorkflowPicker(uuidSchema.optional(), 'Optional contact id filter', 'contact', ['client_id']),
+    ticket_id: withWorkflowPicker(uuidSchema.optional(), 'Optional ticket id filter', 'ticket'),
+    user_id: withWorkflowPicker(uuidSchema.optional(), 'Optional owner user id filter', 'user'),
+    type_id: uuidSchema.optional().describe('Optional interaction type id filter'),
+    status_id: uuidSchema.optional().describe('Optional interaction status id filter'),
+    date_from: isoDateTimeSchema.optional(),
+    date_to: isoDateTimeSchema.optional(),
+    limit: z.number().int().positive().max(200).default(25),
+    on_empty: onEmptySchema.default('return_empty'),
+  })
+  .superRefine((value, refinementCtx) => {
+    const hasMeaningfulFilter = Boolean(
+      value.client_id ||
+      value.contact_id ||
+      value.ticket_id ||
+      value.user_id ||
+      value.type_id ||
+      value.status_id ||
+      value.date_from ||
+      value.date_to
+    );
+
+    if (!hasMeaningfulFilter) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one filter or date range is required',
+      });
+    }
+
+    if (value.date_from && value.date_to && new Date(value.date_from).getTime() > new Date(value.date_to).getTime()) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'date_from must be less than or equal to date_to',
+      });
+    }
+  });
+
+const updateActivityPatchSchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    notes: z.string().nullable().optional(),
+    status_id: uuidSchema.nullable().optional(),
+    visibility: visibilitySchema.optional(),
+    category: z.string().nullable().optional(),
+    tags: z.array(z.string().min(1)).nullable().optional(),
+    interaction_date: isoDateTimeSchema.optional(),
+    start_time: isoDateTimeSchema.nullable().optional(),
+    end_time: isoDateTimeSchema.nullable().optional(),
+    duration: z.number().int().nonnegative().nullable().optional(),
+    type_id: uuidSchema.optional(),
+  })
+  .superRefine((value, refinementCtx) => {
+    const keys = Object.keys(value);
+    if (keys.length === 0) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'patch must include at least one editable field',
+      });
+      return;
+    }
+
+    const hasDefined = keys.some((key) => (value as Record<string, unknown>)[key] !== undefined);
+    if (!hasDefined) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'patch must include at least one defined value',
+      });
+    }
+  });
+
+const scheduleActivityInputSchema = z
+  .object({
+    client_id: withWorkflowPicker(uuidSchema.optional(), 'Optional client id. Required when contact_id is omitted.', 'client'),
+    contact_id: withWorkflowPicker(uuidSchema.optional(), 'Optional contact id. Resolves client when client_id is omitted.', 'contact', ['client_id']),
+    ticket_id: withWorkflowPicker(uuidSchema.optional(), 'Optional ticket id to link the scheduled activity', 'ticket'),
+    type_id: uuidSchema.describe('Interaction type id (system or tenant type)'),
+    title: z.string().min(1),
+    notes: z.string().optional(),
+    status_id: uuidSchema.optional(),
+    start_time: isoDateTimeSchema,
+    end_time: isoDateTimeSchema.optional(),
+    duration: z.number().int().nonnegative().optional(),
+    visibility: visibilitySchema.optional(),
+    category: z.string().optional(),
+    tags: z.array(z.string().min(1)).optional(),
+    assigned_user_id: withWorkflowPicker(uuidSchema.optional(), 'Optional assigned user id. Defaults to workflow actor.', 'user'),
+    owner_user_id: withWorkflowPicker(uuidSchema.optional(), 'Optional owner user id. Defaults to workflow actor.', 'user'),
+    idempotency_key: z.string().optional().describe('Optional external idempotency key'),
+  })
+  .superRefine((value, refinementCtx) => {
+    if (!value.client_id && !value.contact_id) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'client_id or contact_id is required',
+      });
+    }
+
+    if (value.end_time && new Date(value.start_time).getTime() > new Date(value.end_time).getTime()) {
+      refinementCtx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'start_time must be less than or equal to end_time',
+      });
+    }
+  });
+
+const sendQuoteInputSchema = z.object({
+  quote_id: uuidSchema,
+  email_addresses: z.array(z.string().email()).optional(),
+  subject: z.string().optional(),
+  message: z.string().optional(),
+  no_op_if_already_sent: z.boolean().default(true),
+});
+
+function asIsoString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  return null;
+}
+
+function normalizeTags(value: unknown): string[] | null {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    return value.map((tag) => String(tag).trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.map((tag) => String(tag).trim()).filter(Boolean);
+      }
+    } catch {
+      return value.trim() ? [value.trim()] : null;
+    }
+  }
+  return null;
+}
+
+function computeNotesPreview(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (!normalized) return null;
+  return normalized.length > 180 ? `${normalized.slice(0, 180)}…` : normalized;
+}
+
+function coalesceInteractionTypeName(row: Record<string, unknown>): string | null {
+  const tenantTypeName = row.tenant_type_name;
+  if (typeof tenantTypeName === 'string' && tenantTypeName.trim()) return tenantTypeName;
+  const systemTypeName = row.system_type_name;
+  if (typeof systemTypeName === 'string' && systemTypeName.trim()) return systemTypeName;
+  return null;
+}
+
+function coalesceUserName(row: Record<string, unknown>): string | null {
+  const firstName = typeof row.user_first_name === 'string' ? row.user_first_name.trim() : '';
+  const lastName = typeof row.user_last_name === 'string' ? row.user_last_name.trim() : '';
+  const combined = [firstName, lastName].filter(Boolean).join(' ').trim();
+  if (combined) return combined;
+  if (typeof row.user_email === 'string' && row.user_email.trim()) return row.user_email.trim();
+  return null;
+}
+
+function toActivitySummary(row: Record<string, unknown>) {
+  const interactionDate = asIsoString(row.interaction_date);
+  if (!interactionDate) {
+    throw new Error('interaction_date is required for activity summary');
+  }
+
+  return activitySummarySchema.parse({
+    activity_id: row.interaction_id,
+    type_id: row.type_id,
+    type_name: coalesceInteractionTypeName(row),
+    status_id: row.status_id ?? null,
+    status_name: typeof row.status_name === 'string' ? row.status_name : null,
+    client_id: row.client_id ?? null,
+    client_name: typeof row.client_name === 'string' ? row.client_name : null,
+    contact_id: row.contact_name_id ?? null,
+    contact_name: typeof row.contact_full_name === 'string' ? row.contact_full_name : null,
+    ticket_id: row.ticket_id ?? null,
+    ticket_number: row.ticket_number == null ? null : String(row.ticket_number),
+    title: typeof row.title === 'string' ? row.title : null,
+    notes_preview: computeNotesPreview(row.notes),
+    interaction_date: interactionDate,
+    start_time: asIsoString(row.start_time),
+    end_time: asIsoString(row.end_time),
+    duration: typeof row.duration === 'number' ? row.duration : row.duration == null ? null : Number(row.duration),
+    user_id: row.user_id ?? null,
+    user_name: coalesceUserName(row),
+    visibility: typeof row.visibility === 'string' ? row.visibility : null,
+    category: typeof row.category === 'string' ? row.category : null,
+    tags: normalizeTags(row.tags),
+  });
+}
+
+function collectChangedFields(
+  before: z.infer<typeof activitySummarySchema>,
+  after: z.infer<typeof activitySummarySchema>,
+  requestedPatch: Record<string, unknown>
+): string[] {
+  const patchFieldToSummaryField = new Map<string, keyof z.infer<typeof activitySummarySchema>>([
+    ['title', 'title'],
+    ['notes', 'notes_preview'],
+    ['status_id', 'status_id'],
+    ['visibility', 'visibility'],
+    ['category', 'category'],
+    ['tags', 'tags'],
+    ['interaction_date', 'interaction_date'],
+    ['start_time', 'start_time'],
+    ['end_time', 'end_time'],
+    ['duration', 'duration'],
+    ['type_id', 'type_id'],
+  ]);
+
+  const changed = new Set<string>();
+
+  for (const key of Object.keys(requestedPatch)) {
+    const mappedField = patchFieldToSummaryField.get(key);
+    if (!mappedField) continue;
+    const beforeValue = before[mappedField];
+    const afterValue = after[mappedField];
+    if (JSON.stringify(beforeValue) !== JSON.stringify(afterValue)) {
+      changed.add(key);
+    }
+  }
+
+  return [...changed].sort((left, right) => left.localeCompare(right));
+}
+
+async function validateInteractionTypeId(
+  ctx: any,
+  tx: TenantTxContext,
+  typeId: string,
+  fieldName: 'type_id'
+): Promise<void> {
+  const [tenantType, systemType] = await Promise.all([
+    tx.trx('interaction_types').where({ tenant: tx.tenantId, type_id: typeId }).first(),
+    tx.trx('system_interaction_types').where({ type_id: typeId }).first(),
+  ]);
+
+  if (tenantType || systemType) {
+    return;
+  }
+
+  throwActionError(ctx, {
+    category: 'ValidationError',
+    code: 'VALIDATION_ERROR',
+    message: `${fieldName} is not a valid interaction type id for this tenant`,
+    details: { [fieldName]: typeId },
+  });
+}
+
+async function validateInteractionStatusId(
+  ctx: any,
+  tx: TenantTxContext,
+  statusId: string,
+  fieldName: 'status_id'
+): Promise<void> {
+  const status = await tx.trx('statuses')
+    .where({ tenant: tx.tenantId, status_id: statusId, status_type: 'interaction' })
+    .first();
+
+  if (status) {
+    return;
+  }
+
+  throwActionError(ctx, {
+    category: 'ValidationError',
+    code: 'VALIDATION_ERROR',
+    message: `${fieldName} is not a valid interaction status for this tenant`,
+    details: { [fieldName]: statusId },
+  });
+}
+
+async function getDefaultInteractionStatusId(ctx: any, tx: TenantTxContext): Promise<string> {
+  const status = await tx.trx('statuses')
+    .where({
+      tenant: tx.tenantId,
+      status_type: 'interaction',
+      is_default: true,
+    })
+    .first();
+
+  if (status?.status_id) {
+    return status.status_id;
+  }
+
+  throwActionError(ctx, {
+    category: 'ActionError',
+    code: 'INTERNAL_ERROR',
+    message: 'No default interaction status found. Configure an interaction default status to use crm.schedule_activity.',
+  });
+}
+
+async function fetchActivityDetailRow(
+  trx: Knex.Transaction,
+  tenantId: string,
+  activityId: string
+): Promise<Record<string, unknown> | null> {
+  return await trx('interactions as i')
+    .leftJoin('clients as c', function joinClients() {
+      this.on('i.tenant', 'c.tenant').andOn('i.client_id', 'c.client_id');
+    })
+    .leftJoin('contacts as ct', function joinContacts() {
+      this.on('i.tenant', 'ct.tenant').andOn('i.contact_name_id', 'ct.contact_name_id');
+    })
+    .leftJoin('tickets as tk', function joinTickets() {
+      this.on('i.tenant', 'tk.tenant').andOn('i.ticket_id', 'tk.ticket_id');
+    })
+    .leftJoin('users as u', function joinUsers() {
+      this.on('i.tenant', 'u.tenant').andOn('i.user_id', 'u.user_id');
+    })
+    .leftJoin('statuses as st', function joinStatuses() {
+      this.on('i.tenant', 'st.tenant').andOn('i.status_id', 'st.status_id');
+    })
+    .leftJoin('interaction_types as it', function joinInteractionTypes() {
+      this.on('i.tenant', 'it.tenant').andOn('i.type_id', 'it.type_id');
+    })
+    .leftJoin('system_interaction_types as sit', 'i.type_id', 'sit.type_id')
+    .where({ 'i.tenant': tenantId, 'i.interaction_id': activityId })
+    .select(
+      'i.interaction_id',
+      'i.type_id',
+      'i.status_id',
+      'i.client_id',
+      'i.contact_name_id',
+      'i.ticket_id',
+      'i.title',
+      'i.notes',
+      'i.interaction_date',
+      'i.start_time',
+      'i.end_time',
+      'i.duration',
+      'i.user_id',
+      'i.visibility',
+      'i.category',
+      'i.tags',
+      'c.client_name',
+      'ct.full_name as contact_full_name',
+      'tk.ticket_number',
+      'u.first_name as user_first_name',
+      'u.last_name as user_last_name',
+      'u.email as user_email',
+      'st.name as status_name',
+      'it.type_name as tenant_type_name',
+      'sit.type_name as system_type_name'
+    )
+    .first() as Record<string, unknown> | null;
+}
+
+async function fetchActivitySummary(
+  ctx: any,
+  tx: TenantTxContext,
+  activityId: string
+): Promise<z.infer<typeof activitySummarySchema>> {
+  const row = await fetchActivityDetailRow(tx.trx, tx.tenantId, activityId);
+  if (!row) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'NOT_FOUND',
+      message: 'Activity not found',
+      details: { activity_id: activityId },
+    });
+  }
+
+  return toActivitySummary(row);
+}
+
+const maybeWorkflowActor = (userId: string): { actorType: 'USER'; actorUserId: string } => ({
+  actorType: 'USER',
+  actorUserId: userId,
+});
+
+async function publishWorkflowDomainEvent(params: {
+  eventType: string;
+  payload: Record<string, unknown>;
+  tenantId: string;
+  occurredAt: string;
+  actorUserId: string;
+  idempotencyKey: string;
+}): Promise<void> {
+  try {
+    const publishers = (await import('@alga-psa/event-bus/publishers')) as unknown as {
+      publishWorkflowEvent?: (value: {
+        eventType: string;
+        payload: Record<string, unknown>;
+        ctx: {
+          tenantId: string;
+          occurredAt: string;
+          actor: { actorType: 'USER'; actorUserId: string };
+        };
+        idempotencyKey: string;
+      }) => Promise<unknown>;
+    };
+
+    if (!publishers.publishWorkflowEvent) return;
+
+    await publishers.publishWorkflowEvent({
+      eventType: params.eventType,
+      payload: params.payload,
+      ctx: {
+        tenantId: params.tenantId,
+        occurredAt: params.occurredAt,
+        actor: maybeWorkflowActor(params.actorUserId),
+      },
+      idempotencyKey: params.idempotencyKey,
+    });
+  } catch {
+    // Best-effort publication.
+  }
+}
+
+async function maybeStoreQuotePdfBestEffort(
+  trx: Knex.Transaction,
+  tenantId: string,
+  quote: Record<string, unknown>,
+  actorUserId: string
+): Promise<void> {
+  try {
+    const [{ createPDFGenerationService }, documentsModule] = await Promise.all([
+      import('../../../../../packages/billing/src/services'),
+      import('@alga-psa/documents/models'),
+    ]);
+
+    const fileRecord = await createPDFGenerationService(tenantId).generateAndStore({
+      quoteId: String(quote.quote_id),
+      quoteNumber: typeof quote.quote_number === 'string' ? quote.quote_number : undefined,
+      userId: actorUserId,
+    });
+
+    const documentModel = (documentsModule as unknown as {
+      Document: {
+        insert: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
+      };
+      DocumentAssociation: {
+        create: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
+      };
+    }).Document;
+
+    const documentAssociation = (documentsModule as unknown as {
+      DocumentAssociation: {
+        create: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
+      };
+    }).DocumentAssociation;
+
+    const documentId = uuidv4();
+
+    await documentModel.insert(trx, {
+      document_id: documentId,
+      document_name: `Quote_${String(quote.quote_number ?? quote.quote_id)}.pdf`,
+      type_id: null,
+      user_id: actorUserId,
+      created_by: actorUserId,
+      order_number: 0,
+      tenant: tenantId,
+      file_id: fileRecord.file_id,
+      storage_path: fileRecord.storage_path,
+      mime_type: 'application/pdf',
+      file_size: fileRecord.file_size,
+      folder_path: '/Quotes/Generated',
+      is_client_visible: true,
+    });
+
+    await documentAssociation.create(trx, {
+      document_id: documentId,
+      entity_id: String(quote.quote_id),
+      entity_type: 'quote',
+      tenant: tenantId,
+    });
+  } catch {
+    // Best-effort PDF storage.
+  }
+}
+
+async function resolveQuoteRecipients(
+  trx: Knex.Transaction,
+  tenantId: string,
+  quote: Record<string, unknown>,
+  explicitRecipients: string[]
+): Promise<string[]> {
+  const [contactRecipient, clientRecipient] = await Promise.all([
+    quote.contact_id
+      ? trx('contacts')
+        .select('email')
+        .where({ tenant: tenantId, contact_name_id: quote.contact_id })
+        .first<{ email?: string | null }>()
+      : Promise.resolve(null),
+    quote.client_id
+      ? trx('clients')
+        .select('billing_email')
+        .where({ tenant: tenantId, client_id: quote.client_id })
+        .first<{ billing_email?: string | null }>()
+      : Promise.resolve(null),
+  ]);
+
+  return Array.from(
+    new Set(
+      [...explicitRecipients, contactRecipient?.email ?? '', clientRecipient?.billing_email ?? '']
+        .map((email) => String(email).trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+async function sendQuoteEmailBestEffort(params: {
+  tenantId: string;
+  quote: Record<string, unknown>;
+  actorUserId: string;
+  recipients: string[];
+  subject?: string;
+  message?: string;
+}): Promise<{ emailSent: boolean; messageId: string | null }> {
+  if (params.recipients.length === 0) {
+    return { emailSent: false, messageId: null };
+  }
+
+  try {
+    const { TenantEmailService, StaticTemplateProcessor } = getWorkflowEmailProvider();
+    const service = TenantEmailService.getInstance(params.tenantId);
+
+    const portalBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const portalLink = `${portalBaseUrl}/client-portal/billing?tab=quotes`;
+    const defaultSubject = `Quote ${String(params.quote.quote_number ?? params.quote.quote_id)} is ready`;
+    const defaultText = params.message?.trim()
+      ? `${params.message.trim()}\n\nView quote: ${portalLink}`
+      : `Your quote is available in the client portal.\n\nView quote: ${portalLink}`;
+    const defaultHtml = `<p>${params.message?.trim() || 'Your quote is available in the client portal.'}</p><p><a href=\"${portalLink}\">View quote</a></p>`;
+
+    const templateProcessor = new StaticTemplateProcessor(
+      params.subject?.trim() || defaultSubject,
+      defaultHtml,
+      defaultText
+    );
+
+    const emailResult = await service.sendEmail({
+      tenantId: params.tenantId,
+      to: params.recipients.map((email) => ({ email })),
+      templateProcessor,
+      templateData: {},
+      entityType: 'quote',
+      entityId: String(params.quote.quote_id),
+      contactId: (params.quote.contact_id as string | null | undefined) ?? undefined,
+      userId: params.actorUserId,
+    } as any);
+
+    return {
+      emailSent: Boolean(emailResult.success),
+      messageId:
+        typeof (emailResult as Record<string, unknown>).messageId === 'string'
+          ? ((emailResult as Record<string, unknown>).messageId as string)
+          : null,
+    };
+  } catch {
+    return { emailSent: false, messageId: null };
+  }
+}
+
+function toQuoteSummary(quote: Record<string, unknown>) {
+  return quoteSummarySchema.parse({
+    quote_id: quote.quote_id,
+    quote_number: quote.quote_number == null ? null : String(quote.quote_number),
+    status: quote.status == null ? null : String(quote.status),
+    client_id: quote.client_id ?? null,
+    title: String(quote.title ?? ''),
+  });
+}
 
 export function registerCrmActions(): void {
   const registry = getActionRegistryV2();
@@ -25,7 +663,7 @@ export function registerCrmActions(): void {
         id: uuidSchema.describe('Target id')
       }),
       body: z.string().min(1).describe('Note body'),
-      visibility: z.enum(['internal', 'client_visible']).default('internal'),
+      visibility: visibilitySchema.default('internal'),
       tags: z.array(z.string()).optional(),
       category: z.string().optional()
     }),
@@ -50,12 +688,14 @@ export function registerCrmActions(): void {
               : 'project';
       await requirePermission(ctx, tx, { resource: permissionResource, action: 'update' });
 
-      // Policy: client_visible notes require a client/contact/ticket target (project visibility support is tenant-dependent).
       if (input.visibility === 'client_visible' && input.target.type === 'project') {
-        throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: 'client_visible notes are not supported for project targets' });
+        throwActionError(ctx, {
+          category: 'ValidationError',
+          code: 'VALIDATION_ERROR',
+          message: 'client_visible notes are not supported for project targets'
+        });
       }
 
-      // Validate target and set foreign keys.
       let clientId: string | null = null;
       let contactId: string | null = null;
       let ticketId: string | null = null;
@@ -122,5 +762,626 @@ export function registerCrmActions(): void {
 
       return { note_id: noteId, created_at: nowIso, target_type: input.target.type, target_id: input.target.id, target_summary: targetSummary };
     })
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.find_activities
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.find_activities',
+    version: 1,
+    inputSchema: findActivitiesInputSchema,
+    outputSchema: z.object({
+      activities: z.array(activitySummarySchema),
+      count: z.number().int(),
+      matched_filters: z.record(z.unknown()),
+    }),
+    sideEffectful: false,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Find CRM Activities',
+      category: 'Business Operations',
+      description: 'Find CRM activities by client/contact/ticket/user/type/status and date filters',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        // Permission mapping decision: interactions are CRM activity records linked primarily to clients.
+        // Always require client:read. Add contact/ticket read when those scoped filters are supplied.
+        await requirePermission(ctx, tx, { resource: 'client', action: 'read' });
+        if (input.contact_id) {
+          await requirePermission(ctx, tx, { resource: 'contact', action: 'read' });
+        }
+        if (input.ticket_id) {
+          await requirePermission(ctx, tx, { resource: 'ticket', action: 'read' });
+        }
+
+        const query = tx.trx('interactions as i')
+          .leftJoin('clients as c', function joinClients() {
+            this.on('i.tenant', 'c.tenant').andOn('i.client_id', 'c.client_id');
+          })
+          .leftJoin('contacts as ct', function joinContacts() {
+            this.on('i.tenant', 'ct.tenant').andOn('i.contact_name_id', 'ct.contact_name_id');
+          })
+          .leftJoin('tickets as tk', function joinTickets() {
+            this.on('i.tenant', 'tk.tenant').andOn('i.ticket_id', 'tk.ticket_id');
+          })
+          .leftJoin('users as u', function joinUsers() {
+            this.on('i.tenant', 'u.tenant').andOn('i.user_id', 'u.user_id');
+          })
+          .leftJoin('statuses as st', function joinStatuses() {
+            this.on('i.tenant', 'st.tenant').andOn('i.status_id', 'st.status_id');
+          })
+          .leftJoin('interaction_types as it', function joinInteractionTypes() {
+            this.on('i.tenant', 'it.tenant').andOn('i.type_id', 'it.type_id');
+          })
+          .leftJoin('system_interaction_types as sit', 'i.type_id', 'sit.type_id')
+          .where('i.tenant', tx.tenantId)
+          .select(
+            'i.interaction_id',
+            'i.type_id',
+            'i.status_id',
+            'i.client_id',
+            'i.contact_name_id',
+            'i.ticket_id',
+            'i.title',
+            'i.notes',
+            'i.interaction_date',
+            'i.start_time',
+            'i.end_time',
+            'i.duration',
+            'i.user_id',
+            'i.visibility',
+            'i.category',
+            'i.tags',
+            'c.client_name',
+            'ct.full_name as contact_full_name',
+            'tk.ticket_number',
+            'u.first_name as user_first_name',
+            'u.last_name as user_last_name',
+            'u.email as user_email',
+            'st.name as status_name',
+            'it.type_name as tenant_type_name',
+            'sit.type_name as system_type_name'
+          );
+
+        if (input.client_id) query.andWhere('i.client_id', input.client_id);
+        if (input.contact_id) query.andWhere('i.contact_name_id', input.contact_id);
+        if (input.ticket_id) query.andWhere('i.ticket_id', input.ticket_id);
+        if (input.user_id) query.andWhere('i.user_id', input.user_id);
+        if (input.type_id) query.andWhere('i.type_id', input.type_id);
+        if (input.status_id) query.andWhere('i.status_id', input.status_id);
+        if (input.date_from) query.andWhere('i.interaction_date', '>=', input.date_from);
+        if (input.date_to) query.andWhere('i.interaction_date', '<=', input.date_to);
+
+        query.orderBy('i.interaction_date', 'desc').limit(input.limit);
+
+        let rows: Array<Record<string, unknown>>;
+        try {
+          rows = await query;
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const activities = rows.map((row) => toActivitySummary(row));
+        if (activities.length === 0 && input.on_empty === 'error') {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'No CRM activities matched the supplied filters',
+          });
+        }
+
+        return {
+          activities,
+          count: activities.length,
+          matched_filters: {
+            client_id: input.client_id ?? null,
+            contact_id: input.contact_id ?? null,
+            ticket_id: input.ticket_id ?? null,
+            user_id: input.user_id ?? null,
+            type_id: input.type_id ?? null,
+            status_id: input.status_id ?? null,
+            date_from: input.date_from ?? null,
+            date_to: input.date_to ?? null,
+            limit: input.limit,
+          },
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.update_activity
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.update_activity',
+    version: 1,
+    inputSchema: z.object({
+      activity_id: uuidSchema,
+      patch: updateActivityPatchSchema,
+      reason: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      activity_before: activitySummarySchema,
+      activity_after: activitySummarySchema,
+      changed_fields: z.array(z.string()),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Update CRM Activity',
+      category: 'Business Operations',
+      description: 'Patch an existing CRM activity and return before/after differences',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'client', action: 'update' });
+
+        const before = await fetchActivitySummary(ctx, tx, input.activity_id);
+
+        if (input.patch.status_id) {
+          await validateInteractionStatusId(ctx, tx, input.patch.status_id, 'status_id');
+        }
+
+        if (input.patch.type_id) {
+          await validateInteractionTypeId(ctx, tx, input.patch.type_id, 'type_id');
+        }
+
+        const startForValidation = input.patch.start_time ?? before.start_time;
+        const endForValidation = input.patch.end_time ?? before.end_time;
+        if (startForValidation && endForValidation && new Date(startForValidation).getTime() > new Date(endForValidation).getTime()) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'start_time must be less than or equal to end_time',
+          });
+        }
+
+        const updatePatch: Record<string, unknown> = {
+          ...(input.patch.title !== undefined ? { title: input.patch.title } : {}),
+          ...(input.patch.notes !== undefined ? { notes: input.patch.notes } : {}),
+          ...(input.patch.status_id !== undefined ? { status_id: input.patch.status_id } : {}),
+          ...(input.patch.visibility !== undefined ? { visibility: input.patch.visibility } : {}),
+          ...(input.patch.category !== undefined ? { category: input.patch.category } : {}),
+          ...(input.patch.tags !== undefined ? { tags: input.patch.tags } : {}),
+          ...(input.patch.interaction_date !== undefined ? { interaction_date: input.patch.interaction_date } : {}),
+          ...(input.patch.start_time !== undefined ? { start_time: input.patch.start_time } : {}),
+          ...(input.patch.end_time !== undefined ? { end_time: input.patch.end_time } : {}),
+          ...(input.patch.duration !== undefined ? { duration: input.patch.duration } : {}),
+          ...(input.patch.type_id !== undefined ? { type_id: input.patch.type_id } : {}),
+        };
+
+        try {
+          const updatedCount = await tx.trx('interactions')
+            .where({ tenant: tx.tenantId, interaction_id: input.activity_id })
+            .update(updatePatch);
+          if (!updatedCount) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Activity not found',
+              details: { activity_id: input.activity_id },
+            });
+          }
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const after = await fetchActivitySummary(ctx, tx, input.activity_id);
+        const changedFields = collectChangedFields(before, after, input.patch as Record<string, unknown>);
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.update_activity',
+          changedData: {
+            activity_id: input.activity_id,
+            changed_fields: changedFields,
+            reason: input.reason ?? null,
+            before: {
+              status_id: before.status_id,
+              type_id: before.type_id,
+              title: before.title,
+              visibility: before.visibility,
+              category: before.category,
+            },
+            after: {
+              status_id: after.status_id,
+              type_id: after.type_id,
+              title: after.title,
+              visibility: after.visibility,
+              category: after.category,
+            },
+          },
+          details: {
+            action_id: 'crm.update_activity',
+            action_version: 1,
+            activity_id: input.activity_id,
+          },
+        });
+
+        return {
+          activity_before: before,
+          activity_after: after,
+          changed_fields: changedFields,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.schedule_activity
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.schedule_activity',
+    version: 1,
+    inputSchema: scheduleActivityInputSchema,
+    outputSchema: z.object({
+      activity: activitySummarySchema,
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'actionProvided', key: actionProvidedKey },
+    ui: {
+      label: 'Schedule CRM Activity',
+      category: 'Business Operations',
+      description: 'Schedule a follow-up CRM activity linked to client/contact/ticket context',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'client', action: 'update' });
+        if (input.ticket_id) {
+          await requirePermission(ctx, tx, { resource: 'ticket', action: 'read' });
+        }
+
+        let resolvedClientId = input.client_id ?? null;
+        let resolvedContactId = input.contact_id ?? null;
+
+        if (resolvedContactId) {
+          const contact = await tx.trx('contacts')
+            .where({ tenant: tx.tenantId, contact_name_id: resolvedContactId })
+            .first();
+          if (!contact) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Contact not found',
+              details: { contact_id: resolvedContactId },
+            });
+          }
+
+          if (resolvedClientId && contact.client_id !== resolvedClientId) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'contact_id must belong to the selected client',
+              details: { contact_id: resolvedContactId, client_id: resolvedClientId },
+            });
+          }
+
+          resolvedClientId = (contact.client_id as string | null) ?? resolvedClientId;
+        }
+
+        if (!resolvedClientId) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Unable to resolve a client from client_id/contact_id',
+          });
+        }
+
+        const client = await tx.trx('clients').where({ tenant: tx.tenantId, client_id: resolvedClientId }).first();
+        if (!client) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Client not found',
+            details: { client_id: resolvedClientId },
+          });
+        }
+
+        if (input.ticket_id) {
+          const ticket = await tx.trx('tickets').where({ tenant: tx.tenantId, ticket_id: input.ticket_id }).first();
+          if (!ticket) {
+            throwActionError(ctx, {
+              category: 'ActionError',
+              code: 'NOT_FOUND',
+              message: 'Ticket not found',
+              details: { ticket_id: input.ticket_id },
+            });
+          }
+
+          if (ticket.client_id && ticket.client_id !== resolvedClientId) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'ticket_id must belong to the selected client',
+              details: { ticket_id: input.ticket_id, client_id: resolvedClientId },
+            });
+          }
+
+          if (resolvedContactId && ticket.contact_name_id && ticket.contact_name_id !== resolvedContactId) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'ticket_id contact does not match the selected contact_id',
+              details: { ticket_id: input.ticket_id, contact_id: resolvedContactId },
+            });
+          }
+        }
+
+        await validateInteractionTypeId(ctx, tx, input.type_id, 'type_id');
+
+        const statusId = input.status_id ?? (await getDefaultInteractionStatusId(ctx, tx));
+        await validateInteractionStatusId(ctx, tx, statusId, 'status_id');
+
+        const ownerUserId = input.assigned_user_id ?? input.owner_user_id ?? tx.actorUserId;
+        const owner = await tx.trx('users').where({ tenant: tx.tenantId, user_id: ownerUserId }).first();
+        if (!owner) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Assigned user not found',
+            details: { user_id: ownerUserId },
+          });
+        }
+
+        const endTime = input.end_time ?? input.start_time;
+        const derivedDuration =
+          input.duration !== undefined
+            ? input.duration
+            : Math.max(0, Math.round((new Date(endTime).getTime() - new Date(input.start_time).getTime()) / 60000));
+
+        const interactionId = uuidv4();
+
+        try {
+          await tx.trx('interactions').insert({
+            tenant: tx.tenantId,
+            interaction_id: interactionId,
+            type_id: input.type_id,
+            client_id: resolvedClientId,
+            contact_name_id: resolvedContactId,
+            ticket_id: input.ticket_id ?? null,
+            user_id: ownerUserId,
+            title: input.title,
+            notes: input.notes ?? null,
+            interaction_date: input.start_time,
+            start_time: input.start_time,
+            end_time: endTime,
+            duration: derivedDuration,
+            status_id: statusId,
+            visibility: input.visibility ?? 'internal',
+            category: input.category ?? null,
+            tags: input.tags ?? null,
+          });
+        } catch (error) {
+          rethrowAsStandardError(ctx, error);
+        }
+
+        const createdActivity = await fetchActivitySummary(ctx, tx, interactionId);
+        const occurredAt = createdActivity.interaction_date;
+
+        await publishWorkflowDomainEvent({
+          eventType: 'INTERACTION_LOGGED',
+          payload: buildInteractionLoggedPayload({
+            interactionId,
+            clientId: resolvedClientId,
+            contactId: resolvedContactId ?? undefined,
+            interactionType: createdActivity.type_name ?? createdActivity.type_id,
+            interactionOccurredAt: occurredAt,
+            loggedByUserId: ownerUserId,
+            subject: input.title,
+            outcome: createdActivity.status_name ?? undefined,
+          }),
+          tenantId: tx.tenantId,
+          occurredAt,
+          actorUserId: tx.actorUserId,
+          idempotencyKey: `interaction_logged:${interactionId}`,
+        });
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.schedule_activity',
+          changedData: {
+            activity_id: interactionId,
+            client_id: resolvedClientId,
+            contact_id: resolvedContactId,
+            ticket_id: input.ticket_id ?? null,
+            status_id: statusId,
+            type_id: input.type_id,
+            start_time: input.start_time,
+            end_time: endTime,
+            duration: derivedDuration,
+            assigned_user_id: ownerUserId,
+          },
+          details: {
+            action_id: 'crm.schedule_activity',
+            action_version: 1,
+            activity_id: interactionId,
+          },
+        });
+
+        return {
+          activity: createdActivity,
+        };
+      }),
+  });
+
+  // ---------------------------------------------------------------------------
+  // crm.send_quote
+  // ---------------------------------------------------------------------------
+  registry.register({
+    id: 'crm.send_quote',
+    version: 1,
+    inputSchema: sendQuoteInputSchema,
+    outputSchema: z.object({
+      quote: quoteSummarySchema,
+      previous_status: z.string().nullable(),
+      new_status: z.string().nullable(),
+      sent_at: isoDateTimeSchema.nullable(),
+      recipients: z.array(z.string()),
+      email_sent: z.boolean(),
+      message_id: z.string().nullable(),
+      no_op: z.boolean(),
+    }),
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    ui: {
+      label: 'Send Quote',
+      category: 'Business Operations',
+      description: 'Send an existing quote to the client using current quote send semantics',
+    },
+    handler: async (input, ctx) =>
+      withTenantTransaction(ctx, async (tx) => {
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
+        await requirePermission(ctx, tx, { resource: 'billing', action: 'update' });
+
+        const quote = await tx.trx('quotes').where({ tenant: tx.tenantId, quote_id: input.quote_id }).first();
+        if (!quote) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Quote not found',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        if (quote.is_template) {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Quote templates cannot be sent to clients',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        const previousStatus = quote.status == null ? null : String(quote.status);
+        if (previousStatus === 'sent') {
+          if (!input.no_op_if_already_sent) {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'Quote is already sent; resend behavior is not supported by crm.send_quote v1',
+              details: { quote_id: input.quote_id },
+            });
+          }
+
+          const summary = toQuoteSummary(quote);
+          await writeRunAudit(ctx, tx, {
+            operation: 'workflow_action:crm.send_quote',
+            changedData: {
+              quote_id: input.quote_id,
+              previous_status: previousStatus,
+              new_status: previousStatus,
+              no_op: true,
+            },
+            details: {
+              action_id: 'crm.send_quote',
+              action_version: 1,
+              quote_id: input.quote_id,
+            },
+          });
+
+          return {
+            quote: summary,
+            previous_status: previousStatus,
+            new_status: previousStatus,
+            sent_at: asIsoString(quote.sent_at),
+            recipients: [],
+            email_sent: false,
+            message_id: null,
+            no_op: true,
+          };
+        }
+
+        const approvalSettings = await getQuoteApprovalWorkflowSettings(tx.trx, tx.tenantId);
+        if (approvalSettings.approvalRequired) {
+          if (previousStatus !== 'approved') {
+            throwActionError(ctx, {
+              category: 'ValidationError',
+              code: 'VALIDATION_ERROR',
+              message: 'Only approved quotes can be sent when quote approval is required',
+            });
+          }
+        } else if (previousStatus !== 'draft' && previousStatus !== 'approved') {
+          throwActionError(ctx, {
+            category: 'ValidationError',
+            code: 'VALIDATION_ERROR',
+            message: 'Only draft or approved quotes can be sent',
+          });
+        }
+
+        const sentAt = new Date().toISOString();
+        await tx.trx('quotes')
+          .where({ tenant: tx.tenantId, quote_id: input.quote_id })
+          .update({
+            status: 'sent',
+            sent_at: sentAt,
+            updated_by: tx.actorUserId,
+            updated_at: sentAt,
+          });
+
+        const updatedQuote = await tx.trx('quotes').where({ tenant: tx.tenantId, quote_id: input.quote_id }).first();
+        if (!updatedQuote) {
+          throwActionError(ctx, {
+            category: 'ActionError',
+            code: 'NOT_FOUND',
+            message: 'Quote not found after send transition',
+            details: { quote_id: input.quote_id },
+          });
+        }
+
+        await maybeStoreQuotePdfBestEffort(tx.trx, tx.tenantId, updatedQuote, tx.actorUserId);
+
+        const recipients = await resolveQuoteRecipients(tx.trx, tx.tenantId, updatedQuote, input.email_addresses ?? []);
+        const { emailSent, messageId } = await sendQuoteEmailBestEffort({
+          tenantId: tx.tenantId,
+          quote: updatedQuote,
+          actorUserId: tx.actorUserId,
+          recipients,
+          subject: input.subject,
+          message: input.message,
+        });
+
+        const activityDescription = emailSent && recipients.length > 0
+          ? `Quote sent to ${recipients.join(', ')} and published in client portal`
+          : 'Quote published in client portal';
+
+        await QuoteActivity.create(tx.trx, tx.tenantId, {
+          quote_id: input.quote_id,
+          activity_type: 'sent',
+          description: activityDescription,
+          performed_by: tx.actorUserId,
+          metadata: {
+            recipients,
+            email_sent: emailSent,
+            message_id: messageId,
+            workflow_source: 'crm.send_quote',
+          },
+        });
+
+        await writeRunAudit(ctx, tx, {
+          operation: 'workflow_action:crm.send_quote',
+          changedData: {
+            quote_id: input.quote_id,
+            previous_status: previousStatus,
+            new_status: 'sent',
+            sent_at: sentAt,
+            recipients,
+            email_sent: emailSent,
+            message_id: messageId,
+          },
+          details: {
+            action_id: 'crm.send_quote',
+            action_version: 1,
+            quote_id: input.quote_id,
+          },
+        });
+
+        return {
+          quote: toQuoteSummary(updatedQuote),
+          previous_status: previousStatus,
+          new_status: 'sent',
+          sent_at: sentAt,
+          recipients,
+          email_sent: emailSent,
+          message_id: messageId,
+          no_op: false,
+        };
+      }),
   });
 }

--- a/shared/workflow/runtime/actions/businessOperations/crm.ts
+++ b/shared/workflow/runtime/actions/businessOperations/crm.ts
@@ -4,18 +4,20 @@ import type { Knex } from 'knex';
 import { getActionRegistryV2 } from '../../registries/actionRegistry';
 import { withWorkflowJsonSchemaMetadata } from '../../jsonSchemaMetadata';
 import { getWorkflowEmailProvider } from '../../registries/workflowEmailRegistry';
-import Quote from '../../../../../packages/billing/src/models/quote';
-import QuoteItem from '../../../../../packages/billing/src/models/quoteItem';
-import QuoteActivity from '../../../../../packages/billing/src/models/quoteActivity';
-import { getQuoteApprovalWorkflowSettings } from '../../../../../packages/billing/src/lib/quoteApprovalSettings';
-import { createQuoteItemSchema, createQuoteSchema, quoteStatusSchema } from '../../../../../packages/billing/src/schemas/quoteSchemas';
 import {
+  Quote,
+  QuoteActivity,
+  QuoteItem,
+  TagDefinition,
+  TagMapping,
   convertQuoteToDraftContract,
   convertQuoteToDraftContractAndInvoice,
   convertQuoteToDraftInvoice,
-} from '../../../../../packages/billing/src/services/quoteConversionService';
-import TagDefinition from '../../../../../packages/tags/src/models/tagDefinition';
-import TagMapping from '../../../../../packages/tags/src/models/tagMapping';
+  createQuoteItemSchema,
+  createQuoteSchema,
+  getQuoteApprovalWorkflowSettings,
+  quoteStatusSchema,
+} from './crmWorkerDal';
 import {
   uuidSchema,
   isoDateTimeSchema,
@@ -37,6 +39,7 @@ import {
   type AuthorizationSubject,
 } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
+import type { TaggedEntityType } from '@alga-psa/types';
 
 const WORKFLOW_PICKER_HINTS = {
   client: 'Search clients',
@@ -61,6 +64,8 @@ const withWorkflowPicker = <T extends z.ZodTypeAny>(
 const nullableUuidSchema = z.union([uuidSchema, z.null()]);
 const visibilitySchema = z.enum(['internal', 'client_visible']);
 const onEmptySchema = z.enum(['return_empty', 'error']);
+const supportedActivityTagTargetTypes = ['ticket', 'contact', 'client'] as const;
+type SupportedActivityTagTargetType = Extract<TaggedEntityType, typeof supportedActivityTagTargetTypes[number]>;
 
 const activitySummarySchema = z.object({
   activity_id: uuidSchema,
@@ -264,14 +269,6 @@ const createQuoteInputSchema = z.object({
   terms_and_conditions: z.string().optional().nullable(),
   currency_code: z.string().trim().length(3).default('USD'),
   idempotency_key: z.string().optional(),
-}).superRefine((value, refinementCtx) => {
-  if (value.valid_until.getTime() < value.quote_date.getTime()) {
-    refinementCtx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'valid_until must be on or after quote_date',
-      path: ['valid_until'],
-    });
-  }
 });
 
 const addQuoteItemInputSchema = z.object({
@@ -718,65 +715,15 @@ async function publishWorkflowDomainEvent(params: {
 }
 
 async function maybeStoreQuotePdfBestEffort(
-  trx: Knex.Transaction,
-  tenantId: string,
-  quote: Record<string, unknown>,
-  actorUserId: string
+  _trx: Knex.Transaction,
+  _tenantId: string,
+  _quote: Record<string, unknown>,
+  _actorUserId: string
 ): Promise<void> {
-  try {
-    const [{ createPDFGenerationService }, documentsModule] = await Promise.all([
-      import('../../../../../packages/billing/src/services'),
-      import('@alga-psa/documents/models'),
-    ]);
-
-    const fileRecord = await createPDFGenerationService(tenantId).generateAndStore({
-      quoteId: String(quote.quote_id),
-      quoteNumber: typeof quote.quote_number === 'string' ? quote.quote_number : undefined,
-      userId: actorUserId,
-    });
-
-    const documentModel = (documentsModule as unknown as {
-      Document: {
-        insert: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
-      };
-      DocumentAssociation: {
-        create: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
-      };
-    }).Document;
-
-    const documentAssociation = (documentsModule as unknown as {
-      DocumentAssociation: {
-        create: (trx: Knex.Transaction, row: Record<string, unknown>) => Promise<unknown>;
-      };
-    }).DocumentAssociation;
-
-    const documentId = uuidv4();
-
-    await documentModel.insert(trx, {
-      document_id: documentId,
-      document_name: `Quote_${String(quote.quote_number ?? quote.quote_id)}.pdf`,
-      type_id: null,
-      user_id: actorUserId,
-      created_by: actorUserId,
-      order_number: 0,
-      tenant: tenantId,
-      file_id: fileRecord.file_id,
-      storage_path: fileRecord.storage_path,
-      mime_type: 'application/pdf',
-      file_size: fileRecord.file_size,
-      folder_path: '/Quotes/Generated',
-      is_client_visible: true,
-    });
-
-    await documentAssociation.create(trx, {
-      document_id: documentId,
-      entity_id: String(quote.quote_id),
-      entity_type: 'quote',
-      tenant: tenantId,
-    });
-  } catch {
-    // Best-effort PDF storage.
-  }
+  // PDF rendering is a server/UI concern today: the generator imports billing
+  // service barrels, invoice template React renderers, and document models. Keep
+  // the Temporal workflow worker graph worker-safe and skip this optional side
+  // effect until a worker-safe quote PDF provider exists.
 }
 
 async function resolveQuoteRecipients(
@@ -922,7 +869,7 @@ function normalizeQuoteDates<T extends Record<string, unknown>>(value: T): T {
   const normalized = { ...value };
   for (const field of ['quote_date', 'valid_until'] as const) {
     if (normalized[field] instanceof Date) {
-      normalized[field] = (normalized[field] as Date).toISOString();
+      (normalized as Record<string, unknown>)[field] = (normalized[field] as Date).toISOString();
     }
   }
   return normalized;
@@ -965,17 +912,49 @@ type QuoteAuthorizationRecord = {
   created_by: string | null;
 };
 
-function createQuoteAuthorizationKernel(knexOrTrx: Knex | Knex.Transaction) {
+let authorizationSavepointCounter = 0;
+
+async function runAuthorizationLookupInSavepoint<T>(
+  trx: Knex.Transaction,
+  lookup: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  const savepointName = `workflow_auth_lookup_${authorizationSavepointCounter++}`;
+
+  try {
+    await trx.raw(`SAVEPOINT ${savepointName}`);
+    const result = await lookup();
+    await trx.raw(`RELEASE SAVEPOINT ${savepointName}`);
+    return result;
+  } catch {
+    try {
+      await trx.raw(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+      await trx.raw(`RELEASE SAVEPOINT ${savepointName}`);
+    } catch {
+      // Best effort: the caller receives the fallback value, and any unrecoverable
+      // transaction failure will surface on the next required DB operation.
+    }
+    return fallback;
+  }
+}
+
+async function resolveBundleNarrowingRulesSafely(
+  trx: Knex.Transaction,
+  input: Parameters<typeof resolveBundleNarrowingRulesForEvaluation>[1]
+): ReturnType<typeof resolveBundleNarrowingRulesForEvaluation> {
+  return runAuthorizationLookupInSavepoint(
+    trx,
+    () => resolveBundleNarrowingRulesForEvaluation(trx, input),
+    []
+  );
+}
+
+
+function createQuoteAuthorizationKernel(trx: Knex.Transaction) {
   return createAuthorizationKernel({
     builtinProvider: new BuiltinAuthorizationKernelProvider({ mutationGuards: [] }),
     bundleProvider: new BundleAuthorizationKernelProvider({
-      resolveRules: async (input) => {
-        try {
-          return await resolveBundleNarrowingRulesForEvaluation(knexOrTrx, input);
-        } catch {
-          return [];
-        }
-      },
+      resolveRules: async (input) => resolveBundleNarrowingRulesSafely(trx, input),
     }),
     rbacEvaluator: async () => true,
   });
@@ -986,16 +965,29 @@ async function resolveQuoteAuthorizationSubject(
   tenantId: string,
   actorUserId: string
 ): Promise<AuthorizationSubject> {
-  const [roleRows, teamRows, managedRows, userRow] = await Promise.all([
-    trx('user_roles').where({ tenant: tenantId, user_id: actorUserId }).select<{ role_id: string }[]>('role_id').catch(() => []),
-    trx('team_members').where({ tenant: tenantId, user_id: actorUserId }).select<{ team_id: string }[]>('team_id').catch(() => []),
-    trx('users').where({ tenant: tenantId, reports_to: actorUserId }).select<{ user_id: string }[]>('user_id').catch(() => []),
-    trx('users')
+  const roleRows = await runAuthorizationLookupInSavepoint(
+    trx,
+    () => trx('user_roles').where({ tenant: tenantId, user_id: actorUserId }).select<{ role_id: string }[]>('role_id'),
+    []
+  );
+  const teamRows = await runAuthorizationLookupInSavepoint(
+    trx,
+    () => trx('team_members').where({ tenant: tenantId, user_id: actorUserId }).select<{ team_id: string }[]>('team_id'),
+    []
+  );
+  const managedRows = await runAuthorizationLookupInSavepoint(
+    trx,
+    () => trx('users').where({ tenant: tenantId, reports_to: actorUserId }).select<{ user_id: string }[]>('user_id'),
+    []
+  );
+  const userRow = await runAuthorizationLookupInSavepoint(
+    trx,
+    () => trx('users')
       .where({ tenant: tenantId, user_id: actorUserId })
       .select<{ user_type?: string | null; contact_id?: string | null; client_id?: string | null }>('user_type', 'contact_id', 'client_id')
-      .first()
-      .catch(() => null),
-  ]);
+      .first(),
+    null
+  );
 
   const clientId = userRow?.client_id ?? null;
   return {
@@ -1071,6 +1063,30 @@ async function getAuthorizedQuoteForMutation(
   }
 
   return quote;
+}
+
+function resolveSupportedActivityTagTarget(
+  ctx: any,
+  interaction: Record<string, unknown>
+): { type: SupportedActivityTagTargetType; id: string } {
+  if (interaction.ticket_id) {
+    return { type: 'ticket', id: String(interaction.ticket_id) };
+  }
+  if (interaction.contact_name_id) {
+    return { type: 'contact', id: String(interaction.contact_name_id) };
+  }
+  if (interaction.client_id) {
+    return { type: 'client', id: String(interaction.client_id) };
+  }
+
+  throwActionError(ctx, {
+    category: 'ValidationError',
+    code: 'VALIDATION_ERROR',
+    message: 'Activity cannot be tagged because it is not linked to a supported tag target',
+    details: {
+      supported_entity_types: supportedActivityTagTargetTypes,
+    },
+  });
 }
 
 async function resolveInteractionStatus(
@@ -1171,7 +1187,6 @@ export function registerCrmActions(): void {
           };
         }
 
-        const nowIso = new Date().toISOString();
         const typeId = uuidv4();
 
         const displayOrder = input.display_order ?? await (async () => {
@@ -1190,7 +1205,6 @@ export function registerCrmActions(): void {
             icon: input.icon?.trim() || null,
             display_order: displayOrder,
             created_by: tx.actorUserId,
-            created_at: nowIso,
           });
         } catch (error) {
           rethrowAsStandardError(ctx, error);
@@ -1700,28 +1714,49 @@ export function registerCrmActions(): void {
       withTenantTransaction(ctx, async (tx) => {
         await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
 
-        const query = tx.trx('quotes')
-          .where({ tenant: tx.tenantId, is_template: input.is_template });
+        const page = input.page ?? 1;
+        const pageSize = input.pageSize ?? 25;
+        const sortBy = input.sortBy ?? 'quote_date';
+        const sortOrder = input.sortOrder ?? 'desc';
 
-        if (input.quote_id) query.andWhere('quote_id', input.quote_id);
-        if (input.quote_number) query.andWhere('quote_number', input.quote_number);
-        if (input.client_id) query.andWhere('client_id', input.client_id);
-        if (input.status) query.andWhere('status', input.status);
-        if (input.date_from) query.andWhere('quote_date', '>=', input.date_from.toISOString());
-        if (input.date_to) query.andWhere('quote_date', '<=', input.date_to.toISOString());
+        const buildQuery = () => {
+          const query = tx.trx('quotes')
+            .where({ tenant: tx.tenantId, is_template: input.is_template ?? false });
 
-        query.orderBy(input.sortBy, input.sortOrder);
-        query.limit(input.pageSize).offset((input.page - 1) * input.pageSize);
+          if (input.quote_id) query.andWhere('quote_id', input.quote_id);
+          if (input.quote_number) query.andWhere('quote_number', input.quote_number);
+          if (input.client_id) query.andWhere('client_id', input.client_id);
+          if (input.status) query.andWhere('status', input.status);
+          if (input.date_from) query.andWhere('quote_date', '>=', input.date_from.toISOString());
+          if (input.date_to) query.andWhere('quote_date', '<=', input.date_to.toISOString());
 
-        const rows = await query;
+          return query.orderBy(sortBy, sortOrder).orderBy('quote_id', 'asc');
+        };
+
         const authorizedRows: Array<Record<string, unknown>> = [];
-        for (const row of rows) {
-          if (await authorizeQuoteRead(tx.trx, tx.tenantId, tx.actorUserId, row)) {
-            authorizedRows.push(row as Record<string, unknown>);
+        const targetAuthorizedCount = page * pageSize;
+        const sourceBatchSize = Math.max(pageSize, 100);
+        let sourceOffset = 0;
+
+        while (authorizedRows.length < targetAuthorizedCount) {
+          const rows = await buildQuery().limit(sourceBatchSize).offset(sourceOffset);
+          if (rows.length === 0) break;
+
+          sourceOffset += rows.length;
+          for (const row of rows) {
+            if (await authorizeQuoteRead(tx.trx, tx.tenantId, tx.actorUserId, row)) {
+              authorizedRows.push(row as Record<string, unknown>);
+              if (authorizedRows.length >= targetAuthorizedCount) break;
+            }
           }
+
+          if (rows.length < sourceBatchSize) break;
         }
 
-        if (authorizedRows.length === 0 && input.on_empty === 'error') {
+        const pageStart = (page - 1) * pageSize;
+        const pageRows = authorizedRows.slice(pageStart, targetAuthorizedCount);
+
+        if (pageRows.length === 0 && input.on_empty === 'error') {
           throwActionError(ctx, {
             category: 'ActionError',
             code: 'NOT_FOUND',
@@ -1729,14 +1764,14 @@ export function registerCrmActions(): void {
           });
         }
 
-        const summaries = authorizedRows.map((row) => toQuoteDetailSummary(row));
+        const summaries = pageRows.map((row) => toQuoteDetailSummary(row));
         return {
           quotes: summaries,
           first_quote: summaries[0] ?? null,
           count: summaries.length,
           pagination: {
-            page: input.page,
-            page_size: input.pageSize,
+            page,
+            page_size: pageSize,
           },
         };
       }),
@@ -1888,8 +1923,8 @@ export function registerCrmActions(): void {
         if (alreadyConverted && input.no_op_if_already_converted) {
           return {
             quote: toQuoteDetailSummary(quote),
-            contract_id: quote.converted_contract_id ?? null,
-            invoice_id: quote.converted_invoice_id ?? null,
+            contract_id: typeof quote.converted_contract_id === 'string' ? quote.converted_contract_id : null,
+            invoice_id: typeof quote.converted_invoice_id === 'string' ? quote.converted_invoice_id : null,
             no_op: true,
           };
         }
@@ -1977,6 +2012,10 @@ export function registerCrmActions(): void {
     inputSchema: tagActivityInputSchema,
     outputSchema: z.object({
       activity_id: uuidSchema,
+      tagged_entity: z.object({
+        type: z.enum(supportedActivityTagTargetTypes),
+        id: uuidSchema,
+      }),
       added_tags: z.array(z.object({ tag_id: uuidSchema, tag_text: z.string(), mapping_id: uuidSchema })),
       existing_tags: z.array(z.object({ tag_id: uuidSchema, tag_text: z.string(), mapping_id: uuidSchema })),
       added_count: z.number().int(),
@@ -1991,7 +2030,7 @@ export function registerCrmActions(): void {
     },
     handler: async (input, ctx) =>
       withTenantTransaction(ctx, async (tx) => {
-        await requirePermission(ctx, tx, { resource: 'client', action: 'update' });
+        await requirePermission(ctx, tx, { resource: 'interaction', action: 'update' });
 
         const interaction = await tx.trx('interactions')
           .where({ tenant: tx.tenantId, interaction_id: input.activity_id })
@@ -2005,6 +2044,9 @@ export function registerCrmActions(): void {
           });
         }
 
+        const tagTarget = resolveSupportedActivityTagTarget(ctx, interaction as Record<string, unknown>);
+        await requirePermission(ctx, tx, { resource: tagTarget.type, action: 'update' });
+
         const normalizedTags = Array.from(new Set(input.tags.map((tag) => validateTagText(tag))));
         const addedTags: Array<{ tag_id: string; tag_text: string; mapping_id: string }> = [];
         const existingTags: Array<{ tag_id: string; tag_text: string; mapping_id: string }> = [];
@@ -2012,7 +2054,7 @@ export function registerCrmActions(): void {
         const createdMappings: Array<{ tag_id: string; tagged_id: string; created_at?: Date }> = [];
 
         for (const tagText of normalizedTags) {
-          const maybeExistingDefinition = await TagDefinition.findByTextAndType(tx.trx, tx.tenantId, tagText, 'interaction');
+          const maybeExistingDefinition = await TagDefinition.findByTextAndType(tx.trx, tx.tenantId, tagText, tagTarget.type);
           if (!maybeExistingDefinition) {
             await requirePermission(ctx, tx, { resource: 'tag', action: 'create' });
           }
@@ -2021,7 +2063,7 @@ export function registerCrmActions(): void {
             tx.trx,
             tx.tenantId,
             tagText,
-            'interaction',
+            tagTarget.type,
             {}
           );
 
@@ -2029,8 +2071,8 @@ export function registerCrmActions(): void {
             .where({
               tenant: tx.tenantId,
               tag_id: definition.tag_id,
-              tagged_id: input.activity_id,
-              tagged_type: 'interaction',
+              tagged_id: tagTarget.id,
+              tagged_type: tagTarget.type,
             })
             .first();
 
@@ -2039,8 +2081,8 @@ export function registerCrmActions(): void {
               throwActionError(ctx, {
                 category: 'ActionError',
                 code: 'CONFLICT',
-                message: 'Tag is already applied to this activity',
-                details: { activity_id: input.activity_id, tag_text: tagText },
+                message: 'Tag is already applied to this activity target',
+                details: { activity_id: input.activity_id, tagged_entity: tagTarget, tag_text: tagText },
               });
             }
             existingTags.push({
@@ -2053,8 +2095,8 @@ export function registerCrmActions(): void {
 
           const mapping = await TagMapping.insert(tx.trx, tx.tenantId, {
             tag_id: definition.tag_id,
-            tagged_id: input.activity_id,
-            tagged_type: 'interaction',
+            tagged_id: tagTarget.id,
+            tagged_type: tagTarget.type,
             created_by: tx.actorUserId,
           }, tx.actorUserId);
 
@@ -2067,7 +2109,7 @@ export function registerCrmActions(): void {
           }
           createdMappings.push({
             tag_id: definition.tag_id,
-            tagged_id: input.activity_id,
+            tagged_id: tagTarget.id,
             created_at: mapping.created_at,
           });
           addedTags.push({
@@ -2099,7 +2141,7 @@ export function registerCrmActions(): void {
             eventType: 'TAG_APPLIED',
             payload: buildTagAppliedPayload({
               tagId: mapping.tag_id,
-              entityType: 'interaction',
+              entityType: tagTarget.type,
               entityId: mapping.tagged_id,
               appliedByUserId: tx.actorUserId,
               appliedAt: mapping.created_at ?? occurredAt,
@@ -2107,7 +2149,7 @@ export function registerCrmActions(): void {
             tenantId: tx.tenantId,
             occurredAt,
             actorUserId: tx.actorUserId,
-            idempotencyKey: `tag_applied:${mapping.tagged_id}:${mapping.tag_id}`,
+            idempotencyKey: `tag_applied:${tagTarget.type}:${mapping.tagged_id}:${mapping.tag_id}`,
           });
         }
 
@@ -2115,6 +2157,8 @@ export function registerCrmActions(): void {
           operation: 'workflow_action:crm.tag_activity',
           changedData: {
             activity_id: input.activity_id,
+            tagged_entity_type: tagTarget.type,
+            tagged_entity_id: tagTarget.id,
             tags: normalizedTags,
             added_count: addedTags.length,
             existing_count: existingTags.length,
@@ -2123,11 +2167,14 @@ export function registerCrmActions(): void {
             action_id: 'crm.tag_activity',
             action_version: 1,
             activity_id: input.activity_id,
+            tagged_entity_type: tagTarget.type,
+            tagged_entity_id: tagTarget.id,
           },
         });
 
         return {
           activity_id: input.activity_id,
+          tagged_entity: tagTarget,
           added_tags: addedTags,
           existing_tags: existingTags,
           added_count: addedTags.length,
@@ -2338,7 +2385,8 @@ export function registerCrmActions(): void {
         if (input.date_from) query.andWhere('i.interaction_date', '>=', input.date_from);
         if (input.date_to) query.andWhere('i.interaction_date', '<=', input.date_to);
 
-        query.orderBy('i.interaction_date', 'desc').limit(input.limit);
+        const limit = input.limit ?? 25;
+        query.orderBy('i.interaction_date', 'desc').limit(limit);
 
         let rows: Array<Record<string, unknown>>;
         try {
@@ -2368,7 +2416,7 @@ export function registerCrmActions(): void {
             status_id: input.status_id ?? null,
             date_from: input.date_from ?? null,
             date_to: input.date_to ?? null,
-            limit: input.limit,
+            limit,
           },
         };
       }),
@@ -2715,15 +2763,12 @@ export function registerCrmActions(): void {
         await requirePermission(ctx, tx, { resource: 'billing', action: 'read' });
         await requirePermission(ctx, tx, { resource: 'billing', action: 'update' });
 
-        const quote = await tx.trx('quotes').where({ tenant: tx.tenantId, quote_id: input.quote_id }).first();
-        if (!quote) {
-          throwActionError(ctx, {
-            category: 'ActionError',
-            code: 'NOT_FOUND',
-            message: 'Quote not found',
-            details: { quote_id: input.quote_id },
-          });
-        }
+        const quote = await getAuthorizedQuoteForMutation(
+          ctx,
+          tx,
+          input.quote_id,
+          'Permission denied: Cannot update quote'
+        );
 
         if (quote.is_template) {
           throwActionError(ctx, {

--- a/shared/workflow/runtime/actions/businessOperations/crmWorkerDal.ts
+++ b/shared/workflow/runtime/actions/businessOperations/crmWorkerDal.ts
@@ -1,0 +1,1751 @@
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+import type {
+  IContract,
+  IInvoice,
+  IQuote,
+  IQuoteItem,
+  IQuoteActivity,
+  QuoteConversionPreview,
+  QuoteConversionPreviewItem,
+  QuoteStatus,
+  TaggedEntityType,
+} from '@alga-psa/types';
+import { SharedNumberingService } from '../../../../services/numberingService';
+
+export const quoteStatusSchema = z.enum([
+  'draft',
+  'pending_approval',
+  'approved',
+  'sent',
+  'accepted',
+  'rejected',
+  'expired',
+  'converted',
+  'cancelled',
+  'superseded',
+  'archived',
+]);
+
+const quoteItemBillingMethodSchema = z.enum(['fixed', 'hourly', 'usage']);
+const quoteDiscountTypeSchema = z.enum(['percentage', 'fixed']);
+
+const createQuoteBaseSchema = z.object({
+  client_id: z.string().uuid().optional().nullable(),
+  contact_id: z.string().uuid().optional().nullable(),
+  title: z.string().trim().min(1),
+  description: z.string().trim().optional().nullable(),
+  quote_date: z.coerce.date(),
+  valid_until: z.coerce.date(),
+  po_number: z.string().trim().max(255).optional().nullable(),
+  opportunity_id: z.string().uuid().optional().nullable(),
+  internal_notes: z.string().optional().nullable(),
+  client_notes: z.string().optional().nullable(),
+  terms_and_conditions: z.string().optional().nullable(),
+  currency_code: z.string().trim().length(3).default('USD'),
+  tax_source: z.enum(['internal', 'external', 'pending_external']).default('internal'),
+  is_template: z.boolean().default(false),
+  created_by: z.string().uuid().optional().nullable(),
+});
+
+export const createQuoteSchema = createQuoteBaseSchema.superRefine((value, ctx) => {
+  if (!value.is_template && !value.client_id) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'client_id is required for non-template quotes',
+      path: ['client_id'],
+    });
+  }
+
+  if (value.valid_until < value.quote_date) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'valid_until must be on or after quote_date',
+      path: ['valid_until'],
+    });
+  }
+});
+
+const createQuoteItemBaseSchema = z.object({
+  quote_id: z.string().uuid(),
+  service_id: z.string().uuid().optional().nullable(),
+  description: z.string().trim().min(1),
+  quantity: z.number().int().positive(),
+  unit_price: z.number().int().min(0).optional(),
+  unit_of_measure: z.string().trim().optional().nullable(),
+  display_order: z.number().int().min(0).optional(),
+  phase: z.string().trim().optional().nullable(),
+  is_optional: z.boolean().default(false),
+  is_selected: z.boolean().default(true),
+  is_recurring: z.boolean().default(false),
+  billing_frequency: z.string().trim().optional().nullable(),
+  billing_method: quoteItemBillingMethodSchema.optional().nullable(),
+  is_discount: z.boolean().default(false),
+  discount_type: quoteDiscountTypeSchema.optional().nullable(),
+  discount_percentage: z.number().int().min(0).max(100).optional().nullable(),
+  applies_to_item_id: z.string().uuid().optional().nullable(),
+  applies_to_service_id: z.string().uuid().optional().nullable(),
+  is_taxable: z.boolean().default(true),
+  tax_region: z.string().trim().optional().nullable(),
+  tax_rate: z.number().int().min(0).optional().nullable(),
+  location_id: z.string().uuid().optional().nullable(),
+  cost: z.number().int().min(0).optional().nullable(),
+  cost_currency: z.string().trim().length(3).optional().nullable(),
+  created_by: z.string().uuid().optional().nullable(),
+});
+
+export const createQuoteItemSchema = createQuoteItemBaseSchema.superRefine((value, ctx) => {
+  if (value.is_recurring && !value.billing_frequency) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'billing_frequency is required for recurring items',
+      path: ['billing_frequency'],
+    });
+  }
+
+  if (value.is_discount && !value.discount_type) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'discount_type is required for discount items',
+      path: ['discount_type'],
+    });
+  }
+
+  if (value.discount_type === 'percentage' && (value.discount_percentage === undefined || value.discount_percentage === null)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'discount_percentage is required for percentage discounts',
+      path: ['discount_percentage'],
+    });
+  }
+});
+
+const QUOTE_ALLOWED_STATUS_TRANSITIONS: Record<QuoteStatus, QuoteStatus[]> = {
+  draft: ['pending_approval', 'sent', 'cancelled'],
+  pending_approval: ['approved', 'draft', 'cancelled'],
+  approved: ['sent', 'cancelled'],
+  sent: ['accepted', 'rejected', 'expired', 'cancelled'],
+  accepted: ['converted', 'cancelled'],
+  rejected: ['cancelled'],
+  expired: ['cancelled'],
+  converted: [],
+  cancelled: [],
+  superseded: [],
+  archived: [],
+};
+
+function canTransitionQuoteStatus(currentStatus: QuoteStatus, nextStatus: QuoteStatus): boolean {
+  if (currentStatus === nextStatus) {
+    return true;
+  }
+  return QUOTE_ALLOWED_STATUS_TRANSITIONS[currentStatus]?.includes(nextStatus) ?? false;
+}
+
+function toNumber(value: unknown): number {
+  return Number(value ?? 0);
+}
+
+function toQuoteDate(value?: string | Date | null): string {
+  if (!value) {
+    return new Date().toISOString();
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}
+
+function isQuoteItemIncluded(item: { is_optional?: boolean | null; is_selected?: boolean | null }): boolean {
+  if (!item.is_optional) return true;
+  return item.is_selected === true;
+}
+
+function calculateDiscountAmount(
+  item: { quantity?: number | string | null; unit_price?: number | string | null; discount_type?: string | null; discount_percentage?: number | string | null },
+  baseAmount: number
+): number {
+  if (item.discount_type === 'percentage') {
+    return Math.round(baseAmount * (toNumber(item.discount_percentage) / 100));
+  }
+
+  return Math.abs(toNumber(item.quantity || 1) * toNumber(item.unit_price));
+}
+
+function isDateApplicable(row: { start_date?: string | Date | null; end_date?: string | Date | null }, date: string): boolean {
+  const currentDate = new Date(date);
+  if (row.start_date && new Date(row.start_date) > currentDate) return false;
+  if (row.end_date && new Date(row.end_date) < currentDate) return false;
+  return true;
+}
+
+function calculateThresholdBasedTax(
+  thresholds: Array<{ min_amount: number | string; max_amount?: number | string | null; rate: number | string }>,
+  netAmount: number
+): { taxAmount: number; taxRate: number } {
+  let taxAmount = 0;
+  let remainingAmount = netAmount;
+
+  for (const threshold of thresholds) {
+    if (remainingAmount <= 0) break;
+
+    const minAmount = toNumber(threshold.min_amount);
+    const maxAmount = threshold.max_amount == null ? null : toNumber(threshold.max_amount);
+    const taxableAmount = maxAmount == null
+      ? remainingAmount
+      : Math.min(remainingAmount, Math.max(maxAmount - minAmount, 0));
+
+    taxAmount += Math.ceil((taxableAmount * toNumber(threshold.rate)) / 100);
+    remainingAmount -= taxableAmount;
+  }
+
+  return {
+    taxAmount,
+    taxRate: netAmount > 0 ? (taxAmount / netAmount) * 100 : 0,
+  };
+}
+
+async function getApplicableTaxHoliday(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  taxRateId: string,
+  date: string
+): Promise<Record<string, unknown> | undefined> {
+  const currentDate = new Date(date);
+  const holidays = await knexOrTrx('tax_holidays')
+    .where({ tenant, tax_rate_id: taxRateId })
+    .orderBy('start_date');
+
+  return holidays.find((holiday) =>
+    new Date(holiday.start_date) <= currentDate && new Date(holiday.end_date) >= currentDate
+  );
+}
+
+async function calculateComponentTax(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  component: Record<string, unknown>,
+  amount: number,
+  date: string
+): Promise<number> {
+  const holiday = await getApplicableTaxHoliday(knexOrTrx, tenant, String(component.tax_rate_id), date);
+  if (holiday) return 0;
+  return Math.ceil((amount * toNumber(component.rate)) / 100);
+}
+
+async function calculateTaxWithConnection(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  clientId: string,
+  netAmount: number,
+  date: string,
+  regionCode: string | undefined,
+  isTaxable: boolean,
+  currencyCode?: string | null
+): Promise<{ taxAmount: number; taxRate: number }> {
+  const client = await knexOrTrx('clients')
+    .where({ tenant, client_id: clientId })
+    .select('is_tax_exempt')
+    .first();
+
+  if (!client) {
+    throw new Error(`Client ${clientId} not found in tenant ${tenant}`);
+  }
+
+  if (client.is_tax_exempt || !isTaxable) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  const taxSettings = await knexOrTrx('client_tax_settings')
+    .where({ tenant, client_id: clientId })
+    .select('is_reverse_charge_applicable')
+    .first();
+  if (taxSettings?.is_reverse_charge_applicable) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  if (regionCode) {
+    const applicableRates = await knexOrTrx('tax_rates')
+      .where({ tenant, region_code: regionCode, is_active: true })
+      .andWhere('start_date', '<=', date)
+      .andWhere(function dateRange() {
+        this.whereNull('end_date').orWhere('end_date', '>', date);
+      })
+      .andWhere(function currencyRange() {
+        this.whereNull('currency_code');
+        if (currencyCode) this.orWhere('currency_code', currencyCode);
+      })
+      .select('tax_percentage');
+
+    const combinedTaxRate = applicableRates.reduce((sum, rate) => sum + toNumber(rate.tax_percentage), 0);
+    return {
+      taxAmount: netAmount > 0 ? Math.ceil((netAmount * combinedTaxRate) / 100) : 0,
+      taxRate: combinedTaxRate,
+    };
+  }
+
+  const defaultRateAssoc = await knexOrTrx('client_tax_rates')
+    .where({ tenant, client_id: clientId, is_default: true })
+    .whereNull('location_id')
+    .select('tax_rate_id')
+    .first();
+
+  if (!defaultRateAssoc) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  const taxRate = await knexOrTrx('tax_rates')
+    .where({ tenant, tax_rate_id: defaultRateAssoc.tax_rate_id, is_active: true })
+    .andWhere('start_date', '<=', date)
+    .andWhere(function dateRange() {
+      this.whereNull('end_date').orWhere('end_date', '>', date);
+    })
+    .andWhere(function currencyRange() {
+      this.whereNull('currency_code');
+      if (currencyCode) this.orWhere('currency_code', currencyCode);
+    })
+    .first();
+
+  if (!taxRate) {
+    return { taxAmount: 0, taxRate: 0 };
+  }
+
+  if (taxRate.is_composite) {
+    const components = await knexOrTrx('tax_components')
+      .join('composite_tax_mappings', function joinMappings() {
+        this.on('tax_components.tax_component_id', '=', 'composite_tax_mappings.tax_component_id')
+          .andOn('tax_components.tenant', '=', 'composite_tax_mappings.tenant');
+      })
+      .where({
+        'tax_components.tenant': tenant,
+        'composite_tax_mappings.composite_tax_id': taxRate.tax_rate_id,
+      })
+      .orderBy('composite_tax_mappings.sequence')
+      .select('tax_components.*');
+
+    let totalTaxAmount = 0;
+    let taxableAmount = netAmount;
+    for (const component of components) {
+      if (!isDateApplicable(component, date)) continue;
+      const componentTax = await calculateComponentTax(knexOrTrx, tenant, component, taxableAmount, date);
+      totalTaxAmount += componentTax;
+      if (component.is_compound) taxableAmount += componentTax;
+    }
+
+    return {
+      taxAmount: totalTaxAmount,
+      taxRate: netAmount > 0 ? (totalTaxAmount / netAmount) * 100 : 0,
+    };
+  }
+
+  const thresholds = await knexOrTrx('tax_rate_thresholds')
+    .where({ tenant, tax_rate_id: taxRate.tax_rate_id })
+    .orderBy('min_amount');
+
+  if (thresholds.length > 0) {
+    return calculateThresholdBasedTax(thresholds, netAmount);
+  }
+
+  if (netAmount <= 0) {
+    return { taxAmount: 0, taxRate: toNumber(taxRate.tax_percentage) };
+  }
+
+  const taxRatePercentage = toNumber(taxRate.tax_percentage);
+  return {
+    taxAmount: Math.ceil((netAmount * taxRatePercentage) / 100),
+    taxRate: taxRatePercentage,
+  };
+}
+
+async function recalculateQuoteFinancials(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quoteId: string
+): Promise<void> {
+  const quote = await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quoteId })
+    .first() as (Record<string, unknown> & { quote_id: string; client_id?: string | null; quote_date?: string | null; currency_code?: string | null; tax_source?: 'internal' | 'external' | 'pending_external' | null }) | undefined;
+
+  if (!quote) {
+    return;
+  }
+
+  const items = await knexOrTrx('quote_items')
+    .where({ tenant, quote_id: quoteId })
+    .orderBy('display_order', 'asc')
+    .orderBy('created_at', 'asc') as Array<Record<string, unknown> & {
+      quote_item_id: string;
+      service_id?: string | null;
+      quantity: number | string;
+      unit_price: number | string;
+      is_discount?: boolean | null;
+      discount_type?: 'percentage' | 'fixed' | null;
+      discount_percentage?: number | string | null;
+      applies_to_item_id?: string | null;
+      applies_to_service_id?: string | null;
+      is_optional?: boolean | null;
+      is_selected?: boolean | null;
+      is_taxable?: boolean | null;
+      tax_region?: string | null;
+      tax_rate?: number | string | null;
+      location_id?: string | null;
+    }>;
+
+  const client = quote.client_id
+    ? await knexOrTrx('clients')
+        .where({ tenant, client_id: quote.client_id })
+        .select('region_code')
+        .first()
+    : null;
+
+  const distinctLocationIds = Array.from(
+    new Set(
+      items
+        .map((item) => item.location_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
+  const locationRegionMap = new Map<string, string | null>();
+  if (distinctLocationIds.length > 0) {
+    const locationRows = await knexOrTrx('client_locations')
+      .where({ tenant })
+      .whereIn('location_id', distinctLocationIds)
+      .select('location_id', 'region_code');
+    for (const row of locationRows) {
+      locationRegionMap.set(row.location_id as string, (row.region_code as string | null | undefined) ?? null);
+    }
+  }
+
+  const quoteDate = toQuoteDate(quote.quote_date);
+  const currencyCode = quote.currency_code ?? 'USD';
+  const taxSource = quote.tax_source ?? 'internal';
+  const includedBaseItems = items.filter((item) => !item.is_discount && isQuoteItemIncluded(item));
+  const baseSubtotal = includedBaseItems.reduce((sum, item) => sum + (toNumber(item.quantity) * toNumber(item.unit_price)), 0);
+  const baseItemTotals = new Map(includedBaseItems.map((item) => [item.quote_item_id, toNumber(item.quantity) * toNumber(item.unit_price)]));
+  const baseServiceTotals = new Map<string, number>();
+
+  for (const item of includedBaseItems) {
+    if (!item.service_id) {
+      continue;
+    }
+
+    baseServiceTotals.set(
+      item.service_id,
+      (baseServiceTotals.get(item.service_id) ?? 0) + (toNumber(item.quantity) * toNumber(item.unit_price))
+    );
+  }
+
+  let subtotal = 0;
+  let discountTotal = 0;
+  let tax = 0;
+
+  for (const item of items) {
+    const totalPrice = toNumber(item.quantity) * toNumber(item.unit_price);
+    const isIncludedInTotals = isQuoteItemIncluded(item);
+    const isDiscount = item.is_discount === true;
+    const locationRegionCode = item.location_id ? (locationRegionMap.get(item.location_id) ?? null) : null;
+    const taxRegion = item.tax_region ?? locationRegionCode ?? client?.region_code ?? null;
+
+    const scopedBaseAmount = item.applies_to_item_id
+      ? (baseItemTotals.get(item.applies_to_item_id) ?? 0)
+      : item.applies_to_service_id
+        ? (baseServiceTotals.get(item.applies_to_service_id) ?? 0)
+        : baseSubtotal;
+    const resolvedTotalPrice = isDiscount ? calculateDiscountAmount(item, scopedBaseAmount) : totalPrice;
+
+    const netAmount = isIncludedInTotals ? resolvedTotalPrice : 0;
+    let taxAmount = 0;
+    let taxRate = isIncludedInTotals ? toNumber(item.tax_rate) : 0;
+
+    if (isDiscount) {
+      discountTotal += isIncludedInTotals ? resolvedTotalPrice : 0;
+    } else {
+      subtotal += isIncludedInTotals ? resolvedTotalPrice : 0;
+
+      if (isIncludedInTotals && quote.client_id && taxSource === 'internal') {
+        const taxResult = await calculateTaxWithConnection(
+          knexOrTrx,
+          tenant,
+          quote.client_id,
+          netAmount,
+          quoteDate,
+          taxRegion ?? undefined,
+          item.is_taxable !== false,
+          currencyCode
+        );
+
+        taxAmount = taxResult.taxAmount;
+        taxRate = Math.round(Number(taxResult.taxRate ?? 0));
+      } else if (taxSource !== 'internal') {
+        taxAmount = 0;
+        taxRate = 0;
+      }
+
+      tax += taxAmount;
+    }
+
+    await knexOrTrx('quote_items')
+      .where({ tenant, quote_item_id: item.quote_item_id })
+      .update({
+        total_price: resolvedTotalPrice,
+        net_amount: netAmount,
+        tax_amount: taxAmount,
+        tax_region: taxRegion,
+        tax_rate: taxRate,
+        updated_at: knexOrTrx.fn.now(),
+      });
+  }
+
+  await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quoteId })
+    .update({
+      subtotal,
+      discount_total: discountTotal,
+      tax,
+      total_amount: subtotal - discountTotal + tax,
+      updated_at: knexOrTrx.fn.now(),
+    });
+}
+
+function normalizeQuoteItem(row: Record<string, unknown>): IQuoteItem {
+  return {
+    ...row,
+    quantity: Number(row.quantity),
+    unit_price: Number(row.unit_price),
+    total_price: Number(row.total_price),
+    tax_amount: Number(row.tax_amount),
+    net_amount: Number(row.net_amount),
+    discount_percentage: row.discount_percentage == null ? row.discount_percentage : Number(row.discount_percentage),
+    display_order: Number(row.display_order),
+    tax_rate: row.tax_rate == null ? row.tax_rate : Number(row.tax_rate),
+    cost: row.cost == null ? null : Number(row.cost),
+    cost_currency: row.cost_currency ?? null,
+  } as IQuoteItem;
+}
+
+async function getNextQuoteItemDisplayOrder(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quoteId: string
+): Promise<number> {
+  const result = await knexOrTrx('quote_items')
+    .where({ tenant, quote_id: quoteId })
+    .max<{ max?: number | string }>('display_order as max')
+    .first();
+
+  return Number(result?.max ?? -1) + 1;
+}
+
+function ensureIntegerField(value: unknown, fieldName: string): void {
+  if (value !== undefined && value !== null && !Number.isInteger(Number(value))) {
+    throw new Error(`${fieldName} must be an integer`);
+  }
+}
+
+function getTodayStartUTC(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+function isExpiredOnAccess(quote: Pick<IQuote, 'status' | 'valid_until'>): boolean {
+  if (quote.status !== 'sent' || !quote.valid_until) {
+    return false;
+  }
+
+  return new Date(quote.valid_until) < getTodayStartUTC();
+}
+
+async function expireQuoteIfNeeded(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quote: IQuote | null
+): Promise<IQuote | null> {
+  if (!quote || !isExpiredOnAccess(quote)) {
+    return quote;
+  }
+
+  const [expiredQuote] = await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quote.quote_id })
+    .update({
+      status: 'expired',
+      expired_at: knexOrTrx.fn.now(),
+      updated_at: knexOrTrx.fn.now(),
+    })
+    .returning('*');
+
+  await QuoteActivity.create(knexOrTrx, tenant, {
+    quote_id: quote.quote_id,
+    activity_type: 'expired',
+    description: 'Quote automatically expired on access',
+    performed_by: null,
+    metadata: { previous_status: quote.status },
+  });
+
+  return expiredQuote as IQuote;
+}
+
+async function mapQuoteRecord(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quote: IQuote | null
+): Promise<IQuote | null> {
+  const resolvedQuote = await expireQuoteIfNeeded(knexOrTrx, tenant, quote);
+  if (!resolvedQuote) {
+    return null;
+  }
+
+  resolvedQuote.quote_items = await QuoteItem.listByQuoteId(knexOrTrx, tenant, resolvedQuote.quote_id);
+  resolvedQuote.quote_activities = await QuoteActivity.listByQuoteId(knexOrTrx, tenant, resolvedQuote.quote_id);
+  return resolvedQuote;
+}
+
+export const QuoteActivity = {
+  async create(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    activity: Omit<IQuoteActivity, 'activity_id' | 'tenant' | 'created_at'>
+  ): Promise<IQuoteActivity> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for creating quote activity');
+    }
+
+    const [createdActivity] = await knexOrTrx('quote_activities')
+      .insert({ tenant, ...activity, metadata: activity.metadata ?? {} })
+      .returning('*');
+
+    return createdActivity as IQuoteActivity;
+  },
+
+  async listByQuoteId(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    quoteId: string
+  ): Promise<IQuoteActivity[]> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for listing quote activities');
+    }
+
+    return knexOrTrx('quote_activities')
+      .where({ tenant, quote_id: quoteId })
+      .orderBy('created_at', 'asc') as Promise<IQuoteActivity[]>;
+  },
+};
+
+export const QuoteItem = {
+  async listByQuoteId(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    quoteId: string
+  ): Promise<IQuoteItem[]> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for listing quote items');
+    }
+
+    const items = await knexOrTrx('quote_items')
+      .where({ tenant, quote_id: quoteId })
+      .orderBy('display_order', 'asc')
+      .orderBy('created_at', 'asc');
+
+    return items.map((item) => normalizeQuoteItem(item));
+  },
+
+  async create(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    item: Omit<IQuoteItem, 'quote_item_id' | 'tenant' | 'total_price' | 'net_amount' | 'tax_amount' | 'display_order' | 'created_at' | 'updated_at'> & Partial<Pick<IQuoteItem, 'display_order'>>
+  ): Promise<IQuoteItem> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for creating quote item');
+    }
+
+    ensureIntegerField(item.quantity, 'Quantity');
+    ensureIntegerField(item.unit_price, 'Unit price');
+
+    let resolvedItem = { ...item } as Record<string, unknown> & { service_id?: string | null; quote_id: string; display_order?: number; unit_price?: number | null; quantity?: number | null; description?: string | null; service_item_kind?: string | null; cost?: number | null; cost_currency?: string | null };
+
+    if (item.service_id) {
+      const service = await knexOrTrx('service_catalog')
+        .where({ tenant, service_id: item.service_id })
+        .select(
+          'service_name',
+          'sku',
+          'default_rate',
+          'unit_of_measure',
+          'billing_method',
+          'item_kind',
+          'cost',
+          'cost_currency'
+        )
+        .first();
+
+      if (!service) {
+        throw new Error(`Service ${item.service_id} not found in tenant ${tenant}`);
+      }
+
+      let resolvedUnitPrice = resolvedItem.unit_price;
+      if (resolvedUnitPrice == null) {
+        const quote = await knexOrTrx('quotes')
+          .where({ tenant, quote_id: item.quote_id })
+          .select('currency_code')
+          .first();
+        const currencyCode = quote?.currency_code ?? 'USD';
+
+        const priceRow = await knexOrTrx('service_prices')
+          .where({ tenant, service_id: item.service_id, currency_code: currencyCode })
+          .select('rate')
+          .first();
+
+        resolvedUnitPrice = priceRow ? Number(priceRow.rate) : Number(service.default_rate ?? 0);
+      }
+
+      const resolvedItemKind = resolvedItem.service_item_kind ?? service.item_kind ?? 'service';
+
+      resolvedItem = {
+        ...resolvedItem,
+        service_name: resolvedItem.service_name ?? service.service_name,
+        service_sku: resolvedItem.service_sku ?? service.sku ?? null,
+        unit_price: resolvedUnitPrice,
+        unit_of_measure: resolvedItem.unit_of_measure ?? service.unit_of_measure ?? null,
+        billing_method: resolvedItem.billing_method ?? service.billing_method ?? null,
+        service_item_kind: resolvedItemKind,
+        description: resolvedItem.description || service.service_name,
+        cost: resolvedItemKind === 'product' && service.cost != null ? Number(service.cost) : resolvedItem.cost ?? null,
+        cost_currency: resolvedItemKind === 'product' && service.cost_currency ? service.cost_currency : resolvedItem.cost_currency ?? null,
+      };
+    }
+
+    const quantity = Number(resolvedItem.quantity ?? 1);
+    const unitPrice = Number(resolvedItem.unit_price ?? 0);
+    const totalPrice = quantity * unitPrice;
+    const displayOrder = resolvedItem.display_order ?? await getNextQuoteItemDisplayOrder(knexOrTrx, tenant, item.quote_id);
+
+    const [createdItem] = await knexOrTrx('quote_items')
+      .insert({
+        tenant,
+        ...resolvedItem,
+        quantity,
+        unit_price: unitPrice,
+        total_price: totalPrice,
+        net_amount: totalPrice,
+        tax_amount: 0,
+        display_order: displayOrder,
+      })
+      .returning('*');
+
+    await recalculateQuoteFinancials(knexOrTrx, tenant, item.quote_id);
+
+    const refreshedItem = await knexOrTrx('quote_items')
+      .where({ tenant, quote_item_id: createdItem.quote_item_id })
+      .first();
+
+    return normalizeQuoteItem(refreshedItem ?? createdItem);
+  },
+};
+
+export const Quote = {
+  async getById(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    quoteId: string
+  ): Promise<IQuote | null> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for getting quote');
+    }
+
+    const quote = await knexOrTrx('quotes')
+      .where({ tenant, quote_id: quoteId })
+      .first();
+
+    return mapQuoteRecord(knexOrTrx, tenant, (quote ?? null) as IQuote | null);
+  },
+
+  async create(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    quote: Omit<IQuote, 'quote_id' | 'tenant' | 'quote_number' | 'quote_items' | 'quote_activities' | 'created_at' | 'updated_at' | 'status' | 'version'> & Partial<Pick<IQuote, 'status' | 'version'>>
+  ): Promise<IQuote> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for creating quote');
+    }
+
+    const quoteNumber = quote.is_template
+      ? null
+      : await SharedNumberingService.getNextNumber('QUOTE', { knex: knexOrTrx, tenant });
+
+    const [createdQuote] = await knexOrTrx('quotes')
+      .insert({
+        tenant,
+        ...quote,
+        quote_number: quoteNumber,
+        status: quote.is_template ? null : (quote.status ?? 'draft'),
+        version: quote.version ?? 1,
+      })
+      .returning('*');
+
+    await QuoteActivity.create(knexOrTrx, tenant, {
+      quote_id: createdQuote.quote_id,
+      activity_type: 'created',
+      description: quote.is_template ? 'Quote template created' : 'Quote created',
+      performed_by: createdQuote.created_by ?? null,
+      metadata: { is_template: createdQuote.is_template },
+    });
+
+    return createdQuote as IQuote;
+  },
+
+  async update(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    quoteId: string,
+    updateData: Partial<IQuote>
+  ): Promise<IQuote> {
+    if (!tenant) {
+      throw new Error('Tenant context is required for updating quote');
+    }
+
+    const existingQuote = await knexOrTrx('quotes')
+      .where({ tenant, quote_id: quoteId })
+      .first();
+
+    if (!existingQuote) {
+      throw new Error(`Quote ${quoteId} not found in tenant ${tenant}`);
+    }
+
+    if (existingQuote.is_template && updateData.status !== undefined && updateData.status !== null) {
+      throw new Error('Quote templates do not participate in status transitions');
+    }
+
+    if (updateData.status && existingQuote.status && !canTransitionQuoteStatus(existingQuote.status, updateData.status)) {
+      throw new Error(`Invalid quote status transition from ${existingQuote.status} to ${updateData.status}`);
+    }
+
+    const [updatedQuote] = await knexOrTrx('quotes')
+      .where({ tenant, quote_id: quoteId })
+      .update({ ...updateData, updated_at: knexOrTrx.fn.now() })
+      .returning('*');
+
+    await QuoteActivity.create(knexOrTrx, tenant, {
+      quote_id: quoteId,
+      activity_type: updateData.status && updateData.status !== existingQuote.status ? 'status_changed' : 'updated',
+      description: updateData.status && updateData.status !== existingQuote.status
+        ? `Quote status changed from ${existingQuote.status} to ${updateData.status}`
+        : 'Quote updated',
+      performed_by: updatedQuote.updated_by ?? null,
+      metadata: updateData.status && updateData.status !== existingQuote.status
+        ? { previous_status: existingQuote.status, next_status: updateData.status }
+        : {},
+    });
+
+    if (!updatedQuote.is_template) {
+      await recalculateQuoteFinancials(knexOrTrx, tenant, quoteId);
+      const recalculatedQuote = await knexOrTrx('quotes')
+        .where({ tenant, quote_id: quoteId })
+        .first();
+      return (recalculatedQuote ?? updatedQuote) as IQuote;
+    }
+
+    return updatedQuote as IQuote;
+  },
+};
+
+export interface QuoteApprovalWorkflowSettings {
+  approvalRequired: boolean;
+}
+
+function normalizeSettings(rawSettings: unknown): Record<string, any> {
+  if (!rawSettings) {
+    return {};
+  }
+
+  if (typeof rawSettings === 'string') {
+    try {
+      return JSON.parse(rawSettings);
+    } catch {
+      return {};
+    }
+  }
+
+  if (typeof rawSettings === 'object') {
+    return rawSettings as Record<string, any>;
+  }
+
+  return {};
+}
+
+export async function getQuoteApprovalWorkflowSettings(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string
+): Promise<QuoteApprovalWorkflowSettings> {
+  const row = await knexOrTrx('tenant_settings')
+    .select('settings')
+    .where({ tenant })
+    .first<{ settings?: unknown }>();
+
+  const settings = normalizeSettings(row?.settings);
+  return {
+    approvalRequired: settings.billing?.quotes?.approvalRequired === true,
+  };
+}
+
+const tableColumnCache = new Map<string, Set<string>>();
+
+async function getTableColumns(
+  knexOrTrx: Knex | Knex.Transaction,
+  tableName: string
+): Promise<Set<string>> {
+  const cached = tableColumnCache.get(tableName);
+  if (cached) {
+    return cached;
+  }
+
+  const columnInfo = await knexOrTrx(tableName).columnInfo();
+  const columns = new Set(Object.keys(columnInfo));
+  tableColumnCache.set(tableName, columns);
+  return columns;
+}
+
+async function insertRowsUsingExistingColumns(
+  knexOrTrx: Knex | Knex.Transaction,
+  tableName: string,
+  rows: Record<string, unknown>[]
+): Promise<void> {
+  if (rows.length === 0) {
+    return;
+  }
+
+  const columns = await getTableColumns(knexOrTrx, tableName);
+  const filteredRows = rows.map((row) => Object.fromEntries(
+    Object.entries(row).filter(([key, value]) => columns.has(key) && value !== undefined)
+  ));
+
+  await knexOrTrx(tableName).insert(filteredRows);
+}
+
+export interface QuoteToContractConversionResult {
+  quote: IQuote;
+  contract: IContract;
+  clientContractId?: string;
+}
+
+export interface QuoteToInvoiceConversionResult {
+  quote: IQuote;
+  invoice: IInvoice;
+}
+
+export interface QuoteToBothConversionResult {
+  quote: IQuote;
+  contract: IContract;
+  invoice: IInvoice;
+  clientContractId?: string;
+}
+
+function toPreviewItem(
+  item: IQuoteItem,
+  target: QuoteConversionPreviewItem['target'],
+  reason?: string | null,
+  locationName?: string | null
+): QuoteConversionPreviewItem {
+  return {
+    quote_item_id: item.quote_item_id,
+    description: item.description,
+    quantity: item.quantity,
+    unit_price: item.unit_price,
+    total_price: item.total_price,
+    is_optional: item.is_optional,
+    is_selected: item.is_selected,
+    is_recurring: item.is_recurring,
+    is_discount: item.is_discount,
+    billing_method: item.billing_method ?? null,
+    target,
+    reason: reason ?? null,
+    location_id: item.location_id ?? null,
+    location_name: locationName ?? null,
+  };
+}
+
+async function resolveLocationNames(
+  knexOrTrx: Knex | Knex.Transaction | undefined,
+  tenant: string | undefined,
+  items: IQuoteItem[]
+): Promise<Map<string, string>> {
+  const locationIds = Array.from(
+    new Set(
+      items
+        .map((item) => item.location_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
+
+  if (locationIds.length === 0 || !knexOrTrx || !tenant) {
+    return new Map();
+  }
+
+  const rows = await knexOrTrx('client_locations')
+    .where({ tenant })
+    .whereIn('location_id', locationIds)
+    .select('location_id', 'location_name', 'address_line1');
+
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    const name = row.location_name
+      ?? row.address_line1
+      ?? row.location_id;
+    map.set(row.location_id as string, name as string);
+  }
+  return map;
+}
+
+interface ContractLineMapping {
+  item: IQuoteItem;
+  contractLineId: string;
+  contractLineType: 'Fixed' | 'Hourly' | 'Usage';
+}
+
+function mapQuoteItemToContractLineType(item: IQuoteItem): 'Fixed' | 'Hourly' | 'Usage' {
+  if (item.billing_method === 'hourly') {
+    return 'Hourly';
+  }
+
+  if (item.billing_method === 'usage') {
+    return 'Usage';
+  }
+
+  return 'Fixed';
+}
+
+function getContractLineBillingTiming(item: IQuoteItem): 'arrears' | 'advance' {
+  return item.billing_method === 'hourly' || item.billing_method === 'usage'
+    ? 'arrears'
+    : 'advance';
+}
+
+function isItemSelected(item: IQuoteItem): boolean {
+  if (!item.is_optional) return true;
+  return item.is_selected === true;
+}
+
+function getSelectedRecurringItems(items: IQuoteItem[] = []): IQuoteItem[] {
+  return items.filter((item) => {
+    if (!item.is_recurring || item.is_discount) {
+      return false;
+    }
+
+    return isItemSelected(item);
+  });
+}
+
+function getSelectedOneTimeItems(items: IQuoteItem[] = []): IQuoteItem[] {
+  const includedItems = items.filter((item) => {
+    if (item.is_recurring) {
+      return false;
+    }
+
+    return isItemSelected(item);
+  });
+
+  const baseItemIds = new Set(
+    includedItems
+      .filter((item) => !item.is_discount)
+      .map((item) => item.quote_item_id)
+  );
+  const baseServiceIds = new Set(
+    includedItems
+      .filter((item) => !item.is_discount && item.service_id)
+      .map((item) => item.service_id as string)
+  );
+
+  return includedItems.filter((item) => {
+    if (!item.is_discount) {
+      return true;
+    }
+
+    if (!item.applies_to_item_id && !item.applies_to_service_id) {
+      return true;
+    }
+
+    if (item.applies_to_item_id && baseItemIds.has(item.applies_to_item_id)) {
+      return true;
+    }
+
+    if (item.applies_to_service_id && baseServiceIds.has(item.applies_to_service_id)) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export async function buildQuoteConversionPreview(
+  quote: IQuote,
+  knexOrTrx?: Knex | Knex.Transaction,
+  tenant?: string
+): Promise<QuoteConversionPreview> {
+  const quoteItems = quote.quote_items ?? [];
+  const recurringItems = getSelectedRecurringItems(quoteItems);
+  const oneTimeItems = getSelectedOneTimeItems(quoteItems);
+  const recurringIds = new Set(recurringItems.map((item) => item.quote_item_id));
+  const oneTimeIds = new Set(oneTimeItems.map((item) => item.quote_item_id));
+
+  const resolvedTenant = tenant ?? quote.tenant;
+  const locationNameMap = await resolveLocationNames(knexOrTrx, resolvedTenant, quoteItems);
+  const lookupName = (item: IQuoteItem): string | null => (
+    item.location_id ? (locationNameMap.get(item.location_id) ?? null) : null
+  );
+
+  const contractItems: QuoteConversionPreviewItem[] = [];
+  const invoiceItems: QuoteConversionPreviewItem[] = [];
+  const excludedItems: QuoteConversionPreviewItem[] = [];
+
+  for (const item of quoteItems) {
+    if (recurringIds.has(item.quote_item_id)) {
+      contractItems.push(toPreviewItem(item, 'contract', null, lookupName(item)));
+      continue;
+    }
+
+    if (oneTimeIds.has(item.quote_item_id)) {
+      invoiceItems.push(toPreviewItem(item, 'invoice', null, lookupName(item)));
+      continue;
+    }
+
+    let reason = 'Item is not eligible for conversion';
+    if (item.is_optional && item.is_selected !== true) {
+      reason = 'Optional item was not selected by the client';
+    } else if (item.is_discount && item.is_recurring) {
+      reason = 'Recurring discount lines are excluded from contract conversion';
+    } else if (item.is_recurring && !item.service_id) {
+      reason = 'Recurring items must reference a catalog service before contract conversion';
+    } else if (item.is_discount) {
+      reason = 'Discount line does not apply to any converted one-time item';
+    }
+
+    excludedItems.push(toPreviewItem(item, 'excluded', reason, lookupName(item)));
+  }
+
+  const availableActions: Array<'contract' | 'invoice' | 'both'> = [];
+  if (contractItems.length > 0) {
+    availableActions.push('contract');
+  }
+  if (invoiceItems.length > 0) {
+    availableActions.push('invoice');
+  }
+  if (contractItems.length > 0 && invoiceItems.length > 0) {
+    availableActions.push('both');
+  }
+
+  return {
+    quote_id: quote.quote_id,
+    available_actions: availableActions,
+    contract_items: contractItems,
+    invoice_items: invoiceItems,
+    excluded_items: excludedItems,
+  };
+}
+
+const Contract = {
+  async getById(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    contractId: string
+  ): Promise<IContract | null> {
+    const contract = await knexOrTrx('contracts')
+      .where({ tenant, contract_id: contractId })
+      .andWhere((builder) => builder.whereNull('is_template').orWhere('is_template', false))
+      .first();
+    return (contract ?? null) as IContract | null;
+  },
+
+  async create(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    contract: Omit<IContract, 'contract_id'>
+  ): Promise<IContract> {
+    const timestamp = new Date().toISOString();
+    const ownerClientId = typeof contract.owner_client_id === 'string' && contract.owner_client_id.trim().length > 0
+      ? contract.owner_client_id.trim()
+      : null;
+    if (!contract.is_template && !ownerClientId) {
+      throw new Error('Non-template contracts require an owning client');
+    }
+
+    const [created] = await knexOrTrx('contracts')
+      .insert({
+        ...contract,
+        owner_client_id: ownerClientId,
+        contract_id: uuidv4(),
+        tenant,
+        created_at: timestamp,
+        updated_at: timestamp,
+      })
+      .returning('*');
+
+    return created as IContract;
+  },
+};
+
+export async function convertQuoteToDraftContract(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quoteId: string,
+  performedBy?: string | null
+): Promise<QuoteToContractConversionResult> {
+  const quote = await Quote.getById(knexOrTrx, tenant, quoteId);
+
+  if (!quote) {
+    throw new Error(`Quote ${quoteId} not found in tenant ${tenant}`);
+  }
+
+  if (quote.is_template) {
+    throw new Error('Quote templates cannot be converted to contracts');
+  }
+
+  if (quote.status !== 'accepted') {
+    throw new Error('Only accepted quotes can be converted to contracts');
+  }
+
+  if (quote.converted_contract_id) {
+    const existingContract = await Contract.getById(knexOrTrx, tenant, quote.converted_contract_id);
+    if (existingContract) {
+      return {
+        quote: await Quote.getById(knexOrTrx, tenant, quote.quote_id) as IQuote,
+        contract: existingContract,
+      };
+    }
+  }
+
+  const recurringItems = getSelectedRecurringItems(quote.quote_items ?? []);
+  if (recurringItems.length === 0) {
+    throw new Error('Quote does not contain any recurring items selected for contract conversion');
+  }
+
+  const billingFrequency = recurringItems[0]?.billing_frequency || 'monthly';
+
+  if (!quote.client_id) {
+    throw new Error('Quotes must be linked to a client before they can be converted to a contract');
+  }
+
+  const contract = await Contract.create(knexOrTrx, tenant, {
+    contract_name: quote.title,
+    contract_description: quote.description ?? null,
+    billing_frequency: billingFrequency,
+    currency_code: quote.currency_code,
+    is_active: false,
+    status: 'draft',
+    is_template: false,
+    owner_client_id: quote.client_id,
+    template_metadata: {
+      source_quote_id: quote.quote_id,
+      source_quote_number: quote.quote_number ?? null,
+      conversion_kind: 'quote_to_contract',
+    },
+  } as Omit<IContract, 'contract_id'>);
+
+  const nowIso = new Date().toISOString();
+  const contractLineMappings: ContractLineMapping[] = recurringItems.map((item) => ({
+    item,
+    contractLineId: uuidv4(),
+    contractLineType: mapQuoteItemToContractLineType(item),
+  }));
+
+  await knexOrTrx('contract_lines').insert(
+    contractLineMappings.map(({ item, contractLineId, contractLineType }, index) => ({
+      tenant,
+      contract_line_id: contractLineId,
+      contract_id: contract.contract_id,
+      contract_line_name: item.service_name || item.description,
+      description: item.description,
+      billing_frequency: item.billing_frequency || billingFrequency,
+      is_custom: true,
+      contract_line_type: contractLineType,
+      billing_timing: getContractLineBillingTiming(item),
+      display_order: index,
+      custom_rate: contractLineType === 'Fixed' ? item.unit_price : null,
+      enable_proration: false,
+      billing_cycle_alignment: 'start',
+      minimum_billable_time: contractLineType === 'Hourly' ? 15 : null,
+      round_up_to_nearest: contractLineType === 'Hourly' ? 15 : null,
+      is_active: false,
+      location_id: item.location_id ?? null,
+      created_at: nowIso,
+      updated_at: nowIso,
+    }))
+  );
+
+  const configRows = contractLineMappings
+    .filter(({ item }) => Boolean(item.service_id))
+    .map(({ item, contractLineId, contractLineType }) => ({
+      item,
+      contractLineId,
+      contractLineType,
+      configId: uuidv4(),
+      serviceId: item.service_id as string,
+    }));
+
+  await insertRowsUsingExistingColumns(
+    knexOrTrx,
+    'contract_line_services',
+    configRows.map(({ contractLineId, serviceId, item }) => ({
+      tenant,
+      contract_line_id: contractLineId,
+      service_id: serviceId,
+      quantity: item.quantity,
+      custom_rate: item.unit_price,
+      created_at: nowIso,
+      updated_at: nowIso,
+    }))
+  );
+
+  if (configRows.length > 0) {
+    await knexOrTrx('contract_line_service_configuration').insert(
+      configRows.map(({ configId, contractLineId, contractLineType, serviceId, item }) => ({
+        tenant,
+        config_id: configId,
+        contract_line_id: contractLineId,
+        service_id: serviceId,
+        configuration_type: contractLineType,
+        custom_rate: item.unit_price,
+        quantity: item.quantity,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+  }
+
+  const fixedConfigRows = configRows.filter((row) => row.contractLineType === 'Fixed');
+  if (fixedConfigRows.length > 0) {
+    await knexOrTrx('contract_line_service_fixed_config').insert(
+      fixedConfigRows.map(({ configId, item }) => ({
+        tenant,
+        config_id: configId,
+        base_rate: item.unit_price,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+  }
+
+  const hourlyConfigRows = configRows.filter((row) => row.contractLineType === 'Hourly');
+  if (hourlyConfigRows.length > 0) {
+    await knexOrTrx('contract_line_service_hourly_config').insert(
+      hourlyConfigRows.map(({ configId }) => ({
+        tenant,
+        config_id: configId,
+        minimum_billable_time: 15,
+        round_up_to_nearest: 15,
+        enable_overtime: false,
+        overtime_rate: null,
+        overtime_threshold: null,
+        enable_after_hours_rate: false,
+        after_hours_multiplier: null,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+
+    await knexOrTrx('contract_line_service_hourly_configs').insert(
+      hourlyConfigRows.map(({ configId, item }) => ({
+        tenant,
+        config_id: configId,
+        hourly_rate: item.unit_price,
+        minimum_billable_time: 15,
+        round_up_to_nearest: 15,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+  }
+
+  const usageConfigRows = configRows.filter((row) => row.contractLineType === 'Usage');
+  if (usageConfigRows.length > 0) {
+    await knexOrTrx('contract_line_service_usage_config').insert(
+      usageConfigRows.map(({ configId, item }) => ({
+        tenant,
+        config_id: configId,
+        unit_of_measure: item.unit_of_measure || 'unit',
+        enable_tiered_pricing: false,
+        minimum_usage: 0,
+        base_rate: item.unit_price,
+        created_at: nowIso,
+        updated_at: nowIso,
+      }))
+    );
+  }
+
+  const clientContractId = uuidv4();
+  await knexOrTrx('client_contracts').insert({
+    tenant,
+    client_contract_id: clientContractId,
+    client_id: quote.client_id,
+    contract_id: contract.contract_id,
+    start_date: quote.accepted_at || quote.quote_date || nowIso,
+    end_date: null,
+    is_active: true,
+    created_at: nowIso,
+    updated_at: nowIso,
+  });
+
+  await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quote.quote_id })
+    .update({
+      converted_contract_id: contract.contract_id,
+      updated_by: performedBy ?? quote.updated_by ?? quote.created_by ?? null,
+      updated_at: nowIso,
+    });
+
+  await QuoteActivity.create(knexOrTrx, tenant, {
+    quote_id: quote.quote_id,
+    activity_type: 'converted_to_contract',
+    description: `Quote converted to draft contract ${contract.contract_name}`,
+    performed_by: performedBy ?? null,
+    metadata: {
+      contract_id: contract.contract_id,
+      client_contract_id: clientContractId,
+      recurring_item_count: recurringItems.length,
+    },
+  });
+
+  const refreshedQuote = await Quote.getById(knexOrTrx, tenant, quote.quote_id);
+
+  return {
+    quote: refreshedQuote as IQuote,
+    contract,
+    clientContractId,
+  };
+}
+
+export async function convertQuoteToDraftInvoice(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quoteId: string,
+  performedBy?: string | null
+): Promise<QuoteToInvoiceConversionResult> {
+  const quote = await Quote.getById(knexOrTrx, tenant, quoteId);
+
+  if (!quote) {
+    throw new Error(`Quote ${quoteId} not found in tenant ${tenant}`);
+  }
+
+  if (quote.is_template) {
+    throw new Error('Quote templates cannot be converted to invoices');
+  }
+
+  if (quote.status !== 'accepted') {
+    throw new Error('Only accepted quotes can be converted to invoices');
+  }
+
+  if (quote.converted_invoice_id) {
+    const existingInvoice = await knexOrTrx('invoices')
+      .where({ tenant, invoice_id: quote.converted_invoice_id })
+      .first();
+
+    if (existingInvoice) {
+      return {
+        quote: await Quote.getById(knexOrTrx, tenant, quote.quote_id) as IQuote,
+        invoice: {
+          ...existingInvoice,
+          invoice_charges: await knexOrTrx('invoice_charges').where({ tenant, invoice_id: existingInvoice.invoice_id }),
+        } as IInvoice,
+      };
+    }
+  }
+
+  if (!quote.client_id) {
+    throw new Error('Quotes must be linked to a client before they can be converted to an invoice');
+  }
+
+  const oneTimeItems = getSelectedOneTimeItems(quote.quote_items ?? []);
+  if (oneTimeItems.length === 0) {
+    throw new Error('Quote does not contain any one-time items selected for invoice conversion');
+  }
+
+  const nowIso = new Date().toISOString();
+  const invoiceNumber = await SharedNumberingService.getNextNumber('INVOICE', {
+    knex: knexOrTrx,
+    tenant,
+  });
+
+  const invoiceId = uuidv4();
+  await knexOrTrx('invoices').insert({
+    tenant,
+    invoice_id: invoiceId,
+    client_id: quote.client_id,
+    po_number: quote.po_number ?? null,
+    invoice_date: quote.accepted_at || quote.quote_date || nowIso,
+    due_date: quote.accepted_at || quote.quote_date || nowIso,
+    subtotal: 0,
+    tax: 0,
+    total_amount: 0,
+    currency_code: quote.currency_code,
+    status: 'draft',
+    invoice_number: invoiceNumber,
+    credit_applied: 0,
+    is_manual: true,
+    tax_source: quote.tax_source ?? 'internal',
+  });
+
+  const invoiceItemIdsByQuoteItemId = new Map<string, string>();
+  const invoiceChargeRows = oneTimeItems.map((item) => {
+    const itemId = uuidv4();
+    invoiceItemIdsByQuoteItemId.set(item.quote_item_id, itemId);
+
+    const netAmount = item.is_discount
+      ? -Math.abs(Number(item.net_amount ?? item.total_price ?? (item.quantity * item.unit_price)))
+      : Number(item.net_amount ?? (item.quantity * item.unit_price));
+    const taxAmount = item.is_discount ? 0 : Number(item.tax_amount ?? 0);
+
+    return {
+      tenant,
+      item_id: itemId,
+      invoice_id: invoiceId,
+      service_id: item.service_id ?? null,
+      service_item_kind: item.service_item_kind ?? null,
+      service_sku: item.service_sku ?? null,
+      service_name: item.service_name ?? null,
+      description: item.description,
+      quantity: item.quantity,
+      unit_price: item.unit_price,
+      net_amount: netAmount,
+      tax_amount: taxAmount,
+      tax_region: item.tax_region ?? null,
+      tax_rate: item.tax_rate ?? 0,
+      total_price: netAmount + taxAmount,
+      is_manual: true,
+      is_taxable: item.is_discount ? false : (item.is_taxable ?? true),
+      is_discount: item.is_discount ?? false,
+      discount_type: item.discount_type ?? null,
+      discount_percentage: item.discount_percentage ?? null,
+      applies_to_item_id: item.applies_to_item_id ?? null,
+      applies_to_service_id: item.applies_to_service_id ?? null,
+      location_id: item.location_id ?? null,
+      created_by: quote.accepted_by ?? quote.updated_by ?? quote.created_by ?? null,
+      updated_by: quote.accepted_by ?? quote.updated_by ?? quote.created_by ?? null,
+      created_at: nowIso,
+      updated_at: nowIso,
+    };
+  }).map((row) => ({
+    ...row,
+    applies_to_item_id: row.applies_to_item_id
+      ? (invoiceItemIdsByQuoteItemId.get(row.applies_to_item_id) ?? null)
+      : null,
+  }));
+
+  await insertRowsUsingExistingColumns(knexOrTrx, 'invoice_charges', invoiceChargeRows);
+
+  const invoiceSubtotal = invoiceChargeRows.reduce((sum, row) => sum + Number(row.net_amount), 0);
+  const invoiceTax = invoiceChargeRows.reduce((sum, row) => sum + Number(row.tax_amount), 0);
+
+  await knexOrTrx('invoices')
+    .where({ tenant, invoice_id: invoiceId })
+    .update({
+      subtotal: Math.round(invoiceSubtotal),
+      tax: Math.round(invoiceTax),
+      total_amount: Math.round(invoiceSubtotal + invoiceTax),
+    });
+
+  const invoice = await knexOrTrx('invoices')
+    .where({ tenant, invoice_id: invoiceId })
+    .first();
+
+  await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quote.quote_id })
+    .update({
+      converted_invoice_id: invoiceId,
+      updated_by: performedBy ?? quote.updated_by ?? quote.created_by ?? null,
+      updated_at: nowIso,
+    });
+
+  await QuoteActivity.create(knexOrTrx, tenant, {
+    quote_id: quote.quote_id,
+    activity_type: 'converted_to_invoice',
+    description: `Quote converted to draft invoice ${invoiceNumber}`,
+    performed_by: performedBy ?? null,
+    metadata: {
+      invoice_id: invoiceId,
+      invoice_number: invoiceNumber,
+      one_time_item_count: oneTimeItems.length,
+    },
+  });
+
+  const refreshedQuote = await Quote.getById(knexOrTrx, tenant, quote.quote_id);
+
+  return {
+    quote: refreshedQuote as IQuote,
+    invoice: {
+      ...invoice,
+      invoice_charges: invoiceChargeRows,
+    } as IInvoice,
+  };
+}
+
+export async function convertQuoteToDraftContractAndInvoice(
+  knexOrTrx: Knex | Knex.Transaction,
+  tenant: string,
+  quoteId: string,
+  performedBy?: string | null
+): Promise<QuoteToBothConversionResult> {
+  const quote = await Quote.getById(knexOrTrx, tenant, quoteId);
+
+  if (!quote) {
+    throw new Error(`Quote ${quoteId} not found in tenant ${tenant}`);
+  }
+
+  if (quote.status !== 'accepted') {
+    throw new Error('Only accepted quotes can be converted');
+  }
+
+  if (quote.converted_contract_id || quote.converted_invoice_id) {
+    throw new Error('Quote has already started conversion and cannot be converted to both again');
+  }
+
+  const recurringItems = getSelectedRecurringItems(quote.quote_items ?? []);
+  const oneTimeItems = getSelectedOneTimeItems(quote.quote_items ?? []);
+
+  if (recurringItems.length === 0 || oneTimeItems.length === 0) {
+    throw new Error('Quote must contain both recurring and one-time items to convert to both records');
+  }
+
+  const contractResult = await convertQuoteToDraftContract(knexOrTrx, tenant, quoteId, performedBy);
+  const invoiceResult = await convertQuoteToDraftInvoice(knexOrTrx, tenant, quoteId, performedBy);
+  const nowIso = new Date().toISOString();
+
+  await knexOrTrx('quotes')
+    .where({ tenant, quote_id: quoteId })
+    .update({
+      status: 'converted',
+      converted_at: nowIso,
+      updated_by: performedBy ?? quote.updated_by ?? quote.created_by ?? null,
+      updated_at: nowIso,
+    });
+
+  await QuoteActivity.create(knexOrTrx, tenant, {
+    quote_id: quoteId,
+    activity_type: 'converted',
+    description: 'Quote converted to both a draft contract and a draft invoice',
+    performed_by: performedBy ?? null,
+    metadata: {
+      contract_id: contractResult.contract.contract_id,
+      invoice_id: invoiceResult.invoice.invoice_id,
+    },
+  });
+
+  const refreshedQuote = await Quote.getById(knexOrTrx, tenant, quoteId);
+
+  return {
+    quote: refreshedQuote as IQuote,
+    contract: contractResult.contract,
+    invoice: invoiceResult.invoice,
+    clientContractId: contractResult.clientContractId,
+  };
+}
+
+export interface ITagDefinition {
+  tenant: string;
+  tag_id: string;
+  tag_text: string;
+  tagged_type: TaggedEntityType;
+  board_id?: string | null;
+  background_color?: string | null;
+  text_color?: string | null;
+  created_at?: Date;
+}
+
+export interface ITagMapping {
+  tenant: string;
+  mapping_id: string;
+  tag_id: string;
+  tagged_id: string;
+  tagged_type: TaggedEntityType;
+  created_at?: Date;
+  created_by?: string | null;
+}
+
+export const TagDefinition = {
+  async findByTextAndType(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    tagText: string,
+    taggedType: TaggedEntityType
+  ): Promise<ITagDefinition | undefined> {
+    return knexOrTrx<ITagDefinition>('tag_definitions')
+      .where('tag_text', tagText.trim())
+      .where('tagged_type', taggedType)
+      .where('tenant', tenant)
+      .first();
+  },
+
+  async insert(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    definition: Omit<ITagDefinition, 'tag_id' | 'tenant' | 'created_at'>
+  ): Promise<ITagDefinition> {
+    const normalizedDefinition = {
+      ...definition,
+      tag_text: definition.tag_text.trim(),
+      tag_id: uuidv4(),
+      tenant,
+    };
+
+    const [inserted] = await knexOrTrx<ITagDefinition>('tag_definitions')
+      .insert(normalizedDefinition)
+      .returning('*');
+    return inserted;
+  },
+
+  async getOrCreateWithStatus(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    tagText: string,
+    taggedType: TaggedEntityType,
+    defaults: Partial<Omit<ITagDefinition, 'tag_id' | 'tenant' | 'tag_text' | 'tagged_type'>> = {}
+  ): Promise<{ definition: ITagDefinition; created: boolean }> {
+    let definition = await TagDefinition.findByTextAndType(knexOrTrx, tenant, tagText, taggedType);
+
+    if (definition) {
+      return { definition, created: false };
+    }
+
+    try {
+      definition = await TagDefinition.insert(knexOrTrx, tenant, {
+        tag_text: tagText,
+        tagged_type: taggedType,
+        ...defaults,
+      });
+      return { definition, created: true };
+    } catch (insertError: unknown) {
+      const errorCode =
+        typeof insertError === 'object' && insertError !== null && 'code' in insertError
+          ? String((insertError as { code?: unknown }).code)
+          : undefined;
+      const errorMessage = insertError instanceof Error ? insertError.message : undefined;
+
+      if (errorCode === '23505' || errorMessage?.includes('duplicate')) {
+        definition = await TagDefinition.findByTextAndType(knexOrTrx, tenant, tagText, taggedType);
+        if (!definition) {
+          throw insertError;
+        }
+        return { definition, created: false };
+      }
+      throw insertError;
+    }
+  },
+};
+
+export const TagMapping = {
+  async insert(
+    knexOrTrx: Knex | Knex.Transaction,
+    tenant: string,
+    mapping: Omit<ITagMapping, 'mapping_id' | 'tenant' | 'created_at'>,
+    userId?: string
+  ): Promise<ITagMapping> {
+    const fullMapping = {
+      ...mapping,
+      mapping_id: uuidv4(),
+      tenant,
+      created_by: userId || mapping.created_by || null,
+    };
+
+    const [inserted] = await knexOrTrx<ITagMapping>('tag_mappings')
+      .insert(fullMapping)
+      .returning('*');
+
+    return inserted;
+  },
+};

--- a/shared/workflow/runtime/actions/businessOperations/shared.ts
+++ b/shared/workflow/runtime/actions/businessOperations/shared.ts
@@ -28,6 +28,9 @@ export function throwActionError(
 export function rethrowAsStandardError(ctx: ActionContext, error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
 
+  if (error instanceof z.ZodError) {
+    throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message });
+  }
   if (/VALIDATION_ERROR:|validation failed|input validation failed/i.test(message)) {
     throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message });
   }

--- a/shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts
+++ b/shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts
@@ -14,57 +14,72 @@ describe('workflow runtime node smoke for crm actions', () => {
     }
 
     const actionRegistry = getActionRegistryV2();
-    if (!actionRegistry.get('crm.find_activities', 1)) {
+    if (!actionRegistry.get('crm.find_quotes', 1)) {
       registerCrmActions();
     }
   });
 
-  it('T013: action.call can execute crm.find_activities, saveAs output, and use it in a downstream expression', async () => {
+  it('T013: action.call can execute a follow-up crm action, saveAs output, and use it in a downstream expression', async () => {
     const nodeRegistry = getNodeTypeRegistry();
     const actionRegistry = getActionRegistryV2();
 
     const actionCallNode = nodeRegistry.get('action.call');
     const assignNode = nodeRegistry.get('transform.assign');
-    const findActivities = actionRegistry.get('crm.find_activities', 1);
+    const findQuotes = actionRegistry.get('crm.find_quotes', 1);
 
-    if (!actionCallNode || !assignNode || !findActivities) {
+    if (!actionCallNode || !assignNode || !findQuotes) {
       throw new Error('Required runtime registrations are missing');
     }
 
-    const originalHandler = findActivities.handler;
+    const originalHandler = findQuotes.handler;
 
     try {
-      findActivities.handler = async () => ({
-        activities: [
+      findQuotes.handler = async () => ({
+        quotes: [
           {
             activity_id: '00000000-0000-0000-0000-000000000001',
-            type_id: '00000000-0000-0000-0000-000000000011',
-            type_name: 'Call',
-            status_id: null,
-            status_name: null,
+            quote_id: '00000000-0000-0000-0000-000000000001',
+            quote_number: 'Q-1001',
+            status: 'draft',
             client_id: '00000000-0000-0000-0000-000000000111',
-            client_name: 'Acme Corp',
             contact_id: null,
-            contact_name: null,
-            ticket_id: null,
-            ticket_number: null,
-            title: 'Follow-up',
-            notes_preview: null,
-            interaction_date: '2026-04-26T12:00:00.000Z',
-            start_time: '2026-04-26T12:00:00.000Z',
-            end_time: '2026-04-26T12:30:00.000Z',
-            duration: 30,
-            user_id: '00000000-0000-0000-0000-000000000021',
-            user_name: 'Workflow Actor',
-            visibility: 'internal',
-            category: 'follow-up',
-            tags: ['qbr'],
+            title: 'Follow-up Quote',
+            quote_date: '2026-04-26T12:00:00.000Z',
+            valid_until: '2026-05-26T12:00:00.000Z',
+            currency_code: 'USD',
+            subtotal: 5000,
+            discount_total: 0,
+            tax: 0,
+            total_amount: 5000,
+            sent_at: null,
+            converted_contract_id: null,
+            converted_invoice_id: null,
+            is_template: false,
           },
         ],
-        count: 1,
-        matched_filters: {
+        first_quote: {
+          quote_id: '00000000-0000-0000-0000-000000000001',
+          quote_number: 'Q-1001',
+          status: 'draft',
           client_id: '00000000-0000-0000-0000-000000000111',
-          limit: 10,
+          contact_id: null,
+          title: 'Follow-up Quote',
+          quote_date: '2026-04-26T12:00:00.000Z',
+          valid_until: '2026-05-26T12:00:00.000Z',
+          currency_code: 'USD',
+          subtotal: 5000,
+          discount_total: 0,
+          tax: 0,
+          total_amount: 5000,
+          sent_at: null,
+          converted_contract_id: null,
+          converted_invoice_id: null,
+          is_template: false,
+        },
+        count: 1,
+        pagination: {
+          page: 1,
+          page_size: 10,
         },
       });
 
@@ -111,22 +126,22 @@ describe('workflow runtime node smoke for crm actions', () => {
       };
 
       const actionConfig = actionCallNode.configSchema.parse({
-        actionId: 'crm.find_activities',
+        actionId: 'crm.find_quotes',
         version: 1,
         inputMapping: {
           client_id: '00000000-0000-0000-0000-000000000111',
-          limit: 10,
+          pageSize: 10,
           on_empty: 'return_empty',
         },
-        saveAs: 'crmActivities',
+        saveAs: 'crmQuotes',
       });
 
       env = await actionCallNode.handler(env, actionConfig, nodeCtx as any) as Envelope;
 
       const assignConfig = assignNode.configSchema.parse({
         assign: {
-          'payload.crmActivityCount': { $expr: 'vars.crmActivities.count' },
-          'payload.crmFirstTitle': { $expr: 'vars.crmActivities.activities[0].title' },
+          'payload.crmQuoteCount': { $expr: 'vars.crmQuotes.count' },
+          'payload.crmFirstQuoteTitle': { $expr: 'vars.crmQuotes.quotes[0].title' },
         },
       });
 
@@ -135,10 +150,10 @@ describe('workflow runtime node smoke for crm actions', () => {
         stepPath: 'steps.assign-output',
       } as any) as Envelope;
 
-      expect((env.payload as any).crmActivityCount).toBe(1);
-      expect((env.payload as any).crmFirstTitle).toBe('Follow-up');
+      expect((env.payload as any).crmQuoteCount).toBe(1);
+      expect((env.payload as any).crmFirstQuoteTitle).toBe('Follow-up Quote');
     } finally {
-      findActivities.handler = originalHandler;
+      findQuotes.handler = originalHandler;
     }
   });
 });

--- a/shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts
+++ b/shared/workflow/runtime/nodes/__tests__/actionCallCrmSaveAsRuntime.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import type { Envelope } from '../../types';
+import { getNodeTypeRegistry } from '../../registries/nodeTypeRegistry';
+import { getActionRegistryV2 } from '../../registries/actionRegistry';
+import { registerDefaultNodes } from '../registerDefaultNodes';
+import { registerCrmActions } from '../../actions/businessOperations/crm';
+
+describe('workflow runtime node smoke for crm actions', () => {
+  beforeAll(() => {
+    const nodeRegistry = getNodeTypeRegistry();
+    if (!nodeRegistry.get('action.call')) {
+      registerDefaultNodes();
+    }
+
+    const actionRegistry = getActionRegistryV2();
+    if (!actionRegistry.get('crm.find_activities', 1)) {
+      registerCrmActions();
+    }
+  });
+
+  it('T013: action.call can execute crm.find_activities, saveAs output, and use it in a downstream expression', async () => {
+    const nodeRegistry = getNodeTypeRegistry();
+    const actionRegistry = getActionRegistryV2();
+
+    const actionCallNode = nodeRegistry.get('action.call');
+    const assignNode = nodeRegistry.get('transform.assign');
+    const findActivities = actionRegistry.get('crm.find_activities', 1);
+
+    if (!actionCallNode || !assignNode || !findActivities) {
+      throw new Error('Required runtime registrations are missing');
+    }
+
+    const originalHandler = findActivities.handler;
+
+    try {
+      findActivities.handler = async () => ({
+        activities: [
+          {
+            activity_id: '00000000-0000-0000-0000-000000000001',
+            type_id: '00000000-0000-0000-0000-000000000011',
+            type_name: 'Call',
+            status_id: null,
+            status_name: null,
+            client_id: '00000000-0000-0000-0000-000000000111',
+            client_name: 'Acme Corp',
+            contact_id: null,
+            contact_name: null,
+            ticket_id: null,
+            ticket_number: null,
+            title: 'Follow-up',
+            notes_preview: null,
+            interaction_date: '2026-04-26T12:00:00.000Z',
+            start_time: '2026-04-26T12:00:00.000Z',
+            end_time: '2026-04-26T12:30:00.000Z',
+            duration: 30,
+            user_id: '00000000-0000-0000-0000-000000000021',
+            user_name: 'Workflow Actor',
+            visibility: 'internal',
+            category: 'follow-up',
+            tags: ['qbr'],
+          },
+        ],
+        count: 1,
+        matched_filters: {
+          client_id: '00000000-0000-0000-0000-000000000111',
+          limit: 10,
+        },
+      });
+
+      const nowIso = () => new Date().toISOString();
+
+      let env: Envelope = {
+        v: 1,
+        run: {
+          id: 'run-1',
+          workflowId: 'workflow-1',
+          workflowVersion: 1,
+          startedAt: nowIso(),
+        },
+        payload: {},
+        meta: {},
+        vars: {},
+      };
+
+      const nodeCtx = {
+        runId: 'run-1',
+        stepPath: 'steps.crm-find',
+        tenantId: 'tenant-1',
+        nowIso,
+        publishWait: async () => {},
+        actions: {
+          call: async (actionId: string, version: number, args: unknown) => {
+            const action = actionRegistry.get(actionId, version);
+            if (!action) throw new Error(`Unknown action ${actionId}@${version}`);
+
+            const parsedInput = action.inputSchema.parse(args);
+            const output = await action.handler(parsedInput, {
+              runId: 'run-1',
+              stepPath: 'steps.crm-find',
+              idempotencyKey: 'idem-1',
+              attempt: 1,
+              nowIso,
+              env,
+              tenantId: 'tenant-1',
+            } as any);
+
+            return action.outputSchema.parse(output);
+          },
+        },
+      };
+
+      const actionConfig = actionCallNode.configSchema.parse({
+        actionId: 'crm.find_activities',
+        version: 1,
+        inputMapping: {
+          client_id: '00000000-0000-0000-0000-000000000111',
+          limit: 10,
+          on_empty: 'return_empty',
+        },
+        saveAs: 'crmActivities',
+      });
+
+      env = await actionCallNode.handler(env, actionConfig, nodeCtx as any) as Envelope;
+
+      const assignConfig = assignNode.configSchema.parse({
+        assign: {
+          'payload.crmActivityCount': { $expr: 'vars.crmActivities.count' },
+          'payload.crmFirstTitle': { $expr: 'vars.crmActivities.activities[0].title' },
+        },
+      });
+
+      env = await assignNode.handler(env, assignConfig, {
+        ...nodeCtx,
+        stepPath: 'steps.assign-output',
+      } as any) as Envelope;
+
+      expect((env.payload as any).crmActivityCount).toBe(1);
+      expect((env.payload as any).crmFirstTitle).toBe('Follow-up');
+    } finally {
+      findActivities.handler = originalHandler;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add CRM workflow runtime actions/catalog coverage for activity and quote lifecycle flows.
- Keep the workflow-worker runtime dependency graph worker-safe by moving CRM data access into a worker-safe DAL and avoiding server/UI/PDF-only imports.
- Make authorization kernel RBAC dependency explicit via an app/server adapter instead of dynamic/lazy loading from the kernel.
- Add durable build/export fixes for the worker image, including the core deletion config barrel and expanded runtime import validation.

## Validation

Builds/typechecks/tests run locally:

- `npm run build --workspace=@alga-psa/core`
- `npm run build --workspace=@alga-psa/authorization`
- `npm run typecheck --workspace=@alga-psa/authorization`
- `npm run typecheck --workspace=server`
- `npm run typecheck --workspace=sebastian-ee`
- `npm run build --workspace=@alga-psa/shared`
- `npm run build --workspace=@alga-psa/workflows`
- `npm run build --workspace=temporal-workflows`
- `npm run build --workspace=workflow-worker`
- `cd server && npx vitest run src/test/unit/authorization/kernel.engine.test.ts src/test/unit/authorization/kernel.contract.modes.test.ts src/test/unit/authorization/kernel.legacyDirection.test.ts`
- `docker build -f services/workflow-worker/Dockerfile -t workflows_assignee_duplication_ee_env-workflow-worker:latest .`

Live workflow-worker smoke validation against `workflows_assignee_duplication_ee_env`:

- Recreated only the `workflow-worker` service; both worker replicas reported healthy.
- CRM UI/catalog designer smoke: CRM palette/actions rendered, picker-backed quote fields selected, draft saved.
- Activity create/schedule/find smoke succeeded: run `664003a5-b3e0-4f19-9a72-289eca6187a6`.
- Activity status update smoke succeeded, including idempotent second run and clean invalid-status validation failures.
- Quote create/add item/find smoke succeeded: run `a97391f6-db77-46c8-9a23-78f13a8f1ccc`.
- Quote submit/convert/tag activity worker smokes succeeded.
- Send Quote lifecycle/authorization smoke succeeded:
  - first send run `d92bec89-99a4-431a-9fc2-367ec9ff9e36` changed quote `draft -> sent`
  - second run `84bf7157-88d5-47dc-bdb4-e1b43d27203f` returned no-op/existing behavior
  - denied-user run `24aede23-4fae-4c5b-a6d9-bbc3bd25001e` failed with `PERMISSION_DENIED: Permission denied: Cannot update quote`
- Tag CRM Activity supported-target smoke succeeded:
  - first run `f0b2ec4a-7343-4551-a80e-ad0f0d7f2c32` added 2 tags to the ticket target
  - second run `8d6494b6-cddf-443d-be5e-4b8f17bf8488` reported 2 existing tags / no duplicates
  - DB spot-check confirmed zero `tagged_type = 'interaction'` mappings for the activity.

