### PR TITLE
Fix task form cancel-confirm and checklist remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42981,7 +42981,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.38-rc5",
+      "version": "1.0.39-rc5",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -44168,7 +44168,11 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "sdk": {},
+    "sdk": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -47901,7 +47905,7 @@
       }
     },
     "server": {
-      "version": "1.0.38-rc5",
+      "version": "1.0.39-rc5",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",

--- a/packages/projects/src/components/TaskForm.tsx
+++ b/packages/projects/src/components/TaskForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { IProjectPhase, IProjectTask, ITaskChecklistItem, ProjectStatus, IProjectTicketLinkWithDetails, IProjectTaskDependency } from '@alga-psa/types';
 import { IUser } from '@shared/interfaces/user.interfaces';
 import { IPriority } from '@alga-psa/types';
@@ -38,7 +38,7 @@ import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { TextEditor } from '@alga-psa/ui/editor';
 import type { BlockNoteEditor } from '@blocknote/core';
 import { PartialBlock } from '@blocknote/core';
-import { ListChecks, Plus, Trash2, Clock, Ticket } from 'lucide-react';
+import { ListChecks, Pencil, Plus, Trash2, Clock, Ticket } from 'lucide-react';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import UserPicker from '@alga-psa/ui/components/UserPicker';
 import UserAndTeamPicker from '@alga-psa/ui/components/UserAndTeamPicker';
@@ -199,6 +199,16 @@ export default function TaskForm({
     if (prefillData?.pendingTicketLink) return [prefillData.pendingTicketLink];
     return [];
   });
+  // Dirty-check baseline for ticket links. Initialized from the prop, then
+  // replaced with the post-fetch result so we don't flag a "change" just
+  // because TaskTicketLinks refreshed possibly-stale cached data from the
+  // kanban board.
+  const initialTicketLinkIdsRef = useRef<Set<string>>(
+    new Set(task?.ticket_links?.map((link) => link.ticket_id) ?? [])
+  );
+  const handleInitialTicketLinksLoaded = useCallback((links: IProjectTicketLinkWithDetails[]) => {
+    initialTicketLinkIdsRef.current = new Set(links.map((link) => link.ticket_id));
+  }, []);
   const [editingChecklistItemId, setEditingChecklistItemId] = useState<string | null>(null);
   const [isCrossProjectMove, setIsCrossProjectMove] = useState<boolean>(false);
   const [selectedDuplicatePhaseId, setSelectedDuplicatePhaseId] = useState<string | null>(null);
@@ -947,9 +957,11 @@ export default function TaskForm({
       }
     }
 
-    // Compare ticket links - only compare ticket IDs since other fields might differ in format
+    // Compare ticket links - only compare ticket IDs since other fields might differ in format.
+    // Baseline is the post-fetch result captured by handleInitialTicketLinksLoaded so a stale
+    // task.ticket_links prop (e.g. from cached kanban state) doesn't trigger a false dirty flag.
     const currentTicketIds = new Set(pendingTicketLinks.map((link): string => link.ticket_id));
-    const originalTicketIds = new Set(task.ticket_links?.map((link): string => link.ticket_id) || []);
+    const originalTicketIds = initialTicketLinkIdsRef.current;
 
     if (currentTicketIds.size !== originalTicketIds.size) return true;
     for (const id of currentTicketIds) {
@@ -1784,16 +1796,17 @@ export default function TaskForm({
             </div>
 
                 <div className="flex flex-col space-y-2">
-                  {checklistItems.map((item, index): React.JSX.Element => (
-                    <div key={index} className="flex items-center gap-2 w-full">
-                      {isEditingChecklist || editingChecklistItemId === item.checklist_item_id ? (
-                        <>
-                          <Checkbox
-                            checked={item.completed}
-                            onChange={(e) => updateChecklistItem(index, 'completed', e.target.checked)}
-                            className="flex-none"
-                            containerClassName=""
-                          />
+                  {checklistItems.map((item, index): React.JSX.Element => {
+                    const isItemEditing = isEditingChecklist || editingChecklistItemId === item.checklist_item_id;
+                    return (
+                      <div key={index} className="flex items-center gap-2 w-full">
+                        <Checkbox
+                          checked={item.completed}
+                          onChange={(e) => updateChecklistItem(index, 'completed', e.target.checked)}
+                          className="flex-none"
+                          containerClassName=""
+                        />
+                        {isItemEditing ? (
                           <div className="flex-1">
                             <TextArea
                               value={item.item_name}
@@ -1806,32 +1819,47 @@ export default function TaskForm({
                               onKeyDown={handleChecklistItemKeyDown}
                             />
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeChecklistItem(index)}
-                            className="text-destructive flex-none"
-                          >
-                            {t('common:actions.remove', 'Remove')}
-                          </button>
-                        </>
-                      ) : (
-                        <>
-                          <Checkbox
-                            checked={item.completed}
-                            onChange={(e) => updateChecklistItem(index, 'completed', e.target.checked)}
-                            className="flex-none"
-                            containerClassName=""
-                          />
+                        ) : (
                           <span
-                            className={`flex-1 whitespace-pre-wrap ${item.completed ? 'line-through text-gray-500' : ''}`}
+                            className={`flex-1 whitespace-pre-wrap cursor-text ${item.completed ? 'line-through text-gray-500' : ''}`}
                             onClick={() => setEditingChecklistItemId(item.checklist_item_id)} // Start editing when clicked
                           >
                             {item.item_name}
                           </span>
-                        </>
-                      )}
-                    </div>
-                  ))}
+                        )}
+                        <div className="flex items-center gap-1 shrink-0">
+                          {!isItemEditing && (
+                            <Button
+                              id={`edit-checklist-${item.checklist_item_id}`}
+                              type="button"
+                              variant="icon"
+                              size="icon"
+                              onClick={() => setEditingChecklistItemId(item.checklist_item_id)}
+                              title={taskFormT('editChecklistItem', 'Edit checklist item')}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
+                          <Button
+                            id={`remove-checklist-${item.checklist_item_id}`}
+                            type="button"
+                            variant="icon"
+                            size="icon"
+                            // Fire on mousedown (with preventDefault) so the textarea's
+                            // blur handler doesn't unmount this button before click fires.
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              removeChecklistItem(index);
+                            }}
+                            className="text-destructive hover:text-destructive"
+                            title={taskFormT('removeChecklistItem', 'Remove checklist item')}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
 
           </div>
@@ -1878,6 +1906,7 @@ export default function TaskForm({
             initialLinks={task?.ticket_links}
             users={users}
             onLinksChange={setPendingTicketLinks}
+            onInitialLinksLoaded={handleInitialTicketLinksLoaded}
             onTicketCreated={(ticket) => setSessionCreatedTickets(prev => [...prev, ticket])}
             taskData={
               mode === 'edit'

--- a/packages/projects/src/components/TaskTicketLinks.tsx
+++ b/packages/projects/src/components/TaskTicketLinks.tsx
@@ -38,6 +38,7 @@ interface TaskTicketLinksProps {
   initialLinks?: IProjectTicketLinkWithDetails[];
   users: IUser[];
   onLinksChange?: (links: IProjectTicketLinkWithDetails[]) => void;
+  onInitialLinksLoaded?: (links: IProjectTicketLinkWithDetails[]) => void;
   onTicketCreated?: (ticket: { ticket_id: string; ticket_number: string; title: string }) => void;
   taskData?: {
     task_name: string;
@@ -79,6 +80,7 @@ const TaskTicketLinks = forwardRef<TaskTicketLinksRef, TaskTicketLinksProps>(fun
   initialLinks = undefined,
   users,
   onLinksChange,
+  onInitialLinksLoaded,
   onTicketCreated,
   taskData
 }, ref) {
@@ -259,24 +261,29 @@ const TaskTicketLinks = forwardRef<TaskTicketLinksRef, TaskTicketLinksProps>(fun
     }
   };
 
-  // Only fetch links if initialLinks is empty and taskId is available
+  // Refresh links from the server when the task already has cached links
+  // (e.g. opened from the kanban board). The cached copy may be stale or
+  // filtered differently than the user's current permissions, so we re-fetch
+  // and report the result via onInitialLinksLoaded so the dirty-check can use
+  // the post-fetch state as its baseline rather than the stale prop.
   useEffect(() => {
     let mounted = true;
 
     const fetchLinks = async () => {
-      // Skip fetching if we already have initialLinks
       if (taskId && initialLinks) {
         try {
           const links = await getTaskTicketLinksAction(taskId);
           if (mounted) {
             setTaskTicketLinks(links || []);
             onLinksChange?.(links || []);
+            onInitialLinksLoaded?.(links || []);
           }
         } catch (error) {
           console.error('Error fetching ticket links:', error);
           if (mounted) {
             setTaskTicketLinks([]);
             onLinksChange?.([]);
+            onInitialLinksLoaded?.([]);
           }
         }
       }
@@ -286,7 +293,7 @@ const TaskTicketLinks = forwardRef<TaskTicketLinksRef, TaskTicketLinksProps>(fun
     return () => {
       mounted = false;
     };
-  }, [taskId, onLinksChange, initialLinks]);
+  }, [taskId, onLinksChange, onInitialLinksLoaded, initialLinks]);
 
   const filteredTicketOptions = availableTickets
     .filter(ticket => {


### PR DESCRIPTION
  - Capture post-fetch ticket links as the dirty-check baseline so opening a task with linked tickets no longer triggers the "unsaved changes" prompt on cancel when the kanban-cached ticket_links prop diverges from the server-fresh data.
  - Replace the checklist "Remove" text button with pencil + trash icons matching the dependencies row, and fire deletion on mousedown with preventDefault so the textarea's blur handler can't unmount the button before the click resolves.

  "Off with its head!" cried the Queen, but the textarea's onBlur had already vanished the executioner — so the Cheshire checklist item lingered, grinning, until onMouseDown beheaded it before the focus could flee. 🎩👑🪓