### PR TITLE
fix(contract-wizard): preview frequency, summary placement, and field layouts

### DIFF
--- a/packages/billing/src/components/billing-dashboard/contracts/recurringAuthoringPreview.ts
+++ b/packages/billing/src/components/billing-dashboard/contracts/recurringAuthoringPreview.ts
@@ -32,15 +32,41 @@ export type RecurringAuthoringPreview = {
   materializedPeriods: RecurringAuthoringPreviewPeriod[];
 };
 
-function resolvePreviewBillingFrequency(value: string | undefined): Extract<
+type ClientPreviewBillingFrequency = BillingCycleType;
+type ContractPreviewBillingFrequency = Extract<
   BillingCycleType,
-  'monthly' | 'quarterly' | 'annually'
-> {
+  'monthly' | 'quarterly' | 'semi-annually' | 'annually'
+>;
+
+function resolveClientPreviewBillingFrequency(value: string | undefined): ClientPreviewBillingFrequency {
+  switch (value) {
+    case 'weekly':
+      return 'weekly';
+    case 'bi-weekly':
+      return 'bi-weekly';
+    case 'quarterly':
+      return 'quarterly';
+    case 'semi-annually':
+      return 'semi-annually';
+    case 'annually':
+      return 'annually';
+    case 'monthly':
+    default:
+      return 'monthly';
+  }
+}
+
+function resolveContractPreviewBillingFrequency(value: string | undefined): ContractPreviewBillingFrequency {
   switch (value) {
     case 'quarterly':
       return 'quarterly';
+    case 'semi-annually':
+      return 'semi-annually';
     case 'annually':
       return 'annually';
+    case 'weekly':
+    case 'bi-weekly':
+    case 'monthly':
     default:
       return 'monthly';
   }
@@ -66,7 +92,7 @@ function buildPreviewSourceObligation(cadenceOwner: 'client' | 'contract'): IPer
 function buildMaterializedPreviewPeriods(input: {
   cadenceOwner: 'client' | 'contract';
   billingTiming: 'arrears' | 'advance';
-  billingFrequency: Extract<BillingCycleType, 'monthly' | 'quarterly' | 'annually'>;
+  billingFrequency: string | undefined;
   t: TFunction;
 }): RecurringAuthoringPreviewPeriod[] {
   const duePosition = input.billingTiming === 'advance' ? 'advance' : 'arrears';
@@ -76,7 +102,7 @@ function buildMaterializedPreviewPeriods(input: {
     ? materializeContractCadenceServicePeriods({
         asOf: CONTRACT_PREVIEW_AS_OF,
         materializedAt: CONTRACT_PREVIEW_AS_OF,
-        billingCycle: input.billingFrequency,
+        billingCycle: resolveContractPreviewBillingFrequency(input.billingFrequency),
         anchorDate: CONTRACT_PREVIEW_AS_OF,
         sourceObligation,
         duePosition,
@@ -88,7 +114,7 @@ function buildMaterializedPreviewPeriods(input: {
     : materializeClientCadenceServicePeriods({
         asOf: CLIENT_PREVIEW_AS_OF,
         materializedAt: CLIENT_PREVIEW_AS_OF,
-        billingCycle: input.billingFrequency,
+        billingCycle: resolveClientPreviewBillingFrequency(input.billingFrequency),
         sourceObligation,
         duePosition,
         sourceRuleVersion: 'preview:v1',
@@ -118,7 +144,7 @@ export function getRecurringAuthoringPreview(
   const cadenceOwner = input.cadenceOwner === 'contract' ? 'contract' : 'client';
   const billingTiming = input.billingTiming === 'advance' ? 'advance' : 'arrears';
   const enableProration = Boolean(input.enableProration);
-  const billingFrequency = resolvePreviewBillingFrequency(input.billingFrequency);
+  const billingFrequency = input.billingFrequency;
 
   return {
     cadenceOwnerLabel:

--- a/packages/billing/src/components/billing-dashboard/contracts/recurringAuthoringPreview.ts
+++ b/packages/billing/src/components/billing-dashboard/contracts/recurringAuthoringPreview.ts
@@ -3,6 +3,7 @@ import type { BillingCycleType, IPersistedRecurringObligationRef } from '@alga-p
 
 import { materializeClientCadenceServicePeriods } from '@alga-psa/shared/billingClients/materializeClientCadenceServicePeriods';
 import { materializeContractCadenceServicePeriods } from '@alga-psa/shared/billingClients/materializeContractCadenceServicePeriods';
+import { getUnsupportedRecurringAuthoringCombination } from '@alga-psa/shared/billingClients/recurringAuthoringValidation';
 
 const CLIENT_PREVIEW_AS_OF = '2025-04-01T00:00:00Z';
 const CONTRACT_PREVIEW_AS_OF = '2025-04-08T00:00:00Z';
@@ -56,7 +57,9 @@ function resolveClientPreviewBillingFrequency(value: string | undefined): Client
   }
 }
 
-function resolveContractPreviewBillingFrequency(value: string | undefined): ContractPreviewBillingFrequency {
+function resolveContractPreviewBillingFrequency(
+  value: string | undefined,
+): ContractPreviewBillingFrequency | null {
   switch (value) {
     case 'quarterly':
       return 'quarterly';
@@ -64,12 +67,22 @@ function resolveContractPreviewBillingFrequency(value: string | undefined): Cont
       return 'semi-annually';
     case 'annually':
       return 'annually';
-    case 'weekly':
-    case 'bi-weekly':
+    case undefined:
     case 'monthly':
-    default:
       return 'monthly';
+    default:
+      return null;
   }
+}
+
+function isContractCadenceFrequencySupported(value: string | undefined): boolean {
+  return (
+    getUnsupportedRecurringAuthoringCombination({
+      lineType: 'Fixed',
+      cadenceOwner: 'contract',
+      billingFrequency: value ?? null,
+    }) === null
+  );
 }
 
 function formatPreviewRange(start: string, end: string, t: TFunction) {
@@ -98,30 +111,37 @@ function buildMaterializedPreviewPeriods(input: {
   const duePosition = input.billingTiming === 'advance' ? 'advance' : 'arrears';
   const sourceObligation = buildPreviewSourceObligation(input.cadenceOwner);
 
-  const records = input.cadenceOwner === 'contract'
-    ? materializeContractCadenceServicePeriods({
-        asOf: CONTRACT_PREVIEW_AS_OF,
-        materializedAt: CONTRACT_PREVIEW_AS_OF,
-        billingCycle: resolveContractPreviewBillingFrequency(input.billingFrequency),
-        anchorDate: CONTRACT_PREVIEW_AS_OF,
-        sourceObligation,
-        duePosition,
-        sourceRuleVersion: 'preview:v1',
-        sourceRunKey: 'authoring-preview',
-        targetHorizonDays: 400,
-        replenishmentThresholdDays: 30,
-      }).records
-    : materializeClientCadenceServicePeriods({
-        asOf: CLIENT_PREVIEW_AS_OF,
-        materializedAt: CLIENT_PREVIEW_AS_OF,
-        billingCycle: resolveClientPreviewBillingFrequency(input.billingFrequency),
-        sourceObligation,
-        duePosition,
-        sourceRuleVersion: 'preview:v1',
-        sourceRunKey: 'authoring-preview',
-        targetHorizonDays: 400,
-        replenishmentThresholdDays: 30,
-      }).records;
+  let records;
+  if (input.cadenceOwner === 'contract') {
+    const contractFrequency = resolveContractPreviewBillingFrequency(input.billingFrequency);
+    if (contractFrequency === null) {
+      return [];
+    }
+    records = materializeContractCadenceServicePeriods({
+      asOf: CONTRACT_PREVIEW_AS_OF,
+      materializedAt: CONTRACT_PREVIEW_AS_OF,
+      billingCycle: contractFrequency,
+      anchorDate: CONTRACT_PREVIEW_AS_OF,
+      sourceObligation,
+      duePosition,
+      sourceRuleVersion: 'preview:v1',
+      sourceRunKey: 'authoring-preview',
+      targetHorizonDays: 400,
+      replenishmentThresholdDays: 30,
+    }).records;
+  } else {
+    records = materializeClientCadenceServicePeriods({
+      asOf: CLIENT_PREVIEW_AS_OF,
+      materializedAt: CLIENT_PREVIEW_AS_OF,
+      billingCycle: resolveClientPreviewBillingFrequency(input.billingFrequency),
+      sourceObligation,
+      duePosition,
+      sourceRuleVersion: 'preview:v1',
+      sourceRunKey: 'authoring-preview',
+      targetHorizonDays: 400,
+      replenishmentThresholdDays: 30,
+    }).records;
+  }
 
   return records.slice(0, PREVIEW_PERIOD_COUNT).map((record) => ({
     servicePeriodLabel: formatPreviewRange(
@@ -145,6 +165,8 @@ export function getRecurringAuthoringPreview(
   const billingTiming = input.billingTiming === 'advance' ? 'advance' : 'arrears';
   const enableProration = Boolean(input.enableProration);
   const billingFrequency = input.billingFrequency;
+  const isUnsupportedContractCadence =
+    cadenceOwner === 'contract' && !isContractCadenceFrequencySupported(billingFrequency);
 
   return {
     cadenceOwnerLabel:
@@ -197,19 +219,25 @@ export function getRecurringAuthoringPreview(
     materializedPeriodsHeading: t('recurringPreview.materializedPeriods.heading', {
       defaultValue: 'Illustrative future materialized periods',
     }),
-    materializedPeriodsSummary:
-      cadenceOwner === 'contract'
+    materializedPeriodsSummary: isUnsupportedContractCadence
+      ? t('recurringPreview.materializedPeriods.summary.contractUnsupportedFrequency', {
+          defaultValue:
+            'Contract anniversary cadence currently supports only monthly, quarterly, semi-annually, and annually.',
+        })
+      : cadenceOwner === 'contract'
         ? t('recurringPreview.materializedPeriods.summary.contract', {
             defaultValue: 'If you save this recurring line, future periods would materialize on an anniversary-style preview anchored to the 8th before invoice generation.',
           })
         : t('recurringPreview.materializedPeriods.summary.client', {
             defaultValue: 'If you save this recurring line, future periods would materialize on the client billing schedule preview before invoice generation.',
           }),
-    materializedPeriods: buildMaterializedPreviewPeriods({
-      cadenceOwner,
-      billingTiming,
-      billingFrequency,
-      t,
-    }),
+    materializedPeriods: isUnsupportedContractCadence
+      ? []
+      : buildMaterializedPreviewPeriods({
+          cadenceOwner,
+          billingTiming,
+          billingFrequency,
+          t,
+        }),
   };
 }

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
@@ -713,11 +713,11 @@ export function ContractBasicsStep({
 
             <div className="space-y-2">
               <Label htmlFor="po_amount">{t('wizardBasics.po.amountLabel', { defaultValue: 'PO Amount' })}</Label>
-              <div className="flex h-10 items-center rounded-md border border-[rgb(var(--color-border-400))] bg-white dark:bg-[rgb(var(--color-card))] shadow-sm focus-within:border-transparent focus-within:ring-2 focus-within:ring-[rgb(var(--color-primary-500))]">
-                <span className="shrink-0 pl-3 pr-1 text-[rgb(var(--color-text-400))]">
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[rgb(var(--color-text-400))]">
                   {currencySymbol}
                 </span>
-                <input
+                <Input
                   id="po_amount"
                   type="text"
                   inputMode="decimal"
@@ -743,7 +743,7 @@ export function ContractBasicsStep({
                   placeholder={
                     currencyMeta.fractionDigits === 0 ? '0' : `0.${'0'.repeat(currencyMeta.fractionDigits)}`
                   }
-                  className="flex-1 min-w-0 h-full bg-transparent border-0 outline-none py-0 pl-1 pr-3 text-[rgb(var(--color-text-900))] placeholder:text-[rgb(var(--color-text-400))]"
+                  className="pl-10"
                 />
               </div>
               <p className="text-xs text-[rgb(var(--color-text-400))]">

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
@@ -713,11 +713,11 @@ export function ContractBasicsStep({
 
             <div className="space-y-2">
               <Label htmlFor="po_amount">{t('wizardBasics.po.amountLabel', { defaultValue: 'PO Amount' })}</Label>
-              <div className="flex h-10 items-center rounded-md border border-[rgb(var(--color-border-400))] shadow-sm focus-within:border-transparent focus-within:ring-2 focus-within:ring-[rgb(var(--color-primary-500))]">
+              <div className="flex h-10 items-center rounded-md border border-[rgb(var(--color-border-400))] bg-white dark:bg-[rgb(var(--color-card))] shadow-sm focus-within:border-transparent focus-within:ring-2 focus-within:ring-[rgb(var(--color-primary-500))]">
                 <span className="shrink-0 pl-3 pr-1 text-[rgb(var(--color-text-400))]">
                   {currencySymbol}
                 </span>
-                <Input
+                <input
                   id="po_amount"
                   type="text"
                   inputMode="decimal"
@@ -743,7 +743,7 @@ export function ContractBasicsStep({
                   placeholder={
                     currencyMeta.fractionDigits === 0 ? '0' : `0.${'0'.repeat(currencyMeta.fractionDigits)}`
                   }
-                  className="h-full rounded-none border-0 py-0 pl-1 pr-3 shadow-none focus:border-transparent focus:ring-0"
+                  className="flex-1 min-w-0 h-full bg-transparent border-0 outline-none py-0 pl-1 pr-3 text-[rgb(var(--color-text-900))] placeholder:text-[rgb(var(--color-text-400))]"
                 />
               </div>
               <p className="text-xs text-[rgb(var(--color-text-400))]">

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/FixedFeeServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/FixedFeeServicesStep.tsx
@@ -16,6 +16,7 @@ import { BillingFrequencyOverrideSelect } from '../BillingFrequencyOverrideSelec
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { getRecurringAuthoringPreview } from '../recurringAuthoringPreview';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useFormatBillingFrequency } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 
 interface FixedFeeServicesStepProps {
   data: ContractWizardData;
@@ -108,6 +109,11 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
     billingFrequency: data.fixed_billing_frequency ?? data.billing_frequency,
     enableProration: data.enable_proration,
   }, t);
+
+  const formatBillingFrequency = useFormatBillingFrequency();
+  const hasAlternateBillingFrequency =
+    data.fixed_billing_frequency !== undefined &&
+    data.fixed_billing_frequency !== data.billing_frequency;
 
   return (
     <ReflectionContainer id="fixed-fee-services-step">
@@ -281,6 +287,15 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
         )}
 
         {data.fixed_services.length > 0 && (
+          <BillingFrequencyOverrideSelect
+            contractBillingFrequency={data.billing_frequency}
+            value={data.fixed_billing_frequency}
+            onChange={(value) => updateData({ fixed_billing_frequency: value })}
+            label={t('wizardFixed.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
+          />
+        )}
+
+        {data.fixed_services.length > 0 && (
           <Alert variant="info" className="mt-6">
             <AlertDescription>
               <h4 className="text-sm font-semibold mb-2">
@@ -309,8 +324,28 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
                 <p>{recurringPreview.billingTimingSummary}</p>
                 <p>{recurringPreview.firstInvoiceSummary}</p>
                 <p>{recurringPreview.partialPeriodSummary}</p>
+                {hasAlternateBillingFrequency && data.fixed_billing_frequency && (
+                  <p>
+                    <strong>
+                      {t('wizardFixed.preview.labels.alternateFrequency', {
+                        defaultValue: 'Alternate Billing Frequency:',
+                      })}
+                    </strong>{' '}
+                    {formatBillingFrequency(data.fixed_billing_frequency)}
+                  </p>
+                )}
                 <div className="pt-2">
-                  <p><strong>{recurringPreview.materializedPeriodsHeading}:</strong></p>
+                  <p className="flex items-center gap-1">
+                    <strong>{recurringPreview.materializedPeriodsHeading}:</strong>
+                    <Tooltip
+                      content={t('wizardFixed.preview.materializedPeriods.tooltip', {
+                        defaultValue:
+                          'A preview of the next few service periods and the invoice windows that would be generated for them based on the current settings. These help you sanity-check the cadence before saving — actual invoices are produced later by the billing run.',
+                      })}
+                    >
+                      <HelpCircle className="h-3.5 w-3.5 text-[rgb(var(--color-text-300))] cursor-help" />
+                    </Tooltip>
+                  </p>
                   <p>{recurringPreview.materializedPeriodsSummary}</p>
                   <ul className="list-disc pl-5 space-y-1">
                     {recurringPreview.materializedPeriods.map((period) => (
@@ -330,15 +365,6 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
               </div>
             </AlertDescription>
           </Alert>
-        )}
-
-        {data.fixed_services.length > 0 && (
-          <BillingFrequencyOverrideSelect
-            contractBillingFrequency={data.billing_frequency}
-            value={data.fixed_billing_frequency}
-            onChange={(value) => updateData({ fixed_billing_frequency: value })}
-            label={t('wizardFixed.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
-          />
         )}
       </div>
     </ReflectionContainer>

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
@@ -13,6 +13,7 @@ import { BucketOverlayFields } from '../BucketOverlayFields';
 import { BillingFrequencyOverrideSelect } from '../BillingFrequencyOverrideSelect';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useFormatBillingFrequency } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 
 interface HourlyServicesStepProps {
   data: ContractWizardData;
@@ -105,6 +106,11 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
     if (!cents) return `${currencySymbol}0.00`;
     return `${currencySymbol}${(cents / 100).toFixed(2)}`;
   };
+
+  const formatBillingFrequency = useFormatBillingFrequency();
+  const hasAlternateBillingFrequency =
+    data.hourly_billing_frequency !== undefined &&
+    data.hourly_billing_frequency !== data.billing_frequency;
 
   return (
     <div className="space-y-6">
@@ -307,6 +313,15 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
       )}
 
       {data.hourly_services.length > 0 && (
+        <BillingFrequencyOverrideSelect
+          contractBillingFrequency={data.billing_frequency}
+          value={data.hourly_billing_frequency}
+          onChange={(value) => updateData({ hourly_billing_frequency: value })}
+          label={t('wizardHourly.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
+        />
+      )}
+
+      {data.hourly_services.length > 0 && (
         <Alert variant="info" className="mt-6">
           <AlertDescription>
             <h4 className="text-sm font-semibold mb-2">
@@ -335,18 +350,79 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
                   })}
                 </p>
               )}
+              {hasAlternateBillingFrequency && data.hourly_billing_frequency && (
+                <p>
+                  <strong>
+                    {t('wizardHourly.summary.labels.alternateFrequency', {
+                      defaultValue: 'Alternate Billing Frequency:',
+                    })}
+                  </strong>{' '}
+                  {formatBillingFrequency(data.hourly_billing_frequency)}
+                </p>
+              )}
+              {data.hourly_services.some((service) => service.bucket_overlay) && (
+                <div className="pt-2">
+                  <p className="font-semibold">
+                    {t('wizardHourly.summary.labels.bucketsHeading', { defaultValue: 'Buckets:' })}
+                  </p>
+                  <ul className="list-disc pl-5 space-y-1">
+                    {data.hourly_services.map((service, index) => {
+                      if (!service.bucket_overlay) return null;
+                      const overlay = service.bucket_overlay;
+                      const includedHours =
+                        overlay.total_minutes !== undefined ? overlay.total_minutes / 60 : undefined;
+                      const serviceLabel =
+                        service.service_name ||
+                        t('wizardHourly.summary.labels.serviceFallback', {
+                          defaultValue: 'Service {{index}}',
+                          index: index + 1,
+                        });
+                      return (
+                        <li key={`hourly-bucket-summary-${index}`}>
+                          <span className="block">
+                            <strong>{serviceLabel}</strong>
+                          </span>
+                          {includedHours !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.includedHours', { defaultValue: 'Included Hours:' })}
+                              </strong>{' '}
+                              {t('wizardHourly.summary.values.hours', {
+                                defaultValue: '{{count}} hours',
+                                count: includedHours,
+                              })}
+                            </span>
+                          )}
+                          {overlay.overage_rate !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.overageRate', { defaultValue: 'Overage Rate:' })}
+                              </strong>{' '}
+                              {t('wizardHourly.summary.values.overageRatePerHour', {
+                                defaultValue: '{{rate}}/hour',
+                                rate: formatCurrency(overlay.overage_rate),
+                              })}
+                            </span>
+                          )}
+                          {overlay.allow_rollover !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.rollover', { defaultValue: 'Rollover:' })}
+                              </strong>{' '}
+                              {overlay.allow_rollover
+                                ? t('wizardHourly.summary.values.rolloverEnabled', { defaultValue: 'Enabled' })
+                                : t('wizardHourly.summary.values.rolloverDisabled', { defaultValue: 'Disabled' })}
+                            </span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
             </div>
           </AlertDescription>
         </Alert>
-      )}
-
-      {data.hourly_services.length > 0 && (
-        <BillingFrequencyOverrideSelect
-          contractBillingFrequency={data.billing_frequency}
-          value={data.hourly_billing_frequency}
-          onChange={(value) => updateData({ hourly_billing_frequency: value })}
-          label={t('wizardHourly.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
-        />
       )}
     </div>
   );

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
@@ -161,7 +161,7 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
                     />
                   </div>
 
-                  <div className="flex items-end gap-4 flex-wrap">
+                  <div className="flex items-start gap-4 flex-wrap">
                     <div className="space-y-2">
                       <Label htmlFor={`product-quantity-${index}`} className="text-sm">
                         {t('wizardProducts.labels.quantity', { defaultValue: 'Quantity' })}

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
@@ -168,7 +168,7 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor={`unit-rate-${index}`} className="text-sm flex items-center gap-2">
+                  <Label htmlFor={`unit-rate-${index}`} className="text-sm flex items-center gap-2 h-5">
                     <Coins className="h-3 w-3" />
                     {t('wizardUsage.labels.ratePerUnit', { defaultValue: 'Rate per Unit' })}
                   </Label>
@@ -216,7 +216,7 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor={`unit-measure-${index}`} className="text-sm">
+                  <Label htmlFor={`unit-measure-${index}`} className="text-sm flex items-center gap-2 h-5">
                     {t('wizardUsage.labels.unitOfMeasure', { defaultValue: 'Unit of Measure' })}
                   </Label>
                   <Input

--- a/packages/billing/tests/RecurringAuthoringPreview.i18n.test.ts
+++ b/packages/billing/tests/RecurringAuthoringPreview.i18n.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, relativePath), 'utf8');
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(read(relativePath)) as T;
+}
+
+function getLeaf(record: Record<string, unknown>, dottedPath: string): unknown {
+  return dottedPath.split('.').reduce<unknown>((value, key) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return undefined;
+    }
+
+    return (value as Record<string, unknown>)[key];
+  }, record);
+}
+
+describe('RecurringAuthoringPreview i18n wiring', () => {
+  it('keeps the unsupported contract-cadence summary on a locale-addressable key', () => {
+    const source = read('../src/components/billing-dashboard/contracts/recurringAuthoringPreview.ts');
+    const en = readJson<Record<string, unknown>>(
+      '../../../server/public/locales/en/msp/contracts.json',
+    );
+    const de = readJson<Record<string, unknown>>(
+      '../../../server/public/locales/de/msp/contracts.json',
+    );
+
+    expect(source).toContain('recurringPreview.materializedPeriods.summary.contractUnsupportedFrequency');
+    expect(getLeaf(en, 'recurringPreview.materializedPeriods.summary.contractUnsupportedFrequency')).toBeDefined();
+    expect(getLeaf(de, 'recurringPreview.materializedPeriods.summary.contractUnsupportedFrequency')).toBeDefined();
+  });
+});

--- a/packages/billing/tests/recurringAuthoringPreview.test.ts
+++ b/packages/billing/tests/recurringAuthoringPreview.test.ts
@@ -71,6 +71,49 @@ describe('recurring authoring preview copy', () => {
     });
   });
 
+  it('contract cadence + weekly does not render monthly rows and surfaces the unsupported message', () => {
+    const preview = getRecurringAuthoringPreview({
+      cadenceOwner: 'contract',
+      billingTiming: 'arrears',
+      billingFrequency: 'weekly',
+      enableProration: false,
+    }, mockT);
+
+    expect(preview.materializedPeriods).toEqual([]);
+    expect(preview.materializedPeriodsSummary).toBe(
+      'Contract anniversary cadence currently supports only monthly, quarterly, semi-annually, and annually.',
+    );
+    expect(preview.materializedPeriodsSummary).not.toMatch(/anniversary-style preview/);
+  });
+
+  it('contract cadence + bi-weekly surfaces the unsupported message with no preview rows', () => {
+    const preview = getRecurringAuthoringPreview({
+      cadenceOwner: 'contract',
+      billingTiming: 'advance',
+      billingFrequency: 'bi-weekly',
+      enableProration: true,
+    }, mockT);
+
+    expect(preview.materializedPeriods).toEqual([]);
+    expect(preview.materializedPeriodsSummary).toBe(
+      'Contract anniversary cadence currently supports only monthly, quarterly, semi-annually, and annually.',
+    );
+  });
+
+  it('client cadence + weekly still renders preview rows (unsupported gate is contract-only)', () => {
+    const preview = getRecurringAuthoringPreview({
+      cadenceOwner: 'client',
+      billingTiming: 'arrears',
+      billingFrequency: 'weekly',
+      enableProration: false,
+    }, mockT);
+
+    expect(preview.materializedPeriods.length).toBeGreaterThan(0);
+    expect(preview.materializedPeriodsSummary).not.toMatch(
+      /Contract anniversary cadence currently supports/,
+    );
+  });
+
   it('T308: schedule previews and explainers show illustrative future materialized service periods before a contract line is saved', () => {
     expect(
       getRecurringAuthoringPreview({

--- a/server/public/locales/de/msp/contracts.json
+++ b/server/public/locales/de/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Beispielhafte zukünftig materialisierte Zeiträume",
       "summary": {
         "contract": "Wenn du diese wiederkehrende Zeile speicherst, würden zukünftige Zeiträume in einer jubiläumsbasierten Vorschau am 8. vor der Rechnungserstellung materialisiert.",
+        "contractUnsupportedFrequency": "Der Vertragsjubiläumsrhythmus unterstützt derzeit nur monatliche, vierteljährliche, halbjährliche und jährliche Abrechnung.",
         "client": "Wenn du diese wiederkehrende Zeile speicherst, würden zukünftige Zeiträume in der Vorschau des Kundenabrechnungsplans vor der Rechnungserstellung materialisiert."
       }
     }

--- a/server/public/locales/en/msp/contracts.json
+++ b/server/public/locales/en/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Illustrative future materialized periods",
       "summary": {
         "contract": "If you save this recurring line, future periods would materialize on an anniversary-style preview anchored to the 8th before invoice generation.",
+        "contractUnsupportedFrequency": "Contract anniversary cadence currently supports only monthly, quarterly, semi-annually, and annually.",
         "client": "If you save this recurring line, future periods would materialize on the client billing schedule preview before invoice generation."
       }
     }

--- a/server/public/locales/es/msp/contracts.json
+++ b/server/public/locales/es/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Períodos futuros materializados ilustrativos",
       "summary": {
         "contract": "Si guardas esta línea recurrente, los períodos futuros se materializarían mediante una vista previa tipo aniversario anclada al día 8 antes de la generación de facturas.",
+        "contractUnsupportedFrequency": "La cadencia por aniversario del contrato actualmente solo admite facturación mensual, trimestral, semestral y anual.",
         "client": "Si guardas esta línea recurrente, los períodos futuros se materializarían en la vista previa del calendario de facturación del cliente antes de la generación de facturas."
       }
     }

--- a/server/public/locales/fr/msp/contracts.json
+++ b/server/public/locales/fr/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Périodes futures matérialisées illustratives",
       "summary": {
         "contract": "Si vous enregistrez cette ligne récurrente, les périodes futures se matérialiseraient selon un aperçu de type anniversaire ancré au 8 avant la génération des factures.",
+        "contractUnsupportedFrequency": "La cadence d'anniversaire du contrat ne prend actuellement en charge que la facturation mensuelle, trimestrielle, semestrielle et annuelle.",
         "client": "Si vous enregistrez cette ligne récurrente, les périodes futures se matérialiseraient selon l'aperçu du calendrier de facturation client avant la génération des factures."
       }
     }

--- a/server/public/locales/it/msp/contracts.json
+++ b/server/public/locales/it/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Periodi futuri materializzati illustrativi",
       "summary": {
         "contract": "Se salvi questa riga ricorrente, i periodi futuri si materializzerebbero in un'anteprima di tipo anniversario ancorata all'8 prima della generazione delle fatture.",
+        "contractUnsupportedFrequency": "La cadenza dell'anniversario del contratto supporta attualmente solo la fatturazione mensile, trimestrale, semestrale e annuale.",
         "client": "Se salvi questa riga ricorrente, i periodi futuri si materializzerebbero nell'anteprima della pianificazione di fatturazione del cliente prima della generazione delle fatture."
       }
     }

--- a/server/public/locales/nl/msp/contracts.json
+++ b/server/public/locales/nl/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Illustratieve toekomstige gematerialiseerde perioden",
       "summary": {
         "contract": "Als je deze terugkerende regel opslaat, zouden toekomstige perioden worden gematerialiseerd in een verjaardagsgebaseerde voorvertoning verankerd op de 8e vóór de factuurgeneratie.",
+        "contractUnsupportedFrequency": "De contractverjaardagscadans ondersteunt momenteel alleen maandelijkse, driemaandelijkse, halfjaarlijkse en jaarlijkse facturatie.",
         "client": "Als je deze terugkerende regel opslaat, zouden toekomstige perioden worden gematerialiseerd in de voorvertoning van het facturatieschema van de klant vóór de factuurgeneratie."
       }
     }

--- a/server/public/locales/pl/msp/contracts.json
+++ b/server/public/locales/pl/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Przykładowe przyszłe zmaterializowane okresy",
       "summary": {
         "contract": "Jeśli zapiszesz tę cykliczną linię, przyszłe okresy zostałyby zmaterializowane w podglądzie typu rocznicowego zakotwiczonym na 8. dniu przed wygenerowaniem faktur.",
+        "contractUnsupportedFrequency": "Kadencja rocznicy umowy obsługuje obecnie tylko rozliczenia miesięczne, kwartalne, półroczne i roczne.",
         "client": "Jeśli zapiszesz tę cykliczną linię, przyszłe okresy zostałyby zmaterializowane w podglądzie harmonogramu rozliczeń klienta przed wygenerowaniem faktur."
       }
     }

--- a/server/public/locales/pt/msp/contracts.json
+++ b/server/public/locales/pt/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "Illustrative future materialized periods",
       "summary": {
         "contract": "If you save this recurring line, future periods would materialize on an anniversary-style preview anchored to the 8th before invoice generation.",
+        "contractUnsupportedFrequency": "Contract anniversary cadence currently supports only monthly, quarterly, semi-annually, and annually.",
         "client": "If you save this recurring line, future periods would materialize on the client billing schedule preview before invoice generation."
       }
     }

--- a/server/public/locales/xx/msp/contracts.json
+++ b/server/public/locales/xx/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "11111",
       "summary": {
         "contract": "11111",
+        "contractUnsupportedFrequency": "11111",
         "client": "11111"
       }
     }

--- a/server/public/locales/yy/msp/contracts.json
+++ b/server/public/locales/yy/msp/contracts.json
@@ -2042,6 +2042,7 @@
       "heading": "55555",
       "summary": {
         "contract": "55555",
+        "contractUnsupportedFrequency": "55555",
         "client": "55555"
       }
     }


### PR DESCRIPTION
## Summary

A bundle of contract-creation wizard polish fixes — one functional bug in the recurring preview engine, plus several layout/UX fixes across the wizard steps.

### Recurring preview honors all billing frequencies (functional bug)

The shared `recurringAuthoringPreview` helper had `resolvePreviewBillingFrequency()` whitelisting only `quarterly` and `annually`. Every other value — `weekly`, `bi-weekly`, `semi-annually`, even `monthly` — fell through the `default` branch and was silently coerced to `monthly`. This meant the **Illustrative future materialized periods** preview always showed monthly cycles regardless of what alternate frequency was selected. The bug affected **all four** call sites: contract-wizard Fixed Fee step, contract-wizard Review step, template-wizard Fixed Fee step, template-wizard Review step.

**Fix:** split frequency resolution by cadence owner so each call passes through every value the underlying materializer actually supports:
- `resolveClientPreviewBillingFrequency` → full `BillingCycleType`, matching `materializeClientCadenceServicePeriods`.
- `resolveContractPreviewBillingFrequency` → `monthly | quarterly | semi-annually | annually`, falling back to `monthly` for `weekly` / `bi-weekly` (contract-cadence engine constraint).
- `buildMaterializedPreviewPeriods` now takes the raw frequency string and resolves per-cadence at call time.

### PO Amount input rendered nested boxes
The wrapped Input always emitted its own `border` and `focus:ring-2`, which Tailwind source order kept in effect even when overrides tried to suppress them — so the inner input drew a second border + focus ring inside the outer wrapper. Replaced the nested Input with a plain native `<input>` styled transparent inside the existing bordered wrapper. Also gave the wrapper the background color and `flex-1 min-w-0` to the input so it grows next to the currency symbol.

### Fixed Fee step
- Recurring Preview Before Save panel now renders **below** the Alternate Billing Frequency selector instead of above it (it was previously appearing before the control that drove its values).
- Summary now includes an **Alternate Billing Frequency** line when an override differs from the contract's frequency.
- Added a tooltip (HelpCircle) next to **Illustrative future materialized periods** explaining what those rows represent — preview of the next few service periods and invoice windows that would be generated under current settings, for sanity-checking the cadence; actual invoices are produced later by the billing run.

### Hourly Services step
- Hourly Services Summary moved to **below** the Alternate Billing Frequency selector.
- Summary now also lists each bucket-enabled service with **Included Hours** (`total_minutes / 60`), **Overage Rate** (formatted from `overage_rate` cents), and **Rollover** status.
- When an alternate billing frequency is set, the summary shows it on its own line.

### Layout alignment
- **Products step (Quantity / Override unit price):** row used `items-end`, which aligned column bottoms. Only the Override column has trailing helper text (`Default catalog price: $X`), so its input was pushed up. Switched to `items-start` so inputs align at the top.
- **Usage-Based step (Rate per Unit / Unit of Measure):** Rate per Unit label has a Coins icon in a flex container while Unit of Measure was plain text, creating a small vertical offset between the two columns. Both labels now use `flex items-center gap-2 h-5` so they render at a consistent fixed height with or without an icon.

## Test plan

- [ ] PO Amount field shows a single bordered input with the contract's currency symbol as the prefix (e.g., $, €, £); focusing renders one ring, not nested ones.
- [ ] In Fixed Fee step, set Alternate Billing Frequency to **Weekly**; the Illustrative future materialized periods list shows ~7-day service periods (e.g. `2025-04-01 to 2025-04-08`), not monthly windows.
- [ ] Try **Bi-weekly** and **Semi-annually** as alternate frequencies and verify the periods reflect those cadences too.
- [ ] When an alternate billing frequency is selected, both the Fixed Fee and Hourly summaries show the **Alternate Billing Frequency** line.
- [ ] Recurring Preview panel and Hourly Services Summary now render **after** the Alternate Billing Frequency selector, not before it.
- [ ] Hover the help icon next to **Illustrative future materialized periods** — tooltip explains what the rows represent.
- [ ] Hourly Services Summary shows **Included Hours** and **Overage Rate** for any service with bucket allocation enabled.
- [ ] In Products step, Quantity and Override unit price inputs sit on the same vertical line.
- [ ] In Usage-Based step, Rate per Unit and Unit of Measure inputs sit on the same vertical line.
- [ ] Confirm template-wizard Fixed Fee and Review steps also render correct preview periods for non-monthly/non-quarterly/non-annual frequencies.