### PR TITLE
Improve workflow run history view

### DIFF
--- a/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/PRD.md
+++ b/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/PRD.md
@@ -1,0 +1,71 @@
+# Workflow Run Inspector Consolidation
+
+## Problem
+
+Workflow run inspection is split across two overlapping implementations: the Runs tab inline details panel and the full-page Run Studio. They fetch and render much of the same run metadata, step state, logs, audit history, and run actions independently. This creates duplicate maintenance work and makes it likely that users see different capabilities depending on how they open a run.
+
+## Goals
+
+- Preserve two useful user contexts:
+  - quick triage from the Runs tab without losing filters/table context
+  - a shareable full-page run route for deeper investigation
+- Replace the inline under-table detail panel with a right-side drawer optimized for quick triage.
+- Allow users, especially admins working through queues, to move to the previous/next visible run from the drawer.
+- Consolidate the detailed run inspection UI so the drawer and full-page route use the same canonical detail component for run metadata, actions, steps, logs, and audit details.
+- Keep the full-page route available and retain the graph/pipeline visualization as a studio-only enhancement.
+
+## Non-goals
+
+- Changing workflow run database schema or action APIs.
+- Adding new workflow run actions.
+- Reworking the Runs tab filtering model.
+- Building a brand-new graph visualization.
+- Changing permissions beyond reusing existing `canAdmin` and current run action checks.
+
+## Target users and flows
+
+### MSP operator / admin quick triage
+
+1. Open Workflow Control Panel > Runs.
+2. Apply filters or sort the visible run table.
+3. Click a run's Preview/Details action.
+4. A drawer opens on the right with the canonical run detail view.
+5. Use Previous/Next to move through visible runs without closing the drawer.
+6. Use Open full page when deeper graph-oriented debugging is needed.
+
+### Deep investigation / shareable route
+
+1. Open `/msp/workflows/runs/[runId]` from a run ID, external link, or drawer action.
+2. See the Run Studio shell with graph/pipeline context plus the canonical run detail inspector.
+3. Perform the same run actions and inspect the same logs/audit/step details as the drawer.
+
+## UX notes
+
+- The Runs tab should no longer insert a large details card under the table.
+- The drawer should use the shared `Drawer` component and a wide responsive width suitable for dense diagnostics.
+- The row action label should communicate quick triage, e.g. `Preview` or `Details`.
+- The run ID link should continue to navigate to the full-page route.
+- The drawer header/navigation should include Previous, Next, Open full page, and Close affordances.
+- Previous/Next operate over the currently loaded `runs` array in the table.
+
+## Integration notes
+
+- Existing action APIs from `@alga-psa/workflows/actions` should continue to be used.
+- `WorkflowRunDetails` is the current richest reusable detail component and should become the canonical inspector surface used by both the drawer and Run Studio.
+- `RunStudioShell` should become more of a shell/layout around studio-only graph context plus the canonical detail inspector.
+
+## Acceptance criteria
+
+- Runs tab opens run details in a drawer instead of an inline card below the table.
+- Drawer can navigate to previous/next loaded run and updates selected row state.
+- Drawer provides an Open full page action for the selected run.
+- Full-page run route still works at `/msp/workflows/runs/[runId]`.
+- Full-page route uses the same canonical detail component as the drawer for detail/actions/log/audit content.
+- Existing run action buttons continue to typecheck and render with unique IDs.
+- `cd server && npm run typecheck -- --pretty false` passes.
+
+## Risks and mitigations
+
+- **Large component duplication:** Mitigate by keeping the canonical detail component intact and making Run Studio compose it instead of duplicating detail panels.
+- **Drawer too narrow for diagnostics:** Use a wide drawer width and preserve internal scrolling.
+- **Navigation ambiguity:** Keep run ID as full-page navigation and use row action for quick drawer triage.

--- a/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/SCRATCHPAD.md
@@ -1,0 +1,125 @@
+# Scratchpad
+
+## Decisions
+
+- Keep both UX entry points: quick triage from Runs tab and full-page route for deep investigation/shareable links.
+- Do not keep two independent detail implementations. Use `WorkflowRunDetails` as the canonical detail/action/log/audit inspector.
+- Replace the Runs tab inline details card with a `Drawer` so operators can inspect runs without losing the table context.
+- Add Previous/Next drawer navigation over the currently loaded `runs` array.
+- Keep Run Studio's graph/pipeline as a full-page-only enhancement around the canonical inspector.
+
+## Relevant files
+
+- `ee/server/src/components/workflow-designer/WorkflowRunList.tsx`
+- `ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx`
+- `ee/server/src/components/workflow-run-studio/RunStudioShell.tsx`
+- `server/src/app/msp/workflows/runs/[runId]/page.tsx`
+- `packages/ui/src/components/Drawer.tsx`
+
+## Validation commands
+
+- `cd server && npm run typecheck -- --pretty false`
+
+## Notes
+
+- Current branch: `feature/combine-workflow-details-run-info`.
+- The workflow palette/layout PR has been merged into `origin/main` and is present in this branch.
+
+## 2026-04-28 implementation notes
+
+- `WorkflowRunList.tsx` now opens `WorkflowRunDetails` inside `Drawer` instead of rendering an inline card below the table.
+- Drawer navigation uses the currently loaded `runs` array and updates `selectedRunId` for Previous/Next.
+- Drawer includes an `Open full page` action that navigates to `/msp/workflows/runs/${runId}`.
+- `RunStudioShell.tsx` was simplified substantially. It now owns only studio shell concerns: loading graph context, graph/list view toggle, refresh/polling for active runs, and admin permission lookup. Detailed run metadata/actions/logs/audit rendering is delegated to `WorkflowRunDetails`.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 scroll fix
+
+- Drawer preview content now has an explicit viewport-bounded scrolling container so timeline, selected step details, logs, and audit sections can be reached.
+- Run Studio shell now uses a viewport-height layout with a scrollable canonical inspector column, keeping the graph column visible while details scroll independently.
+- Validation passed again: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 UI click-through results
+
+Tested with `alga-dev` against `http://localhost:3872`.
+
+### Full-page Workflow Run Studio checklist
+
+- Refresh button: clicked, page remained stable and run details stayed loaded.
+- Graph/List toggle: clicked List and Graph; list rendered run steps and graph rendered ReactFlow nodes.
+- Graph controls: clicked zoom in, zoom out, and fit view; no visible product breakage.
+- Graph/step selection: clicked a graph node and the Step Timeline View button; step details rendered.
+- Step filters: opened Step status and Node type dropdowns, selected Succeeded and action.call, toggled Collapse nested blocks, then reset filters back to All statuses / All types.
+- Details scroll: scrolled details column to logs and audit sections; `#workflow-run-audit-export` was reachable in viewport.
+- Envelope tabs: clicked Payload, Vars, Meta, Error, Raw, then Payload again.
+- Logs: typed a log search, applied, reset, selected Info level, applied, reset, and clicked Export CSV.
+- Audit: scrolled to and clicked Export Audit CSV.
+- Run actions: clicked Export. Opened Retry and Replay confirmation dialogs without confirming destructive actions.
+
+### Runs tab drawer checklist
+
+- Back to Runs page from full-page studio worked.
+- Preview button opened the run preview drawer.
+- Drawer showed canonical `WorkflowRunDetails` content for selected run.
+- Next and Previous controls moved between loaded runs and updated the displayed run ID.
+- Drawer content scroll container exposed bottom content; audit export was reachable in viewport.
+- Open full page navigated from drawer to `/msp/workflows/runs/[runId]`.
+- Returning to the Runs page closed the drawer and preserved the Runs view.
+
+### Notes
+
+- Console contained existing local-env noise about `localhost:3000/locales/en/common.json` and an Electron CSP warning.
+- Radix reported a missing Dialog description warning while confirmation dialogs were open.
+- ReactFlow emitted page errors after synthetic `alga-dev browser-press-key Escape` calls; this appears tied to the automation key event target rather than normal click-through behavior. Future testing should close dialogs via their Cancel buttons instead of synthetic Escape.
+
+## 2026-04-28 UI once-over fixes
+
+- Fixed the confirmation dialog accessibility warning by ensuring `ConfirmationDialog` always renders a `DialogDescription` for Radix.
+- Adjusted `DialogDescription` to accept a custom class so confirmation dialogs can provide an sr-only description without adding duplicate visible text.
+- Improved `WorkflowRunDetails` header layout: run ID now wraps/breaks safely and action buttons wrap instead of running off the right edge.
+- Added horizontal scrolling/min widths for the Step Timeline and Audit Trail tables.
+- Improved log filter/action layout so Apply/Reset/Export CSV wrap and align better in constrained widths.
+- Rechecked full-page and drawer layouts with `alga-dev`; visible buttons stayed within viewport bounds and bottom sections remained reachable by scrolling.
+- Reopened Retry dialog after the accessibility change and saw no new missing-description console warning.
+- Validation passed again: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 visual grid button placement pass
+
+- Moved run action buttons into a full-width toolbar below the run identity block so they no longer crowd or clip against the right edge of the header.
+- Reduced header action buttons to `size="sm"` for better density in drawer/full-page contexts.
+- Reworked Step Timeline controls into a simple two-column filter grid with the collapse toggle on its own row, avoiding the previous baseline mismatch beside select controls.
+- Reworked Run Logs controls so Search and Level occupy the filter row and Apply/Reset/Export CSV sit together in a single right-aligned toolbar row.
+- Rechecked element bounds with `alga-dev`; key controls are within the viewport and aligned more consistently.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 step timeline row-click improvement
+
+- Made Step Timeline rows clickable and keyboard-activatable (`Enter`/`Space`) so users do not need to horizontally scroll to the View button on narrower screens.
+- Preserved the View button for explicit affordance and stopped propagation so clicking it does not double-handle the row click.
+- Verified via `alga-dev` that timeline rows expose `role="button"` and clicking a row selects/opens step details.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 audit trail DataTable + user display
+
+- Changed the Workflow Run Details Audit Trail from a custom `Table` to the shared `DataTable` component.
+- Added audit-user lookup through `getAllUsersBasic(true)` for admins and display user full name plus email/username instead of raw `user_id` when available.
+- Kept a safe fallback for system/unknown users.
+- Verified with `alga-dev` that the audit table renders via the datatable container and shows a human-readable user (`Paula Policy Admin`, `glinda@emeraldcity.oz`) instead of only the UUID.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 step timeline DataTable
+
+- Changed the Step Timeline from custom `Table` components to the shared `DataTable` component.
+- Preserved whole-row click behavior through `DataTable` `onRowClick`, so users can select a step without horizontally scrolling to the View button.
+- Kept the explicit View action as the standard action column.
+- Set non-paginated DataTables to use a page size matching loaded rows so Step Timeline and Audit Trail do not silently show only the first 10 rows.
+- Verified with `alga-dev` that the Step Timeline renders as a datatable and clicking a row updates the selected `step` URL param.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.
+
+## 2026-04-28 run logs DataTable
+
+- Changed Run Logs from custom `Table` components to the shared `DataTable` component.
+- Preserved log filtering, reset, export, and load-more behavior.
+- Set non-paginated log DataTable page size to the loaded log count so loaded logs are not truncated to the default page size.
+- Verified with `alga-dev` that Run Logs renders as a datatable container.
+- Validation passed: `cd server && npm run typecheck -- --pretty false`.

--- a/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/features.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "F001",
+    "description": "Replace the Runs tab inline under-table details card with a right-side drawer for quick run triage.",
+    "implemented": true,
+    "prdRefs": ["UX notes", "Acceptance criteria"]
+  },
+  {
+    "id": "F002",
+    "description": "Keep run ID links navigating to the full-page run route for shareable deep investigation.",
+    "implemented": true,
+    "prdRefs": ["Target users and flows", "UX notes"]
+  },
+  {
+    "id": "F003",
+    "description": "Add Previous and Next drawer navigation across the currently loaded Runs table rows.",
+    "implemented": true,
+    "prdRefs": ["Target users and flows", "Acceptance criteria"]
+  },
+  {
+    "id": "F004",
+    "description": "Add an Open full page action in the drawer for the selected run.",
+    "implemented": true,
+    "prdRefs": ["UX notes", "Acceptance criteria"]
+  },
+  {
+    "id": "F005",
+    "description": "Use WorkflowRunDetails as the canonical run inspector for drawer detail/action/log/audit content.",
+    "implemented": true,
+    "prdRefs": ["Integration notes", "Acceptance criteria"]
+  },
+  {
+    "id": "F006",
+    "description": "Refactor RunStudioShell so the full-page route composes studio-only graph context with the canonical run inspector instead of maintaining a separate detail system.",
+    "implemented": true,
+    "prdRefs": ["Goals", "Integration notes"]
+  },
+  {
+    "id": "F007",
+    "description": "Preserve existing full-page graph/pipeline visualization for deep investigation.",
+    "implemented": true,
+    "prdRefs": ["Goals", "Non-goals"]
+  },
+  {
+    "id": "F008",
+    "description": "Ensure all new drawer/navigation controls have unique kebab-case IDs.",
+    "implemented": true,
+    "prdRefs": ["Acceptance criteria"]
+  }
+]

--- a/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-run-inspector-consolidation/tests.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "T001",
+    "description": "Typecheck the server workspace after consolidating the run inspector surfaces.",
+    "implemented": true,
+    "featureIds": ["F001", "F003", "F004", "F005", "F006", "F008"]
+  },
+  {
+    "id": "T002",
+    "description": "Manual smoke: from Workflow Control Panel > Runs, open a run in the drawer, move previous/next through loaded rows, and close the drawer without losing table filters.",
+    "implemented": true,
+    "featureIds": ["F001", "F003"]
+  },
+  {
+    "id": "T003",
+    "description": "Manual smoke: verify the drawer Open full page action and run ID link both reach /msp/workflows/runs/[runId].",
+    "implemented": true,
+    "featureIds": ["F002", "F004"]
+  },
+  {
+    "id": "T004",
+    "description": "Manual smoke: verify the full-page run route still shows graph/pipeline context and the canonical detail inspector content/actions.",
+    "implemented": true,
+    "featureIds": ["F005", "F006", "F007"]
+  }
+]

--- a/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
+import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { Input } from '@alga-psa/ui/components/Input';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -39,8 +40,10 @@ import {
   useWorkflowLogLevelOptions,
   useWorkflowStepStatusOptions,
 } from '@alga-psa/workflows/hooks/useWorkflowEnumOptions';
+import { getAllUsersBasic } from '@alga-psa/user-composition/actions';
 
 import type { WorkflowDefinition, Step, IfBlock, ForEachBlock, TryCatchBlock } from '@alga-psa/workflows/runtime/client';
+import type { ColumnDefinition, IUser } from '@alga-psa/types';
 import { pathDepth } from '@alga-psa/workflows/authoring';
 import {
   getWorkflowScheduleStatusBadgeClass,
@@ -294,6 +297,11 @@ const truncateJsonPreview = (value: unknown, maxChars: number) => {
   return { preview: `${serialized.slice(0, maxChars)}\n… truncated …`, truncated: true };
 };
 
+const getUserDisplayName = (user: Pick<IUser, 'first_name' | 'last_name' | 'username' | 'email'>): string => {
+  const fullName = [user.first_name, user.last_name].filter(Boolean).join(' ').trim();
+  return fullName || user.username || user.email;
+};
+
 interface WorkflowRunDetailsProps {
   runId: string;
   workflowName?: string;
@@ -347,6 +355,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
   const [auditLogs, setAuditLogs] = useState<WorkflowAuditLogRecord[]>([]);
   const [auditCursor, setAuditCursor] = useState<number | null>(null);
   const [auditLoading, setAuditLoading] = useState(false);
+  const [auditUserMap, setAuditUserMap] = useState<Map<string, IUser>>(new Map());
   const auditLimit = 25;
   const selectedStepPathRef = useRef<string | null>(null);
   const emptyValueLabel = t('runDetails.common.emptyValue', { defaultValue: '—' });
@@ -459,9 +468,26 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
     [auditLimit, canAdmin, runId, t]
   );
 
+  const fetchAuditUsers = useCallback(async () => {
+    if (!canAdmin) {
+      setAuditUserMap(new Map());
+      return;
+    }
+    try {
+      const users = await getAllUsersBasic(true);
+      setAuditUserMap(new Map(users.map((user) => [user.user_id, user])));
+    } catch {
+      setAuditUserMap(new Map());
+    }
+  }, [canAdmin]);
+
   useEffect(() => {
     fetchDetails();
   }, [fetchDetails]);
+
+  useEffect(() => {
+    fetchAuditUsers();
+  }, [fetchAuditUsers]);
 
   useEffect(() => {
     setSelectedStepPath(null);
@@ -592,6 +618,124 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
     ];
   }, [steps, stepTypeById, t]);
 
+  const logColumns: ColumnDefinition<WorkflowRunLogRecord>[] = useMemo(() => [
+    {
+      title: t('runDetails.logs.columns.timestamp', { defaultValue: 'Timestamp' }),
+      dataIndex: 'created_at',
+      width: '180px',
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <div className="whitespace-nowrap text-xs text-gray-500">{formatDateTime(log.created_at)}</div>
+      ),
+    },
+    {
+      title: t('runDetails.logs.columns.level', { defaultValue: 'Level' }),
+      dataIndex: 'level',
+      width: '120px',
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <Badge className={STATUS_STYLES[log.level] ?? 'bg-gray-100 text-gray-600'}>
+          {formatWorkflowLogLevel(log.level)}
+        </Badge>
+      ),
+    },
+    {
+      title: t('runDetails.logs.columns.message', { defaultValue: 'Message' }),
+      dataIndex: 'message',
+      sortable: false,
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <div className="min-w-[18rem] max-w-[28rem]">
+          <div className="text-sm text-gray-800 break-words">{log.message}</div>
+          {log.context_json && (
+            <pre className="mt-1 max-h-24 max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-gray-900 text-gray-100 text-xs p-2">
+              {truncateJsonPreview(log.context_json, 2000).preview}
+            </pre>
+          )}
+        </div>
+      ),
+    },
+    {
+      title: t('runDetails.logs.columns.step', { defaultValue: 'Step' }),
+      dataIndex: 'step_path',
+      width: '180px',
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <div className="max-w-[12rem] break-all text-xs text-gray-500">{log.step_path ?? emptyValueLabel}</div>
+      ),
+    },
+    {
+      title: t('runDetails.logs.columns.event', { defaultValue: 'Event' }),
+      dataIndex: 'event_name',
+      width: '180px',
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <div className="max-w-[12rem] break-all text-xs text-gray-500">{log.event_name ?? emptyValueLabel}</div>
+      ),
+    },
+    {
+      title: t('runDetails.logs.columns.correlation', { defaultValue: 'Correlation' }),
+      dataIndex: 'correlation_key',
+      width: '180px',
+      render: (_value: unknown, log: WorkflowRunLogRecord) => (
+        <div className="max-w-[12rem] break-all text-xs text-gray-500">{log.correlation_key ?? emptyValueLabel}</div>
+      ),
+    },
+  ], [emptyValueLabel, formatDateTime, formatWorkflowLogLevel, t]);
+
+  const auditColumns: ColumnDefinition<WorkflowAuditLogRecord>[] = useMemo(() => [
+    {
+      title: t('runDetails.audit.columns.timestamp', { defaultValue: 'Timestamp' }),
+      dataIndex: 'timestamp',
+      width: '180px',
+      render: (_value: unknown, record: WorkflowAuditLogRecord) => (
+        <div className="whitespace-nowrap text-xs text-gray-500">{formatDateTime(record.timestamp)}</div>
+      ),
+    },
+    {
+      title: t('runDetails.audit.columns.operation', { defaultValue: 'Operation' }),
+      dataIndex: 'operation',
+      width: '140px',
+      render: (_value: unknown, record: WorkflowAuditLogRecord) => (
+        <div className="whitespace-nowrap text-xs text-gray-700">{record.operation}</div>
+      ),
+    },
+    {
+      title: t('runDetails.audit.columns.user', { defaultValue: 'User' }),
+      dataIndex: 'user_id',
+      width: '220px',
+      render: (_value: unknown, record: WorkflowAuditLogRecord) => {
+        if (!record.user_id) {
+          return <span className="text-xs text-gray-500">{t('runDetails.audit.systemUser', { defaultValue: 'system' })}</span>;
+        }
+        const auditUser = auditUserMap.get(record.user_id);
+        if (!auditUser) {
+          return (
+            <div className="min-w-0 text-xs">
+              <div className="font-medium text-gray-700">
+                {t('runDetails.audit.unknownUser', { defaultValue: 'Unknown user' })}
+              </div>
+              <div className="font-mono text-[11px] text-gray-500 break-all">{record.user_id}</div>
+            </div>
+          );
+        }
+        return (
+          <div className="min-w-0 text-xs">
+            <div className="font-medium text-gray-700 truncate">{getUserDisplayName(auditUser)}</div>
+            <div className="text-[11px] text-gray-500 truncate">{auditUser.email || auditUser.username}</div>
+          </div>
+        );
+      },
+    },
+    {
+      title: t('runDetails.audit.columns.details', { defaultValue: 'Details' }),
+      dataIndex: 'details',
+      sortable: false,
+      render: (_value: unknown, record: WorkflowAuditLogRecord) => (
+        record.details ? (
+          <pre className="max-h-24 max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-gray-900 text-gray-100 text-xs p-2">
+            {truncateJsonPreview(record.details, 2000).preview}
+          </pre>
+        ) : emptyValueLabel
+      ),
+    },
+  ], [auditUserMap, emptyValueLabel, formatDateTime, t]);
+
   const filteredSteps = useMemo(() => {
     return steps.filter((step) => {
       if (stepStatusFilter !== 'all' && step.status !== stepStatusFilter) {
@@ -607,6 +751,92 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
       return true;
     });
   }, [steps, stepStatusFilter, stepTypeFilter, stepTypeById, collapseNested]);
+
+  const stepTimelineColumns: ColumnDefinition<WorkflowRunStepRecord>[] = useMemo(() => [
+    {
+      title: t('runDetails.stepTimeline.columns.stepPath', { defaultValue: 'Step Path' }),
+      dataIndex: 'step_path',
+      width: '260px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <div className="max-w-[18rem] break-all font-mono text-xs">{step.step_path}</div>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.type', { defaultValue: 'Type' }),
+      dataIndex: 'definition_step_id',
+      width: '130px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <div className="text-xs text-gray-500">
+          {stepTypeById.get(step.definition_step_id) ?? emptyValueLabel}
+        </div>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.status', { defaultValue: 'Status' }),
+      dataIndex: 'status',
+      width: '150px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <Badge className={STATUS_STYLES[step.status] ?? 'bg-gray-100 text-gray-600'}>
+          {formatWorkflowStepStatus(step.status)}
+        </Badge>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.attempt', { defaultValue: 'Attempt' }),
+      dataIndex: 'attempt',
+      width: '100px',
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.duration', { defaultValue: 'Duration' }),
+      dataIndex: 'duration_ms',
+      width: '120px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => formatDurationMs(step.duration_ms),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.nextRetry', { defaultValue: 'Next Retry' }),
+      dataIndex: ['step_id', 'next_retry'],
+      width: '160px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <div className="text-xs text-gray-500">
+          {formatDateTime(retryWaitsByStep.get(step.step_path)?.timeout_at ?? null)}
+        </div>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.started', { defaultValue: 'Started' }),
+      dataIndex: 'started_at',
+      width: '180px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <div className="whitespace-nowrap">{formatDateTime(step.started_at)}</div>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.error', { defaultValue: 'Error' }),
+      dataIndex: 'error_json',
+      sortable: false,
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <div className="max-w-[18rem] break-words text-xs text-destructive">
+          {(step.error_json as any)?.message ?? emptyValueLabel}
+        </div>
+      ),
+    },
+    {
+      title: t('runDetails.stepTimeline.columns.action', { defaultValue: 'Action' }),
+      dataIndex: ['step_id', 'action'],
+      width: '110px',
+      sortable: false,
+      render: (_value: unknown, step: WorkflowRunStepRecord) => (
+        <Button
+          id={`workflow-run-step-${step.step_id}`}
+          variant="outline"
+          size="sm"
+          onClick={() => setSelectedStepPath(step.step_path)}
+        >
+          {t('runDetails.actions.view', { defaultValue: 'View' })}
+        </Button>
+      ),
+    },
+  ], [emptyValueLabel, formatDateTime, formatWorkflowStepStatus, retryWaitsByStep, stepTypeById, t]);
 
   const handleApplyLogFilters = () => {
     fetchLogs(0, false, logFilters);
@@ -802,17 +1032,16 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
   const hasRedactions = Array.isArray((redactedSnapshot as any)?.meta?.redactions)
     ? (redactedSnapshot as any).meta.redactions.length > 0
     : false;
-  const stepColumnCount = 9;
 
   return (
     <div className="space-y-4 min-w-0 max-w-full">
       <Card className="p-4 space-y-3">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+        <div className="min-w-0">
+          <div className="min-w-0">
             <div className="text-sm text-gray-500">
               {t('runDetails.header.runIdLabel', { defaultValue: 'Run ID' })}
             </div>
-            <div id="workflow-run-detail-id" className="text-lg font-semibold text-gray-900">
+            <div id="workflow-run-detail-id" className="break-all text-lg font-semibold text-gray-900">
               {runId}
             </div>
             <div className="text-sm text-gray-600">
@@ -827,44 +1056,44 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
               </div>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="mt-3 flex flex-wrap items-center justify-end gap-2 border-t border-[rgb(var(--color-border-200))] pt-3">
             {canResume && (
-              <Button id="workflow-run-resume" variant="outline" onClick={() => setConfirmAction('resume')}>
+              <Button id="workflow-run-resume" variant="outline" size="sm" onClick={() => setConfirmAction('resume')}>
                 <Play className="h-4 w-4 mr-2" />
                 {t('runDetails.actions.resume', { defaultValue: 'Resume' })}
               </Button>
             )}
             {canCancel && (
-              <Button id="workflow-run-cancel" variant="outline" onClick={() => setConfirmAction('cancel')}>
+              <Button id="workflow-run-cancel" variant="outline" size="sm" onClick={() => setConfirmAction('cancel')}>
                 <StopCircle className="h-4 w-4 mr-2" />
                 {t('runDetails.actions.cancel', { defaultValue: 'Cancel' })}
               </Button>
             )}
             {run && (
-              <Button id="workflow-run-export" variant="outline" onClick={handleExport}>
+              <Button id="workflow-run-export" variant="outline" size="sm" onClick={handleExport}>
                 {t('runDetails.actions.export', { defaultValue: 'Export' })}
               </Button>
             )}
             {canRetry && (
-              <Button id="workflow-run-retry" variant="outline" onClick={() => setConfirmAction('retry')}>
+              <Button id="workflow-run-retry" variant="outline" size="sm" onClick={() => setConfirmAction('retry')}>
                 <RotateCcw className="h-4 w-4 mr-2" />
                 {t('runDetails.actions.retry', { defaultValue: 'Retry' })}
               </Button>
             )}
             {canReplay && (
-              <Button id="workflow-run-replay" variant="outline" onClick={() => setConfirmAction('replay')}>
+              <Button id="workflow-run-replay" variant="outline" size="sm" onClick={() => setConfirmAction('replay')}>
                 <Repeat className="h-4 w-4 mr-2" />
                 {t('runDetails.actions.replay', { defaultValue: 'Replay' })}
               </Button>
             )}
             {canRequeue && (
-              <Button id="workflow-run-requeue" variant="outline" onClick={() => setConfirmAction('requeue')}>
+              <Button id="workflow-run-requeue" variant="outline" size="sm" onClick={() => setConfirmAction('requeue')}>
                 <RefreshCw className="h-4 w-4 mr-2" />
                 {t('runDetails.actions.requeueEvent', { defaultValue: 'Requeue Event' })}
               </Button>
             )}
             {onClose && (
-              <Button id="workflow-run-close" variant="ghost" onClick={onClose}>
+              <Button id="workflow-run-close" variant="ghost" size="sm" onClick={onClose}>
                 {t('runDetails.actions.close', { defaultValue: 'Close' })}
               </Button>
             )}
@@ -980,7 +1209,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
       </Card>
 
       <Card className="p-4">
-        <div className="flex items-center justify-between mb-3">
+        <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
           <div>
             <div className="text-sm font-semibold text-gray-800">
               {t('runDetails.stepTimeline.title', { defaultValue: 'Step Timeline' })}
@@ -997,8 +1226,8 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
             </span>
           )}
         </div>
-        <div className="flex flex-wrap items-center gap-4 mb-4">
-          <div className="min-w-[180px]">
+        <div className="mb-4 grid grid-cols-1 items-end gap-4 md:grid-cols-[minmax(180px,220px)_minmax(220px,280px)]">
+          <div>
             <CustomSelect
               id="workflow-run-step-status-filter"
               label={t('runDetails.stepTimeline.stepStatusLabel', { defaultValue: 'Step status' })}
@@ -1007,7 +1236,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
               onValueChange={setStepStatusFilter}
             />
           </div>
-          <div className="min-w-[220px]">
+          <div>
             <CustomSelect
               id="workflow-run-step-type-filter"
               label={t('runDetails.stepTimeline.nodeTypeLabel', { defaultValue: 'Node type' })}
@@ -1016,74 +1245,41 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
               onValueChange={setStepTypeFilter}
             />
           </div>
-          <Switch
-            id="workflow-run-collapse-nested"
-            checked={collapseNested}
-            onCheckedChange={setCollapseNested}
-            label={t('runDetails.stepTimeline.collapseNestedLabel', {
-              defaultValue: 'Collapse nested blocks',
-            })}
-          />
+          <div className="md:col-span-2">
+            <Switch
+              id="workflow-run-collapse-nested"
+              checked={collapseNested}
+              onCheckedChange={setCollapseNested}
+              label={t('runDetails.stepTimeline.collapseNestedLabel', {
+                defaultValue: 'Collapse nested blocks',
+              })}
+            />
+          </div>
         </div>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>{t('runDetails.stepTimeline.columns.stepPath', { defaultValue: 'Step Path' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.type', { defaultValue: 'Type' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.status', { defaultValue: 'Status' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.attempt', { defaultValue: 'Attempt' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.duration', { defaultValue: 'Duration' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.nextRetry', { defaultValue: 'Next Retry' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.started', { defaultValue: 'Started' })}</TableHead>
-              <TableHead>{t('runDetails.stepTimeline.columns.error', { defaultValue: 'Error' })}</TableHead>
-              <TableHead></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {filteredSteps.map((step) => (
-              <TableRow
-                key={step.step_id}
-                data-state={selectedStepPath === step.step_path ? 'selected' : undefined}
-              >
-                <TableCell className="font-mono text-xs">{step.step_path}</TableCell>
-                <TableCell className="text-xs text-gray-500">
-                  {stepTypeById.get(step.definition_step_id) ?? emptyValueLabel}
-                </TableCell>
-                <TableCell>
-                  <Badge className={STATUS_STYLES[step.status] ?? 'bg-gray-100 text-gray-600'}>
-                    {formatWorkflowStepStatus(step.status)}
-                  </Badge>
-                </TableCell>
-                <TableCell>{step.attempt}</TableCell>
-                <TableCell>{formatDurationMs(step.duration_ms)}</TableCell>
-                <TableCell className="text-xs text-gray-500">
-                  {formatDateTime(retryWaitsByStep.get(step.step_path)?.timeout_at ?? null)}
-                </TableCell>
-                <TableCell>{formatDateTime(step.started_at)}</TableCell>
-                <TableCell className="text-xs text-destructive">
-                  {(step.error_json as any)?.message ?? emptyValueLabel}
-                </TableCell>
-                <TableCell>
-                  <Button
-                    id={`workflow-run-step-${step.step_id}`}
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setSelectedStepPath(step.step_path)}
-                  >
-                    {t('runDetails.actions.view', { defaultValue: 'View' })}
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-            {!isLoading && filteredSteps.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={stepColumnCount} className="text-center text-sm text-gray-500 py-6">
-                  {t('runDetails.stepTimeline.empty', { defaultValue: 'No step history yet.' })}
-                </TableCell>
-              </TableRow>
+        {isLoading && filteredSteps.length === 0 && (
+          <div className="py-2 text-sm text-gray-500">
+            {t('runDetails.stepTimeline.loading', { defaultValue: 'Loading...' })}
+          </div>
+        )}
+        {!isLoading && filteredSteps.length === 0 && (
+          <div className="py-6 text-center text-sm text-gray-500">
+            {t('runDetails.stepTimeline.empty', { defaultValue: 'No step history yet.' })}
+          </div>
+        )}
+        {filteredSteps.length > 0 && (
+          <DataTable
+            id="workflow-run-step-timeline"
+            data={filteredSteps}
+            columns={stepTimelineColumns}
+            pagination={false}
+            pageSize={Math.max(filteredSteps.length, 1)}
+            initialSorting={[{ id: 'started_at', desc: false }]}
+            onRowClick={(step) => setSelectedStepPath(step.step_path)}
+            rowClassName={(step) => (
+              step.step_path === selectedStepPath ? 'bg-table-selected' : ''
             )}
-          </TableBody>
-        </Table>
+          />
+        )}
       </Card>
 
       {selectedStep && (
@@ -1369,7 +1565,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 defaultValue: 'Operational log events for this run.',
               })}
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
+            <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-[minmax(12rem,1fr)_minmax(12rem,14rem)]">
               <Input
                 id="workflow-run-logs-search"
                 label={t('runDetails.logs.searchLabel', { defaultValue: 'Search' })}
@@ -1386,7 +1582,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 value={logFilters.level}
                 onValueChange={(value) => setLogFilters((prev) => ({ ...prev, level: value }))}
               />
-              <div className="flex items-end gap-2">
+              <div className="flex flex-wrap items-center gap-2 lg:col-span-2 lg:justify-end">
                 <Button id="workflow-run-logs-apply" onClick={handleApplyLogFilters} disabled={logLoading}>
                   {t('runDetails.actions.apply', { defaultValue: 'Apply' })}
                 </Button>
@@ -1407,49 +1603,25 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 </Button>
               </div>
             </div>
-            <div className="mt-4 max-w-full overflow-x-auto">
-              <Table className="min-w-[960px]">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t('runDetails.logs.columns.timestamp', { defaultValue: 'Timestamp' })}</TableHead>
-                    <TableHead>{t('runDetails.logs.columns.level', { defaultValue: 'Level' })}</TableHead>
-                    <TableHead>{t('runDetails.logs.columns.message', { defaultValue: 'Message' })}</TableHead>
-                    <TableHead>{t('runDetails.logs.columns.step', { defaultValue: 'Step' })}</TableHead>
-                    <TableHead>{t('runDetails.logs.columns.event', { defaultValue: 'Event' })}</TableHead>
-                    <TableHead>{t('runDetails.logs.columns.correlation', { defaultValue: 'Correlation' })}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {logs.map((log) => (
-                    <TableRow key={log.log_id}>
-                      <TableCell className="whitespace-nowrap text-xs text-gray-500">{formatDateTime(log.created_at)}</TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <Badge className={STATUS_STYLES[log.level] ?? 'bg-gray-100 text-gray-600'}>
-                          {formatWorkflowLogLevel(log.level)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="max-w-[28rem] min-w-[18rem]">
-                        <div className="text-sm text-gray-800 break-words">{log.message}</div>
-                        {log.context_json && (
-                          <pre className="mt-1 max-h-24 max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-gray-900 text-gray-100 text-xs p-2">
-                            {truncateJsonPreview(log.context_json, 2000).preview}
-                          </pre>
-                        )}
-                      </TableCell>
-                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.step_path ?? emptyValueLabel}</TableCell>
-                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.event_name ?? emptyValueLabel}</TableCell>
-                      <TableCell className="max-w-[12rem] break-all text-xs text-gray-500">{log.correlation_key ?? emptyValueLabel}</TableCell>
-                    </TableRow>
-                  ))}
-                  {!logLoading && logs.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={6} className="text-center text-sm text-gray-500 py-6">
-                        {noLogEntriesLabel}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
+            <div className="mt-4">
+              {logLoading && logs.length === 0 && (
+                <div className="py-2 text-sm text-gray-500">
+                  {t('runDetails.logs.loading', { defaultValue: 'Loading logs...' })}
+                </div>
+              )}
+              {!logLoading && logs.length === 0 && (
+                <div className="py-6 text-center text-sm text-gray-500">{noLogEntriesLabel}</div>
+              )}
+              {logs.length > 0 && (
+                <DataTable
+                  id="workflow-run-logs-table"
+                  data={logs}
+                  columns={logColumns}
+                  pagination={false}
+                  pageSize={Math.max(logs.length, 1)}
+                  initialSorting={[{ id: 'created_at', desc: true }]}
+                />
+              )}
               {logCursor !== null && (
                 <div className="flex justify-center mt-3">
                   <Button
@@ -1475,7 +1647,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                   defaultValue: 'Administrative actions for this run.',
                 })}
               </div>
-              <div className="flex items-center gap-2 mt-2">
+              <div className="mt-2 flex flex-wrap items-center gap-2">
                 <Button
                   id="workflow-run-audit-export"
                   variant="outline"
@@ -1485,41 +1657,24 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
                 </Button>
               </div>
               <div className="mt-3">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>{t('runDetails.audit.columns.timestamp', { defaultValue: 'Timestamp' })}</TableHead>
-                      <TableHead>{t('runDetails.audit.columns.operation', { defaultValue: 'Operation' })}</TableHead>
-                      <TableHead>{t('runDetails.audit.columns.user', { defaultValue: 'User' })}</TableHead>
-                      <TableHead>{t('runDetails.audit.columns.details', { defaultValue: 'Details' })}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {auditLogs.map((log) => (
-                      <TableRow key={log.audit_id}>
-                        <TableCell className="text-xs text-gray-500">{formatDateTime(log.timestamp)}</TableCell>
-                        <TableCell className="text-xs text-gray-700">{log.operation}</TableCell>
-                        <TableCell className="text-xs text-gray-500">
-                          {log.user_id ?? t('runDetails.audit.systemUser', { defaultValue: 'system' })}
-                        </TableCell>
-                        <TableCell>
-                          {log.details ? (
-                            <pre className="max-h-24 overflow-auto rounded bg-gray-900 text-gray-100 text-xs p-2">
-                              {truncateJsonPreview(log.details, 2000).preview}
-                            </pre>
-                          ) : emptyValueLabel}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    {!auditLoading && auditLogs.length === 0 && (
-                      <TableRow>
-                        <TableCell colSpan={4} className="text-center text-sm text-gray-500 py-6">
-                          {noAuditEntriesLabel}
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
+                {auditLoading && auditLogs.length === 0 && (
+                  <div className="py-2 text-sm text-gray-500">
+                    {t('runDetails.audit.loading', { defaultValue: 'Loading audit trail...' })}
+                  </div>
+                )}
+                {!auditLoading && auditLogs.length === 0 && (
+                  <div className="py-6 text-center text-sm text-gray-500">{noAuditEntriesLabel}</div>
+                )}
+                {auditLogs.length > 0 && (
+                  <DataTable
+                    id="workflow-run-audit-trail"
+                    data={auditLogs}
+                    columns={auditColumns}
+                    pagination={false}
+                    pageSize={Math.max(auditLogs.length, 1)}
+                    initialSorting={[{ id: 'timestamp', desc: true }]}
+                  />
+                )}
                 {auditCursor !== null && (
                   <div className="flex justify-center mt-3">
                     <Button

--- a/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunDetails.tsx
@@ -785,6 +785,7 @@ const WorkflowRunDetails: React.FC<WorkflowRunDetailsProps> = ({
       title: t('runDetails.stepTimeline.columns.attempt', { defaultValue: 'Attempt' }),
       dataIndex: 'attempt',
       width: '100px',
+      render: (_value: unknown, step: WorkflowRunStepRecord) => step.attempt,
     },
     {
       title: t('runDetails.stepTimeline.columns.duration', { defaultValue: 'Duration' }),

--- a/ee/server/src/components/workflow-designer/WorkflowRunList.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowRunList.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { RefreshCw } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, RefreshCw } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Input } from '@alga-psa/ui/components/Input';
@@ -12,6 +12,7 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
+import Drawer from '@alga-psa/ui/components/Drawer';
 import WorkflowRunDialog from './WorkflowRunDialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@alga-psa/ui/components/Table';
 import { toast } from 'react-hot-toast';
@@ -257,6 +258,20 @@ const WorkflowRunList: React.FC<WorkflowRunListProps> = ({
     () => runs.filter((run) => selectedRunIds.has(run.run_id)),
     [runs, selectedRunIds]
   );
+  const selectedRunIndex = useMemo(
+    () => runs.findIndex((run) => run.run_id === selectedRunId),
+    [runs, selectedRunId]
+  );
+  const selectedRun = selectedRunIndex >= 0 ? runs[selectedRunIndex] : null;
+  const canSelectPreviousRun = selectedRunIndex > 0;
+  const canSelectNextRun = selectedRunIndex >= 0 && selectedRunIndex < runs.length - 1;
+  const handleSelectAdjacentRun = useCallback((direction: -1 | 1) => {
+    if (selectedRunIndex < 0) return;
+    const nextRun = runs[selectedRunIndex + direction];
+    if (nextRun) {
+      setSelectedRunId(nextRun.run_id);
+    }
+  }, [runs, selectedRunIndex]);
   const showSelection = canAdmin;
 
   const showTenantColumn = useMemo(() => {
@@ -907,7 +922,7 @@ const WorkflowRunList: React.FC<WorkflowRunListProps> = ({
                       size="sm"
                       onClick={() => setSelectedRunId(run.run_id)}
                     >
-                      {t('runList.actions.details', { defaultValue: 'Details' })}
+                      {t('runList.actions.preview', { defaultValue: 'Preview' })}
                     </Button>
                   </TableCell>
                 </TableRow>
@@ -944,20 +959,76 @@ const WorkflowRunList: React.FC<WorkflowRunListProps> = ({
           )}
         </Card>
 
+      </div>
+
+      <Drawer
+        id="workflow-run-preview-drawer"
+        isOpen={Boolean(selectedRunId)}
+        onClose={handleRunDetailsClose}
+        width="min(92vw, 1120px)"
+        hideCloseButton
+      >
         {selectedRunId && (
-          <Card className="p-4">
+          <div className="max-h-[calc(100vh-3rem)] min-w-0 space-y-4 overflow-y-auto pr-2">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[rgb(var(--color-border-200))] pb-4 pr-2">
+              <div>
+                <div className="text-sm font-semibold text-[rgb(var(--color-text-900))]">
+                  {t('runList.preview.title', { defaultValue: 'Run preview' })}
+                </div>
+                <div className="text-xs text-[rgb(var(--color-text-500))]">
+                  {selectedRun
+                    ? t('runList.preview.position', {
+                        defaultValue: '{{current}} of {{total}} loaded runs',
+                        current: selectedRunIndex + 1,
+                        total: runs.length,
+                      })
+                    : t('runList.preview.selectedRun', { defaultValue: 'Selected run' })}
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  id="workflow-run-preview-previous"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleSelectAdjacentRun(-1)}
+                  disabled={!canSelectPreviousRun}
+                >
+                  <ChevronLeft className="mr-1 h-4 w-4" />
+                  {t('runList.preview.previous', { defaultValue: 'Previous' })}
+                </Button>
+                <Button
+                  id="workflow-run-preview-next"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleSelectAdjacentRun(1)}
+                  disabled={!canSelectNextRun}
+                >
+                  {t('runList.preview.next', { defaultValue: 'Next' })}
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </Button>
+                <Button
+                  id="workflow-run-preview-open-full-page"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => window.location.assign(`/msp/workflows/runs/${selectedRunId}`)}
+                >
+                  <ExternalLink className="mr-1 h-4 w-4" />
+                  {t('runList.preview.openFullPage', { defaultValue: 'Open full page' })}
+                </Button>
+                <Button id="workflow-run-preview-close" variant="ghost" size="sm" onClick={handleRunDetailsClose}>
+                  {t('runList.preview.close', { defaultValue: 'Close' })}
+                </Button>
+              </div>
+            </div>
             <WorkflowRunDetails
               runId={selectedRunId}
-              workflowName={workflowNameMap.get(runs.find((run) => run.run_id === selectedRunId)?.workflow_id ?? '')}
-              workflowTrigger={workflowTriggerMap.get(
-                runs.find((run) => run.run_id === selectedRunId)?.workflow_id ?? ''
-              )}
+              workflowName={workflowNameMap.get(selectedRun?.workflow_id ?? '')}
+              workflowTrigger={workflowTriggerMap.get(selectedRun?.workflow_id ?? '')}
               canAdmin={canAdmin}
-              onClose={handleRunDetailsClose}
             />
-          </Card>
+          </div>
         )}
-      </div>
+      </Drawer>
 
       {showSelection && (
         <>

--- a/ee/server/src/components/workflow-run-studio/RunStudioShell.tsx
+++ b/ee/server/src/components/workflow-run-studio/RunStudioShell.tsx
@@ -2,217 +2,63 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@alga-psa/ui/components/Button';
 import { Card } from '@alga-psa/ui/components/Card';
 import { Badge } from '@alga-psa/ui/components/Badge';
-import { Button } from '@alga-psa/ui/components/Button';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@alga-psa/ui/components/Dialog';
-import { Input } from '@alga-psa/ui/components/Input';
-import { TextArea } from '@alga-psa/ui/components/TextArea';
-import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { mapWorkflowServerError } from '../workflow-designer/workflowServerErrors';
-import { RefreshCw } from 'lucide-react';
-import toast from 'react-hot-toast';
-import {
-  getWorkflowRunAction,
-  getWorkflowDefinitionVersionAction,
-  getWorkflowRunSummaryMetadataAction,
-  getWorkflowScheduleStateAction,
-  listWorkflowRunsAction,
-  listWorkflowRunLogsAction,
-  listWorkflowRunStepsAction,
-  listWorkflowRunTimelineEventsAction,
-  cancelWorkflowRunAction,
-  replayWorkflowRunAction
-} from '@alga-psa/workflows/actions';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getCurrentUserPermissions } from '@alga-psa/user-composition/actions';
+import {
+  getWorkflowDefinitionVersionAction,
+  getWorkflowRunAction,
+  listWorkflowRunsAction,
+  listWorkflowRunStepsAction,
+} from '@alga-psa/workflows/actions';
+import { useFormatWorkflowRunStatus } from '@alga-psa/workflows/hooks/useWorkflowEnumOptions';
+import { type NodeStep, type Step, type WorkflowDefinition } from '@alga-psa/workflows/runtime/client';
+import toast from 'react-hot-toast';
 import WorkflowGraph from '../workflow-graph/WorkflowGraph';
-import { type WorkflowDefinition, type Step } from '@alga-psa/workflows/runtime/client';
-import type { IfBlock, ForEachBlock, TryCatchBlock, NodeStep } from '@alga-psa/workflows/runtime/client';
-import {
-  PipelineStart,
-  PipelineConnector,
-  getStepTypeColor,
-  getStepTypeIcon
-} from '../workflow-designer/pipeline/PipelineComponents';
-import {
-  getWorkflowScheduleStatusBadgeClass,
-  isTimeTriggeredRun
-} from '../workflow-designer/workflowRunTriggerPresentation';
-import {
-  useFormatWorkflowRunTrigger,
-  useFormatWorkflowScheduleStatus,
-} from '../workflow-designer/useWorkflowRunTriggerPresentation';
-import { useFormatWorkflowLogLevel, useFormatWorkflowRunStatus } from '@alga-psa/workflows/hooks/useWorkflowEnumOptions';
-
-type WorkflowRunRecord = {
-  run_id: string;
-  workflow_id: string;
-  workflow_version: number;
-  tenant_id?: string | null;
-  status: string;
-  node_path?: string | null;
-  trigger_type?: 'event' | 'schedule' | 'recurring' | null;
-  trigger_metadata_json?: Record<string, unknown> | null;
-  event_type?: string | null;
-  input_json?: Record<string, unknown> | null;
-  resume_event_name?: string | null;
-  started_at: string;
-  updated_at: string;
-  completed_at?: string | null;
-};
-
-type WorkflowScheduleStateSummary = {
-  status?: 'scheduled' | 'paused' | 'disabled' | 'completed' | 'failed' | null;
-};
-
-type WorkflowRunSummary = {
-  workflow_name?: string | null;
-};
-
-type WorkflowRunStepRecord = {
-  step_id: string;
-  run_id: string;
-  step_path: string;
-  definition_step_id: string;
-  status: string;
-  attempt: number;
-  duration_ms?: number | null;
-  started_at: string;
-  completed_at?: string | null;
-};
-
-type WorkflowRunLogRecord = {
-  log_id: string;
-  level: string;
-  message: string;
-  step_path?: string | null;
-  created_at: string;
-};
-
-type WorkflowRunSnapshotRecord = {
-  snapshot_id: string;
-  run_id: string;
-  step_path: string;
-  envelope_json: Record<string, unknown>;
-  size_bytes: number;
-  created_at: string;
-};
-
-type WorkflowActionInvocationRecord = {
-  invocation_id: string;
-  run_id: string;
-  step_path: string;
-  action_id: string;
-  action_version: number;
-  idempotency_key: string;
-  status: string;
-  attempt: number;
-  input_json?: Record<string, unknown> | null;
-  output_json?: Record<string, unknown> | null;
-  error_message?: string | null;
-  created_at: string;
-  started_at?: string | null;
-  completed_at?: string | null;
-};
-
-type WorkflowRunSummaryMetadata = {
-  runId: string;
-  status: string;
-  workflowId: string;
-  workflowVersion: number;
-  startedAt: string;
-  completedAt?: string | null;
-  durationMs?: number | null;
-  stepsCount: number;
-  logsCount: number;
-  waitsCount: number;
-};
-
-type WorkflowRunTimelineEvent =
-  | {
-      type: 'step';
-      step_id: string;
-      step_path: string;
-      definition_step_id: string;
-      status: string;
-      attempt: number;
-      duration_ms?: number | null;
-      started_at: string;
-      completed_at?: string | null;
-      timestamp: string;
-    }
-  | {
-      type: 'wait';
-      wait_id: string;
-      step_path: string;
-      wait_type: string;
-      status: string;
-      event_name?: string | null;
-      key?: string | null;
-      timeout_at?: string | null;
-      created_at: string;
-      resolved_at?: string | null;
-      timestamp: string;
-    };
-
-type RunStudioShellProps = {
-  runId: string;
-};
+import WorkflowRunDetails from '../workflow-designer/WorkflowRunDetails';
 
 const statusBadgeClasses: Record<string, string> = {
   RUNNING: 'bg-cyan-500/15 text-cyan-600 border-cyan-500/30',
   WAITING: 'bg-yellow-500/15 text-yellow-600 border-yellow-500/30',
   SUCCEEDED: 'bg-green-500/15 text-green-600 border-green-500/30',
   FAILED: 'bg-red-500/15 text-red-600 border-red-500/30',
-  CANCELED: 'bg-gray-500/15 text-gray-600 border-gray-500/30'
+  CANCELED: 'bg-gray-500/15 text-gray-600 border-gray-500/30',
+};
+
+type RunStudioShellProps = {
+  runId: string;
+};
+
+type WorkflowRunRecord = {
+  run_id: string;
+  workflow_id: string;
+  workflow_version: number;
+  status: string;
+};
+
+type WorkflowRunStepRecord = {
+  step_id: string;
+  step_path: string;
+  definition_step_id: string;
+  status: string;
+  started_at: string;
 };
 
 const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
   const { t } = useTranslation('msp/workflows');
-  const { formatDate } = useFormatters();
   const formatWorkflowRunStatus = useFormatWorkflowRunStatus();
-  const formatWorkflowLogLevel = useFormatWorkflowLogLevel();
-  const formatWorkflowRunTrigger = useFormatWorkflowRunTrigger();
-  const formatWorkflowScheduleStatus = useFormatWorkflowScheduleStatus();
-  const formatDateTime = useCallback(
-    (value: Date | string) => {
-      const date = value instanceof Date ? value : new Date(value);
-      return formatDate(date, { dateStyle: 'medium', timeStyle: 'short' });
-    },
-    [formatDate]
-  );
-  const formatTimeOnly = useCallback(
-    (value: Date | string) => {
-      const date = value instanceof Date ? value : new Date(value);
-      return formatDate(date, { timeStyle: 'medium' });
-    },
-    [formatDate]
-  );
   const [run, setRun] = useState<WorkflowRunRecord | null>(null);
-  const [scheduleState, setScheduleState] = useState<WorkflowScheduleStateSummary | null>(null);
+  const [workflowName, setWorkflowName] = useState<string | undefined>(undefined);
   const [definition, setDefinition] = useState<WorkflowDefinition | null>(null);
-  const [runSummary, setRunSummary] = useState<WorkflowRunSummary | null>(null);
-  const [summaryMetadata, setSummaryMetadata] = useState<WorkflowRunSummaryMetadata | null>(null);
   const [steps, setSteps] = useState<WorkflowRunStepRecord[]>([]);
-  const [logs, setLogs] = useState<WorkflowRunLogRecord[]>([]);
-  const [snapshots, setSnapshots] = useState<WorkflowRunSnapshotRecord[]>([]);
-  const [invocations, setInvocations] = useState<WorkflowActionInvocationRecord[]>([]);
-  const [timelineEvents, setTimelineEvents] = useState<WorkflowRunTimelineEvent[]>([]);
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
-  const [userPermissions, setUserPermissions] = useState<string[]>([]);
-  const [runActionMode, setRunActionMode] = useState<'cancel' | 'replay' | null>(null);
-  const [runActionReason, setRunActionReason] = useState('');
-  const [replayPayloadText, setReplayPayloadText] = useState('');
-  const [replayPayloadError, setReplayPayloadError] = useState<string | null>(null);
-  const [isSubmittingAction, setIsSubmittingAction] = useState(false);
-  const [logSearch, setLogSearch] = useState('');
-  const [logLevelFilters, setLogLevelFilters] = useState<string[]>([]);
-  const [timelineSearch, setTimelineSearch] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [polling, setPolling] = useState(false);
-  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
-  const [now, setNow] = useState<Date>(new Date());
   const [pipelineViewMode, setPipelineViewMode] = useState<'graph' | 'list'>('graph');
+  const [canAdmin, setCanAdmin] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<Date | null>(null);
 
   useEffect(() => {
     try {
@@ -229,141 +75,13 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
     } catch {}
   }, [pipelineViewMode]);
 
-  const fetchRun = async () => {
-    setLoading(true);
-    try {
-      const data = await getWorkflowRunAction({ runId });
-      setRun(data as WorkflowRunRecord);
-      try {
-        if (data?.workflow_id) {
-          const nextScheduleState = await getWorkflowScheduleStateAction({ workflowId: data.workflow_id });
-          setScheduleState((nextScheduleState ?? null) as WorkflowScheduleStateSummary | null);
-        } else {
-          setScheduleState(null);
-        }
-      } catch {
-        setScheduleState(null);
-      }
-      try {
-        const runResult = await listWorkflowRunsAction({ runId, limit: 1, cursor: 0 });
-        setRunSummary((runResult?.runs?.[0] ?? null) as WorkflowRunSummary | null);
-      } catch {
-        setRunSummary(null);
-      }
-      if (data?.workflow_id && data?.workflow_version) {
-        const version = await getWorkflowDefinitionVersionAction({
-          workflowId: data.workflow_id,
-          version: data.workflow_version
-        });
-        setDefinition((version?.definition_json ?? null) as WorkflowDefinition | null);
-      }
-      try {
-        const summary = await getWorkflowRunSummaryMetadataAction({ runId });
-        setSummaryMetadata(summary as WorkflowRunSummaryMetadata);
-      } catch {
-        setSummaryMetadata(null);
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchStepsAndLogs = async () => {
-    try {
-      const stepResult = await listWorkflowRunStepsAction({ runId });
-      setSteps(stepResult.steps ?? []);
-      setSnapshots(stepResult.snapshots ?? []);
-      setInvocations(stepResult.invocations ?? []);
-      const timelineResult = await listWorkflowRunTimelineEventsAction({ runId });
-      setTimelineEvents((timelineResult as { events?: WorkflowRunTimelineEvent[] } | null)?.events ?? []);
-      const logResult = await listWorkflowRunLogsAction({ runId, limit: 200, cursor: 0 });
-      setLogs(logResult.logs ?? []);
-      setLastUpdatedAt(new Date());
-    } catch {
-      // ignore for now
-    }
-  };
-
-  useEffect(() => {
-    fetchRun();
-    fetchStepsAndLogs();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runId]);
-
-  const triggerLabel = useMemo(
-    () => formatWorkflowRunTrigger(run?.trigger_type ?? null, run?.event_type ?? null),
-    [formatWorkflowRunTrigger, run?.event_type, run?.trigger_type]
-  );
-  const triggerMetadata = (run?.trigger_metadata_json ?? null) as Record<string, unknown> | null;
-
   useEffect(() => {
     getCurrentUserPermissions()
-      .then((perms) => setUserPermissions(perms ?? []))
-      .catch(() => setUserPermissions([]));
+      .then((permissions) => setCanAdmin((permissions ?? []).includes('workflow:admin')))
+      .catch(() => setCanAdmin(false));
   }, []);
 
-  useEffect(() => {
-    if (!run) return;
-    const shouldPoll = run.status === 'RUNNING' || run.status === 'WAITING';
-    if (!shouldPoll) return;
-    setPolling(true);
-    const interval = setInterval(() => {
-      fetchRun();
-      fetchStepsAndLogs();
-    }, 4000);
-    return () => {
-      clearInterval(interval);
-      setPolling(false);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [run?.status, runId]);
-
-  useEffect(() => {
-    if (!run || (run.status !== 'RUNNING' && run.status !== 'WAITING')) return;
-    const tick = setInterval(() => setNow(new Date()), 1000);
-    return () => clearInterval(tick);
-  }, [run?.status]);
-
-  const status = run?.status ?? 'UNKNOWN';
-  const badgeClass = statusBadgeClasses[status] ?? 'bg-gray-500/15 text-gray-600 border-gray-500/30';
-
-  const stepStatusMap = useMemo(() => {
-    const map = new Map<string, WorkflowRunStepRecord>();
-    for (const step of steps) {
-      const existing = map.get(step.definition_step_id);
-      if (!existing) {
-        map.set(step.definition_step_id, step);
-        continue;
-      }
-      if (new Date(step.started_at).getTime() > new Date(existing.started_at).getTime()) {
-        map.set(step.definition_step_id, step);
-      }
-    }
-    return map;
-  }, [steps]);
-
-  const stepStatusById = useMemo(() => {
-    const map = new Map<string, string>();
-    stepStatusMap.forEach((record, stepId) => {
-      map.set(stepId, record.status);
-    });
-    return map;
-  }, [stepStatusMap]);
-
-  const orderedSteps = useMemo(() => {
-    if (!definition?.steps) return [] as Step[];
-    return definition.steps as Step[];
-  }, [definition]);
-
-  const definitionStepMap = useMemo(() => {
-    const map = new Map<string, Step>();
-    for (const step of orderedSteps) {
-      map.set(step.id, step);
-    }
-    return map;
-  }, [orderedSteps]);
-
-  const getStepLabel = (step: Step): string => {
+  const getStepLabel = useCallback((step: Step): string => {
     if (step.type === 'action.call') {
       const config = (step as NodeStep).config as { actionId?: string } | undefined;
       return config?.actionId
@@ -395,596 +113,162 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
       return t('runStudio.stepLabels.assign', { defaultValue: 'Assign' });
     }
     return step.id;
-  };
+  }, [t]);
 
-  const stepPathMap = useMemo(() => {
-    const map = new Map<string, string>();
+  const fetchStudioContext = useCallback(async (showLoading = true) => {
+    if (showLoading) {
+      setIsLoading(true);
+    }
+    try {
+      const [runData, stepData, runListData] = await Promise.all([
+        getWorkflowRunAction({ runId }),
+        listWorkflowRunStepsAction({ runId }),
+        listWorkflowRunsAction({ runId, limit: 1, cursor: 0 }),
+      ]);
+      const nextRun = runData as WorkflowRunRecord;
+      setRun(nextRun);
+      setSteps((stepData.steps ?? []) as WorkflowRunStepRecord[]);
+      setWorkflowName((runListData?.runs?.[0]?.workflow_name ?? undefined) as string | undefined);
+
+      if (nextRun?.workflow_id && nextRun?.workflow_version) {
+        const version = await getWorkflowDefinitionVersionAction({
+          workflowId: nextRun.workflow_id,
+          version: nextRun.workflow_version,
+        });
+        setDefinition((version?.definition_json ?? null) as WorkflowDefinition | null);
+      } else {
+        setDefinition(null);
+      }
+      setLastRefreshedAt(new Date());
+    } catch (error) {
+      toast.error(t('runStudio.toasts.loadFailed', { defaultValue: 'Failed to load run studio' }));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [runId, t]);
+
+  useEffect(() => {
+    fetchStudioContext();
+  }, [fetchStudioContext]);
+
+  useEffect(() => {
+    if (!run || (run.status !== 'RUNNING' && run.status !== 'WAITING')) return;
+    const interval = window.setInterval(() => {
+      fetchStudioContext(false);
+    }, 4000);
+    return () => window.clearInterval(interval);
+  }, [fetchStudioContext, run]);
+
+  const orderedSteps = useMemo(() => {
+    return (definition?.steps ?? []) as Step[];
+  }, [definition]);
+
+  const stepStatusById = useMemo(() => {
+    const latestByDefinitionId = new Map<string, WorkflowRunStepRecord>();
     for (const step of steps) {
-      const existing = map.get(step.definition_step_id);
-      if (!existing) {
-        map.set(step.definition_step_id, step.step_path);
-        continue;
-      }
-      const prev = steps.find((item) => item.step_path === existing);
-      if (!prev) {
-        map.set(step.definition_step_id, step.step_path);
-        continue;
-      }
-      if (new Date(step.started_at).getTime() > new Date(prev.started_at).getTime()) {
-        map.set(step.definition_step_id, step.step_path);
+      const existing = latestByDefinitionId.get(step.definition_step_id);
+      if (!existing || new Date(step.started_at).getTime() > new Date(existing.started_at).getTime()) {
+        latestByDefinitionId.set(step.definition_step_id, step);
       }
     }
-    return map;
-  }, [steps]);
 
-  const stepPathToDefinitionId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const step of steps) {
-      if (!map.has(step.step_path)) {
-        map.set(step.step_path, step.definition_step_id);
-      }
-    }
-    return map;
+    const statuses = new Map<string, string>();
+    latestByDefinitionId.forEach((step, definitionStepId) => {
+      statuses.set(definitionStepId, step.status);
+    });
+    return statuses;
   }, [steps]);
 
   const selectedStep = useMemo(() => {
-    if (!selectedStepId || !definition?.steps) return null;
-    return (definition.steps as Step[]).find((step) => step.id === selectedStepId) ?? null;
-  }, [definition?.steps, selectedStepId]);
+    if (!selectedStepId) return null;
+    return orderedSteps.find((step) => step.id === selectedStepId) ?? null;
+  }, [orderedSteps, selectedStepId]);
 
-  const selectedStepPath = selectedStepId ? stepPathMap.get(selectedStepId) ?? null : null;
-
-  const selectedSnapshot = useMemo(() => {
-    if (!selectedStepPath) return null;
-    const matching = snapshots.filter((snapshot) => snapshot.step_path === selectedStepPath);
-    return matching.length ? matching[matching.length - 1] : null;
-  }, [snapshots, selectedStepPath]);
-
-  const selectedInvocation = useMemo(() => {
-    if (!selectedStepPath) return null;
-    const matching = invocations.filter((invocation) => invocation.step_path === selectedStepPath);
-    return matching.length ? matching[matching.length - 1] : null;
-  }, [invocations, selectedStepPath]);
-
-  const timelineEntries = useMemo(() => {
-    const search = timelineSearch.trim().toLowerCase();
-    const stepGroups = new Map<string, WorkflowRunTimelineEvent[]>();
-    const waitEntries = [] as Array<{
-      kind: 'wait';
-      stepPath: string;
-      stepId: string | null;
-      waitType: string;
-      status: string;
-      createdAt: string;
-      resolvedAt?: string | null;
-      eventName?: string | null;
-      key?: string | null;
-    }>;
-
-    timelineEvents.forEach((event) => {
-      if (event.type === 'wait') {
-        waitEntries.push({
-          kind: 'wait',
-          stepPath: event.step_path,
-          stepId: stepPathToDefinitionId.get(event.step_path) ?? null,
-          waitType: event.wait_type,
-          status: event.status,
-          createdAt: event.created_at,
-          resolvedAt: event.resolved_at ?? null,
-          eventName: event.event_name ?? null,
-          key: event.key ?? null
-        });
-        return;
-      }
-      if (!stepGroups.has(event.step_path)) {
-        stepGroups.set(event.step_path, []);
-      }
-      stepGroups.get(event.step_path)!.push(event);
-    });
-
-    const stepEntries = Array.from(stepGroups.entries()).map(([stepPath, attempts]) => {
-      const sorted = [...attempts].sort((a, b) => (a as any).attempt - (b as any).attempt);
-      const first = sorted[0] as Extract<WorkflowRunTimelineEvent, { type: 'step' }>;
-      const last = sorted[sorted.length - 1] as Extract<WorkflowRunTimelineEvent, { type: 'step' }>;
-      const stepId = first.definition_step_id ?? stepPathToDefinitionId.get(stepPath) ?? null;
-      const label = stepId && definitionStepMap.get(stepId)
-        ? getStepLabel(definitionStepMap.get(stepId) as Step)
-        : stepPath;
-      return {
-        kind: 'step' as const,
-        stepPath,
-        stepId,
-        label,
-        status: last.status,
-        startedAt: first.started_at,
-        attempts: sorted as Extract<WorkflowRunTimelineEvent, { type: 'step' }>[]
-      };
-    });
-
-    const combined = [...stepEntries, ...waitEntries].sort((a, b) => {
-      const aTime = a.kind === 'step' ? new Date(a.startedAt).getTime() : new Date(a.createdAt).getTime();
-      const bTime = b.kind === 'step' ? new Date(b.startedAt).getTime() : new Date(b.createdAt).getTime();
-      return aTime - bTime;
-    });
-
-    if (!search) return combined;
-    return combined.filter((entry) => {
-      if (entry.kind === 'step') {
-        const haystack = `${entry.stepPath} ${entry.status}`.toLowerCase();
-        return haystack.includes(search);
-      }
-      const haystack = `${entry.stepPath} ${entry.waitType} ${entry.status} ${entry.eventName ?? ''} ${entry.key ?? ''}`.toLowerCase();
-      return haystack.includes(search);
-    });
-  }, [definitionStepMap, stepPathToDefinitionId, timelineEvents, timelineSearch]);
-
-  const getStepStatusStyle = (record?: WorkflowRunStepRecord) => {
-    if (!record) {
-      return {
-        badge: {
-          label: t('runStudio.status.pending', { defaultValue: 'Pending' }),
-          className: 'bg-gray-500/15 text-gray-600 border-gray-500/30'
-        },
-        card: 'border-gray-200',
-        pulse: false,
-        stripe: false,
-        timestamp: null
-      };
-    }
-    const timestamp = record.completed_at ?? record.started_at;
-    switch (record.status) {
-      case 'STARTED':
-        return {
-          badge: {
-            label: t('runStudio.status.running', { defaultValue: 'Running' }),
-            className: 'bg-cyan-500/15 text-cyan-600 border-cyan-500/30'
-          },
-          card: 'border-cyan-500/30 ring-2 ring-cyan-500/30',
-          pulse: true,
-          stripe: false,
-          timestamp
-        };
-      case 'SUCCEEDED':
-        return {
-          badge: {
-            label: t('runStudio.status.succeeded', { defaultValue: 'Succeeded' }),
-            className: 'bg-green-500/15 text-green-600 border-green-500/30'
-          },
-          card: 'border-green-500/30 ring-1 ring-green-500/30',
-          pulse: false,
-          stripe: false,
-          timestamp
-        };
-      case 'FAILED':
-        return {
-          badge: {
-            label: t('runStudio.status.failed', { defaultValue: 'Failed' }),
-            className: 'bg-red-500/15 text-red-600 border-red-500/30'
-          },
-          card: 'border-red-500/30 ring-2 ring-red-500/30',
-          pulse: false,
-          stripe: false,
-          timestamp
-        };
-      case 'RETRY_SCHEDULED':
-        return {
-          badge: {
-            label: t('runStudio.status.retrying', { defaultValue: 'Retrying' }),
-            className: 'bg-yellow-500/15 text-yellow-600 border-yellow-500/30'
-          },
-          card: 'border-yellow-500/30 ring-1 ring-yellow-500/30',
-          pulse: false,
-          stripe: true,
-          timestamp
-        };
-      case 'CANCELED':
-        return {
-          badge: {
-            label: t('runStudio.status.canceled', { defaultValue: 'Canceled' }),
-            className: 'bg-gray-500/15 text-gray-600 border-gray-500/30'
-          },
-          card: 'border-gray-200',
-          pulse: false,
-          stripe: false,
-          timestamp
-        };
-      default:
-        return {
-          badge: { label: record.status, className: 'bg-gray-500/15 text-gray-600 border-gray-500/30' },
-          card: 'border-gray-200',
-          pulse: false,
-          stripe: false,
-          timestamp
-        };
-    }
-  };
-
-  const renderPipe = (pipeSteps: Step[], pipePath: string, isRoot: boolean) => {
-    return (
-      <div data-pipe-path={pipePath} className="flex flex-col items-stretch">
-        {isRoot && pipeSteps.length > 0 && (
-          <div className="flex flex-col items-center mb-2">
-            <PipelineStart />
-            <PipelineConnector position="start" />
-          </div>
-        )}
-        {pipeSteps.length === 0 && (
-          <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-4 text-xs text-gray-500">
-            {t('runStudio.pipeline.emptyBranch', { defaultValue: 'No steps in this branch.' })}
-          </div>
-        )}
-        {pipeSteps.map((step, index) => (
-          <React.Fragment key={step.id}>
-            {renderStepCard(step, `${pipePath}.steps[${index}]`)}
-            {index < pipeSteps.length - 1 && (
-              <div className="flex justify-center">
-                <PipelineConnector position="middle" />
-              </div>
-            )}
-          </React.Fragment>
-        ))}
-        {pipeSteps.length > 0 && (
-          <div className="flex justify-center">
-            <PipelineConnector position="end" />
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  const renderStepCard = (step: Step, stepPath: string) => {
-    const colors = getStepTypeColor(step.type);
-    const icon = getStepTypeIcon(step.type);
-    const record = stepStatusMap.get(step.id);
-    const statusInfo = getStepStatusStyle(record);
-    const timestampLabel = statusInfo.timestamp
-      ? formatDateTime(statusInfo.timestamp)
-      : t('runStudio.status.pending', { defaultValue: 'Pending' });
-    const title = t('runStudio.stepCard.lastStatus', {
-      defaultValue: 'Last status: {{status}} ({{timestamp}})',
-      status: statusInfo.badge.label,
-      timestamp: timestampLabel,
-    });
-    const isSelected = selectedStepId === step.id;
-
-    const stripeStyle = statusInfo.stripe
-      ? {
-        backgroundImage:
-          'repeating-linear-gradient(135deg, rgba(252, 211, 77, 0.25), rgba(252, 211, 77, 0.25) 6px, transparent 6px, transparent 12px)'
-      }
-      : undefined;
-
-    return (
-      <Card
-        key={step.id}
-        title={title}
-        style={stripeStyle}
-        className={`p-3 border-l-4 ${colors.border} border-r border-t border-b ${statusInfo.card} ${
-          statusInfo.pulse ? 'animate-pulse' : ''
-        } ${isSelected ? 'ring-2 ring-primary-300' : ''} transition-all cursor-pointer`}
-        data-testid={`run-step-card-${step.id}`}
-        onClick={() => setSelectedStepId(step.id)}
-      >
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <div className={`flex-shrink-0 ${colors.icon}`}>{icon}</div>
-              <span className="text-sm font-medium text-gray-900 truncate">{getStepLabel(step)}</span>
-              {step.type.startsWith('control.') && (
-                <Badge className={`text-xs ${colors.badge}`}>
-                  {step.type === 'control.if'
-                    ? t('runStudio.stepCard.badges.if', { defaultValue: 'If' })
-                    : step.type === 'control.forEach'
-                      ? t('runStudio.stepCard.badges.loop', { defaultValue: 'Loop' })
-                      : step.type === 'control.tryCatch'
-                        ? t('runStudio.stepCard.badges.try', { defaultValue: 'Try' })
-                        : t('runStudio.stepCard.badges.block', { defaultValue: 'Block' })}
-                </Badge>
-              )}
-            </div>
-            <div className="text-xs text-gray-500 mt-1">{step.type}</div>
-          </div>
-          <div className="flex items-center gap-2">
-            {record?.attempt && record.attempt > 1 && (
-              <Badge variant="warning" className="text-xs">
-                {t('runStudio.stepCard.attempt', {
-                  defaultValue: 'Attempt {{attempt}}',
-                  attempt: record.attempt,
-                })}
-              </Badge>
-            )}
-            <Badge className={statusInfo.badge.className}>{statusInfo.badge.label}</Badge>
-          </div>
-        </div>
-
-        {step.type === 'control.if' && (() => {
-          const ifStep = step as IfBlock;
-          const thenPath = `${stepPath}.then`;
-          const elsePath = `${stepPath}.else`;
-          return (
-            <div className="mt-3 space-y-2">
-              <RunBlockSection title={t('runStudio.stepCard.sections.then', { defaultValue: 'THEN' })}>
-                {renderPipe(ifStep.then, thenPath, false)}
-              </RunBlockSection>
-              <RunBlockSection title={t('runStudio.stepCard.sections.else', { defaultValue: 'ELSE' })}>
-                {renderPipe(ifStep.else ?? [], elsePath, false)}
-              </RunBlockSection>
-            </div>
-          );
-        })()}
-
-        {step.type === 'control.tryCatch' && (() => {
-          const tcStep = step as TryCatchBlock;
-          const tryPath = `${stepPath}.try`;
-          const catchPath = `${stepPath}.catch`;
-          return (
-            <div className="mt-3 space-y-2">
-              <RunBlockSection title={t('runStudio.stepCard.sections.try', { defaultValue: 'TRY' })}>
-                {renderPipe(tcStep.try, tryPath, false)}
-              </RunBlockSection>
-              <RunBlockSection title={t('runStudio.stepCard.sections.catch', { defaultValue: 'CATCH' })}>
-                {renderPipe(tcStep.catch, catchPath, false)}
-              </RunBlockSection>
-            </div>
-          );
-        })()}
-
-        {step.type === 'control.forEach' && (() => {
-          const feStep = step as ForEachBlock;
-          const bodyPath = `${stepPath}.body`;
-          return (
-            <div className="mt-3">
-              <div className="text-xs text-gray-500 mb-2">
-                {t('runStudio.stepCard.forEachSummary', {
-                  defaultValue: 'Item: {{itemVar}} | Concurrency: {{concurrency}}',
-                  itemVar: feStep.itemVar,
-                  concurrency: feStep.concurrency ?? 1,
-                })}
-              </div>
-              <RunBlockSection title={t('runStudio.stepCard.sections.body', { defaultValue: 'BODY' })}>
-                {renderPipe(feStep.body, bodyPath, false)}
-              </RunBlockSection>
-            </div>
-          );
-        })()}
-      </Card>
-    );
-  };
-
-  const durationMs = run
-    ? new Date(run.completed_at ?? now).getTime() - new Date(run.started_at).getTime()
-    : null;
-  const durationSeconds = durationMs != null ? Math.max(0, Math.floor(durationMs / 1000)) : null;
-
-  const logLevelStyles: Record<string, string> = {
-    ERROR: 'text-destructive bg-destructive/10 border-destructive/20',
-    WARN: 'text-warning-foreground bg-warning/10 border-warning/20',
-    INFO: 'text-info-foreground bg-info/10 border-info/20',
-    DEBUG: 'text-muted-foreground bg-muted border-border'
-  };
-
-  const filteredLogs = useMemo(() => {
-    const search = logSearch.trim().toLowerCase();
-    return logs.filter((log) => {
-      const level = (log.level || '').toUpperCase();
-      if (logLevelFilters.length && !logLevelFilters.includes(level)) {
-        return false;
-      }
-      if (!search) return true;
-      const haystack = `${log.message ?? ''} ${log.step_path ?? ''}`.toLowerCase();
-      return haystack.includes(search);
-    });
-  }, [logs, logLevelFilters, logSearch]);
-
-  const toggleLogLevel = (level: string) => {
-    setLogLevelFilters((prev) => (
-      prev.includes(level) ? prev.filter((item) => item !== level) : [...prev, level]
-    ));
-  };
-
-  const canAdmin = useMemo(() => userPermissions.includes('workflow:admin'), [userPermissions]);
-  const isRunFinished = run?.status ? ['SUCCEEDED', 'FAILED', 'CANCELED'].includes(run.status) : false;
-  const canCancel = canAdmin && run?.status && ['RUNNING', 'WAITING'].includes(run.status);
-  const canReplay = canAdmin && run?.status && isRunFinished;
-  const actionReasonValid = runActionReason.trim().length >= 3;
-  const runError = (run as { error_json?: Record<string, unknown> | null; resume_event_name?: string | null; resume_event_payload?: Record<string, unknown> | null }) ?? {};
-
-  const lastSucceededStep = useMemo(() => {
-    const succeeded = steps.filter((step) => step.status === 'SUCCEEDED');
-    if (!succeeded.length) return null;
-    const last = succeeded.reduce((acc, current) => (
-      new Date(current.started_at).getTime() > new Date(acc.started_at).getTime() ? current : acc
-    ), succeeded[0]);
-    const stepId = stepPathToDefinitionId.get(last.step_path) ?? null;
-    const label = stepId && definitionStepMap.get(stepId)
-      ? getStepLabel(definitionStepMap.get(stepId) as Step)
-      : last.step_path;
-    return { stepId, label, stepPath: last.step_path };
-  }, [definitionStepMap, steps, stepPathToDefinitionId]);
-
-  const openCancel = () => {
-    setRunActionMode('cancel');
-    setRunActionReason('');
-  };
-
-  const openReplay = () => {
-    const payload = run?.input_json ?? {};
-    setReplayPayloadText(JSON.stringify(payload, null, 2));
-    setReplayPayloadError(null);
-    setRunActionMode('replay');
-    setRunActionReason('');
-  };
-
-  const handleReplayPayloadChange = (value: string) => {
-    setReplayPayloadText(value);
-    try {
-      JSON.parse(value);
-      setReplayPayloadError(null);
-    } catch (err) {
-      setReplayPayloadError(err instanceof Error ? err.message : t('runStudio.dialog.errors.invalidJson', {
-        defaultValue: 'Invalid JSON',
-      }));
-    }
-  };
-
-  const handleRunActionConfirm = async () => {
-    if (!runActionMode || !run) return;
-    if (!actionReasonValid) {
-      toast.error(t('runStudio.toasts.reasonRequired', {
-        defaultValue: 'Reason is required (min 3 characters).',
-      }));
-      return;
-    }
-    setIsSubmittingAction(true);
-    try {
-      if (runActionMode === 'cancel') {
-        await cancelWorkflowRunAction({ runId: run.run_id, reason: runActionReason, source: 'run-studio' });
-        toast.success(t('runStudio.toasts.canceled', { defaultValue: 'Run canceled.' }));
-      } else {
-        let payload: Record<string, unknown> = {};
-        try {
-          payload = JSON.parse(replayPayloadText || '{}');
-        } catch (err) {
-          setReplayPayloadError(err instanceof Error ? err.message : t('runStudio.dialog.errors.invalidJson', {
-            defaultValue: 'Invalid JSON',
-          }));
-          setIsSubmittingAction(false);
-          return;
-        }
-        const result = await replayWorkflowRunAction({
-          runId: run.run_id,
-          reason: runActionReason,
-          payload,
-          source: 'run-studio'
-        });
-        const newRunId = (result as { runId?: string } | undefined)?.runId;
-        if (newRunId) {
-          window.location.assign(`/msp/workflows/runs/${newRunId}`);
-          return;
-        }
-        toast.success(t('runStudio.toasts.replayStarted', { defaultValue: 'Run replay started.' }));
-      }
-      setRunActionMode(null);
-      fetchRun();
-      fetchStepsAndLogs();
-    } catch (error) {
-      toast.error(mapWorkflowServerError(t, error, t('runStudio.toasts.actionFailed', {
-        defaultValue: 'Failed to perform action.',
-      })));
-    } finally {
-      setIsSubmittingAction(false);
-    }
-  };
+  const runStatus = run?.status ?? 'UNKNOWN';
 
   return (
-    <div className="h-full flex flex-col gap-4 p-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="text-sm text-gray-500">
-            {t('runStudio.header.kicker', { defaultValue: 'Run Studio' })}
+    <div className="flex h-screen min-h-0 flex-col overflow-hidden bg-[rgb(var(--color-background))] p-6">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link className="text-sm text-primary-600 hover:text-primary-700" href="/msp/workflow-control?section=runs">
+            {t('runStudio.navigation.backToRuns', { defaultValue: '← Back to workflow runs' })}
+          </Link>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold text-[rgb(var(--color-text-900))]">
+              {t('runStudio.title', { defaultValue: 'Workflow Run Studio' })}
+            </h1>
+            <Badge className={statusBadgeClasses[runStatus] ?? 'bg-gray-100 text-gray-600'}>
+              {run?.status ? formatWorkflowRunStatus(run.status) : t('runStudio.status.loading', { defaultValue: 'Loading' })}
+            </Badge>
           </div>
-          <h1 className="text-2xl font-semibold text-gray-900">
-            {runSummary?.workflow_name ?? t('runStudio.header.fallbackTitle', { defaultValue: 'Workflow Run' })}
-          </h1>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
-            <span className="font-mono">{runId}</span>
-            {run?.workflow_version ? (
-              <span>
-                {t('runStudio.header.version', {
-                  defaultValue: 'Version {{version}}',
-                  version: run.workflow_version,
-                })}
-              </span>
-            ) : null}
-            {lastUpdatedAt ? (
-              <span>
-                {t('runStudio.header.updated', {
-                  defaultValue: 'Updated {{time}}',
-                  time: formatTimeOnly(lastUpdatedAt),
-                })}
-              </span>
-            ) : null}
-          </div>
-          <div className="mt-2 text-xs">
-            <Link href="/msp/workflow-control" className="text-primary-600 hover:text-primary-700">
-              {t('runStudio.header.backToWorkflows', { defaultValue: '← Back to Workflows' })}
-            </Link>
+          <div className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
+            <span className="font-mono break-all">{runId}</span>
+            {workflowName ? <span> · {workflowName}</span> : null}
           </div>
         </div>
-	        <div className="flex items-center gap-2">
-	          <Badge className={badgeClass}>{formatWorkflowRunStatus(status)}</Badge>
-	          <Button id="workflow-run-replay" variant="outline" size="sm" onClick={openReplay} disabled={!canReplay}>
-	            {t('runStudio.actions.replay', { defaultValue: 'Replay' })}
-	          </Button>
-	          <Button id="workflow-run-cancel" variant="outline" size="sm" onClick={openCancel} disabled={!canCancel}>
-	            {t('runStudio.actions.cancel', { defaultValue: 'Cancel' })}
-	          </Button>
-	          <Button
-	            id="workflow-run-refresh"
-	            variant="outline"
-	            size="sm"
-	            onClick={() => { fetchRun(); fetchStepsAndLogs(); }}
-	            disabled={loading}
-	          >
-	            <RefreshCw className={`h-4 w-4 ${loading || polling ? 'animate-spin' : ''}`} />
-	          </Button>
-	        </div>
-	      </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {lastRefreshedAt ? (
+            <span className="text-xs text-[rgb(var(--color-text-500))]">
+              {t('runStudio.lastRefreshed', {
+                defaultValue: 'Last refreshed {{time}}',
+                time: lastRefreshedAt.toLocaleTimeString(),
+              })}
+            </span>
+          ) : null}
+          <Button
+            id="workflow-run-studio-refresh"
+            variant="outline"
+            size="sm"
+            onClick={() => fetchStudioContext()}
+            disabled={isLoading}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" />
+            {t('runStudio.actions.refresh', { defaultValue: 'Refresh' })}
+          </Button>
+        </div>
+      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
-        <Card className="lg:col-span-2 p-4 flex flex-col min-h-[420px] min-w-0 overflow-hidden">
-          {run?.status === 'FAILED' && (
-            <div className="mb-3 rounded border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              <div className="font-semibold">
-                {t('runStudio.failure.title', { defaultValue: 'Run failed' })}
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(28rem,42rem)_minmax(0,1fr)]">
+        <Card className="flex min-h-[32rem] min-w-0 flex-col overflow-hidden p-4">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-[rgb(var(--color-text-800))]">
+                {t('runStudio.pipeline.title', { defaultValue: 'Execution Pipeline' })}
               </div>
-              {lastSucceededStep && (
-                <div className="mt-1 text-xs">
-                  {t('runStudio.failure.lastSuccessfulStep', {
-                    defaultValue: 'Last successful step: {{label}}',
-                    label: lastSucceededStep.label,
-                  })}
-                </div>
-              )}
+              <div className="text-xs text-[rgb(var(--color-text-500))]">
+                {selectedStep
+                  ? t('runStudio.pipeline.selectedStep', {
+                      defaultValue: 'Selected: {{label}}',
+                      label: getStepLabel(selectedStep),
+                    })
+                  : t('runStudio.pipeline.selectPrompt', { defaultValue: 'Select a step to highlight it.' })}
+              </div>
             </div>
-          )}
-          <div className="flex items-center justify-between mb-2">
-            <div className="text-sm font-semibold text-gray-800">
-              {t('runStudio.pipeline.title', { defaultValue: 'Execution Pipeline' })}
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2 text-xs text-gray-500">
-                <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-cyan-500" />{t('runStudio.status.running', { defaultValue: 'Running' })}</span>
-                <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-green-500" />{t('runStudio.status.succeeded', { defaultValue: 'Succeeded' })}</span>
-                <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-yellow-500" />{t('runStudio.status.retrying', { defaultValue: 'Retrying' })}</span>
-                <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-red-500" />{t('runStudio.status.failed', { defaultValue: 'Failed' })}</span>
-                <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-gray-500" />{t('runStudio.status.pending', { defaultValue: 'Pending' })}</span>
-              </div>
-	              <div className="flex items-center gap-2">
-	                <Button
-	                  id="workflow-run-pipeline-view-graph"
-	                  variant={pipelineViewMode === 'graph' ? 'default' : 'outline'}
-	                  size="sm"
-	                  onClick={() => setPipelineViewMode('graph')}
-	                >
-	                  {t('runStudio.pipeline.view.graph', { defaultValue: 'Graph' })}
-	                </Button>
-	                <Button
-	                  id="workflow-run-pipeline-view-list"
-	                  variant={pipelineViewMode === 'list' ? 'default' : 'outline'}
-	                  size="sm"
-	                  onClick={() => setPipelineViewMode('list')}
-	                >
-	                  {t('runStudio.pipeline.view.list', { defaultValue: 'List' })}
-                </Button>
-              </div>
+            <div className="flex items-center gap-2">
+              <Button
+                id="workflow-run-pipeline-view-graph"
+                variant={pipelineViewMode === 'graph' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setPipelineViewMode('graph')}
+              >
+                {t('runStudio.pipeline.view.graph', { defaultValue: 'Graph' })}
+              </Button>
+              <Button
+                id="workflow-run-pipeline-view-list"
+                variant={pipelineViewMode === 'list' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setPipelineViewMode('list')}
+              >
+                {t('runStudio.pipeline.view.list', { defaultValue: 'List' })}
+              </Button>
             </div>
           </div>
+
           {pipelineViewMode === 'graph' ? (
-            <div className="flex-1 overflow-hidden rounded border border-gray-200 bg-white">
+            <div className="min-h-0 flex-1 overflow-hidden rounded border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))]">
               {orderedSteps.length === 0 ? (
-                <div className="h-full flex items-center justify-center text-sm text-gray-500">
-                  {loading
+                <div className="flex h-full items-center justify-center text-sm text-[rgb(var(--color-text-500))]">
+                  {isLoading
                     ? t('runStudio.pipeline.states.loadingDefinition', { defaultValue: 'Loading workflow definition…' })
                     : t('runStudio.pipeline.states.noSteps', { defaultValue: 'No steps to display.' })}
                 </div>
@@ -1001,453 +285,50 @@ const RunStudioShell: React.FC<RunStudioShellProps> = ({ runId }) => {
               )}
             </div>
           ) : (
-            <div className="flex-1 overflow-auto space-y-2">
-              {orderedSteps.length === 0 && (
-                <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
-                  {loading
+            <div className="min-h-0 flex-1 overflow-auto rounded border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] p-3">
+              {orderedSteps.length === 0 ? (
+                <div className="rounded border border-dashed border-[rgb(var(--color-border-200))] p-6 text-sm text-[rgb(var(--color-text-500))]">
+                  {isLoading
                     ? t('runStudio.pipeline.states.loadingDefinitionPlain', { defaultValue: 'Loading workflow definition...' })
                     : t('runStudio.pipeline.states.noSteps', { defaultValue: 'No steps to display.' })}
                 </div>
+              ) : (
+                <div className="space-y-2">
+                  {orderedSteps.map((step) => (
+                    <button
+                      id={`workflow-run-studio-step-${step.id}`}
+                      key={step.id}
+                      type="button"
+                      onClick={() => setSelectedStepId(step.id)}
+                      className={`w-full rounded border p-3 text-left text-sm transition-colors ${
+                        selectedStepId === step.id
+                          ? 'border-primary-400 bg-primary-50 dark:bg-primary-500/20'
+                          : 'border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] hover:bg-[rgb(var(--color-background))]'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="font-medium text-[rgb(var(--color-text-800))]">{getStepLabel(step)}</span>
+                        <Badge className="bg-gray-100 text-gray-700">
+                          {stepStatusById.get(step.id) ?? t('runStudio.status.pending', { defaultValue: 'Pending' })}
+                        </Badge>
+                      </div>
+                      <div className="mt-1 text-xs text-[rgb(var(--color-text-500))]">{step.type}</div>
+                    </button>
+                  ))}
+                </div>
               )}
-              {orderedSteps.length > 0 && renderPipe(orderedSteps, 'root', true)}
             </div>
           )}
         </Card>
-        <Card className="p-4 flex flex-col min-h-[420px] min-w-0 overflow-x-hidden overflow-y-auto">
-          <div className="text-sm font-semibold text-gray-800 mb-2">
-            {t('runStudio.details.title', { defaultValue: 'Run Details' })}
-          </div>
-          <div className="space-y-3 text-xs text-gray-600 mb-4">
-            <div>
-              <div className="text-[11px] uppercase text-gray-400">
-                {t('runStudio.details.fields.runId', { defaultValue: 'Run Id' })}
-              </div>
-              <div className="font-mono text-gray-700 break-all">{runId}</div>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <div className="text-[11px] uppercase text-gray-400">
-                  {t('runStudio.details.fields.started', { defaultValue: 'Started' })}
-                </div>
-                <div>{run?.started_at ? formatDateTime(run.started_at) : '-'}</div>
-              </div>
-              <div>
-                <div className="text-[11px] uppercase text-gray-400">
-                  {t('runStudio.details.fields.duration', { defaultValue: 'Duration' })}
-                </div>
-                <div>{durationSeconds != null ? `${durationSeconds}s` : '-'}</div>
-              </div>
-              <div>
-                <div className="text-[11px] uppercase text-gray-400">
-                  {t('runStudio.details.fields.tenant', { defaultValue: 'Tenant' })}
-                </div>
-                <div className="font-mono break-all">{run?.tenant_id ?? '-'}</div>
-              </div>
-              <div>
-                <div className="text-[11px] uppercase text-gray-400">
-                  {t('runStudio.details.fields.trigger', { defaultValue: 'Trigger' })}
-                </div>
-                <div>{triggerLabel}</div>
-              </div>
-              {run?.event_type && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.eventType', { defaultValue: 'Event Type' })}
-                  </div>
-                  <div className="font-mono break-all">{run.event_type}</div>
-                </div>
-              )}
-              {isTimeTriggeredRun(run?.trigger_type) && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.scheduleState', { defaultValue: 'Schedule State' })}
-                  </div>
-                  <Badge className={getWorkflowScheduleStatusBadgeClass(scheduleState?.status)}>
-                    {formatWorkflowScheduleStatus(scheduleState?.status)}
-                  </Badge>
-                </div>
-              )}
-              {isTimeTriggeredRun(run?.trigger_type) && typeof triggerMetadata?.scheduledFor === 'string' && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.scheduledFor', { defaultValue: 'Scheduled For' })}
-                  </div>
-                  <div>{formatDateTime(String(triggerMetadata.scheduledFor))}</div>
-                </div>
-              )}
-              {run?.trigger_type === 'recurring' && typeof triggerMetadata?.cron === 'string' && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.cron', { defaultValue: 'Cron' })}
-                  </div>
-                  <div className="font-mono break-all">{String(triggerMetadata.cron)}</div>
-                </div>
-              )}
-              {run?.status === 'WAITING' && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.waitingFor', { defaultValue: 'Waiting For' })}
-                  </div>
-                  <div>{runError.resume_event_name ?? t('runStudio.details.values.resumeEvent', { defaultValue: 'Resume event' })}</div>
-                </div>
-              )}
-              {summaryMetadata && (
-                <div>
-                  <div className="text-[11px] uppercase text-gray-400">
-                    {t('runStudio.details.fields.counts', { defaultValue: 'Counts' })}
-                  </div>
-                  <div>
-                    {t('runStudio.details.values.counts', {
-                      defaultValue: '{{steps}} steps · {{logs}} logs · {{waits}} waits',
-                      steps: summaryMetadata.stepsCount,
-                      logs: summaryMetadata.logsCount,
-                      waits: summaryMetadata.waitsCount,
-                    })}
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
 
-          {(runError.error_json || runError.resume_event_payload) && (
-            <div className="space-y-3 mb-4">
-              <div className="text-sm font-semibold text-gray-800">
-                {t('runStudio.errors.title', { defaultValue: 'Run Errors' })}
-              </div>
-              {runError.error_json && (
-                <RunJsonPanel title={t('runStudio.errors.runErrorPayload', { defaultValue: 'Run Error Payload' })} value={runError.error_json} />
-              )}
-              {runError.resume_event_payload && (
-                <RunJsonPanel title={t('runStudio.errors.resumeEventPayload', { defaultValue: 'Resume Event Payload' })} value={runError.resume_event_payload} />
-              )}
-            </div>
-          )}
-
-          <div className="text-sm font-semibold text-gray-800 mb-2">
-            {t('runStudio.stepDetails.title', { defaultValue: 'Step Details' })}
-          </div>
-          {!selectedStep && (
-            <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-4 text-sm text-gray-500 mb-4">
-              {t('runStudio.stepDetails.empty', {
-                defaultValue: 'Select a step in the pipeline to inspect inputs, outputs, and snapshots.',
-              })}
-            </div>
-          )}
-          {selectedStep && (
-            <div className="space-y-3 mb-4">
-              <div className="text-xs text-gray-600">
-                <div className="text-[11px] uppercase text-gray-400">
-                  {t('runStudio.stepDetails.fields.step', { defaultValue: 'Step' })}
-                </div>
-                <div className="font-medium text-gray-800">{getStepLabel(selectedStep)}</div>
-                <div className="text-[11px] text-gray-500">{selectedStep.type}</div>
-                {selectedStepPath ? <div className="font-mono text-[11px] text-gray-500">{selectedStepPath}</div> : null}
-              </div>
-              <RunJsonPanel title={t('runStudio.stepDetails.panels.configuration', { defaultValue: 'Step Configuration' })} value={selectedStep} />
-              {selectedInvocation?.input_json && (
-                <RunJsonPanel title={t('runStudio.stepDetails.panels.inputResolved', { defaultValue: 'Input (Resolved)' })} value={selectedInvocation.input_json} />
-              )}
-              {selectedInvocation?.output_json && (
-                <RunJsonPanel title={t('runStudio.stepDetails.panels.output', { defaultValue: 'Output' })} value={selectedInvocation.output_json} />
-              )}
-              {selectedInvocation?.error_message && (
-                <div className="rounded border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                  {selectedInvocation.error_message}
-                </div>
-              )}
-              {selectedSnapshot?.envelope_json && (
-                <RunJsonPanel title={t('runStudio.stepDetails.panels.envelopeSnapshot', { defaultValue: 'Envelope Snapshot' })} value={selectedSnapshot.envelope_json} />
-              )}
-            </div>
-          )}
-
-          <div className="text-sm font-semibold text-gray-800 mb-2">
-            {t('runStudio.timeline.title', { defaultValue: 'Execution Timeline' })}
-          </div>
-          <div className="mb-2">
-            <Input
-              id="workflow-run-timeline-search"
-              label={t('runStudio.timeline.searchLabel', { defaultValue: 'Search timeline' })}
-              value={timelineSearch}
-              onChange={(event) => setTimelineSearch(event.target.value)}
-              placeholder={t('runStudio.timeline.searchPlaceholder', {
-                defaultValue: 'Search step path, wait type, status',
-              })}
-            />
-          </div>
-          <div className="mb-4 max-h-64 overflow-auto rounded border border-gray-200 bg-white">
-            {timelineEntries.length === 0 && (
-              <div className="p-4 text-sm text-gray-500">
-                {t('runStudio.timeline.empty', { defaultValue: 'No timeline entries yet.' })}
-              </div>
-            )}
-            {timelineEntries.map((entry, index) => (
-              <div key={`${entry.kind}-${entry.stepPath}-${index}`} className="border-b border-gray-100 px-3 py-2 text-xs text-gray-700">
-                {entry.kind === 'step' ? (
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between gap-2">
-                      <div>
-                        <div className="font-medium text-gray-800">{entry.label}</div>
-                        <div className="font-mono text-[10px] text-gray-400">{entry.stepPath}</div>
-                      </div>
-	                      {entry.stepId && (
-	                        <Button
-	                          id={`workflow-run-timeline-jump-${entry.stepId ?? index}`}
-	                          variant="ghost"
-	                          size="sm"
-	                          onClick={() => setSelectedStepId(entry.stepId!)}
-	                        >
-	                          {t('runStudio.timeline.actions.jump', { defaultValue: 'Jump' })}
-	                        </Button>
-	                      )}
-                    </div>
-                    {entry.attempts.map((attempt) => {
-                      const duration = attempt.completed_at
-                        ? Math.max(0, new Date(attempt.completed_at).getTime() - new Date(attempt.started_at).getTime())
-                        : null;
-                      return (
-                        <div key={attempt.step_id} className="flex items-center justify-between text-[11px] text-gray-500">
-                          <span>
-                            {t('runStudio.timeline.attempt', {
-                              defaultValue: 'Attempt {{attempt}} · {{status}}',
-                              attempt: attempt.attempt,
-                              status: attempt.status,
-                            })}
-                          </span>
-                          <span>{duration != null ? `${duration}ms` : t('runStudio.timeline.inProgress', { defaultValue: 'In progress' })}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between gap-2">
-                      <div>
-                        <div className="font-medium text-gray-800">
-                          {t('runStudio.timeline.waitTitle', {
-                            defaultValue: 'Wait · {{waitType}}',
-                            waitType: entry.waitType,
-                          })}
-                        </div>
-                        <div className="font-mono text-[10px] text-gray-400">{entry.stepPath}</div>
-                      </div>
-	                      {entry.stepId && (
-	                        <Button
-	                          id={`workflow-run-timeline-jump-${entry.stepId ?? index}`}
-	                          variant="ghost"
-	                          size="sm"
-	                          onClick={() => setSelectedStepId(entry.stepId!)}
-	                        >
-	                          {t('runStudio.timeline.actions.jump', { defaultValue: 'Jump' })}
-	                        </Button>
-	                      )}
-                    </div>
-                    <div className="text-[11px] text-gray-500">
-                      {t('runStudio.timeline.statusLine', {
-                        defaultValue: 'Status: {{status}}',
-                        status: entry.status,
-                      })}
-                      {entry.eventName ? t('runStudio.timeline.eventSegment', {
-                        defaultValue: ' · Event: {{eventName}}',
-                        eventName: entry.eventName,
-                      }) : ''}
-                      {entry.key ? t('runStudio.timeline.keySegment', {
-                        defaultValue: ' · Key: {{key}}',
-                        key: entry.key,
-                      }) : ''}
-                    </div>
-                    <div className="text-[11px] text-gray-500">
-                      {t('runStudio.timeline.createdLine', {
-                        defaultValue: 'Created: {{createdAt}}',
-                        createdAt: formatDateTime(entry.createdAt),
-                      })}
-                      {entry.resolvedAt ? t('runStudio.timeline.resolvedSegment', {
-                        defaultValue: ' · Resolved: {{resolvedAt}}',
-                        resolvedAt: formatDateTime(entry.resolvedAt),
-                      }) : ''}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-
-          <div className="text-sm font-semibold text-gray-800 mb-2">
-            {t('runStudio.logs.title', { defaultValue: 'Run Logs' })}
-          </div>
-          <div className="mb-2 space-y-2">
-            <Input
-              id="workflow-run-log-search"
-              label={t('runStudio.logs.searchLabel', { defaultValue: 'Search logs' })}
-              value={logSearch}
-              onChange={(event) => setLogSearch(event.target.value)}
-              placeholder={t('runStudio.logs.searchPlaceholder', {
-                defaultValue: 'Search message or step path',
-              })}
-            />
-            <div className="flex flex-wrap gap-2">
-	              {['ERROR', 'WARN', 'INFO', 'DEBUG'].map((level) => (
-	                <Button
-	                  key={level}
-	                  id={`workflow-run-log-level-${level}`}
-	                  variant={logLevelFilters.includes(level) ? 'default' : 'outline'}
-	                  size="sm"
-	                  onClick={() => toggleLogLevel(level)}
-	                >
-	                  {formatWorkflowLogLevel(level as 'ERROR' | 'WARN' | 'INFO' | 'DEBUG')}
-	                </Button>
-	              ))}
-	              {logLevelFilters.length > 0 && (
-	                <Button
-	                  id="workflow-run-log-level-clear"
-	                  variant="ghost"
-	                  size="sm"
-	                  onClick={() => setLogLevelFilters([])}
-	                >
-	                  {t('runStudio.logs.actions.clear', { defaultValue: 'Clear' })}
-	                </Button>
-	              )}
-            </div>
-          </div>
-          <div className="flex-1 min-w-0 overflow-auto rounded border border-gray-200 bg-white">
-            {filteredLogs.length === 0 && (
-              <div className="p-4 text-sm text-gray-500">
-                {t('runStudio.logs.empty', { defaultValue: 'No logs yet.' })}
-              </div>
-            )}
-            {filteredLogs.map((log) => (
-              <div key={log.log_id} className="min-w-0 border-b border-gray-100 px-3 py-2 text-xs text-gray-700">
-                <div className="flex min-w-0 items-center justify-between gap-2">
-                  <span className="shrink-0 font-mono text-gray-500">{formatTimeOnly(log.created_at)}</span>
-                  <span className={`shrink-0 text-[10px] uppercase tracking-wide border px-2 py-0.5 rounded ${logLevelStyles[(log.level || '').toUpperCase()] ?? 'text-gray-400 border-gray-200'}`}>
-                    {log.level}
-                  </span>
-                </div>
-                <div className="mt-1 break-words">{log.message}</div>
-                {log.step_path && (
-                  <div className="mt-1 break-all font-mono text-[10px] text-gray-400">{log.step_path}</div>
-                )}
-              </div>
-            ))}
-          </div>
-        </Card>
+        <div className="min-h-0 min-w-0 overflow-y-auto pr-2 pb-6">
+          <WorkflowRunDetails
+            runId={runId}
+            workflowName={workflowName}
+            canAdmin={canAdmin}
+          />
+        </div>
       </div>
-
-      <Dialog
-        isOpen={runActionMode !== null}
-        onClose={() => setRunActionMode(null)}
-        title={runActionMode === 'cancel'
-          ? t('runStudio.dialog.title.cancel', { defaultValue: 'Cancel Run' })
-          : t('runStudio.dialog.title.replay', { defaultValue: 'Replay Run' })}
-        className="max-w-2xl"
-        footer={(
-          <div className="flex justify-end space-x-2">
-            <Button id="workflow-run-action-close" variant="outline" onClick={() => setRunActionMode(null)}>
-              {t('runStudio.dialog.actions.close', { defaultValue: 'Close' })}
-            </Button>
-            <Button
-              id="workflow-run-action-confirm"
-              onClick={handleRunActionConfirm}
-              disabled={!actionReasonValid || isSubmittingAction || (runActionMode === 'replay' && !!replayPayloadError)}
-            >
-              {isSubmittingAction
-                ? t('runStudio.dialog.actions.working', { defaultValue: 'Working...' })
-                : runActionMode === 'cancel'
-                  ? t('runStudio.dialog.actions.confirmCancel', { defaultValue: 'Confirm Cancel' })
-                  : t('runStudio.dialog.actions.startReplay', { defaultValue: 'Start Replay' })}
-            </Button>
-          </div>
-        )}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {runActionMode === 'cancel'
-                ? t('runStudio.dialog.heading.cancel', { defaultValue: 'Cancel Workflow Run' })
-                : t('runStudio.dialog.heading.replay', { defaultValue: 'Replay Workflow Run' })}
-            </DialogTitle>
-            <DialogDescription>
-              {runActionMode === 'cancel'
-                ? t('runStudio.dialog.description.cancel', {
-                  defaultValue: 'Canceling will stop any in-progress or waiting steps for this run.',
-                })
-                : t('runStudio.dialog.description.replay', {
-                  defaultValue: 'Replaying will start a new run using the payload below.',
-                })}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <Input
-              id="workflow-run-action-reason"
-              label={t('runStudio.dialog.fields.reason', { defaultValue: 'Reason' })}
-              value={runActionReason}
-              onChange={(event) => setRunActionReason(event.target.value)}
-              placeholder={t('runStudio.dialog.fields.reasonPlaceholder', {
-                defaultValue: 'e.g. Canceling to adjust inputs',
-              })}
-            />
-
-            {runActionMode === 'replay' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {t('runStudio.dialog.fields.payloadJson', { defaultValue: 'Payload (JSON)' })}
-                </label>
-                <TextArea
-                  id="workflow-run-replay-payload"
-                  value={replayPayloadText}
-                  onChange={(event) => handleReplayPayloadChange(event.target.value)}
-                  rows={10}
-                  className={replayPayloadError ? 'border-destructive' : ''}
-                />
-                {replayPayloadError && (
-                  <div className="text-xs text-destructive mt-1">{replayPayloadError}</div>
-                )}
-              </div>
-            )}
-          </div>
-
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
-};
-
-const RunBlockSection: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => {
-  const [isOpen, setIsOpen] = useState(true);
-  return (
-    <div className="border border-gray-200 rounded-md bg-gray-50">
-      <button
-        className="flex items-center gap-2 px-3 py-2 text-[11px] font-semibold uppercase text-gray-600 w-full"
-        type="button"
-        onClick={() => setIsOpen((prev) => !prev)}
-      >
-        <span className="text-xs">{isOpen ? '▾' : '▸'}</span>
-        {title}
-      </button>
-      {isOpen && <div className="p-3">{children}</div>}
-    </div>
-  );
-};
-
-const RunJsonPanel: React.FC<{ title: string; value: unknown }> = ({ title, value }) => {
-  const { t } = useTranslation('msp/workflows');
-  const extracted = value as { message?: string; name?: string; errorType?: string; category?: string } | null;
-  const summary = extracted
-    ? [extracted.errorType, extracted.category, extracted.name].filter(Boolean).join(' · ')
-    : null;
-  let content = '';
-  try {
-    content = JSON.stringify(value ?? null, null, 2);
-  } catch {
-    content = t('runStudio.jsonPanel.serializeFailed', { defaultValue: 'Unable to serialize value.' });
-  }
-  return (
-    <div className="rounded border border-gray-200 bg-white">
-      <div className="border-b border-gray-100 px-3 py-2 text-[11px] uppercase text-gray-500">{title}</div>
-      {summary && <div className="px-3 pt-2 text-[11px] text-gray-600">{summary}</div>}
-      {extracted?.message && <div className="px-3 text-[11px] text-gray-600">{extracted.message}</div>}
-      <pre className="max-h-60 max-w-full overflow-auto whitespace-pre-wrap break-words p-3 text-[11px] text-gray-700">{content}</pre>
     </div>
   );
 };

--- a/packages/ui/src/components/ConfirmationDialog.tsx
+++ b/packages/ui/src/components/ConfirmationDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './Dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter } from './Dialog';
 import { Button } from './Button';
 import { RadioGroup } from './RadioGroup';
 import { useRegisterUIComponent } from '../ui-reflection/useRegisterUIComponent';
@@ -83,6 +83,9 @@ export const ConfirmationDialog = ({
       }}
     >
       <DialogContent>
+        <DialogDescription className="sr-only">
+          {typeof message === 'string' ? message : title}
+        </DialogDescription>
         {typeof message === 'string' ? (
           <p className="text-gray-600">{message}</p>
         ) : (

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -537,8 +537,10 @@ export function DialogFooter({ children, className }: { children: ReactNode; cla
 
 export const DialogTrigger = RadixDialog.Trigger;
 
-export function DialogDescription({ children }: { children: ReactNode }): React.ReactElement {
+export function DialogDescription({ children, className }: { children: ReactNode; className?: string }): React.ReactElement {
   return (
-    <RadixDialog.Description className="text-sm text-muted-foreground mb-4">{children}</RadixDialog.Description>
+    <RadixDialog.Description className={className ?? 'text-sm text-muted-foreground mb-4'}>
+      {children}
+    </RadixDialog.Description>
   );
 }


### PR DESCRIPTION
## Summary
- consolidate workflow run details into a shared inspector used by the Runs drawer and full-page Run Studio
- replace inline run details with a preview drawer with previous/next navigation and full-page handoff
- simplify Run Studio around graph/list context plus the canonical run details inspector
- convert Step Timeline, Run Logs, and Audit Trail to standard DataTable controls
- show human-readable audit users instead of raw user IDs where available
- improve run history layout, scrolling, button placement, and confirmation dialog accessibility

## Testing
- cd server && npm run typecheck -- --pretty false
- algadev click-through of full-page run studio and Runs preview drawer, including row selection, drawer navigation, filters, exports, dialogs, and scroll reachability