### PR TITLE
Fix Teams meeting organizer and appointment links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,8 @@ yarn-error.log*
 CLAUDE.md
 .claude/
 .codex/
+AGENTS.md
+.agents/
 
 # vercel
 .vercel

--- a/docs/integrations/teams-meetings-setup.md
+++ b/docs/integrations/teams-meetings-setup.md
@@ -6,7 +6,7 @@ This runbook enables automatic Teams meeting creation for approved appointment r
 
 - A tenant with the Teams integration installed and `install_status = active`.
 - A Microsoft app registration already used by the tenant's Teams integration.
-- A dedicated organizer account, for example `scheduling@acme.com`.
+- A dedicated organizer account, for example `scheduling@acme.com`, and its Microsoft Entra user object ID.
 - PowerShell access to Microsoft Teams / Skype for Business Online cmdlets for Application Access Policy management.
 
 ## 1. Grant Graph application permission
@@ -30,6 +30,7 @@ Connect-MicrosoftTeams
 
 $appId = "<your-app-registration-client-id>"
 $organizerUpn = "scheduling@acme.com"
+$organizerObjectId = (Get-CsOnlineUser -Identity $organizerUpn).ExternalDirectoryObjectId
 
 New-CsApplicationAccessPolicy `
   -Identity "Alga-Appointment-Meetings" `
@@ -38,23 +39,23 @@ New-CsApplicationAccessPolicy `
 
 Grant-CsApplicationAccessPolicy `
   -PolicyName "Alga-Appointment-Meetings" `
-  -Identity $organizerUpn
+  -Identity $organizerObjectId
 ```
 
-Wait roughly 5 to 10 minutes for policy propagation before verification.
+Wait up to 30 minutes for policy propagation before verification.
 
 ## 3. Save the organizer in Alga PSA
 
 In the MSP app:
 
 1. Go to `Scheduling -> Availability Settings -> Teams Meetings`.
-2. Enter the organizer UPN or Microsoft user ID.
+2. Enter the organizer's Microsoft Entra user object ID.
 3. Click `Save`.
 4. Click `Verify`.
 
 Verification does two checks:
 
-- `GET /users/{upn}` to confirm the Microsoft user exists.
+- `GET /users/{id}` to confirm the Microsoft user exists.
 - A short create/delete meeting round-trip to confirm the Application Access Policy is actually allowing app-only meeting creation.
 
 ## 4. Expected behavior after setup
@@ -72,12 +73,12 @@ Verification does two checks:
 
 ### Verify says the user was not found
 
-- Confirm the value in Availability Settings is the organizer's UPN or Microsoft user ID.
+- Confirm the value in Availability Settings is the organizer's Microsoft Entra user object ID. UPNs can work for normal user lookup, but Microsoft Graph online meetings expects the object ID in `/users/{userId}/onlineMeetings`.
 - Test the account directly in Graph:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://graph.microsoft.com/v1.0/users/scheduling@acme.com"
+  "https://graph.microsoft.com/v1.0/users/<organizer-object-id>"
 ```
 
 ### Verify says the policy is missing

--- a/packages/scheduling/src/components/schedule/AvailabilitySettings.tsx
+++ b/packages/scheduling/src/components/schedule/AvailabilitySettings.tsx
@@ -19,7 +19,7 @@ import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { ColumnDefinition } from '@alga-psa/types';
 import toast from 'react-hot-toast';
 import { handleError } from '@alga-psa/ui/lib/errorHandling';
-import { Plus, Trash2, Save } from 'lucide-react';
+import { ExternalLink, Plus, Trash2, Save } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
@@ -1527,6 +1527,7 @@ export default function AvailabilitySettings({ isOpen, onClose }: AvailabilitySe
 
 $appId = "<your-app-registration-client-id>"
 $organizerUpn = "scheduling@acme.com"
+$organizerObjectId = (Get-CsOnlineUser -Identity $organizerUpn).ExternalDirectoryObjectId
 
 New-CsApplicationAccessPolicy \`
   -Identity "Alga-Appointment-Meetings" \`
@@ -1535,15 +1536,27 @@ New-CsApplicationAccessPolicy \`
 
 Grant-CsApplicationAccessPolicy \`
   -PolicyName "Alga-Appointment-Meetings" \`
-  -Identity $organizerUpn`}</pre>
+  -Identity $organizerObjectId`}</pre>
                         <p className="text-xs mt-1 text-gray-600">
                           {t('availabilitySettings.teamsMeetings.prerequisites.steps.step2.note', {
-                            defaultValue: 'Allow 5–10 minutes for policy propagation before clicking Verify.',
+                            defaultValue: 'Allow up to 30 minutes for policy propagation before clicking Verify.',
                           })}
                         </p>
                       </section>
                     </div>
                   </details>
+                  <Button
+                    id="open-teams-meetings-runbook"
+                    type="button"
+                    variant="outline"
+                    className="w-fit"
+                    onClick={() => window.open('/docs/integrations/teams-meetings-setup.md', '_blank', 'noopener,noreferrer')}
+                  >
+                    <ExternalLink className="h-4 w-4 mr-2" />
+                    {t('availabilitySettings.teamsMeetings.actions.openRunbook', {
+                      defaultValue: 'Open setup runbook',
+                    })}
+                  </Button>
                 </AlertDescription>
               </Alert>
 
@@ -1559,12 +1572,12 @@ Grant-CsApplicationAccessPolicy \`
                   <div>
                     <Label htmlFor="default-meeting-organizer-upn">
                       {t('availabilitySettings.teamsMeetings.organizer.label', {
-                        defaultValue: 'Default meeting organizer (UPN or Microsoft user ID)',
+                        defaultValue: 'Default meeting organizer Microsoft user object ID',
                       })}
                     </Label>
                     <p className="text-xs text-gray-600 mb-2">
                       {t('availabilitySettings.teamsMeetings.organizer.help', {
-                        defaultValue: 'Approved appointments create Teams meetings as this Microsoft user. A UPN such as scheduling@acme.com is usually the safest choice.',
+                        defaultValue: 'Approved appointments create Teams meetings as this Microsoft user. Use the Entra object ID; UPNs can return 404 from Microsoft Graph onlineMeetings.',
                       })}
                     </p>
                     <Input
@@ -1575,7 +1588,7 @@ Grant-CsApplicationAccessPolicy \`
                         setMeetingOrganizerVerification(null);
                       }}
                       placeholder={t('availabilitySettings.teamsMeetings.organizer.placeholder', {
-                        defaultValue: 'scheduling@acme.com',
+                        defaultValue: '00000000-0000-0000-0000-000000000000',
                       })}
                     />
                   </div>

--- a/server/public/docs/integrations/teams-meetings-setup.md
+++ b/server/public/docs/integrations/teams-meetings-setup.md
@@ -10,8 +10,8 @@ Canonical source:
 
 1. Grant Microsoft Graph application permission `OnlineMeetings.ReadWrite.All`.
 2. Create an Application Access Policy for the organizer account.
-3. Save the organizer in `Scheduling -> Availability Settings -> Teams Meetings`.
-4. Click `Verify` after policy propagation.
+3. Save the organizer's Microsoft Entra user object ID in `Scheduling -> Availability Settings -> Teams Meetings`.
+4. Click `Verify` after policy propagation. Microsoft says policy changes can take up to 30 minutes to affect Graph calls.
 
 ## PowerShell example
 
@@ -20,6 +20,7 @@ Connect-MicrosoftTeams
 
 $appId = "<your-app-registration-client-id>"
 $organizerUpn = "scheduling@acme.com"
+$organizerObjectId = (Get-CsOnlineUser -Identity $organizerUpn).ExternalDirectoryObjectId
 
 New-CsApplicationAccessPolicy `
   -Identity "Alga-Appointment-Meetings" `
@@ -28,7 +29,7 @@ New-CsApplicationAccessPolicy `
 
 Grant-CsApplicationAccessPolicy `
   -PolicyName "Alga-Appointment-Meetings" `
-  -Identity $organizerUpn
+  -Identity $organizerObjectId
 ```
 
 ## References

--- a/server/public/locales/de/msp/schedule.json
+++ b/server/public/locales/de/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Application Access Policy erstellen",
             "intro": "Die reine App-Besprechungserstellung muss dem Organisator-Konto ausdrücklich erlaubt werden.",
-            "note": "Warten Sie 5–10 Minuten auf die Richtlinienverbreitung, bevor Sie auf Verifizieren klicken."
+            "note": "Warten Sie bis zu 30 Minuten auf die Richtlinienverbreitung, bevor Sie auf Verifizieren klicken."
           }
         }
       },
       "organizer": {
         "title": "Besprechungsorganisator",
-        "label": "Standard-Besprechungsorganisator (UPN oder Microsoft-Benutzer-ID)",
-        "help": "Genehmigte Termine erstellen Teams-Besprechungen als dieser Microsoft-Benutzer. Ein UPN wie scheduling@acme.com ist meist die sicherste Wahl.",
-        "placeholder": "scheduling@acme.com"
+        "label": "Microsoft-Benutzerobjekt-ID des Standard-Besprechungsorganisators",
+        "help": "Genehmigte Termine erstellen Teams-Besprechungen als dieser Microsoft-Benutzer. Verwenden Sie die Entra-Objekt-ID; UPNs können bei Microsoft Graph onlineMeetings 404 zurückgeben.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Speichern",
         "saving": "Wird gespeichert...",
         "verify": "Verifizieren",
-        "verifying": "Wird verifiziert..."
+        "verifying": "Wird verifiziert...",
+        "openRunbook": "Setup-Runbook öffnen"
       },
       "feedback": {
         "saveSuccess": "Teams-Besprechungsorganisator gespeichert",

--- a/server/public/locales/en/msp/schedule.json
+++ b/server/public/locales/en/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Create an Application Access Policy",
             "intro": "App-only meeting creation must be explicitly allowed for the organizer account.",
-            "note": "Allow 5–10 minutes for policy propagation before clicking Verify."
+            "note": "Allow up to 30 minutes for policy propagation before clicking Verify."
           }
         }
       },
       "organizer": {
         "title": "Meeting organizer",
-        "label": "Default meeting organizer (UPN or Microsoft user ID)",
-        "help": "Approved appointments create Teams meetings as this Microsoft user. A UPN such as scheduling@acme.com is usually the safest choice.",
-        "placeholder": "scheduling@acme.com"
+        "label": "Default meeting organizer Microsoft user object ID",
+        "help": "Approved appointments create Teams meetings as this Microsoft user. Use the Entra object ID; UPNs can return 404 from Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Save",
         "saving": "Saving...",
         "verify": "Verify",
-        "verifying": "Verifying..."
+        "verifying": "Verifying...",
+        "openRunbook": "Open setup runbook"
       },
       "feedback": {
         "saveSuccess": "Teams meeting organizer saved",

--- a/server/public/locales/es/msp/schedule.json
+++ b/server/public/locales/es/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Crear una Application Access Policy",
             "intro": "La creación de reuniones solo por aplicación debe permitirse explícitamente para la cuenta organizadora.",
-            "note": "Espera de 5 a 10 minutos a que se propague la directiva antes de hacer clic en Verificar."
+            "note": "Espera hasta 30 minutos a que se propague la directiva antes de hacer clic en Verificar."
           }
         }
       },
       "organizer": {
         "title": "Organizador de la reunión",
-        "label": "Organizador de reunión predeterminado (UPN o ID de usuario de Microsoft)",
-        "help": "Las citas aprobadas crean reuniones de Teams como este usuario de Microsoft. Un UPN como scheduling@acme.com suele ser la opción más segura.",
-        "placeholder": "scheduling@acme.com"
+        "label": "ID de objeto de usuario de Microsoft del organizador de reunión predeterminado",
+        "help": "Las citas aprobadas crean reuniones de Teams como este usuario de Microsoft. Usa el ID de objeto de Entra; los UPN pueden devolver 404 desde Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Guardar",
         "saving": "Guardando...",
         "verify": "Verificar",
-        "verifying": "Verificando..."
+        "verifying": "Verificando...",
+        "openRunbook": "Abrir runbook de configuración"
       },
       "feedback": {
         "saveSuccess": "Organizador de reunión de Teams guardado",

--- a/server/public/locales/fr/msp/schedule.json
+++ b/server/public/locales/fr/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Créer une Application Access Policy",
             "intro": "La création de réunions en mode application uniquement doit être explicitement autorisée pour le compte organisateur.",
-            "note": "Attendez 5 à 10 minutes pour la propagation de la stratégie avant de cliquer sur Vérifier."
+            "note": "Attendez jusqu'à 30 minutes pour la propagation de la stratégie avant de cliquer sur Vérifier."
           }
         }
       },
       "organizer": {
         "title": "Organisateur de la réunion",
-        "label": "Organisateur de réunion par défaut (UPN ou ID utilisateur Microsoft)",
-        "help": "Les rendez-vous approuvés créent des réunions Teams au nom de cet utilisateur Microsoft. Un UPN tel que scheduling@acme.com est généralement le choix le plus sûr.",
-        "placeholder": "scheduling@acme.com"
+        "label": "ID d'objet utilisateur Microsoft de l'organisateur de réunion par défaut",
+        "help": "Les rendez-vous approuvés créent des réunions Teams au nom de cet utilisateur Microsoft. Utilisez l'ID d'objet Entra ; les UPN peuvent renvoyer 404 depuis Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Enregistrer",
         "saving": "Enregistrement...",
         "verify": "Vérifier",
-        "verifying": "Vérification..."
+        "verifying": "Vérification...",
+        "openRunbook": "Ouvrir le runbook de configuration"
       },
       "feedback": {
         "saveSuccess": "Organisateur de réunion Teams enregistré",

--- a/server/public/locales/it/msp/schedule.json
+++ b/server/public/locales/it/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Crea una Application Access Policy",
             "intro": "La creazione di riunioni con sola app deve essere esplicitamente consentita per l'account organizzatore.",
-            "note": "Attendi 5–10 minuti per la propagazione dei criteri prima di fare clic su Verifica."
+            "note": "Attendi fino a 30 minuti per la propagazione dei criteri prima di fare clic su Verifica."
           }
         }
       },
       "organizer": {
         "title": "Organizzatore della riunione",
-        "label": "Organizzatore riunione predefinito (UPN o ID utente Microsoft)",
-        "help": "Gli appuntamenti approvati creano riunioni Teams per conto di questo utente Microsoft. Un UPN come scheduling@acme.com è di solito la scelta più sicura.",
-        "placeholder": "scheduling@acme.com"
+        "label": "ID oggetto utente Microsoft dell'organizzatore riunione predefinito",
+        "help": "Gli appuntamenti approvati creano riunioni Teams per conto di questo utente Microsoft. Usa l'ID oggetto Entra; gli UPN possono restituire 404 da Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Salva",
         "saving": "Salvataggio...",
         "verify": "Verifica",
-        "verifying": "Verifica in corso..."
+        "verifying": "Verifica in corso...",
+        "openRunbook": "Apri runbook di configurazione"
       },
       "feedback": {
         "saveSuccess": "Organizzatore riunione Teams salvato",

--- a/server/public/locales/nl/msp/schedule.json
+++ b/server/public/locales/nl/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Een Application Access Policy maken",
             "intro": "Het aanmaken van vergaderingen uitsluitend via de app moet expliciet worden toegestaan voor het organisatoraccount.",
-            "note": "Wacht 5–10 minuten op de doorvoering van het beleid voordat u op Verifiëren klikt."
+            "note": "Wacht tot 30 minuten op de doorvoering van het beleid voordat u op Verifiëren klikt."
           }
         }
       },
       "organizer": {
         "title": "Vergaderorganisator",
-        "label": "Standaard vergaderorganisator (UPN of Microsoft-gebruikers-ID)",
-        "help": "Goedgekeurde afspraken maken Teams-vergaderingen aan als deze Microsoft-gebruiker. Een UPN zoals scheduling@acme.com is meestal de veiligste keuze.",
-        "placeholder": "scheduling@acme.com"
+        "label": "Microsoft-gebruikersobject-id van standaardvergaderorganisator",
+        "help": "Goedgekeurde afspraken maken Teams-vergaderingen aan als deze Microsoft-gebruiker. Gebruik de Entra-object-id; UPN's kunnen 404 teruggeven vanuit Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Opslaan",
         "saving": "Opslaan...",
         "verify": "Verifiëren",
-        "verifying": "Verifiëren..."
+        "verifying": "Verifiëren...",
+        "openRunbook": "Setup-runbook openen"
       },
       "feedback": {
         "saveSuccess": "Teams-vergaderorganisator opgeslagen",

--- a/server/public/locales/pl/msp/schedule.json
+++ b/server/public/locales/pl/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Utwórz Application Access Policy",
             "intro": "Tworzenie spotkań tylko przez aplikację musi zostać wyraźnie dozwolone dla konta organizatora.",
-            "note": "Odczekaj 5–10 minut na propagację zasady przed kliknięciem Weryfikuj."
+            "note": "Poczekaj do 30 minut na propagację zasad przed kliknięciem Weryfikuj."
           }
         }
       },
       "organizer": {
         "title": "Organizator spotkania",
-        "label": "Domyślny organizator spotkania (UPN lub ID użytkownika Microsoft)",
-        "help": "Zatwierdzone spotkania tworzą spotkania Teams jako ten użytkownik Microsoft. UPN taki jak scheduling@acme.com jest zazwyczaj najbezpieczniejszym wyborem.",
-        "placeholder": "scheduling@acme.com"
+        "label": "Identyfikator obiektu użytkownika Microsoft domyślnego organizatora spotkania",
+        "help": "Zatwierdzone spotkania tworzą spotkania Teams jako ten użytkownik Microsoft. Użyj identyfikatora obiektu Entra; UPN może zwracać 404 z Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Zapisz",
         "saving": "Zapisywanie...",
         "verify": "Weryfikuj",
-        "verifying": "Weryfikacja..."
+        "verifying": "Weryfikacja...",
+        "openRunbook": "Otwórz runbook konfiguracji"
       },
       "feedback": {
         "saveSuccess": "Organizator spotkania Teams zapisany",

--- a/server/public/locales/pt/msp/schedule.json
+++ b/server/public/locales/pt/msp/schedule.json
@@ -445,21 +445,22 @@
           "step2": {
             "title": "2. Criar uma Application Access Policy",
             "intro": "A criação de reuniões apenas por aplicação deve ser explicitamente permitida para a conta do organizador.",
-            "note": "Aguarde 5 a 10 minutos para a propagação da política antes de clicar em Verificar."
+            "note": "Aguarde até 30 minutos pela propagação da política antes de clicar em Verificar."
           }
         }
       },
       "organizer": {
         "title": "Organizador da reunião",
-        "label": "Organizador de reunião predefinido (UPN ou ID de utilizador Microsoft)",
-        "help": "Os agendamentos aprovados criam reuniões do Teams como este utilizador Microsoft. Um UPN como scheduling@acme.com costuma ser a opção mais segura.",
-        "placeholder": "scheduling@acme.com"
+        "label": "ID do objeto de utilizador Microsoft do organizador predefinido da reunião",
+        "help": "Os agendamentos aprovados criam reuniões do Teams como este utilizador Microsoft. Use o ID do objeto Entra; UPNs podem devolver 404 do Microsoft Graph onlineMeetings.",
+        "placeholder": "00000000-0000-0000-0000-000000000000"
       },
       "actions": {
         "save": "Guardar",
         "saving": "A guardar...",
         "verify": "Verificar",
-        "verifying": "A verificar..."
+        "verifying": "A verificar...",
+        "openRunbook": "Abrir runbook de configuração"
       },
       "feedback": {
         "saveSuccess": "Organizador de reunião do Teams guardado",

--- a/server/public/locales/xx/msp/schedule.json
+++ b/server/public/locales/xx/msp/schedule.json
@@ -459,7 +459,8 @@
         "save": "11111",
         "saving": "11111",
         "verify": "11111",
-        "verifying": "11111"
+        "verifying": "11111",
+        "openRunbook": "11111"
       },
       "feedback": {
         "saveSuccess": "11111",

--- a/server/public/locales/yy/msp/schedule.json
+++ b/server/public/locales/yy/msp/schedule.json
@@ -459,7 +459,8 @@
         "save": "55555",
         "saving": "55555",
         "verify": "55555",
-        "verifying": "55555"
+        "verifying": "55555",
+        "openRunbook": "55555"
       },
       "feedback": {
         "saveSuccess": "55555",

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -61,6 +61,7 @@ const apiKeySkipPaths = [
   '/api/documents/view/',
   '/api/email/webhooks/',
   '/api/calendar/webhooks/',
+  '/api/calendar/appointment/',
   '/api/email/oauth/',
   '/api/teams/auth/',
   '/api/teams/bot/',

--- a/server/src/test/unit/middleware.apiKeyAuth.test.ts
+++ b/server/src/test/unit/middleware.apiKeyAuth.test.ts
@@ -12,6 +12,10 @@ describe('shouldSkipApiKeyAuth', () => {
     expect(shouldSkipApiKeyAuth('/api/documents/123/thumbnail')).toBe(true);
   });
 
+  it('allows public appointment calendar downloads from email links', () => {
+    expect(shouldSkipApiKeyAuth('/api/calendar/appointment/2187d639-b796-4b0e-b760-8a2576bb435f.ics')).toBe(true);
+  });
+
   it('still requires an API key for unrelated API routes', () => {
     expect(shouldSkipApiKeyAuth('/api/teams/package/upload')).toBe(false);
     expect(shouldSkipApiKeyAuth('/api/instanceinfo')).toBe(false);


### PR DESCRIPTION
  Switch the Teams meeting organizer to require a Microsoft Entra
  user object ID instead of a UPN, since Graph /onlineMeetings
  returns 404 for UPNs. Bump policy-propagation wait to 30 minutes,
  add an "Open setup runbook" button, and allow public .ics
  downloads at /api/calendar/appointment/* so emailed calendar
  links resolve without an API key. Also ignore AGENTS.md and
  .agents/ alongside the other AI tool configs.

  Down the wrong rabbit hole the UPN tumbled, returning naught but
  404s and a frowning Caterpillar — only the proper object-ID
  incantation may summon a meeting now, and the .ics scrolls at
  last drift out of the inbox without surrendering a key. 🐛📅✨