### PR TITLE
fix(tickets): remove duplicate icon from unsaved changes alert

### DIFF
--- a/packages/tickets/src/components/ticket/TicketInfo.tsx
+++ b/packages/tickets/src/components/ticket/TicketInfo.tsx
@@ -25,7 +25,7 @@ import { ResponseStateDisplay } from '../ResponseStateSelect';
 import styles from './TicketDetails.module.css';
 import { getTicketCategories, getTicketCategoriesByBoard, BoardCategoryData } from '@alga-psa/tickets/actions';
 import { ItilLabels, calculateItilPriority } from '@alga-psa/tickets/lib/itilUtils';
-import { Pencil, Check, X, HelpCircle, Save, AlertCircle, PauseCircle, Users, Mail } from 'lucide-react';
+import { Pencil, Check, X, HelpCircle, Save, PauseCircle, Users, Mail } from 'lucide-react';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import UserAvatar from '@alga-psa/ui/components/UserAvatar';
@@ -936,9 +936,8 @@ const TicketInfo: React.FC<TicketInfoProps> = ({
           {/* Unsaved changes alert banner */}
           {hasUnsavedChanges && (
             <Alert variant="warning" className="mb-4">
-              <AlertDescription className="flex items-center gap-2">
-                <AlertCircle className="h-4 w-4" />
-                <span>{t('info.unsavedChanges', 'You have unsaved changes. Click "Save Changes" to apply them.')}</span>
+              <AlertDescription>
+                {t('info.unsavedChanges', 'You have unsaved changes. Click "Save Changes" to apply them.')}
               </AlertDescription>
             </Alert>
           )}


### PR DESCRIPTION
## Summary
- The unsaved-changes banner in the ticket detail view was rendering two icons: the `AlertTriangle` injected by the `Alert variant=\"warning\"` wrapper, plus an extra `AlertCircle` placed inside `AlertDescription`.
- Removed the redundant `AlertCircle` (and its now-unused import) so the banner shows only the standard warning triangle.

## Test plan
- [ ] Open a ticket, edit a field to trigger the unsaved-changes banner, and verify only one warning icon is shown.
- [ ] Confirm the banner copy and layout still look correct (no missing padding around the icon).