### PR TITLE
Add mobile app QR card to MSP dashboard

### DIFF
--- a/packages/onboarding/src/components/dashboard/DashboardOnboardingSection.tsx
+++ b/packages/onboarding/src/components/dashboard/DashboardOnboardingSection.tsx
@@ -10,6 +10,7 @@ import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutoma
 import type { ButtonComponent } from '@alga-psa/ui/ui-reflection/types';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { Badge } from '@alga-psa/ui/components/Badge';
+import { Button } from '@alga-psa/ui/components/Button';
 import { Progress } from '@alga-psa/ui/components/Progress';
 import { STEP_DEFINITIONS, type StepDefinition } from '@alga-psa/onboarding/lib';
 import {
@@ -19,6 +20,7 @@ import {
   type OnboardingStepServerState,
 } from '@alga-psa/onboarding/actions';
 import { ArrowRight, CheckCircle2, Circle, EyeOff, RotateCcw, Sparkles } from 'lucide-react';
+import { useHiddenCardsExtras, type ExtraHiddenItem } from './HiddenCardsExtrasContext';
 
 interface OnboardingProgressSummary {
   completed: number;
@@ -318,6 +320,7 @@ export default function DashboardOnboardingSection({
 }: DashboardOnboardingSectionProps) {
   const { t } = useTranslation(['msp/dashboard', 'msp/core']);
   const posthog = usePostHog();
+  const extraHiddenItems = useHiddenCardsExtras();
   const [dismissedStepIds, setDismissedStepIds] = useState<OnboardingStepId[]>(() =>
     getInitialDismissedStepIds(stepStates, initialDismissedStepIds)
   );
@@ -509,10 +512,11 @@ export default function DashboardOnboardingSection({
         </div>
       ) : null}
 
-      {hiddenSteps.length > 0 ? (
+      {hiddenSteps.length > 0 || extraHiddenItems.length > 0 ? (
         <div className={cn('mt-6', visibleSteps.length > 0 && !isOnboardingComplete && 'pt-2')}>
           <HiddenStepsPanel
             steps={translatedHiddenSteps}
+            extras={extraHiddenItems}
             t={t}
             onRestore={handleRestore}
             isPending={isPending}
@@ -526,25 +530,34 @@ export default function DashboardOnboardingSection({
 
 function HiddenStepsPanel({
   steps,
+  extras,
   t,
   onRestore,
   isPending,
   activeStepId,
 }: {
   steps: OnboardingStep[];
+  extras: ExtraHiddenItem[];
   t: DashboardTranslator;
   onRestore: (step: OnboardingStep) => void;
   isPending: boolean;
   activeStepId: OnboardingStepId | null;
 }) {
+  const totalCount = steps.length + extras.length;
+
   return (
     <div className="rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-border-50))] p-4">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm font-semibold text-[rgb(var(--color-text-800))]">
-          {t('onboarding.hidden.title', {
-            defaultValue: 'Hidden setup cards ({{count}})',
-            count: steps.length,
-          })}
+          {extras.length > 0
+            ? t('onboarding.hidden.titleCombined', {
+                defaultValue: 'Hidden cards ({{count}})',
+                count: totalCount,
+              })
+            : t('onboarding.hidden.title', {
+                defaultValue: 'Hidden setup cards ({{count}})',
+                count: steps.length,
+              })}
         </p>
         <p className="text-xs text-[rgb(var(--color-text-500))]">
           {t('onboarding.hidden.subtitle', {
@@ -567,6 +580,22 @@ function HiddenStepsPanel({
               ? t('onboarding.cta.restoring', { defaultValue: 'Restoring...' })
               : step.title}
           </button>
+        ))}
+        {extras.map((extra) => (
+          <Button
+            key={extra.id}
+            id={`restore-dashboard-extra-${extra.id}`}
+            variant="outline"
+            size="xs"
+            className="gap-1.5"
+            onClick={() => extra.onRestore()}
+            disabled={extra.isRestoring}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            {extra.isRestoring
+              ? t('onboarding.cta.restoring', { defaultValue: 'Restoring...' })
+              : extra.title}
+          </Button>
         ))}
       </div>
     </div>

--- a/packages/onboarding/src/components/dashboard/HiddenCardsExtrasContext.tsx
+++ b/packages/onboarding/src/components/dashboard/HiddenCardsExtrasContext.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+
+export interface ExtraHiddenItem {
+  id: string;
+  title: string;
+  onRestore: () => void | Promise<void>;
+  isRestoring?: boolean;
+}
+
+const HiddenCardsExtrasContext = createContext<ExtraHiddenItem[]>([]);
+
+interface ProviderProps {
+  value: ExtraHiddenItem[];
+  children: React.ReactNode;
+}
+
+export function HiddenCardsExtrasProvider({ value, children }: ProviderProps) {
+  return (
+    <HiddenCardsExtrasContext.Provider value={value}>
+      {children}
+    </HiddenCardsExtrasContext.Provider>
+  );
+}
+
+export function useHiddenCardsExtras(): ExtraHiddenItem[] {
+  return useContext(HiddenCardsExtrasContext);
+}

--- a/packages/onboarding/src/components/dashboard/index.ts
+++ b/packages/onboarding/src/components/dashboard/index.ts
@@ -1,5 +1,6 @@
 export * from './DashboardOnboardingSection';
 export * from './DashboardOnboardingSkeleton';
 export * from './DashboardOnboardingSlot';
+export * from './HiddenCardsExtrasContext';
 export * from './OnboardingChecklist';
 

--- a/server/public/locales/de/msp/dashboard.json
+++ b/server/public/locales/de/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Ausgeblendete Setup-Karten ({{count}})",
-      "subtitle": "Stellen Sie eine Karte wieder her, wenn Sie sie später benötigen."
+      "subtitle": "Stellen Sie eine Karte wieder her, wenn Sie sie später benötigen.",
+      "titleCombined": "Ausgeblendete Karten ({{count}})"
     },
     "checklist": {
       "title": "Onboarding-Checkliste",
@@ -154,5 +155,24 @@
       "restoreFailed": "Onboarding-Schritt konnte nicht wiederhergestellt werden."
     }
   },
-  "mspDashboard": "MSP-Dashboard"
+  "mspDashboard": "MSP-Dashboard",
+  "mobileApp": {
+    "title": "Lade die AlgaPSA Mobile App herunter",
+    "description": "Scanne einen QR-Code mit deinem Smartphone, um die AlgaPSA Mobile App herunterzuladen.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "QR-Code zur AlgaPSA App im Apple App Store",
+    "playStoreQrAlt": "QR-Code zur AlgaPSA App bei Google Play",
+    "hide": "Ausblenden",
+    "hiding": "Wird ausgeblendet...",
+    "dismissAria": "Mobile-App-Karte ausblenden",
+    "dismissError": "Karte konnte nicht ausgeblendet werden.",
+    "restore": "Hol dir die AlgaPSA Mobile App",
+    "restoring": "Wird wiederhergestellt...",
+    "restoreError": "Karte konnte nicht wiederhergestellt werden.",
+    "hidden": {
+      "title": "Ausgeblendete Mobile-App-Karte",
+      "subtitle": "Stelle sie wieder her, wenn du sie später benötigst."
+    }
+  }
 }

--- a/server/public/locales/en/msp/dashboard.json
+++ b/server/public/locales/en/msp/dashboard.json
@@ -38,6 +38,25 @@
     "description": "Explore deployment runbooks and best practices in the knowledge base.",
     "cta": "Visit resources"
   },
+  "mobileApp": {
+    "title": "Download AlgaPSA Mobile app",
+    "description": "Scan a QR code with your phone to download the AlgaPSA mobile app.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "QR code linking to the AlgaPSA app on the Apple App Store",
+    "playStoreQrAlt": "QR code linking to the AlgaPSA app on Google Play",
+    "hide": "Hide",
+    "hiding": "Hiding...",
+    "dismissAria": "Hide mobile app card",
+    "dismissError": "Failed to hide the card.",
+    "restore": "Get AlgaPSA Mobile app",
+    "restoring": "Restoring...",
+    "restoreError": "Failed to restore the card.",
+    "hidden": {
+      "title": "Hidden mobile app card",
+      "subtitle": "Restore it if you need it later."
+    }
+  },
   "onboarding": {
     "completeTitle": "Onboarding complete",
     "incompleteTitle": "Complete your setup",
@@ -87,7 +106,8 @@
     },
     "hidden": {
       "title": "Hidden setup cards ({{count}})",
-      "subtitle": "Restore any card if you need it later."
+      "subtitle": "Restore any card if you need it later.",
+      "titleCombined": "Hidden cards ({{count}})"
     },
     "checklist": {
       "title": "Onboarding checklist",

--- a/server/public/locales/es/msp/dashboard.json
+++ b/server/public/locales/es/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Tarjetas de configuración ocultas ({{count}})",
-      "subtitle": "Restaura cualquier tarjeta si la necesitas más adelante."
+      "subtitle": "Restaura cualquier tarjeta si la necesitas más adelante.",
+      "titleCombined": "Tarjetas ocultas ({{count}})"
     },
     "checklist": {
       "title": "Checklist de incorporación",
@@ -154,5 +155,24 @@
       "restoreFailed": "No se pudo restaurar el paso de incorporación."
     }
   },
-  "mspDashboard": "Panel MSP"
+  "mspDashboard": "Panel MSP",
+  "mobileApp": {
+    "title": "Descarga la aplicación móvil de AlgaPSA",
+    "description": "Escanea un código QR con tu teléfono para descargar la aplicación móvil de AlgaPSA.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "Código QR que enlaza con la aplicación de AlgaPSA en la App Store de Apple",
+    "playStoreQrAlt": "Código QR que enlaza con la aplicación de AlgaPSA en Google Play",
+    "hide": "Ocultar",
+    "hiding": "Ocultando...",
+    "dismissAria": "Ocultar la tarjeta de la aplicación móvil",
+    "dismissError": "No se pudo ocultar la tarjeta.",
+    "restore": "Obtén la aplicación móvil de AlgaPSA",
+    "restoring": "Restaurando...",
+    "restoreError": "No se pudo restaurar la tarjeta.",
+    "hidden": {
+      "title": "Tarjeta de la aplicación móvil oculta",
+      "subtitle": "Restáurala si la necesitas más adelante."
+    }
+  }
 }

--- a/server/public/locales/fr/msp/dashboard.json
+++ b/server/public/locales/fr/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Cartes de configuration masquées ({{count}})",
-      "subtitle": "Restaurez une carte si vous en avez besoin plus tard."
+      "subtitle": "Restaurez une carte si vous en avez besoin plus tard.",
+      "titleCombined": "Cartes masquées ({{count}})"
     },
     "checklist": {
       "title": "Checklist d'onboarding",
@@ -154,5 +155,24 @@
       "restoreFailed": "Impossible de restaurer l'étape d'onboarding."
     }
   },
-  "mspDashboard": "Tableau de bord MSP"
+  "mspDashboard": "Tableau de bord MSP",
+  "mobileApp": {
+    "title": "Téléchargez l'application mobile AlgaPSA",
+    "description": "Scannez un QR code avec votre téléphone pour télécharger l'application mobile AlgaPSA.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "QR code menant à l'application AlgaPSA sur l'App Store d'Apple",
+    "playStoreQrAlt": "QR code menant à l'application AlgaPSA sur Google Play",
+    "hide": "Masquer",
+    "hiding": "Masquage...",
+    "dismissAria": "Masquer la carte de l'application mobile",
+    "dismissError": "Échec du masquage de la carte.",
+    "restore": "Obtenez l'application mobile AlgaPSA",
+    "restoring": "Restauration...",
+    "restoreError": "Échec de la restauration de la carte.",
+    "hidden": {
+      "title": "Carte de l'application mobile masquée",
+      "subtitle": "Restaurez-la si vous en avez besoin plus tard."
+    }
+  }
 }

--- a/server/public/locales/it/msp/dashboard.json
+++ b/server/public/locales/it/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Schede di configurazione nascoste ({{count}})",
-      "subtitle": "Ripristina una scheda se ti serve più avanti."
+      "subtitle": "Ripristina una scheda se ti serve più avanti.",
+      "titleCombined": "Schede nascoste ({{count}})"
     },
     "checklist": {
       "title": "Checklist di onboarding",
@@ -154,5 +155,24 @@
       "restoreFailed": "Impossibile ripristinare il passaggio di onboarding."
     }
   },
-  "mspDashboard": "Dashboard MSP"
+  "mspDashboard": "Dashboard MSP",
+  "mobileApp": {
+    "title": "Scarica l'app mobile AlgaPSA",
+    "description": "Scansiona un codice QR con il telefono per scaricare l'app mobile AlgaPSA.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "Codice QR per l'app AlgaPSA sull'Apple App Store",
+    "playStoreQrAlt": "Codice QR per l'app AlgaPSA su Google Play",
+    "hide": "Nascondi",
+    "hiding": "Nascondo...",
+    "dismissAria": "Nascondi la scheda dell'app mobile",
+    "dismissError": "Impossibile nascondere la scheda.",
+    "restore": "Ottieni l'app mobile AlgaPSA",
+    "restoring": "Ripristino...",
+    "restoreError": "Impossibile ripristinare la scheda.",
+    "hidden": {
+      "title": "Scheda dell'app mobile nascosta",
+      "subtitle": "Ripristinala se ti serve più avanti."
+    }
+  }
 }

--- a/server/public/locales/nl/msp/dashboard.json
+++ b/server/public/locales/nl/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Verborgen setupkaarten ({{count}})",
-      "subtitle": "Herstel een kaart als je die later nodig hebt."
+      "subtitle": "Herstel een kaart als je die later nodig hebt.",
+      "titleCombined": "Verborgen kaarten ({{count}})"
     },
     "checklist": {
       "title": "Onboardingchecklist",
@@ -154,5 +155,24 @@
       "restoreFailed": "Onboardingstap kon niet worden hersteld."
     }
   },
-  "mspDashboard": "MSP-dashboard"
+  "mspDashboard": "MSP-dashboard",
+  "mobileApp": {
+    "title": "Download de AlgaPSA mobiele app",
+    "description": "Scan een QR-code met je telefoon om de AlgaPSA mobiele app te downloaden.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "QR-code die naar de AlgaPSA-app in de Apple App Store verwijst",
+    "playStoreQrAlt": "QR-code die naar de AlgaPSA-app in Google Play verwijst",
+    "hide": "Verbergen",
+    "hiding": "Verbergen...",
+    "dismissAria": "Mobiele-app-kaart verbergen",
+    "dismissError": "Kaart kon niet worden verborgen.",
+    "restore": "Haal de AlgaPSA mobiele app",
+    "restoring": "Herstellen...",
+    "restoreError": "Kaart kon niet worden hersteld.",
+    "hidden": {
+      "title": "Verborgen mobiele-app-kaart",
+      "subtitle": "Herstel hem als je hem later nodig hebt."
+    }
+  }
 }

--- a/server/public/locales/pl/msp/dashboard.json
+++ b/server/public/locales/pl/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Ukryte karty konfiguracji ({{count}})",
-      "subtitle": "Przywróć dowolną kartę, jeśli będzie potrzebna później."
+      "subtitle": "Przywróć dowolną kartę, jeśli będzie potrzebna później.",
+      "titleCombined": "Ukryte karty ({{count}})"
     },
     "checklist": {
       "title": "Lista kontrolna onboardingu",
@@ -154,5 +155,24 @@
       "restoreFailed": "Nie udało się przywrócić kroku onboardingu."
     }
   },
-  "mspDashboard": "Pulpit MSP"
+  "mspDashboard": "Pulpit MSP",
+  "mobileApp": {
+    "title": "Pobierz aplikację mobilną AlgaPSA",
+    "description": "Zeskanuj kod QR telefonem, aby pobrać aplikację mobilną AlgaPSA.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "Kod QR z linkiem do aplikacji AlgaPSA w Apple App Store",
+    "playStoreQrAlt": "Kod QR z linkiem do aplikacji AlgaPSA w Google Play",
+    "hide": "Ukryj",
+    "hiding": "Ukrywanie...",
+    "dismissAria": "Ukryj kartę aplikacji mobilnej",
+    "dismissError": "Nie udało się ukryć karty.",
+    "restore": "Pobierz aplikację mobilną AlgaPSA",
+    "restoring": "Przywracanie...",
+    "restoreError": "Nie udało się przywrócić karty.",
+    "hidden": {
+      "title": "Ukryta karta aplikacji mobilnej",
+      "subtitle": "Przywróć ją, jeśli będzie potrzebna później."
+    }
+  }
 }

--- a/server/public/locales/pt/msp/dashboard.json
+++ b/server/public/locales/pt/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "Hidden setup cards ({{count}})",
-      "subtitle": "Restore any card if you need it later."
+      "subtitle": "Restore any card if you need it later.",
+      "titleCombined": "Hidden cards ({{count}})"
     },
     "checklist": {
       "title": "Onboarding checklist",
@@ -154,5 +155,24 @@
       "restoreFailed": "Failed to restore onboarding step."
     }
   },
-  "mspDashboard": "Painel MSP"
+  "mspDashboard": "Painel MSP",
+  "mobileApp": {
+    "title": "Download AlgaPSA Mobile app",
+    "description": "Scan a QR code with your phone to download the AlgaPSA mobile app.",
+    "appStore": "App Store (iOS)",
+    "playStore": "Google Play (Android)",
+    "appStoreQrAlt": "QR code linking to the AlgaPSA app on the Apple App Store",
+    "playStoreQrAlt": "QR code linking to the AlgaPSA app on Google Play",
+    "hide": "Hide",
+    "hiding": "Hiding...",
+    "dismissAria": "Hide mobile app card",
+    "dismissError": "Failed to hide the card.",
+    "restore": "Get AlgaPSA Mobile app",
+    "restoring": "Restoring...",
+    "restoreError": "Failed to restore the card.",
+    "hidden": {
+      "title": "Hidden mobile app card",
+      "subtitle": "Restore it if you need it later."
+    }
+  }
 }

--- a/server/public/locales/xx/msp/dashboard.json
+++ b/server/public/locales/xx/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "11111 {{count}} 11111",
-      "subtitle": "11111"
+      "subtitle": "11111",
+      "titleCombined": "11111 {{count}} 11111"
     },
     "checklist": {
       "title": "11111",
@@ -154,5 +155,24 @@
       "restoreFailed": "11111"
     }
   },
-  "mspDashboard": "11111"
+  "mspDashboard": "11111",
+  "mobileApp": {
+    "title": "11111",
+    "description": "11111",
+    "appStore": "11111",
+    "playStore": "11111",
+    "appStoreQrAlt": "11111",
+    "playStoreQrAlt": "11111",
+    "hide": "11111",
+    "hiding": "11111",
+    "dismissAria": "11111",
+    "dismissError": "11111",
+    "restore": "11111",
+    "restoring": "11111",
+    "restoreError": "11111",
+    "hidden": {
+      "title": "11111",
+      "subtitle": "11111"
+    }
+  }
 }

--- a/server/public/locales/yy/msp/dashboard.json
+++ b/server/public/locales/yy/msp/dashboard.json
@@ -87,7 +87,8 @@
     },
     "hidden": {
       "title": "55555 {{count}} 55555",
-      "subtitle": "55555"
+      "subtitle": "55555",
+      "titleCombined": "55555 {{count}} 55555"
     },
     "checklist": {
       "title": "55555",
@@ -154,5 +155,24 @@
       "restoreFailed": "55555"
     }
   },
-  "mspDashboard": "55555"
+  "mspDashboard": "55555",
+  "mobileApp": {
+    "title": "55555",
+    "description": "55555",
+    "appStore": "55555",
+    "playStore": "55555",
+    "appStoreQrAlt": "55555",
+    "playStoreQrAlt": "55555",
+    "hide": "55555",
+    "hiding": "55555",
+    "dismissAria": "55555",
+    "dismissError": "55555",
+    "restore": "55555",
+    "restoring": "55555",
+    "restoreError": "55555",
+    "hidden": {
+      "title": "55555",
+      "subtitle": "55555"
+    }
+  }
 }

--- a/server/src/app/msp/dashboard/page.tsx
+++ b/server/src/app/msp/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import DashboardContainer from '@/components/dashboard/DashboardContainer';
+import { getDashboardMobileAppCardDismissedAction } from '@/lib/actions/dashboardMobileAppActions';
 import { DashboardOnboardingSkeleton, DashboardOnboardingSlot } from '@alga-psa/onboarding/components';
 import { isEnterprise } from '@/lib/features';
 import type { Metadata } from 'next';
@@ -10,7 +11,9 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic';
 
-function DashboardPage() {
+async function DashboardPage() {
+  const mobileAppCardDismissed = await getDashboardMobileAppCardDismissedAction().catch(() => false);
+
   return (
     <DashboardContainer
       onboardingSection={
@@ -20,6 +23,7 @@ function DashboardPage() {
           </Suspense>
         ) : undefined
       }
+      initialMobileAppCardDismissed={mobileAppCardDismissed}
     />
   );
 }

--- a/server/src/components/dashboard/DashboardContainer.tsx
+++ b/server/src/components/dashboard/DashboardContainer.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useTransition } from 'react';
 import Link from 'next/link';
 import toast from 'react-hot-toast';
 import { usePostHog } from 'posthog-js/react';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
+import { Button } from '@alga-psa/ui/components/Button';
 import { usePerformanceTracking } from '@alga-psa/analytics/client';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { HiddenCardsExtrasProvider, type ExtraHiddenItem } from '@alga-psa/onboarding/components';
 import { isEnterprise } from '@/lib/features';
+import MobileAppCard from '@/components/dashboard/MobileAppCard';
+import {
+  dismissDashboardMobileAppCardAction,
+  restoreDashboardMobileAppCardAction,
+} from '@/lib/actions/dashboardMobileAppActions';
 
 // App shell: dashboard landing container (server-owned, uses analytics).
 import {
@@ -18,10 +25,12 @@ import {
   ClipboardList,
   Calendar,
   Sparkles,
+  RotateCcw,
 } from 'lucide-react';
 
 interface DashboardContainerProps {
   onboardingSection?: React.ReactNode;
+  initialMobileAppCardDismissed?: boolean;
 }
 
 interface FeatureCardProps {
@@ -175,9 +184,54 @@ function CommunityWelcomeBanner({ title, description }: { title: string; descrip
   );
 }
 
-const WelcomeDashboard = ({ onboardingSection }: DashboardContainerProps) => {
+const WelcomeDashboard = ({ onboardingSection, initialMobileAppCardDismissed = false }: DashboardContainerProps) => {
   const posthog = usePostHog();
   const { t } = useTranslation('msp/dashboard');
+  const [mobileDismissed, setMobileDismissed] = useState(initialMobileAppCardDismissed);
+  const [isMobilePending, startMobileTransition] = useTransition();
+
+  const handleDismissMobileApp = () => {
+    if (isMobilePending) return;
+    setMobileDismissed(true);
+    startMobileTransition(async () => {
+      try {
+        await dismissDashboardMobileAppCardAction();
+      } catch (err) {
+        console.error('Error dismissing mobile app card:', err);
+        toast.error(
+          t('mobileApp.dismissError', { defaultValue: 'Failed to hide the card.' })
+        );
+        setMobileDismissed(false);
+      }
+    });
+  };
+
+  const handleRestoreMobileApp = () => {
+    if (isMobilePending) return;
+    setMobileDismissed(false);
+    startMobileTransition(async () => {
+      try {
+        await restoreDashboardMobileAppCardAction();
+      } catch (err) {
+        console.error('Error restoring mobile app card:', err);
+        toast.error(
+          t('mobileApp.restoreError', { defaultValue: 'Failed to restore the card.' })
+        );
+        setMobileDismissed(true);
+      }
+    });
+  };
+
+  const mobileExtras: ExtraHiddenItem[] = mobileDismissed
+    ? [
+        {
+          id: 'mobile-app',
+          title: t('mobileApp.restore', { defaultValue: 'Get the mobile app' }),
+          onRestore: handleRestoreMobileApp,
+          isRestoring: isMobilePending,
+        },
+      ]
+    : [];
 
   usePerformanceTracking('dashboard');
 
@@ -228,7 +282,11 @@ const WelcomeDashboard = ({ onboardingSection }: DashboardContainerProps) => {
                 />
               )}
 
-              {isEnterprise ? onboardingSection : null}
+              {isEnterprise ? (
+                <HiddenCardsExtrasProvider value={mobileExtras}>
+                  {onboardingSection}
+                </HiddenCardsExtrasProvider>
+              ) : null}
 
               <div>
                 <h2 className="text-xl font-semibold mb-4" style={{ color: 'rgb(var(--color-text-900))' }}>
@@ -275,6 +333,36 @@ const WelcomeDashboard = ({ onboardingSection }: DashboardContainerProps) => {
                   )}
                 </div>
               </div>
+
+              {!mobileDismissed ? (
+                <MobileAppCard onDismiss={handleDismissMobileApp} isDismissing={isMobilePending} />
+              ) : !isEnterprise ? (
+                <div className="rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-border-50))] p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[rgb(var(--color-text-800))]">
+                      {t('mobileApp.hidden.title', { defaultValue: 'Hidden mobile app card' })}
+                    </p>
+                    <p className="text-xs text-[rgb(var(--color-text-500))]">
+                      {t('mobileApp.hidden.subtitle', { defaultValue: 'Restore it if you need it later.' })}
+                    </p>
+                  </div>
+                  <div className="mt-3">
+                    <Button
+                      id="restore-dashboard-mobile-app-card"
+                      variant="outline"
+                      size="xs"
+                      className="gap-1.5"
+                      onClick={handleRestoreMobileApp}
+                      disabled={isMobilePending}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      {isMobilePending
+                        ? t('mobileApp.restoring', { defaultValue: 'Restoring...' })
+                        : t('mobileApp.restore', { defaultValue: 'Get the mobile app' })}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
 
               <div className="rounded-lg border border-dashed border-[rgb(var(--color-border-200))] bg-white p-4">
                 <div className="flex flex-col md:flex-row items-center justify-between gap-4">

--- a/server/src/components/dashboard/MobileAppCard.tsx
+++ b/server/src/components/dashboard/MobileAppCard.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import qrcode from 'qrcode';
+import { Smartphone, EyeOff } from 'lucide-react';
+import { Button } from '@alga-psa/ui/components/Button';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+
+const APP_STORE_URL = 'https://apps.apple.com/app/id6760326836';
+const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.alga.psa.mobile';
+
+interface StoreLinkProps {
+  url: string;
+  label: string;
+  qrAlt: string;
+  qrDataUrl: string | null;
+}
+
+function StoreLink({ url, label, qrAlt, qrDataUrl }: StoreLinkProps) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex flex-col items-center gap-2 rounded-md border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-primary-500"
+    >
+      {qrDataUrl ? (
+        <img
+          src={qrDataUrl}
+          alt={qrAlt}
+          width={160}
+          height={160}
+          className="h-40 w-40"
+          style={{ imageRendering: 'pixelated' }}
+        />
+      ) : (
+        <div className="h-40 w-40 animate-pulse rounded bg-slate-100" />
+      )}
+      <span className="text-sm font-medium text-slate-900">{label}</span>
+    </a>
+  );
+}
+
+interface MobileAppCardProps {
+  onDismiss: () => void;
+  isDismissing?: boolean;
+}
+
+export default function MobileAppCard({ onDismiss, isDismissing = false }: MobileAppCardProps) {
+  const { t } = useTranslation('msp/dashboard');
+  const [iosQr, setIosQr] = useState<string | null>(null);
+  const [androidQr, setAndroidQr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const options = { margin: 1, width: 640 };
+
+    Promise.all([
+      qrcode.toDataURL(APP_STORE_URL, options),
+      qrcode.toDataURL(PLAY_STORE_URL, options),
+    ])
+      .then(([ios, android]) => {
+        if (cancelled) return;
+        setIosQr(ios);
+        setAndroidQr(android);
+      })
+      .catch((err) => {
+        console.error('Error generating mobile app QR codes:', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hideLabel = isDismissing
+    ? t('mobileApp.hiding', { defaultValue: 'Hiding...' })
+    : t('mobileApp.hide', { defaultValue: 'Hide' });
+
+  return (
+    <div className="relative rounded-xl border border-slate-200 bg-white p-6 shadow-[0_2px_10px_rgba(15,23,42,0.06)]">
+      <Button
+        id="dismiss-dashboard-mobile-app-card"
+        variant="outline"
+        size="xs"
+        onClick={onDismiss}
+        disabled={isDismissing}
+        className="absolute right-4 top-4 z-10 gap-1"
+        aria-label={t('mobileApp.dismissAria', { defaultValue: 'Hide mobile app card' })}
+      >
+        <EyeOff className="h-3.5 w-3.5" />
+        {hideLabel}
+      </Button>
+
+      <div className="mb-4 flex items-center gap-2">
+        <Smartphone className="h-5 w-5 text-slate-700" />
+        <h2 className="text-xl font-semibold" style={{ color: 'rgb(var(--color-text-900))' }}>
+          {t('mobileApp.title', { defaultValue: 'Get the mobile app' })}
+        </h2>
+      </div>
+      <p className="mb-6 text-sm" style={{ color: 'rgb(var(--color-text-500))' }}>
+        {t('mobileApp.description', {
+          defaultValue: 'Scan a QR code with your phone to download the Alga PSA mobile app.',
+        })}
+      </p>
+      <div className="flex flex-wrap items-start justify-center gap-12 py-2">
+        <StoreLink
+          url={APP_STORE_URL}
+          label={t('mobileApp.appStore', { defaultValue: 'App Store (iOS)' })}
+          qrAlt={t('mobileApp.appStoreQrAlt', {
+            defaultValue: 'QR code linking to the Alga PSA app on the Apple App Store',
+          })}
+          qrDataUrl={iosQr}
+        />
+        <StoreLink
+          url={PLAY_STORE_URL}
+          label={t('mobileApp.playStore', { defaultValue: 'Google Play (Android)' })}
+          qrAlt={t('mobileApp.playStoreQrAlt', {
+            defaultValue: 'QR code linking to the Alga PSA app on Google Play',
+          })}
+          qrDataUrl={androidQr}
+        />
+      </div>
+    </div>
+  );
+}

--- a/server/src/lib/actions/dashboardMobileAppActions.ts
+++ b/server/src/lib/actions/dashboardMobileAppActions.ts
@@ -1,0 +1,56 @@
+'use server';
+
+import { withAuth } from '@alga-psa/auth';
+import { createTenantKnex } from '@alga-psa/db';
+
+const SETTING_NAME = 'dashboardMobileAppCardDismissed';
+
+export const getDashboardMobileAppCardDismissedAction = withAuth(async (
+  user,
+  { tenant }
+): Promise<boolean> => {
+  const { knex } = await createTenantKnex();
+  const pref = await knex('user_preferences')
+    .where({ tenant, user_id: user.user_id, setting_name: SETTING_NAME })
+    .first();
+
+  if (!pref?.setting_value) return false;
+  const value = typeof pref.setting_value === 'string'
+    ? pref.setting_value.replace(/"/g, '')
+    : pref.setting_value;
+  return value === true || value === 'true';
+});
+
+export const dismissDashboardMobileAppCardAction = withAuth(async (
+  user,
+  { tenant }
+): Promise<{ success: true }> => {
+  const { knex } = await createTenantKnex();
+  await knex('user_preferences')
+    .insert({
+      tenant,
+      user_id: user.user_id,
+      setting_name: SETTING_NAME,
+      setting_value: JSON.stringify(true),
+      updated_at: knex.fn.now(),
+    })
+    .onConflict(['tenant', 'user_id', 'setting_name'])
+    .merge({
+      setting_value: JSON.stringify(true),
+      updated_at: knex.fn.now(),
+    });
+
+  return { success: true };
+});
+
+export const restoreDashboardMobileAppCardAction = withAuth(async (
+  user,
+  { tenant }
+): Promise<{ success: true }> => {
+  const { knex } = await createTenantKnex();
+  await knex('user_preferences')
+    .where({ tenant, user_id: user.user_id, setting_name: SETTING_NAME })
+    .delete();
+
+  return { success: true };
+});


### PR DESCRIPTION
  A new "Get the mobile app" dashboard card renders QR codes for the iOS
  App Store and Google Play listings, side by side with store labels.
  Users can hide the card from the dashboard and restore it later.

  - MobileAppCard component (client-side QR via qrcode lib) and dashboardMobileAppActions (get/dismiss/restore persisted in user_preferences as dashboardMobileAppCardDismissed).
  - HiddenCardsExtrasContext lets the onboarding hidden-cards panel surface the mobile-app restore button alongside hidden onboarding steps when enterprise onboarding is active; CE gets a standalone hidden-card panel with its own restore control.
  - Dashboard page reads the dismissed flag server-side and passes initialMobileAppCardDismissed into DashboardContainer.
  - Translations added across de/en/es/fr/it/nl/pl/pt/xx/yy.

  "Curiouser and curiouser!" cried Alice as the dashboard sprouted two
  square gardens of black-and-white pixels — one marked iOS, the other
  Android — and a polite EyeOff button whispered, "you may tuck me away,
  and one day RotateCcw me back." 📱🔳🐰