### PR TITLE
Fix workflow run log panel overflow

### DIFF
--- a/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
@@ -805,7 +805,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
   const stepColumnCount = 9;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 min-w-0 max-w-full">
       <Card className="p-4 space-y-3">
         <div className="flex items-start justify-between gap-4">
           <div>
@@ -1360,7 +1360,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
             })}
           </div>
 
-          <div>
+          <div className="min-w-0 max-w-full">
             <div className="text-sm font-medium text-gray-700">
               {t('runDetails.logs.title', { defaultValue: 'Run Logs' })}
             </div>
@@ -1407,8 +1407,8 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 </Button>
               </div>
             </div>
-            <div className="mt-4">
-              <Table>
+            <div className="mt-4 max-w-full overflow-x-auto">
+              <Table className="min-w-[960px]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t('runDetails.logs.columns.timestamp', { defaultValue: 'Timestamp' })}</TableHead>
@@ -1422,23 +1422,23 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 <TableBody>
                   {logs.map((log) => (
                     <TableRow key={log.log_id}>
-                      <TableCell className="text-xs text-gray-500">{formatDateTime(log.created_at)}</TableCell>
-                      <TableCell>
+                      <TableCell className="whitespace-nowrap text-xs text-gray-500">{formatDateTime(log.created_at)}</TableCell>
+                      <TableCell className="whitespace-nowrap">
                         <Badge className={STATUS_STYLES[log.level] ?? 'bg-gray-100 text-gray-600'}>
                           {formatWorkflowLogLevel(log.level)}
                         </Badge>
                       </TableCell>
-                      <TableCell>
-                        <div className="text-sm text-gray-800">{log.message}</div>
+                      <TableCell className="max-w-[28rem] min-w-[18rem]">
+                        <div className="text-sm text-gray-800 break-words">{log.message}</div>
                         {log.context_json && (
-                          <pre className="mt-1 max-h-24 overflow-auto rounded bg-gray-900 text-gray-100 text-xs p-2">
+                          <pre className="mt-1 max-h-24 max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-gray-900 text-gray-100 text-xs p-2">
                             {truncateJsonPreview(log.context_json, 2000).preview}
                           </pre>
                         )}
                       </TableCell>
-                      <TableCell className="text-xs text-gray-500">{log.step_path ?? emptyValueLabel}</TableCell>
-                      <TableCell className="text-xs text-gray-500">{log.event_name ?? emptyValueLabel}</TableCell>
-                      <TableCell className="text-xs text-gray-500">{log.correlation_key ?? emptyValueLabel}</TableCell>
+                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.step_path ?? emptyValueLabel}</TableCell>
+                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.event_name ?? emptyValueLabel}</TableCell>
+                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.correlation_key ?? emptyValueLabel}</TableCell>
                     </TableRow>
                   ))}
                   {!logLoading && logs.length === 0 && (

--- a/ee/server/src/components/workflow-run-studio/RunStudioShell.tsx
+++ b/ee/server/src/components/workflow-run-studio/RunStudioShell.tsx
@@ -931,8 +931,8 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
 	        </div>
 	      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0">
-        <Card className="lg:col-span-2 p-4 flex flex-col min-h-[420px]">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
+        <Card className="lg:col-span-2 p-4 flex flex-col min-h-[420px] min-w-0 overflow-hidden">
           {run?.status === 'FAILED' && (
             <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
               <div className="font-semibold">
@@ -1013,7 +1013,7 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
             </div>
           )}
         </Card>
-        <Card className="p-4 flex flex-col min-h-[420px]">
+        <Card className="p-4 flex flex-col min-h-[420px] min-w-0 overflow-x-hidden overflow-y-auto">
           <div className="text-sm font-semibold text-gray-800 mb-2">
             {t('runStudio.details.title', { defaultValue: 'Run Details' })}
           </div>
@@ -1022,7 +1022,7 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
               <div className="text-[11px] uppercase text-gray-400">
                 {t('runStudio.details.fields.runId', { defaultValue: 'Run Id' })}
               </div>
-              <div className="font-mono text-gray-700">{runId}</div>
+              <div className="font-mono text-gray-700 break-all">{runId}</div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
@@ -1041,7 +1041,7 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
                 <div className="text-[11px] uppercase text-gray-400">
                   {t('runStudio.details.fields.tenant', { defaultValue: 'Tenant' })}
                 </div>
-                <div className="font-mono">{run?.tenant_id ?? '-'}</div>
+                <div className="font-mono break-all">{run?.tenant_id ?? '-'}</div>
               </div>
               <div>
                 <div className="text-[11px] uppercase text-gray-400">
@@ -1054,7 +1054,7 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
                   <div className="text-[11px] uppercase text-gray-400">
                     {t('runStudio.details.fields.eventType', { defaultValue: 'Event Type' })}
                   </div>
-                  <div className="font-mono">{run.event_type}</div>
+                  <div className="font-mono break-all">{run.event_type}</div>
                 </div>
               )}
               {isTimeTriggeredRun(run?.trigger_type) && (
@@ -1080,7 +1080,7 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
                   <div className="text-[11px] uppercase text-gray-400">
                     {t('runStudio.details.fields.cron', { defaultValue: 'Cron' })}
                   </div>
-                  <div className="font-mono">{String(triggerMetadata.cron)}</div>
+                  <div className="font-mono break-all">{String(triggerMetadata.cron)}</div>
                 </div>
               )}
               {run?.status === 'WAITING' && (
@@ -1309,23 +1309,23 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
 	              )}
             </div>
           </div>
-          <div className="flex-1 overflow-auto rounded border border-gray-200 bg-white">
+          <div className="flex-1 min-w-0 overflow-auto rounded border border-gray-200 bg-white">
             {filteredLogs.length === 0 && (
               <div className="p-4 text-sm text-gray-500">
                 {t('runStudio.logs.empty', { defaultValue: 'No logs yet.' })}
               </div>
             )}
             {filteredLogs.map((log) => (
-              <div key={log.log_id} className="border-b border-gray-100 px-3 py-2 text-xs text-gray-700">
-                <div className="flex items-center justify-between">
-                  <span className="font-mono text-gray-500">{formatTimeOnly(log.created_at)}</span>
-                  <span className={`text-[10px] uppercase tracking-wide border px-2 py-0.5 rounded ${logLevelStyles[(log.level || '').toUpperCase()] ?? 'text-gray-400 border-gray-200'}`}>
+              <div key={log.log_id} className="min-w-0 border-b border-gray-100 px-3 py-2 text-xs text-gray-700">
+                <div className="flex min-w-0 items-center justify-between gap-2">
+                  <span className="shrink-0 font-mono text-gray-500">{formatTimeOnly(log.created_at)}</span>
+                  <span className={`shrink-0 text-[10px] uppercase tracking-wide border px-2 py-0.5 rounded ${logLevelStyles[(log.level || '').toUpperCase()] ?? 'text-gray-400 border-gray-200'}`}>
                     {log.level}
                   </span>
                 </div>
-                <div className="mt-1">{log.message}</div>
+                <div className="mt-1 break-words">{log.message}</div>
                 {log.step_path && (
-                  <div className="mt-1 font-mono text-[10px] text-gray-400">{log.step_path}</div>
+                  <div className="mt-1 break-all font-mono text-[10px] text-gray-400">{log.step_path}</div>
                 )}
               </div>
             ))}
@@ -1447,7 +1447,7 @@ const RunJsonPanel: React.FC<{ title: string; value: unknown }> = ({ title, valu
       <div className="border-b border-gray-100 px-3 py-2 text-[11px] uppercase text-gray-500">{title}</div>
       {summary && <div className="px-3 pt-2 text-[11px] text-gray-600">{summary}</div>}
       {extracted?.message && <div className="px-3 text-[11px] text-gray-600">{extracted.message}</div>}
-      <pre className="max-h-60 overflow-auto p-3 text-[11px] text-gray-700 whitespace-pre-wrap">{content}</pre>
+      <pre className="max-h-60 max-w-full overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-gray-700">{content}</pre>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- constrain workflow run detail containers so long log content cannot expand past the panel
- add bounded horizontal scrolling and wrapping for inline run log tables
- prevent Run Studio side-panel log/detail values from overflowing horizontally

## Testing
- npm -w server run typecheck