### PR TITLE
Retry temporal activity writes on read-only DB

### DIFF
--- a/ee/temporal-workflows/src/activities/customer-tracking-activities.ts
+++ b/ee/temporal-workflows/src/activities/customer-tracking-activities.ts
@@ -5,7 +5,7 @@
  */
 
 import { Context } from '@temporalio/activity';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, withAdminTransactionRetryReadOnly } from '@alga-psa/db/admin.js';
 import { ClientModel } from '@alga-psa/shared/models/clientModel.js';
 import { ContactModel } from '@alga-psa/shared/models/contactModel.js';
 import { TagModel } from '@alga-psa/shared/models/tagModel.js';
@@ -233,7 +233,7 @@ export async function deleteCustomerClientActivity(input: {
       clientId: input.clientId
     });
     
-    await adminKnex.transaction(async (trx: Knex.Transaction<any, any[]>) => {
+    await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction<any, any[]>) => {
       // Delete client (contacts and tags will cascade)
       await trx('clients')
         .where({
@@ -272,7 +272,7 @@ export async function deleteCustomerContactActivity(input: {
       contactId: input.contactId
     });
     
-    await adminKnex.transaction(async (trx: Knex.Transaction<any, any[]>) => {
+    await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction<any, any[]>) => {
       await trx('contacts')
         .where({
           contact_name_id: input.contactId,

--- a/ee/temporal-workflows/src/activities/entra-discovery-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-discovery-activities.ts
@@ -1,5 +1,6 @@
 import logger from '@alga-psa/core/logger';
 import { createTenantKnex, runWithTenant } from '@alga-psa/db/tenant';
+import { retryOnTenantReadOnly } from '@alga-psa/db';
 import { getEntraProviderAdapter } from '@ee/lib/integrations/entra/providers';
 import type { EntraConnectionType } from '@ee/interfaces/entra.interfaces';
 import type {
@@ -38,35 +39,40 @@ export async function discoverManagedTenantsActivity(
     return { discoveredTenantCount: 0 };
   }
 
-  await runWithTenant(input.tenantId, async () => {
-    const { knex } = await createTenantKnex();
-    const now = knex.fn.now();
+  // Retry once on read-only errors (PgBouncer/Patroni post-failover stale pool).
+  await retryOnTenantReadOnly(
+    () =>
+      runWithTenant(input.tenantId, async () => {
+        const { knex } = await createTenantKnex();
+        const now = knex.fn.now();
 
-    await knex('entra_managed_tenants')
-      .insert(
-        discovered.map((item) => ({
-          tenant: input.tenantId,
-          entra_tenant_id: item.entraTenantId,
-          display_name: item.displayName,
-          primary_domain: item.primaryDomain,
-          source_user_count: item.sourceUserCount,
-          discovered_at: now,
-          last_seen_at: now,
-          metadata: item.raw || {},
-          created_at: now,
-          updated_at: now,
-        }))
-      )
-      .onConflict(['tenant', 'entra_tenant_id'])
-      .merge({
-        display_name: knex.raw('EXCLUDED.display_name'),
-        primary_domain: knex.raw('EXCLUDED.primary_domain'),
-        source_user_count: knex.raw('EXCLUDED.source_user_count'),
-        metadata: knex.raw('EXCLUDED.metadata'),
-        last_seen_at: now,
-        updated_at: now,
-      });
-  });
+        await knex('entra_managed_tenants')
+          .insert(
+            discovered.map((item) => ({
+              tenant: input.tenantId,
+              entra_tenant_id: item.entraTenantId,
+              display_name: item.displayName,
+              primary_domain: item.primaryDomain,
+              source_user_count: item.sourceUserCount,
+              discovered_at: now,
+              last_seen_at: now,
+              metadata: item.raw || {},
+              created_at: now,
+              updated_at: now,
+            }))
+          )
+          .onConflict(['tenant', 'entra_tenant_id'])
+          .merge({
+            display_name: knex.raw('EXCLUDED.display_name'),
+            primary_domain: knex.raw('EXCLUDED.primary_domain'),
+            source_user_count: knex.raw('EXCLUDED.source_user_count'),
+            metadata: knex.raw('EXCLUDED.metadata'),
+            last_seen_at: now,
+            updated_at: now,
+          });
+      }),
+    { logLabel: 'discoverManagedTenantsActivity' }
+  );
 
   logger.info('Completed discoverManagedTenantsActivity', {
     tenantId: input.tenantId,

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -1,6 +1,7 @@
 import logger from '@alga-psa/core/logger';
 import { randomUUID } from 'crypto';
 import { createTenantKnex, runWithTenant } from '@alga-psa/db/tenant';
+import { retryOnTenantReadOnly } from '@alga-psa/db';
 import { getEntraProviderAdapter } from '@ee/lib/integrations/entra/providers';
 import { executeEntraSync } from '@ee/lib/integrations/entra/sync/syncEngine';
 import { filterEntraUsersForTenant } from '@ee/lib/integrations/entra/settingsService';
@@ -165,52 +166,56 @@ export async function upsertSyncRunActivity(
     initiatedBy: input.initiatedBy,
   });
 
-  return runWithTenant(input.tenantId, async () => {
-    const { knex } = await createTenantKnex();
-    const now = knex.fn.now();
+  return retryOnTenantReadOnly(
+    () =>
+      runWithTenant(input.tenantId, async () => {
+        const { knex } = await createTenantKnex();
+        const now = knex.fn.now();
 
-    const existing = await knex('entra_sync_runs')
-      .where({
-        tenant: input.tenantId,
-        workflow_id: input.workflowId,
-      })
-      .first(['run_id']);
+        const existing = await knex('entra_sync_runs')
+          .where({
+            tenant: input.tenantId,
+            workflow_id: input.workflowId,
+          })
+          .first(['run_id']);
 
-    if (existing?.run_id) {
-      await knex('entra_sync_runs')
-        .where({
+        if (existing?.run_id) {
+          await knex('entra_sync_runs')
+            .where({
+              tenant: input.tenantId,
+              run_id: existing.run_id,
+            })
+            .update({
+              status: 'running',
+              initiated_by: input.initiatedBy || null,
+              updated_at: now,
+            });
+          return { runId: String(existing.run_id) };
+        }
+
+        const runId = randomUUID();
+        await knex('entra_sync_runs').insert({
           tenant: input.tenantId,
-          run_id: existing.run_id,
-        })
-        .update({
+          run_id: runId,
+          workflow_id: input.workflowId,
+          run_type: input.runType,
           status: 'running',
           initiated_by: input.initiatedBy || null,
+          started_at: now,
+          completed_at: null,
+          total_tenants: 0,
+          processed_tenants: 0,
+          succeeded_tenants: 0,
+          failed_tenants: 0,
+          summary: knex.raw(`'{}'::jsonb`),
+          created_at: now,
           updated_at: now,
         });
-      return { runId: String(existing.run_id) };
-    }
 
-    const runId = randomUUID();
-    await knex('entra_sync_runs').insert({
-      tenant: input.tenantId,
-      run_id: runId,
-      workflow_id: input.workflowId,
-      run_type: input.runType,
-      status: 'running',
-      initiated_by: input.initiatedBy || null,
-      started_at: now,
-      completed_at: null,
-      total_tenants: 0,
-      processed_tenants: 0,
-      succeeded_tenants: 0,
-      failed_tenants: 0,
-      summary: knex.raw(`'{}'::jsonb`),
-      created_at: now,
-      updated_at: now,
-    });
-
-    return { runId };
-  });
+        return { runId };
+      }),
+    { logLabel: 'upsertSyncRunActivity' }
+  );
 }
 
 export async function finalizeSyncRunActivity(
@@ -223,26 +228,30 @@ export async function finalizeSyncRunActivity(
     summary: input.summary,
   });
 
-  await runWithTenant(input.tenantId, async () => {
-    const { knex } = await createTenantKnex();
-    const now = knex.fn.now();
+  await retryOnTenantReadOnly(
+    () =>
+      runWithTenant(input.tenantId, async () => {
+        const { knex } = await createTenantKnex();
+        const now = knex.fn.now();
 
-    await knex('entra_sync_runs')
-      .where({
-        tenant: input.tenantId,
-        run_id: input.runId,
-      })
-      .update({
-        status: input.status,
-        completed_at: now,
-        total_tenants: input.summary.totalTenants,
-        processed_tenants: input.summary.processedTenants,
-        succeeded_tenants: input.summary.succeededTenants,
-        failed_tenants: input.summary.failedTenants,
-        summary: knex.raw('?::jsonb', [JSON.stringify(input.summary)]),
-        updated_at: now,
-      });
-  });
+        await knex('entra_sync_runs')
+          .where({
+            tenant: input.tenantId,
+            run_id: input.runId,
+          })
+          .update({
+            status: input.status,
+            completed_at: now,
+            total_tenants: input.summary.totalTenants,
+            processed_tenants: input.summary.processedTenants,
+            succeeded_tenants: input.summary.succeededTenants,
+            failed_tenants: input.summary.failedTenants,
+            summary: knex.raw('?::jsonb', [JSON.stringify(input.summary)]),
+            updated_at: now,
+          });
+      }),
+    { logLabel: 'finalizeSyncRunActivity' }
+  );
 }
 
 export async function recordSyncTenantResultActivity(
@@ -255,49 +264,53 @@ export async function recordSyncTenantResultActivity(
     status: input.result.status,
   });
 
-  await runWithTenant(input.tenantId, async () => {
-    const { knex } = await createTenantKnex();
-    const now = knex.fn.now();
+  await retryOnTenantReadOnly(
+    () =>
+      runWithTenant(input.tenantId, async () => {
+        const { knex } = await createTenantKnex();
+        const now = knex.fn.now();
 
-    const existing = await knex('entra_sync_run_tenants')
-      .where({
-        tenant: input.tenantId,
-        run_id: input.runId,
-        managed_tenant_id: input.result.managedTenantId,
-      })
-      .first(['run_tenant_id']);
+        const existing = await knex('entra_sync_run_tenants')
+          .where({
+            tenant: input.tenantId,
+            run_id: input.runId,
+            managed_tenant_id: input.result.managedTenantId,
+          })
+          .first(['run_tenant_id']);
 
-    const row = {
-      tenant: input.tenantId,
-      run_id: input.runId,
-      managed_tenant_id: input.result.managedTenantId,
-      client_id: input.result.clientId || null,
-      status: input.result.status,
-      created_count: input.result.created,
-      linked_count: input.result.linked,
-      updated_count: input.result.updated,
-      ambiguous_count: input.result.ambiguous,
-      inactivated_count: input.result.inactivated,
-      error_message: input.result.errorMessage || null,
-      started_at: now,
-      completed_at: now,
-      updated_at: now,
-    };
-
-    if (existing?.run_tenant_id) {
-      await knex('entra_sync_run_tenants')
-        .where({
+        const row = {
           tenant: input.tenantId,
-          run_tenant_id: existing.run_tenant_id,
-        })
-        .update(row);
-      return;
-    }
+          run_id: input.runId,
+          managed_tenant_id: input.result.managedTenantId,
+          client_id: input.result.clientId || null,
+          status: input.result.status,
+          created_count: input.result.created,
+          linked_count: input.result.linked,
+          updated_count: input.result.updated,
+          ambiguous_count: input.result.ambiguous,
+          inactivated_count: input.result.inactivated,
+          error_message: input.result.errorMessage || null,
+          started_at: now,
+          completed_at: now,
+          updated_at: now,
+        };
 
-    await knex('entra_sync_run_tenants').insert({
-      ...row,
-      run_tenant_id: randomUUID(),
-      created_at: now,
-    });
-  });
+        if (existing?.run_tenant_id) {
+          await knex('entra_sync_run_tenants')
+            .where({
+              tenant: input.tenantId,
+              run_tenant_id: existing.run_tenant_id,
+            })
+            .update(row);
+          return;
+        }
+
+        await knex('entra_sync_run_tenants').insert({
+          ...row,
+          run_tenant_id: randomUUID(),
+          created_at: now,
+        });
+      }),
+    { logLabel: 'recordSyncTenantResultActivity' }
+  );
 }

--- a/ee/temporal-workflows/src/activities/extension-domain-activities.ts
+++ b/ee/temporal-workflows/src/activities/extension-domain-activities.ts
@@ -1,4 +1,4 @@
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, retryOnAdminReadOnly } from '@alga-psa/db/admin.js';
 import { computeDomain as sharedComputeDomain } from '@alga-psa/shared/extensions/domain.js';
 import type { Knex } from 'knex';
 import { KubeConfig, CustomObjectsApi } from '@kubernetes/client-node';
@@ -73,10 +73,15 @@ export async function ensureDomainMapping(input: EnsureDomainMappingInput): Prom
         if (newDomain.length <= 63) {
           // Attempt DB update so EE server reflects new domain
           try {
-            const knex: Knex = await getAdminConnection();
-            await knex('tenant_extension_install')
-              .where({ runner_domain: domainName })
-              .update({ runner_domain: newDomain, updated_at: knex.fn.now() });
+            await retryOnAdminReadOnly(
+              async () => {
+                const knex: Knex = await getAdminConnection();
+                await knex('tenant_extension_install')
+                  .where({ runner_domain: domainName })
+                  .update({ runner_domain: newDomain, updated_at: knex.fn.now() });
+              },
+              { logLabel: 'extension-domain:updateRunnerDomain' }
+            );
           } catch {
             // best-effort; continue even if DB update fails
           }
@@ -271,9 +276,6 @@ export async function ensureDomainMapping(input: EnsureDomainMappingInput): Prom
 }
 
 export async function updateInstallStatus(input: UpdateInstallStatusInput): Promise<{ updated: boolean }> {
-  const knex: Knex = await getAdminConnection();
-  const now = knex.fn.now();
-
   if (!input.installId && !input.runnerDomain) {
     throw new Error('installId or runnerDomain required');
   }
@@ -290,23 +292,31 @@ export async function updateInstallStatus(input: UpdateInstallStatusInput): Prom
     runnerDomainToSet = ref.name;
   }
 
-  const update: any = {
-    runner_status: JSON.stringify(patch.runner_status),
-    runner_ref: input.runnerRef ? JSON.stringify(input.runnerRef) : null,
-    updated_at: now,
-  };
-  if (runnerDomainToSet) {
-    update.runner_domain = runnerDomainToSet;
-  }
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex: Knex = await getAdminConnection();
+      const now = knex.fn.now();
 
-  let q = knex('tenant_extension_install').update(update);
+      const update: any = {
+        runner_status: JSON.stringify(patch.runner_status),
+        runner_ref: input.runnerRef ? JSON.stringify(input.runnerRef) : null,
+        updated_at: now,
+      };
+      if (runnerDomainToSet) {
+        update.runner_domain = runnerDomainToSet;
+      }
 
-  if (input.installId) {
-    q = q.where({ id: input.installId });
-  } else if (input.runnerDomain) {
-    q = q.where({ runner_domain: input.runnerDomain });
-  }
+      let q = knex('tenant_extension_install').update(update);
 
-  const count = await q;
-  return { updated: (Array.isArray(count) ? count.length : Number(count)) > 0 };
+      if (input.installId) {
+        q = q.where({ id: input.installId });
+      } else if (input.runnerDomain) {
+        q = q.where({ runner_domain: input.runnerDomain });
+      }
+
+      const count = await q;
+      return { updated: (Array.isArray(count) ? count.length : Number(count)) > 0 };
+    },
+    { logLabel: 'updateInstallStatus' }
+  );
 }

--- a/ee/temporal-workflows/src/activities/job-activities.ts
+++ b/ee/temporal-workflows/src/activities/job-activities.ts
@@ -1,5 +1,5 @@
 import { createLogger, format, transports } from 'winston';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, withAdminTransactionRetryReadOnly } from '@alga-psa/db/admin.js';
 import type { Knex } from 'knex';
 import type { JobStatus } from '../types/job.js';
 
@@ -30,8 +30,7 @@ async function runWithTenant<T>(
   tenantId: string,
   callback: (trx: Knex.Transaction) => Promise<T>
 ): Promise<T> {
-  const knex = await getAdminConnection();
-  return knex.transaction(async (trx) => {
+  return withAdminTransactionRetryReadOnly(async (trx) => {
     await trx.raw(`SET LOCAL app.current_tenant = '${tenantId}'`);
     return callback(trx);
   });

--- a/ee/temporal-workflows/src/activities/license-management-activities.ts
+++ b/ee/temporal-workflows/src/activities/license-management-activities.ts
@@ -4,7 +4,7 @@
  */
 
 import { Context } from '@temporalio/activity';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, withAdminTransactionRetryReadOnly } from '@alga-psa/db/admin.js';
 import type { Knex } from 'knex';
 
 const logger = () => Context.current().log;
@@ -30,47 +30,45 @@ export async function updateTenantLicenseCount(
   });
 
   try {
-    const knex = await getAdminConnection();
-    
-    await knex.transaction(async (trx: Knex.Transaction) => {
+    await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction) => {
       // Check for idempotency if event ID is provided
       if (input.eventId) {
         const existing = await trx('tenants')
-          .where({ 
+          .where({
             tenant: input.tenantId,
-            stripe_event_id: input.eventId 
+            stripe_event_id: input.eventId
           })
           .first();
-        
+
         if (existing) {
-          log.info('Event already processed, skipping update', { 
+          log.info('Event already processed, skipping update', {
             tenantId: input.tenantId,
-            eventId: input.eventId 
+            eventId: input.eventId
           });
           return;
         }
       }
-      
+
       // Update the tenant's license count
       const result = await trx('tenants')
         .where({ tenant: input.tenantId })
         .update({
           licensed_user_count: input.licenseCount,
-          last_license_update: knex.fn.now(),
+          last_license_update: trx.fn.now(),
           stripe_event_id: input.eventId || null,
-          updated_at: knex.fn.now()
+          updated_at: trx.fn.now()
         });
-      
+
       if (result === 0) {
         throw new Error(`Tenant not found: ${input.tenantId}`);
       }
-      
-      log.info('Tenant license count updated successfully', { 
+
+      log.info('Tenant license count updated successfully', {
         tenantId: input.tenantId,
-        licenseCount: input.licenseCount 
+        licenseCount: input.licenseCount
       });
     });
-    
+
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     log.error('Failed to update tenant license count', { 

--- a/ee/temporal-workflows/src/activities/ninjaone-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/ninjaone-sync-activities.ts
@@ -4,8 +4,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { heartbeat } from '@temporalio/activity';
 
 import logger from '@alga-psa/core/logger';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
-import { withTransaction } from '@alga-psa/db';
+import {
+  getAdminConnection,
+  refreshAdminConnection,
+  withAdminTransactionRetryReadOnly,
+  retryOnAdminReadOnly,
+} from '@alga-psa/db/admin.js';
+import { withTransaction, isReadOnlyError } from '@alga-psa/db';
 import { getRedisStreamClient } from '@alga-psa/workflow-streams';
 
 import { createNinjaOneClient, NinjaOneClient } from '@ee/lib/integrations/ninjaone/ninjaOneClient';
@@ -78,6 +83,33 @@ class NinjaOneSyncWorker {
     }
     if (!this.auditUserId) {
       this.auditUserId = await this.getDefaultAuditUserId();
+    }
+  }
+
+  /**
+   * Run a non-transaction write against the cached admin pool with one
+   * automatic retry on read-only errors. PgBouncer/Patroni post-failover
+   * stale-pool issue — see @alga-psa/db/readOnlyRetry for details. After
+   * a refresh, this.knex is re-acquired so subsequent operations see the
+   * new pool.
+   */
+  private async runWriteWithRetry<T>(
+    label: string,
+    op: (knex: Knex) => Promise<T>
+  ): Promise<T> {
+    if (!this.knex) {
+      this.knex = await getAdminConnection();
+    }
+    try {
+      return await op(this.knex);
+    } catch (err) {
+      if (!isReadOnlyError(err)) throw err;
+      logger.warn(
+        `[NinjaOneSyncWorker.${label}] admin pool returned a read-only connection; refreshing and retrying once`,
+        { tenantId: this.tenantId, error: err instanceof Error ? err.message : String(err) }
+      );
+      this.knex = await refreshAdminConnection();
+      return await op(this.knex);
     }
   }
 
@@ -536,7 +568,7 @@ class NinjaOneSyncWorker {
     const createRequest = mappingResult.createRequest;
     const baseAssetData = mappingResult.baseFields!;
 
-    return await withTransaction(this.knex!, async (trx: Knex.Transaction) => {
+    return await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction) => {
       const now = new Date().toISOString();
 
       const [asset] = await trx('assets')
@@ -634,7 +666,7 @@ class NinjaOneSyncWorker {
         break;
     }
 
-    return await withTransaction(this.knex!, async (trx: Knex.Transaction) => {
+    return await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction) => {
       const now = new Date().toISOString();
 
       // Get current asset to check if client_id needs updating
@@ -747,14 +779,16 @@ class NinjaOneSyncWorker {
   private async updateAssetLastSeen(assetId: string, device: NinjaOneDeviceDetail): Promise<void> {
     const now = new Date().toISOString();
 
-    await this.knex!('assets')
-      .where({ tenant: this.tenantId, asset_id: assetId })
-      .update({
-        agent_status: device.offline ? 'offline' : 'online',
-        last_seen_at: unixTimestampToIso(device.lastContact),
-        last_rmm_sync_at: now,
-        updated_at: now,
-      });
+    await this.runWriteWithRetry('updateAssetLastSeen', (knex) =>
+      knex('assets')
+        .where({ tenant: this.tenantId, asset_id: assetId })
+        .update({
+          agent_status: device.offline ? 'offline' : 'online',
+          last_seen_at: unixTimestampToIso(device.lastContact),
+          last_rmm_sync_at: now,
+          updated_at: now,
+        })
+    );
   }
 
   private async handleDeletedDevices(mappings: RmmOrganizationMapping[]): Promise<number> {
@@ -790,7 +824,7 @@ class NinjaOneSyncWorker {
   private async markAssetAsDeleted(assetId: string): Promise<void> {
     const now = new Date().toISOString();
 
-    await withTransaction(this.knex!, async (trx: Knex.Transaction) => {
+    await withAdminTransactionRetryReadOnly(async (trx: Knex.Transaction) => {
       await trx('assets')
         .where({ tenant: this.tenantId, asset_id: assetId })
         .update({
@@ -902,9 +936,11 @@ class NinjaOneSyncWorker {
   }
 
   private async updateOrganizationMappingLastSynced(mappingId: string): Promise<void> {
-    await this.knex!('rmm_organization_mappings')
-      .where({ tenant: this.tenantId, mapping_id: mappingId })
-      .update({ last_synced_at: new Date().toISOString() });
+    await this.runWriteWithRetry('updateOrganizationMappingLastSynced', (knex) =>
+      knex('rmm_organization_mappings')
+        .where({ tenant: this.tenantId, mapping_id: mappingId })
+        .update({ last_synced_at: new Date().toISOString() })
+    );
   }
 
   private async updateSyncStatus(status: RmmSyncStatus, errorMessage?: string): Promise<void> {
@@ -919,9 +955,11 @@ class NinjaOneSyncWorker {
       updateData.sync_error = undefined;
     }
 
-    await this.knex!('rmm_integrations')
-      .where({ tenant: this.tenantId, integration_id: this.integrationId })
-      .update(updateData);
+    await this.runWriteWithRetry('updateSyncStatus', (knex) =>
+      knex('rmm_integrations')
+        .where({ tenant: this.tenantId, integration_id: this.integrationId })
+        .update(updateData)
+    );
   }
 
   private async updateIntegrationAfterSync(
@@ -946,9 +984,11 @@ class NinjaOneSyncWorker {
       updateData.sync_error = undefined;
     }
 
-    await this.knex!('rmm_integrations')
-      .where({ tenant: this.tenantId, integration_id: this.integrationId })
-      .update(updateData);
+    await this.runWriteWithRetry('updateIntegrationAfterSync', (knex) =>
+      knex('rmm_integrations')
+        .where({ tenant: this.tenantId, integration_id: this.integrationId })
+        .update(updateData)
+    );
   }
 
   private async emitSyncStartedEvent(syncType: 'full' | 'incremental'): Promise<void> {
@@ -1098,7 +1138,24 @@ export async function syncNinjaOneOrganizationsActivity(input: {
 
   try {
     const { tenantId, integrationId } = input;
-    const knex = await getAdminConnection();
+    let knex = await getAdminConnection();
+
+    // Wrap each write so a stale read-only connection from PgBouncer/Patroni
+    // post-failover is recovered transparently. Re-binds the outer `knex`
+    // var on refresh so subsequent operations use the new pool.
+    const writeWithRetry = async <T>(label: string, op: () => Promise<T>): Promise<T> => {
+      try {
+        return await op();
+      } catch (err) {
+        if (!isReadOnlyError(err)) throw err;
+        logger.warn(
+          `[syncNinjaOneOrganizationsActivity:${label}] admin pool returned a read-only connection; refreshing and retrying once`,
+          { tenantId, error: err instanceof Error ? err.message : String(err) }
+        );
+        knex = await refreshAdminConnection();
+        return await op();
+      }
+    };
 
     const integration = await knex('rmm_integrations')
       .where({ tenant: tenantId, integration_id: integrationId, provider: 'ninjaone' })
@@ -1108,12 +1165,14 @@ export async function syncNinjaOneOrganizationsActivity(input: {
       throw new Error('NinjaOne integration not configured');
     }
 
-    await knex('rmm_integrations')
-      .where({ tenant: tenantId, integration_id: integrationId })
-      .update({
-        sync_status: 'syncing',
-        updated_at: knex.fn.now(),
-      });
+    await writeWithRetry('markSyncing', () =>
+      knex('rmm_integrations')
+        .where({ tenant: tenantId, integration_id: integrationId })
+        .update({
+          sync_status: 'syncing',
+          updated_at: knex.fn.now(),
+        })
+    );
 
     const client = await createNinjaOneClient(tenantId);
     const organizations: NinjaOneOrganization[] = await client.getOrganizations();
@@ -1131,24 +1190,28 @@ export async function syncNinjaOneOrganizationsActivity(input: {
           .first();
 
         if (existingMapping) {
-          await knex('rmm_organization_mappings')
-            .where({ tenant: tenantId, mapping_id: existingMapping.mapping_id })
-            .update({
-              external_organization_name: org.name,
-              metadata: JSON.stringify({ description: org.description, tags: org.tags }),
-              updated_at: knex.fn.now(),
-            });
+          await writeWithRetry('updateOrgMapping', () =>
+            knex('rmm_organization_mappings')
+              .where({ tenant: tenantId, mapping_id: existingMapping.mapping_id })
+              .update({
+                external_organization_name: org.name,
+                metadata: JSON.stringify({ description: org.description, tags: org.tags }),
+                updated_at: knex.fn.now(),
+              })
+          );
           itemsUpdated++;
         } else {
-          await knex('rmm_organization_mappings').insert({
-            tenant: tenantId,
-            integration_id: integration.integration_id,
-            external_organization_id: String(org.id),
-            external_organization_name: org.name,
-            auto_sync_assets: true,
-            auto_create_tickets: false,
-            metadata: JSON.stringify({ description: org.description, tags: org.tags }),
-          });
+          await writeWithRetry('insertOrgMapping', () =>
+            knex('rmm_organization_mappings').insert({
+              tenant: tenantId,
+              integration_id: integration.integration_id,
+              external_organization_id: String(org.id),
+              external_organization_name: org.name,
+              auto_sync_assets: true,
+              auto_create_tickets: false,
+              metadata: JSON.stringify({ description: org.description, tags: org.tags }),
+            })
+          );
           itemsCreated++;
         }
       } catch (orgError) {
@@ -1158,14 +1221,16 @@ export async function syncNinjaOneOrganizationsActivity(input: {
       }
     }
 
-    await knex('rmm_integrations')
-      .where({ tenant: tenantId, integration_id: integrationId })
-      .update({
-        sync_status: 'completed',
-        last_sync_at: knex.fn.now(),
-        sync_error: errors.length > 0 ? errors.join('; ') : null,
-        updated_at: knex.fn.now(),
-      });
+    await writeWithRetry('markCompleted', () =>
+      knex('rmm_integrations')
+        .where({ tenant: tenantId, integration_id: integrationId })
+        .update({
+          sync_status: 'completed',
+          last_sync_at: knex.fn.now(),
+          sync_error: errors.length > 0 ? errors.join('; ') : null,
+          updated_at: knex.fn.now(),
+        })
+    );
 
     return {
       success: errors.length === 0,
@@ -1184,14 +1249,19 @@ export async function syncNinjaOneOrganizationsActivity(input: {
     logger.error('[NinjaOneActions] Error syncing organizations (Temporal worker):', extractErrorInfo(error));
 
     try {
-      const knex = await getAdminConnection();
-      await knex('rmm_integrations')
-        .where({ tenant: input.tenantId, integration_id: input.integrationId })
-        .update({
-          sync_status: 'error',
-          sync_error: errorMessage,
-          updated_at: knex.fn.now(),
-        });
+      await retryOnAdminReadOnly(
+        async () => {
+          const knex = await getAdminConnection();
+          await knex('rmm_integrations')
+            .where({ tenant: input.tenantId, integration_id: input.integrationId })
+            .update({
+              sync_status: 'error',
+              sync_error: errorMessage,
+              updated_at: knex.fn.now(),
+            });
+        },
+        { logLabel: 'syncNinjaOneOrganizationsActivity:errorPath' }
+      );
     } catch {
       // Ignore update errors
     }

--- a/ee/temporal-workflows/src/activities/portal-domain-activities.ts
+++ b/ee/temporal-workflows/src/activities/portal-domain-activities.ts
@@ -9,7 +9,7 @@ import type { Knex } from "knex";
 import { dump as dumpYaml } from "js-yaml";
 import os from "os";
 
-import { getAdminConnection } from "@alga-psa/db/admin.js";
+import { getAdminConnection, retryOnAdminReadOnly } from "@alga-psa/db/admin.js";
 
 import type {
   PortalDomainActivityRecord,
@@ -230,31 +230,41 @@ export async function loadPortalDomain(args: {
 export async function markPortalDomainStatus(
   args: MarkStatusInput,
 ): Promise<void> {
-  const knex = await getConnection();
-  const updates: Record<string, unknown> = {
-    status: args.status,
-    updated_at: knex.fn.now(),
-    last_checked_at: knex.fn.now(),
-  };
+  await retryOnAdminReadOnly(
+    async () => {
+      const knex = await getConnection();
+      const updates: Record<string, unknown> = {
+        status: args.status,
+        updated_at: knex.fn.now(),
+        last_checked_at: knex.fn.now(),
+      };
 
-  if (args.statusMessage !== undefined) {
-    updates.status_message = args.statusMessage;
-  }
+      if (args.statusMessage !== undefined) {
+        updates.status_message = args.statusMessage;
+      }
 
-  if (args.verificationDetails !== undefined) {
-    updates.verification_details = args.verificationDetails;
-  }
+      if (args.verificationDetails !== undefined) {
+        updates.verification_details = args.verificationDetails;
+      }
 
-  await knex(TABLE_NAME).where({ id: args.portalDomainId }).update(updates);
+      await knex(TABLE_NAME).where({ id: args.portalDomainId }).update(updates);
+    },
+    { logLabel: 'markPortalDomainStatus' }
+  );
 }
 
 export async function deletePortalDomainRecord(
   args: { portalDomainId: string; tenantId: string },
 ): Promise<void> {
-  const knex = await getConnection();
-  await knex(TABLE_NAME)
-    .where({ id: args.portalDomainId, tenant: args.tenantId })
-    .delete();
+  await retryOnAdminReadOnly(
+    async () => {
+      const knex = await getConnection();
+      await knex(TABLE_NAME)
+        .where({ id: args.portalDomainId, tenant: args.tenantId })
+        .delete();
+    },
+    { logLabel: 'deletePortalDomainRecord' }
+  );
 }
 
 export async function verifyCnameRecord(
@@ -528,12 +538,18 @@ export async function applyPortalDomainResources(args: { tenantId: string; porta
 
   for (const manifest of manifests) {
     try {
-      await knex(TABLE_NAME).where({ id: manifest.record.id }).update({
-        certificate_secret_name: manifest.secretName,
-        last_synced_resource_version: null,
-        updated_at: knex.fn.now(),
-        last_checked_at: knex.fn.now(),
-      });
+      await retryOnAdminReadOnly(
+        async () => {
+          const k = await getConnection();
+          await k(TABLE_NAME).where({ id: manifest.record.id }).update({
+            certificate_secret_name: manifest.secretName,
+            last_synced_resource_version: null,
+            updated_at: k.fn.now(),
+            last_checked_at: k.fn.now(),
+          });
+        },
+        { logLabel: 'portal-domain:syncSecret' }
+      );
     } catch (error) {
       errors.push(
         formatErrorMessage(
@@ -554,12 +570,18 @@ export async function applyPortalDomainResources(args: { tenantId: string; porta
 
   if (cleanupIds.length > 0) {
     try {
-      await knex(TABLE_NAME).whereIn("id", cleanupIds).update({
-        certificate_secret_name: null,
-        last_synced_resource_version: null,
-        updated_at: knex.fn.now(),
-        last_checked_at: knex.fn.now(),
-      });
+      await retryOnAdminReadOnly(
+        async () => {
+          const k = await getConnection();
+          await k(TABLE_NAME).whereIn("id", cleanupIds).update({
+            certificate_secret_name: null,
+            last_synced_resource_version: null,
+            updated_at: k.fn.now(),
+            last_checked_at: k.fn.now(),
+          });
+        },
+        { logLabel: 'portal-domain:cleanupDisabled' }
+      );
     } catch (error) {
       errors.push(
         formatErrorMessage(

--- a/ee/temporal-workflows/src/activities/premium-trial-activities.ts
+++ b/ee/temporal-workflows/src/activities/premium-trial-activities.ts
@@ -7,7 +7,7 @@
  */
 
 import { Context } from '@temporalio/activity';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, retryOnAdminReadOnly } from '@alga-psa/db/admin.js';
 
 const logger = () => Context.current().log;
 
@@ -45,29 +45,36 @@ export async function checkExpiredPremiumTrialsActivity(): Promise<CheckExpiredP
 
     for (const sub of expiredTrials) {
       try {
-        // Revert tenant plan to pro
-        await knex('tenants')
-          .where({ tenant: sub.tenant })
-          .update({ plan: 'pro', updated_at: knex.fn.now() });
+        await retryOnAdminReadOnly(
+          async () => {
+            const k = await getAdminConnection();
 
-        // Clear trial metadata on the subscription
-        const currentSub = await knex('stripe_subscriptions')
-          .where({ stripe_subscription_id: sub.stripe_subscription_id })
-          .select('metadata')
-          .first();
+            // Revert tenant plan to pro
+            await k('tenants')
+              .where({ tenant: sub.tenant })
+              .update({ plan: 'pro', updated_at: k.fn.now() });
 
-        const metadata = currentSub?.metadata || {};
-        const { premium_trial, premium_trial_started, premium_trial_end, ...remainingMetadata } = metadata;
+            // Clear trial metadata on the subscription
+            const currentSub = await k('stripe_subscriptions')
+              .where({ stripe_subscription_id: sub.stripe_subscription_id })
+              .select('metadata')
+              .first();
 
-        await knex('stripe_subscriptions')
-          .where({ stripe_subscription_id: sub.stripe_subscription_id })
-          .update({
-            metadata: {
-              ...remainingMetadata,
-              premium_trial_reverted: new Date().toISOString(),
-            },
-            updated_at: knex.fn.now(),
-          });
+            const metadata = currentSub?.metadata || {};
+            const { premium_trial, premium_trial_started, premium_trial_end, ...remainingMetadata } = metadata;
+
+            await k('stripe_subscriptions')
+              .where({ stripe_subscription_id: sub.stripe_subscription_id })
+              .update({
+                metadata: {
+                  ...remainingMetadata,
+                  premium_trial_reverted: new Date().toISOString(),
+                },
+                updated_at: k.fn.now(),
+              });
+          },
+          { logLabel: 'checkExpiredPremiumTrialsActivity' }
+        );
 
         reverted.push(sub.tenant);
         log.info(`Reverted expired Premium trial for tenant ${sub.tenant}`);

--- a/ee/temporal-workflows/src/activities/resend-welcome-email-activities.ts
+++ b/ee/temporal-workflows/src/activities/resend-welcome-email-activities.ts
@@ -1,5 +1,5 @@
 import { Context } from '@temporalio/activity';
-import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { getAdminConnection, retryOnAdminReadOnly } from '@alga-psa/db/admin.js';
 import { hashPassword } from '@alga-psa/core/encryption';
 import { generateTemporaryPassword as generatePassword } from './email-activities.js';
 import { sendWelcomeEmail as sendEmail } from './email-activities.js';
@@ -72,15 +72,20 @@ export async function updateUserPassword(
   const log = logger();
   log.info('Updating user password', { userId, tenantId });
 
-  const knex = await getAdminConnection();
   const hashedPassword = await hashPassword(password);
 
-  await knex('users')
-    .where({ user_id: userId, tenant: tenantId })
-    .update({
-      hashed_password: hashedPassword,
-      updated_at: knex.fn.now(),
-    });
+  await retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      await knex('users')
+        .where({ user_id: userId, tenant: tenantId })
+        .update({
+          hashed_password: hashedPassword,
+          updated_at: knex.fn.now(),
+        });
+    },
+    { logLabel: 'updateUserPassword' }
+  );
 
   log.info('Password updated successfully', { userId });
 }
@@ -128,22 +133,27 @@ export async function logAuditEvent(input: AuditEventInput): Promise<void> {
     resourceType: input.resourceType
   });
 
-  const knex = await getAdminConnection();
   const MASTER_BILLING_TENANT_ID = process.env.MASTER_BILLING_TENANT_ID!;
 
-  // Log to extension_audit_logs table (unified table for all extension actions)
-  await knex('extension_audit_logs').insert({
-    tenant: MASTER_BILLING_TENANT_ID,  // Extension actions logged under master tenant
-    event_type: `tenant.${input.action.toLowerCase().replace(/_/g, '.')}`,
-    user_id: input.triggeredBy,
-    user_email: input.triggeredByEmail,
-    resource_type: input.resourceType,
-    resource_id: input.resourceId,
-    details: JSON.stringify({
-      ...input.details,
-      targetTenantId: input.tenantId,
-    }),
-  });
+  await retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      // Log to extension_audit_logs table (unified table for all extension actions)
+      await knex('extension_audit_logs').insert({
+        tenant: MASTER_BILLING_TENANT_ID,  // Extension actions logged under master tenant
+        event_type: `tenant.${input.action.toLowerCase().replace(/_/g, '.')}`,
+        user_id: input.triggeredBy,
+        user_email: input.triggeredByEmail,
+        resource_type: input.resourceType,
+        resource_id: input.resourceId,
+        details: JSON.stringify({
+          ...input.details,
+          targetTenantId: input.tenantId,
+        }),
+      });
+    },
+    { logLabel: 'logAuditEvent' }
+  );
 
   log.info('Audit event logged successfully', { action: input.action });
 }

--- a/ee/temporal-workflows/src/activities/sla-activities.ts
+++ b/ee/temporal-workflows/src/activities/sla-activities.ts
@@ -1,6 +1,6 @@
 import { Context } from '@temporalio/activity';
 import { v4 as uuidv4 } from 'uuid';
-import { createTenantKnex, withTransaction } from '@alga-psa/db';
+import { withTenantTransactionRetryReadOnly } from '@alga-psa/db';
 import type { Knex } from 'knex';
 import type {
   IBusinessHoursScheduleWithEntries,
@@ -304,6 +304,5 @@ async function withTenantTransaction(
   tenantId: string,
   fn: (trx: Knex.Transaction) => Promise<void>
 ): Promise<void> {
-  const { knex } = await createTenantKnex(tenantId);
-  await withTransaction(knex, fn);
+  await withTenantTransactionRetryReadOnly(tenantId, fn);
 }

--- a/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
+++ b/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
@@ -1,4 +1,4 @@
-import { getAdminConnection } from '@alga-psa/db/admin';
+import { getAdminConnection, retryOnAdminReadOnly } from '@alga-psa/db/admin';
 import { getFormValidationService } from '@shared/task-inbox';
 import {
   WorkflowRuntimeV2,
@@ -36,10 +36,15 @@ export async function executeWorkflowRuntimeV2Run(input: {
   runId: string;
   executionKey: string;
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  initializeWorkflowRuntimeV2();
-  const runtime = new WorkflowRuntimeV2();
-  await runtime.executeRun(knex, input.runId, `temporal:${input.executionKey}`);
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      initializeWorkflowRuntimeV2();
+      const runtime = new WorkflowRuntimeV2();
+      await runtime.executeRun(knex, input.runId, `temporal:${input.executionKey}`);
+    },
+    { logLabel: 'executeWorkflowRuntimeV2Run' }
+  );
 }
 
 export async function loadWorkflowRuntimeV2PinnedDefinition(input: {
@@ -110,15 +115,20 @@ export async function completeWorkflowRuntimeV2Run(input: {
   runId: string;
   status: 'SUCCEEDED' | 'FAILED' | 'CANCELED';
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  await knex('workflow_runs')
-    .where({ run_id: input.runId })
-    .update({
-      status: input.status,
-      node_path: null,
-      completed_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    });
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      await knex('workflow_runs')
+        .where({ run_id: input.runId })
+        .update({
+          status: input.status,
+          node_path: null,
+          completed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+    },
+    { logLabel: 'completeWorkflowRuntimeV2Run' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2StepStart(input: {
@@ -126,23 +136,28 @@ export async function projectWorkflowRuntimeV2StepStart(input: {
   stepPath: string;
   definitionStepId: string;
 }): Promise<{ stepId: string }> {
-  const knex = await getAdminConnection();
-  const latest = await WorkflowRunStepModelV2.getLatestByRunAndPath(knex, input.runId, input.stepPath);
-  const attempt = (latest?.attempt ?? 0) + 1;
-  const step = await WorkflowRunStepModelV2.create(knex, {
-    run_id: input.runId,
-    step_path: input.stepPath,
-    definition_step_id: input.definitionStepId,
-    status: 'STARTED',
-    attempt,
-  });
-  await WorkflowRunModelV2.update(knex, input.runId, {
-    node_path: input.stepPath,
-    status: 'RUNNING',
-  });
-  return {
-    stepId: step.step_id,
-  };
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const latest = await WorkflowRunStepModelV2.getLatestByRunAndPath(knex, input.runId, input.stepPath);
+      const attempt = (latest?.attempt ?? 0) + 1;
+      const step = await WorkflowRunStepModelV2.create(knex, {
+        run_id: input.runId,
+        step_path: input.stepPath,
+        definition_step_id: input.definitionStepId,
+        status: 'STARTED',
+        attempt,
+      });
+      await WorkflowRunModelV2.update(knex, input.runId, {
+        node_path: input.stepPath,
+        status: 'RUNNING',
+      });
+      return {
+        stepId: step.step_id,
+      };
+    },
+    { logLabel: 'projectWorkflowRuntimeV2StepStart' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2StepCompletion(input: {
@@ -152,33 +167,38 @@ export async function projectWorkflowRuntimeV2StepCompletion(input: {
   status: 'SUCCEEDED' | 'FAILED' | 'CANCELED';
   errorMessage?: string;
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  const now = new Date().toISOString();
-  const step = await knex('workflow_run_steps')
-    .where({ step_id: input.stepId })
-    .first();
-  const startedAt = step?.started_at ? new Date(step.started_at).getTime() : Date.now();
-  const durationMs = Math.max(Date.now() - startedAt, 0);
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const now = new Date().toISOString();
+      const step = await knex('workflow_run_steps')
+        .where({ step_id: input.stepId })
+        .first();
+      const startedAt = step?.started_at ? new Date(step.started_at).getTime() : Date.now();
+      const durationMs = Math.max(Date.now() - startedAt, 0);
 
-  await WorkflowRunStepModelV2.update(knex, input.stepId, {
-    status: input.status,
-    duration_ms: durationMs,
-    completed_at: now,
-    error_json: input.status === 'FAILED' && input.errorMessage
-      ? { message: input.errorMessage }
-      : null,
-  });
+      await WorkflowRunStepModelV2.update(knex, input.stepId, {
+        status: input.status,
+        duration_ms: durationMs,
+        completed_at: now,
+        error_json: input.status === 'FAILED' && input.errorMessage
+          ? { message: input.errorMessage }
+          : null,
+      });
 
-  await WorkflowRunModelV2.update(knex, input.runId, {
-    status: input.status === 'FAILED'
-      ? 'FAILED'
-      : input.status === 'CANCELED'
-        ? 'CANCELED'
-        : 'RUNNING',
-    error_json: input.status === 'FAILED' && input.errorMessage
-      ? { message: input.errorMessage, nodePath: input.stepPath }
-      : null,
-  });
+      await WorkflowRunModelV2.update(knex, input.runId, {
+        status: input.status === 'FAILED'
+          ? 'FAILED'
+          : input.status === 'CANCELED'
+            ? 'CANCELED'
+            : 'RUNNING',
+        error_json: input.status === 'FAILED' && input.errorMessage
+          ? { message: input.errorMessage, nodePath: input.stepPath }
+          : null,
+      });
+    },
+    { logLabel: 'projectWorkflowRuntimeV2StepCompletion' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2TimeWaitStart(input: {
@@ -191,19 +211,24 @@ export async function projectWorkflowRuntimeV2TimeWaitStart(input: {
     dueAt: string;
   };
 }): Promise<{ waitId: string }> {
-  const knex = await getAdminConnection();
-  const wait = await WorkflowRunWaitModelV2.create(knex, {
-    run_id: input.runId,
-    step_path: input.stepPath,
-    wait_type: 'time',
-    timeout_at: input.dueAt,
-    status: 'WAITING',
-    payload: input.payload,
-  });
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const wait = await WorkflowRunWaitModelV2.create(knex, {
+        run_id: input.runId,
+        step_path: input.stepPath,
+        wait_type: 'time',
+        timeout_at: input.dueAt,
+        status: 'WAITING',
+        payload: input.payload,
+      });
 
-  return {
-    waitId: wait.wait_id,
-  };
+      return {
+        waitId: wait.wait_id,
+      };
+    },
+    { logLabel: 'projectWorkflowRuntimeV2TimeWaitStart' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2TimeWaitResolved(input: {
@@ -211,12 +236,17 @@ export async function projectWorkflowRuntimeV2TimeWaitResolved(input: {
   runId: string;
   status: 'RESOLVED' | 'CANCELED';
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  const now = new Date().toISOString();
-  await WorkflowRunWaitModelV2.update(knex, input.waitId, {
-    status: input.status,
-    resolved_at: now,
-  });
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const now = new Date().toISOString();
+      await WorkflowRunWaitModelV2.update(knex, input.waitId, {
+        status: input.status,
+        resolved_at: now,
+      });
+    },
+    { logLabel: 'projectWorkflowRuntimeV2TimeWaitResolved' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2EventWaitStart(input: {
@@ -232,21 +262,26 @@ export async function projectWorkflowRuntimeV2EventWaitStart(input: {
     timeoutAt: string | null;
   };
 }): Promise<{ waitId: string }> {
-  const knex = await getAdminConnection();
-  const wait = await WorkflowRunWaitModelV2.create(knex, {
-    run_id: input.runId,
-    step_path: input.stepPath,
-    wait_type: 'event',
-    event_name: input.eventName,
-    key: input.correlationKey,
-    timeout_at: input.timeoutAt,
-    status: 'WAITING',
-    payload: input.payload,
-  });
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const wait = await WorkflowRunWaitModelV2.create(knex, {
+        run_id: input.runId,
+        step_path: input.stepPath,
+        wait_type: 'event',
+        event_name: input.eventName,
+        key: input.correlationKey,
+        timeout_at: input.timeoutAt,
+        status: 'WAITING',
+        payload: input.payload,
+      });
 
-  return {
-    waitId: wait.wait_id,
-  };
+      return {
+        waitId: wait.wait_id,
+      };
+    },
+    { logLabel: 'projectWorkflowRuntimeV2EventWaitStart' }
+  );
 }
 
 export async function projectWorkflowRuntimeV2EventWaitResolved(input: {
@@ -255,19 +290,24 @@ export async function projectWorkflowRuntimeV2EventWaitResolved(input: {
   status: 'RESOLVED' | 'CANCELED';
   matchedEventId?: string | null;
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  const now = new Date().toISOString();
-  const existing = await knex('workflow_run_waits').where({ wait_id: input.waitId }).first(['payload']);
-  const payload = isRecord(existing?.payload) ? existing.payload : {};
-  await WorkflowRunWaitModelV2.update(knex, input.waitId, {
-    status: input.status,
-    resolved_at: now,
-    payload: {
-      ...payload,
-      matchedEventId: input.matchedEventId ?? null,
-      resolvedAt: now,
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const now = new Date().toISOString();
+      const existing = await knex('workflow_run_waits').where({ wait_id: input.waitId }).first(['payload']);
+      const payload = isRecord(existing?.payload) ? existing.payload : {};
+      await WorkflowRunWaitModelV2.update(knex, input.waitId, {
+        status: input.status,
+        resolved_at: now,
+        payload: {
+          ...payload,
+          matchedEventId: input.matchedEventId ?? null,
+          resolvedAt: now,
+        },
+      });
     },
-  });
+    { logLabel: 'projectWorkflowRuntimeV2EventWaitResolved' }
+  );
 }
 
 export async function startWorkflowRuntimeV2HumanTaskWait(input: {
@@ -283,39 +323,44 @@ export async function startWorkflowRuntimeV2HumanTaskWait(input: {
   taskId: string;
   eventName: string;
 }> {
-  const knex = await getAdminConnection();
-  const taskId = await WorkflowTaskModel.createTask(knex, input.tenantId ?? '', {
-    execution_id: input.runId,
-    task_definition_type: 'system',
-    system_task_definition_task_type: input.taskType,
-    title: input.title,
-    description: input.description ?? '',
-    status: WorkflowTaskStatus.PENDING,
-    priority: 'medium',
-    context_data: input.contextData,
-  } as never);
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const taskId = await WorkflowTaskModel.createTask(knex, input.tenantId ?? '', {
+        execution_id: input.runId,
+        task_definition_type: 'system',
+        system_task_definition_task_type: input.taskType,
+        title: input.title,
+        description: input.description ?? '',
+        status: WorkflowTaskStatus.PENDING,
+        priority: 'medium',
+        context_data: input.contextData,
+      } as never);
 
-  const formSchema = await resolveTaskFormSchema(knex, input.tenantId, input.taskType);
-  const wait = await WorkflowRunWaitModelV2.create(knex, {
-    run_id: input.runId,
-    step_path: input.stepPath,
-    wait_type: 'human',
-    key: taskId,
-    event_name: 'HUMAN_TASK_COMPLETED',
-    status: 'WAITING',
-    payload: {
-      taskId,
-      contextData: input.contextData,
-      formSchema,
-      taskType: input.taskType,
+      const formSchema = await resolveTaskFormSchema(knex, input.tenantId, input.taskType);
+      const wait = await WorkflowRunWaitModelV2.create(knex, {
+        run_id: input.runId,
+        step_path: input.stepPath,
+        wait_type: 'human',
+        key: taskId,
+        event_name: 'HUMAN_TASK_COMPLETED',
+        status: 'WAITING',
+        payload: {
+          taskId,
+          contextData: input.contextData,
+          formSchema,
+          taskType: input.taskType,
+        },
+      });
+
+      return {
+        waitId: wait.wait_id,
+        taskId,
+        eventName: 'HUMAN_TASK_COMPLETED',
+      };
     },
-  });
-
-  return {
-    waitId: wait.wait_id,
-    taskId,
-    eventName: 'HUMAN_TASK_COMPLETED',
-  };
+    { logLabel: 'startWorkflowRuntimeV2HumanTaskWait' }
+  );
 }
 
 export async function resolveWorkflowRuntimeV2HumanTaskWait(input: {
@@ -324,19 +369,24 @@ export async function resolveWorkflowRuntimeV2HumanTaskWait(input: {
   status: 'RESOLVED' | 'CANCELED';
   payload: Record<string, unknown>;
 }): Promise<void> {
-  const knex = await getAdminConnection();
-  const now = new Date().toISOString();
-  const existing = await knex('workflow_run_waits').where({ wait_id: input.waitId }).first(['payload']);
-  const currentPayload = isRecord(existing?.payload) ? existing.payload : {};
-  await WorkflowRunWaitModelV2.update(knex, input.waitId, {
-    status: input.status,
-    resolved_at: now,
-    payload: {
-      ...currentPayload,
-      ...input.payload,
-      resolvedAt: now,
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const now = new Date().toISOString();
+      const existing = await knex('workflow_run_waits').where({ wait_id: input.waitId }).first(['payload']);
+      const currentPayload = isRecord(existing?.payload) ? existing.payload : {};
+      await WorkflowRunWaitModelV2.update(knex, input.waitId, {
+        status: input.status,
+        resolved_at: now,
+        payload: {
+          ...currentPayload,
+          ...input.payload,
+          resolvedAt: now,
+        },
+      });
     },
-  });
+    { logLabel: 'resolveWorkflowRuntimeV2HumanTaskWait' }
+  );
 }
 
 export async function validateWorkflowRuntimeV2HumanTaskResponse(input: {
@@ -386,6 +436,7 @@ export async function executeWorkflowRuntimeV2NodeStep(input: {
   };
   scopes: WorkflowRuntimeV2ScopeState;
 }): Promise<{ scopes: WorkflowRuntimeV2ScopeState }> {
+  return retryOnAdminReadOnly(async () => {
   initializeWorkflowRuntimeV2();
   const knex = await getAdminConnection();
   const nodeRegistry = getNodeTypeRegistry();
@@ -462,6 +513,7 @@ export async function executeWorkflowRuntimeV2NodeStep(input: {
         : null,
     },
   };
+  }, { logLabel: 'executeWorkflowRuntimeV2NodeStep' });
 }
 
 export async function executeWorkflowRuntimeV2ActionStep(input: {
@@ -475,6 +527,7 @@ export async function executeWorkflowRuntimeV2ActionStep(input: {
   };
   scopes: WorkflowRuntimeV2ScopeState;
 }): Promise<{ output: unknown; saveAsPath: string | null }> {
+  return retryOnAdminReadOnly(async () => {
   initializeWorkflowRuntimeV2();
   const knex = await getAdminConnection();
 
@@ -519,6 +572,7 @@ export async function executeWorkflowRuntimeV2ActionStep(input: {
     output,
     saveAsPath: typeof config.saveAs === 'string' ? config.saveAs : null,
   };
+  }, { logLabel: 'executeWorkflowRuntimeV2ActionStep' });
 }
 
 export async function startWorkflowRuntimeV2ChildRun(input: {
@@ -533,8 +587,10 @@ export async function startWorkflowRuntimeV2ChildRun(input: {
   rootRunId: string;
   temporalWorkflowId: string;
 }> {
-  const knex = await getAdminConnection();
-  const parentRun = await WorkflowRunModelV2.getById(knex, input.parentRunId);
+  return retryOnAdminReadOnly(
+    async () => {
+      const knex = await getAdminConnection();
+      const parentRun = await WorkflowRunModelV2.getById(knex, input.parentRunId);
   if (!parentRun) {
     throw new Error(`Parent workflow run not found: ${input.parentRunId}`);
   }
@@ -576,16 +632,19 @@ export async function startWorkflowRuntimeV2ChildRun(input: {
     parentRunId: parentRun.run_id,
     rootRunId,
   });
-  await WorkflowRunModelV2.update(knex, childRunId, {
-    parent_run_id: parentRun.run_id,
-    root_run_id: rootRunId,
-  });
+      await WorkflowRunModelV2.update(knex, childRunId, {
+        parent_run_id: parentRun.run_id,
+        root_run_id: rootRunId,
+      });
 
-  return {
-    childRunId,
-    rootRunId,
-    temporalWorkflowId: `workflow-runtime-v2:run:${childRunId}`,
-  };
+      return {
+        childRunId,
+        rootRunId,
+        temporalWorkflowId: `workflow-runtime-v2:run:${childRunId}`,
+      };
+    },
+    { logLabel: 'startWorkflowRuntimeV2ChildRun' }
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,10 +14,13 @@ export { default as knexConfig } from './lib/knexfile';
 export { default as Knex } from './lib/knex-turbopack';
 
 // Admin Connection
-export { getAdminConnection, destroyAdminConnection, refreshAdminConnection } from './lib/admin';
+export { getAdminConnection, destroyAdminConnection, refreshAdminConnection, withAdminTransactionRetryReadOnly, retryOnAdminReadOnly } from './lib/admin';
 
 // Tenant Connection
-export { getConnection, withTransaction, createTenantKnex, runWithTenant, getTenantContext, setTenantContext, resetTenantConnectionPool } from './lib/tenant';
+export { getConnection, withTransaction, createTenantKnex, runWithTenant, getTenantContext, setTenantContext, resetTenantConnectionPool, destroyTenantConnection, refreshTenantConnection, withTenantTransactionRetryReadOnly, retryOnTenantReadOnly } from './lib/tenant';
+
+// Read-only error helpers (for callers building their own retry strategies)
+export { isReadOnlyError, READ_ONLY_ERROR_RE } from './lib/readOnlyRetry';
 export { resolveTenantId, requireTenantId } from './lib/tenantId';
 
 // Audit logging

--- a/packages/db/src/lib/admin.ts
+++ b/packages/db/src/lib/admin.ts
@@ -9,6 +9,7 @@ import type { Knex } from 'knex';
 import knexfile from './knexfile';
 import logger from '@alga-psa/core/logger';
 import { getSecret } from '@alga-psa/core/secrets';
+import { isReadOnlyError, retryOnReadOnly } from './readOnlyRetry';
 
 let adminConnection: Knex | null = null;
 
@@ -116,4 +117,43 @@ export async function refreshAdminConnection(): Promise<Knex> {
         /* ignore; destroyAdminConnection clears the ref regardless */
     }
     return await getAdminConnection();
+}
+
+/**
+ * Run a callback inside an admin-scoped transaction with one automatic
+ * retry on read-only errors. Mirrors withTenantTransactionRetryReadOnly()
+ * for the admin pool — see ./readOnlyRetry.ts for the rationale.
+ */
+export async function withAdminTransactionRetryReadOnly<T>(
+    callback: (trx: Knex.Transaction) => Promise<T>
+): Promise<T> {
+    try {
+        const conn = await getAdminConnection();
+        return await conn.transaction(callback);
+    } catch (err) {
+        if (!isReadOnlyError(err)) throw err;
+        logger.warn(
+            '[db/admin] admin pool returned a read-only connection (likely post-failover stale pool); refreshing pool and retrying once',
+            { error: err instanceof Error ? err.message : String(err) }
+        );
+        const conn = await refreshAdminConnection();
+        return await conn.transaction(callback);
+    }
+}
+
+/**
+ * Run an operation against the admin pool with one automatic retry on
+ * read-only errors. Mirror of retryOnTenantReadOnly() for the admin
+ * pool — useful for callers that don't fit a single-transaction shape
+ * (e.g. an activity that issues many separate queries with a loop in
+ * the middle).
+ */
+export async function retryOnAdminReadOnly<T>(
+    op: () => Promise<T>,
+    context?: { logLabel?: string }
+): Promise<T> {
+    return retryOnReadOnly(op, refreshAdminConnection, {
+        logLabel: context?.logLabel ?? 'db/admin',
+        logger,
+    });
 }

--- a/packages/db/src/lib/readOnlyRetry.ts
+++ b/packages/db/src/lib/readOnlyRetry.ts
@@ -1,0 +1,51 @@
+/**
+ * Read-only error detection for Citus/Patroni HA setups behind PgBouncer.
+ *
+ * PgBouncer transaction-pooling occasionally hands out a backend connection
+ * that has become read-only (e.g., after a Patroni failover the backend is
+ * now attached to what used to be the leader and is now a standby). The
+ * process-cached pool's own probe can pass on those connections, so the
+ * actual write fails later with one of these errors:
+ *   - "cannot execute UPDATE in a read-only transaction"
+ *   - "writing to worker nodes is not currently allowed" (Citus distributed table)
+ *   - any other "... in a read-only ..." variant
+ *
+ * Callers use isReadOnlyError() to detect the pattern, then refresh their
+ * connection pool and retry once.
+ */
+
+export const READ_ONLY_ERROR_RE =
+  /read-only transaction|writing to worker nodes|cannot execute [A-Z]+ in a read-only/i;
+
+export function isReadOnlyError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return READ_ONLY_ERROR_RE.test(msg);
+}
+
+/**
+ * Run an operation, and if it fails with a read-only error refresh the
+ * tenant pool and retry once. For tenant-pool callers that don't fit the
+ * single-transaction shape of withTenantTransactionRetryReadOnly (e.g.
+ * code that issues multiple separate queries inside runWithTenant).
+ *
+ * The refresh callback is injected so the helper has no static dependency
+ * on the tenant module; @alga-psa/db's index re-exports a wired-up
+ * `retryOnTenantReadOnly` that uses refreshTenantConnection.
+ */
+export async function retryOnReadOnly<T>(
+  op: () => Promise<T>,
+  refresh: () => Promise<unknown>,
+  context?: { logLabel?: string; logger?: { warn: (msg: string, meta?: unknown) => void } }
+): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    if (!isReadOnlyError(err)) throw err;
+    context?.logger?.warn(
+      `[${context.logLabel ?? 'pool'}] connection pool returned a read-only connection; refreshing and retrying once`,
+      { error: err instanceof Error ? err.message : String(err) }
+    );
+    await refresh();
+    return await op();
+  }
+}

--- a/packages/db/src/lib/tenant.ts
+++ b/packages/db/src/lib/tenant.ts
@@ -9,6 +9,7 @@ import type { Knex as KnexType } from './knex-turbopack';
 import { getKnexConfig } from './knexfile';
 import logger from '@alga-psa/core/logger';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { isReadOnlyError, retryOnReadOnly } from './readOnlyRetry';
 
 type PoolConfig = KnexType.PoolConfig & {
   afterCreate?: (connection: any, done: (err: Error | null, connection: any) => void) => void;
@@ -79,6 +80,50 @@ export async function getConnection(tenantId?: string | null): Promise<KnexType>
   return sharedKnexInstance;
 }
 
+/**
+ * Destroy the cached tenant Knex pool. Used by refreshTenantConnection()
+ * to discard a pool that's started handing out read-only backend
+ * connections (e.g. PgBouncer in front of a Patroni HA setup retains
+ * stale backend connections after a coordinator failover).
+ */
+export async function destroyTenantConnection(): Promise<void> {
+  if (sharedKnexInstance) {
+    try {
+      await sharedKnexInstance.destroy();
+    } finally {
+      sharedKnexInstance = null;
+    }
+  }
+}
+
+/**
+ * Force-recreate the tenant pool. Callers should use this after catching a
+ * "read-only transaction" / "writing to worker nodes" / "cannot execute
+ * UPDATE in a read-only" error, so the next call to getConnection() returns
+ * a freshly-reconnected pool. Mirrors refreshAdminConnection() from
+ * @alga-psa/db/admin.
+ */
+export async function refreshTenantConnection(): Promise<KnexType> {
+  await destroyTenantConnection();
+  return await getConnection(null);
+}
+
+/**
+ * Run an operation against the tenant pool with one automatic retry on
+ * read-only errors. For callers that don't fit the single-transaction
+ * shape of withTenantTransactionRetryReadOnly (e.g. code that issues
+ * multiple separate queries inside runWithTenant blocks).
+ */
+export async function retryOnTenantReadOnly<T>(
+  op: () => Promise<T>,
+  context?: { logLabel?: string }
+): Promise<T> {
+  return retryOnReadOnly(op, refreshTenantConnection, {
+    logLabel: context?.logLabel ?? 'db/tenant',
+    logger,
+  });
+}
+
 export async function withTransaction<T>(
   tenantId: string,
   callback: (trx: KnexType.Transaction) => Promise<T>
@@ -117,6 +162,43 @@ export async function withTransaction<T>(
   }
 
   return knex.transaction(callback);
+}
+
+/**
+ * Run a callback inside a tenant-scoped transaction with one automatic
+ * retry on read-only errors.
+ *
+ * If the inner work throws a "read-only" error (see isReadOnlyError),
+ * this drops the cached tenant pool, recreates it, and re-runs the
+ * callback once. The original transaction has already been rolled back
+ * by Knex when its inner query failed, so the retry executes a fresh
+ * transaction against the new pool. Non-read-only errors propagate
+ * unchanged.
+ *
+ * Use this in temporal activities and other tenant-path code that does
+ * DB writes and may sit behind PgBouncer/Patroni HA.
+ */
+export async function withTenantTransactionRetryReadOnly<T>(
+  tenantId: string,
+  callback: (trx: KnexType.Transaction) => Promise<T>
+): Promise<T> {
+  try {
+    const knex = await getConnection(tenantId);
+    return await tenantContext.run(tenantId, () =>
+      knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx)))
+    );
+  } catch (err) {
+    if (!isReadOnlyError(err)) throw err;
+    logger.warn(
+      '[db/tenant] tenant pool returned a read-only connection (likely post-failover stale pool); refreshing pool and retrying once',
+      { error: err instanceof Error ? err.message : String(err) }
+    );
+    await refreshTenantConnection();
+    const knex = await getConnection(tenantId);
+    return await tenantContext.run(tenantId, () =>
+      knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx)))
+    );
+  }
 }
 
 export async function createTenantKnex(


### PR DESCRIPTION
  PgBouncer in front of Patroni HA hands out backend connections that
  become read-only after a coordinator failover. The cached pool's
  SELECT 1 probe (and even a pg_is_in_recovery() check) can pass on a
  backend that's about to reject writes, so activities fail with
  "cannot execute UPDATE in a read-only transaction" or "writing to
  worker nodes is not currently allowed". Until now only
  tenant-deletion-activities.ts had inline retry; SLA self-heal,
  NinjaOne sync, entra sync, workflow-runtime-v2, and others did not.

  Add shared helpers to @alga-psa/db (isReadOnlyError +
  {retryOnTenantReadOnly, retryOnAdminReadOnly,
  withTenantTransactionRetryReadOnly,
  withAdminTransactionRetryReadOnly,
  refresh{Tenant,Admin}Connection}) and apply them to every temporal
  activity file that issues writes through createTenantKnex or
  getAdminConnection. Each wrapped op refreshes the cached pool and
  retries once on read-only errors; non-read-only errors propagate
  unchanged.

  The Tin Man, after the next Patroni failover, will tap his oilcan
  once on the read-only connection — refreshTenantConnection() — and
  walk on without rusting in place. 🛢️ 🌪️ 🧠