### PR TITLE
Fix inbound email ticket-created notifications

### DIFF
--- a/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
+++ b/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const publishEventMock = vi.fn();
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: (...args: any[]) => publishEventMock(...args),
+}));
+
+describe('WorkflowEventPublisher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    publishEventMock.mockResolvedValue(undefined);
+  });
+
+  it('publishes ticket-created events through the configured event bus fanout', async () => {
+    const { WorkflowEventPublisher } = await import('../workflowEventPublisher');
+    const publisher = new WorkflowEventPublisher();
+
+    await publisher.publishTicketCreated({
+      tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+      ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+      metadata: {
+        source: 'email',
+        board_id: 'd7853ff0-f826-43a4-a032-f5056b2c0202',
+      },
+    });
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(publishEventMock).toHaveBeenCalledWith({
+      eventType: 'TICKET_CREATED',
+      payload: {
+        tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+        ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        userId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        source: 'email',
+        board_id: 'd7853ff0-f826-43a4-a032-f5056b2c0202',
+      },
+    }, undefined);
+  });
+
+  it('keeps inbound-created comment notifications on the internal-notifications channel only', async () => {
+    const { WorkflowEventPublisher } = await import('../workflowEventPublisher');
+    const publisher = new WorkflowEventPublisher();
+
+    await publisher.publishCommentCreated({
+      tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+      ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+      commentId: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
+      metadata: {
+        isInternal: false,
+      },
+    });
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(publishEventMock).toHaveBeenCalledWith({
+      eventType: 'TICKET_COMMENT_ADDED',
+      payload: {
+        tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+        ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        userId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        comment: {
+          id: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
+          content: '',
+          author: 'System',
+          isInternal: false,
+        },
+      },
+    }, { channel: 'internal-notifications' });
+  });
+});

--- a/shared/workflow/adapters/workflowEventPublisher.ts
+++ b/shared/workflow/adapters/workflowEventPublisher.ts
@@ -5,48 +5,33 @@
  */
 
 import type { IEventPublisher } from '@alga-psa/types';
-import { v4 as uuidv4 } from 'uuid';
+import type { PublishOptions } from '@alga-psa/event-bus/publishers';
 
 /**
- * Helper function to publish events to notification channels
- * This ensures workflow-created tickets trigger the same notifications as server-created tickets
+ * Publish workflow-originated ticket events through the shared event bus.
+ *
+ * Inbound email ticket creation runs from shared workflow code, not the Next.js
+ * ticket action path. Publishing through @alga-psa/event-bus keeps the stream
+ * names and fanout channels aligned with the app subscribers (emailservice::v7
+ * and internal-notifications). Do not write raw Redis stream names here; they
+ * can drift from the configured subscriber channels.
  */
-async function publishToNotificationChannels(
+async function publishNotificationEvent(
   eventType: string,
-  tenant: string,
-  payload: Record<string, any>
+  payload: Record<string, any>,
+  options?: PublishOptions
 ): Promise<void> {
   try {
-    const { RedisStreamClient } = await import('../streams/redisStreamClient');
-    const client = new RedisStreamClient();
-    await client.initialize();
+    const { publishEvent } = await import('@alga-psa/event-bus/publishers');
+    await publishEvent({ eventType: eventType as any, payload } as any, options);
 
-    const event = {
-      id: uuidv4(),
-      eventType,
-      timestamp: new Date().toISOString(),
-      payload
-    };
-
-    const eventJson = JSON.stringify(event);
-
-    // Publish to email notifications channel
-    const emailStream = `events:${eventType}:email-notifications`;
-    await client.publishToStream(emailStream, {
-      event: eventJson,
-      channel: 'email-notifications'
+    console.log(`[WorkflowEventPublisher] Published ${eventType} through event bus`, {
+      tenantId: payload.tenantId,
+      ticketId: payload.ticketId,
+      channel: options?.channel,
     });
-
-    // Publish to internal notifications channel
-    const internalStream = `events:${eventType}:internal-notifications`;
-    await client.publishToStream(internalStream, {
-      event: eventJson,
-      channel: 'internal-notifications'
-    });
-
-    console.log(`[WorkflowEventPublisher] Published ${eventType} to notification channels`);
   } catch (error) {
-    console.error(`[WorkflowEventPublisher] Failed to publish ${eventType} to notification channels:`, error);
+    console.error(`[WorkflowEventPublisher] Failed to publish ${eventType} through event bus:`, error);
     // Don't throw - notification failure shouldn't break ticket operations
   }
 }
@@ -65,7 +50,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishToNotificationChannels('TICKET_CREATED', data.tenantId, payload);
+    await publishNotificationEvent('TICKET_CREATED', payload);
   }
 
   async publishTicketUpdated(data: {
@@ -83,7 +68,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishToNotificationChannels('TICKET_UPDATED', data.tenantId, payload);
+    await publishNotificationEvent('TICKET_UPDATED', payload);
   }
 
   async publishTicketClosed(data: {
@@ -99,7 +84,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishToNotificationChannels('TICKET_CLOSED', data.tenantId, payload);
+    await publishNotificationEvent('TICKET_CLOSED', payload);
   }
 
   async publishCommentCreated(data: {
@@ -121,7 +106,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       }
     };
 
-    await publishToNotificationChannels('TICKET_COMMENT_ADDED', data.tenantId, payload);
+    await publishNotificationEvent('TICKET_COMMENT_ADDED', payload, { channel: 'internal-notifications' });
   }
 
   /**
@@ -140,6 +125,6 @@ export class WorkflowEventPublisher implements IEventPublisher {
       assignedByUserId: data.assignedByUserId
     };
 
-    await publishToNotificationChannels('TICKET_ASSIGNED', data.tenantId, payload);
+    await publishNotificationEvent('TICKET_ASSIGNED', payload);
   }
 }


### PR DESCRIPTION
## Summary
- Fix inbound-email-created ticket notifications from the provider callback/email-service path.
- The email-service calls shared inbound email code (`processInboundEmailInApp` -> `createTicketFromEmail`), whose `WorkflowEventPublisher` was writing raw Redis stream names that production subscribers do not consume.
- Route those events through `@alga-psa/event-bus/publishers` so ticket-created/assigned events fan out to the configured email and internal-notification streams.
- Preserve comment-created events as internal-notification-only to avoid extra new-comment emails from the initial inbound email body.
- Add unit coverage for the publisher fanout behavior.

## Production evidence
- Cloud Solution Pros/Jaime inbound tickets 1280/1283/1284/1285/1286/1287 had no New Ticket email/internal notification rows, while closed notifications were sent.
- Example 1287 came from Microsoft inbound email: `email_processed_messages.queueProvider = microsoft`, `source = email`, `ticket_origin = inbound_email`, `entered_by = null`.
- The email-service logged publishing to unconsumed streams like `events:TICKET_CREATED:email-notifications`.
- App subscribers consume `alga-psa:event-stream:emailservice::v7:TICKET_CREATED` and `alga-psa:event-stream:internal-notifications:TICKET_CREATED`.
- Manual/web tickets in the same tenant still generated New Ticket notifications correctly.

## Tests
- `npm -w shared run typecheck`
- `npx vitest run --config shared/vitest.config.ts shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts`
