### PR TITLE
Wake paused SLA workflows to detect missed closures

### DIFF
--- a/ee/server/src/lib/sla/TemporalSlaBackend.ts
+++ b/ee/server/src/lib/sla/TemporalSlaBackend.ts
@@ -75,7 +75,7 @@ export class TemporalSlaBackend implements ISlaBackend {
   async completeSla(
     ticketId: string,
     type: 'response' | 'resolution',
-    met: boolean
+    met: boolean | null
   ): Promise<void> {
     const handle = await this.getHandle(ticketId);
     const signalName = type === 'response' ? 'completeResponse' : 'completeResolution';

--- a/ee/temporal-workflows/src/workflows/__tests__/sla-ticket-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/sla-ticket-workflow.test.ts
@@ -318,4 +318,54 @@ describe('slaTicketWorkflow', () => {
       await env.teardown();
     }
   });
+
+  it('self-completes while paused when the close signal was missed', async () => {
+    let closeChecks = 0;
+    const sendCalls: Array<unknown> = [];
+    const { env, worker, taskQueue } = await setupWorkflowTest({
+      completeIfTicketClosed: async () => {
+        closeChecks += 1;
+        if (closeChecks < 2) {
+          return {
+            closed: false,
+            responseMet: null,
+            resolutionMet: null,
+          };
+        }
+
+        return {
+          closed: true,
+          responseMet: true,
+          resolutionMet: true,
+        };
+      },
+      sendSlaNotification: async (input: unknown) => {
+        sendCalls.push(input);
+      },
+    });
+    try {
+      await worker.runUntil(async () => {
+        const handle = await env.client.workflow.start(slaTicketWorkflow, {
+          args: [
+            {
+              ticketId: 'ticket-paused-close',
+              tenantId: 'tenant-paused-close',
+              policyTargets: [target],
+              businessHoursSchedule: schedule24x7,
+            },
+          ],
+          taskQueue,
+          workflowId: 'sla-ticket-tenant-paused-close-ticket-paused-close',
+        });
+
+        await handle.signal('pause', { reason: 'awaiting_client' });
+        await handle.result();
+      });
+
+      expect(closeChecks).toBeGreaterThanOrEqual(2);
+      expect(sendCalls).toEqual([]);
+    } finally {
+      await env.teardown();
+    }
+  });
 });

--- a/ee/temporal-workflows/src/workflows/sla-ticket-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/sla-ticket-workflow.ts
@@ -50,7 +50,7 @@ export interface PauseSignal {
 }
 
 export interface CompleteSignal {
-  met: boolean;
+  met: boolean | null;
 }
 
 const activities = proxyActivities<{
@@ -256,7 +256,7 @@ export async function slaTicketWorkflow(
   // row has been deleted exit as 'cancelled' so the two cases are
   // distinguishable in workflow state and downstream metrics.
   const checkClosedAndComplete = async (
-    triggeredBy: 'startup' | 'wake'
+    triggeredBy: 'startup' | 'wake' | 'pause'
   ): Promise<boolean> => {
     const result = await activities.completeIfTicketClosed({
       tenantId,
@@ -319,13 +319,20 @@ export async function slaTicketWorkflow(
 
       while (state.pauseState.isPaused && !cancelled && !resolutionCompleted &&
              !(phase.phase === 'response' && responseCompleted)) {
-        await condition(
+        const resumedOrCompleted = await condition(
           () =>
             !state.pauseState.isPaused ||
             cancelled ||
             resolutionCompleted ||
-            (phase.phase === 'response' && responseCompleted)
+            (phase.phase === 'response' && responseCompleted),
+          60_000
         );
+
+        if (!resumedOrCompleted && state.pauseState.isPaused) {
+          if (await checkClosedAndComplete('pause')) {
+            break;
+          }
+        }
       }
 
       if (cancelled || resolutionCompleted) {

--- a/packages/sla/src/services/__tests__/slaBackendSignals.test.ts
+++ b/packages/sla/src/services/__tests__/slaBackendSignals.test.ts
@@ -118,6 +118,19 @@ describe('SLA backend signaling', () => {
     expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'resolution', true);
   });
 
+  it("recordResolution still completes the backend when met is null", async () => {
+    const trx = createAdvancedMockTrx();
+    trx.setData('tickets', {
+      sla_policy_id: POLICY_ID,
+      sla_resolution_at: null,
+      sla_resolution_due_at: null,
+      sla_total_pause_minutes: 0,
+    });
+
+    await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
+    expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'resolution', null);
+  });
+
   it('pauseSla signals backend.pauseSla()', async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {

--- a/packages/sla/src/services/backends/ISlaBackend.ts
+++ b/packages/sla/src/services/backends/ISlaBackend.ts
@@ -18,7 +18,7 @@ export interface ISlaBackend {
   completeSla(
     ticketId: string,
     type: 'response' | 'resolution',
-    met: boolean
+    met: boolean | null
   ): Promise<void>;
   cancelSla(ticketId: string): Promise<void>;
   getSlaStatus(ticketId: string): Promise<ISlaStatus | null>;

--- a/packages/sla/src/services/backends/PgBossSlaBackend.ts
+++ b/packages/sla/src/services/backends/PgBossSlaBackend.ts
@@ -40,7 +40,7 @@ export class PgBossSlaBackend implements ISlaBackend {
   async completeSla(
     ticketId: string,
     type: 'response' | 'resolution',
-    _met: boolean
+    _met: boolean | null
   ): Promise<void> {
     await this.withTicketTransaction(ticketId, async (trx, tenant) => {
       if (type === 'response') {

--- a/packages/sla/src/services/slaService.ts
+++ b/packages/sla/src/services/slaService.ts
@@ -359,7 +359,7 @@ export async function recordResolution(
       met
     });
 
-    if (!options?.skipBackend && met !== null) {
+    if (!options?.skipBackend) {
       try {
         const backend = await SlaBackendFactory.getBackend();
         await backend.completeSla(ticketId, 'resolution', met);

--- a/server/src/lib/eventBus/subscribers/slaSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/slaSubscriber.ts
@@ -18,7 +18,12 @@ import {
   type TicketClosedEvent,
   type TicketCommentAddedEvent
 } from '@alga-psa/event-schemas';
-import { createTenantKnex, runWithTenant, withTransaction } from '@alga-psa/db';
+import {
+  createTenantKnex,
+  runWithTenant,
+  withTransaction,
+  withTenantTransactionRetryReadOnly
+} from '@alga-psa/db';
 import {
   startSlaForTicket,
   recordFirstResponse,
@@ -230,57 +235,61 @@ async function handleTicketUpdatedEvent(event: unknown): Promise<void> {
  * Handle ticket closed event - record resolution
  */
 async function handleTicketClosedEvent(event: unknown): Promise<void> {
+  const validated = EventSchemas.TICKET_CLOSED.parse(event) as TicketClosedEvent;
+  const { tenantId, ticketId, userId } = validated.payload;
+
+  logger.info('[SlaSubscriber] Handling TICKET_CLOSED', { tenantId, ticketId });
+
   try {
-    const validated = EventSchemas.TICKET_CLOSED.parse(event) as TicketClosedEvent;
-    const { tenantId, ticketId, userId } = validated.payload;
+    await withTenantTransactionRetryReadOnly(tenantId, async (trx: Knex.Transaction) => {
+      // Get the closed_at time from the ticket
+      const ticket = await trx('tickets')
+        .where({ tenant: tenantId, ticket_id: ticketId })
+        .select('closed_at')
+        .first();
 
-    logger.info('[SlaSubscriber] Handling TICKET_CLOSED', { tenantId, ticketId });
+      const closedAt = ticket?.closed_at ? new Date(ticket.closed_at) : new Date();
 
-    await runWithTenant(tenantId, async () => {
-      const { knex } = await createTenantKnex();
+      const result = await recordResolution(
+        trx,
+        tenantId,
+        ticketId,
+        closedAt,
+        userId
+      );
 
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
-        // Get the closed_at time from the ticket
-        const ticket = await trx('tickets')
-          .where({ tenant: tenantId, ticket_id: ticketId })
-          .select('closed_at')
-          .first();
-
-        const closedAt = ticket?.closed_at ? new Date(ticket.closed_at) : new Date();
-
-        const result = await recordResolution(
-          trx,
+      if (result.success && result.met !== null) {
+        logger.info('[SlaSubscriber] Recorded ticket resolution', {
           tenantId,
           ticketId,
-          closedAt,
-          userId
-        );
+          met: result.met,
+          resolvedAt: result.recorded_at.toISOString()
+        });
+        return;
+      }
 
-        if (result.success && result.met !== null) {
-          logger.info('[SlaSubscriber] Recorded ticket resolution', {
-            tenantId,
-            ticketId,
-            met: result.met,
-            resolvedAt: result.recorded_at.toISOString()
-          });
-        } else if (result.success && result.met === null) {
-          logger.info('[SlaSubscriber] TICKET_CLOSED handled but no SLA tracked', {
-            tenantId,
-            ticketId
-          });
-        } else {
-          logger.error('[SlaSubscriber] recordResolution returned failure', {
-            tenantId,
-            ticketId,
-            error: result.error
-          });
-        }
+      if (result.success && result.met === null) {
+        logger.info('[SlaSubscriber] TICKET_CLOSED handled but no SLA tracked', {
+          tenantId,
+          ticketId
+        });
+        return;
+      }
+
+      logger.error('[SlaSubscriber] recordResolution returned failure', {
+        tenantId,
+        ticketId,
+        error: result.error
       });
+      throw new Error(result.error || 'recordResolution failed');
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_CLOSED event', {
+      tenantId,
+      ticketId,
       error: error instanceof Error ? error.message : 'Unknown error'
     });
+    throw error;
   }
 }
 

--- a/server/src/test/unit/sla/slaSubscriber.test.ts
+++ b/server/src/test/unit/sla/slaSubscriber.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+const withTenantTransactionRetryReadOnlyMock = vi.hoisted(() => vi.fn());
+const recordResolutionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: loggerMock,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(),
+  runWithTenant: vi.fn(),
+  withTransaction: vi.fn(),
+  withTenantTransactionRetryReadOnly: (
+    tenantId: string,
+    callback: (trx: unknown) => Promise<unknown>
+  ) => withTenantTransactionRetryReadOnlyMock(tenantId, callback),
+}));
+
+vi.mock('@alga-psa/sla', () => ({
+  startSlaForTicket: vi.fn(),
+  recordFirstResponse: vi.fn(),
+  recordResolution: (...args: unknown[]) => recordResolutionMock(...args),
+  handlePriorityChange: vi.fn(),
+  handlePolicyChange: vi.fn(),
+  handleStatusChange: vi.fn(),
+  handleResponseStateChange: vi.fn(),
+}));
+
+import { __testHooks } from '../../../lib/eventBus/subscribers/slaSubscriber';
+
+function createClosedTicketTrx(closedAt = '2026-04-28T22:24:44Z') {
+  const chain = {
+    where: vi.fn(),
+    select: vi.fn(),
+    first: vi.fn(async () => ({ closed_at: closedAt })),
+  };
+  chain.where.mockReturnValue(chain);
+  chain.select.mockReturnValue(chain);
+
+  return vi.fn((table: string) => {
+    if (table !== 'tickets') {
+      throw new Error(`Unexpected table ${table}`);
+    }
+    return chain;
+  });
+}
+
+describe('slaSubscriber TICKET_CLOSED handling', () => {
+  beforeEach(() => {
+    loggerMock.info.mockReset();
+    loggerMock.error.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.debug.mockReset();
+    recordResolutionMock.mockReset();
+    withTenantTransactionRetryReadOnlyMock.mockReset();
+  });
+
+  it('rethrows recordResolution failures so the event bus can retry', async () => {
+    const trx = createClosedTicketTrx();
+    withTenantTransactionRetryReadOnlyMock.mockImplementation(async (_tenantId, callback) => callback(trx));
+    recordResolutionMock.mockResolvedValue({
+      success: false,
+      met: null,
+      recorded_at: new Date('2026-04-28T22:24:44Z'),
+      error: 'transient failure',
+    });
+
+    const event = {
+      id: '00000000-0000-0000-0000-000000000001',
+      eventType: 'TICKET_CLOSED' as const,
+      timestamp: '2026-04-28T22:24:45Z',
+      payload: {
+        tenantId: '00000000-0000-0000-0000-000000000002',
+        ticketId: '00000000-0000-0000-0000-000000000003',
+        userId: '00000000-0000-0000-0000-000000000004',
+      },
+    };
+
+    await expect(__testHooks.handleTicketClosedEvent(event)).rejects.toThrow('transient failure');
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      '[SlaSubscriber] recordResolution returned failure',
+      expect.objectContaining({
+        tenantId: '00000000-0000-0000-0000-000000000002',
+        ticketId: '00000000-0000-0000-0000-000000000003',
+        error: 'transient failure',
+      })
+    );
+  });
+});


### PR DESCRIPTION
  - Allow null `met` through completeSla so backends can record SLAs that were never tracked when a ticket closes.
  - Add a 60s safety condition timeout while the SLA workflow is paused so it polls completeIfTicketClosed for a missed TICKET_CLOSED signal.
  - Rewire the TICKET_CLOSED subscriber onto withTenantTransactionRetryReadOnly and rethrow recordResolution failures so the event bus can retry.

  Like the Cheshire Cat — sometimes `met` is neither true nor false, just a
  grin in the dark — the paused workflow now peeks every sixty seconds to
  see if its ticket has quietly vanished down the rabbit hole. 🐱✨⏰