### PR TITLE
Add workflow step quota enforcement and resume handling

### DIFF
--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/OPERATIONS.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/OPERATIONS.md
@@ -1,0 +1,46 @@
+# Workflow Step Quota Operations Notes
+
+## Quota Source Resolution
+
+1. Active Stripe subscription period (`trialing`, `active`, `past_due`, `unpaid`) with valid `current_period_start`/`current_period_end`.
+2. If unavailable, fallback to current UTC calendar month.
+
+Limit precedence:
+
+1. `stripe_prices.metadata.workflow_step_limit`
+2. `stripe_products.metadata.workflow_step_limit`
+3. Tier default (`solo=150`, `pro=750`, `premium=10000`)
+
+`workflow_step_limit=unlimited` sets unlimited cap (`effective_limit = null`) while continuing to increment usage.
+
+## Pause Behavior
+
+- Reservation occurs at step start.
+- On exhaustion, run is set to `WAITING` at current `node_path`.
+- Quota pause is recorded in `workflow_run_waits` with `wait_type='quota'`, `status='WAITING'`, and payload including `usedCount`, `effectiveLimit`, and period metadata.
+- Quota-blocked step does not create a `workflow_run_steps` row.
+
+## Resume Behavior
+
+Automatic resume:
+
+- Recurring job `workflow-quota-resume-scan` scans quota waits.
+- Uses `FOR UPDATE SKIP LOCKED` and batch sizing.
+- Resumes at most tenant remaining finite capacity per scan.
+- Sets wait to `RESOLVED`, run to `RUNNING`, then re-enters runtime execution.
+
+Manual resume:
+
+- `resumeWorkflowRunFromQuotaPauseAction` checks tenant ownership + permission.
+- If still exhausted, returns a structured response with `usedCount`, `effectiveLimit`, and `periodEnd`.
+- If eligible, resolves quota wait and resumes through runtime path (no quota bypass).
+
+## Reconciliation Procedure
+
+Use `workflowStepQuotaService.reconcileUsagePeriod(tenant, periodStart, periodEnd)`:
+
+- Counter source: `workflow_step_usage_periods.used_count`
+- Ledger source: `workflow_run_steps` joined to `workflow_runs` for tenant and step `started_at` inside period
+- Drift: `counterUsedCount - ledgerStepCount`
+
+Investigate non-zero drift by checking runtime paths that may create step rows without quota reservation.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/PRD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/PRD.md
@@ -1,0 +1,279 @@
+# PRD — Workflow Step Quota Accounting
+
+- Slug: `2026-04-28-workflow-step-quota-accounting`
+- Date: `2026-04-28`
+- Status: Draft
+
+## Summary
+
+Add tenant-level accounting and enforcement for workflow step executions. Each tenant receives a workflow step allotment per payment period. Every workflow step attempt consumes one unit when the step starts. When a tenant exhausts its allotment, workflows pause at the current step instead of failing. Paused workflows can resume automatically when quota becomes available or manually after the same eligibility check passes.
+
+The payment period is the tenant's active Stripe subscription period. If no valid active Stripe subscription period exists, the system falls back to the current UTC calendar month and tier default limits.
+
+## Problem
+
+Workflow steps are a licensed resource, but the workflow runtime currently has no tenant-level accounting or enforcement for step executions. Existing `workflow_run_steps` rows provide an execution audit trail, but they are not designed for fast, concurrency-safe quota enforcement across both DB and Temporal workflow runtimes.
+
+Without quota accounting, tenants can exceed plan allotments, runaway loops or retries can burn runtime capacity without licensing protection, and support/product teams lack a clear per-period usage object.
+
+## Goals
+
+- Count every workflow step attempt for a tenant when the step starts.
+- Enforce tenant plan allotments per payment period.
+- Use Stripe subscription `current_period_start` and `current_period_end` as the primary quota window.
+- Fall back to the current UTC calendar month with tier defaults when no active Stripe period exists.
+- Support tier defaults of:
+  - `solo`: 150 steps per period
+  - `pro`: 750 steps per period
+  - `premium`: 10,000 steps per period
+- Support Stripe metadata override via `workflow_step_limit`, including numeric values and `unlimited`.
+- Pause workflows on quota exhaustion instead of failing them.
+- Resume quota-paused workflows automatically via scheduled job and manually via user/admin action.
+- Use one shared enforcement path for DB runtime, Temporal runtime, automatic resume, and manual resume.
+- Preserve `workflow_run_steps` as the execution audit ledger while adding a dedicated counter table for enforcement.
+
+## Non-goals
+
+- Do not use contract-system `recurring_service_periods`, cadence ownership, invoice windows, or contract line periods for workflow quota windows.
+- Do not bill customers directly from workflow step usage in this phase.
+- Do not build a full customer-facing usage dashboard in this phase unless needed for manual resume messaging.
+- Do not auto-repair counter drift initially; report drift for diagnosis first.
+- Do not treat quota exhaustion as workflow failure or trigger normal retry policies.
+- Do not change the semantics of action idempotency or workflow step retry policies except that retry attempts consume step quota when they start.
+
+## Users and Primary Flows
+
+### Tenant workflow executor
+
+A workflow run starts or resumes. Before each step attempt, the runtime reserves one step unit. If quota is available, the step executes normally. If quota is exhausted, the run pauses at the current `node_path` and records a quota wait.
+
+### MSP admin / tenant user
+
+A user viewing a quota-paused run sees that the workflow is waiting because the tenant exhausted its workflow step allotment. The user can retry/resume manually. If quota is still exhausted, the system returns a clear message with current usage, limit, and reset time. If quota is available, the run resumes through normal runtime execution.
+
+### Background scheduler
+
+A recurring job scans quota waits. When a tenant's next payment period starts or the tenant's effective limit increases, the job resumes eligible quota-paused runs. Actual quota consumption still happens when the runtime re-enters step start.
+
+### Support / operations
+
+Support can inspect the tenant's current usage period, effective limit, source, and drift report comparing the enforcement counter to `workflow_run_steps` audit rows.
+
+## UX / UI Notes
+
+- Quota-paused runs should be displayed as waiting/paused, not failed.
+- The run detail or inspector should surface a clear reason such as: "Workflow step quota exceeded for current billing period."
+- Manual resume should be available only for quota-paused runs and should not bypass quota.
+- If quota remains exhausted, the response should include:
+  - used count
+  - effective limit, or `unlimited`
+  - reset/payment period end time
+  - quota source, if useful for support
+- UI changes can be minimal in the first implementation if existing run logs/wait records are visible enough for operators.
+
+## Requirements
+
+### Functional Requirements
+
+1. Count every step attempt at step start.
+2. Do not count quota-blocked steps because they did not start.
+3. Count retry attempts as new step attempts.
+4. Count `forEach` body attempts per item/attempt.
+5. Count `event.wait`, `time.wait`, and `human.task` steps when first entered.
+6. Resolve quota windows from active Stripe subscription periods when available.
+7. Fall back to current UTC calendar month when no valid active Stripe period is available.
+8. Resolve effective limits using Stripe price metadata, then Stripe product metadata, then tier defaults.
+9. Support `workflow_step_limit=unlimited` as an unlimited cap while still recording usage.
+10. Atomically reserve quota across concurrent workers.
+11. Pause runs at the current step when quota is exhausted.
+12. Create or reuse a `workflow_run_waits` row with `wait_type = 'quota'` on quota exhaustion.
+13. Preserve the current `workflow_runs.node_path` while quota-paused.
+14. Resume eligible quota-paused runs via scheduled job.
+15. Resume eligible quota-paused runs via manual user/admin action.
+16. Prevent manual resume from bypassing quota.
+17. Provide a reconciliation/reporting path comparing enforcement counters to `workflow_run_steps` audit rows.
+
+### Non-functional Requirements
+
+- Quota reservation must be concurrency-safe across DB runtime workers and Temporal activity workers.
+- Runtime enforcement must avoid expensive aggregate counts on every step.
+- Missing or invalid Stripe metadata must not crash workflow execution.
+- Missing Stripe period data must not immediately disable workflows; use fallback calendar periods with tier defaults.
+- Quota pause must not be treated as a workflow failure for retry or auto-pause failure-rate logic.
+- The design must use `tenant` as the column name in new schema, not `tenant_id`.
+
+## Data / API / Integrations
+
+### New enforcement table
+
+Create `workflow_step_usage_periods`:
+
+```text
+- tenant                  not null
+- period_start            timestamptz not null
+- period_end              timestamptz not null
+- period_source           text not null -- stripe_subscription | fallback_calendar
+- stripe_subscription_id  nullable
+- effective_limit         integer nullable -- null means unlimited
+- used_count              integer not null default 0
+- limit_source            text not null -- stripe_price_metadata | stripe_product_metadata | tier_default | unlimited_metadata
+- tier                    text not null
+- metadata_json           jsonb nullable
+- created_at              timestamptz not null
+- updated_at              timestamptz not null
+```
+
+Use a composite primary key or unique key on `(tenant, period_start, period_end)`. Add indexes for `(tenant, period_end)` and `(period_end)`.
+
+### Quota resolver
+
+The resolver returns a normalized quota summary:
+
+```ts
+{
+  tenant: string;
+  periodStart: string;
+  periodEnd: string;
+  periodSource: 'stripe_subscription' | 'fallback_calendar';
+  stripeSubscriptionId?: string | null;
+  effectiveLimit: number | null; // null = unlimited
+  usedCount: number;
+  remaining: number | null; // null = unlimited
+  tier: 'solo' | 'pro' | 'premium';
+  limitSource:
+    | 'stripe_price_metadata'
+    | 'stripe_product_metadata'
+    | 'tier_default'
+    | 'unlimited_metadata';
+}
+```
+
+### Stripe integration
+
+Preferred active subscription selection:
+
+- `status IN ('trialing', 'active', 'past_due', 'unpaid')`
+- valid `current_period_start` and `current_period_end`
+- if multiple subscriptions exist, prefer `trialing`, then `active`, then `past_due`, then `unpaid`
+
+Metadata key:
+
+```text
+workflow_step_limit
+```
+
+Valid values:
+
+- positive integer string/number, e.g. `750`
+- `unlimited`
+
+Precedence:
+
+1. Stripe price metadata
+2. Stripe product metadata
+3. Tier default
+
+### Runtime integration points
+
+DB runtime:
+
+- `shared/workflow/runtime/runtime/workflowRuntimeV2.ts`
+- Enforcement point: immediately after `resolveStepAtPath()` and before `WorkflowRunStepModelV2.create()`.
+
+Temporal runtime:
+
+- `ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts`
+- Enforcement point: `projectWorkflowRuntimeV2StepStart()` before `WorkflowRunStepModelV2.create()`.
+
+### Quota wait payload
+
+Use existing `workflow_run_waits` table with:
+
+```text
+wait_type = 'quota'
+status = 'WAITING'
+timeout_at = period_end
+payload = {
+  reason: 'workflow_step_quota_exceeded',
+  tenant,
+  periodStart,
+  periodEnd,
+  usedCount,
+  effectiveLimit,
+  periodSource,
+  limitSource
+}
+```
+
+### Scheduled job
+
+Add a recurring job handler such as `workflow-quota-resume-scan` that scans quota waits and resumes eligible runs. Use the existing job system and batch/locking safeguards.
+
+### Manual resume API/action
+
+Add a user/admin action such as `resumeWorkflowRunFromQuotaPause(runId)` that verifies permissions, confirms the run is quota-paused, checks quota eligibility, and resumes the run only when allowed.
+
+## Security / Permissions
+
+- Quota counters and wait records must remain tenant-isolated.
+- Manual resume must verify the user has permission to manage or operate the workflow run for the tenant.
+- Manual resume must not allow cross-tenant run access.
+- Manual resume must not bypass the runtime reservation path.
+- If RLS policies apply to workflow runtime tables in the target environment, add matching policies for `workflow_step_usage_periods`.
+
+## Observability
+
+Use `workflow_run_logs` and service logs for:
+
+- quota reservation success
+- quota exceeded / run quota-paused
+- quota-paused run resumed by scheduled job
+- quota-paused run resumed by manual action
+- resume skipped with reason
+- invalid Stripe metadata fallback
+- fallback-calendar period usage
+- reconciliation drift findings
+
+The counter table should store enough metadata to answer why a limit was applied, including period source, limit source, tier, Stripe subscription id, and fallback reason when applicable.
+
+## Rollout / Migration
+
+1. Add the enforcement table with indexes and tenant isolation/RLS if needed.
+2. Add shared quota resolver/reservation service behind the runtime integration.
+3. Integrate DB runtime step-start enforcement.
+4. Integrate Temporal activity step-start enforcement.
+5. Add quota wait/resume handling.
+6. Add scheduled resume scan job.
+7. Add manual resume action and minimal UI/API surfacing.
+8. Add reconciliation/reporting helper.
+9. Backfill is not required because enforcement starts from newly created usage period rows. Historical step-row reconciliation can report prior usage if needed.
+
+Rollout should be staged so that quota resolution and counter creation can be tested before hard enforcement is enabled if a feature flag or environment toggle is desired during deployment.
+
+## Risks
+
+- Counter drift could occur if any runtime path creates step rows without using the quota service.
+- Concurrent resume scans could resume more runs than remaining quota, but runtime reservation still protects final enforcement.
+- Stripe sync gaps could cause fallback-calendar periods to be used unexpectedly.
+- Temporal workflow behavior must treat quota as a controlled wait/pause, not an activity failure that causes unintended retries.
+- Existing UI may not clearly distinguish quota wait from other waits until minimal UI surfacing is added.
+
+## Open Questions
+
+- Should zero-limit metadata ever be valid, or should it remain invalid and fall back to tier default? Current design treats zero as invalid.
+- What exact permission should gate manual quota resume if no dedicated workflow-run operation permission exists?
+- Should rollout include an explicit enforcement feature flag, or is the plan to enforce immediately once shipped?
+
+## Acceptance Criteria (Definition of Done)
+
+- A tenant's workflow step usage is counted in `workflow_step_usage_periods` per resolved payment period.
+- The runtime atomically reserves one unit before each step attempt across DB and Temporal engines.
+- A tenant at the finite limit is quota-paused before a new step starts.
+- Quota-paused runs have `workflow_runs.status = 'WAITING'`, preserve `node_path`, and have a `workflow_run_waits.wait_type = 'quota'` record.
+- Quota-blocked steps do not create `workflow_run_steps` rows and do not increment usage.
+- Unlimited tenants continue executing while usage is still recorded.
+- Stripe metadata overrides and tier defaults resolve as specified.
+- Missing Stripe periods use the UTC calendar month fallback with tier defaults.
+- Scheduled resume scan resumes eligible quota-paused runs without bypassing runtime quota checks.
+- Manual resume resumes eligible quota-paused runs and returns a helpful exhausted-quota response otherwise.
+- Tests cover quota resolution, atomic reservation, DB runtime enforcement, Temporal runtime enforcement, resume behavior, and reconciliation drift detection.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD
@@ -1,0 +1,4 @@
+
+- (2026-04-28) Implemented `server/migrations/20260428120000_create_workflow_step_usage_periods.cjs` for `workflow_step_usage_periods` with primary key `(tenant, period_start, period_end)`, `tenant` FK isolation, and required quota fields.
+- (2026-04-28) Added period indexes `idx_workflow_step_usage_periods_tenant_period_end` and `idx_workflow_step_usage_periods_period_end` plus period bounds check `period_start < period_end`.
+- (2026-04-28) Migration grants server DB user privileges when `DB_USER_SERVER` is present, matching newer migration conventions.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD
@@ -1,4 +1,0 @@
-
-- (2026-04-28) Implemented `server/migrations/20260428120000_create_workflow_step_usage_periods.cjs` for `workflow_step_usage_periods` with primary key `(tenant, period_start, period_end)`, `tenant` FK isolation, and required quota fields.
-- (2026-04-28) Added period indexes `idx_workflow_step_usage_periods_tenant_period_end` and `idx_workflow_step_usage_periods_period_end` plus period bounds check `period_start < period_end`.
-- (2026-04-28) Migration grants server DB user privileges when `DB_USER_SERVER` is present, matching newer migration conventions.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -1,0 +1,85 @@
+# Scratchpad — Workflow Step Quota Accounting
+
+- Plan slug: `2026-04-28-workflow-step-quota-accounting`
+- Created: `2026-04-28`
+
+## What This Is
+
+Rolling notes for the workflow step quota accounting plan. Keep decisions, discoveries, commands, links, and gotchas here as implementation proceeds.
+
+## Decisions
+
+- (2026-04-28) Count every workflow step attempt at step start. Retries, failed attempts, `forEach` item attempts, and wait/human-task entry attempts all count. Quota-blocked steps do not count because they never start.
+- (2026-04-28) Quota exhaustion pauses workflow runs instead of failing them. Runs remain at the current `node_path` with `workflow_runs.status = 'WAITING'` and a `workflow_run_waits.wait_type = 'quota'` record.
+- (2026-04-28) Use Stripe subscription periods as the primary payment period source: `stripe_subscriptions.current_period_start` through `current_period_end`.
+- (2026-04-28) Do not use contract `recurring_service_periods`, cadence ownership, invoice windows, or contract-line periods for this feature. Workflow quota is tenant platform licensing usage, not client contract billing usage.
+- (2026-04-28) If no valid active Stripe period exists, fall back to the current UTC calendar month with tier defaults.
+- (2026-04-28) Tier defaults are `solo = 150`, `pro = 750`, and `premium = 10000` workflow step attempts per period.
+- (2026-04-28) Use hybrid limit resolution: Stripe price metadata first, Stripe product metadata second, tier default last.
+- (2026-04-28) Support `workflow_step_limit=unlimited`; unlimited tenants still record usage but are not quota-paused.
+- (2026-04-28) Use a dedicated atomic counter table for enforcement and keep `workflow_run_steps` as the detailed audit/reconciliation ledger.
+- (2026-04-28) Use column name `tenant` in new schema rather than `tenant_id`, per project schema convention and user instruction.
+- (2026-04-28) Resume quota-paused workflows through both a recurring job and a manual resume action. Manual resume must not bypass quota.
+
+## Discoveries / Constraints
+
+- (2026-04-28) DB workflow runtime creates step rows in `shared/workflow/runtime/runtime/workflowRuntimeV2.ts` inside `executeRun()` after `resolveStepAtPath()` and before `executeStep()`.
+- (2026-04-28) Temporal runtime creates projected step rows in `ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts` via `projectWorkflowRuntimeV2StepStart()`.
+- (2026-04-28) Existing workflow runtime tables include `workflow_runs`, `workflow_run_steps`, `workflow_run_waits`, `workflow_action_invocations`, `workflow_run_snapshots`, and `workflow_runtime_events` from migration `server/migrations/20251221090000_create_workflow_runtime_v2_tables.cjs`.
+- (2026-04-28) Tenant tiers are defined in `packages/types/src/constants/tenantTiers.ts` as `solo`, `pro`, and `premium`.
+- (2026-04-28) `packages/types/src/constants/tierFeatures.ts` already notes that `WORKFLOW_DESIGNER` is available to all tiers and that a usage cap was planned separately.
+- (2026-04-28) Stripe subscription table is created in EE migration `ee/server/migrations/20251014120000_create_stripe_integration_tables.cjs` and includes `current_period_start`, `current_period_end`, `stripe_price_id`, `status`, and `metadata`.
+- (2026-04-28) Existing scheduled job infrastructure includes `server/src/lib/jobs/initializeScheduledJobs.ts`, `registerAllHandlers.ts`, and `jobHandlerRegistry.ts`.
+
+## Commands / Runbooks
+
+- (2026-04-28) Create plan folder: `mkdir -p ee/docs/plans/2026-04-28-workflow-step-quota-accounting`.
+- (2026-04-28) Validate plan JSON manually or with the alga-plan validation helper after edits.
+
+## Links / References
+
+- `shared/workflow/runtime/runtime/workflowRuntimeV2.ts`
+- `ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts`
+- `server/migrations/20251221090000_create_workflow_runtime_v2_tables.cjs`
+- `ee/server/migrations/20251014120000_create_stripe_integration_tables.cjs`
+- `packages/types/src/constants/tenantTiers.ts`
+- `packages/types/src/constants/tierFeatures.ts`
+- `server/src/lib/jobs/initializeScheduledJobs.ts`
+- `server/src/lib/jobs/registerAllHandlers.ts`
+- `server/src/lib/jobs/jobHandlerRegistry.ts`
+
+## Open Questions
+
+- Should zero-limit metadata ever be valid, or should it remain invalid and fall back to tier default? Current PRD treats zero as invalid.
+- What exact permission should gate manual quota resume if no dedicated workflow-run operation permission exists?
+- Should rollout include an explicit enforcement feature flag, or is the plan to enforce immediately once shipped?
+
+## Implementation Notes (2026-04-28)
+
+- Added shared quota service at `shared/workflow/runtime/services/workflowStepQuotaService.ts`.
+- Resolver behavior implemented:
+  - Preferred Stripe subscription period from `stripe_subscriptions` with status priority `trialing > active > past_due > unpaid` and valid `current_period_start/end`.
+  - Fallback period to UTC month boundaries when Stripe tables/subscription period are unavailable.
+  - Tier defaults from `tenants.plan`: `solo=150`, `pro=750`, `premium=10000`.
+  - Metadata precedence implemented: `stripe_prices.metadata.workflow_step_limit` -> `stripe_products.metadata.workflow_step_limit` -> tier default.
+  - `workflow_step_limit=unlimited` maps to `effective_limit = null`.
+  - Invalid metadata safely ignored (falls through to next source).
+- Atomic reservation implemented in same service:
+  - Upserts `workflow_step_usage_periods` by `(tenant, period_start, period_end)`.
+  - Takes row lock (`FOR UPDATE`) before reservation decision.
+  - Finite limits reject at/above limit without increment.
+  - Unlimited limits always increment `used_count`.
+- DB runtime enforcement integrated in `shared/workflow/runtime/runtime/workflowRuntimeV2.ts`:
+  - Reservation now occurs before STARTED step row creation.
+  - On exhaustion: run is set `WAITING`, `node_path` preserved, and quota wait (`wait_type='quota'`) is created/reused.
+- Temporal projection enforcement integrated in `ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts` and workflow handling in `ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts`:
+  - Reservation happens before STARTED step projection.
+  - On exhaustion: quota wait created/reused, run marked WAITING, activity returns `quotaPaused` result, workflow exits without treating it as failure.
+- Added integration tests in `server/src/test/integration/workflowStepQuotaService.integration.test.ts` covering:
+  - Stripe period resolution.
+  - Fallback calendar month + tier default.
+  - Metadata precedence and unlimited.
+  - Finite reservation rejection-at-limit.
+  - Unlimited reservation increments.
+- Command run:
+  - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -91,3 +91,24 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
   - `logger.info` when resolver uses fallback UTC calendar periods due to missing Stripe period or missing Stripe tables.
 - Validation command run:
   - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).
+- Added scheduled quota resume scan job handler: `server/src/lib/jobs/handlers/workflowQuotaResumeScanHandler.ts`.
+  - Scans `workflow_run_waits` with `wait_type='quota'` and `status='WAITING'`.
+  - Uses `FOR UPDATE SKIP LOCKED` + configurable `batchSize` (default 100) for concurrency-safe scan batches.
+  - Applies per-tenant capacity gating from `workflowStepQuotaService.resolveQuotaSummary()`:
+    - finite tenants resume up to `effectiveLimit - usedCount`
+    - unlimited tenants resume all selected waits
+  - Resolves selected waits, sets runs to `RUNNING`, writes run log entries, and re-enters DB runtime via `WorkflowRuntimeV2.executeRun()` without pre-consuming quota.
+- Registered/scheduled job plumbing:
+  - `server/src/lib/jobs/registerAllHandlers.ts` registration name `workflow-quota-resume-scan`.
+  - `server/src/lib/jobs/index.ts` legacy registration + `scheduleWorkflowQuotaResumeScanJob()`.
+  - `server/src/lib/jobs/initializeScheduledJobs.ts` schedules recurring scan cron `*/5 * * * *`.
+- Added manual quota resume action:
+  - `ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts` exports `resumeWorkflowRunFromQuotaPauseAction`.
+  - Verifies permission and tenant ownership, requires `WAITING` + `quota` wait, checks current quota summary, returns structured exhausted-quota response when still blocked, otherwise resolves quota wait and executes runtime (no bypass of step-start reservation).
+- Validation attempt:
+  - `cd server && npm test -- src/test/integration/workflowRuntimeV2.control.integration.test.ts` (fails in current env due missing module resolution for `@alga-psa/authorization/kernel`, unrelated to quota changes).
+- Added test coverage for concurrent finite quota reservations:
+  - `server/src/test/integration/workflowStepQuotaService.integration.test.ts`
+  - New case fires 12 concurrent reservations against finite limit 3 and asserts exactly 3 allows, 9 denies, and persisted `used_count=3`.
+- Validation command run:
+  - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -83,3 +83,4 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
   - Unlimited reservation increments.
 - Command run:
   - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).
+- Added T005 coverage in `server/src/test/integration/workflowStepQuotaService.integration.test.ts` to verify uniqueness and upsert behavior on `(tenant, period_start, period_end)`.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -123,3 +123,24 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
   - Structured log assertions for invalid metadata fallback, reservation success, quota exhaustion, and fallback-calendar usage.
 - Validation command run:
   - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass after fixture fix for `workflow_definitions.tenant_id`).
+- Added DB runtime quota integration coverage in `server/src/test/integration/workflowRuntimeV2.control.integration.test.ts`:
+  - Reserve-before-step-start assertion (no `workflow_run_steps` rows exist before reservation callback returns).
+  - Quota exhaustion on second step pauses run with `wait_type='quota'`, keeps `node_path`, and avoids blocked-step row creation.
+  - Retry and forEach attempt accounting assertions against `workflow_step_usage_periods.used_count`.
+  - Event wait accounting assertion that first entry consumes quota and resume does not double count.
+- Added Temporal coverage:
+  - `ee/temporal-workflows/src/activities/__tests__/workflow-runtime-v2-activities.test.ts` adds `projectWorkflowRuntimeV2StepStart` tests for reserve-before-start and quota pause projection.
+  - `ee/temporal-workflows/src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts` adds quota paused short-circuit behavior test (`stepId:null`, `quotaPaused:true`).
+- Validation attempts:
+  - `cd server && npm test -- src/test/integration/workflowRuntimeV2.control.integration.test.ts` fails in current env with known module resolution issue: `@alga-psa/authorization/kernel` missing from runtime action import graph.
+  - `cd ee/temporal-workflows && TEMPORAL_TEST_SKIP_ENV_BOOTSTRAP=1 npm test -- src/activities/__tests__/workflow-runtime-v2-activities.test.ts src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts`:
+    - activities tests pass.
+    - workflow tests fail in current env due package resolution of `@alga-psa/workflows/lib/workflowRuntimeV2TemporalContract` when run in isolation.
+- Added manual quota resume integration coverage in `server/src/test/integration/workflowRuntimeV2.control.integration.test.ts`:
+  - Resume succeeds when quota is available and runtime re-entry still calls quota reservation.
+  - Resume returns `quota_exhausted` response with `usedCount`, `effectiveLimit`, `periodStart`, and `periodEnd` when quota remains exhausted.
+- Added unit job coverage in `server/src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts`:
+  - Finite exhausted tenants are skipped while eligible tenants are resolved/resumed.
+  - Repeated scans do not resolve/execute the same wait twice once status has moved to `RESOLVED`.
+- Validation command run:
+  - `cd server && npm test -- src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts` (pass).

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -112,3 +112,9 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
   - New case fires 12 concurrent reservations against finite limit 3 and asserts exactly 3 allows, 9 denies, and persisted `used_count=3`.
 - Validation command run:
   - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).
+- Added minimal run-level quota pause surfacing in workflow run detail responses:
+  - `listWorkflowRunStepsAction` and `exportWorkflowRunDetailAction` now return `quotaPause` derived from active quota wait payload.
+- Added reconciliation helper to quota service:
+  - `workflowStepQuotaService.reconcileUsagePeriod(tenant, periodStart, periodEnd)` compares counter usage to step ledger count and returns drift.
+- Added support/engineering documentation:
+  - `ee/docs/plans/2026-04-28-workflow-step-quota-accounting/OPERATIONS.md` covering quota source/limits, pause/resume behavior, and reconciliation runbook.

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -84,3 +84,10 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
 - Command run:
   - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).
 - Added T005 coverage in `server/src/test/integration/workflowStepQuotaService.integration.test.ts` to verify uniqueness and upsert behavior on `(tenant, period_start, period_end)`.
+- Added structured observability logs in `shared/workflow/runtime/services/workflowStepQuotaService.ts`:
+  - `logger.debug` on successful quota reservation with tenant/period/limit context.
+  - `logger.warn` on quota exhaustion at reservation with tenant/period/used/limit context.
+  - `logger.warn` when invalid `workflow_step_limit` metadata is detected on Stripe price/product and fallback resolution is used.
+  - `logger.info` when resolver uses fallback UTC calendar periods due to missing Stripe period or missing Stripe tables.
+- Validation command run:
+  - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass).

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/SCRATCHPAD.md
@@ -118,3 +118,8 @@ Rolling notes for the workflow step quota accounting plan. Keep decisions, disco
   - `workflowStepQuotaService.reconcileUsagePeriod(tenant, periodStart, periodEnd)` compares counter usage to step ledger count and returns drift.
 - Added support/engineering documentation:
   - `ee/docs/plans/2026-04-28-workflow-step-quota-accounting/OPERATIONS.md` covering quota source/limits, pause/resume behavior, and reconciliation runbook.
+- Added diagnostic/observability integration coverage in `server/src/test/integration/workflowStepQuotaService.integration.test.ts`:
+  - Reconciliation drift test for `reconcileUsagePeriod()` (`counterUsedCount`, `ledgerStepCount`, `drift`).
+  - Structured log assertions for invalid metadata fallback, reservation success, quota exhaustion, and fallback-calendar usage.
+- Validation command run:
+  - `cd server && npm test -- src/test/integration/workflowStepQuotaService.integration.test.ts` (pass after fixture fix for `workflow_definitions.tenant_id`).

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
@@ -154,7 +154,7 @@
   {
     "id": "F019",
     "description": "Implement a scheduled workflow-quota-resume-scan job that finds WAITING quota waits and resumes eligible runs.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Data / API / Integrations > Scheduled job"
     ]
@@ -162,7 +162,7 @@
   {
     "id": "F020",
     "description": "Add locking and batch limits to the quota resume scan so concurrent scans do not resolve the same waits.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Requirements > Non-functional Requirements",
       "Data / API / Integrations > Scheduled job"
@@ -171,7 +171,7 @@
   {
     "id": "F021",
     "description": "Resume at most the finite remaining capacity for a tenant during each scan while relying on runtime reservation for final enforcement.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Users and Primary Flows > Background scheduler"
     ]
@@ -179,7 +179,7 @@
   {
     "id": "F022",
     "description": "Add a manual resume action for quota-paused workflow runs that verifies tenant ownership, permissions, and quota eligibility.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Data / API / Integrations > Manual resume API/action",
       "Security / Permissions"
@@ -188,7 +188,7 @@
   {
     "id": "F023",
     "description": "Return a helpful exhausted-quota response from manual resume when quota is still unavailable, including usage, limit, and reset time.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "UX / UI Notes"
     ]
@@ -196,7 +196,7 @@
   {
     "id": "F024",
     "description": "Trigger or enqueue normal workflow execution after an automatic or manual quota resume without pre-consuming quota.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Users and Primary Flows",
       "Acceptance Criteria (Definition of Done)"

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
@@ -223,7 +223,7 @@
   {
     "id": "F027",
     "description": "Ensure workflow retries consume a new step unit only when the retry step attempt starts.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Requirements > Functional Requirements"
     ]
@@ -231,7 +231,7 @@
   {
     "id": "F028",
     "description": "Ensure forEach body executions consume one step unit per item attempt.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Requirements > Functional Requirements"
     ]
@@ -239,7 +239,7 @@
   {
     "id": "F029",
     "description": "Ensure wait and human task steps consume one step unit when first entered and do not double-count while merely waiting.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Requirements > Functional Requirements"
     ]

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
@@ -205,7 +205,7 @@
   {
     "id": "F025",
     "description": "Expose minimal run-level quota pause information through existing run logs, wait records, or inspector surfaces.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "UX / UI Notes",
       "Observability"
@@ -214,7 +214,7 @@
   {
     "id": "F026",
     "description": "Implement a reconciliation helper that compares workflow_step_usage_periods.used_count to workflow_run_steps joined through workflow_runs for the same tenant and period.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Observability",
       "Requirements > Functional Requirements"
@@ -247,7 +247,7 @@
   {
     "id": "F030",
     "description": "Document quota source, limits, pause behavior, resume behavior, and reconciliation procedure for future support and engineering use.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Rollout / Migration",
       "Observability"

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
@@ -1,0 +1,256 @@
+[
+  {
+    "id": "F001",
+    "description": "Create the workflow_step_usage_periods table keyed by tenant, period_start, and period_end with fields for period source, effective limit, used count, limit source, tier, Stripe subscription id, metadata, and timestamps.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > New enforcement table"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Add indexes and tenant isolation/RLS support for workflow_step_usage_periods consistent with workflow runtime tables.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > New enforcement table",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Implement a quota resolver that selects the tenant's active Stripe subscription period when available.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Stripe integration"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Implement fallback quota periods using the current UTC calendar month when no valid active Stripe subscription period exists.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "Data / API / Integrations > Quota resolver"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Resolve tenant tier defaults for workflow step limits: solo 150, pro 750, and premium 10000.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "Data / API / Integrations > Quota resolver"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Read workflow_step_limit from Stripe price metadata and use it as the highest-precedence finite or unlimited limit override.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Stripe integration"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Read workflow_step_limit from Stripe product metadata as a fallback override when price metadata is missing or invalid.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Stripe integration"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Treat workflow_step_limit=unlimited as effective_limit null while continuing to record used_count.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements",
+      "Data / API / Integrations > Stripe integration"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Ignore invalid workflow_step_limit metadata and fall back to the next valid source without crashing workflow execution.",
+    "implemented": true,
+    "prdRefs": [
+      "Non-functional Requirements",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Implement an atomic quota reservation service that upserts and locks the tenant period row before incrementing used_count.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements",
+      "Data / API / Integrations > New enforcement table"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Reject finite quota reservations without incrementing used_count when used_count is already at or above effective_limit.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Allow unlimited quota reservations to increment used_count and continue execution regardless of current count.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Integrate quota reservation into WorkflowRuntimeV2 before workflow_run_steps STARTED rows are created.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Runtime integration points"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "Integrate quota reservation into projectWorkflowRuntimeV2StepStart before Temporal workflow_run_steps STARTED rows are created.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Runtime integration points"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Create or reuse a workflow_run_waits record with wait_type quota when a reservation is rejected for quota exhaustion.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations > Quota wait payload"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Mark quota-exhausted runs WAITING at the current node_path without creating a workflow_run_steps row for the blocked step.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements > Functional Requirements",
+      "Acceptance Criteria (Definition of Done)"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "Ensure quota pauses are treated as controlled waits rather than workflow failures, retryable step errors, or auto-pause failure-rate inputs.",
+    "implemented": true,
+    "prdRefs": [
+      "Non-goals",
+      "Requirements > Non-functional Requirements"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Log quota reservation, quota exhaustion, invalid metadata fallback, and fallback-calendar usage with structured workflow/runtime context.",
+    "implemented": false,
+    "prdRefs": [
+      "Observability"
+    ]
+  },
+  {
+    "id": "F019",
+    "description": "Implement a scheduled workflow-quota-resume-scan job that finds WAITING quota waits and resumes eligible runs.",
+    "implemented": false,
+    "prdRefs": [
+      "Data / API / Integrations > Scheduled job"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "Add locking and batch limits to the quota resume scan so concurrent scans do not resolve the same waits.",
+    "implemented": false,
+    "prdRefs": [
+      "Requirements > Non-functional Requirements",
+      "Data / API / Integrations > Scheduled job"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "Resume at most the finite remaining capacity for a tenant during each scan while relying on runtime reservation for final enforcement.",
+    "implemented": false,
+    "prdRefs": [
+      "Users and Primary Flows > Background scheduler"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "Add a manual resume action for quota-paused workflow runs that verifies tenant ownership, permissions, and quota eligibility.",
+    "implemented": false,
+    "prdRefs": [
+      "Data / API / Integrations > Manual resume API/action",
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "Return a helpful exhausted-quota response from manual resume when quota is still unavailable, including usage, limit, and reset time.",
+    "implemented": false,
+    "prdRefs": [
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "Trigger or enqueue normal workflow execution after an automatic or manual quota resume without pre-consuming quota.",
+    "implemented": false,
+    "prdRefs": [
+      "Users and Primary Flows",
+      "Acceptance Criteria (Definition of Done)"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Expose minimal run-level quota pause information through existing run logs, wait records, or inspector surfaces.",
+    "implemented": false,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Observability"
+    ]
+  },
+  {
+    "id": "F026",
+    "description": "Implement a reconciliation helper that compares workflow_step_usage_periods.used_count to workflow_run_steps joined through workflow_runs for the same tenant and period.",
+    "implemented": false,
+    "prdRefs": [
+      "Observability",
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F027",
+    "description": "Ensure workflow retries consume a new step unit only when the retry step attempt starts.",
+    "implemented": false,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F028",
+    "description": "Ensure forEach body executions consume one step unit per item attempt.",
+    "implemented": false,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F029",
+    "description": "Ensure wait and human task steps consume one step unit when first entered and do not double-count while merely waiting.",
+    "implemented": false,
+    "prdRefs": [
+      "Requirements > Functional Requirements"
+    ]
+  },
+  {
+    "id": "F030",
+    "description": "Document quota source, limits, pause behavior, resume behavior, and reconciliation procedure for future support and engineering use.",
+    "implemented": false,
+    "prdRefs": [
+      "Rollout / Migration",
+      "Observability"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/features.json
@@ -146,7 +146,7 @@
   {
     "id": "F018",
     "description": "Log quota reservation, quota exhaustion, invalid metadata fallback, and fallback-calendar usage with structured workflow/runtime context.",
-    "implemented": false,
+    "implemented": true,
     "prdRefs": [
       "Observability"
     ]

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -56,7 +56,7 @@
   {
     "id": "T007",
     "description": "DB integration: concurrent finite reservations cannot increase used_count beyond effective_limit.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F010",
       "F011"

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -74,7 +74,7 @@
   {
     "id": "T009",
     "description": "Runtime integration: DB WorkflowRuntimeV2 reserves quota before creating a STARTED step row and executes normally under the limit.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F010",
       "F013"
@@ -83,7 +83,7 @@
   {
     "id": "T010",
     "description": "Runtime integration: DB WorkflowRuntimeV2 quota exhaustion creates a quota wait, marks the run WAITING at the current node_path, and creates no step row for the blocked step.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F015",
       "F016",
@@ -93,7 +93,7 @@
   {
     "id": "T011",
     "description": "Runtime integration: retry attempts and forEach body attempts each consume additional quota when the attempt starts.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F027",
       "F028"
@@ -102,7 +102,7 @@
   {
     "id": "T012",
     "description": "Runtime integration: event.wait, time.wait, or human.task consumes quota on first entry and does not repeatedly consume while the run remains waiting.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F029"
     ]
@@ -110,7 +110,7 @@
   {
     "id": "T013",
     "description": "Temporal integration: projectWorkflowRuntimeV2StepStart reserves quota before creating a STARTED step row and reports quota exhaustion as a controlled pause/wait path.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F014",
       "F015",
@@ -121,7 +121,7 @@
   {
     "id": "T014",
     "description": "Job integration: workflow-quota-resume-scan skips exhausted tenants, resolves eligible quota waits, and sets matching runs back to RUNNING without pre-consuming quota.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F019",
       "F021",
@@ -131,7 +131,7 @@
   {
     "id": "T015",
     "description": "Job integration: concurrent quota resume scans use row locking or equivalent safeguards so the same wait is not resolved twice.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F020"
     ]
@@ -139,7 +139,7 @@
   {
     "id": "T016",
     "description": "Action/API integration: manual quota resume verifies tenant ownership and permissions, resumes when quota is available, and does not bypass runtime reservation.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F022",
       "F024"
@@ -148,7 +148,7 @@
   {
     "id": "T017",
     "description": "Action/API integration: manual quota resume returns used count, effective limit, and reset time when quota remains exhausted.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F023",
       "F025"

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -38,7 +38,7 @@
   {
     "id": "T005",
     "description": "DB integration: migrated workflow_step_usage_periods supports insert/upsert by tenant, period_start, and period_end and enforces uniqueness.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F001",
       "F002"

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -1,0 +1,181 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit: quota resolver uses an active Stripe subscription current_period_start/current_period_end and stores period_source stripe_subscription.",
+    "implemented": true,
+    "featureIds": [
+      "F003"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Unit: quota resolver falls back to the current UTC calendar month and tier defaults when no valid active Stripe period exists.",
+    "implemented": true,
+    "featureIds": [
+      "F004",
+      "F005"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Unit: quota resolver applies metadata precedence of Stripe price metadata, then product metadata, then tier default.",
+    "implemented": true,
+    "featureIds": [
+      "F005",
+      "F006",
+      "F007"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "Unit: quota resolver maps workflow_step_limit=unlimited to effective_limit null and ignores invalid metadata by falling back safely.",
+    "implemented": true,
+    "featureIds": [
+      "F008",
+      "F009"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "DB integration: migrated workflow_step_usage_periods supports insert/upsert by tenant, period_start, and period_end and enforces uniqueness.",
+    "implemented": false,
+    "featureIds": [
+      "F001",
+      "F002"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "DB integration: atomic reservation increments used_count below a finite limit and rejects without incrementing at the limit.",
+    "implemented": true,
+    "featureIds": [
+      "F010",
+      "F011"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "DB integration: concurrent finite reservations cannot increase used_count beyond effective_limit.",
+    "implemented": false,
+    "featureIds": [
+      "F010",
+      "F011"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "DB integration: unlimited reservations always succeed and still increment used_count for reporting.",
+    "implemented": true,
+    "featureIds": [
+      "F008",
+      "F012"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "Runtime integration: DB WorkflowRuntimeV2 reserves quota before creating a STARTED step row and executes normally under the limit.",
+    "implemented": false,
+    "featureIds": [
+      "F010",
+      "F013"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "Runtime integration: DB WorkflowRuntimeV2 quota exhaustion creates a quota wait, marks the run WAITING at the current node_path, and creates no step row for the blocked step.",
+    "implemented": false,
+    "featureIds": [
+      "F015",
+      "F016",
+      "F017"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "Runtime integration: retry attempts and forEach body attempts each consume additional quota when the attempt starts.",
+    "implemented": false,
+    "featureIds": [
+      "F027",
+      "F028"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "Runtime integration: event.wait, time.wait, or human.task consumes quota on first entry and does not repeatedly consume while the run remains waiting.",
+    "implemented": false,
+    "featureIds": [
+      "F029"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Temporal integration: projectWorkflowRuntimeV2StepStart reserves quota before creating a STARTED step row and reports quota exhaustion as a controlled pause/wait path.",
+    "implemented": false,
+    "featureIds": [
+      "F014",
+      "F015",
+      "F016",
+      "F017"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Job integration: workflow-quota-resume-scan skips exhausted tenants, resolves eligible quota waits, and sets matching runs back to RUNNING without pre-consuming quota.",
+    "implemented": false,
+    "featureIds": [
+      "F019",
+      "F021",
+      "F024"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Job integration: concurrent quota resume scans use row locking or equivalent safeguards so the same wait is not resolved twice.",
+    "implemented": false,
+    "featureIds": [
+      "F020"
+    ]
+  },
+  {
+    "id": "T016",
+    "description": "Action/API integration: manual quota resume verifies tenant ownership and permissions, resumes when quota is available, and does not bypass runtime reservation.",
+    "implemented": false,
+    "featureIds": [
+      "F022",
+      "F024"
+    ]
+  },
+  {
+    "id": "T017",
+    "description": "Action/API integration: manual quota resume returns used count, effective limit, and reset time when quota remains exhausted.",
+    "implemented": false,
+    "featureIds": [
+      "F023",
+      "F025"
+    ]
+  },
+  {
+    "id": "T018",
+    "description": "Diagnostic integration: reconciliation reports drift between workflow_step_usage_periods.used_count and workflow_run_steps joined to workflow_runs for a tenant period.",
+    "implemented": false,
+    "featureIds": [
+      "F026"
+    ]
+  },
+  {
+    "id": "T019",
+    "description": "Observability: quota reservation, quota exceeded, resume, invalid metadata fallback, and fallback-calendar usage emit structured logs or workflow run logs with tenant and period context.",
+    "implemented": false,
+    "featureIds": [
+      "F018"
+    ]
+  },
+  {
+    "id": "T020",
+    "description": "Documentation review: support and engineering notes describe quota source, default limits, metadata override, pause/resume behavior, and reconciliation procedure.",
+    "implemented": false,
+    "featureIds": [
+      "F030"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -157,7 +157,7 @@
   {
     "id": "T018",
     "description": "Diagnostic integration: reconciliation reports drift between workflow_step_usage_periods.used_count and workflow_run_steps joined to workflow_runs for a tenant period.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F026"
     ]
@@ -165,7 +165,7 @@
   {
     "id": "T019",
     "description": "Observability: quota reservation, quota exceeded, resume, invalid metadata fallback, and fallback-calendar usage emit structured logs or workflow run logs with tenant and period context.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F018"
     ]

--- a/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
+++ b/ee/docs/plans/2026-04-28-workflow-step-quota-accounting/tests.json
@@ -173,7 +173,7 @@
   {
     "id": "T020",
     "description": "Documentation review: support and engineering notes describe quota source, default limits, metadata override, pause/resume behavior, and reconciliation procedure.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F030"
     ]

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -2857,6 +2857,100 @@ export const resumeWorkflowRunAction = withAuth(async (user, { tenant }, input: 
   return { ok: true };
 });
 
+export const resumeWorkflowRunFromQuotaPauseAction = withAuth(async (user, { tenant }, input: unknown) => {
+  initializeWorkflowRuntimeV2();
+  const parsed = RunActionInput.parse(input);
+  const { knex } = await createTenantKnex();
+  await requireWorkflowPermission(user, 'admin', knex);
+  const runRecord = await requireRunTenantAccess(knex, parsed.runId, tenant);
+  assertLegacyRunControlSupported(runRecord, 'resume');
+
+  if (runRecord.status !== 'WAITING') {
+    return throwHttpError(409, 'Run is not waiting');
+  }
+
+  const quotaWait = await knex('workflow_run_waits')
+    .where({
+      run_id: parsed.runId,
+      wait_type: 'quota',
+      status: 'WAITING',
+    })
+    .orderBy('created_at', 'asc')
+    .first<{ wait_id: string; step_path: string | null }>();
+
+  if (!quotaWait) {
+    return throwHttpError(409, 'Run is not quota-paused');
+  }
+
+  const { workflowStepQuotaService } = await import('@alga-psa/workflows/runtime/core');
+  const quotaSummary = await workflowStepQuotaService.resolveQuotaSummary(knex, runRecord.tenant_id ?? tenant);
+  const quotaExhausted = quotaSummary.effectiveLimit != null && quotaSummary.usedCount >= quotaSummary.effectiveLimit;
+
+  if (quotaExhausted) {
+    return {
+      ok: false,
+      resumed: false,
+      reason: 'quota_exhausted',
+      quota: {
+        usedCount: quotaSummary.usedCount,
+        effectiveLimit: quotaSummary.effectiveLimit,
+        periodEnd: quotaSummary.periodEnd,
+        periodStart: quotaSummary.periodStart,
+        periodSource: quotaSummary.periodSource,
+        limitSource: quotaSummary.limitSource,
+      },
+    };
+  }
+
+  await WorkflowRunWaitModelV2.update(knex, quotaWait.wait_id, {
+    status: 'RESOLVED',
+    resolved_at: new Date().toISOString(),
+  });
+
+  const resumePayload = {
+    __admin_override: true,
+    reason: parsed.reason,
+    waitId: quotaWait.wait_id,
+    waitType: 'quota',
+    quotaResume: true,
+  };
+
+  await WorkflowRunModelV2.update(knex, parsed.runId, {
+    status: 'RUNNING',
+    resume_event_name: 'ADMIN_RESUME',
+    resume_event_payload: resumePayload,
+    resume_error: null,
+  });
+
+  await WorkflowRunLogModelV2.create(knex, {
+    run_id: parsed.runId,
+    tenant_id: runRecord?.tenant_id ?? null,
+    step_path: quotaWait.step_path ?? null,
+    level: 'INFO',
+    message: 'Quota-paused run resumed by operator',
+    context_json: {
+      reason: parsed.reason,
+      waitId: quotaWait.wait_id,
+      waitType: 'quota',
+    },
+    source: parsed.source ?? 'api',
+  });
+
+  await auditWorkflowEvent(knex, user, {
+    operation: 'workflow_run_resume',
+    tableName: 'workflow_runs',
+    recordId: parsed.runId,
+    changedData: { status: 'RUNNING' },
+    details: { reason: parsed.reason, waitType: 'quota' },
+    source: parsed.source ?? 'api'
+  });
+
+  const runtime = new WorkflowRuntimeV2();
+  await runtime.executeRun(knex, parsed.runId, `admin-${user.user_id}`);
+
+  return { ok: true, resumed: true };
+});
+
 export const retryWorkflowRunAction = withAuth(async (user, { tenant }, input: unknown) => {
   initializeWorkflowRuntimeV2();
   const parsed = RunActionInput.parse(input);

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -62,7 +62,8 @@ import {
 import {
   cancelWorkflowRuntimeV2TemporalRun,
   signalWorkflowRuntimeV2Event,
-  signalWorkflowRuntimeV2HumanTask
+  signalWorkflowRuntimeV2HumanTask,
+  signalWorkflowRuntimeV2QuotaResume
 } from '../lib/workflowRuntimeV2Temporal';
 import { resolveWorkflowEventCorrelation } from '../lib/workflowEventCorrelation';
 import type { DeletionValidationResult } from '@alga-psa/types';
@@ -2885,7 +2886,6 @@ export const resumeWorkflowRunFromQuotaPauseAction = withAuth(async (user, { ten
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'admin', knex);
   const runRecord = await requireRunTenantAccess(knex, parsed.runId, tenant);
-  assertLegacyRunControlSupported(runRecord, 'resume');
 
   if (runRecord.status !== 'WAITING') {
     return throwHttpError(409, 'Run is not waiting');
@@ -2902,6 +2902,9 @@ export const resumeWorkflowRunFromQuotaPauseAction = withAuth(async (user, { ten
 
   if (!quotaWait) {
     return throwHttpError(409, 'Run is not quota-paused');
+  }
+  if (!quotaWait.step_path || runRecord.node_path !== quotaWait.step_path) {
+    return throwHttpError(409, 'Quota pause is stale for this run');
   }
 
   const { workflowStepQuotaService } = await import('@alga-psa/workflows/runtime/core');
@@ -2939,9 +2942,10 @@ export const resumeWorkflowRunFromQuotaPauseAction = withAuth(async (user, { ten
 
   await WorkflowRunModelV2.update(knex, parsed.runId, {
     status: 'RUNNING',
-    resume_event_name: 'ADMIN_RESUME',
-    resume_event_payload: resumePayload,
+    resume_event_name: runRecord.engine === 'temporal' ? null : 'ADMIN_RESUME',
+    resume_event_payload: runRecord.engine === 'temporal' ? null : resumePayload,
     resume_error: null,
+    error_json: null,
   });
 
   await WorkflowRunLogModelV2.create(knex, {
@@ -2967,8 +2971,17 @@ export const resumeWorkflowRunFromQuotaPauseAction = withAuth(async (user, { ten
     source: parsed.source ?? 'api'
   });
 
-  const runtime = new WorkflowRuntimeV2();
-  await runtime.executeRun(knex, parsed.runId, `admin-${user.user_id}`);
+  if (runRecord.engine === 'temporal') {
+    await signalWorkflowRuntimeV2QuotaResume({
+      runId: parsed.runId,
+      waitId: quotaWait.wait_id,
+      reason: parsed.reason,
+      resumedBy: `admin-${user.user_id}`,
+    });
+  } else {
+    const runtime = new WorkflowRuntimeV2();
+    await runtime.executeRun(knex, parsed.runId, `admin-${user.user_id}`);
+  }
 
   return { ok: true, resumed: true };
 });

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -106,6 +106,21 @@ const EXPORT_EVENTS_LIMIT = 1000;
 const EXPORT_AUDIT_LIMIT = 5000;
 const EXPORT_LOGS_LIMIT = 5000;
 
+const extractQuotaPauseSummary = (waits: Array<{ wait_type?: string | null; status?: string | null; payload?: any }>) => {
+  const quotaWait = waits.find((wait) => wait.wait_type === 'quota' && wait.status === 'WAITING');
+  const payload = quotaWait?.payload;
+  if (!payload || typeof payload !== 'object') return null;
+  return {
+    reason: payload.reason ?? 'workflow_step_quota_exceeded',
+    periodStart: payload.periodStart ?? null,
+    periodEnd: payload.periodEnd ?? null,
+    usedCount: payload.usedCount ?? null,
+    effectiveLimit: payload.effectiveLimit ?? null,
+    periodSource: payload.periodSource ?? null,
+    limitSource: payload.limitSource ?? null,
+  };
+};
+
 const csvEscape = (value: unknown) => {
   if (value === null || value === undefined) return '';
   const text = String(value);
@@ -2660,7 +2675,13 @@ export const listWorkflowRunStepsAction = withAuth(async (user, { tenant }, inpu
     envelope_json: applyRunStudioRedactions(snapshot.envelope_json, cfg) as any
   }));
 
-  return { steps, snapshots: sanitizedSnapshots, invocations: redactedInvocations, waits };
+  return {
+    steps,
+    snapshots: sanitizedSnapshots,
+    invocations: redactedInvocations,
+    waits,
+    quotaPause: extractQuotaPauseSummary(waits),
+  };
 });
 
 export const exportWorkflowRunDetailAction = withAuth(async (user, { tenant }, input: unknown) => {
@@ -2710,7 +2731,8 @@ export const exportWorkflowRunDetailAction = withAuth(async (user, { tenant }, i
     steps,
     snapshots: sanitizedSnapshots,
     invocations: sanitizedInvocations,
-    waits
+    waits,
+    quotaPause: extractQuotaPauseSummary(waits),
   };
 });
 

--- a/ee/packages/workflows/src/lib/workflowRuntimeV2Temporal.ts
+++ b/ee/packages/workflows/src/lib/workflowRuntimeV2Temporal.ts
@@ -1,6 +1,7 @@
 export {
   WORKFLOW_RUNTIME_V2_EVENT_SIGNAL,
   WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL,
+  WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW,
   type WorkflowRuntimeV2TemporalRunInput,
@@ -9,6 +10,7 @@ export {
 import {
   WORKFLOW_RUNTIME_V2_EVENT_SIGNAL,
   WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL,
+  WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW,
   type WorkflowRuntimeV2TemporalRunInput,
@@ -100,6 +102,35 @@ export async function signalWorkflowRuntimeV2HumanTask(input: {
       taskId: input.taskId,
       eventName: input.eventName ?? 'HUMAN_TASK_COMPLETED',
       payload: input.payload ?? {},
+    });
+  } finally {
+    await connection.close().catch(() => undefined);
+  }
+}
+
+export async function signalWorkflowRuntimeV2QuotaResume(input: {
+  runId: string;
+  waitId?: string | null;
+  reason?: string | null;
+  resumedBy?: string | null;
+}): Promise<void> {
+  const temporal = await import('@temporalio/client');
+  const connection = await temporal.Connection.connect({
+    address: process.env.TEMPORAL_ADDRESS || DEFAULT_TEMPORAL_ADDRESS,
+  });
+  const client = new temporal.Client({
+    connection,
+    namespace: process.env.TEMPORAL_NAMESPACE || DEFAULT_TEMPORAL_NAMESPACE,
+  });
+
+  const temporalWorkflowId = `workflow-runtime-v2:run:${input.runId}`;
+  try {
+    const handle = client.workflow.getHandle(temporalWorkflowId);
+    await handle.signal(WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL, {
+      waitId: input.waitId ?? null,
+      reason: input.reason ?? 'quota_available',
+      resumedBy: input.resumedBy ?? null,
+      resumedAt: new Date().toISOString(),
     });
   } finally {
     await connection.close().catch(() => undefined);

--- a/ee/packages/workflows/src/lib/workflowRuntimeV2TemporalContract.ts
+++ b/ee/packages/workflows/src/lib/workflowRuntimeV2TemporalContract.ts
@@ -2,6 +2,7 @@ export const WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE = 'workflow-runtime-v2';
 export const WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW = 'workflowRuntimeV2RunWorkflow';
 export const WORKFLOW_RUNTIME_V2_EVENT_SIGNAL = 'workflowRuntimeV2Event';
 export const WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL = 'workflowRuntimeV2HumanTask';
+export const WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL = 'workflowRuntimeV2QuotaResume';
 
 export type WorkflowRuntimeV2TemporalRunInput = {
   runId: string;

--- a/ee/temporal-workflows/src/activities/__tests__/workflow-runtime-v2-activities.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/workflow-runtime-v2-activities.test.ts
@@ -10,10 +10,18 @@ const mocks = vi.hoisted(() => ({
   resolveExpressionsWithSecrets: vi.fn(),
   actionRegistryGet: vi.fn(),
   actionHandler: vi.fn(),
+  getRunById: vi.fn(),
+  getLatestStepByPath: vi.fn(),
+  createRunStep: vi.fn(),
+  updateRun: vi.fn(),
+  createWait: vi.fn(),
+  updateWait: vi.fn(),
+  reserveStepStart: vi.fn(),
 }));
 
 vi.mock('@alga-psa/db/admin', () => ({
   getAdminConnection: mocks.getAdminConnection,
+  retryOnAdminReadOnly: async (fn: () => Promise<unknown>) => fn(),
 }));
 
 vi.mock('@alga-psa/workflows/runtime/core', () => ({
@@ -32,6 +40,9 @@ vi.mock('@alga-psa/workflows/runtime/core', () => ({
   generateIdempotencyKey: () => 'generated-idempotency-key',
   initializeWorkflowRuntimeV2: mocks.initializeWorkflowRuntimeV2,
   createSecretResolverFromProvider: (provider: unknown) => provider,
+  workflowStepQuotaService: {
+    reserveStepStart: mocks.reserveStepStart,
+  },
 }));
 
 vi.mock('@alga-psa/shared/workflow/secrets', () => ({
@@ -47,9 +58,18 @@ vi.mock('@alga-psa/workflows/persistence', () => ({
     update: mocks.updateInvocation,
   },
   WorkflowDefinitionVersionModelV2: {},
-  WorkflowRunStepModelV2: {},
-  WorkflowRunModelV2: {},
-  WorkflowRunWaitModelV2: {},
+  WorkflowRunStepModelV2: {
+    getLatestByRunAndPath: mocks.getLatestStepByPath,
+    create: mocks.createRunStep,
+  },
+  WorkflowRunModelV2: {
+    getById: mocks.getRunById,
+    update: mocks.updateRun,
+  },
+  WorkflowRunWaitModelV2: {
+    create: mocks.createWait,
+    update: mocks.updateWait,
+  },
   WorkflowTaskModel: {},
   WorkflowTaskStatus: {
     PENDING: 'PENDING',
@@ -59,7 +79,15 @@ vi.mock('@alga-psa/workflows/persistence', () => ({
 describe('workflow-runtime-v2 activities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getAdminConnection.mockResolvedValue({});
+    const waitsQuery = {
+      where: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue(null),
+    };
+    const knex = ((table: string) => {
+      if (table === 'workflow_run_waits') return waitsQuery;
+      throw new Error(`Unexpected table ${table}`);
+    }) as any;
+    mocks.getAdminConnection.mockResolvedValue(knex);
     mocks.resolveInputMapping.mockResolvedValue({});
     mocks.resolveExpressionsWithSecrets.mockResolvedValue(null);
     mocks.findInvocationByIdempotency.mockResolvedValue(null);
@@ -79,6 +107,31 @@ describe('workflow-runtime-v2 activities', () => {
         parse: (value: unknown) => value,
       },
       handler: mocks.actionHandler,
+    });
+    mocks.getRunById.mockResolvedValue({
+      run_id: 'run-1',
+      tenant_id: 'tenant-1',
+    });
+    mocks.getLatestStepByPath.mockResolvedValue(null);
+    mocks.createRunStep.mockResolvedValue({ step_id: 'step-1' });
+    mocks.updateRun.mockResolvedValue(undefined);
+    mocks.createWait.mockResolvedValue({ wait_id: 'wait-1' });
+    mocks.updateWait.mockResolvedValue(undefined);
+    mocks.reserveStepStart.mockResolvedValue({
+      allowed: true,
+      summary: {
+        tenant: 'tenant-1',
+        periodStart: '2026-04-01T00:00:00.000Z',
+        periodEnd: '2026-05-01T00:00:00.000Z',
+        periodSource: 'fallback_calendar',
+        stripeSubscriptionId: null,
+        effectiveLimit: 750,
+        usedCount: 1,
+        remaining: 749,
+        tier: 'pro',
+        limitSource: 'tier_default',
+      },
+      usedCountAfter: 1,
     });
   });
 
@@ -155,5 +208,53 @@ describe('workflow-runtime-v2 activities', () => {
         },
       }),
     );
+  });
+
+  it('projects STARTED step only after successful quota reservation', async () => {
+    const { projectWorkflowRuntimeV2StepStart } = await import('../workflow-runtime-v2-activities');
+    const result = await projectWorkflowRuntimeV2StepStart({
+      runId: 'run-1',
+      stepPath: 'root.steps[0]',
+      definitionStepId: 'step-a',
+    });
+    expect(mocks.reserveStepStart).toHaveBeenCalledWith(expect.anything(), 'tenant-1');
+    expect(mocks.createRunStep).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        run_id: 'run-1',
+        step_path: 'root.steps[0]',
+        definition_step_id: 'step-a',
+        status: 'STARTED',
+        attempt: 1,
+      }),
+    );
+    expect(result).toEqual({ stepId: 'step-1' });
+  });
+
+  it('returns quotaPaused and does not create STARTED row when reservation is denied', async () => {
+    mocks.reserveStepStart.mockResolvedValueOnce({
+      allowed: false,
+      summary: {
+        tenant: 'tenant-1',
+        periodStart: '2026-04-01T00:00:00.000Z',
+        periodEnd: '2026-05-01T00:00:00.000Z',
+        periodSource: 'fallback_calendar',
+        stripeSubscriptionId: null,
+        effectiveLimit: 1,
+        usedCount: 1,
+        remaining: 0,
+        tier: 'pro',
+        limitSource: 'tier_default',
+      },
+    });
+    const { projectWorkflowRuntimeV2StepStart } = await import('../workflow-runtime-v2-activities');
+    const result = await projectWorkflowRuntimeV2StepStart({
+      runId: 'run-1',
+      stepPath: 'root.steps[0]',
+      definitionStepId: 'step-a',
+    });
+    expect(result).toEqual({ stepId: null, quotaPaused: true });
+    expect(mocks.createRunStep).not.toHaveBeenCalled();
+    expect(mocks.createWait).toHaveBeenCalled();
   });
 });

--- a/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
+++ b/ee/temporal-workflows/src/activities/tenant-deletion-activities.ts
@@ -42,7 +42,7 @@ const TENANT_TABLES_DELETION_ORDER: string[] = [
   'workflow_task_history', 'workflow_form_schemas',
 
   // Workflow runtime V2 (child tables first, then parent)
-  'workflow_run_logs', 'workflow_runtime_events',
+  'workflow_run_logs', 'workflow_runtime_events', 'workflow_step_usage_periods',
   'workflow_runs', 'tenant_workflow_schedule', 'workflow_definitions',
 
   // Task/project details

--- a/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
+++ b/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
@@ -185,6 +185,13 @@ export async function projectWorkflowRuntimeV2StepStart(input: {
           await WorkflowRunModelV2.update(knex, input.runId, {
             node_path: input.stepPath,
             status: 'WAITING',
+            error_json: {
+              category: 'QuotaExceeded',
+              message: 'Workflow step quota exceeded for current billing period',
+              nodePath: input.stepPath,
+              at: new Date().toISOString(),
+              data: payload,
+            },
           });
           return {
             stepId: null,

--- a/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
+++ b/ee/temporal-workflows/src/activities/workflow-runtime-v2-activities.ts
@@ -31,6 +31,7 @@ import {
   WorkflowTaskModel,
   WorkflowTaskStatus,
 } from '@alga-psa/workflows/persistence';
+import { workflowStepQuotaService } from '@alga-psa/workflows/runtime/core';
 
 export async function executeWorkflowRuntimeV2Run(input: {
   runId: string;
@@ -135,10 +136,63 @@ export async function projectWorkflowRuntimeV2StepStart(input: {
   runId: string;
   stepPath: string;
   definitionStepId: string;
-}): Promise<{ stepId: string }> {
+}): Promise<{ stepId: string | null; quotaPaused?: boolean }> {
   return retryOnAdminReadOnly(
     async () => {
       const knex = await getAdminConnection();
+      const run = await WorkflowRunModelV2.getById(knex, input.runId);
+      if (!run) {
+        throw new Error(`Run ${input.runId} not found`);
+      }
+
+      if (run.tenant_id) {
+        const reservation = await workflowStepQuotaService.reserveStepStart(knex, run.tenant_id);
+        if (!reservation.allowed) {
+          const existingWait = await knex('workflow_run_waits')
+            .where({
+              run_id: input.runId,
+              step_path: input.stepPath,
+              wait_type: 'quota',
+              status: 'WAITING',
+            })
+            .first<{ wait_id: string }>();
+          const payload = {
+            reason: 'workflow_step_quota_exceeded',
+            tenant: reservation.summary.tenant,
+            periodStart: reservation.summary.periodStart,
+            periodEnd: reservation.summary.periodEnd,
+            usedCount: reservation.summary.usedCount,
+            effectiveLimit: reservation.summary.effectiveLimit,
+            periodSource: reservation.summary.periodSource,
+            limitSource: reservation.summary.limitSource,
+          };
+          if (existingWait) {
+            await WorkflowRunWaitModelV2.update(knex, existingWait.wait_id, {
+              timeout_at: reservation.summary.periodEnd,
+              payload,
+            });
+          } else {
+            await WorkflowRunWaitModelV2.create(knex, {
+              run_id: input.runId,
+              step_path: input.stepPath,
+              wait_type: 'quota',
+              timeout_at: reservation.summary.periodEnd,
+              status: 'WAITING',
+              payload,
+            });
+          }
+
+          await WorkflowRunModelV2.update(knex, input.runId, {
+            node_path: input.stepPath,
+            status: 'WAITING',
+          });
+          return {
+            stepId: null,
+            quotaPaused: true,
+          };
+        }
+      }
+
       const latest = await WorkflowRunStepModelV2.getLatestByRunAndPath(knex, input.runId, input.stepPath);
       const attempt = (latest?.attempt ?? 0) + 1;
       const step = await WorkflowRunStepModelV2.create(knex, {

--- a/ee/temporal-workflows/src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts
@@ -331,6 +331,57 @@ describe('workflowRuntimeV2RunWorkflow', () => {
     });
   });
 
+  it('treats quota pause at step start as controlled wait and exits without completion', async () => {
+    const definition: WorkflowDefinition = {
+      id: 'wf_quota_pause',
+      name: 'Quota Pause',
+      version: 1,
+      payloadSchemaRef: 'payload.test.v1',
+      steps: [
+        {
+          id: 'step_action',
+          type: 'action.call',
+          config: { actionId: 'ticket.update', version: 1 },
+        },
+      ],
+    };
+
+    mockActivities.loadWorkflowRuntimeV2PinnedDefinition.mockResolvedValue({
+      definition,
+      initialScopes: {
+        payload: {},
+        workflow: {},
+        lexical: [],
+        system: {
+          runId: 'run_quota_pause',
+          workflowId: 'wf_quota_pause',
+          workflowVersion: 1,
+          tenantId: 'tenant_1',
+          definitionHash: 'hash_quota_pause',
+          runtimeSemanticsVersion: '2026-04-08.temporal-native.v1',
+        },
+      },
+    });
+    mockActivities.projectWorkflowRuntimeV2StepStart.mockResolvedValueOnce({
+      stepId: null,
+      quotaPaused: true,
+    });
+
+    const { workflowRuntimeV2RunWorkflow } = await loadWorkflow();
+    await workflowRuntimeV2RunWorkflow({
+      runId: 'run_quota_pause',
+      tenantId: 'tenant_1',
+      workflowId: 'wf_quota_pause',
+      workflowVersion: 1,
+      triggerType: null,
+      executionKey: 'exec_quota_pause',
+    });
+
+    expect(mockActivities.executeWorkflowRuntimeV2ActionStep).not.toHaveBeenCalled();
+    expect(mockActivities.projectWorkflowRuntimeV2StepCompletion).not.toHaveBeenCalled();
+    expect(mockActivities.completeWorkflowRuntimeV2Run).not.toHaveBeenCalled();
+  });
+
   it('keeps Temporal interpreter state synchronized for non-action node steps', async () => {
     const definition: WorkflowDefinition = {
       id: 'wf_2_node_sync',

--- a/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
@@ -45,7 +45,7 @@ const activities = proxyActivities<{
     runId: string;
     stepPath: string;
     definitionStepId: string;
-  }): Promise<{ stepId: string }>;
+  }): Promise<{ stepId: string | null; quotaPaused?: boolean }>;
   projectWorkflowRuntimeV2StepCompletion(input: {
     runId: string;
     stepId: string;
@@ -324,6 +324,11 @@ export async function workflowRuntimeV2RunWorkflow(
       stepPath: current.path,
       definitionStepId: current.step.id,
     });
+    if (stepProjection.quotaPaused || !stepProjection.stepId) {
+      return {
+        scopes: state.scopes,
+      };
+    }
 
     try {
       if (current.step.type === 'control.return') {

--- a/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
@@ -2,6 +2,7 @@ import { condition, continueAsNew, defineQuery, defineSignal, executeChild, prox
 import {
   WORKFLOW_RUNTIME_V2_EVENT_SIGNAL,
   WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL,
+  WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   type WorkflowRuntimeV2TemporalRunInput,
 } from '@alga-psa/workflows/lib/workflowRuntimeV2TemporalContract';
@@ -195,8 +196,12 @@ type WorkflowRuntimeV2HumanTaskSignalPayload = {
 
 const workflowRuntimeV2HumanTaskSignal = defineSignal<[WorkflowRuntimeV2HumanTaskSignalPayload]>(WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL);
 
+const workflowRuntimeV2QuotaResumeSignal = defineSignal<[
+  { waitId?: string | null; reason?: string | null; resumedBy?: string | null; resumedAt?: string | null }
+]>(WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL);
+
 type WorkflowRuntimeV2CurrentWait = {
-  type: 'time.wait' | 'event.wait' | 'human.task';
+  type: 'time.wait' | 'event.wait' | 'human.task' | 'quota';
   stepPath: string;
   descriptor: Record<string, unknown>;
 };
@@ -234,6 +239,10 @@ export async function workflowRuntimeV2RunWorkflow(
   const pendingHumanTaskSignals: WorkflowRuntimeV2HumanTaskSignalPayload[] = [];
   setHandler(workflowRuntimeV2HumanTaskSignal, (signal) => {
     pendingHumanTaskSignals.push(normalizeHumanTaskSignalPayload(signal));
+  });
+  let quotaResumeRequested = false;
+  setHandler(workflowRuntimeV2QuotaResumeSignal, () => {
+    quotaResumeRequested = true;
   });
   let queryCurrentStepPath: string | null = null;
   let queryStepCount = 0;
@@ -325,9 +334,21 @@ export async function workflowRuntimeV2RunWorkflow(
       definitionStepId: current.step.id,
     });
     if (stepProjection.quotaPaused || !stepProjection.stepId) {
-      return {
-        scopes: state.scopes,
+      queryCurrentWait = {
+        type: 'quota',
+        stepPath: current.path,
+        descriptor: { reason: 'workflow_step_quota_exceeded' },
       };
+      const quotaResumeReceived = await condition(
+        () => quotaResumeRequested,
+        3650 * 24 * 60 * 60 * 1000
+      );
+      if (!quotaResumeReceived) {
+        return { scopes: state.scopes };
+      }
+      quotaResumeRequested = false;
+      queryCurrentWait = null;
+      continue;
     }
 
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42901,7 +42901,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.34-rc5",
+      "version": "1.0.35-rc5",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -47824,7 +47824,7 @@
       }
     },
     "server": {
-      "version": "1.0.34-rc5",
+      "version": "1.0.35-rc5",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/server/migrations/20260428120000_create_workflow_step_usage_periods.cjs
+++ b/server/migrations/20260428120000_create_workflow_step_usage_periods.cjs
@@ -28,6 +28,18 @@ exports.up = async function up(knex) {
     CHECK (period_start < period_end)
   `);
 
+  await knex.schema.raw(`
+    ALTER TABLE workflow_step_usage_periods
+    ADD CONSTRAINT workflow_step_usage_periods_used_count_check
+    CHECK (used_count >= 0)
+  `);
+
+  await knex.schema.raw(`
+    ALTER TABLE workflow_step_usage_periods
+    ADD CONSTRAINT workflow_step_usage_periods_effective_limit_check
+    CHECK (effective_limit IS NULL OR effective_limit > 0)
+  `);
+
   const dbUserServer = process.env.DB_USER_SERVER;
   if (dbUserServer) {
     const escapedUser = dbUserServer.replace(/"/g, '""');

--- a/server/migrations/20260428120000_create_workflow_step_usage_periods.cjs
+++ b/server/migrations/20260428120000_create_workflow_step_usage_periods.cjs
@@ -1,0 +1,42 @@
+/**
+ * Create tenant-scoped workflow step quota usage counters by billing period.
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('workflow_step_usage_periods', (table) => {
+    table.uuid('tenant').notNullable();
+    table.timestamp('period_start', { useTz: true }).notNullable();
+    table.timestamp('period_end', { useTz: true }).notNullable();
+    table.text('period_source').notNullable();
+    table.uuid('stripe_subscription_id');
+    table.integer('effective_limit');
+    table.integer('used_count').notNullable().defaultTo(0);
+    table.text('limit_source').notNullable();
+    table.text('tier').notNullable();
+    table.jsonb('metadata_json');
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+    table.primary(['tenant', 'period_start', 'period_end']);
+    table.foreign('tenant').references('tenants.tenant').onDelete('CASCADE');
+    table.index(['tenant', 'period_end'], 'idx_workflow_step_usage_periods_tenant_period_end');
+    table.index(['period_end'], 'idx_workflow_step_usage_periods_period_end');
+  });
+
+  await knex.schema.raw(`
+    ALTER TABLE workflow_step_usage_periods
+    ADD CONSTRAINT workflow_step_usage_periods_period_bounds_check
+    CHECK (period_start < period_end)
+  `);
+
+  const dbUserServer = process.env.DB_USER_SERVER;
+  if (dbUserServer) {
+    const escapedUser = dbUserServer.replace(/"/g, '""');
+    await knex.schema.raw(`
+      GRANT ALL PRIVILEGES ON TABLE workflow_step_usage_periods TO "${escapedUser}";
+    `);
+  }
+};
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('workflow_step_usage_periods');
+};

--- a/server/src/lib/jobs/handlers/workflowQuotaResumeScanHandler.ts
+++ b/server/src/lib/jobs/handlers/workflowQuotaResumeScanHandler.ts
@@ -7,6 +7,7 @@ import {
 import {
   WorkflowRunLogModelV2,
 } from '@alga-psa/workflows/persistence';
+import { signalWorkflowRuntimeV2QuotaResume } from '@alga-psa/workflows/lib/workflowRuntimeV2Temporal';
 
 export interface WorkflowQuotaResumeScanJobData extends Record<string, unknown> {
   tenantId: string;
@@ -19,6 +20,7 @@ type QuotaWaitCandidate = {
   step_path: string;
   tenant_id: string | null;
   engine: string | null;
+  node_path: string | null;
 };
 
 const DEFAULT_BATCH_SIZE = 100;
@@ -48,7 +50,7 @@ export async function workflowQuotaResumeScanHandler(data: WorkflowQuotaResumeSc
         .forUpdate()
         .skipLocked()
         .limit(batchSize)
-        .select('w.wait_id', 'w.run_id', 'w.step_path', 'r.tenant_id', 'r.engine');
+        .select('w.wait_id', 'w.run_id', 'w.step_path', 'r.tenant_id', 'r.engine', 'r.node_path');
 
       if (candidates.length === 0) {
         return [] as QuotaWaitCandidate[];
@@ -57,7 +59,7 @@ export async function workflowQuotaResumeScanHandler(data: WorkflowQuotaResumeSc
       const selected: QuotaWaitCandidate[] = [];
       const byTenant = new Map<string, QuotaWaitCandidate[]>();
       for (const candidate of candidates) {
-        if (!candidate.tenant_id) continue;
+        if (!candidate.tenant_id || candidate.node_path !== candidate.step_path) continue;
         const list = byTenant.get(candidate.tenant_id) ?? [];
         list.push(candidate);
         byTenant.set(candidate.tenant_id, list);
@@ -106,6 +108,7 @@ export async function workflowQuotaResumeScanHandler(data: WorkflowQuotaResumeSc
           resume_event_name: null,
           resume_event_payload: null,
           resume_error: null,
+          error_json: null,
         });
 
       for (const selectedWait of selected) {
@@ -131,7 +134,13 @@ export async function workflowQuotaResumeScanHandler(data: WorkflowQuotaResumeSc
 
     for (const item of resumptions) {
       if (item.engine === 'temporal') {
-        logger.info('[WorkflowQuotaResumeScanJob] Temporal quota wait resolved in projection; waiting for runtime re-entry path', {
+        await signalWorkflowRuntimeV2QuotaResume({
+          runId: item.run_id,
+          waitId: item.wait_id,
+          reason: 'quota_available',
+          resumedBy: workerId,
+        });
+        logger.info('[WorkflowQuotaResumeScanJob] Temporal quota wait signaled for resume', {
           runId: item.run_id,
           waitId: item.wait_id,
         });

--- a/server/src/lib/jobs/handlers/workflowQuotaResumeScanHandler.ts
+++ b/server/src/lib/jobs/handlers/workflowQuotaResumeScanHandler.ts
@@ -1,0 +1,148 @@
+import logger from '@alga-psa/core/logger';
+import { getAdminConnection } from '@alga-psa/db/admin';
+import {
+  WorkflowRuntimeV2,
+  workflowStepQuotaService,
+} from '@alga-psa/workflows/runtime/core';
+import {
+  WorkflowRunLogModelV2,
+} from '@alga-psa/workflows/persistence';
+
+export interface WorkflowQuotaResumeScanJobData extends Record<string, unknown> {
+  tenantId: string;
+  batchSize?: number;
+}
+
+type QuotaWaitCandidate = {
+  wait_id: string;
+  run_id: string;
+  step_path: string;
+  tenant_id: string | null;
+  engine: string | null;
+};
+
+const DEFAULT_BATCH_SIZE = 100;
+
+function toFiniteCapacity(effectiveLimit: number | null, usedCount: number): number | null {
+  if (effectiveLimit == null) return null;
+  return Math.max(effectiveLimit - usedCount, 0);
+}
+
+export async function workflowQuotaResumeScanHandler(data: WorkflowQuotaResumeScanJobData): Promise<void> {
+  const batchSize = Math.max(1, Math.min(Number(data.batchSize ?? DEFAULT_BATCH_SIZE), 500));
+  const knex = await getAdminConnection();
+  const runtime = new WorkflowRuntimeV2();
+  const workerId = 'job:workflow-quota-resume-scan';
+
+  let resumedTotal = 0;
+  while (true) {
+    const resumptions = await knex.transaction(async (trx) => {
+      const nowIso = new Date().toISOString();
+      const candidates = await trx<QuotaWaitCandidate>('workflow_run_waits as w')
+        .join('workflow_runs as r', 'r.run_id', 'w.run_id')
+        .where('w.wait_type', 'quota')
+        .where('w.status', 'WAITING')
+        .where('r.status', 'WAITING')
+        .whereNotNull('r.tenant_id')
+        .orderBy('w.created_at', 'asc')
+        .forUpdate()
+        .skipLocked()
+        .limit(batchSize)
+        .select('w.wait_id', 'w.run_id', 'w.step_path', 'r.tenant_id', 'r.engine');
+
+      if (candidates.length === 0) {
+        return [] as QuotaWaitCandidate[];
+      }
+
+      const selected: QuotaWaitCandidate[] = [];
+      const byTenant = new Map<string, QuotaWaitCandidate[]>();
+      for (const candidate of candidates) {
+        if (!candidate.tenant_id) continue;
+        const list = byTenant.get(candidate.tenant_id) ?? [];
+        list.push(candidate);
+        byTenant.set(candidate.tenant_id, list);
+      }
+
+      for (const [tenantId, waits] of byTenant.entries()) {
+        const summary = await workflowStepQuotaService.resolveQuotaSummary(trx, tenantId);
+        const capacity = toFiniteCapacity(summary.effectiveLimit, summary.usedCount);
+
+        if (capacity === 0) {
+          logger.debug('[WorkflowQuotaResumeScanJob] Skipping tenant with exhausted quota', {
+            tenant: tenantId,
+            periodStart: summary.periodStart,
+            periodEnd: summary.periodEnd,
+            effectiveLimit: summary.effectiveLimit,
+            usedCount: summary.usedCount,
+          });
+          continue;
+        }
+
+        if (capacity == null) {
+          selected.push(...waits);
+          continue;
+        }
+        selected.push(...waits.slice(0, capacity));
+      }
+
+      if (selected.length === 0) return [];
+
+      const selectedWaitIds = selected.map((entry) => entry.wait_id);
+      const selectedRunIds = selected.map((entry) => entry.run_id);
+
+      await trx('workflow_run_waits')
+        .whereIn('wait_id', selectedWaitIds)
+        .andWhere({ status: 'WAITING' })
+        .update({
+          status: 'RESOLVED',
+          resolved_at: nowIso,
+        });
+
+      await trx('workflow_runs')
+        .whereIn('run_id', selectedRunIds)
+        .andWhere({ status: 'WAITING' })
+        .update({
+          status: 'RUNNING',
+          resume_event_name: null,
+          resume_event_payload: null,
+          resume_error: null,
+        });
+
+      for (const selectedWait of selected) {
+        await WorkflowRunLogModelV2.create(trx, {
+          run_id: selectedWait.run_id,
+          tenant_id: selectedWait.tenant_id,
+          step_path: selectedWait.step_path,
+          level: 'INFO',
+          message: 'Quota wait resolved by scheduled scan',
+          context_json: {
+            waitId: selectedWait.wait_id,
+            resumedBy: workerId,
+          },
+          source: 'worker',
+        });
+      }
+
+      return selected;
+    });
+
+    if (resumptions.length === 0) break;
+    resumedTotal += resumptions.length;
+
+    for (const item of resumptions) {
+      if (item.engine === 'temporal') {
+        logger.info('[WorkflowQuotaResumeScanJob] Temporal quota wait resolved in projection; waiting for runtime re-entry path', {
+          runId: item.run_id,
+          waitId: item.wait_id,
+        });
+        continue;
+      }
+      await runtime.executeRun(knex, item.run_id, workerId);
+    }
+  }
+
+  logger.info('[WorkflowQuotaResumeScanJob] Completed quota resume scan', {
+    resumedRuns: resumedTotal,
+    batchSize,
+  });
+}

--- a/server/src/lib/jobs/index.ts
+++ b/server/src/lib/jobs/index.ts
@@ -23,6 +23,10 @@ import {
   GooglePubSubVerificationJobData
 } from './handlers/calendarWebhookMaintenanceHandler';
 import { slaTimerHandler, SlaTimerJobData } from './handlers/slaTimerHandler';
+import {
+  workflowQuotaResumeScanHandler,
+  WorkflowQuotaResumeScanJobData,
+} from './handlers/workflowQuotaResumeScanHandler';
 import { JobService } from '../../services/job.service';
 import { getConnection } from '../db/db';
 import { StorageService } from '../../lib/storage/StorageService';
@@ -177,6 +181,13 @@ export const initializeScheduler = async (storageService?: StorageService) => {
       );
     }
 
+    jobScheduler.registerJobHandler<WorkflowQuotaResumeScanJobData>(
+      'workflow-quota-resume-scan',
+      async (job: Job<WorkflowQuotaResumeScanJobData>) => {
+        await workflowQuotaResumeScanHandler(job.data);
+      }
+    );
+
     // Note: Password reset token cleanup is handled automatically during token operations
     // No pg-boss job needed
 
@@ -200,7 +211,8 @@ export type {
   AssetImportJobData,
   EmailWebhookMaintenanceJobData,
   RenewalQueueProcessorJobData,
-  SlaTimerJobData
+  SlaTimerJobData,
+  WorkflowQuotaResumeScanJobData
 };
 // Export job scheduling helper functions
 export const scheduleInvoiceGeneration = async (
@@ -468,5 +480,17 @@ export const scheduleSlaTimerJob = async (
     'sla-timer',
     cronExpression,
     { tenantId }
+  );
+};
+
+export const scheduleWorkflowQuotaResumeScanJob = async (
+  cronExpression: string = '*/5 * * * *',
+  batchSize: number = 100
+): Promise<string | null> => {
+  const scheduler = await initializeScheduler();
+  return await scheduler.scheduleRecurringJob<WorkflowQuotaResumeScanJobData>(
+    'workflow-quota-resume-scan',
+    cronExpression,
+    { tenantId: 'system', batchSize }
   );
 };

--- a/server/src/lib/jobs/index.ts
+++ b/server/src/lib/jobs/index.ts
@@ -34,6 +34,11 @@ import logger from '@alga-psa/core/logger';
 import type { IRecurringRunExecutionWindowIdentity } from '@alga-psa/types';
 import type { IRecurringDueSelectionInput } from '@alga-psa/types';
 
+const isEnterpriseWorkflowEdition = (): boolean =>
+  process.env.EDITION === 'enterprise'
+  || process.env.EDITION === 'ee'
+  || process.env.NEXT_PUBLIC_EDITION === 'enterprise';
+
 // =============================================================================
 // NEW JOB RUNNER ABSTRACTION EXPORTS
 // =============================================================================
@@ -181,12 +186,14 @@ export const initializeScheduler = async (storageService?: StorageService) => {
       );
     }
 
-    jobScheduler.registerJobHandler<WorkflowQuotaResumeScanJobData>(
-      'workflow-quota-resume-scan',
-      async (job: Job<WorkflowQuotaResumeScanJobData>) => {
-        await workflowQuotaResumeScanHandler(job.data);
-      }
-    );
+    if (isEnterpriseWorkflowEdition()) {
+      jobScheduler.registerJobHandler<WorkflowQuotaResumeScanJobData>(
+        'workflow-quota-resume-scan',
+        async (job: Job<WorkflowQuotaResumeScanJobData>) => {
+          await workflowQuotaResumeScanHandler(job.data);
+        }
+      );
+    }
 
     // Note: Password reset token cleanup is handled automatically during token operations
     // No pg-boss job needed
@@ -487,6 +494,9 @@ export const scheduleWorkflowQuotaResumeScanJob = async (
   cronExpression: string = '*/5 * * * *',
   batchSize: number = 100
 ): Promise<string | null> => {
+  if (!isEnterpriseWorkflowEdition()) {
+    return null;
+  }
   const scheduler = await initializeScheduler();
   return await scheduler.scheduleRecurringJob<WorkflowQuotaResumeScanJobData>(
     'workflow-quota-resume-scan',

--- a/server/src/lib/jobs/initializeScheduledJobs.ts
+++ b/server/src/lib/jobs/initializeScheduledJobs.ts
@@ -2,6 +2,11 @@ import { initializeScheduler, scheduleExpiredCreditsJob, scheduleExpiringCredits
 import logger from '@alga-psa/core/logger';
 import { getConnection } from 'server/src/lib/db/db';
 
+const isEnterpriseWorkflowEdition = (): boolean =>
+  process.env.EDITION === 'enterprise'
+  || process.env.EDITION === 'ee'
+  || process.env.NEXT_PUBLIC_EDITION === 'enterprise';
+
 /**
  * Initialize all scheduled jobs for the application
  * This function sets up recurring jobs that need to run on a schedule
@@ -227,19 +232,21 @@ export async function initializeScheduledJobs(): Promise<void> {
      }
    }
 
-   try {
-     const cron = '*/5 * * * *';
-     const quotaResumeJobId = await scheduleWorkflowQuotaResumeScanJob(cron);
-     if (quotaResumeJobId) {
-       logger.info(`Scheduled workflow quota resume scan job with ID ${quotaResumeJobId}`);
-     } else {
-       logger.info('Workflow quota resume scan job already scheduled (singleton active)', {
-         cron,
-         returnedJobId: quotaResumeJobId,
-       });
+   if (isEnterpriseWorkflowEdition()) {
+     try {
+       const cron = '*/5 * * * *';
+       const quotaResumeJobId = await scheduleWorkflowQuotaResumeScanJob(cron);
+       if (quotaResumeJobId) {
+         logger.info(`Scheduled workflow quota resume scan job with ID ${quotaResumeJobId}`);
+       } else {
+         logger.info('Workflow quota resume scan job already scheduled (singleton active)', {
+           cron,
+           returnedJobId: quotaResumeJobId,
+         });
+       }
+     } catch (error) {
+       logger.error('Failed to schedule workflow quota resume scan job', error);
      }
-   } catch (error) {
-     logger.error('Failed to schedule workflow quota resume scan job', error);
    }
    
    logger.info('All scheduled jobs initialized');

--- a/server/src/lib/jobs/initializeScheduledJobs.ts
+++ b/server/src/lib/jobs/initializeScheduledJobs.ts
@@ -1,4 +1,4 @@
-import { initializeScheduler, scheduleExpiredCreditsJob, scheduleExpiringCreditsNotificationJob, scheduleCreditReconciliationJob, scheduleQuoteAutoExpirationJob, scheduleReconcileBucketUsageJob, scheduleCleanupTemporaryFormsJob, scheduleCleanupAiSessionKeysJob, scheduleMicrosoftWebhookRenewalJob, scheduleGooglePubSubVerificationJob, scheduleGoogleGmailWatchRenewalJob, scheduleEmailWebhookMaintenanceJob, scheduleRenewalQueueProcessingJob, scheduleSlaTimerJob } from './index';
+import { initializeScheduler, scheduleExpiredCreditsJob, scheduleExpiringCreditsNotificationJob, scheduleCreditReconciliationJob, scheduleQuoteAutoExpirationJob, scheduleReconcileBucketUsageJob, scheduleCleanupTemporaryFormsJob, scheduleCleanupAiSessionKeysJob, scheduleMicrosoftWebhookRenewalJob, scheduleGooglePubSubVerificationJob, scheduleGoogleGmailWatchRenewalJob, scheduleEmailWebhookMaintenanceJob, scheduleRenewalQueueProcessingJob, scheduleSlaTimerJob, scheduleWorkflowQuotaResumeScanJob } from './index';
 import logger from '@alga-psa/core/logger';
 import { getConnection } from 'server/src/lib/db/db';
 
@@ -225,6 +225,21 @@ export async function initializeScheduledJobs(): Promise<void> {
      } catch (error) {
        logger.error('Failed to schedule AI session key cleanup job', error);
      }
+   }
+
+   try {
+     const cron = '*/5 * * * *';
+     const quotaResumeJobId = await scheduleWorkflowQuotaResumeScanJob(cron);
+     if (quotaResumeJobId) {
+       logger.info(`Scheduled workflow quota resume scan job with ID ${quotaResumeJobId}`);
+     } else {
+       logger.info('Workflow quota resume scan job already scheduled (singleton active)', {
+         cron,
+         returnedJobId: quotaResumeJobId,
+       });
+     }
+   } catch (error) {
+     logger.error('Failed to schedule workflow quota resume scan job', error);
    }
    
    logger.info('All scheduled jobs initialized');

--- a/server/src/lib/jobs/registerAllHandlers.ts
+++ b/server/src/lib/jobs/registerAllHandlers.ts
@@ -88,7 +88,9 @@ export async function registerAllJobHandlers(
   const {
     jobService,
     storageService,
-    includeEnterprise = process.env.EDITION === 'enterprise',
+    includeEnterprise = process.env.EDITION === 'enterprise'
+      || process.env.EDITION === 'ee'
+      || process.env.NEXT_PUBLIC_EDITION === 'enterprise',
     force = false,
   } = options;
 
@@ -347,7 +349,7 @@ export async function registerAllJobHandlers(
 
   if (!includeEnterprise) {
     // SLA timer handler - checks SLA thresholds and sends notifications
-  JobHandlerRegistry.register<SlaTimerJobData & BaseJobData>(
+    JobHandlerRegistry.register<SlaTimerJobData & BaseJobData>(
       {
         name: 'sla-timer',
         handler: async (_jobId, data) => {
@@ -357,19 +359,7 @@ export async function registerAllJobHandlers(
         timeoutMs: 300000, // 5 minutes
       },
       registerOpts
-  );
-
-  JobHandlerRegistry.register<WorkflowQuotaResumeScanJobData & BaseJobData>(
-    {
-      name: 'workflow-quota-resume-scan',
-      handler: async (_jobId, data) => {
-        await workflowQuotaResumeScanHandler(data);
-      },
-      retry: { maxAttempts: 2 },
-      timeoutMs: 120000,
-    },
-    registerOpts
-  );
+    );
   }
 
   // ============================================================================
@@ -377,6 +367,17 @@ export async function registerAllJobHandlers(
   // ============================================================================
 
   if (includeEnterprise) {
+    JobHandlerRegistry.register<WorkflowQuotaResumeScanJobData & BaseJobData>(
+      {
+        name: 'workflow-quota-resume-scan',
+        handler: async (_jobId, data) => {
+          await workflowQuotaResumeScanHandler(data);
+        },
+        retry: { maxAttempts: 2 },
+        timeoutMs: 120000,
+      },
+      registerOpts
+    );
     // Cleanup AI session keys handler (EE only)
     JobHandlerRegistry.register<CleanupAiSessionKeysJobData & BaseJobData>(
       {
@@ -426,6 +427,12 @@ export function getAvailableJobHandlers(): string[] {
     // SLA
     'sla-timer',
     // Enterprise-only
-    ...(process.env.EDITION === 'enterprise' ? ['cleanup-ai-session-keys'] : []),
+    ...(
+      process.env.EDITION === 'enterprise'
+      || process.env.EDITION === 'ee'
+      || process.env.NEXT_PUBLIC_EDITION === 'enterprise'
+        ? ['cleanup-ai-session-keys', 'workflow-quota-resume-scan']
+        : []
+    ),
   ];
 }

--- a/server/src/lib/jobs/registerAllHandlers.ts
+++ b/server/src/lib/jobs/registerAllHandlers.ts
@@ -53,6 +53,10 @@ import {
   WorkflowScheduledRunJobData,
 } from './handlers/workflowScheduledRunHandlers';
 import { slaTimerHandler, SlaTimerJobData } from './handlers/slaTimerHandler';
+import {
+  workflowQuotaResumeScanHandler,
+  WorkflowQuotaResumeScanJobData,
+} from './handlers/workflowQuotaResumeScanHandler';
 
 /**
  * Options for registering handlers
@@ -343,7 +347,7 @@ export async function registerAllJobHandlers(
 
   if (!includeEnterprise) {
     // SLA timer handler - checks SLA thresholds and sends notifications
-    JobHandlerRegistry.register<SlaTimerJobData & BaseJobData>(
+  JobHandlerRegistry.register<SlaTimerJobData & BaseJobData>(
       {
         name: 'sla-timer',
         handler: async (_jobId, data) => {
@@ -353,7 +357,19 @@ export async function registerAllJobHandlers(
         timeoutMs: 300000, // 5 minutes
       },
       registerOpts
-    );
+  );
+
+  JobHandlerRegistry.register<WorkflowQuotaResumeScanJobData & BaseJobData>(
+    {
+      name: 'workflow-quota-resume-scan',
+      handler: async (_jobId, data) => {
+        await workflowQuotaResumeScanHandler(data);
+      },
+      retry: { maxAttempts: 2 },
+      timeoutMs: 120000,
+    },
+    registerOpts
+  );
   }
 
   // ============================================================================

--- a/server/src/test/integration/workflowRuntimeV2.control.integration.test.ts
+++ b/server/src/test/integration/workflowRuntimeV2.control.integration.test.ts
@@ -15,10 +15,12 @@ import {
   submitWorkflowEventAction,
   listWorkflowEventsAction,
   resumeWorkflowRunAction,
+  resumeWorkflowRunFromQuotaPauseAction,
   retryWorkflowRunAction,
   cancelWorkflowRunAction
 } from '@alga-psa/workflows/actions';
 import { WorkflowRuntimeV2 } from '@alga-psa/workflows/runtime';
+import { workflowStepQuotaService } from '@alga-psa/workflows/runtime';
 import { getActionRegistryV2, getSchemaRegistry } from '@alga-psa/workflows/runtime';
 import WorkflowRunModelV2 from '@alga-psa/workflows/persistence/workflowRunModelV2';
 import WorkflowRunStepModelV2 from '@alga-psa/workflows/persistence/workflowRunStepModelV2';
@@ -115,6 +117,14 @@ let tenantId: string;
 let userId: string;
 
 const actionRestores: Array<() => void> = [];
+
+async function latestWorkflowStepUsageCount(tenant: string): Promise<number> {
+  const row = await db('workflow_step_usage_periods')
+    .where({ tenant })
+    .orderBy('updated_at', 'desc')
+    .first<{ used_count: number }>();
+  return row?.used_count ?? 0;
+}
 
 function stubAction(actionId: string, version: number, handler: any) {
   const registry = getActionRegistryV2();
@@ -1417,5 +1427,194 @@ describe('workflow runtime v2 control-flow + waits integration tests', () => {
     await Promise.all([worker.tick(), worker.tick()]);
     const waits = await db('workflow_run_waits').where({ run_id: run.runId, wait_type: 'retry', status: 'WAITING' });
     expect(waits.length).toBe(0);
+  });
+
+  it('DB runtime reserves quota before STARTED step row creation and executes under limit.', async () => {
+    const workflowId = await createDraftWorkflow({ steps: [stateSetStep('state-1', 'READY')] });
+    await publishWorkflow(workflowId, 1);
+    const runtime = new WorkflowRuntimeV2();
+    const runId = await runtime.startRun(db, { workflowId, version: 1, payload: {}, tenantId });
+    const reserveSpy = vi.spyOn(workflowStepQuotaService, 'reserveStepStart');
+    reserveSpy.mockImplementation(async (knex, tenant) => {
+      const existingStepRows = await knex('workflow_run_steps').where({ run_id: runId });
+      expect(existingStepRows).toHaveLength(0);
+      return {
+        allowed: true,
+        summary: await workflowStepQuotaService.resolveQuotaSummary(knex, tenant),
+        usedCountAfter: 1,
+      };
+    });
+    try {
+      await runtime.executeRun(db, runId, 'worker');
+    } finally {
+      reserveSpy.mockRestore();
+    }
+    const steps = await WorkflowRunStepModelV2.listByRun(db, runId);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].status).toBe('SUCCEEDED');
+  });
+
+  it('DB runtime quota exhaustion pauses run with quota wait and no blocked step row.', async () => {
+    const workflowId = await createDraftWorkflow({ steps: [stateSetStep('s1', 'A'), stateSetStep('s2', 'B')] });
+    await publishWorkflow(workflowId, 1);
+    const runtime = new WorkflowRuntimeV2();
+    const runId = await runtime.startRun(db, { workflowId, version: 1, payload: {}, tenantId });
+    const reserveSpy = vi.spyOn(workflowStepQuotaService, 'reserveStepStart');
+    let calls = 0;
+    reserveSpy.mockImplementation(async (knex, tenant) => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          allowed: true,
+          summary: await workflowStepQuotaService.resolveQuotaSummary(knex, tenant),
+          usedCountAfter: 1,
+        };
+      }
+      return {
+        allowed: false,
+        summary: {
+          ...(await workflowStepQuotaService.resolveQuotaSummary(knex, tenant)),
+          usedCount: 1,
+          effectiveLimit: 1,
+          remaining: 0,
+        },
+      };
+    });
+    try {
+      await runtime.executeRun(db, runId, 'worker');
+    } finally {
+      reserveSpy.mockRestore();
+    }
+
+    const run = await WorkflowRunModelV2.getById(db, runId);
+    const quotaWait = await db('workflow_run_waits').where({ run_id: runId, wait_type: 'quota', status: 'WAITING' }).first();
+    const steps = await WorkflowRunStepModelV2.listByRun(db, runId);
+    expect(run?.status).toBe('WAITING');
+    expect(run?.node_path).toBe('root.steps[1]');
+    expect(quotaWait).toBeDefined();
+    expect(steps).toHaveLength(1);
+    expect(steps[0].definition_step_id).toBe('s1');
+  });
+
+  it('Retry step attempts consume additional quota when each attempt starts.', async () => {
+    const workflowId = await createDraftWorkflow({ steps: [{ id: 'retry', type: 'test.retryNode', config: { key: 'quota-retry', failCount: 1 } }] });
+    await publishWorkflow(workflowId, 1);
+    const run = await startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: {} });
+    await db('workflow_run_waits').where({ run_id: run.runId, wait_type: 'retry' }).update({ timeout_at: new Date(Date.now() - 500).toISOString() });
+    const worker = new WorkflowRuntimeV2Worker('worker');
+    await worker.tick();
+    expect(await latestWorkflowStepUsageCount(tenantId)).toBe(2);
+  });
+
+  it('forEach body executions consume one quota unit per item attempt.', async () => {
+    const workflowId = await createDraftWorkflow({
+      steps: [forEachStep('for-1', { items: { $expr: 'payload.items' }, itemVar: 'item', body: [assignStep('assign-item', { 'vars.last': { $expr: 'vars.item' } })] })]
+    });
+    await publishWorkflow(workflowId, 1);
+    const run = await startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: { items: [1, 2, 3] } });
+    const bodySteps = await db('workflow_run_steps').where({ run_id: run.runId, definition_step_id: 'assign-item' });
+    expect(bodySteps).toHaveLength(3);
+    expect(await latestWorkflowStepUsageCount(tenantId)).toBe(4);
+  });
+
+  it('event.wait consumes quota on first entry and does not double-count when resumed.', async () => {
+    const workflowId = await createDraftWorkflow({
+      steps: [eventWaitStep('wait-1', { eventName: 'PING', correlationKeyExpr: { $expr: '"quota-key"' } })]
+    });
+    await publishWorkflow(workflowId, 1);
+    const run = await startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: {} });
+    const usedBeforeResume = await latestWorkflowStepUsageCount(tenantId);
+    expect(usedBeforeResume).toBe(1);
+    await submitWorkflowEventAction({ eventName: 'PING', correlationKey: 'quota-key', payload: {} });
+    const usedAfterResume = await latestWorkflowStepUsageCount(tenantId);
+    const runRecord = await WorkflowRunModelV2.getById(db, run.runId);
+    expect(runRecord?.status).toBe('SUCCEEDED');
+    expect(usedAfterResume).toBe(1);
+  });
+
+  it('Manual quota resume resumes eligible run and still goes through runtime quota reservation.', async () => {
+    const workflowId = await createDraftWorkflow({ steps: [stateSetStep('s1', 'A'), stateSetStep('s2', 'B')] });
+    await publishWorkflow(workflowId, 1);
+    const runtime = new WorkflowRuntimeV2();
+    const runId = await runtime.startRun(db, { workflowId, version: 1, payload: {}, tenantId });
+    const reserveSpy = vi.spyOn(workflowStepQuotaService, 'reserveStepStart');
+    let call = 0;
+    reserveSpy.mockImplementation(async (knex, tenant) => {
+      call += 1;
+      if (call === 2) {
+        return {
+          allowed: false,
+          summary: {
+            ...(await workflowStepQuotaService.resolveQuotaSummary(knex, tenant)),
+            usedCount: 1,
+            effectiveLimit: 1,
+            remaining: 0,
+          },
+        };
+      }
+      return {
+        allowed: true,
+        summary: await workflowStepQuotaService.resolveQuotaSummary(knex, tenant),
+        usedCountAfter: call,
+      };
+    });
+    try {
+      await runtime.executeRun(db, runId, 'worker');
+      const before = await WorkflowRunModelV2.getById(db, runId);
+      expect(before?.status).toBe('WAITING');
+      const resumeResult = await resumeWorkflowRunFromQuotaPauseAction({ runId, reason: 'quota available' });
+      expect(resumeResult).toEqual({ ok: true, resumed: true });
+      expect(reserveSpy).toHaveBeenCalledTimes(3);
+      const after = await WorkflowRunModelV2.getById(db, runId);
+      expect(after?.status).toBe('SUCCEEDED');
+    } finally {
+      reserveSpy.mockRestore();
+    }
+  });
+
+  it('Manual quota resume returns usage, limit, and reset time when still exhausted.', async () => {
+    const workflowId = await createDraftWorkflow({ steps: [stateSetStep('only-step', 'A')] });
+    await publishWorkflow(workflowId, 1);
+    const run = await startWorkflowRunAction({ workflowId, workflowVersion: 1, payload: {} });
+    await WorkflowRunModelV2.update(db, run.runId, { status: 'WAITING' });
+    await WorkflowRunWaitModelV2.create(db, {
+      run_id: run.runId,
+      step_path: 'root.steps[0]',
+      wait_type: 'quota',
+      timeout_at: '2026-05-01T00:00:00.000Z',
+      status: 'WAITING',
+      payload: { reason: 'workflow_step_quota_exceeded' },
+    });
+    const summarySpy = vi.spyOn(workflowStepQuotaService, 'resolveQuotaSummary');
+    summarySpy.mockResolvedValue({
+      tenant: tenantId,
+      periodStart: '2026-04-01T00:00:00.000Z',
+      periodEnd: '2026-05-01T00:00:00.000Z',
+      periodSource: 'fallback_calendar',
+      stripeSubscriptionId: null,
+      effectiveLimit: 10,
+      usedCount: 10,
+      remaining: 0,
+      tier: 'pro',
+      limitSource: 'tier_default',
+    });
+    try {
+      const result = await resumeWorkflowRunFromQuotaPauseAction({ runId: run.runId, reason: 'try resume' });
+      expect(result).toEqual({
+        ok: false,
+        resumed: false,
+        reason: 'quota_exhausted',
+        quota: {
+          usedCount: 10,
+          effectiveLimit: 10,
+          periodEnd: '2026-05-01T00:00:00.000Z',
+          periodStart: '2026-04-01T00:00:00.000Z',
+          periodSource: 'fallback_calendar',
+          limitSource: 'tier_default',
+        },
+      });
+    } finally {
+      summarySpy.mockRestore();
+    }
   });
 });

--- a/server/src/test/integration/workflowStepQuotaService.integration.test.ts
+++ b/server/src/test/integration/workflowStepQuotaService.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import type { Knex } from 'knex';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { v4 as uuidv4 } from 'uuid';
 import { createTestDbConnection } from '../../../test-utils/dbConfig';
 import { workflowStepQuotaService } from '../../../../shared/workflow/runtime/services/workflowStepQuotaService';
+import logger from '@alga-psa/core/logger';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -266,5 +267,103 @@ describe('workflowStepQuotaService', () => {
 
     const row = await db('workflow_step_usage_periods').where({ tenant }).first<{ used_count: number }>();
     expect(row?.used_count).toBe(3);
+  });
+
+  it('reports reconciliation drift between usage counter and step ledger', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'pro');
+    const periodStart = '2026-04-01T00:00:00.000Z';
+    const periodEnd = '2026-05-01T00:00:00.000Z';
+
+    await db('workflow_step_usage_periods').insert({
+      tenant,
+      period_start: periodStart,
+      period_end: periodEnd,
+      period_source: 'fallback_calendar',
+      stripe_subscription_id: null,
+      effective_limit: 750,
+      used_count: 5,
+      limit_source: 'tier_default',
+      tier: 'pro',
+    });
+
+    const workflowId = uuidv4();
+    await db('workflow_definitions').insert({
+      workflow_id: workflowId,
+      tenant_id: tenant,
+      name: 'Quota Drift Workflow',
+      payload_schema_ref: 'schema://none',
+      draft_definition: {},
+      draft_version: 1,
+      status: 'published',
+    });
+
+    const runId = uuidv4();
+    await db('workflow_runs').insert({
+      run_id: runId,
+      tenant_id: tenant,
+      workflow_id: workflowId,
+      workflow_version: 1,
+      status: 'RUNNING',
+      node_path: '0',
+      started_at: '2026-04-10T00:00:00.000Z',
+      input_json: {},
+    });
+
+    await db('workflow_run_steps').insert([
+      { step_id: uuidv4(), run_id: runId, step_path: '0', definition_step_id: 'a', status: 'SUCCEEDED', attempt: 1, started_at: '2026-04-10T00:00:00.000Z' },
+      { step_id: uuidv4(), run_id: runId, step_path: '1', definition_step_id: 'b', status: 'SUCCEEDED', attempt: 1, started_at: '2026-04-10T00:00:01.000Z' },
+      { step_id: uuidv4(), run_id: runId, step_path: '2', definition_step_id: 'c', status: 'SUCCEEDED', attempt: 1, started_at: '2026-04-10T00:00:02.000Z' },
+    ]);
+
+    const reconciliation = await workflowStepQuotaService.reconcileUsagePeriod(db, tenant, periodStart, periodEnd);
+    expect(reconciliation.counterUsedCount).toBe(5);
+    expect(reconciliation.ledgerStepCount).toBe(3);
+    expect(reconciliation.drift).toBe(2);
+  });
+
+  it('emits structured observability logs for fallback, invalid metadata fallback, reservation, and quota exhaustion', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'solo');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+      workflowStepLimitPrice: 'invalid',
+      workflowStepLimitProduct: '1',
+    });
+
+    const infoSpy = vi.spyOn(logger, 'info');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const debugSpy = vi.spyOn(logger, 'debug');
+
+    await workflowStepQuotaService.resolveQuotaSummary(db, tenant, new Date('2026-04-20T00:00:00.000Z'));
+    await workflowStepQuotaService.reserveStepStart(db, tenant);
+    await workflowStepQuotaService.reserveStepStart(db, tenant);
+
+    const fallbackTenant = uuidv4();
+    await seedTenant(db, fallbackTenant, 'pro');
+    await workflowStepQuotaService.resolveQuotaSummary(db, fallbackTenant, new Date('2026-04-20T00:00:00.000Z'));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid workflow_step_limit metadata on Stripe price'),
+      expect.objectContaining({ tenant })
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Reserved workflow step quota'),
+      expect.objectContaining({ tenant })
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Workflow step quota exceeded at reservation'),
+      expect.objectContaining({ tenant })
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Using fallback calendar period'),
+      expect.objectContaining({ tenant: fallbackTenant })
+    );
+
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 });

--- a/server/src/test/integration/workflowStepQuotaService.integration.test.ts
+++ b/server/src/test/integration/workflowStepQuotaService.integration.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import type { Knex } from 'knex';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { workflowStepQuotaService } from '../../../../shared/workflow/runtime/services/workflowStepQuotaService';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const stripeMigration = require(path.resolve(__dirname, '../../../../ee/server/migrations/20251014120000_create_stripe_integration_tables.cjs')) as {
+  up: (knex: Knex) => Promise<void>;
+};
+
+let db: Knex;
+
+async function ensureStripeTables(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable('stripe_subscriptions'))) {
+    await stripeMigration.up(knex);
+  }
+}
+
+async function seedTenant(knex: Knex, tenant: string, plan: 'solo' | 'pro' | 'premium' = 'pro'): Promise<void> {
+  const hasCompanyName = await knex.schema.hasColumn('tenants', 'company_name');
+  const hasClientName = await knex.schema.hasColumn('tenants', 'client_name');
+  const hasEmail = await knex.schema.hasColumn('tenants', 'email');
+  const payload: Record<string, unknown> = {
+    tenant,
+    plan,
+  };
+  if (hasCompanyName) payload.company_name = 'Quota Test Co';
+  if (hasClientName) payload.client_name = 'Quota Test Co';
+  if (hasEmail) payload.email = `${tenant}@example.com`;
+  await knex('tenants').insert(payload);
+}
+
+async function seedStripePeriod(knex: Knex, tenant: string, args: {
+  status: 'trialing' | 'active' | 'past_due' | 'unpaid';
+  workflowStepLimitPrice?: unknown;
+  workflowStepLimitProduct?: unknown;
+  start: string;
+  end: string;
+}): Promise<void> {
+  const customerId = uuidv4();
+  const productId = uuidv4();
+  const priceId = uuidv4();
+  const subscriptionId = uuidv4();
+
+  await knex('stripe_customers').insert({
+    tenant,
+    stripe_customer_id: customerId,
+    stripe_customer_external_id: `cus_${uuidv4()}`,
+    email: 'billing@example.com',
+    name: 'Billing',
+  });
+
+  await knex('stripe_products').insert({
+    tenant,
+    stripe_product_id: productId,
+    stripe_product_external_id: `prod_${uuidv4()}`,
+    name: 'Plan Product',
+    product_type: 'license',
+    metadata: args.workflowStepLimitProduct == null ? {} : { workflow_step_limit: args.workflowStepLimitProduct },
+  });
+
+  await knex('stripe_prices').insert({
+    tenant,
+    stripe_price_id: priceId,
+    stripe_price_external_id: `price_${uuidv4()}`,
+    stripe_product_id: productId,
+    unit_amount: 1000,
+    metadata: args.workflowStepLimitPrice == null ? {} : { workflow_step_limit: args.workflowStepLimitPrice },
+  });
+
+  await knex('stripe_subscriptions').insert({
+    tenant,
+    stripe_subscription_id: subscriptionId,
+    stripe_subscription_external_id: `sub_${uuidv4()}`,
+    stripe_customer_id: customerId,
+    stripe_price_id: priceId,
+    quantity: 1,
+    status: args.status,
+    current_period_start: args.start,
+    current_period_end: args.end,
+  });
+}
+
+beforeAll(async () => {
+  db = await createTestDbConnection({ runSeeds: false });
+  await ensureStripeTables(db);
+});
+
+beforeEach(async () => {
+  await db.raw('TRUNCATE workflow_step_usage_periods, stripe_subscriptions, stripe_prices, stripe_products, stripe_customers, tenants RESTART IDENTITY CASCADE');
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('workflowStepQuotaService', () => {
+  it('uses active Stripe period for resolver with stripe_subscription source', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'pro');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+    });
+
+    const summary = await workflowStepQuotaService.resolveQuotaSummary(db, tenant, new Date('2026-04-15T00:00:00.000Z'));
+
+    expect(summary.periodSource).toBe('stripe_subscription');
+    expect(summary.periodStart).toBe('2026-04-01T00:00:00.000Z');
+    expect(summary.periodEnd).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('falls back to UTC calendar month and tier defaults without valid stripe period', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'solo');
+
+    const summary = await workflowStepQuotaService.resolveQuotaSummary(db, tenant, new Date('2026-04-15T10:10:10.000Z'));
+
+    expect(summary.periodSource).toBe('fallback_calendar');
+    expect(summary.periodStart).toBe('2026-04-01T00:00:00.000Z');
+    expect(summary.periodEnd).toBe('2026-05-01T00:00:00.000Z');
+    expect(summary.effectiveLimit).toBe(150);
+    expect(summary.limitSource).toBe('tier_default');
+  });
+
+  it('applies metadata precedence price > product > tier default and supports unlimited', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'premium');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+      workflowStepLimitProduct: '5000',
+      workflowStepLimitPrice: '1200',
+    });
+
+    const priceSummary = await workflowStepQuotaService.resolveQuotaSummary(db, tenant);
+    expect(priceSummary.effectiveLimit).toBe(1200);
+    expect(priceSummary.limitSource).toBe('stripe_price_metadata');
+
+    await db('stripe_prices').where({ tenant }).update({ metadata: { workflow_step_limit: 'invalid' } });
+    const productSummary = await workflowStepQuotaService.resolveQuotaSummary(db, tenant);
+    expect(productSummary.effectiveLimit).toBe(5000);
+    expect(productSummary.limitSource).toBe('stripe_product_metadata');
+
+    await db('stripe_products').where({ tenant }).update({ metadata: { workflow_step_limit: 'unlimited' } });
+    const unlimitedSummary = await workflowStepQuotaService.resolveQuotaSummary(db, tenant);
+    expect(unlimitedSummary.effectiveLimit).toBeNull();
+    expect(unlimitedSummary.limitSource).toBe('unlimited_metadata');
+  });
+
+  it('reserves finite quota atomically and rejects at limit without incrementing', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'solo');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+      workflowStepLimitPrice: '2',
+    });
+
+    const first = await workflowStepQuotaService.reserveStepStart(db, tenant);
+    const second = await workflowStepQuotaService.reserveStepStart(db, tenant);
+    const third = await workflowStepQuotaService.reserveStepStart(db, tenant);
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(third.allowed).toBe(false);
+
+    const row = await db('workflow_step_usage_periods').where({ tenant }).first<{ used_count: number }>();
+    expect(row?.used_count).toBe(2);
+  });
+
+  it('allows unlimited reservations and still increments used_count', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'pro');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+      workflowStepLimitPrice: 'unlimited',
+    });
+
+    const results = await Promise.all([
+      workflowStepQuotaService.reserveStepStart(db, tenant),
+      workflowStepQuotaService.reserveStepStart(db, tenant),
+      workflowStepQuotaService.reserveStepStart(db, tenant),
+      workflowStepQuotaService.reserveStepStart(db, tenant),
+    ]);
+
+    expect(results.every((result) => result.allowed)).toBe(true);
+    const row = await db('workflow_step_usage_periods').where({ tenant }).first<{ used_count: number; effective_limit: number | null }>();
+    expect(row?.effective_limit).toBeNull();
+    expect(row?.used_count).toBe(4);
+  });
+});

--- a/server/src/test/integration/workflowStepQuotaService.integration.test.ts
+++ b/server/src/test/integration/workflowStepQuotaService.integration.test.ts
@@ -244,4 +244,27 @@ describe('workflowStepQuotaService', () => {
     expect(row?.effective_limit).toBeNull();
     expect(row?.used_count).toBe(4);
   });
+
+  it('does not allow concurrent finite reservations to exceed effective_limit', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'solo');
+    await seedStripePeriod(db, tenant, {
+      status: 'active',
+      start: '2026-04-01T00:00:00.000Z',
+      end: '2026-05-01T00:00:00.000Z',
+      workflowStepLimitPrice: '3',
+    });
+
+    const reservations = await Promise.all(
+      Array.from({ length: 12 }).map(() => workflowStepQuotaService.reserveStepStart(db, tenant))
+    );
+
+    const allowedCount = reservations.filter((reservation) => reservation.allowed).length;
+    const deniedCount = reservations.length - allowedCount;
+    expect(allowedCount).toBe(3);
+    expect(deniedCount).toBe(9);
+
+    const row = await db('workflow_step_usage_periods').where({ tenant }).first<{ used_count: number }>();
+    expect(row?.used_count).toBe(3);
+  });
 });

--- a/server/src/test/integration/workflowStepQuotaService.integration.test.ts
+++ b/server/src/test/integration/workflowStepQuotaService.integration.test.ts
@@ -101,6 +101,50 @@ afterAll(async () => {
 });
 
 describe('workflowStepQuotaService', () => {
+  it('enforces uniqueness on (tenant, period_start, period_end) and supports upsert', async () => {
+    const tenant = uuidv4();
+    await seedTenant(db, tenant, 'pro');
+    const periodStart = '2026-04-01T00:00:00.000Z';
+    const periodEnd = '2026-05-01T00:00:00.000Z';
+
+    await db('workflow_step_usage_periods').insert({
+      tenant,
+      period_start: periodStart,
+      period_end: periodEnd,
+      period_source: 'fallback_calendar',
+      stripe_subscription_id: null,
+      effective_limit: 750,
+      used_count: 1,
+      limit_source: 'tier_default',
+      tier: 'pro',
+    });
+
+    await db('workflow_step_usage_periods')
+      .insert({
+        tenant,
+        period_start: periodStart,
+        period_end: periodEnd,
+        period_source: 'fallback_calendar',
+        stripe_subscription_id: null,
+        effective_limit: 750,
+        used_count: 2,
+        limit_source: 'tier_default',
+        tier: 'pro',
+      })
+      .onConflict(['tenant', 'period_start', 'period_end'])
+      .merge({
+        used_count: 2,
+        updated_at: db.fn.now(),
+      });
+
+    const rows = await db('workflow_step_usage_periods')
+      .where({ tenant, period_start: periodStart, period_end: periodEnd })
+      .select('*');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].used_count).toBe(2);
+  });
+
   it('uses active Stripe period for resolver with stripe_subscription source', async () => {
     const tenant = uuidv4();
     await seedTenant(db, tenant, 'pro');

--- a/server/src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts
+++ b/server/src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts
@@ -6,6 +6,7 @@ type WaitRow = {
   step_path: string;
   tenant_id: string;
   engine: string | null;
+  node_path?: string | null;
   status: 'WAITING' | 'RESOLVED';
 };
 
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   resolveQuotaSummary: vi.fn(),
   executeRun: vi.fn(),
   createRunLog: vi.fn(),
+  signalQuotaResume: vi.fn(),
 }));
 
 vi.mock('@alga-psa/db/admin', () => ({
@@ -35,6 +37,10 @@ vi.mock('@alga-psa/workflows/persistence', () => ({
   },
 }));
 
+vi.mock('@alga-psa/workflows/lib/workflowRuntimeV2Temporal', () => ({
+  signalWorkflowRuntimeV2QuotaResume: mocks.signalQuotaResume,
+}));
+
 function buildMockKnex(initialWaits: WaitRow[]) {
   const waits = new Map(initialWaits.map((wait) => [wait.wait_id, { ...wait }]));
   let selectedWaitIds: string[] = [];
@@ -47,6 +53,7 @@ function buildMockKnex(initialWaits: WaitRow[]) {
       step_path: w.step_path,
       tenant_id: w.tenant_id,
       engine: w.engine,
+      node_path: w.node_path ?? w.step_path,
     }));
   };
 
@@ -106,6 +113,7 @@ describe('workflowQuotaResumeScanHandler', () => {
     vi.clearAllMocks();
     mocks.createRunLog.mockResolvedValue(undefined);
     mocks.executeRun.mockResolvedValue(undefined);
+    mocks.signalQuotaResume.mockResolvedValue(undefined);
   });
 
   it('resumes only eligible tenants and sets runs back to RUNNING without pre-consuming quota', async () => {
@@ -131,6 +139,29 @@ describe('workflowQuotaResumeScanHandler', () => {
       expect.anything(),
       expect.objectContaining({ run_id: 'run-b1' }),
     );
+  });
+
+  it('signals Temporal runs instead of executing them with the DB runtime', async () => {
+    const { knex } = buildMockKnex([
+      { wait_id: 'wait-temporal', run_id: 'run-temporal', step_path: 'root.steps[1]', tenant_id: 'tenant-1', engine: 'temporal', status: 'WAITING' },
+    ]);
+    mocks.getAdminConnection.mockResolvedValue(knex);
+    mocks.resolveQuotaSummary.mockResolvedValue({
+      effectiveLimit: null,
+      usedCount: 0,
+      periodStart: '2026-04-01T00:00:00.000Z',
+      periodEnd: '2026-05-01T00:00:00.000Z',
+    });
+
+    const { workflowQuotaResumeScanHandler } = await import('../../../lib/jobs/handlers/workflowQuotaResumeScanHandler');
+    await workflowQuotaResumeScanHandler({ tenantId: 'ignored', batchSize: 10 });
+
+    expect(mocks.executeRun).not.toHaveBeenCalled();
+    expect(mocks.signalQuotaResume).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-temporal',
+      waitId: 'wait-temporal',
+      reason: 'quota_available',
+    }));
   });
 
   it('does not resolve the same wait twice across repeated scans', async () => {

--- a/server/src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts
+++ b/server/src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type WaitRow = {
+  wait_id: string;
+  run_id: string;
+  step_path: string;
+  tenant_id: string;
+  engine: string | null;
+  status: 'WAITING' | 'RESOLVED';
+};
+
+const mocks = vi.hoisted(() => ({
+  getAdminConnection: vi.fn(),
+  resolveQuotaSummary: vi.fn(),
+  executeRun: vi.fn(),
+  createRunLog: vi.fn(),
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: mocks.getAdminConnection,
+}));
+
+vi.mock('@alga-psa/workflows/runtime/core', () => ({
+  WorkflowRuntimeV2: class WorkflowRuntimeV2 {
+    executeRun = mocks.executeRun;
+  },
+  workflowStepQuotaService: {
+    resolveQuotaSummary: mocks.resolveQuotaSummary,
+  },
+}));
+
+vi.mock('@alga-psa/workflows/persistence', () => ({
+  WorkflowRunLogModelV2: {
+    create: mocks.createRunLog,
+  },
+}));
+
+function buildMockKnex(initialWaits: WaitRow[]) {
+  const waits = new Map(initialWaits.map((wait) => [wait.wait_id, { ...wait }]));
+  let selectedWaitIds: string[] = [];
+
+  const selectCandidates = () => {
+    const candidates = Array.from(waits.values()).filter((w) => w.status === 'WAITING');
+    return candidates.map((w) => ({
+      wait_id: w.wait_id,
+      run_id: w.run_id,
+      step_path: w.step_path,
+      tenant_id: w.tenant_id,
+      engine: w.engine,
+    }));
+  };
+
+  const trx = ((table: string) => {
+    if (table === 'workflow_run_waits as w') {
+      const chain: any = {
+        join: () => chain,
+        where: () => chain,
+        whereNotNull: () => chain,
+        orderBy: () => chain,
+        forUpdate: () => chain,
+        skipLocked: () => chain,
+        limit: () => chain,
+        select: async () => selectCandidates(),
+      };
+      return chain;
+    }
+
+    if (table === 'workflow_run_waits') {
+      const chain: any = {
+        whereIn: (_col: string, ids: string[]) => {
+          selectedWaitIds = ids;
+          return chain;
+        },
+        andWhere: () => chain,
+        update: async () => {
+          for (const id of selectedWaitIds) {
+            const row = waits.get(id);
+            if (row) row.status = 'RESOLVED';
+          }
+        },
+      };
+      return chain;
+    }
+
+    if (table === 'workflow_runs') {
+      const chain: any = {
+        whereIn: () => chain,
+        andWhere: () => chain,
+        update: async () => undefined,
+      };
+      return chain;
+    }
+
+    throw new Error(`Unexpected table ${table}`);
+  }) as any;
+
+  const knex: any = {
+    transaction: async (fn: (tx: any) => Promise<any>) => fn(trx),
+  };
+
+  return { knex, waits };
+}
+
+describe('workflowQuotaResumeScanHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createRunLog.mockResolvedValue(undefined);
+    mocks.executeRun.mockResolvedValue(undefined);
+  });
+
+  it('resumes only eligible tenants and sets runs back to RUNNING without pre-consuming quota', async () => {
+    const { knex } = buildMockKnex([
+      { wait_id: 'wait-a1', run_id: 'run-a1', step_path: 'root.steps[1]', tenant_id: 'tenant-a', engine: 'db', status: 'WAITING' },
+      { wait_id: 'wait-b1', run_id: 'run-b1', step_path: 'root.steps[2]', tenant_id: 'tenant-b', engine: 'db', status: 'WAITING' },
+    ]);
+    mocks.getAdminConnection.mockResolvedValue(knex);
+    mocks.resolveQuotaSummary.mockImplementation(async (_trx: unknown, tenant: string) => {
+      if (tenant === 'tenant-a') {
+        return { effectiveLimit: 1, usedCount: 1, periodStart: '2026-04-01T00:00:00.000Z', periodEnd: '2026-05-01T00:00:00.000Z' };
+      }
+      return { effectiveLimit: 5, usedCount: 2, periodStart: '2026-04-01T00:00:00.000Z', periodEnd: '2026-05-01T00:00:00.000Z' };
+    });
+
+    const { workflowQuotaResumeScanHandler } = await import('../../../lib/jobs/handlers/workflowQuotaResumeScanHandler');
+    await workflowQuotaResumeScanHandler({ tenantId: 'ignored', batchSize: 10 });
+
+    expect(mocks.executeRun).toHaveBeenCalledTimes(1);
+    expect(mocks.executeRun).toHaveBeenCalledWith(expect.anything(), 'run-b1', 'job:workflow-quota-resume-scan');
+    expect(mocks.createRunLog).toHaveBeenCalledTimes(1);
+    expect(mocks.createRunLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ run_id: 'run-b1' }),
+    );
+  });
+
+  it('does not resolve the same wait twice across repeated scans', async () => {
+    const { knex, waits } = buildMockKnex([
+      { wait_id: 'wait-1', run_id: 'run-1', step_path: 'root.steps[1]', tenant_id: 'tenant-1', engine: 'db', status: 'WAITING' },
+    ]);
+    mocks.getAdminConnection.mockResolvedValue(knex);
+    mocks.resolveQuotaSummary.mockResolvedValue({
+      effectiveLimit: null,
+      usedCount: 0,
+      periodStart: '2026-04-01T00:00:00.000Z',
+      periodEnd: '2026-05-01T00:00:00.000Z',
+    });
+
+    const { workflowQuotaResumeScanHandler } = await import('../../../lib/jobs/handlers/workflowQuotaResumeScanHandler');
+    await workflowQuotaResumeScanHandler({ tenantId: 'ignored', batchSize: 10 });
+    await workflowQuotaResumeScanHandler({ tenantId: 'ignored', batchSize: 10 });
+
+    expect(waits.get('wait-1')?.status).toBe('RESOLVED');
+    expect(mocks.executeRun).toHaveBeenCalledTimes(1);
+    expect(mocks.createRunLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shared/workflow/runtime/index.ts
+++ b/shared/workflow/runtime/index.ts
@@ -38,3 +38,11 @@ export {
   enforceSnapshotSize
 } from './utils/redactionUtils';
 export { evaluateEventWaitFilters } from './utils/eventWaitFilters';
+export {
+  WorkflowStepQuotaService,
+  workflowStepQuotaService,
+  type WorkflowStepQuotaSummary,
+  type WorkflowStepQuotaReservationResult,
+  type WorkflowStepQuotaLimitSource,
+  type WorkflowStepQuotaPeriodSource
+} from './services/workflowStepQuotaService';

--- a/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
+++ b/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
@@ -32,6 +32,7 @@ import WorkflowRunWaitModelV2 from '../../persistence/workflowRunWaitModelV2';
 import WorkflowActionInvocationModelV2 from '../../persistence/workflowActionInvocationModelV2';
 import WorkflowRunSnapshotModelV2 from '../../persistence/workflowRunSnapshotModelV2';
 import WorkflowRunLogModelV2 from '../../persistence/workflowRunLogModelV2';
+import { workflowStepQuotaService } from '../services/workflowStepQuotaService';
 import { ZodError } from 'zod';
 import { createHash } from 'crypto';
 
@@ -263,6 +264,13 @@ export class WorkflowRuntimeV2 {
       }
 
       const stepStart = Date.now();
+      if (run.tenant_id) {
+        const reservation = await workflowStepQuotaService.reserveStepStart(knex, run.tenant_id);
+        if (!reservation.allowed) {
+          await this.pauseForQuota(knex, run, currentPath, reservation.summary);
+          return;
+        }
+      }
       const attempt = await this.nextAttempt(knex, runId, currentPath);
       const stepRecord = await WorkflowRunStepModelV2.create(knex, {
         run_id: runId,
@@ -968,6 +976,73 @@ export class WorkflowRuntimeV2 {
     const last = await WorkflowRunStepModelV2.getLatestByRunAndPath(knex, runId, stepPath);
     if (!last) return 1;
     return last.attempt + 1;
+  }
+
+  private async pauseForQuota(
+    knex: Knex,
+    run: WorkflowRunRecord,
+    stepPath: string,
+    summary: {
+      periodStart: string;
+      periodEnd: string;
+      usedCount: number;
+      effectiveLimit: number | null;
+      periodSource: string;
+      limitSource: string;
+      tenant: string;
+    }
+  ): Promise<void> {
+    const existingWait = await knex('workflow_run_waits')
+      .where({
+        run_id: run.run_id,
+        step_path: stepPath,
+        wait_type: 'quota',
+        status: 'WAITING',
+      })
+      .first<{ wait_id: string }>();
+
+    const payload = {
+      reason: 'workflow_step_quota_exceeded',
+      tenant: summary.tenant,
+      periodStart: summary.periodStart,
+      periodEnd: summary.periodEnd,
+      usedCount: summary.usedCount,
+      effectiveLimit: summary.effectiveLimit,
+      periodSource: summary.periodSource,
+      limitSource: summary.limitSource,
+    };
+
+    if (existingWait) {
+      await WorkflowRunWaitModelV2.update(knex, existingWait.wait_id, {
+        timeout_at: summary.periodEnd,
+        payload,
+      });
+    } else {
+      await WorkflowRunWaitModelV2.create(knex, {
+        run_id: run.run_id,
+        step_path: stepPath,
+        wait_type: 'quota',
+        timeout_at: summary.periodEnd,
+        status: 'WAITING',
+        payload,
+      });
+    }
+
+    await WorkflowRunModelV2.update(knex, run.run_id, {
+      status: 'WAITING',
+      node_path: stepPath,
+      resume_event_name: null,
+      resume_event_payload: null,
+      resume_error: null,
+    });
+
+    await this.logRunEvent(knex, run, {
+      level: 'WARN',
+      message: 'Workflow step quota exceeded; run paused',
+      stepPath,
+      context: payload,
+      source: 'runtime',
+    });
   }
 
   private async markRunCompleted(knex: Knex, runId: string, status: WorkflowRunStatus): Promise<void> {

--- a/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
+++ b/shared/workflow/runtime/runtime/workflowRuntimeV2.ts
@@ -27,7 +27,7 @@ import { parseNodePath } from '../utils/nodePathUtils';
 import WorkflowDefinitionModelV2 from '../../persistence/workflowDefinitionModelV2';
 import WorkflowDefinitionVersionModelV2 from '../../persistence/workflowDefinitionVersionModelV2';
 import WorkflowRunModelV2, { type WorkflowRunRecord } from '../../persistence/workflowRunModelV2';
-import WorkflowRunStepModelV2 from '../../persistence/workflowRunStepModelV2';
+import WorkflowRunStepModelV2, { type WorkflowRunStepRecord } from '../../persistence/workflowRunStepModelV2';
 import WorkflowRunWaitModelV2 from '../../persistence/workflowRunWaitModelV2';
 import WorkflowActionInvocationModelV2 from '../../persistence/workflowActionInvocationModelV2';
 import WorkflowRunSnapshotModelV2 from '../../persistence/workflowRunSnapshotModelV2';
@@ -263,16 +263,18 @@ export class WorkflowRuntimeV2 {
         return;
       }
 
-      const stepStart = Date.now();
-      if (run.tenant_id) {
+      const resumedWaitStepRecord = await this.getResumableWaitStepRecord(knex, run, currentPath);
+      const resumedStepStartedAt = resumedWaitStepRecord?.started_at ? new Date(resumedWaitStepRecord.started_at).getTime() : NaN;
+      const stepStart = Number.isNaN(resumedStepStartedAt) ? Date.now() : resumedStepStartedAt;
+      if (!resumedWaitStepRecord && run.tenant_id) {
         const reservation = await workflowStepQuotaService.reserveStepStart(knex, run.tenant_id);
         if (!reservation.allowed) {
           await this.pauseForQuota(knex, run, currentPath, reservation.summary);
           return;
         }
       }
-      const attempt = await this.nextAttempt(knex, runId, currentPath);
-      const stepRecord = await WorkflowRunStepModelV2.create(knex, {
+      const attempt = resumedWaitStepRecord?.attempt ?? await this.nextAttempt(knex, runId, currentPath);
+      const stepRecord = resumedWaitStepRecord ?? await WorkflowRunStepModelV2.create(knex, {
         run_id: runId,
         step_path: currentPath,
         definition_step_id: step.id,
@@ -282,7 +284,7 @@ export class WorkflowRuntimeV2 {
 
       await this.logRunEvent(knex, run, {
         level: 'INFO',
-        message: 'Step started',
+        message: resumedWaitStepRecord ? 'Step resumed from wait' : 'Step started',
         stepId: stepRecord.step_id,
         stepPath: currentPath,
         context: {
@@ -978,6 +980,29 @@ export class WorkflowRuntimeV2 {
     return last.attempt + 1;
   }
 
+  private async getResumableWaitStepRecord(
+    knex: Knex,
+    run: WorkflowRunRecord,
+    stepPath: string
+  ): Promise<WorkflowRunStepRecord | null> {
+    if (!run.resume_event_name && !run.resume_error) return null;
+
+    const latest = await WorkflowRunStepModelV2.getLatestByRunAndPath(knex, run.run_id, stepPath);
+    if (!latest || latest.status !== 'STARTED') return null;
+
+    const resolvedWait = await knex('workflow_run_waits')
+      .where({
+        run_id: run.run_id,
+        step_path: stepPath,
+        status: 'RESOLVED'
+      })
+      .whereIn('wait_type', ['event', 'human', 'time'])
+      .orderBy('resolved_at', 'desc')
+      .first<{ wait_id: string }>();
+
+    return resolvedWait ? latest : null;
+  }
+
   private async pauseForQuota(
     knex: Knex,
     run: WorkflowRunRecord,
@@ -1034,6 +1059,13 @@ export class WorkflowRuntimeV2 {
       resume_event_name: null,
       resume_event_payload: null,
       resume_error: null,
+      error_json: {
+        category: 'QuotaExceeded',
+        message: 'Workflow step quota exceeded for current billing period',
+        nodePath: stepPath,
+        at: new Date().toISOString(),
+        data: payload
+      },
     });
 
     await this.logRunEvent(knex, run, {

--- a/shared/workflow/runtime/services/workflowStepQuotaService.ts
+++ b/shared/workflow/runtime/services/workflowStepQuotaService.ts
@@ -47,6 +47,15 @@ export type WorkflowStepQuotaReservationResult =
     summary: WorkflowStepQuotaSummary;
   };
 
+export type WorkflowStepQuotaReconciliation = {
+  tenant: string;
+  periodStart: string;
+  periodEnd: string;
+  counterUsedCount: number;
+  ledgerStepCount: number;
+  drift: number;
+};
+
 type StripeSubscriptionRow = {
   stripe_subscription_id: string;
   stripe_price_id: string;
@@ -337,6 +346,42 @@ export class WorkflowStepQuotaService {
         },
       };
     });
+  }
+
+  async reconcileUsagePeriod(
+    knex: Knex,
+    tenant: string,
+    periodStart: string,
+    periodEnd: string
+  ): Promise<WorkflowStepQuotaReconciliation> {
+    const usage = await knex<UsageRow>('workflow_step_usage_periods')
+      .where({
+        tenant,
+        period_start: periodStart,
+        period_end: periodEnd,
+      })
+      .first();
+
+    const ledgerRow = await knex('workflow_run_steps as s')
+      .join('workflow_runs as r', 'r.run_id', 's.run_id')
+      .where('r.tenant_id', tenant)
+      .andWhere('s.started_at', '>=', periodStart)
+      .andWhere('s.started_at', '<', periodEnd)
+      .count<{ count: string }>('s.step_id as count')
+      .first();
+
+    const counterUsedCount = usage?.used_count ?? 0;
+    const ledgerStepCount = Number(ledgerRow?.count ?? 0);
+    const drift = counterUsedCount - ledgerStepCount;
+
+    return {
+      tenant,
+      periodStart,
+      periodEnd,
+      counterUsedCount,
+      ledgerStepCount,
+      drift,
+    };
   }
 }
 

--- a/shared/workflow/runtime/services/workflowStepQuotaService.ts
+++ b/shared/workflow/runtime/services/workflowStepQuotaService.ts
@@ -1,0 +1,285 @@
+import type { Knex } from 'knex';
+import { resolveTier, type TenantTier } from '@alga-psa/types';
+
+const WORKFLOW_STEP_LIMIT_METADATA_KEY = 'workflow_step_limit';
+const ACTIVE_STATUSES = ['trialing', 'active', 'past_due', 'unpaid'] as const;
+const STATUS_PRIORITY: Record<string, number> = {
+  trialing: 0,
+  active: 1,
+  past_due: 2,
+  unpaid: 3,
+};
+const TIER_DEFAULT_LIMITS: Record<TenantTier, number> = {
+  solo: 150,
+  pro: 750,
+  premium: 10000,
+};
+
+export type WorkflowStepQuotaPeriodSource = 'stripe_subscription' | 'fallback_calendar';
+export type WorkflowStepQuotaLimitSource =
+  | 'stripe_price_metadata'
+  | 'stripe_product_metadata'
+  | 'tier_default'
+  | 'unlimited_metadata';
+
+export type WorkflowStepQuotaSummary = {
+  tenant: string;
+  periodStart: string;
+  periodEnd: string;
+  periodSource: WorkflowStepQuotaPeriodSource;
+  stripeSubscriptionId: string | null;
+  effectiveLimit: number | null;
+  usedCount: number;
+  remaining: number | null;
+  tier: TenantTier;
+  limitSource: WorkflowStepQuotaLimitSource;
+};
+
+export type WorkflowStepQuotaReservationResult =
+  | {
+    allowed: true;
+    summary: WorkflowStepQuotaSummary;
+    usedCountAfter: number;
+  }
+  | {
+    allowed: false;
+    summary: WorkflowStepQuotaSummary;
+  };
+
+type StripeSubscriptionRow = {
+  stripe_subscription_id: string;
+  stripe_price_id: string;
+  status: string;
+  current_period_start: string | Date | null;
+  current_period_end: string | Date | null;
+};
+
+type MetadataLimit = {
+  effectiveLimit: number | null;
+  limitSource: WorkflowStepQuotaLimitSource;
+};
+
+type UsageRow = {
+  tenant: string;
+  period_start: string | Date;
+  period_end: string | Date;
+  period_source: WorkflowStepQuotaPeriodSource;
+  stripe_subscription_id: string | null;
+  effective_limit: number | null;
+  used_count: number;
+  limit_source: WorkflowStepQuotaLimitSource;
+  tier: TenantTier;
+};
+
+function toIso(value: string | Date): string {
+  return typeof value === 'string' ? new Date(value).toISOString() : value.toISOString();
+}
+
+function currentUtcMonthPeriod(now = new Date()): { periodStart: string; periodEnd: string } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const periodStart = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)).toISOString();
+  const periodEnd = new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)).toISOString();
+  return { periodStart, periodEnd };
+}
+
+function parseLimitMetadata(raw: unknown, source: 'stripe_price_metadata' | 'stripe_product_metadata'): MetadataLimit | null {
+  if (raw == null) return null;
+
+  const normalized = String(raw).trim().toLowerCase();
+  if (normalized === 'unlimited') {
+    return { effectiveLimit: null, limitSource: 'unlimited_metadata' };
+  }
+
+  const parsed = Number(normalized);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return { effectiveLimit: parsed, limitSource: source };
+  }
+
+  return null;
+}
+
+async function hasStripeTables(knex: Knex): Promise<boolean> {
+  const [subs, prices, products] = await Promise.all([
+    knex.schema.hasTable('stripe_subscriptions'),
+    knex.schema.hasTable('stripe_prices'),
+    knex.schema.hasTable('stripe_products'),
+  ]);
+  return subs && prices && products;
+}
+
+async function getTenantTier(knex: Knex, tenant: string): Promise<TenantTier> {
+  const row = await knex('tenants').where({ tenant }).select('plan').first<{ plan?: string | null }>();
+  return resolveTier(row?.plan ?? null).tier;
+}
+
+async function findPreferredSubscription(knex: Knex, tenant: string): Promise<StripeSubscriptionRow | null> {
+  const subscriptions = await knex<StripeSubscriptionRow>('stripe_subscriptions')
+    .where({ tenant })
+    .whereIn('status', ACTIVE_STATUSES as unknown as string[])
+    .whereNotNull('current_period_start')
+    .whereNotNull('current_period_end')
+    .select('stripe_subscription_id', 'stripe_price_id', 'status', 'current_period_start', 'current_period_end');
+
+  const sorted = subscriptions
+    .filter((row) => row.current_period_start && row.current_period_end)
+    .sort((a, b) => {
+      const left = STATUS_PRIORITY[a.status] ?? Number.MAX_SAFE_INTEGER;
+      const right = STATUS_PRIORITY[b.status] ?? Number.MAX_SAFE_INTEGER;
+      if (left !== right) return left - right;
+      return new Date(a.current_period_start as string).getTime() - new Date(b.current_period_start as string).getTime();
+    });
+
+  return sorted[0] ?? null;
+}
+
+async function resolveMetadataLimit(knex: Knex, tenant: string, priceId: string): Promise<MetadataLimit | null> {
+  const price = await knex('stripe_prices')
+    .where({ tenant, stripe_price_id: priceId })
+    .first<{ metadata?: Record<string, unknown> | null; stripe_product_id?: string | null }>();
+
+  const priceValue = parseLimitMetadata(price?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY], 'stripe_price_metadata');
+  if (priceValue) return priceValue;
+
+  if (!price?.stripe_product_id) return null;
+
+  const product = await knex('stripe_products')
+    .where({ tenant, stripe_product_id: price.stripe_product_id })
+    .first<{ metadata?: Record<string, unknown> | null }>();
+
+  return parseLimitMetadata(product?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY], 'stripe_product_metadata');
+}
+
+export class WorkflowStepQuotaService {
+  async resolveQuotaSummary(knex: Knex, tenant: string, now = new Date()): Promise<WorkflowStepQuotaSummary> {
+    const tier = await getTenantTier(knex, tenant);
+    const defaultLimit = TIER_DEFAULT_LIMITS[tier];
+
+    let periodStart: string;
+    let periodEnd: string;
+    let periodSource: WorkflowStepQuotaPeriodSource = 'fallback_calendar';
+    let stripeSubscriptionId: string | null = null;
+    let effectiveLimit: number | null = defaultLimit;
+    let limitSource: WorkflowStepQuotaLimitSource = 'tier_default';
+
+    if (await hasStripeTables(knex)) {
+      const subscription = await findPreferredSubscription(knex, tenant);
+      if (subscription?.current_period_start && subscription.current_period_end) {
+        periodStart = toIso(subscription.current_period_start);
+        periodEnd = toIso(subscription.current_period_end);
+        periodSource = 'stripe_subscription';
+        stripeSubscriptionId = subscription.stripe_subscription_id;
+
+        const metadataLimit = await resolveMetadataLimit(knex, tenant, subscription.stripe_price_id);
+        if (metadataLimit) {
+          effectiveLimit = metadataLimit.effectiveLimit;
+          limitSource = metadataLimit.limitSource;
+        }
+      } else {
+        const fallback = currentUtcMonthPeriod(now);
+        periodStart = fallback.periodStart;
+        periodEnd = fallback.periodEnd;
+      }
+    } else {
+      const fallback = currentUtcMonthPeriod(now);
+      periodStart = fallback.periodStart;
+      periodEnd = fallback.periodEnd;
+    }
+
+    const usage = await knex<UsageRow>('workflow_step_usage_periods')
+      .where({ tenant, period_start: periodStart, period_end: periodEnd })
+      .first();
+
+    const usedCount = usage?.used_count ?? 0;
+    const remaining = effectiveLimit == null ? null : Math.max(effectiveLimit - usedCount, 0);
+
+    return {
+      tenant,
+      periodStart,
+      periodEnd,
+      periodSource,
+      stripeSubscriptionId,
+      effectiveLimit,
+      usedCount,
+      remaining,
+      tier,
+      limitSource,
+    };
+  }
+
+  async reserveStepStart(knex: Knex, tenant: string, now = new Date()): Promise<WorkflowStepQuotaReservationResult> {
+    return knex.transaction(async (trx) => {
+      const summary = await this.resolveQuotaSummary(trx, tenant, now);
+      const metadataJson = {
+        reservedAt: now.toISOString(),
+      };
+
+      await trx('workflow_step_usage_periods')
+        .insert({
+          tenant: summary.tenant,
+          period_start: summary.periodStart,
+          period_end: summary.periodEnd,
+          period_source: summary.periodSource,
+          stripe_subscription_id: summary.stripeSubscriptionId,
+          effective_limit: summary.effectiveLimit,
+          used_count: 0,
+          limit_source: summary.limitSource,
+          tier: summary.tier,
+          metadata_json: metadataJson,
+          created_at: trx.fn.now(),
+          updated_at: trx.fn.now(),
+        })
+        .onConflict(['tenant', 'period_start', 'period_end'])
+        .merge({
+          period_source: summary.periodSource,
+          stripe_subscription_id: summary.stripeSubscriptionId,
+          effective_limit: summary.effectiveLimit,
+          limit_source: summary.limitSource,
+          tier: summary.tier,
+          metadata_json: metadataJson,
+          updated_at: trx.fn.now(),
+        });
+
+      const usage = await trx<UsageRow>('workflow_step_usage_periods')
+        .where({ tenant: summary.tenant, period_start: summary.periodStart, period_end: summary.periodEnd })
+        .forUpdate()
+        .first();
+
+      if (!usage) {
+        throw new Error('workflow_step_usage_periods row missing after upsert');
+      }
+
+      if (usage.effective_limit != null && usage.used_count >= usage.effective_limit) {
+        return {
+          allowed: false,
+          summary: {
+            ...summary,
+            usedCount: usage.used_count,
+            remaining: 0,
+          },
+        };
+      }
+
+      const [updated] = await trx<UsageRow>('workflow_step_usage_periods')
+        .where({ tenant: summary.tenant, period_start: summary.periodStart, period_end: summary.periodEnd })
+        .update({
+          used_count: trx.raw('used_count + 1'),
+          updated_at: trx.fn.now(),
+        })
+        .returning('*');
+
+      const usedCountAfter = updated.used_count;
+      return {
+        allowed: true,
+        usedCountAfter,
+        summary: {
+          ...summary,
+          usedCount: usedCountAfter,
+          remaining: updated.effective_limit == null ? null : Math.max(updated.effective_limit - usedCountAfter, 0),
+        },
+      };
+    });
+  }
+}
+
+export const workflowStepQuotaService = new WorkflowStepQuotaService();

--- a/shared/workflow/runtime/services/workflowStepQuotaService.ts
+++ b/shared/workflow/runtime/services/workflowStepQuotaService.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex';
 import { resolveTier, type TenantTier } from '@alga-psa/types';
+import logger from '@alga-psa/core/logger';
 
 const WORKFLOW_STEP_LIMIT_METADATA_KEY = 'workflow_step_limit';
 const ACTIVE_STATUSES = ['trialing', 'active', 'past_due', 'unpaid'] as const;
@@ -99,6 +100,12 @@ function parseLimitMetadata(raw: unknown, source: 'stripe_price_metadata' | 'str
   return null;
 }
 
+function isMetadataValuePresent(raw: unknown): boolean {
+  if (raw == null) return false;
+  if (typeof raw === 'string' && raw.trim() === '') return false;
+  return true;
+}
+
 async function hasStripeTables(knex: Knex): Promise<boolean> {
   const [subs, prices, products] = await Promise.all([
     knex.schema.hasTable('stripe_subscriptions'),
@@ -138,8 +145,17 @@ async function resolveMetadataLimit(knex: Knex, tenant: string, priceId: string)
     .where({ tenant, stripe_price_id: priceId })
     .first<{ metadata?: Record<string, unknown> | null; stripe_product_id?: string | null }>();
 
-  const priceValue = parseLimitMetadata(price?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY], 'stripe_price_metadata');
+  const priceRaw = price?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY];
+  const priceValue = parseLimitMetadata(priceRaw, 'stripe_price_metadata');
   if (priceValue) return priceValue;
+  if (isMetadataValuePresent(priceRaw)) {
+    logger.warn('[WorkflowStepQuotaService] Invalid workflow_step_limit metadata on Stripe price; falling back', {
+      tenant,
+      stripePriceId: priceId,
+      metadataKey: WORKFLOW_STEP_LIMIT_METADATA_KEY,
+      metadataValue: priceRaw,
+    });
+  }
 
   if (!price?.stripe_product_id) return null;
 
@@ -147,7 +163,19 @@ async function resolveMetadataLimit(knex: Knex, tenant: string, priceId: string)
     .where({ tenant, stripe_product_id: price.stripe_product_id })
     .first<{ metadata?: Record<string, unknown> | null }>();
 
-  return parseLimitMetadata(product?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY], 'stripe_product_metadata');
+  const productRaw = product?.metadata?.[WORKFLOW_STEP_LIMIT_METADATA_KEY];
+  const productValue = parseLimitMetadata(productRaw, 'stripe_product_metadata');
+  if (productValue) return productValue;
+  if (isMetadataValuePresent(productRaw)) {
+    logger.warn('[WorkflowStepQuotaService] Invalid workflow_step_limit metadata on Stripe product; falling back to tier default', {
+      tenant,
+      stripePriceId: priceId,
+      stripeProductId: price.stripe_product_id,
+      metadataKey: WORKFLOW_STEP_LIMIT_METADATA_KEY,
+      metadataValue: productRaw,
+    });
+  }
+  return null;
 }
 
 export class WorkflowStepQuotaService {
@@ -179,11 +207,23 @@ export class WorkflowStepQuotaService {
         const fallback = currentUtcMonthPeriod(now);
         periodStart = fallback.periodStart;
         periodEnd = fallback.periodEnd;
+        logger.info('[WorkflowStepQuotaService] Using fallback calendar period (no valid active Stripe subscription period)', {
+          tenant,
+          periodStart,
+          periodEnd,
+          tier,
+        });
       }
     } else {
       const fallback = currentUtcMonthPeriod(now);
       periodStart = fallback.periodStart;
       periodEnd = fallback.periodEnd;
+      logger.info('[WorkflowStepQuotaService] Using fallback calendar period (Stripe tables unavailable)', {
+        tenant,
+        periodStart,
+        periodEnd,
+        tier,
+      });
     }
 
     const usage = await knex<UsageRow>('workflow_step_usage_periods')
@@ -250,6 +290,15 @@ export class WorkflowStepQuotaService {
       }
 
       if (usage.effective_limit != null && usage.used_count >= usage.effective_limit) {
+        logger.warn('[WorkflowStepQuotaService] Workflow step quota exceeded at reservation', {
+          tenant: summary.tenant,
+          periodStart: summary.periodStart,
+          periodEnd: summary.periodEnd,
+          periodSource: summary.periodSource,
+          limitSource: summary.limitSource,
+          effectiveLimit: usage.effective_limit,
+          usedCount: usage.used_count,
+        });
         return {
           allowed: false,
           summary: {
@@ -269,6 +318,15 @@ export class WorkflowStepQuotaService {
         .returning('*');
 
       const usedCountAfter = updated.used_count;
+      logger.debug('[WorkflowStepQuotaService] Reserved workflow step quota', {
+        tenant: summary.tenant,
+        periodStart: summary.periodStart,
+        periodEnd: summary.periodEnd,
+        periodSource: summary.periodSource,
+        limitSource: summary.limitSource,
+        effectiveLimit: updated.effective_limit,
+        usedCountAfter,
+      });
       return {
         allowed: true,
         usedCountAfter,

--- a/shared/workflow/runtime/services/workflowStepQuotaService.ts
+++ b/shared/workflow/runtime/services/workflowStepQuotaService.ts
@@ -57,6 +57,7 @@ export type WorkflowStepQuotaReconciliation = {
 };
 
 type StripeSubscriptionRow = {
+  tenant: string;
   stripe_subscription_id: string;
   stripe_price_id: string;
   status: string;
@@ -79,6 +80,7 @@ type UsageRow = {
   used_count: number;
   limit_source: WorkflowStepQuotaLimitSource;
   tier: TenantTier;
+  updated_at?: string | Date;
 };
 
 function toIso(value: string | Date): string {
@@ -129,13 +131,16 @@ async function getTenantTier(knex: Knex, tenant: string): Promise<TenantTier> {
   return resolveTier(row?.plan ?? null).tier;
 }
 
-async function findPreferredSubscription(knex: Knex, tenant: string): Promise<StripeSubscriptionRow | null> {
+async function findPreferredSubscription(knex: Knex, tenant: string, now: Date): Promise<StripeSubscriptionRow | null> {
+  const nowIso = now.toISOString();
   const subscriptions = await knex<StripeSubscriptionRow>('stripe_subscriptions')
     .where({ tenant })
     .whereIn('status', ACTIVE_STATUSES as unknown as string[])
     .whereNotNull('current_period_start')
     .whereNotNull('current_period_end')
-    .select('stripe_subscription_id', 'stripe_price_id', 'status', 'current_period_start', 'current_period_end');
+    .andWhere('current_period_start', '<=', nowIso)
+    .andWhere('current_period_end', '>', nowIso)
+    .select('tenant', 'stripe_subscription_id', 'stripe_price_id', 'status', 'current_period_start', 'current_period_end');
 
   const sorted = subscriptions
     .filter((row) => row.current_period_start && row.current_period_end)
@@ -143,7 +148,7 @@ async function findPreferredSubscription(knex: Knex, tenant: string): Promise<St
       const left = STATUS_PRIORITY[a.status] ?? Number.MAX_SAFE_INTEGER;
       const right = STATUS_PRIORITY[b.status] ?? Number.MAX_SAFE_INTEGER;
       if (left !== right) return left - right;
-      return new Date(a.current_period_start as string).getTime() - new Date(b.current_period_start as string).getTime();
+      return new Date(b.current_period_start as string).getTime() - new Date(a.current_period_start as string).getTime();
     });
 
   return sorted[0] ?? null;
@@ -200,7 +205,7 @@ export class WorkflowStepQuotaService {
     let limitSource: WorkflowStepQuotaLimitSource = 'tier_default';
 
     if (await hasStripeTables(knex)) {
-      const subscription = await findPreferredSubscription(knex, tenant);
+      const subscription = await findPreferredSubscription(knex, tenant, now);
       if (subscription?.current_period_start && subscription.current_period_end) {
         periodStart = toIso(subscription.current_period_start);
         periodEnd = toIso(subscription.current_period_end);

--- a/shared/workflow/runtime/types.ts
+++ b/shared/workflow/runtime/types.ts
@@ -525,7 +525,8 @@ export type WorkflowErrorCategory =
   | 'ExpressionError'
   | 'TransientError'
   | 'ActionError'
-  | 'TimeoutError';
+  | 'TimeoutError'
+  | 'QuotaExceeded';
 
 export type PublishError = {
   severity: 'error' | 'warning';

--- a/shared/workflow/runtime/types.ts
+++ b/shared/workflow/runtime/types.ts
@@ -518,7 +518,7 @@ export function isWorkflowTimeTrigger(trigger: WorkflowTrigger | null | undefine
 
 export type WorkflowRunStatus = 'RUNNING' | 'WAITING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED';
 export type WorkflowRunStepStatus = 'STARTED' | 'SUCCEEDED' | 'FAILED' | 'RETRY_SCHEDULED' | 'CANCELED';
-export type WorkflowRunWaitType = 'event' | 'retry' | 'human' | 'timeout' | 'time';
+export type WorkflowRunWaitType = 'event' | 'retry' | 'human' | 'timeout' | 'time' | 'quota';
 
 export type WorkflowErrorCategory =
   | 'ValidationError'


### PR DESCRIPTION
## Summary
- Add workflow step usage-period accounting with Stripe/tier limit resolution, including unlimited metadata support.
- Enforce quota reservations in the v2 workflow runtime and Temporal workflow path, pausing runs when quota is exhausted.
- Add quota resume flows via admin action and scheduled scan, with stale-wait guardrails and Temporal quota-resume signaling.
- Add reconciliation/observability helpers, job registration/scheduling, docs, migration grants, and unit/integration coverage.

## Validation
- `npm --prefix server test -- src/test/unit/jobs/workflowQuotaResumeScanHandler.unit.test.ts`
- Live Run Studio + DB smoke: happy path increments usage and succeeds.
- Live Run Studio + DB smoke: exhausted quota pauses before first step without incrementing usage.
- Live Run Studio + DB smoke: generic Temporal resume is rejected while run remains waiting.
- Live DB/job smoke: quota resume scan resolves the original wait and resumes exactly one step when one unit is freed.
- Live Run Studio + DB smoke: `forEach` counts one control step plus each body attempt (`+4` for three items).
- Live Run Studio + DB smoke: unlimited metadata keeps `effective_limit = null`, does not block high usage, and still increments usage.
- Live DB/job smoke: stale quota wait remains `WAITING`, creates no step rows, and is not resumed by scanner.

## Notes
- For unlimited metadata, the implementation records `limit_source = unlimited_metadata` while preserving the price/product metadata precedence for finite values.
