### PR TITLE
Improve project task import: fallback pickers, phase-scoped status resolution, better preview

### DIFF
--- a/packages/projects/src/actions/phaseTaskImportActions.ts
+++ b/packages/projects/src/actions/phaseTaskImportActions.ts
@@ -191,7 +191,8 @@ export async function groupRowsIntoPhases(
   serviceLookup: Record<string, string>,
   statusLookup: Record<string, string> = {},
   statusLookupByPhase: Record<string, Record<string, string>> = {},
-  agentResolutions: IAgentResolution[] = []
+  agentResolutions: IAgentResolution[] = [],
+  defaultPhaseName: string = DEFAULT_PHASE_NAME
 ): Promise<IGroupedPhaseData[]> {
   const phaseMap = new Map<string, IGroupedPhaseData>();
 
@@ -201,10 +202,12 @@ export async function groupRowsIntoPhases(
     agentResolutionMap.set(resolution.originalAgentName.toLowerCase().trim(), resolution);
   });
 
+  const fallbackPhaseName = defaultPhaseName?.trim() || DEFAULT_PHASE_NAME;
+
   for (const row of rows) {
     if (!row.task_name?.trim()) continue;
 
-    const phaseName = row.phase_name?.trim() || DEFAULT_PHASE_NAME;
+    const phaseName = row.phase_name?.trim() || fallbackPhaseName;
 
     if (!phaseMap.has(phaseName)) {
       phaseMap.set(phaseName, {
@@ -268,14 +271,15 @@ export async function groupRowsIntoPhases(
       status_name: statusName || null,
       status_mapping_id: phaseStatusLookup[statusNameLower] || null,
       tags: row.tags ? row.tags.split(',').map(t => t.trim()).filter(t => t) : [],
+      csvRowNumber: row.csvRowNumber,
     });
   }
 
-  // Sort phases: named phases in order of appearance, then "Unsorted Tasks" last
+  // Sort phases: named phases in order of appearance, then the fallback phase last
   const phases = Array.from(phaseMap.values());
   phases.sort((a, b) => {
-    if (a.phase_name === DEFAULT_PHASE_NAME) return 1;
-    if (b.phase_name === DEFAULT_PHASE_NAME) return -1;
+    if (a.phase_name === fallbackPhaseName) return 1;
+    if (b.phase_name === fallbackPhaseName) return -1;
     return 0;
   });
 
@@ -391,7 +395,7 @@ export const getImportReferenceData = withAuth(async (
 
   return await withTransaction(db, async (trx: Knex.Transaction) => {
     // Fetch all reference data in parallel within the same transaction
-    const [users, priorities, services, statusReferenceData] = await Promise.all([
+    const [users, priorities, services, phases, statusReferenceData] = await Promise.all([
       // Users (only active internal/MSP agents - exclude client portal users)
       trx('users')
         .select('user_id', 'username', 'first_name', 'last_name', 'email', 'user_type', 'is_inactive', 'tenant')
@@ -413,6 +417,13 @@ export const getImportReferenceData = withAuth(async (
         .where('tenant', tenant)
         .where('is_active', true)
         .orderBy('service_name'),
+
+      // Existing phases for the project (used as fallback phase options)
+      projectId && tenant
+        ? ProjectModel.getPhases(trx, tenant, projectId).then(rows =>
+            rows.map(row => ({ phase_id: row.phase_id, phase_name: row.phase_name }))
+          )
+        : Promise.resolve([] as Array<{ phase_id: string; phase_name: string }>),
 
       projectId && tenant
         ? getImportStatusReferenceData(trx, tenant, projectId)
@@ -444,6 +455,7 @@ export const getImportReferenceData = withAuth(async (
       users,
       priorities,
       services,
+      phases,
       statusMappings: statusReferenceData.statusMappings as IImportReferenceData['statusMappings'],
       userLookup,
       priorityLookup,
@@ -471,23 +483,25 @@ export async function validatePhaseTaskImportDataWithReferenceData(
     statusLookupByPhase = {},
   } = referenceData;
 
-  // Collect unique status names from CSV that don't match existing statuses
-  const csvStatusNames = new Set<string>();
+  // Collect unique (phase, status) pairs from CSV. We preserve original casing for display
+  // while using a normalized key for de-duplication and lookup.
+  const csvStatusPairs = new Map<string, { phaseName: string; statusName: string }>();
   rows.forEach(row => {
     const statusName = row.status?.trim();
     if (statusName) {
-      const phaseKey = row.phase_name?.trim().toLowerCase() || DEFAULT_PHASE_NAME.toLowerCase();
-      csvStatusNames.add(`${phaseKey}::${statusName}`);
+      const phaseName = row.phase_name?.trim() || DEFAULT_PHASE_NAME;
+      const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
+      if (!csvStatusPairs.has(key)) {
+        csvStatusPairs.set(key, { phaseName, statusName });
+      }
     }
   });
 
-  const unmatchedStatuses: string[] = [];
-  csvStatusNames.forEach((phaseScopedStatus) => {
-    const [phaseKey, ...rest] = phaseScopedStatus.split('::');
-    const statusName = rest.join('::');
-    const lookup = statusLookupByPhase[phaseKey] || statusLookup;
+  const unmatchedStatuses: Array<{ phaseName: string; statusName: string }> = [];
+  csvStatusPairs.forEach(({ phaseName, statusName }) => {
+    const lookup = statusLookupByPhase[phaseName.toLowerCase()] || statusLookup;
     if (!lookup[statusName.toLowerCase()]) {
-      unmatchedStatuses.push(statusName);
+      unmatchedStatuses.push({ phaseName, statusName });
     }
   });
 
@@ -595,7 +609,7 @@ export async function validatePhaseTaskImportDataWithReferenceData(
     serviceLookup,
     statusLookup,
     statusLookupByPhase,
-    unmatchedStatuses: Array.from(new Set(unmatchedStatuses)),
+    unmatchedStatuses,
     unmatchedAgents,
   };
 }
@@ -643,7 +657,7 @@ export const validatePhaseTaskImportData = withAuth(async (
 
   const statusLookup: Record<string, string> = {};
   let statusLookupByPhase: Record<string, Record<string, string>> = {};
-  const unmatchedStatuses: string[] = [];
+  const unmatchedStatuses: Array<{ phaseName: string; statusName: string }> = [];
 
   if (projectId && tenant) {
     const statusReferenceData = await getImportStatusReferenceData(db, tenant, projectId);
@@ -651,22 +665,23 @@ export const validatePhaseTaskImportData = withAuth(async (
     statusLookupByPhase = statusReferenceData.statusLookupByPhase;
   }
 
-  // Collect unique status names from CSV that don't match existing statuses
-  const csvStatusNames = new Set<string>();
+  // Collect unique (phase, status) pairs from CSV. We preserve original casing for display.
+  const csvStatusPairs = new Map<string, { phaseName: string; statusName: string }>();
   rows.forEach(row => {
     const statusName = row.status?.trim();
     if (statusName) {
-      const phaseKey = row.phase_name?.trim().toLowerCase() || DEFAULT_PHASE_NAME.toLowerCase();
-      csvStatusNames.add(`${phaseKey}::${statusName}`);
+      const phaseName = row.phase_name?.trim() || DEFAULT_PHASE_NAME;
+      const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
+      if (!csvStatusPairs.has(key)) {
+        csvStatusPairs.set(key, { phaseName, statusName });
+      }
     }
   });
 
-  csvStatusNames.forEach((phaseScopedStatus) => {
-    const [phaseKey, ...rest] = phaseScopedStatus.split('::');
-    const statusName = rest.join('::');
-    const lookup = statusLookupByPhase[phaseKey] || statusLookup;
+  csvStatusPairs.forEach(({ phaseName, statusName }) => {
+    const lookup = statusLookupByPhase[phaseName.toLowerCase()] || statusLookup;
     if (!lookup[statusName.toLowerCase()]) {
-      unmatchedStatuses.push(statusName);
+      unmatchedStatuses.push({ phaseName, statusName });
     }
   });
 
@@ -784,7 +799,7 @@ export const validatePhaseTaskImportData = withAuth(async (
     serviceLookup,
     statusLookup,
     statusLookupByPhase,
-    unmatchedStatuses: Array.from(new Set(unmatchedStatuses)),
+    unmatchedStatuses,
     unmatchedAgents,
   };
 });
@@ -802,7 +817,8 @@ export const importPhasesAndTasks = withAuth(async (
   { tenant },
   projectId: string,
   groupedPhases: IGroupedPhaseData[],
-  statusResolutions: IStatusResolution[] = []
+  statusResolutions: IStatusResolution[] = [],
+  defaultStatusMappingId?: string
 ): Promise<IPhaseTaskImportResult> => {
   const { knex: db } = await createTenantKnex();
 
@@ -823,7 +839,7 @@ export const importPhasesAndTasks = withAuth(async (
       throw new Error('No status mappings found for project. Please configure task statuses first.');
     }
 
-    // Build a map of status name -> mapping ID
+    // Build a global map of status name -> mapping ID for matched (already-existing) statuses
     const statusMappingByName: Record<string, string> = {};
     statusMappings.forEach((mapping: IProjectStatusMapping) => {
       const statusName = mapping.custom_name || mapping.status_name || mapping.name;
@@ -832,21 +848,37 @@ export const importPhasesAndTasks = withAuth(async (
       }
     });
 
-    // Process status resolutions to create new statuses or map to existing
+    // Build phase-scoped resolution lookup: phaseName(lower) -> statusName(lower) -> mapping_id
+    const resolvedByPhase: Map<string, Map<string, string>> = new Map();
+    const setResolved = (phaseName: string, statusName: string, mappingId: string) => {
+      const phaseKey = phaseName.toLowerCase().trim();
+      if (!resolvedByPhase.has(phaseKey)) resolvedByPhase.set(phaseKey, new Map());
+      resolvedByPhase.get(phaseKey)!.set(statusName.toLowerCase().trim(), mappingId);
+    };
+
     let defaultUnspecifiedStatusId: string | null = null;
 
     for (const resolution of statusResolutions) {
+      const phaseName = resolution.phaseName || DEFAULT_PHASE_NAME;
       if (resolution.action === 'create') {
-        // Create a new status mapping for this status name
-        const newMapping = await createNewStatusMapping(trx, projectId, resolution.originalStatusName, statusMappings.length, tenant);
-        statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = newMapping.project_status_mapping_id;
-        statusMappings = [...statusMappings, newMapping];
+        // Find or create a status by this name (deduped at the tenant level by createNewStatusMapping).
+        const existingByName = statusMappings.find(
+          m => (m.custom_name || m.status_name || m.name || '').toLowerCase().trim() ===
+            resolution.originalStatusName.toLowerCase().trim()
+        );
+        let mappingId: string;
+        if (existingByName) {
+          mappingId = existingByName.project_status_mapping_id;
+        } else {
+          const newMapping = await createNewStatusMapping(trx, projectId, resolution.originalStatusName, statusMappings.length, tenant);
+          mappingId = newMapping.project_status_mapping_id;
+          statusMappings = [...statusMappings, newMapping];
+        }
+        setResolved(phaseName, resolution.originalStatusName, mappingId);
+        statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = mappingId;
       } else if (resolution.action === 'map_to_existing' && resolution.mappedStatusId) {
-        // Map to an existing status
-        statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = resolution.mappedStatusId;
+        setResolved(phaseName, resolution.originalStatusName, resolution.mappedStatusId);
       } else if (resolution.action === 'use_default') {
-        // Will use the default "No Status Specified" column
-        // Create it if it doesn't exist
         if (!defaultUnspecifiedStatusId) {
           const existingDefault = statusMappings.find(
             m => (m.custom_name || m.status_name || m.name || '').toLowerCase() === DEFAULT_UNSPECIFIED_STATUS_NAME.toLowerCase()
@@ -859,12 +891,18 @@ export const importPhasesAndTasks = withAuth(async (
             statusMappings = [...statusMappings, newMapping];
           }
         }
-        statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = defaultUnspecifiedStatusId;
+        setResolved(phaseName, resolution.originalStatusName, defaultUnspecifiedStatusId);
       }
     }
 
-    // Default status for tasks without any status specified
+    // Default status for tasks without any status specified.
+    // Prefer caller-provided default if it exists in the project's mappings; otherwise fall back to first.
     const firstStatusMappingId = statusMappings[0].project_status_mapping_id;
+    const fallbackStatusMappingId =
+      defaultStatusMappingId &&
+      statusMappings.some((m: IProjectStatusMapping) => m.project_status_mapping_id === defaultStatusMappingId)
+        ? defaultStatusMappingId
+        : firstStatusMappingId;
 
     // Get existing phases
     const existingPhases = await ProjectModel.getPhases(trx, tenant, projectId);
@@ -943,12 +981,15 @@ export const importPhasesAndTasks = withAuth(async (
               // Already resolved during grouping
               taskStatusMappingId = taskData.status_mapping_id;
             } else if (taskData.status_name) {
-              // Look up from resolutions
-              const resolvedId = statusMappingByName[taskData.status_name.toLowerCase().trim()];
-              taskStatusMappingId = resolvedId || defaultUnspecifiedStatusId || firstStatusMappingId;
+              // Prefer phase-scoped resolution; fall back to global match, then default.
+              const phaseKey = groupedPhase.phase_name.toLowerCase().trim();
+              const statusKey = taskData.status_name.toLowerCase().trim();
+              const phaseScoped = resolvedByPhase.get(phaseKey)?.get(statusKey);
+              const globalMatched = statusMappingByName[statusKey];
+              taskStatusMappingId = phaseScoped || globalMatched || defaultUnspecifiedStatusId || fallbackStatusMappingId;
             } else {
-              // No status specified - use first status
-              taskStatusMappingId = firstStatusMappingId;
+              // No status specified - use the user-selected fallback (or first as last resort)
+              taskStatusMappingId = fallbackStatusMappingId;
             }
 
             const newTask = await ProjectTaskModel.addTask(trx, tenant, phase.phase_id, {
@@ -1028,12 +1069,17 @@ export const importPhasesAndTasks = withAuth(async (
             tasksCreated++;
           } catch (taskError) {
             const errorMessage = taskError instanceof Error ? taskError.message : 'Unknown error';
-            errors.push(`Failed to create task "${taskData.task_name}": ${errorMessage}`);
+            const rowRef = taskData.csvRowNumber ? ` (row ${taskData.csvRowNumber})` : '';
+            errors.push(`Failed to create task "${taskData.task_name}"${rowRef}: ${errorMessage}`);
           }
         }
       } catch (phaseError) {
         const errorMessage = phaseError instanceof Error ? phaseError.message : 'Unknown error';
-        errors.push(`Failed to process phase "${groupedPhase.phase_name}": ${errorMessage}`);
+        const rowNumbers = groupedPhase.tasks
+          .map(t => t.csvRowNumber)
+          .filter((n): n is number => typeof n === 'number');
+        const rowRef = rowNumbers.length > 0 ? ` (rows ${rowNumbers.join(', ')})` : '';
+        errors.push(`Failed to process phase "${groupedPhase.phase_name}"${rowRef}: ${errorMessage}`);
       }
     }
 

--- a/packages/projects/src/actions/phaseTaskImportActions.ts
+++ b/packages/projects/src/actions/phaseTaskImportActions.ts
@@ -818,7 +818,8 @@ export const importPhasesAndTasks = withAuth(async (
   projectId: string,
   groupedPhases: IGroupedPhaseData[],
   statusResolutions: IStatusResolution[] = [],
-  defaultStatusMappingId?: string
+  defaultStatusMappingId?: string,
+  defaultPhaseName?: string
 ): Promise<IPhaseTaskImportResult> => {
   const { knex: db } = await createTenantKnex();
 
@@ -848,6 +849,31 @@ export const importPhasesAndTasks = withAuth(async (
       }
     });
 
+    // Get existing phases
+    const existingPhases = await ProjectModel.getPhases(trx, tenant, projectId);
+    const existingPhaseMap = new Map<string, IProjectPhase>();
+    existingPhases.forEach(phase => {
+      existingPhaseMap.set(phase.phase_name.toLowerCase(), phase);
+    });
+
+    // Build per-phase status fallbacks. The user's "default status" choice in the dialog is
+    // scoped to a specific phase (the chosen fallback phase) — applying it globally would
+    // silently override per-phase status sets for tasks in other phases.
+    const projectWideMappings = (): IProjectStatusMapping[] =>
+      statusMappings.filter((m: IProjectStatusMapping) => !m.phase_id);
+    const phaseScopedMappings = (phaseId: string): IProjectStatusMapping[] =>
+      statusMappings.filter((m: IProjectStatusMapping) => m.phase_id === phaseId);
+
+    // Decide whether a "create" or "use_default" resolution for a given phase should produce
+    // a phase-scoped mapping. We mirror the read-side logic in getImportStatusReferenceData:
+    // a phase whose project_status_mappings include any phase-scoped row uses ONLY those for
+    // its status set, so a project-wide insert there wouldn't show up for the phase afterward.
+    const targetPhaseIdForResolution = (phaseName: string): string | null => {
+      const phaseEntity = existingPhaseMap.get(phaseName.toLowerCase().trim());
+      if (!phaseEntity) return null;
+      return phaseScopedMappings(phaseEntity.phase_id).length > 0 ? phaseEntity.phase_id : null;
+    };
+
     // Build phase-scoped resolution lookup: phaseName(lower) -> statusName(lower) -> mapping_id
     const resolvedByPhase: Map<string, Map<string, string>> = new Map();
     const setResolved = (phaseName: string, statusName: string, mappingId: string) => {
@@ -856,60 +882,118 @@ export const importPhasesAndTasks = withAuth(async (
       resolvedByPhase.get(phaseKey)!.set(statusName.toLowerCase().trim(), mappingId);
     };
 
-    let defaultUnspecifiedStatusId: string | null = null;
+    // "use_default" resolutions share a single 'No Status Specified' status per phase scope.
+    // Different phase scopes need different mappings so the default is visible for each phase.
+    const defaultUnspecifiedStatusByScope = new Map<string, string>();
+    const scopeKey = (phaseId: string | null): string => phaseId ?? '__project_wide__';
 
     for (const resolution of statusResolutions) {
       const phaseName = resolution.phaseName || DEFAULT_PHASE_NAME;
+      const targetPhaseId = targetPhaseIdForResolution(phaseName);
       if (resolution.action === 'create') {
-        // Find or create a status by this name (deduped at the tenant level by createNewStatusMapping).
+        // Reuse an existing mapping in the same scope (phase-scoped or project-wide) when a
+        // status by this name is already mapped there; otherwise insert a new mapping pinned
+        // to that scope so the read-side lookups will surface it for the phase afterward.
         const existingByName = statusMappings.find(
-          m => (m.custom_name || m.status_name || m.name || '').toLowerCase().trim() ===
-            resolution.originalStatusName.toLowerCase().trim()
+          (m) =>
+            (m.custom_name || m.status_name || m.name || '').toLowerCase().trim() ===
+              resolution.originalStatusName.toLowerCase().trim() &&
+            (m.phase_id ?? null) === targetPhaseId
         );
         let mappingId: string;
         if (existingByName) {
           mappingId = existingByName.project_status_mapping_id;
         } else {
-          const newMapping = await createNewStatusMapping(trx, projectId, resolution.originalStatusName, statusMappings.length, tenant);
+          const newMapping = await createNewStatusMapping(
+            trx,
+            projectId,
+            resolution.originalStatusName,
+            statusMappings.length,
+            tenant,
+            targetPhaseId
+          );
           mappingId = newMapping.project_status_mapping_id;
           statusMappings = [...statusMappings, newMapping];
         }
         setResolved(phaseName, resolution.originalStatusName, mappingId);
-        statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = mappingId;
+        // The global by-name index is used as a last-resort fallback for unmatched statuses.
+        // Only populate it for project-wide resolutions so phase-scoped creates don't bleed
+        // into other phases' lookups.
+        if (targetPhaseId === null) {
+          statusMappingByName[resolution.originalStatusName.toLowerCase().trim()] = mappingId;
+        }
       } else if (resolution.action === 'map_to_existing' && resolution.mappedStatusId) {
         setResolved(phaseName, resolution.originalStatusName, resolution.mappedStatusId);
       } else if (resolution.action === 'use_default') {
-        if (!defaultUnspecifiedStatusId) {
+        const key = scopeKey(targetPhaseId);
+        let mappingId = defaultUnspecifiedStatusByScope.get(key);
+        if (!mappingId) {
           const existingDefault = statusMappings.find(
-            m => (m.custom_name || m.status_name || m.name || '').toLowerCase() === DEFAULT_UNSPECIFIED_STATUS_NAME.toLowerCase()
+            (m) =>
+              (m.custom_name || m.status_name || m.name || '').toLowerCase() ===
+                DEFAULT_UNSPECIFIED_STATUS_NAME.toLowerCase() &&
+              (m.phase_id ?? null) === targetPhaseId
           );
           if (existingDefault) {
-            defaultUnspecifiedStatusId = existingDefault.project_status_mapping_id;
+            mappingId = existingDefault.project_status_mapping_id;
           } else {
-            const newMapping = await createNewStatusMapping(trx, projectId, DEFAULT_UNSPECIFIED_STATUS_NAME, statusMappings.length, tenant);
-            defaultUnspecifiedStatusId = newMapping.project_status_mapping_id;
+            const newMapping = await createNewStatusMapping(
+              trx,
+              projectId,
+              DEFAULT_UNSPECIFIED_STATUS_NAME,
+              statusMappings.length,
+              tenant,
+              targetPhaseId
+            );
+            mappingId = newMapping.project_status_mapping_id;
             statusMappings = [...statusMappings, newMapping];
           }
+          defaultUnspecifiedStatusByScope.set(key, mappingId);
         }
-        setResolved(phaseName, resolution.originalStatusName, defaultUnspecifiedStatusId);
+        setResolved(phaseName, resolution.originalStatusName, mappingId);
       }
     }
 
-    // Default status for tasks without any status specified.
-    // Prefer caller-provided default if it exists in the project's mappings; otherwise fall back to first.
     const firstStatusMappingId = statusMappings[0].project_status_mapping_id;
-    const fallbackStatusMappingId =
-      defaultStatusMappingId &&
-      statusMappings.some((m: IProjectStatusMapping) => m.project_status_mapping_id === defaultStatusMappingId)
-        ? defaultStatusMappingId
-        : firstStatusMappingId;
 
-    // Get existing phases
-    const existingPhases = await ProjectModel.getPhases(trx, tenant, projectId);
-    const existingPhaseMap = new Map<string, IProjectPhase>();
-    existingPhases.forEach(phase => {
-      existingPhaseMap.set(phase.phase_name.toLowerCase(), phase);
-    });
+    const firstMappingForPhase = (phaseName: string): string => {
+      const phaseEntity = existingPhaseMap.get(phaseName.toLowerCase().trim());
+      if (phaseEntity) {
+        const phaseSpecific = phaseScopedMappings(phaseEntity.phase_id);
+        if (phaseSpecific.length > 0) {
+          return phaseSpecific[0].project_status_mapping_id;
+        }
+      }
+      return projectWideMappings()[0]?.project_status_mapping_id || firstStatusMappingId;
+    };
+
+    const isMappingValidForPhase = (phaseName: string, mappingId: string): boolean => {
+      const phaseEntity = existingPhaseMap.get(phaseName.toLowerCase().trim());
+      if (phaseEntity) {
+        const phaseSpecific = phaseScopedMappings(phaseEntity.phase_id);
+        if (phaseSpecific.length > 0) {
+          return phaseSpecific.some(m => m.project_status_mapping_id === mappingId);
+        }
+      }
+      return (
+        projectWideMappings().some(m => m.project_status_mapping_id === mappingId) ||
+        statusMappings.some((m: IProjectStatusMapping) => m.project_status_mapping_id === mappingId)
+      );
+    };
+
+    const normalizedDefaultPhase = defaultPhaseName?.toLowerCase().trim();
+    const fallbackForPhase = (phaseName: string): string => {
+      const phaseKey = phaseName.toLowerCase().trim();
+      if (
+        normalizedDefaultPhase &&
+        phaseKey === normalizedDefaultPhase &&
+        defaultStatusMappingId &&
+        isMappingValidForPhase(phaseName, defaultStatusMappingId)
+      ) {
+        return defaultStatusMappingId;
+      }
+      return firstMappingForPhase(phaseName);
+    };
 
     let phasesCreated = 0;
     let tasksCreated = 0;
@@ -981,15 +1065,18 @@ export const importPhasesAndTasks = withAuth(async (
               // Already resolved during grouping
               taskStatusMappingId = taskData.status_mapping_id;
             } else if (taskData.status_name) {
-              // Prefer phase-scoped resolution; fall back to global match, then default.
+              // Prefer phase-scoped resolution; fall back to global match, then per-phase default.
               const phaseKey = groupedPhase.phase_name.toLowerCase().trim();
               const statusKey = taskData.status_name.toLowerCase().trim();
               const phaseScoped = resolvedByPhase.get(phaseKey)?.get(statusKey);
               const globalMatched = statusMappingByName[statusKey];
-              taskStatusMappingId = phaseScoped || globalMatched || defaultUnspecifiedStatusId || fallbackStatusMappingId;
+              taskStatusMappingId =
+                phaseScoped || globalMatched || fallbackForPhase(groupedPhase.phase_name);
             } else {
-              // No status specified - use the user-selected fallback (or first as last resort)
-              taskStatusMappingId = fallbackStatusMappingId;
+              // No status specified - use the per-phase fallback. The user-chosen "default
+              // status" only applies to tasks whose phase matches the chosen fallback phase;
+              // tasks in other phases get the first valid status for their phase.
+              taskStatusMappingId = fallbackForPhase(groupedPhase.phase_name);
             }
 
             const newTask = await ProjectTaskModel.addTask(trx, tenant, phase.phase_id, {
@@ -1104,7 +1191,8 @@ async function createNewStatusMapping(
   projectId: string,
   statusName: string,
   existingCount: number,
-  tenant: string
+  tenant: string,
+  phaseId: string | null = null
 ): Promise<IProjectStatusMapping> {
   // Use advisory lock to serialize status creation for this tenant/type combination
   // This matches the logic in createTenantProjectStatus
@@ -1151,10 +1239,14 @@ async function createNewStatusMapping(
       .returning('*');
   }
 
-  // Check if a mapping already exists for this status in this project
-  const existingMapping = await trx('project_status_mappings')
-    .where({ tenant, project_id: projectId, status_id: status.status_id })
-    .first();
+  // Check if a mapping already exists in the same scope (phase-scoped or project-wide).
+  // A project-wide mapping and a phase-scoped mapping for the same status are distinct rows
+  // and serve different read paths, so the existence check must include phase_id.
+  const existingMappingQuery = trx('project_status_mappings')
+    .where({ tenant, project_id: projectId, status_id: status.status_id });
+  const existingMapping = phaseId === null
+    ? await existingMappingQuery.whereNull('phase_id').first()
+    : await existingMappingQuery.where({ phase_id: phaseId }).first();
 
   if (existingMapping) {
     return {
@@ -1170,6 +1262,7 @@ async function createNewStatusMapping(
       tenant,
       project_id: projectId,
       status_id: status.status_id,
+      phase_id: phaseId,
       display_order: existingCount + 1,
       is_visible: true,
       is_standard: false,

--- a/packages/projects/src/components/PhaseTaskImportDialog.tsx
+++ b/packages/projects/src/components/PhaseTaskImportDialog.tsx
@@ -63,6 +63,57 @@ const MAX_IMPORT_ROWS = 5000;
 // Threshold for showing confirmation before import
 const LARGE_IMPORT_THRESHOLD = 100;
 
+/**
+ * Recompute the set of unmatched (phase, status) pairs given the current fallback phase.
+ *
+ * The fallback phase determines the effective phase for rows whose phase_name is blank,
+ * which in turn determines which phase-scoped status set their statuses are looked up in.
+ * Mirrors the server-side logic in validatePhaseTaskImportDataWithReferenceData so that
+ * the preview stays consistent if the user changes the fallback phase.
+ */
+function computeUnmatchedStatusState(
+  validationResults: ITaskImportValidationResult[],
+  defaultPhaseName: string,
+  statusLookup: Record<string, string>,
+  statusLookupByPhase: Record<string, Record<string, string>>
+): {
+  unmatchedStatuses: Array<{ phaseName: string; statusName: string }>;
+  unmatchedStatusInfo: IUnmatchedStatusInfo[];
+} {
+  const fallbackPhase = defaultPhaseName?.trim() || DEFAULT_PHASE_NAME;
+  const pairs = new Map<string, { phaseName: string; statusName: string }>();
+  const infoMap = new Map<string, IUnmatchedStatusInfo>();
+
+  for (const result of validationResults) {
+    const statusName = result.data.status?.trim();
+    if (!statusName) continue;
+    const phaseName = result.data.phase_name?.trim() || fallbackPhase;
+    const lookup = statusLookupByPhase[phaseName.toLowerCase()] || statusLookup;
+    if (lookup[statusName.toLowerCase()]) continue;
+
+    const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
+    if (!pairs.has(key)) {
+      pairs.set(key, { phaseName, statusName });
+      infoMap.set(key, {
+        statusName,
+        phaseName,
+        taskCount: 0,
+        taskNames: [],
+      });
+    }
+    const info = infoMap.get(key)!;
+    info.taskCount++;
+    if (info.taskNames.length < 3) {
+      info.taskNames.push(result.data.task_name || 'Unnamed task');
+    }
+  }
+
+  return {
+    unmatchedStatuses: Array.from(pairs.values()),
+    unmatchedStatusInfo: Array.from(infoMap.values()),
+  };
+}
+
 const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
   isOpen,
   onClose,
@@ -298,7 +349,6 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
       setServiceLookup(validationResponse.serviceLookup);
       setStatusLookup(validationResponse.statusLookup);
       setStatusLookupByPhase(validationResponse.statusLookupByPhase || {});
-      setUnmatchedStatuses(validationResponse.unmatchedStatuses);
       setUnmatchedAgents(validationResponse.unmatchedAgents);
 
       // Use reference data for dropdowns (no additional fetches needed)
@@ -316,36 +366,18 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
         '';
       setDefaultStatusMappingId(initialDefaultStatusId);
 
-      // Compute unmatched status info per (phase, status) pair
-      const unmatchedSet = new Set(
-        validationResponse.unmatchedStatuses.map(p => `${p.phaseName.toLowerCase()}::${p.statusName.toLowerCase()}`)
+      // Initial unmatched-status computation uses the dialog's current defaultPhaseName.
+      // The effect at the end of this file keeps these in sync if the user picks a different fallback phase.
+      const initial = computeUnmatchedStatusState(
+        validationResponse.validationResults,
+        defaultPhaseName,
+        validationResponse.statusLookup,
+        validationResponse.statusLookupByPhase || {}
       );
-      const statusInfoMap = new Map<string, IUnmatchedStatusInfo>();
-      validationResponse.validationResults.forEach(result => {
-        const statusName = result.data.status?.trim();
-        if (!statusName) return;
-        const phaseName = result.data.phase_name?.trim() || DEFAULT_PHASE_NAME;
-        const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
-        if (!unmatchedSet.has(key)) return;
-        if (!statusInfoMap.has(key)) {
-          statusInfoMap.set(key, {
-            statusName,
-            phaseName,
-            taskCount: 0,
-            taskNames: [],
-          });
-        }
-        const info = statusInfoMap.get(key)!;
-        info.taskCount++;
-        if (info.taskNames.length < 3) {
-          info.taskNames.push(result.data.task_name || 'Unnamed task');
-        }
-      });
-      setUnmatchedStatusInfo(Array.from(statusInfoMap.values()));
-
-      // Initialize status resolutions with default action, one per (phase, status) pair
+      setUnmatchedStatuses(initial.unmatchedStatuses);
+      setUnmatchedStatusInfo(initial.unmatchedStatusInfo);
       setStatusResolutions(
-        validationResponse.unmatchedStatuses.map(({ phaseName, statusName }) => ({
+        initial.unmatchedStatuses.map(({ phaseName, statusName }) => ({
           originalStatusName: statusName,
           phaseName,
           action: 'use_default' as StatusResolutionAction,
@@ -430,7 +462,8 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
         projectId,
         groupedPhases,
         statusResolutions,
-        defaultStatusMappingId || undefined
+        defaultStatusMappingId || undefined,
+        defaultPhaseName || undefined
       );
       setImportResult(result);
       onImportComplete(result);
@@ -441,7 +474,7 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     } finally {
       setIsProcessing(false);
     }
-  }, [isProcessing, groupedPhases, projectId, onImportComplete, statusResolutions, importT, defaultStatusMappingId]);
+  }, [isProcessing, groupedPhases, projectId, onImportComplete, statusResolutions, importT, defaultStatusMappingId, defaultPhaseName]);
 
   // Handle status resolution changes — keyed by (phase, status)
   const handleStatusResolutionChange = useCallback((
@@ -659,6 +692,36 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
       if (cancelled) return;
       setGroupedPhases(grouped);
       setExpandedPhases(new Set(grouped.map(p => p.phase_name)));
+
+      // Recompute unmatched statuses against the new effective phase. A status that was
+      // matched under the previous fallback phase may no longer be valid (and vice versa),
+      // so we must regenerate the resolution UI's source of truth — otherwise the import
+      // silently picks a global match or default for newly-invalid statuses.
+      const recomputed = computeUnmatchedStatusState(
+        validationResults,
+        defaultPhaseName,
+        statusLookup,
+        statusLookupByPhase
+      );
+      setUnmatchedStatuses(recomputed.unmatchedStatuses);
+      setUnmatchedStatusInfo(recomputed.unmatchedStatusInfo);
+      // Preserve any resolutions the user has already configured for pairs that still exist;
+      // drop pairs that are now matched, and add new pairs with the default action.
+      setStatusResolutions(prev => {
+        const prevByKey = new Map(
+          prev.map(r => [`${r.phaseName.toLowerCase()}::${r.originalStatusName.toLowerCase()}`, r])
+        );
+        return recomputed.unmatchedStatuses.map(({ phaseName, statusName }) => {
+          const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
+          return (
+            prevByKey.get(key) ?? {
+              originalStatusName: statusName,
+              phaseName,
+              action: 'use_default' as StatusResolutionAction,
+            }
+          );
+        });
+      });
     })();
     return () => {
       cancelled = true;

--- a/packages/projects/src/components/PhaseTaskImportDialog.tsx
+++ b/packages/projects/src/components/PhaseTaskImportDialog.tsx
@@ -15,6 +15,7 @@ import { Upload, AlertTriangle, Check, ChevronDown, ChevronRight } from 'lucide-
 import { parseCSV } from '@alga-psa/core';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
 import {
   generatePhaseTaskCSVTemplate,
   getImportReferenceData,
@@ -99,8 +100,18 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
   const [statusLookup, setStatusLookup] = useState<Record<string, string>>({});
   const [statusLookupByPhase, setStatusLookupByPhase] = useState<Record<string, Record<string, string>>>({});
 
-  // Status resolution state
-  const [unmatchedStatuses, setUnmatchedStatuses] = useState<string[]>([]);
+  // Existing project phases (for the fallback phase picker)
+  const [availablePhases, setAvailablePhases] = useState<IImportReferenceData['phases']>([]);
+
+  // Default fallback selections (apply when CSV row has no phase/status)
+  const [defaultPhaseName, setDefaultPhaseName] = useState<string>(DEFAULT_PHASE_NAME);
+  const [defaultStatusMappingId, setDefaultStatusMappingId] = useState<string>('');
+
+  // Preview filter for the validation results table
+  const [previewRowFilter, setPreviewRowFilter] = useState<'all' | 'imported' | 'skipped'>('all');
+
+  // Status resolution state — phase-scoped pairs
+  const [unmatchedStatuses, setUnmatchedStatuses] = useState<Array<{ phaseName: string; statusName: string }>>([]);
   const [unmatchedStatusInfo, setUnmatchedStatusInfo] = useState<IUnmatchedStatusInfo[]>([]);
   const [statusResolutions, setStatusResolutions] = useState<IStatusResolution[]>([]);
   const [projectStatusMappings, setProjectStatusMappings] = useState<IProjectStatusMapping[]>([]);
@@ -152,6 +163,10 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
       setUnmatchedAgentInfo([]);
       setAgentResolutions([]);
       setAvailableUsers([]);
+      setAvailablePhases([]);
+      setDefaultPhaseName(DEFAULT_PHASE_NAME);
+      setDefaultStatusMappingId('');
+      setPreviewRowFilter('all');
       setRowsTruncated(null);
       setImportConfirmed(false);
     }
@@ -260,9 +275,9 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     setErrors([]);
 
     try {
-      // Map CSV data to ITaskImportRow objects
-      const mappedRows: ITaskImportRow[] = fullCSVData.map((row) => {
-        const mappedData: ITaskImportRow = {};
+      // Map CSV data to ITaskImportRow objects (header is row 1, first data row is row 2)
+      const mappedRows: ITaskImportRow[] = fullCSVData.map((row, rowIndex) => {
+        const mappedData: ITaskImportRow = { csvRowNumber: rowIndex + 2 };
         columnMappings.forEach((mapping, index) => {
           if (mapping.taskField) {
             (mappedData as Record<string, string>)[mapping.taskField] = row[index] || '';
@@ -287,34 +302,52 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
       setUnmatchedAgents(validationResponse.unmatchedAgents);
 
       // Use reference data for dropdowns (no additional fetches needed)
-      setProjectStatusMappings(referenceData.statusMappings as IProjectStatusMapping[]);
+      const projectMappings = referenceData.statusMappings as IProjectStatusMapping[];
+      setProjectStatusMappings(projectMappings);
       setAvailableUsers(referenceData.users);
+      setAvailablePhases(referenceData.phases || []);
 
-      // Compute unmatched status info (which tasks have each unmatched status)
+      // Initialize the default fallback status to the first project-level mapping (preserving previous behavior).
+      // Prefer mappings without a phase_id (project-wide).
+      const defaultMappings = projectMappings.filter((m) => !m.phase_id);
+      const initialDefaultStatusId =
+        defaultMappings[0]?.project_status_mapping_id ||
+        projectMappings[0]?.project_status_mapping_id ||
+        '';
+      setDefaultStatusMappingId(initialDefaultStatusId);
+
+      // Compute unmatched status info per (phase, status) pair
+      const unmatchedSet = new Set(
+        validationResponse.unmatchedStatuses.map(p => `${p.phaseName.toLowerCase()}::${p.statusName.toLowerCase()}`)
+      );
       const statusInfoMap = new Map<string, IUnmatchedStatusInfo>();
       validationResponse.validationResults.forEach(result => {
         const statusName = result.data.status?.trim();
-        if (statusName && validationResponse.unmatchedStatuses.includes(statusName)) {
-          if (!statusInfoMap.has(statusName)) {
-            statusInfoMap.set(statusName, {
-              statusName,
-              taskCount: 0,
-              taskNames: [],
-            });
-          }
-          const info = statusInfoMap.get(statusName)!;
-          info.taskCount++;
-          if (info.taskNames.length < 3) {
-            info.taskNames.push(result.data.task_name || 'Unnamed task');
-          }
+        if (!statusName) return;
+        const phaseName = result.data.phase_name?.trim() || DEFAULT_PHASE_NAME;
+        const key = `${phaseName.toLowerCase()}::${statusName.toLowerCase()}`;
+        if (!unmatchedSet.has(key)) return;
+        if (!statusInfoMap.has(key)) {
+          statusInfoMap.set(key, {
+            statusName,
+            phaseName,
+            taskCount: 0,
+            taskNames: [],
+          });
+        }
+        const info = statusInfoMap.get(key)!;
+        info.taskCount++;
+        if (info.taskNames.length < 3) {
+          info.taskNames.push(result.data.task_name || 'Unnamed task');
         }
       });
       setUnmatchedStatusInfo(Array.from(statusInfoMap.values()));
 
-      // Initialize status resolutions with default action
+      // Initialize status resolutions with default action, one per (phase, status) pair
       setStatusResolutions(
-        validationResponse.unmatchedStatuses.map(statusName => ({
+        validationResponse.unmatchedStatuses.map(({ phaseName, statusName }) => ({
           originalStatusName: statusName,
+          phaseName,
           action: 'use_default' as StatusResolutionAction,
         }))
       );
@@ -368,7 +401,9 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
         validationResponse.priorityLookup,
         validationResponse.serviceLookup,
         validationResponse.statusLookup,
-        validationResponse.statusLookupByPhase || {}
+        validationResponse.statusLookupByPhase || {},
+        [],
+        defaultPhaseName
       );
       setGroupedPhases(grouped);
 
@@ -381,7 +416,7 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     } finally {
       setIsProcessing(false);
     }
-  }, [fullCSVData, columnMappings, validateMappings, projectId, importT]);
+  }, [fullCSVData, columnMappings, validateMappings, projectId, importT, defaultPhaseName]);
 
   const handleImport = useCallback(async () => {
     if (isProcessing || groupedPhases.length === 0) return;
@@ -391,7 +426,12 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     setErrors([]);
 
     try {
-      const result = await importPhasesAndTasks(projectId, groupedPhases, statusResolutions);
+      const result = await importPhasesAndTasks(
+        projectId,
+        groupedPhases,
+        statusResolutions,
+        defaultStatusMappingId || undefined
+      );
       setImportResult(result);
       onImportComplete(result);
       setStep('complete');
@@ -401,17 +441,18 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     } finally {
       setIsProcessing(false);
     }
-  }, [isProcessing, groupedPhases, projectId, onImportComplete, statusResolutions, importT]);
+  }, [isProcessing, groupedPhases, projectId, onImportComplete, statusResolutions, importT, defaultStatusMappingId]);
 
-  // Handle status resolution changes
+  // Handle status resolution changes — keyed by (phase, status)
   const handleStatusResolutionChange = useCallback((
+    phaseName: string,
     statusName: string,
     action: StatusResolutionAction,
     mappedStatusId?: string
   ) => {
     setStatusResolutions(prev =>
       prev.map(resolution =>
-        resolution.originalStatusName === statusName
+        resolution.originalStatusName === statusName && resolution.phaseName === phaseName
           ? { ...resolution, action, mappedStatusId }
           : resolution
       )
@@ -458,7 +499,8 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
       serviceLookup,
       statusLookup,
       statusLookupByPhase,
-      agentResolutions
+      agentResolutions,
+      defaultPhaseName
     );
     setGroupedPhases(grouped);
 
@@ -467,7 +509,7 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     } else {
       handleImport();
     }
-  }, [validationResults, userLookup, priorityLookup, serviceLookup, statusLookup, statusLookupByPhase, agentResolutions, unmatchedStatuses, handleImport]);
+  }, [validationResults, userLookup, priorityLookup, serviceLookup, statusLookup, statusLookupByPhase, agentResolutions, unmatchedStatuses, handleImport, defaultPhaseName]);
 
   const handleClose = useCallback(() => {
     if (!isProcessing) {
@@ -511,6 +553,117 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
     invalidCount: validationResults.filter(r => !r.isValid).length,
     totalTasks: groupedPhases.reduce((sum, phase) => sum + phase.tasks.length, 0),
   }), [validationResults, groupedPhases]);
+
+  // Counts of valid rows with no phase / status — used to gate fallback pickers
+  const { unphasedRowCount, unstatusedRowCount } = useMemo(() => {
+    const valid = validationResults.filter(r => r.isValid);
+    return {
+      unphasedRowCount: valid.filter(r => !r.data.phase_name?.trim()).length,
+      unstatusedRowCount: valid.filter(r => !r.data.status?.trim()).length,
+    };
+  }, [validationResults]);
+
+  // Status mappings scoped to the chosen default phase.
+  // If the chosen phase has phase-specific statuses, only those are valid; otherwise project-wide ones apply.
+  const fallbackStatusOptions = useMemo(() => {
+    const matchedPhase = availablePhases.find(
+      (p) => p.phase_name.toLowerCase().trim() === defaultPhaseName.toLowerCase().trim()
+    );
+    if (matchedPhase) {
+      const phaseScoped = projectStatusMappings.filter((m) => m.phase_id === matchedPhase.phase_id);
+      if (phaseScoped.length > 0) return phaseScoped;
+    }
+    return projectStatusMappings.filter((m) => !m.phase_id);
+  }, [availablePhases, defaultPhaseName, projectStatusMappings]);
+
+  // Keep the selected default status valid when the phase changes
+  useEffect(() => {
+    if (fallbackStatusOptions.length === 0) return;
+    const stillValid = fallbackStatusOptions.some(
+      (m) => m.project_status_mapping_id === defaultStatusMappingId
+    );
+    if (!stillValid) {
+      setDefaultStatusMappingId(fallbackStatusOptions[0].project_status_mapping_id);
+    }
+  }, [fallbackStatusOptions, defaultStatusMappingId]);
+
+  // Resolve the status that will actually be applied to a row, taking phase-specific status sets into account.
+  const resolveDisplayStatus = useCallback((row: ITaskImportRow): {
+    name: string;
+    isUnmatched: boolean;
+    isFallback: boolean;
+  } => {
+    const effectivePhase = (row.phase_name?.trim() || defaultPhaseName).toLowerCase().trim();
+    const phaseMatch = availablePhases.find(
+      (p) => p.phase_name.toLowerCase().trim() === effectivePhase
+    );
+    const phaseSpecific = phaseMatch
+      ? projectStatusMappings.filter((m) => m.phase_id === phaseMatch.phase_id)
+      : [];
+    const projectWide = projectStatusMappings.filter((m) => !m.phase_id);
+    const effectiveMappings = phaseSpecific.length > 0 ? phaseSpecific : projectWide;
+
+    const labelOf = (id: string) => {
+      const m = projectStatusMappings.find((x) => x.project_status_mapping_id === id);
+      return m?.custom_name || m?.status_name || m?.name || '—';
+    };
+
+    const csvStatus = row.status?.trim();
+    if (csvStatus) {
+      const lookup = statusLookupByPhase[effectivePhase] || statusLookup;
+      const id = lookup[csvStatus.toLowerCase()];
+      if (id) return { name: labelOf(id), isUnmatched: false, isFallback: false };
+      return { name: csvStatus, isUnmatched: true, isFallback: false };
+    }
+
+    // Empty CSV status → fallback. Honor user's explicit pick when the row's phase is the chosen default phase.
+    if (
+      effectivePhase === defaultPhaseName.toLowerCase().trim() &&
+      defaultStatusMappingId &&
+      effectiveMappings.some((m) => m.project_status_mapping_id === defaultStatusMappingId)
+    ) {
+      return { name: labelOf(defaultStatusMappingId), isUnmatched: false, isFallback: true };
+    }
+    const first = effectiveMappings[0];
+    if (first) {
+      return { name: labelOf(first.project_status_mapping_id), isUnmatched: false, isFallback: true };
+    }
+    return { name: '—', isUnmatched: false, isFallback: true };
+  }, [availablePhases, projectStatusMappings, statusLookupByPhase, statusLookup, defaultPhaseName, defaultStatusMappingId]);
+
+  // Regroup tasks when the user picks a different fallback phase in preview.
+  // Skip the initial render — handlePreview already produces the first grouping.
+  const previewInitializedRef = React.useRef(false);
+  useEffect(() => {
+    if (step !== 'preview') {
+      previewInitializedRef.current = false;
+      return;
+    }
+    if (!previewInitializedRef.current) {
+      previewInitializedRef.current = true;
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const validRows = validationResults.filter(r => r.isValid).map(r => r.data);
+      const grouped = await groupRowsIntoPhases(
+        validRows,
+        userLookup,
+        priorityLookup,
+        serviceLookup,
+        statusLookup,
+        statusLookupByPhase,
+        agentResolutions,
+        defaultPhaseName
+      );
+      if (cancelled) return;
+      setGroupedPhases(grouped);
+      setExpandedPhases(new Set(grouped.map(p => p.phase_name)));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [defaultPhaseName, step, validationResults, userLookup, priorityLookup, serviceLookup, statusLookup, statusLookupByPhase, agentResolutions]);
 
   // Check if all map_to_existing resolutions have a valid selection
   const hasIncompleteStatusMappings = useMemo(() => {
@@ -812,6 +965,62 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                   />
                 </div>
               </div>
+
+              {/* Fallback phase picker — only shown when at least one valid row has no phase */}
+              {unphasedRowCount > 0 && (
+                <div className="flex items-center justify-between py-3 border-b">
+                  <div>
+                    <div className="text-gray-900 font-medium">
+                      {importT('fallbackPhaseLabel', 'Default phase for tasks without phase_name')}
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      {importT('fallbackPhaseHelp', '{{count}} row(s) have no phase. Pick an existing phase or keep the default to create one.', {
+                        count: unphasedRowCount,
+                      })}
+                    </div>
+                  </div>
+                  <CustomSelect
+                    options={[
+                      {
+                        value: DEFAULT_PHASE_NAME,
+                        label: importT('fallbackPhaseCreateDefault', 'Create new phase: "{{name}}"', { name: DEFAULT_PHASE_NAME }),
+                      },
+                      ...availablePhases.map(p => ({
+                        value: p.phase_name,
+                        label: p.phase_name,
+                      })),
+                    ]}
+                    value={defaultPhaseName}
+                    onValueChange={(value) => setDefaultPhaseName(value)}
+                    className="w-64"
+                  />
+                </div>
+              )}
+
+              {/* Fallback status picker — scoped to the statuses available for the selected default phase */}
+              {unstatusedRowCount > 0 && fallbackStatusOptions.length > 0 && (
+                <div className="flex items-center justify-between py-3 border-b">
+                  <div>
+                    <div className="text-gray-900 font-medium">
+                      {importT('fallbackStatusLabel', 'Default status for tasks without status')}
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      {importT('fallbackStatusHelp', '{{count}} row(s) have no status. The selected status will be assigned to those tasks.', {
+                        count: unstatusedRowCount,
+                      })}
+                    </div>
+                  </div>
+                  <CustomSelect
+                    options={fallbackStatusOptions.map(mapping => ({
+                      value: mapping.project_status_mapping_id,
+                      label: mapping.custom_name || mapping.status_name || mapping.name || 'Unnamed',
+                    }))}
+                    value={defaultStatusMappingId}
+                    onValueChange={(value) => setDefaultStatusMappingId(value)}
+                    className="w-64"
+                  />
+                </div>
+              )}
             </div>
 
             {/* Grouped Preview */}
@@ -851,29 +1060,77 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
               </div>
             </div>
 
+            {/* Row filter — lets users focus on rows that will be skipped vs. imported */}
+            <div className="mb-2 flex items-center justify-between">
+              <h4 className="text-sm font-medium text-gray-700">
+                {importT('rowResultsTitle', 'Row Results')}
+              </h4>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-gray-500">{importT('rowFilterLabel', 'Show:')}</span>
+                <CustomSelect
+                  options={[
+                    {
+                      value: 'all',
+                      label: importT('rowFilterAll', 'All rows ({{count}})', { count: validationResults.length }),
+                    },
+                    {
+                      value: 'imported',
+                      label: importT('rowFilterImported', 'Will be imported ({{count}})', {
+                        count: importOptions.skipInvalidRows ? validCount : validationResults.length,
+                      }),
+                    },
+                    {
+                      value: 'skipped',
+                      label: importT('rowFilterSkipped', 'Will be skipped ({{count}})', {
+                        count: importOptions.skipInvalidRows ? invalidCount : 0,
+                      }),
+                    },
+                  ]}
+                  value={previewRowFilter}
+                  onValueChange={(value) => {
+                    setPreviewRowFilter(value as 'all' | 'imported' | 'skipped');
+                    setCurrentPage(1);
+                  }}
+                  className="w-56"
+                />
+              </div>
+            </div>
+
             {/* Validation Results Table */}
             <div className="max-h-64 overflow-x-auto overflow-y-auto">
               <DataTable
-                key={`${currentPage}-${pageSize}`}
+                key={`${currentPage}-${pageSize}-${previewRowFilter}`}
                 id="phase-task-import-preview-table"
                 pagination={true}
                 currentPage={currentPage}
                 onPageChange={setCurrentPage}
                 pageSize={pageSize}
                 onItemsPerPageChange={handlePageSizeChange}
-                data={validationResults.map((result) => ({
-                  status: result.isValid,
-                  rowNumber: result.rowNumber,
-                  phase_name: result.data.phase_name || DEFAULT_PHASE_NAME,
-                  task_name: result.data.task_name,
-                  assigned_to: result.data.assigned_to,
-                  estimated_hours: result.data.estimated_hours,
-                  errors: result.errors,
-                  warnings: result.warnings,
-                }))}
+                data={validationResults
+                  .filter((result) => {
+                    if (previewRowFilter === 'all') return true;
+                    // When skipInvalidRows is off, every row is "to be imported" or blocks the import — no rows are skipped.
+                    const willBeSkipped = importOptions.skipInvalidRows ? !result.isValid : false;
+                    if (previewRowFilter === 'skipped') return willBeSkipped;
+                    return !willBeSkipped;
+                  })
+                  .map((result) => {
+                    const resolvedStatus = resolveDisplayStatus(result.data);
+                    return {
+                      status: result.isValid,
+                      rowNumber: result.rowNumber,
+                      phase_name: result.data.phase_name || defaultPhaseName,
+                      task_name: result.data.task_name,
+                      assigned_to: result.data.assigned_to,
+                      estimated_hours: result.data.estimated_hours,
+                      resolvedStatus,
+                      errors: result.errors,
+                      warnings: result.warnings,
+                    };
+                  })}
                 columns={[
                   {
-                    title: importT('table.status', 'Status'),
+                    title: importT('table.valid', 'Valid'),
                     dataIndex: 'status',
                     render: (value: boolean) =>
                       value ? (
@@ -901,6 +1158,34 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                   {
                     title: importT('table.task', 'Task'),
                     dataIndex: 'task_name',
+                  },
+                  {
+                    title: importT('table.status', 'Status'),
+                    dataIndex: 'resolvedStatus',
+                    render: (value: unknown) => {
+                      const v = value as { name: string; isUnmatched: boolean; isFallback: boolean };
+                      if (v.isUnmatched) {
+                        return (
+                          <Tooltip content={importT('statusUnmatchedTooltip', 'Status does not match any existing status for this phase. Resolve in the mapping steps before import.')}>
+                            <div className="flex flex-col items-start gap-1 cursor-help min-w-0">
+                              <span className="text-sm break-words whitespace-normal">{v.name}</span>
+                              <Badge variant="warning" size="sm">{importT('statusUnmatchedSuffix', 'Unmatched')}</Badge>
+                            </div>
+                          </Tooltip>
+                        );
+                      }
+                      if (v.isFallback) {
+                        return (
+                          <Tooltip content={importT('statusFallbackTooltip', 'Using the default fallback status for this phase.')}>
+                            <div className="flex flex-col items-start gap-1 cursor-help min-w-0">
+                              <span className="text-sm break-words whitespace-normal">{v.name}</span>
+                              <Badge variant="default-muted" size="sm">{importT('statusFallbackSuffix', 'Default')}</Badge>
+                            </div>
+                          </Tooltip>
+                        );
+                      }
+                      return <span className="text-sm break-words whitespace-normal">{v.name}</span>;
+                    },
                   },
                   {
                     title: importT('table.issues', 'Issues'),
@@ -971,6 +1256,16 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                 <AlertDescription>
                   <strong>{importT('invalidRowsCount', '{{count}} row(s)', { count: invalidCount })}</strong>{' '}
                   {importT('invalidRowsBlockingError', 'have validation errors. Enable "Skip invalid rows" to proceed with only the valid rows, or go back and fix your CSV.')}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Show notice when skip is enabled so users see how many rows are being dropped */}
+            {invalidCount > 0 && importOptions.skipInvalidRows && (
+              <Alert variant="warning" className="mt-4">
+                <AlertDescription>
+                  <strong>{importT('rowsToBeSkippedCount', '{{count}} row(s) will be skipped', { count: invalidCount })}</strong>{' '}
+                  {importT('rowsToBeSkippedHelp', 'because they failed validation. Use the filter above to review them.')}
                 </AlertDescription>
               </Alert>
             )}
@@ -1157,17 +1452,33 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
             <div className="space-y-4 max-h-96 overflow-y-auto">
               {unmatchedStatusInfo.map((statusInfo) => {
                 const resolution = statusResolutions.find(
-                  r => r.originalStatusName === statusInfo.statusName
+                  r => r.originalStatusName === statusInfo.statusName && r.phaseName === statusInfo.phaseName
                 );
+
+                // Determine the status options available for this phase.
+                // If the phase exists and has phase-specific mappings, show those; otherwise show project-wide mappings.
+                const phaseMatch = availablePhases.find(
+                  (p) => p.phase_name.toLowerCase().trim() === statusInfo.phaseName.toLowerCase().trim()
+                );
+                const phaseSpecific = phaseMatch
+                  ? projectStatusMappings.filter((m) => m.phase_id === phaseMatch.phase_id)
+                  : [];
+                const projectWideMappings = projectStatusMappings.filter((m) => !m.phase_id);
+                const mapOptions = phaseSpecific.length > 0 ? phaseSpecific : projectWideMappings;
+                const radioName = `status-${statusInfo.phaseName}-${statusInfo.statusName}`;
+                const cardKey = `${statusInfo.phaseName}::${statusInfo.statusName}`;
 
                 return (
                   <div
-                    key={statusInfo.statusName}
+                    key={cardKey}
                     className="border rounded-lg p-4 bg-gray-50"
                   >
                     <div className="flex items-start justify-between mb-3">
                       <div>
                         <span className="font-medium text-gray-900">&quot;{statusInfo.statusName}&quot;</span>
+                        <Badge variant="default-muted" size="sm" className="ml-2">
+                          {importT('inPhaseBadge', 'in {{phase}}', { phase: statusInfo.phaseName })}
+                        </Badge>
                         <span className="ml-2 text-sm text-gray-500">
                           {importT('taskCountLabel', '({{count}} task{{plural}})', {
                             count: statusInfo.taskCount,
@@ -1185,9 +1496,9 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                       <label className="flex items-center gap-2 cursor-pointer">
                         <input
                           type="radio"
-                          name={`status-${statusInfo.statusName}`}
+                          name={radioName}
                           checked={resolution?.action === 'create'}
-                          onChange={() => handleStatusResolutionChange(statusInfo.statusName, 'create')}
+                          onChange={() => handleStatusResolutionChange(statusInfo.phaseName, statusInfo.statusName, 'create')}
                           className="text-primary-500"
                         />
                         <span className="text-sm">
@@ -1198,9 +1509,9 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                       <label className="flex items-center gap-2 cursor-pointer">
                         <input
                           type="radio"
-                          name={`status-${statusInfo.statusName}`}
+                          name={radioName}
                           checked={resolution?.action === 'use_default'}
-                          onChange={() => handleStatusResolutionChange(statusInfo.statusName, 'use_default')}
+                          onChange={() => handleStatusResolutionChange(statusInfo.phaseName, statusInfo.statusName, 'use_default')}
                           className="text-primary-500"
                         />
                         <span className="text-sm">
@@ -1212,24 +1523,24 @@ const PhaseTaskImportDialog: React.FC<PhaseTaskImportDialogProps> = ({
                         <label className="flex items-center gap-2 cursor-pointer">
                           <input
                             type="radio"
-                            name={`status-${statusInfo.statusName}`}
+                            name={radioName}
                             checked={resolution?.action === 'map_to_existing'}
                             onChange={() => {
-                              const firstStatus = projectStatusMappings[0]?.project_status_mapping_id;
-                              handleStatusResolutionChange(statusInfo.statusName, 'map_to_existing', firstStatus);
+                              const firstStatus = mapOptions[0]?.project_status_mapping_id;
+                              handleStatusResolutionChange(statusInfo.phaseName, statusInfo.statusName, 'map_to_existing', firstStatus);
                             }}
                             className="text-primary-500"
                           />
                           <span className="text-sm">{importT('mapToExistingStatus', 'Map to existing:')}</span>
                         </label>
                         <CustomSelect
-                          options={projectStatusMappings.map(mapping => ({
+                          options={mapOptions.map(mapping => ({
                             value: mapping.project_status_mapping_id,
                             label: mapping.custom_name || mapping.status_name || mapping.name || 'Unnamed',
                           }))}
                           value={resolution?.mappedStatusId || ''}
                           onValueChange={(value) =>
-                            handleStatusResolutionChange(statusInfo.statusName, 'map_to_existing', value)
+                            handleStatusResolutionChange(statusInfo.phaseName, statusInfo.statusName, 'map_to_existing', value)
                           }
                           disabled={resolution?.action !== 'map_to_existing'}
                           className="w-48"

--- a/packages/types/src/interfaces/phaseTaskImport.interfaces.ts
+++ b/packages/types/src/interfaces/phaseTaskImport.interfaces.ts
@@ -79,6 +79,8 @@ export interface ITaskImportRow {
   task_type?: string;
   status?: string;
   tags?: string;
+  /** Source row number in the CSV (header is row 1, first data row is row 2). Not from CSV. */
+  csvRowNumber?: number;
 }
 
 /**
@@ -122,6 +124,8 @@ export interface IGroupedTaskData {
   /** Resolved status mapping ID (null if unmatched) */
   status_mapping_id: string | null;
   tags: string[];
+  /** Source CSV row number for error reporting */
+  csvRowNumber?: number;
 }
 
 /**
@@ -149,8 +153,8 @@ export interface IPhaseTaskValidationResponse {
   statusLookup: Record<string, string>;
   /** phase name -> (status name -> project_status_mapping_id) */
   statusLookupByPhase?: Record<string, Record<string, string>>;
-  /** List of status names that don't match */
-  unmatchedStatuses: string[];
+  /** Phase-scoped pairs of (phase, status) that don't match */
+  unmatchedStatuses: Array<{ phaseName: string; statusName: string }>;
   /** List of agent names that don't match */
   unmatchedAgents: string[];
 }
@@ -165,6 +169,7 @@ export interface IImportReferenceData {
   users: IImportUser[];
   priorities: Array<{ priority_id: string; priority_name: string }>;
   services: Array<{ service_id: string; service_name: string }>;
+  phases: Array<{ phase_id: string; phase_name: string }>;
   statusMappings: Array<{
     project_status_mapping_id: string;
     phase_id?: string;
@@ -182,10 +187,13 @@ export interface IImportReferenceData {
 }
 
 /**
- * Information about an unmatched status and affected tasks
+ * Information about an unmatched status and affected tasks.
+ * Scoped per (phase, status) so phase-specific status sets can be honored when resolving.
  */
 export interface IUnmatchedStatusInfo {
   statusName: string;
+  /** Phase the affected tasks belong to (or DEFAULT_PHASE_NAME for unphased tasks) */
+  phaseName: string;
   taskCount: number;
   /** First few task names for display */
   taskNames: string[];
@@ -198,6 +206,8 @@ export type StatusResolutionAction = 'create' | 'use_default' | 'map_to_existing
 
 export interface IStatusResolution {
   originalStatusName: string;
+  /** Phase whose tasks this resolution applies to */
+  phaseName: string;
   action: StatusResolutionAction;
   /** If action is 'map_to_existing', the target status ID */
   mappedStatusId?: string;

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Zeile",
       "phase": "Phase",
       "task": "Aufgabe",
-      "issues": "Probleme"
+      "issues": "Probleme",
+      "valid": "Gültig"
     },
     "fields": {
       "task_name": "Aufgabenname *",
@@ -602,7 +603,24 @@
       "task_type": "Aufgabentyp",
       "status": "Status",
       "tags": "Tags"
-    }
+    },
+    "fallbackPhaseLabel": "Standardphase für Aufgaben ohne phase_name",
+    "fallbackPhaseHelp": "{{count}} Zeile(n) ohne Phase. Wählen Sie eine vorhandene Phase oder behalten Sie die Vorgabe, um eine neue zu erstellen.",
+    "fallbackPhaseCreateDefault": "Neue Phase erstellen: „{{name}}\"",
+    "fallbackStatusLabel": "Standardstatus für Aufgaben ohne Status",
+    "fallbackStatusHelp": "{{count}} Zeile(n) ohne Status. Der ausgewählte Status wird diesen Aufgaben zugewiesen.",
+    "rowResultsTitle": "Zeilenergebnisse",
+    "rowFilterLabel": "Anzeigen:",
+    "rowFilterAll": "Alle Zeilen ({{count}})",
+    "rowFilterImported": "Werden importiert ({{count}})",
+    "rowFilterSkipped": "Werden übersprungen ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} Zeile(n) werden übersprungen",
+    "rowsToBeSkippedHelp": "weil sie die Validierung nicht bestanden haben. Verwenden Sie den Filter oben, um sie zu überprüfen.",
+    "statusUnmatchedSuffix": "Nicht zugeordnet",
+    "statusUnmatchedTooltip": "Der Status entspricht keinem vorhandenen Status für diese Phase. Bitte vor dem Import in den Zuordnungsschritten lösen.",
+    "statusFallbackSuffix": "Standard",
+    "statusFallbackTooltip": "Verwendung des Standard-Ersatzstatus für diese Phase.",
+    "inPhaseBadge": "in {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Row",
       "phase": "Phase",
       "task": "Task",
-      "issues": "Issues"
+      "issues": "Issues",
+      "valid": "Valid"
     },
     "fields": {
       "task_name": "Task Name *",
@@ -602,7 +603,24 @@
       "task_type": "Task Type",
       "status": "Status",
       "tags": "Tags"
-    }
+    },
+    "fallbackPhaseLabel": "Default phase for tasks without phase_name",
+    "fallbackPhaseHelp": "{{count}} row(s) have no phase. Pick an existing phase or keep the default to create one.",
+    "fallbackPhaseCreateDefault": "Create new phase: \"{{name}}\"",
+    "fallbackStatusLabel": "Default status for tasks without status",
+    "fallbackStatusHelp": "{{count}} row(s) have no status. The selected status will be assigned to those tasks.",
+    "rowResultsTitle": "Row Results",
+    "rowFilterLabel": "Show:",
+    "rowFilterAll": "All rows ({{count}})",
+    "rowFilterImported": "Will be imported ({{count}})",
+    "rowFilterSkipped": "Will be skipped ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} row(s) will be skipped",
+    "rowsToBeSkippedHelp": "because they failed validation. Use the filter above to review them.",
+    "statusUnmatchedSuffix": "Unmatched",
+    "statusUnmatchedTooltip": "Status does not match any existing status for this phase. Resolve in the mapping steps before import.",
+    "statusFallbackSuffix": "Default",
+    "statusFallbackTooltip": "Using the default fallback status for this phase.",
+    "inPhaseBadge": "in {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Fila",
       "phase": "Fase",
       "task": "Tarea",
-      "issues": "Incidencias"
+      "issues": "Incidencias",
+      "valid": "Válido"
     },
     "fields": {
       "task_name": "Nombre de la tarea *",
@@ -602,7 +603,24 @@
       "task_type": "Tipo de tarea",
       "status": "Estado",
       "tags": "Etiquetas"
-    }
+    },
+    "fallbackPhaseLabel": "Fase predeterminada para tareas sin phase_name",
+    "fallbackPhaseHelp": "{{count}} fila(s) no tienen fase. Elija una fase existente o mantenga el valor predeterminado para crear una.",
+    "fallbackPhaseCreateDefault": "Crear nueva fase: \"{{name}}\"",
+    "fallbackStatusLabel": "Estado predeterminado para tareas sin estado",
+    "fallbackStatusHelp": "{{count}} fila(s) no tienen estado. El estado seleccionado se asignará a esas tareas.",
+    "rowResultsTitle": "Resultados de filas",
+    "rowFilterLabel": "Mostrar:",
+    "rowFilterAll": "Todas las filas ({{count}})",
+    "rowFilterImported": "Se importarán ({{count}})",
+    "rowFilterSkipped": "Se omitirán ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} fila(s) se omitirán",
+    "rowsToBeSkippedHelp": "porque no superaron la validación. Use el filtro de arriba para revisarlas.",
+    "statusUnmatchedSuffix": "Sin coincidencia",
+    "statusUnmatchedTooltip": "El estado no coincide con ningún estado existente para esta fase. Resuélvalo en los pasos de mapeo antes de importar.",
+    "statusFallbackSuffix": "Predeterminado",
+    "statusFallbackTooltip": "Usando el estado predeterminado de respaldo para esta fase.",
+    "inPhaseBadge": "en {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Ligne",
       "phase": "Phase",
       "task": "Tâche",
-      "issues": "Problèmes"
+      "issues": "Problèmes",
+      "valid": "Valide"
     },
     "fields": {
       "task_name": "Nom de la tâche *",
@@ -602,7 +603,24 @@
       "task_type": "Type de tâche",
       "status": "Statut",
       "tags": "Étiquettes"
-    }
+    },
+    "fallbackPhaseLabel": "Phase par défaut pour les tâches sans phase_name",
+    "fallbackPhaseHelp": "{{count}} ligne(s) sans phase. Choisissez une phase existante ou conservez la valeur par défaut pour en créer une.",
+    "fallbackPhaseCreateDefault": "Créer une nouvelle phase : « {{name}} »",
+    "fallbackStatusLabel": "Statut par défaut pour les tâches sans statut",
+    "fallbackStatusHelp": "{{count}} ligne(s) sans statut. Le statut sélectionné sera attribué à ces tâches.",
+    "rowResultsTitle": "Résultats par ligne",
+    "rowFilterLabel": "Afficher :",
+    "rowFilterAll": "Toutes les lignes ({{count}})",
+    "rowFilterImported": "Seront importées ({{count}})",
+    "rowFilterSkipped": "Seront ignorées ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} ligne(s) seront ignorées",
+    "rowsToBeSkippedHelp": "car elles n'ont pas passé la validation. Utilisez le filtre ci-dessus pour les examiner.",
+    "statusUnmatchedSuffix": "Non apparié",
+    "statusUnmatchedTooltip": "Le statut ne correspond à aucun statut existant pour cette phase. À résoudre dans les étapes de mappage avant l'import.",
+    "statusFallbackSuffix": "Par défaut",
+    "statusFallbackTooltip": "Utilisation du statut de repli par défaut pour cette phase.",
+    "inPhaseBadge": "dans {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Riga",
       "phase": "Fase",
       "task": "Attività",
-      "issues": "Problemi"
+      "issues": "Problemi",
+      "valid": "Valido"
     },
     "fields": {
       "task_name": "Nome attività *",
@@ -602,7 +603,24 @@
       "task_type": "Tipo attività",
       "status": "Stato",
       "tags": "Tag"
-    }
+    },
+    "fallbackPhaseLabel": "Fase predefinita per attività senza phase_name",
+    "fallbackPhaseHelp": "{{count}} riga/righe senza fase. Scegli una fase esistente o mantieni il valore predefinito per crearne una.",
+    "fallbackPhaseCreateDefault": "Crea nuova fase: \"{{name}}\"",
+    "fallbackStatusLabel": "Stato predefinito per attività senza stato",
+    "fallbackStatusHelp": "{{count}} riga/righe senza stato. Lo stato selezionato verrà assegnato a tali attività.",
+    "rowResultsTitle": "Risultati delle righe",
+    "rowFilterLabel": "Mostra:",
+    "rowFilterAll": "Tutte le righe ({{count}})",
+    "rowFilterImported": "Saranno importate ({{count}})",
+    "rowFilterSkipped": "Saranno ignorate ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} riga/righe saranno ignorate",
+    "rowsToBeSkippedHelp": "perché non hanno superato la convalida. Usa il filtro sopra per esaminarle.",
+    "statusUnmatchedSuffix": "Non corrispondente",
+    "statusUnmatchedTooltip": "Lo stato non corrisponde a nessuno stato esistente per questa fase. Risolvi nei passaggi di mappatura prima dell'importazione.",
+    "statusFallbackSuffix": "Predefinito",
+    "statusFallbackTooltip": "Utilizzo dello stato di ripiego predefinito per questa fase.",
+    "inPhaseBadge": "in {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Rij",
       "phase": "Fase",
       "task": "Taak",
-      "issues": "Problemen"
+      "issues": "Problemen",
+      "valid": "Geldig"
     },
     "fields": {
       "task_name": "Taaknaam *",
@@ -602,7 +603,24 @@
       "task_type": "Taaktype",
       "status": "Status",
       "tags": "Labels"
-    }
+    },
+    "fallbackPhaseLabel": "Standaardfase voor taken zonder phase_name",
+    "fallbackPhaseHelp": "{{count}} rij(en) zonder fase. Kies een bestaande fase of behoud de standaard om er een te maken.",
+    "fallbackPhaseCreateDefault": "Nieuwe fase maken: \"{{name}}\"",
+    "fallbackStatusLabel": "Standaardstatus voor taken zonder status",
+    "fallbackStatusHelp": "{{count}} rij(en) zonder status. De geselecteerde status wordt aan die taken toegewezen.",
+    "rowResultsTitle": "Rijresultaten",
+    "rowFilterLabel": "Tonen:",
+    "rowFilterAll": "Alle rijen ({{count}})",
+    "rowFilterImported": "Worden geïmporteerd ({{count}})",
+    "rowFilterSkipped": "Worden overgeslagen ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} rij(en) worden overgeslagen",
+    "rowsToBeSkippedHelp": "omdat ze de validatie niet hebben doorstaan. Gebruik het filter hierboven om ze te bekijken.",
+    "statusUnmatchedSuffix": "Geen overeenkomst",
+    "statusUnmatchedTooltip": "Status komt niet overeen met een bestaande status voor deze fase. Los op in de mappingstappen voor de import.",
+    "statusFallbackSuffix": "Standaard",
+    "statusFallbackTooltip": "De standaard fallback-status voor deze fase wordt gebruikt.",
+    "inPhaseBadge": "in {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Wiersz",
       "phase": "Faza",
       "task": "Zadanie",
-      "issues": "Problemy"
+      "issues": "Problemy",
+      "valid": "Prawidłowe"
     },
     "fields": {
       "task_name": "Nazwa zadania *",
@@ -602,7 +603,24 @@
       "task_type": "Typ zadania",
       "status": "Status",
       "tags": "Tagi"
-    }
+    },
+    "fallbackPhaseLabel": "Domyślna faza dla zadań bez phase_name",
+    "fallbackPhaseHelp": "{{count}} wiersz(y) bez fazy. Wybierz istniejącą fazę lub pozostaw wartość domyślną, aby utworzyć nową.",
+    "fallbackPhaseCreateDefault": "Utwórz nową fazę: „{{name}}\"",
+    "fallbackStatusLabel": "Domyślny status dla zadań bez statusu",
+    "fallbackStatusHelp": "{{count}} wiersz(y) bez statusu. Wybrany status zostanie przypisany do tych zadań.",
+    "rowResultsTitle": "Wyniki wierszy",
+    "rowFilterLabel": "Pokaż:",
+    "rowFilterAll": "Wszystkie wiersze ({{count}})",
+    "rowFilterImported": "Zostaną zaimportowane ({{count}})",
+    "rowFilterSkipped": "Zostaną pominięte ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} wiersz(y) zostanie pominiętych",
+    "rowsToBeSkippedHelp": "ponieważ nie przeszły walidacji. Użyj filtra powyżej, aby je przejrzeć.",
+    "statusUnmatchedSuffix": "Brak dopasowania",
+    "statusUnmatchedTooltip": "Status nie pasuje do żadnego istniejącego statusu dla tej fazy. Rozwiąż to w krokach mapowania przed importem.",
+    "statusFallbackSuffix": "Domyślny",
+    "statusFallbackTooltip": "Używany jest domyślny status zastępczy dla tej fazy.",
+    "inPhaseBadge": "w {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -587,7 +587,8 @@
       "row": "Row",
       "phase": "Phase",
       "task": "Task",
-      "issues": "Issues"
+      "issues": "Issues",
+      "valid": "Válido"
     },
     "fields": {
       "task_name": "Task Name *",
@@ -602,7 +603,24 @@
       "task_type": "Task Type",
       "status": "Status",
       "tags": "Tags"
-    }
+    },
+    "fallbackPhaseLabel": "Fase padrão para tarefas sem phase_name",
+    "fallbackPhaseHelp": "{{count}} linha(s) sem fase. Escolha uma fase existente ou mantenha o padrão para criar uma.",
+    "fallbackPhaseCreateDefault": "Criar nova fase: \"{{name}}\"",
+    "fallbackStatusLabel": "Status padrão para tarefas sem status",
+    "fallbackStatusHelp": "{{count}} linha(s) sem status. O status selecionado será atribuído a essas tarefas.",
+    "rowResultsTitle": "Resultados das linhas",
+    "rowFilterLabel": "Mostrar:",
+    "rowFilterAll": "Todas as linhas ({{count}})",
+    "rowFilterImported": "Serão importadas ({{count}})",
+    "rowFilterSkipped": "Serão ignoradas ({{count}})",
+    "rowsToBeSkippedCount": "{{count}} linha(s) serão ignoradas",
+    "rowsToBeSkippedHelp": "porque falharam na validação. Use o filtro acima para revisá-las.",
+    "statusUnmatchedSuffix": "Sem correspondência",
+    "statusUnmatchedTooltip": "O status não corresponde a nenhum status existente para esta fase. Resolva nas etapas de mapeamento antes de importar.",
+    "statusFallbackSuffix": "Padrão",
+    "statusFallbackTooltip": "Usando o status padrão de fallback para esta fase.",
+    "inPhaseBadge": "em {{phase}}"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -587,7 +587,8 @@
       "row": "11111",
       "phase": "11111",
       "task": "11111",
-      "issues": "11111"
+      "issues": "11111",
+      "valid": "11111"
     },
     "fields": {
       "task_name": "11111",
@@ -602,7 +603,24 @@
       "task_type": "11111",
       "status": "11111",
       "tags": "11111"
-    }
+    },
+    "fallbackPhaseLabel": "11111",
+    "fallbackPhaseHelp": "11111",
+    "fallbackPhaseCreateDefault": "11111",
+    "fallbackStatusLabel": "11111",
+    "fallbackStatusHelp": "11111",
+    "rowResultsTitle": "11111",
+    "rowFilterLabel": "11111",
+    "rowFilterAll": "11111",
+    "rowFilterImported": "11111",
+    "rowFilterSkipped": "11111",
+    "rowsToBeSkippedCount": "11111",
+    "rowsToBeSkippedHelp": "11111",
+    "statusUnmatchedSuffix": "11111",
+    "statusUnmatchedTooltip": "11111",
+    "statusFallbackSuffix": "11111",
+    "statusFallbackTooltip": "11111",
+    "inPhaseBadge": "11111"
   },
   "dialogs": {
     "moveTask": {

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -587,7 +587,8 @@
       "row": "55555",
       "phase": "55555",
       "task": "55555",
-      "issues": "55555"
+      "issues": "55555",
+      "valid": "55555"
     },
     "fields": {
       "task_name": "55555",
@@ -602,7 +603,24 @@
       "task_type": "55555",
       "status": "55555",
       "tags": "55555"
-    }
+    },
+    "fallbackPhaseLabel": "55555",
+    "fallbackPhaseHelp": "55555",
+    "fallbackPhaseCreateDefault": "55555",
+    "fallbackStatusLabel": "55555",
+    "fallbackStatusHelp": "55555",
+    "rowResultsTitle": "55555",
+    "rowFilterLabel": "55555",
+    "rowFilterAll": "55555",
+    "rowFilterImported": "55555",
+    "rowFilterSkipped": "55555",
+    "rowsToBeSkippedCount": "55555",
+    "rowsToBeSkippedHelp": "55555",
+    "statusUnmatchedSuffix": "55555",
+    "statusUnmatchedTooltip": "55555",
+    "statusFallbackSuffix": "55555",
+    "statusFallbackTooltip": "55555",
+    "inPhaseBadge": "55555"
   },
   "dialogs": {
     "moveTask": {


### PR DESCRIPTION
## Summary

Closes several gaps in the project CSV phase/task import flow that surfaced while reviewing the import wizard.

### Fallback pickers (preview step)
- **Default phase for tasks without phase_name** — picker lists every existing phase on the project plus a "Create new 'Unsorted Tasks' phase" option. Only appears when at least one valid row has no phase_name. Changing the selection re-groups the preview live.
- **Default status for tasks without status** — picker filters to statuses scoped to the chosen default phase (phase-specific mappings if the phase has any, otherwise project-wide). Replaces the previous silent "first status" default.
- `groupRowsIntoPhases` accepts a new `defaultPhaseName` parameter; `importPhasesAndTasks` accepts a new `defaultStatusMappingId` parameter.

### Phase-scoped status resolution
- `IUnmatchedStatusInfo` and `IStatusResolution` now carry `phaseName`. The validation response returns `Array<{phaseName, statusName}>` instead of a flat string array, so the same status name appearing under two phases produces two resolution entries.
- Resolution step renders one card per (phase, status) pair, labels the affected phase with a branded `Badge`, and filters the "Map to existing" dropdown to that phase's available statuses.
- `importPhasesAndTasks` applies resolutions through a `phase → status → mappingId` map, so a task in Phase A gets Phase A's resolution and a task in Phase B gets Phase B's even when the CSV status string is identical.

### Row Results preview improvements
- New **Status** column showing the resolved status per row using phase-aware lookup. Three states: matched (plain), unmatched (warning `Badge` with tooltip directing users to the mapping steps), fallback (default `Badge` indicating the user-selected default will be applied).
- Existing valid/invalid icon column renamed to **Valid** so the two columns aren't both labeled "Status".
- New **row filter** dropdown: All / Will be imported / Will be skipped, with live counts.
- New warning alert when "Skip invalid rows" is enabled showing how many rows will be dropped.
- Indicators use the existing `Badge` component variants (`warning`, `default-muted`) wired to brand color tokens — no hardcoded Tailwind palette values.

### Error reporting
- `ITaskImportRow` and `IGroupedTaskData` carry an optional `csvRowNumber` so the origin row survives the validate → group → import pipeline.
- Task and phase creation errors now include the originating CSV row number(s).

### Reference data
- `getImportReferenceData` returns the project's existing phases (used to populate the fallback phase picker without an extra fetch). `IImportReferenceData` gains a `phases` field.

## Test plan

- [ ] Import a CSV where some rows omit `phase_name`. Confirm the preview shows the **Default phase** picker, listing existing phases plus "Create new 'Unsorted Tasks'", and that switching it re-groups the preview live.
- [ ] Import a CSV where some rows omit `status`. Confirm the **Default status** picker is scoped to the chosen default phase's statuses and that the chosen status is applied to those tasks on import.
- [ ] Import a CSV where the same status string (e.g. "Test") appears in two different phases that have different status mappings. Confirm two cards appear in the resolution step, each filtered to its phase's mappings, and that the resolutions are applied per-phase on import.
- [ ] Confirm the **Status** column in Row Results shows matched/unmatched/default states correctly with branded badges.
- [ ] Toggle "Skip invalid rows" with invalid rows present — confirm the warning alert reports the count and the "Will be skipped" filter shows them.
- [ ] Trigger a task creation error (e.g., constraint violation) and confirm the resulting error message includes the CSV row number.