### PR TITLE
Avoid tenant colocation for workflow definitions

### DIFF
--- a/server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs
+++ b/server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs
@@ -86,8 +86,11 @@ const ensureWorkflowDefinitionsCitusDistribution = async (knex) => {
     `);
   }
 
+  // `tenants.tenant` is uuid, while Workflow Runtime V2 stores tenant_id as text/string
+  // for consistency with workflow_runs and tenant_workflow_schedule. Do not colocate with
+  // `tenants`, because Citus requires matching distribution column types for colocation.
   await knex.raw(`
-    SELECT create_distributed_table('workflow_definitions', 'tenant_id', colocate_with => 'tenants')
+    SELECT create_distributed_table('workflow_definitions', 'tenant_id', colocate_with => 'none')
   `);
 };
 


### PR DESCRIPTION
## Summary\n- distribute workflow_definitions with colocate_with => 'none' instead of colocating with tenants\n- document why: tenants.tenant is uuid while Workflow Runtime V2 tenant_id columns are text/string\n\n## Validation\n- node -e "require('./server/migrations/20260425200000_add_tenant_id_to_workflow_definitions.cjs')"\n- npx tsc --noEmit --pretty false --project tsconfig.json