### PR TITLE
Add search filter to user activities table

### DIFF
--- a/ee/packages/workflows/src/components/user-activities/filters/ActivitiesTableFilters.tsx
+++ b/ee/packages/workflows/src/components/user-activities/filters/ActivitiesTableFilters.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from "@alga-psa/ui/components/Button";
 import { Label } from "@alga-psa/ui/components/Label";
 import { Checkbox } from "@alga-psa/ui/components/Checkbox";
+import { SearchInput } from "@alga-psa/ui/components/SearchInput";
 import { StringDateRangePicker } from "@alga-psa/ui/components/DateRangePicker";
 import CustomSelect from "@alga-psa/ui/components/CustomSelect";
 import TreeSelect, { TreeSelectOption } from "@alga-psa/ui/components/TreeSelect";
@@ -175,6 +176,24 @@ export function ActivitiesTableFilters({
     },
     [filters, onChange]
   );
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const search = e.target.value;
+      const next: ActivityFiltersType = { ...filters, search };
+      if (!search.trim()) {
+        delete next.search;
+      }
+      onChange(next);
+    },
+    [filters, onChange]
+  );
+
+  const handleSearchClear = useCallback(() => {
+    const next: ActivityFiltersType = { ...filters };
+    delete next.search;
+    onChange(next);
+  }, [filters, onChange]);
 
   // -------- Ticket board (multi-select) ------------------------------------
 
@@ -506,6 +525,20 @@ export function ActivitiesTableFilters({
 
       {/* Shared filters row */}
       <div className="flex flex-wrap items-end gap-x-4 gap-y-2">
+        <div className="min-w-[220px] max-w-[320px] flex-1">
+          <Label htmlFor="activities-search-input" className="text-sm font-semibold mb-1 block">
+            {t('filters.labels.search', { defaultValue: 'Search' })}
+          </Label>
+          <SearchInput
+            id="activities-search-input"
+            value={filters.search || ''}
+            onChange={handleSearchChange}
+            onClear={handleSearchClear}
+            placeholder={t('filters.placeholders.search', { defaultValue: 'Search activities...' })}
+            className="w-full h-10 py-2 text-sm"
+          />
+        </div>
+
         {isPriorityFilterAvailable && priorities.length > 0 && (
           <div className="min-w-[180px]">
             <Label htmlFor="priority-select" className="text-sm font-semibold mb-1 block">

--- a/server/public/locales/de/msp/user-activities.json
+++ b/server/public/locales/de/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Aufgaben:",
       "priority": "Priorität",
       "dueDate": "Fälligkeitsdatum",
-      "showClosed": "Geschlossene anzeigen"
+      "showClosed": "Geschlossene anzeigen",
+      "search": "Suche"
     },
     "activityTypeOptions": {
       "schedule": "Zeitplan",
@@ -409,7 +410,8 @@
       "allStatuses": "Alle Status",
       "allProjects": "Alle Projekte",
       "allPriorities": "Alle Prioritäten",
-      "selectPriority": "Priorität auswählen..."
+      "selectPriority": "Priorität auswählen...",
+      "search": "Aktivitäten suchen..."
     },
     "actions": {
       "reset": "Zurücksetzen"

--- a/server/public/locales/en/msp/user-activities.json
+++ b/server/public/locales/en/msp/user-activities.json
@@ -395,6 +395,7 @@
       "tickets": "Tickets:",
       "tasks": "Tasks:",
       "priority": "Priority",
+      "search": "Search",
       "dueDate": "Due Date",
       "showClosed": "Show closed"
     },
@@ -409,7 +410,8 @@
       "allStatuses": "All Statuses",
       "allProjects": "All Projects",
       "allPriorities": "All Priorities",
-      "selectPriority": "Select Priority..."
+      "selectPriority": "Select Priority...",
+      "search": "Search activities..."
     },
     "actions": {
       "reset": "Reset"

--- a/server/public/locales/es/msp/user-activities.json
+++ b/server/public/locales/es/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Tareas:",
       "priority": "Prioridad",
       "dueDate": "Fecha de vencimiento",
-      "showClosed": "Mostrar cerradas"
+      "showClosed": "Mostrar cerradas",
+      "search": "Buscar"
     },
     "activityTypeOptions": {
       "schedule": "Calendario",
@@ -409,7 +410,8 @@
       "allStatuses": "Todos los estados",
       "allProjects": "Todos los proyectos",
       "allPriorities": "Todas las prioridades",
-      "selectPriority": "Seleccionar prioridad..."
+      "selectPriority": "Seleccionar prioridad...",
+      "search": "Buscar actividades..."
     },
     "actions": {
       "reset": "Restablecer"

--- a/server/public/locales/fr/msp/user-activities.json
+++ b/server/public/locales/fr/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Tâches :",
       "priority": "Priorité",
       "dueDate": "Date d'échéance",
-      "showClosed": "Afficher les fermées"
+      "showClosed": "Afficher les fermées",
+      "search": "Rechercher"
     },
     "activityTypeOptions": {
       "schedule": "Calendrier",
@@ -409,7 +410,8 @@
       "allStatuses": "Tous les statuts",
       "allProjects": "Tous les projets",
       "allPriorities": "Toutes les priorités",
-      "selectPriority": "Sélectionner une priorité..."
+      "selectPriority": "Sélectionner une priorité...",
+      "search": "Rechercher des activités..."
     },
     "actions": {
       "reset": "Réinitialiser"

--- a/server/public/locales/it/msp/user-activities.json
+++ b/server/public/locales/it/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Attività:",
       "priority": "Priorità",
       "dueDate": "Data di scadenza",
-      "showClosed": "Mostra chiuse"
+      "showClosed": "Mostra chiuse",
+      "search": "Cerca"
     },
     "activityTypeOptions": {
       "schedule": "Pianificazione",
@@ -409,7 +410,8 @@
       "allStatuses": "Tutti gli stati",
       "allProjects": "Tutti i progetti",
       "allPriorities": "Tutte le priorità",
-      "selectPriority": "Selezioni la priorità..."
+      "selectPriority": "Selezioni la priorità...",
+      "search": "Cerca attività..."
     },
     "actions": {
       "reset": "Reimposta"

--- a/server/public/locales/nl/msp/user-activities.json
+++ b/server/public/locales/nl/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Taken:",
       "priority": "Prioriteit",
       "dueDate": "Vervaldatum",
-      "showClosed": "Gesloten weergeven"
+      "showClosed": "Gesloten weergeven",
+      "search": "Zoeken"
     },
     "activityTypeOptions": {
       "schedule": "Schema",
@@ -409,7 +410,8 @@
       "allStatuses": "Alle statussen",
       "allProjects": "Alle projecten",
       "allPriorities": "Alle prioriteiten",
-      "selectPriority": "Selecteer prioriteit..."
+      "selectPriority": "Selecteer prioriteit...",
+      "search": "Activiteiten zoeken..."
     },
     "actions": {
       "reset": "Resetten"

--- a/server/public/locales/pl/msp/user-activities.json
+++ b/server/public/locales/pl/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Zadania:",
       "priority": "Priorytet",
       "dueDate": "Termin",
-      "showClosed": "Pokaż zamknięte"
+      "showClosed": "Pokaż zamknięte",
+      "search": "Szukaj"
     },
     "activityTypeOptions": {
       "schedule": "Harmonogram",
@@ -409,7 +410,8 @@
       "allStatuses": "Wszystkie statusy",
       "allProjects": "Wszystkie projekty",
       "allPriorities": "Wszystkie priorytety",
-      "selectPriority": "Wybierz priorytet..."
+      "selectPriority": "Wybierz priorytet...",
+      "search": "Szukaj aktywności..."
     },
     "actions": {
       "reset": "Resetuj"

--- a/server/public/locales/pt/msp/user-activities.json
+++ b/server/public/locales/pt/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "Tarefas:",
       "priority": "Prioridade",
       "dueDate": "Data de vencimento",
-      "showClosed": "Exibir fechadas"
+      "showClosed": "Exibir fechadas",
+      "search": "Pesquisar"
     },
     "activityTypeOptions": {
       "schedule": "Agenda",
@@ -409,7 +410,8 @@
       "allStatuses": "Todos os status",
       "allProjects": "Todos os projetos",
       "allPriorities": "Todas as prioridades",
-      "selectPriority": "Selecione a prioridade..."
+      "selectPriority": "Selecione a prioridade...",
+      "search": "Pesquisar atividades..."
     },
     "actions": {
       "reset": "Redefinir"

--- a/server/public/locales/xx/msp/user-activities.json
+++ b/server/public/locales/xx/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "11111",
       "priority": "11111",
       "dueDate": "11111",
-      "showClosed": "11111"
+      "showClosed": "11111",
+      "search": "11111"
     },
     "activityTypeOptions": {
       "schedule": "11111",
@@ -409,7 +410,8 @@
       "allStatuses": "11111",
       "allProjects": "11111",
       "allPriorities": "11111",
-      "selectPriority": "11111"
+      "selectPriority": "11111",
+      "search": "11111"
     },
     "actions": {
       "reset": "11111"

--- a/server/public/locales/yy/msp/user-activities.json
+++ b/server/public/locales/yy/msp/user-activities.json
@@ -396,7 +396,8 @@
       "tasks": "55555",
       "priority": "55555",
       "dueDate": "55555",
-      "showClosed": "55555"
+      "showClosed": "55555",
+      "search": "55555"
     },
     "activityTypeOptions": {
       "schedule": "55555",
@@ -409,7 +410,8 @@
       "allStatuses": "55555",
       "allProjects": "55555",
       "allPriorities": "55555",
-      "selectPriority": "55555"
+      "selectPriority": "55555",
+      "search": "55555"
     },
     "actions": {
       "reset": "55555"


### PR DESCRIPTION
## Summary
- Add a SearchInput control to the shared user activities table filters
- Wire the input to the existing ActivityFilters.search field and clear it when empty
- Add English locale strings for the new search label and placeholder

## Validation
- npx eslint ee/packages/workflows/src/components/user-activities/filters/ActivitiesTableFilters.tsx (no errors; existing warnings remain)
- Verified in browser with algadev that the search input appears, filters results, and matches the due date control height