### PR TITLE
fix(notifications): include title/url diff in ticket-updated emails

### DIFF
--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -1816,6 +1816,20 @@ export const updateTicketWithCache = withAuth(async (user, { tenant }, id: strin
     // Build structured changes object with old/new values
     const structuredChanges: Record<string, any> = {};
 
+    if (updateData.title !== undefined && updateData.title !== currentTicket.title) {
+      structuredChanges.title = {
+        old: currentTicket.title,
+        new: updateData.title
+      };
+    }
+
+    if (updateData.url !== undefined && updateData.url !== currentTicket.url) {
+      structuredChanges.url = {
+        old: currentTicket.url,
+        new: updateData.url
+      };
+    }
+
     if (updateData.status_id !== undefined && updateData.status_id !== currentTicket.status_id) {
       structuredChanges.status_id = {
         old: currentTicket.status_id,

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -677,6 +677,20 @@ export const updateTicket = withAuth(async (user, { tenant }, id: string, data: 
       // Build structured changes object with old/new values
       const structuredChanges: Record<string, any> = {};
 
+      if (updateData.title !== undefined && updateData.title !== currentTicket.title) {
+        structuredChanges.title = {
+          old: currentTicket.title,
+          new: updateData.title
+        };
+      }
+
+      if (updateData.url !== undefined && updateData.url !== currentTicket.url) {
+        structuredChanges.url = {
+          old: currentTicket.url,
+          new: updateData.url
+        };
+      }
+
       if (updateData.status_id !== undefined && updateData.status_id !== currentTicket.status_id) {
         structuredChanges.status_id = {
           old: currentTicket.status_id,

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -953,9 +953,33 @@ export class TicketService extends BaseService<ITicket> {
         }
       }
 
+      const structuredChanges: Record<string, { old: unknown; new: unknown }> = {};
+      const trackedChangeFields: Array<keyof ITicket> = [
+        'title',
+        'url',
+        'status_id',
+        'priority_id',
+        'assigned_to',
+        'board_id',
+        'category_id',
+        'subcategory_id',
+        'due_date',
+      ];
+      for (const field of trackedChangeFields) {
+        const nextValue = (cleanedData as Record<string, unknown>)[field as string];
+        const previousValue = (currentTicket as Record<string, unknown>)[field as string];
+        if (nextValue !== undefined && nextValue !== previousValue) {
+          structuredChanges[field as string] = {
+            old: previousValue,
+            new: nextValue,
+          };
+        }
+      }
+
       await this.safePublishEvent('TICKET_UPDATED', context, {
         ticketId: ticket.ticket_id,
         updatedByUserId: context.userId,
+        changes: structuredChanges,
       });
 
       return this.withDescriptionHtml(ticket as ITicket);


### PR DESCRIPTION
## Summary

- Renaming a ticket's title (or several other fields) fires a `TICKET_UPDATED` email whose "Changes Made" box renders empty, so recipients see "Ticket Updated" with no indication of what changed.
- Root cause: the change-builder in both server-action paths only tracked `status_id`, `priority_id`, `assigned_to`, `board_id`, `category_id`, `subcategory_id`, and `due_date`. The REST API path in `TicketService.update` did not pass a `changes` payload at all.
- Fix: track `title` and `url` in `structuredChanges` in `ticketActions.updateTicket` and `optimizedTicketActions`, and build the same diff in `TicketService.update` so the REST API path also populates the email.

## Notes

- No template changes needed: the email template at `server/migrations/utils/templates/email/tickets/ticketUpdated.cjs` already renders `{{{ticket.changes}}}`, and `formatChanges()` / `formatFieldName()` / `resolveValue()` in `ticketEmailSubscriber.ts` already humanize keys (`title` → "Title") and pass plain string values through.
- Schema validation at the publisher casts to `any`, so the existing `{ old, new }` shape is preserved (the reader at `ticketEmailSubscriber.ts:326` reads `old`/`new`, not `previous`/`new`).
- Description and tags are intentionally **not** tracked in this PR — description is BlockNote JSON and would render noisily; tags need a comparison helper. Worth a follow-up if desired.

## Test plan

- [ ] Rename a ticket title via the UI and confirm the resulting email's "Changes Made" box reads `Title: <old> → <new>`.
- [ ] Change `priority` and `assigned_to` together via the UI and confirm both lines appear.
- [ ] Update a ticket via the REST API (`PATCH /api/v1/tickets/:id`) with a title change and confirm the email includes the diff (this path previously rendered an empty box for ANY field).
- [ ] Close a ticket via the UI and confirm the `TICKET_CLOSED` email still works (changes flow unchanged).
- [ ] Verify multi-field updates: status + priority change together still render both lines.