### PR TITLE
Polish SSO settings, dashboard, tenant tooling

### DIFF
--- a/ee/server/src/components/settings/security/SsoBulkAssignmentForm.tsx
+++ b/ee/server/src/components/settings/security/SsoBulkAssignmentForm.tsx
@@ -516,6 +516,7 @@ export default function SsoBulkAssignmentForm({ providerOptions }: SsoBulkAssign
           <div className="space-y-3">
             <Label className="block text-sm font-medium text-muted-foreground">{t("ssoBulk.form.actionLabel")}</Label>
             <ViewSwitcher
+              className="w-fit"
               currentView={assignmentMode}
               onChange={(value) => {
                 if (value === "link" || value === "unlink") {

--- a/ee/server/src/lib/testing/tenant-creation.ts
+++ b/ee/server/src/lib/testing/tenant-creation.ts
@@ -34,6 +34,7 @@ export interface TenantCreationInput {
   companyName?: string;
   clientName?: string;
   contractLine?: string;
+  productCode?: 'psa' | 'algadesk';
 }
 
 export interface TenantCreationResult {
@@ -61,18 +62,22 @@ export interface CreateAdminUserResult {
  */
 export async function createTenant(
   db: Knex,
-  input: { tenantName: string; email: string; clientName?: string }
+  input: { tenantName: string; email: string; clientName?: string; productCode?: 'psa' | 'algadesk' }
 ): Promise<CreateTenantResult> {
   return await db.transaction(async (trx) => {
     // Create tenant first
     const tenantCompanyName = input.clientName ?? input.tenantName;
+    const tenantInsert: Record<string, unknown> = {
+      client_name: tenantCompanyName,
+      email: input.email,
+      created_at: new Date(),
+      updated_at: new Date()
+    };
+    if (input.productCode) {
+      tenantInsert.product_code = input.productCode;
+    }
     const tenantResult = await trx('tenants')
-      .insert({
-        client_name: tenantCompanyName,
-        email: input.email,
-        created_at: new Date(),
-        updated_at: new Date()
-      })
+      .insert(tenantInsert)
       .returning('tenant');
     
     const tenantId = tenantResult[0].tenant || tenantResult[0];
@@ -246,6 +251,7 @@ export async function createTenantComplete(
       tenantName: input.tenantName,
       email: input.adminUser.email,
       clientName: input.clientName,
+      productCode: input.productCode,
     });
 
     // Step 2: Create admin user

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev:sdk": "npm -w sdk/alga-client-sdk run dev",
     "start:workflow-worker": "cd services/workflow-worker && npm run start",
     "dev:workflow-worker": "cd services/workflow-worker && npm run dev",
-    "create-tenant": "cd server && npm run create-tenant",
+    "create-tenant": "cd server && npm run create-tenant --",
     "rollback-tenant": "cd server && npm run rollback-tenant",
     "lint": "eslint \"{server,ee/server,ee/packages,shared,services,packages}/**/*.{js,mjs,cjs,ts,jsx,tsx}\"",
     "guard:temporal-packaging-contract": "node scripts/check-temporal-worker-packaging-contract.mjs",

--- a/packages/ui/src/components/ViewSwitcher.tsx
+++ b/packages/ui/src/components/ViewSwitcher.tsx
@@ -39,7 +39,6 @@ const ViewSwitcher = <T extends string>({
             onClick={() => onChange(option.value)}
             className="rounded-none border-0 h-full"
             aria-pressed={isActive}
-            title={`Switch to ${option.label} view`}
             disabled={option.disabled}
           >
             {IconComponent && <IconComponent className="h-4 w-4 mr-2" />}

--- a/scripts/seed-tenant-onboarding.cjs
+++ b/scripts/seed-tenant-onboarding.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * One-off helper: run the EE onboarding seeds (roles, permissions, role_permissions)
+ * for a single existing tenant. Use when a tenant was created via a path that did
+ * not run the Temporal `run_onboarding_seeds` activity.
+ *
+ * Usage:
+ *   node scripts/seed-tenant-onboarding.cjs <tenantId>
+ */
+
+const path = require('path');
+
+const tenantId = process.argv[2];
+if (!tenantId) {
+  console.error('Usage: node scripts/seed-tenant-onboarding.cjs <tenantId>');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+
+const knex = require(path.join(repoRoot, 'node_modules/knex'))({
+  client: 'pg',
+  connection: {
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT_DIRECT || 5432),
+    user: process.env.DB_USER_ADMIN || 'postgres',
+    password: process.env.DB_PASSWORD_ADMIN || 'postpass123',
+    database: process.env.DB_NAME_SERVER || 'server',
+  },
+});
+
+const seedFiles = [
+  'ee/server/seeds/onboarding/01_roles.cjs',
+  'ee/server/seeds/onboarding/02_permissions.cjs',
+  'ee/server/seeds/onboarding/03_role_permissions.cjs',
+];
+
+(async () => {
+  try {
+    for (const rel of seedFiles) {
+      const seed = require(path.join(repoRoot, rel));
+      console.log(`\n>>> Running ${rel} for tenant ${tenantId}`);
+      await seed.seed(knex, tenantId);
+    }
+    console.log('\nDone.');
+  } catch (err) {
+    console.error('Seed run failed:', err);
+    process.exitCode = 1;
+  } finally {
+    await knex.destroy();
+  }
+})();

--- a/server/public/locales/de/msp/dashboard.json
+++ b/server/public/locales/de/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Willkommen zurück",
     "descriptionCommunity": "Springen Sie von Ihrem Dashboard direkt zu Tickets, Planung, Projekten und Berichten."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Willkommen bei AlgaDesk",
+      "description": "Behalten Sie das Ticket-Aufkommen, die E-Mail-Kanal-Gesundheit und jede Konversation im Blick."
+    },
+    "metrics": {
+      "openTickets": "Offene Tickets",
+      "awaitingCustomer": "Wartet auf Kunde",
+      "awaitingInternal": "Wartet intern",
+      "activeEmailChannels": "Aktive E-Mail-Kanäle"
+    },
+    "aging": {
+      "title": "Ticket-Alter",
+      "under2Days": "Unter 2 Tagen",
+      "days2To7": "2 bis 7 Tage",
+      "over7Days": "Über 7 Tage"
+    },
+    "emailHealth": {
+      "title": "E-Mail-Kanal-Gesundheit",
+      "summary": "{{healthy}} von {{active}} aktiven Kanälen sind verbunden.",
+      "totalConfigured": "Konfigurierte Kanäle insgesamt: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Kürzlich aktualisierte Tickets",
+      "empty": "Keine kürzliche Ticket-Aktivität."
+    }
+  },
   "features": {
     "heading": "Plattformfunktionen",
     "comingSoon": "Demnächst verfügbar!",

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "SSO-Verwaltungswerkzeuge werden geladen...",
       "sessions": "Aktive Sitzungen werden geladen..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "Single Sign-On",
-        "description": "SSO-Massenzuweisungs-Werkzeuge werden geladen..."
-      },
-      "autoLink": {
-        "title": "SSO für neue interne Benutzer automatisch einrichten",
-        "description": "Aktivieren Sie diese Option, um jedem neuen Mitarbeiterkonto sofort Ihren Unternehmens-SSO-Anbieter zuzuweisen, sodass eine passwortbasierte Anmeldung nicht erforderlich ist.",
-        "body": "Wenn aktiviert, können neu hinzugefügte MSP-Benutzer sich mit Google oder Microsoft über ihre geschäftliche E-Mail-Adresse anmelden. Sie müssen ihr Konto nicht manuell verknüpfen.",
-        "toggleLabel": "Automatischen SSO-Abgleich umschalten",
-        "disabledInfo": "Aktivieren Sie diese Option, damit neue und bestehende Mitarbeiter den „SSO verbinden“-Vorgang überspringen können, wenn ihre E-Mail-Adresse bereits mit einem konfigurierten Anbieter übereinstimmt. Wir protokollieren weiterhin jede automatische Verknüpfung."
-      },
-      "bulk": {
-        "title": "SSO-Massenzuweisung",
-        "description": "Wählen Sie interne Benutzer aus der Liste unten aus und verknüpfen Sie sie mit einem konfigurierten Google- oder Microsoft-Anbieter. Verwenden Sie die Vorschau, um die Auswirkungen vor der Ausführung zu überprüfen.",
-        "noProviders": "Es sind noch keine SSO-Anbieter konfiguriert. Fügen Sie OAuth-Anmeldedaten hinzu, um mit Massenzuweisungen fortzufahren."
-      },
-      "errors": {
-        "loadProviders": "SSO-Anbieterkonfiguration konnte nicht geladen werden.",
-        "updatePreferences": "SSO-Einstellungen konnten nicht aktualisiert werden."
-      },
-      "form": {
-        "title": "Anbieter auswählen & Benutzer wählen",
-        "description": "Wählen Sie den konfigurierten SSO-Anbieter für Ihre Mitarbeiter und suchen und wählen Sie dann die zu verknüpfenden Benutzer aus.",
-        "providerLabel": "Anbieter",
-        "notConfigured": "Nicht konfiguriert",
-        "providerNotConfiguredAlert": "Stellen Sie OAuth-Anmeldedaten für diesen Anbieter bereit, bevor Sie Konten verknüpfen.",
-        "actionLabel": "Aktion",
-        "linkSelected": "Ausgewählte Benutzer verknüpfen",
-        "unlinkSelected": "Verknüpfung ausgewählter Benutzer aufheben",
-        "actionPlaceholder": "SSO-Massenaktion auswählen",
-        "actionDescription": "Beim Verknüpfen wird der Anbieter zu jedem ausgewählten Benutzer hinzugefügt. Beim Aufheben der Verknüpfung wird der Anbieter entfernt, sodass der Benutzer wieder zur Passwort-/TOTP-Anmeldung zurückkehrt, bis er erneut verknüpft.",
-        "searchLabel": "Interne Benutzer suchen",
-        "searchPlaceholder": "Nach E-Mail oder Name suchen",
-        "noneSelected": "Noch keine Benutzer ausgewählt.",
-        "selected_one": "{{count}} Benutzer ausgewählt.",
-        "selected_other": "{{count}} Benutzer ausgewählt.",
-        "clearSelection": "Auswahl löschen",
-        "loadingUsers": "Benutzer werden geladen...",
-        "noMatch": "Keine Benutzer entsprechen dieser Suche.",
-        "noUsers": "Keine internen Benutzer gefunden.",
-        "clientPortalComing": "Massenzuweisungen für das Kundenportal sind in Kürze verfügbar. Vorerst gilt dieses Werkzeug nur für interne MSP-Benutzer.",
-        "loadUsersFailed": "Zuweisbare Benutzer konnten nicht geladen werden.",
-        "actions": {
-          "previewLink": "Zuweisung in der Vorschau anzeigen",
-          "previewUnlink": "Aufhebung in der Vorschau anzeigen",
-          "link": "Konten verknüpfen",
-          "unlink": "Verknüpfung der Konten aufheben",
-          "preparingPreview": "Vorschau wird vorbereitet…",
-          "linking": "Konten werden verknüpft…",
-          "unlinking": "Verknüpfung der Konten wird aufgehoben…",
-          "bulkLabel": "SSO-Massenaktionen {{location}}"
-        },
-        "table": {
-          "email": "E-Mail",
-          "id": "ID",
-          "name": "Name",
-          "status": "Status",
-          "active": "Aktiv",
-          "inactive": "Inaktiv",
-          "linkedProviders": "Verknüpfte Anbieter",
-          "unlinked": "Nicht verknüpft",
-          "lastLogin": "Letzte Anmeldung"
-        },
-        "toast": {
-          "providerRequiredTitle": "Anbieter erforderlich",
-          "providerRequiredDescription": "Wählen Sie einen konfigurierten Anbieter aus, bevor Sie fortfahren.",
-          "noUsersTitle": "Keine Benutzer ausgewählt",
-          "noUsersDescription": "Wählen Sie mindestens einen Benutzer aus der Tabelle aus.",
-          "failedTitle": "Massenzuweisung fehlgeschlagen",
-          "failedDescription": "SSO-Massenzuweisung konnte nicht verarbeitet werden.",
-          "linkCompleteTitle": "Verknüpfung abgeschlossen",
-          "unlinkCompleteTitle": "Aufhebung abgeschlossen",
-          "previewReadyTitle": "Vorschau bereit",
-          "linkedCount": "{{count}} Konten über {{provider}} verknüpft.",
-          "unlinkedCount": "Verknüpfung von {{count}} Konten über {{provider}} aufgehoben.",
-          "previewUnlink_one": "Vorschau bereit. Wir heben die Verknüpfung von {{count}} ausgewählten Benutzer auf.",
-          "previewUnlink_other": "Vorschau bereit. Wir heben die Verknüpfung von {{count}} ausgewählten Benutzern auf.",
-          "previewLink": "Vorschau bereit. Überprüfen Sie die Zusammenfassung, bevor Sie Konten verknüpfen."
-        },
-        "results": {
-          "completeTitle": "Zuweisung abgeschlossen",
-          "previewTitle": "Vorschau-Ergebnisse",
-          "noneMatched": "Keiner der ausgewählten Benutzer entsprach den aktuellen Filtern.",
-          "processed_one": "{{count}} Benutzer verarbeitet.",
-          "processed_other": "{{count}} Benutzer verarbeitet.",
-          "candidatesSelected": "{{count}} ausgewählt",
-          "unlinked": "Verknüpfung aufgehoben",
-          "wouldUnlink": "Verknüpfung würde aufgehoben",
-          "linked": "Verknüpft",
-          "wouldLink": "Würde verknüpft",
-          "alreadyUnlinked": "Bereits nicht verknüpft",
-          "alreadyLinked": "Bereits verknüpft",
-          "skippedInactive": "Übersprungen (inaktiv)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Rollen an Benutzer zuweisen",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Sitzungen werden geladen...",
         "noMatch": "Keine Sitzungen entsprechen Ihrer Suche",
         "noSessions": "Keine aktiven Sitzungen gefunden"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "Single Sign-On",
+      "description": "SSO-Massenzuweisungs-Werkzeuge werden geladen..."
+    },
+    "autoLink": {
+      "title": "SSO für neue interne Benutzer automatisch einrichten",
+      "description": "Aktivieren Sie diese Option, um jedem neuen Mitarbeiterkonto sofort Ihren Unternehmens-SSO-Anbieter zuzuweisen, sodass eine passwortbasierte Anmeldung nicht erforderlich ist.",
+      "body": "Wenn aktiviert, können neu hinzugefügte MSP-Benutzer sich mit Google oder Microsoft über ihre geschäftliche E-Mail-Adresse anmelden. Sie müssen ihr Konto nicht manuell verknüpfen.",
+      "toggleLabel": "Automatischen SSO-Abgleich umschalten",
+      "disabledInfo": "Aktivieren Sie diese Option, damit neue und bestehende Mitarbeiter den „SSO verbinden“-Vorgang überspringen können, wenn ihre E-Mail-Adresse bereits mit einem konfigurierten Anbieter übereinstimmt. Wir protokollieren weiterhin jede automatische Verknüpfung."
+    },
+    "bulk": {
+      "title": "SSO-Massenzuweisung",
+      "description": "Wählen Sie interne Benutzer aus der Liste unten aus und verknüpfen Sie sie mit einem konfigurierten Google- oder Microsoft-Anbieter. Verwenden Sie die Vorschau, um die Auswirkungen vor der Ausführung zu überprüfen.",
+      "noProviders": "Es sind noch keine SSO-Anbieter konfiguriert. Fügen Sie OAuth-Anmeldedaten hinzu, um mit Massenzuweisungen fortzufahren."
+    },
+    "errors": {
+      "loadProviders": "SSO-Anbieterkonfiguration konnte nicht geladen werden.",
+      "updatePreferences": "SSO-Einstellungen konnten nicht aktualisiert werden."
+    },
+    "form": {
+      "title": "Anbieter auswählen & Benutzer wählen",
+      "description": "Wählen Sie den konfigurierten SSO-Anbieter für Ihre Mitarbeiter und suchen und wählen Sie dann die zu verknüpfenden Benutzer aus.",
+      "providerLabel": "Anbieter",
+      "notConfigured": "Nicht konfiguriert",
+      "providerNotConfiguredAlert": "Stellen Sie OAuth-Anmeldedaten für diesen Anbieter bereit, bevor Sie Konten verknüpfen.",
+      "actionLabel": "Aktion",
+      "linkSelected": "Ausgewählte Benutzer verknüpfen",
+      "unlinkSelected": "Verknüpfung ausgewählter Benutzer aufheben",
+      "actionPlaceholder": "SSO-Massenaktion auswählen",
+      "actionDescription": "Beim Verknüpfen wird der Anbieter zu jedem ausgewählten Benutzer hinzugefügt. Beim Aufheben der Verknüpfung wird der Anbieter entfernt, sodass der Benutzer wieder zur Passwort-/TOTP-Anmeldung zurückkehrt, bis er erneut verknüpft.",
+      "searchLabel": "Interne Benutzer suchen",
+      "searchPlaceholder": "Nach E-Mail oder Name suchen",
+      "noneSelected": "Noch keine Benutzer ausgewählt.",
+      "selected_one": "{{count}} Benutzer ausgewählt.",
+      "selected_other": "{{count}} Benutzer ausgewählt.",
+      "clearSelection": "Auswahl löschen",
+      "loadingUsers": "Benutzer werden geladen...",
+      "noMatch": "Keine Benutzer entsprechen dieser Suche.",
+      "noUsers": "Keine internen Benutzer gefunden.",
+      "clientPortalComing": "Massenzuweisungen für das Kundenportal sind in Kürze verfügbar. Vorerst gilt dieses Werkzeug nur für interne MSP-Benutzer.",
+      "loadUsersFailed": "Zuweisbare Benutzer konnten nicht geladen werden.",
+      "actions": {
+        "previewLink": "Zuweisung in der Vorschau anzeigen",
+        "previewUnlink": "Aufhebung in der Vorschau anzeigen",
+        "link": "Konten verknüpfen",
+        "unlink": "Verknüpfung der Konten aufheben",
+        "preparingPreview": "Vorschau wird vorbereitet…",
+        "linking": "Konten werden verknüpft…",
+        "unlinking": "Verknüpfung der Konten wird aufgehoben…",
+        "bulkLabel": "SSO-Massenaktionen {{location}}"
+      },
+      "table": {
+        "email": "E-Mail",
+        "id": "ID",
+        "name": "Name",
+        "status": "Status",
+        "active": "Aktiv",
+        "inactive": "Inaktiv",
+        "linkedProviders": "Verknüpfte Anbieter",
+        "unlinked": "Nicht verknüpft",
+        "lastLogin": "Letzte Anmeldung"
+      },
+      "toast": {
+        "providerRequiredTitle": "Anbieter erforderlich",
+        "providerRequiredDescription": "Wählen Sie einen konfigurierten Anbieter aus, bevor Sie fortfahren.",
+        "noUsersTitle": "Keine Benutzer ausgewählt",
+        "noUsersDescription": "Wählen Sie mindestens einen Benutzer aus der Tabelle aus.",
+        "failedTitle": "Massenzuweisung fehlgeschlagen",
+        "failedDescription": "SSO-Massenzuweisung konnte nicht verarbeitet werden.",
+        "linkCompleteTitle": "Verknüpfung abgeschlossen",
+        "unlinkCompleteTitle": "Aufhebung abgeschlossen",
+        "previewReadyTitle": "Vorschau bereit",
+        "linkedCount": "{{count}} Konten über {{provider}} verknüpft.",
+        "unlinkedCount": "Verknüpfung von {{count}} Konten über {{provider}} aufgehoben.",
+        "previewUnlink_one": "Vorschau bereit. Wir heben die Verknüpfung von {{count}} ausgewählten Benutzer auf.",
+        "previewUnlink_other": "Vorschau bereit. Wir heben die Verknüpfung von {{count}} ausgewählten Benutzern auf.",
+        "previewLink": "Vorschau bereit. Überprüfen Sie die Zusammenfassung, bevor Sie Konten verknüpfen."
+      },
+      "results": {
+        "completeTitle": "Zuweisung abgeschlossen",
+        "previewTitle": "Vorschau-Ergebnisse",
+        "noneMatched": "Keiner der ausgewählten Benutzer entsprach den aktuellen Filtern.",
+        "processed_one": "{{count}} Benutzer verarbeitet.",
+        "processed_other": "{{count}} Benutzer verarbeitet.",
+        "candidatesSelected": "{{count}} ausgewählt",
+        "unlinked": "Verknüpfung aufgehoben",
+        "wouldUnlink": "Verknüpfung würde aufgehoben",
+        "linked": "Verknüpft",
+        "wouldLink": "Würde verknüpft",
+        "alreadyUnlinked": "Bereits nicht verknüpft",
+        "alreadyLinked": "Bereits verknüpft",
+        "skippedInactive": "Übersprungen (inaktiv)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/en/msp/dashboard.json
+++ b/server/public/locales/en/msp/dashboard.json
@@ -10,6 +10,33 @@
     "titleCommunity": "Welcome back",
     "descriptionCommunity": "Jump into tickets, scheduling, projects, and reporting from your dashboard."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Welcome to AlgaDesk",
+      "description": "Track ticket workload, monitor email-channel health, and stay on top of every conversation."
+    },
+    "metrics": {
+      "openTickets": "Open tickets",
+      "awaitingCustomer": "Awaiting customer",
+      "awaitingInternal": "Awaiting internal",
+      "activeEmailChannels": "Active email channels"
+    },
+    "aging": {
+      "title": "Ticket aging",
+      "under2Days": "Under 2 days",
+      "days2To7": "2 to 7 days",
+      "over7Days": "Over 7 days"
+    },
+    "emailHealth": {
+      "title": "Email channel health",
+      "summary": "{{healthy}} of {{active}} active channels are connected.",
+      "totalConfigured": "Total configured channels: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Recently updated tickets",
+      "empty": "No recent ticket activity."
+    }
+  },
   "features": {
     "heading": "Platform Features",
     "comingSoon": "Coming soon!",

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "Loading SSO management tools...",
       "sessions": "Loading active sessions..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "Single Sign-On",
-        "description": "Loading SSO bulk assignment tools..."
-      },
-      "autoLink": {
-        "title": "Automatically set up SSO for new internal users",
-        "description": "Turn this on to provision every new staff account with your corporate SSO provider right away, so they never need a password-based sign-in.",
-        "body": "When enabled, newly added MSP users can sign in with Google or Microsoft using their work email. They will not have to manually link their account.",
-        "toggleLabel": "Toggle automatic SSO matching",
-        "disabledInfo": "Enable this toggle to let new and existing staff skip the “Connect SSO” flow when their email already matches a configured provider. We’ll still log every automatic link."
-      },
-      "bulk": {
-        "title": "Bulk Single Sign-On Assignment",
-        "description": "Select internal users from the list below and link them to a configured Google or Microsoft provider. Use preview to double-check the impact before executing.",
-        "noProviders": "No SSO providers are configured yet. Add OAuth credentials to continue with bulk assignments."
-      },
-      "errors": {
-        "loadProviders": "Unable to load SSO provider configuration.",
-        "updatePreferences": "Unable to update SSO preferences."
-      },
-      "form": {
-        "title": "Choose provider & select users",
-        "description": "Pick the configured SSO provider for your staff, then search and select the users who should be linked.",
-        "providerLabel": "Provider",
-        "notConfigured": "Not configured",
-        "providerNotConfiguredAlert": "Provide OAuth credentials for this provider before linking accounts.",
-        "actionLabel": "Action",
-        "linkSelected": "Link selected users",
-        "unlinkSelected": "Unlink selected users",
-        "actionPlaceholder": "Select SSO bulk action",
-        "actionDescription": "Linking adds the provider to each selected user. Unlinking removes the provider so the user returns to password/TOTP sign-in until they link again.",
-        "searchLabel": "Find internal users",
-        "searchPlaceholder": "Search by email or name",
-        "noneSelected": "No users selected yet.",
-        "selected_one": "{{count}} user selected.",
-        "selected_other": "{{count}} users selected.",
-        "clearSelection": "Clear selection",
-        "loadingUsers": "Loading users...",
-        "noMatch": "No users match this search.",
-        "noUsers": "No internal users found.",
-        "clientPortalComing": "Client portal bulk assignments are coming soon. For now, this tool applies only to internal MSP users.",
-        "loadUsersFailed": "Unable to load assignable users.",
-        "actions": {
-          "previewLink": "Preview assignment",
-          "previewUnlink": "Preview unlink",
-          "link": "Link accounts",
-          "unlink": "Unlink accounts",
-          "preparingPreview": "Preparing preview…",
-          "linking": "Linking accounts…",
-          "unlinking": "Unlinking accounts…",
-          "bulkLabel": "Bulk SSO actions {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Name",
-          "status": "Status",
-          "active": "Active",
-          "inactive": "Inactive",
-          "linkedProviders": "Linked providers",
-          "unlinked": "Unlinked",
-          "lastLogin": "Last login"
-        },
-        "toast": {
-          "providerRequiredTitle": "Provider required",
-          "providerRequiredDescription": "Select a configured provider before continuing.",
-          "noUsersTitle": "No users selected",
-          "noUsersDescription": "Select at least one user from the table.",
-          "failedTitle": "Bulk assignment failed",
-          "failedDescription": "Unable to process SSO bulk assignment.",
-          "linkCompleteTitle": "Link complete",
-          "unlinkCompleteTitle": "Unlink complete",
-          "previewReadyTitle": "Preview ready",
-          "linkedCount": "Linked {{count}} accounts via {{provider}}.",
-          "unlinkedCount": "Unlinked {{count}} accounts via {{provider}}.",
-          "previewUnlink_one": "Preview ready. We'll unlink {{count}} selected user.",
-          "previewUnlink_other": "Preview ready. We'll unlink {{count}} selected users.",
-          "previewLink": "Preview ready. Review the summary before linking accounts."
-        },
-        "results": {
-          "completeTitle": "Assignment complete",
-          "previewTitle": "Preview results",
-          "noneMatched": "None of the selected users matched the current filters.",
-          "processed_one": "Processed {{count}} user.",
-          "processed_other": "Processed {{count}} users.",
-          "candidatesSelected": "{{count}} selected",
-          "unlinked": "Unlinked",
-          "wouldUnlink": "Would unlink",
-          "linked": "Linked",
-          "wouldLink": "Would link",
-          "alreadyUnlinked": "Already unlinked",
-          "alreadyLinked": "Already linked",
-          "skippedInactive": "Skipped (inactive)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Assign Roles to Users",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Loading sessions...",
         "noMatch": "No sessions match your search",
         "noSessions": "No active sessions found"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "Single Sign-On",
+      "description": "Loading SSO bulk assignment tools..."
+    },
+    "autoLink": {
+      "title": "Automatically set up SSO for new internal users",
+      "description": "Turn this on to provision every new staff account with your corporate SSO provider right away, so they never need a password-based sign-in.",
+      "body": "When enabled, newly added MSP users can sign in with Google or Microsoft using their work email. They will not have to manually link their account.",
+      "toggleLabel": "Toggle automatic SSO matching",
+      "disabledInfo": "Enable this toggle to let new and existing staff skip the “Connect SSO” flow when their email already matches a configured provider. We’ll still log every automatic link."
+    },
+    "bulk": {
+      "title": "Bulk Single Sign-On Assignment",
+      "description": "Select internal users from the list below and link them to a configured Google or Microsoft provider. Use preview to double-check the impact before executing.",
+      "noProviders": "No SSO providers are configured yet. Add OAuth credentials to continue with bulk assignments."
+    },
+    "errors": {
+      "loadProviders": "Unable to load SSO provider configuration.",
+      "updatePreferences": "Unable to update SSO preferences."
+    },
+    "form": {
+      "title": "Choose provider & select users",
+      "description": "Pick the configured SSO provider for your staff, then search and select the users who should be linked.",
+      "providerLabel": "Provider",
+      "notConfigured": "Not configured",
+      "providerNotConfiguredAlert": "Provide OAuth credentials for this provider before linking accounts.",
+      "actionLabel": "Action",
+      "linkSelected": "Link selected users",
+      "unlinkSelected": "Unlink selected users",
+      "actionPlaceholder": "Select SSO bulk action",
+      "actionDescription": "Linking adds the provider to each selected user. Unlinking removes the provider so the user returns to password/TOTP sign-in until they link again.",
+      "searchLabel": "Find internal users",
+      "searchPlaceholder": "Search by email or name",
+      "noneSelected": "No users selected yet.",
+      "selected_one": "{{count}} user selected.",
+      "selected_other": "{{count}} users selected.",
+      "clearSelection": "Clear selection",
+      "loadingUsers": "Loading users...",
+      "noMatch": "No users match this search.",
+      "noUsers": "No internal users found.",
+      "clientPortalComing": "Client portal bulk assignments are coming soon. For now, this tool applies only to internal MSP users.",
+      "loadUsersFailed": "Unable to load assignable users.",
+      "actions": {
+        "previewLink": "Preview assignment",
+        "previewUnlink": "Preview unlink",
+        "link": "Link accounts",
+        "unlink": "Unlink accounts",
+        "preparingPreview": "Preparing preview…",
+        "linking": "Linking accounts…",
+        "unlinking": "Unlinking accounts…",
+        "bulkLabel": "Bulk SSO actions {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Name",
+        "status": "Status",
+        "active": "Active",
+        "inactive": "Inactive",
+        "linkedProviders": "Linked providers",
+        "unlinked": "Unlinked",
+        "lastLogin": "Last login"
+      },
+      "toast": {
+        "providerRequiredTitle": "Provider required",
+        "providerRequiredDescription": "Select a configured provider before continuing.",
+        "noUsersTitle": "No users selected",
+        "noUsersDescription": "Select at least one user from the table.",
+        "failedTitle": "Bulk assignment failed",
+        "failedDescription": "Unable to process SSO bulk assignment.",
+        "linkCompleteTitle": "Link complete",
+        "unlinkCompleteTitle": "Unlink complete",
+        "previewReadyTitle": "Preview ready",
+        "linkedCount": "Linked {{count}} accounts via {{provider}}.",
+        "unlinkedCount": "Unlinked {{count}} accounts via {{provider}}.",
+        "previewUnlink_one": "Preview ready. We'll unlink {{count}} selected user.",
+        "previewUnlink_other": "Preview ready. We'll unlink {{count}} selected users.",
+        "previewLink": "Preview ready. Review the summary before linking accounts."
+      },
+      "results": {
+        "completeTitle": "Assignment complete",
+        "previewTitle": "Preview results",
+        "noneMatched": "None of the selected users matched the current filters.",
+        "processed_one": "Processed {{count}} user.",
+        "processed_other": "Processed {{count}} users.",
+        "candidatesSelected": "{{count}} selected",
+        "unlinked": "Unlinked",
+        "wouldUnlink": "Would unlink",
+        "linked": "Linked",
+        "wouldLink": "Would link",
+        "alreadyUnlinked": "Already unlinked",
+        "alreadyLinked": "Already linked",
+        "skippedInactive": "Skipped (inactive)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/es/msp/dashboard.json
+++ b/server/public/locales/es/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Bienvenido de nuevo",
     "descriptionCommunity": "Accede rápidamente a tickets, programación, proyectos e informes desde tu panel."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Bienvenido a AlgaDesk",
+      "description": "Controla la carga de tickets, supervisa el estado de los canales de correo y no pierdas ninguna conversación."
+    },
+    "metrics": {
+      "openTickets": "Tickets abiertos",
+      "awaitingCustomer": "En espera del cliente",
+      "awaitingInternal": "En espera interna",
+      "activeEmailChannels": "Canales de correo activos"
+    },
+    "aging": {
+      "title": "Antigüedad de tickets",
+      "under2Days": "Menos de 2 días",
+      "days2To7": "De 2 a 7 días",
+      "over7Days": "Más de 7 días"
+    },
+    "emailHealth": {
+      "title": "Estado de los canales de correo",
+      "summary": "{{healthy}} de {{active}} canales activos están conectados.",
+      "totalConfigured": "Canales configurados en total: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Tickets actualizados recientemente",
+      "empty": "No hay actividad reciente de tickets."
+    }
+  },
   "features": {
     "heading": "Funciones de la plataforma",
     "comingSoon": "¡Próximamente!",

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "Cargando herramientas de gestión de SSO...",
       "sessions": "Cargando sesiones activas..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "Inicio de sesión único",
-        "description": "Cargando herramientas de asignación masiva de SSO..."
-      },
-      "autoLink": {
-        "title": "Configurar SSO automáticamente para nuevos usuarios internos",
-        "description": "Active esta opción para aprovisionar cada nueva cuenta de personal con su proveedor SSO corporativo de inmediato, de modo que nunca necesiten un inicio de sesión basado en contraseña.",
-        "body": "Cuando está habilitado, los nuevos usuarios MSP añadidos pueden iniciar sesión con Google o Microsoft utilizando su correo electrónico de trabajo. No tendrán que vincular su cuenta manualmente.",
-        "toggleLabel": "Alternar coincidencia automática de SSO",
-        "disabledInfo": "Active este interruptor para permitir que el personal nuevo y existente omita el flujo de \"Conectar SSO\" cuando su correo electrónico ya coincide con un proveedor configurado. Aún registraremos cada vínculo automático."
-      },
-      "bulk": {
-        "title": "Asignación masiva de inicio de sesión único",
-        "description": "Seleccione los usuarios internos de la lista a continuación y vincúlelos a un proveedor de Google o Microsoft configurado. Use la vista previa para verificar el impacto antes de ejecutar.",
-        "noProviders": "Aún no hay proveedores SSO configurados. Agregue credenciales OAuth para continuar con las asignaciones masivas."
-      },
-      "errors": {
-        "loadProviders": "No se pudo cargar la configuración del proveedor SSO.",
-        "updatePreferences": "No se pudieron actualizar las preferencias de SSO."
-      },
-      "form": {
-        "title": "Elegir proveedor y seleccionar usuarios",
-        "description": "Elija el proveedor SSO configurado para su personal, luego busque y seleccione los usuarios que deben vincularse.",
-        "providerLabel": "Proveedor",
-        "notConfigured": "No configurado",
-        "providerNotConfiguredAlert": "Proporcione credenciales OAuth para este proveedor antes de vincular cuentas.",
-        "actionLabel": "Acción",
-        "linkSelected": "Vincular usuarios seleccionados",
-        "unlinkSelected": "Desvincular usuarios seleccionados",
-        "actionPlaceholder": "Seleccionar acción masiva de SSO",
-        "actionDescription": "Vincular agrega el proveedor a cada usuario seleccionado. Desvincular elimina el proveedor para que el usuario regrese al inicio de sesión con contraseña/TOTP hasta que vuelva a vincularse.",
-        "searchLabel": "Buscar usuarios internos",
-        "searchPlaceholder": "Buscar por correo electrónico o nombre",
-        "noneSelected": "Aún no hay usuarios seleccionados.",
-        "selected_one": "{{count}} usuario seleccionado.",
-        "selected_other": "{{count}} usuarios seleccionados.",
-        "clearSelection": "Limpiar selección",
-        "loadingUsers": "Cargando usuarios...",
-        "noMatch": "Ningún usuario coincide con esta búsqueda.",
-        "noUsers": "No se encontraron usuarios internos.",
-        "clientPortalComing": "Las asignaciones masivas del portal del cliente estarán disponibles próximamente. Por ahora, esta herramienta se aplica solo a usuarios MSP internos.",
-        "loadUsersFailed": "No se pudieron cargar los usuarios asignables.",
-        "actions": {
-          "previewLink": "Vista previa de asignación",
-          "previewUnlink": "Vista previa de desvinculación",
-          "link": "Vincular cuentas",
-          "unlink": "Desvincular cuentas",
-          "preparingPreview": "Preparando vista previa…",
-          "linking": "Vinculando cuentas…",
-          "unlinking": "Desvinculando cuentas…",
-          "bulkLabel": "Acciones masivas SSO {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Nombre",
-          "status": "Estado",
-          "active": "Activo",
-          "inactive": "Inactivo",
-          "linkedProviders": "Proveedores vinculados",
-          "unlinked": "Sin vincular",
-          "lastLogin": "Último inicio de sesión"
-        },
-        "toast": {
-          "providerRequiredTitle": "Proveedor requerido",
-          "providerRequiredDescription": "Seleccione un proveedor configurado antes de continuar.",
-          "noUsersTitle": "No hay usuarios seleccionados",
-          "noUsersDescription": "Seleccione al menos un usuario de la tabla.",
-          "failedTitle": "Error en la asignación masiva",
-          "failedDescription": "No se pudo procesar la asignación masiva de SSO.",
-          "linkCompleteTitle": "Vinculación completada",
-          "unlinkCompleteTitle": "Desvinculación completada",
-          "previewReadyTitle": "Vista previa lista",
-          "linkedCount": "Se vincularon {{count}} cuentas mediante {{provider}}.",
-          "unlinkedCount": "Se desvincularon {{count}} cuentas mediante {{provider}}.",
-          "previewUnlink_one": "Vista previa lista. Desvincularemos {{count}} usuario seleccionado.",
-          "previewUnlink_other": "Vista previa lista. Desvincularemos {{count}} usuarios seleccionados.",
-          "previewLink": "Vista previa lista. Revise el resumen antes de vincular las cuentas."
-        },
-        "results": {
-          "completeTitle": "Asignación completada",
-          "previewTitle": "Resultados de la vista previa",
-          "noneMatched": "Ninguno de los usuarios seleccionados coincide con los filtros actuales.",
-          "processed_one": "Se procesó {{count}} usuario.",
-          "processed_other": "Se procesaron {{count}} usuarios.",
-          "candidatesSelected": "{{count}} seleccionados",
-          "unlinked": "Desvinculados",
-          "wouldUnlink": "Se desvincularía",
-          "linked": "Vinculados",
-          "wouldLink": "Se vincularía",
-          "alreadyUnlinked": "Ya desvinculados",
-          "alreadyLinked": "Ya vinculados",
-          "skippedInactive": "Omitidos (inactivos)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Asignar roles a usuarios",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Cargando sesiones...",
         "noMatch": "Ninguna sesión coincide con su búsqueda",
         "noSessions": "No se encontraron sesiones activas"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "Inicio de sesión único",
+      "description": "Cargando herramientas de asignación masiva de SSO..."
+    },
+    "autoLink": {
+      "title": "Configurar SSO automáticamente para nuevos usuarios internos",
+      "description": "Active esta opción para aprovisionar cada nueva cuenta de personal con su proveedor SSO corporativo de inmediato, de modo que nunca necesiten un inicio de sesión basado en contraseña.",
+      "body": "Cuando está habilitado, los nuevos usuarios MSP añadidos pueden iniciar sesión con Google o Microsoft utilizando su correo electrónico de trabajo. No tendrán que vincular su cuenta manualmente.",
+      "toggleLabel": "Alternar coincidencia automática de SSO",
+      "disabledInfo": "Active este interruptor para permitir que el personal nuevo y existente omita el flujo de \"Conectar SSO\" cuando su correo electrónico ya coincide con un proveedor configurado. Aún registraremos cada vínculo automático."
+    },
+    "bulk": {
+      "title": "Asignación masiva de inicio de sesión único",
+      "description": "Seleccione los usuarios internos de la lista a continuación y vincúlelos a un proveedor de Google o Microsoft configurado. Use la vista previa para verificar el impacto antes de ejecutar.",
+      "noProviders": "Aún no hay proveedores SSO configurados. Agregue credenciales OAuth para continuar con las asignaciones masivas."
+    },
+    "errors": {
+      "loadProviders": "No se pudo cargar la configuración del proveedor SSO.",
+      "updatePreferences": "No se pudieron actualizar las preferencias de SSO."
+    },
+    "form": {
+      "title": "Elegir proveedor y seleccionar usuarios",
+      "description": "Elija el proveedor SSO configurado para su personal, luego busque y seleccione los usuarios que deben vincularse.",
+      "providerLabel": "Proveedor",
+      "notConfigured": "No configurado",
+      "providerNotConfiguredAlert": "Proporcione credenciales OAuth para este proveedor antes de vincular cuentas.",
+      "actionLabel": "Acción",
+      "linkSelected": "Vincular usuarios seleccionados",
+      "unlinkSelected": "Desvincular usuarios seleccionados",
+      "actionPlaceholder": "Seleccionar acción masiva de SSO",
+      "actionDescription": "Vincular agrega el proveedor a cada usuario seleccionado. Desvincular elimina el proveedor para que el usuario regrese al inicio de sesión con contraseña/TOTP hasta que vuelva a vincularse.",
+      "searchLabel": "Buscar usuarios internos",
+      "searchPlaceholder": "Buscar por correo electrónico o nombre",
+      "noneSelected": "Aún no hay usuarios seleccionados.",
+      "selected_one": "{{count}} usuario seleccionado.",
+      "selected_other": "{{count}} usuarios seleccionados.",
+      "clearSelection": "Limpiar selección",
+      "loadingUsers": "Cargando usuarios...",
+      "noMatch": "Ningún usuario coincide con esta búsqueda.",
+      "noUsers": "No se encontraron usuarios internos.",
+      "clientPortalComing": "Las asignaciones masivas del portal del cliente estarán disponibles próximamente. Por ahora, esta herramienta se aplica solo a usuarios MSP internos.",
+      "loadUsersFailed": "No se pudieron cargar los usuarios asignables.",
+      "actions": {
+        "previewLink": "Vista previa de asignación",
+        "previewUnlink": "Vista previa de desvinculación",
+        "link": "Vincular cuentas",
+        "unlink": "Desvincular cuentas",
+        "preparingPreview": "Preparando vista previa…",
+        "linking": "Vinculando cuentas…",
+        "unlinking": "Desvinculando cuentas…",
+        "bulkLabel": "Acciones masivas SSO {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Nombre",
+        "status": "Estado",
+        "active": "Activo",
+        "inactive": "Inactivo",
+        "linkedProviders": "Proveedores vinculados",
+        "unlinked": "Sin vincular",
+        "lastLogin": "Último inicio de sesión"
+      },
+      "toast": {
+        "providerRequiredTitle": "Proveedor requerido",
+        "providerRequiredDescription": "Seleccione un proveedor configurado antes de continuar.",
+        "noUsersTitle": "No hay usuarios seleccionados",
+        "noUsersDescription": "Seleccione al menos un usuario de la tabla.",
+        "failedTitle": "Error en la asignación masiva",
+        "failedDescription": "No se pudo procesar la asignación masiva de SSO.",
+        "linkCompleteTitle": "Vinculación completada",
+        "unlinkCompleteTitle": "Desvinculación completada",
+        "previewReadyTitle": "Vista previa lista",
+        "linkedCount": "Se vincularon {{count}} cuentas mediante {{provider}}.",
+        "unlinkedCount": "Se desvincularon {{count}} cuentas mediante {{provider}}.",
+        "previewUnlink_one": "Vista previa lista. Desvincularemos {{count}} usuario seleccionado.",
+        "previewUnlink_other": "Vista previa lista. Desvincularemos {{count}} usuarios seleccionados.",
+        "previewLink": "Vista previa lista. Revise el resumen antes de vincular las cuentas."
+      },
+      "results": {
+        "completeTitle": "Asignación completada",
+        "previewTitle": "Resultados de la vista previa",
+        "noneMatched": "Ninguno de los usuarios seleccionados coincide con los filtros actuales.",
+        "processed_one": "Se procesó {{count}} usuario.",
+        "processed_other": "Se procesaron {{count}} usuarios.",
+        "candidatesSelected": "{{count}} seleccionados",
+        "unlinked": "Desvinculados",
+        "wouldUnlink": "Se desvincularía",
+        "linked": "Vinculados",
+        "wouldLink": "Se vincularía",
+        "alreadyUnlinked": "Ya desvinculados",
+        "alreadyLinked": "Ya vinculados",
+        "skippedInactive": "Omitidos (inactivos)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/fr/msp/dashboard.json
+++ b/server/public/locales/fr/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Bon retour",
     "descriptionCommunity": "Accédez rapidement aux tickets, à la planification, aux projets et aux rapports depuis votre tableau de bord."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Bienvenue sur AlgaDesk",
+      "description": "Suivez la charge de tickets, l'état des canaux e-mail et chaque conversation."
+    },
+    "metrics": {
+      "openTickets": "Tickets ouverts",
+      "awaitingCustomer": "En attente du client",
+      "awaitingInternal": "En attente interne",
+      "activeEmailChannels": "Canaux e-mail actifs"
+    },
+    "aging": {
+      "title": "Ancienneté des tickets",
+      "under2Days": "Moins de 2 jours",
+      "days2To7": "De 2 à 7 jours",
+      "over7Days": "Plus de 7 jours"
+    },
+    "emailHealth": {
+      "title": "État des canaux e-mail",
+      "summary": "{{healthy}} sur {{active}} canaux actifs sont connectés.",
+      "totalConfigured": "Total des canaux configurés : {{total}}"
+    },
+    "recentTickets": {
+      "title": "Tickets récemment mis à jour",
+      "empty": "Aucune activité récente sur les tickets."
+    }
+  },
   "features": {
     "heading": "Fonctionnalités de la plateforme",
     "comingSoon": "Bientôt disponible !",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "Chargement des outils de gestion SSO...",
       "sessions": "Chargement des sessions actives..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "SSO",
-        "description": "Chargement des outils d'attribution SSO en masse..."
-      },
-      "autoLink": {
-        "title": "Configurer automatiquement le SSO pour les nouveaux utilisateurs internes",
-        "description": "Activez cette option pour provisionner immédiatement chaque nouveau compte du personnel avec votre fournisseur SSO d'entreprise, afin qu'ils n'aient jamais besoin d'une connexion par mot de passe.",
-        "body": "Lorsque cette option est activée, les utilisateurs MSP nouvellement ajoutés peuvent se connecter avec Google ou Microsoft en utilisant leur adresse e-mail professionnelle. Ils n'auront pas à lier manuellement leur compte.",
-        "toggleLabel": "Activer la correspondance SSO automatique",
-        "disabledInfo": "Activez cette option pour permettre au personnel nouveau et existant d'éviter le flux « Connecter SSO » lorsque leur e-mail correspond déjà à un fournisseur configuré. Nous enregistrerons toujours chaque liaison automatique."
-      },
-      "bulk": {
-        "title": "Attribution SSO en masse",
-        "description": "Sélectionnez les utilisateurs internes dans la liste ci-dessous et liez-les à un fournisseur Google ou Microsoft configuré. Utilisez l'aperçu pour vérifier l'impact avant l'exécution.",
-        "noProviders": "Aucun fournisseur SSO n'est encore configuré. Ajoutez des identifiants OAuth pour continuer avec les attributions en masse."
-      },
-      "errors": {
-        "loadProviders": "Impossible de charger la configuration du fournisseur SSO.",
-        "updatePreferences": "Impossible de mettre à jour les préférences SSO."
-      },
-      "form": {
-        "title": "Choisir un fournisseur et sélectionner les utilisateurs",
-        "description": "Choisissez le fournisseur SSO configuré pour votre personnel, puis recherchez et sélectionnez les utilisateurs à lier.",
-        "providerLabel": "Fournisseur",
-        "notConfigured": "Non configuré",
-        "providerNotConfiguredAlert": "Fournissez des identifiants OAuth pour ce fournisseur avant de lier des comptes.",
-        "actionLabel": "Action",
-        "linkSelected": "Lier les utilisateurs sélectionnés",
-        "unlinkSelected": "Délier les utilisateurs sélectionnés",
-        "actionPlaceholder": "Sélectionner une action SSO en masse",
-        "actionDescription": "La liaison ajoute le fournisseur à chaque utilisateur sélectionné. La déliaison supprime le fournisseur afin que l'utilisateur revienne à la connexion par mot de passe/TOTP jusqu'à ce qu'il se relie.",
-        "searchLabel": "Rechercher des utilisateurs internes",
-        "searchPlaceholder": "Rechercher par e-mail ou par nom",
-        "noneSelected": "Aucun utilisateur sélectionné pour le moment.",
-        "selected_one": "{{count}} utilisateur sélectionné.",
-        "selected_other": "{{count}} utilisateurs sélectionnés.",
-        "clearSelection": "Effacer la sélection",
-        "loadingUsers": "Chargement des utilisateurs...",
-        "noMatch": "Aucun utilisateur ne correspond à cette recherche.",
-        "noUsers": "Aucun utilisateur interne trouvé.",
-        "clientPortalComing": "Les attributions en masse pour le portail client arrivent bientôt. Pour l'instant, cet outil ne s'applique qu'aux utilisateurs MSP internes.",
-        "loadUsersFailed": "Impossible de charger les utilisateurs assignables.",
-        "actions": {
-          "previewLink": "Aperçu de l'attribution",
-          "previewUnlink": "Aperçu de la déliaison",
-          "link": "Lier les comptes",
-          "unlink": "Délier les comptes",
-          "preparingPreview": "Préparation de l'aperçu…",
-          "linking": "Liaison des comptes…",
-          "unlinking": "Déliaison des comptes…",
-          "bulkLabel": "Actions SSO en masse {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Nom",
-          "status": "Statut",
-          "active": "Actif",
-          "inactive": "Inactif",
-          "linkedProviders": "Fournisseurs liés",
-          "unlinked": "Non lié",
-          "lastLogin": "Dernière connexion"
-        },
-        "toast": {
-          "providerRequiredTitle": "Fournisseur requis",
-          "providerRequiredDescription": "Sélectionnez un fournisseur configuré avant de continuer.",
-          "noUsersTitle": "Aucun utilisateur sélectionné",
-          "noUsersDescription": "Sélectionnez au moins un utilisateur dans le tableau.",
-          "failedTitle": "Échec de l'attribution en masse",
-          "failedDescription": "Impossible de traiter l'attribution SSO en masse.",
-          "linkCompleteTitle": "Liaison terminée",
-          "unlinkCompleteTitle": "Déliaison terminée",
-          "previewReadyTitle": "Aperçu prêt",
-          "linkedCount": "{{count}} comptes liés via {{provider}}.",
-          "unlinkedCount": "{{count}} comptes déliés via {{provider}}.",
-          "previewUnlink_one": "Aperçu prêt. Nous délierons {{count}} utilisateur sélectionné.",
-          "previewUnlink_other": "Aperçu prêt. Nous délierons {{count}} utilisateurs sélectionnés.",
-          "previewLink": "Aperçu prêt. Vérifiez le résumé avant de lier les comptes."
-        },
-        "results": {
-          "completeTitle": "Attribution terminée",
-          "previewTitle": "Résultats de l'aperçu",
-          "noneMatched": "Aucun des utilisateurs sélectionnés ne correspond aux filtres actuels.",
-          "processed_one": "{{count}} utilisateur traité.",
-          "processed_other": "{{count}} utilisateurs traités.",
-          "candidatesSelected": "{{count}} sélectionnés",
-          "unlinked": "Non liés",
-          "wouldUnlink": "Seraient déliés",
-          "linked": "Liés",
-          "wouldLink": "Seraient liés",
-          "alreadyUnlinked": "Déjà déliés",
-          "alreadyLinked": "Déjà liés",
-          "skippedInactive": "Ignorés (inactifs)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Attribuer des rôles aux utilisateurs",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Chargement des sessions...",
         "noMatch": "Aucune session ne correspond à votre recherche",
         "noSessions": "Aucune session active trouvée"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "SSO",
+      "description": "Chargement des outils d'attribution SSO en masse..."
+    },
+    "autoLink": {
+      "title": "Configurer automatiquement le SSO pour les nouveaux utilisateurs internes",
+      "description": "Activez cette option pour provisionner immédiatement chaque nouveau compte du personnel avec votre fournisseur SSO d'entreprise, afin qu'ils n'aient jamais besoin d'une connexion par mot de passe.",
+      "body": "Lorsque cette option est activée, les utilisateurs MSP nouvellement ajoutés peuvent se connecter avec Google ou Microsoft en utilisant leur adresse e-mail professionnelle. Ils n'auront pas à lier manuellement leur compte.",
+      "toggleLabel": "Activer la correspondance SSO automatique",
+      "disabledInfo": "Activez cette option pour permettre au personnel nouveau et existant d'éviter le flux « Connecter SSO » lorsque leur e-mail correspond déjà à un fournisseur configuré. Nous enregistrerons toujours chaque liaison automatique."
+    },
+    "bulk": {
+      "title": "Attribution SSO en masse",
+      "description": "Sélectionnez les utilisateurs internes dans la liste ci-dessous et liez-les à un fournisseur Google ou Microsoft configuré. Utilisez l'aperçu pour vérifier l'impact avant l'exécution.",
+      "noProviders": "Aucun fournisseur SSO n'est encore configuré. Ajoutez des identifiants OAuth pour continuer avec les attributions en masse."
+    },
+    "errors": {
+      "loadProviders": "Impossible de charger la configuration du fournisseur SSO.",
+      "updatePreferences": "Impossible de mettre à jour les préférences SSO."
+    },
+    "form": {
+      "title": "Choisir un fournisseur et sélectionner les utilisateurs",
+      "description": "Choisissez le fournisseur SSO configuré pour votre personnel, puis recherchez et sélectionnez les utilisateurs à lier.",
+      "providerLabel": "Fournisseur",
+      "notConfigured": "Non configuré",
+      "providerNotConfiguredAlert": "Fournissez des identifiants OAuth pour ce fournisseur avant de lier des comptes.",
+      "actionLabel": "Action",
+      "linkSelected": "Lier les utilisateurs sélectionnés",
+      "unlinkSelected": "Délier les utilisateurs sélectionnés",
+      "actionPlaceholder": "Sélectionner une action SSO en masse",
+      "actionDescription": "La liaison ajoute le fournisseur à chaque utilisateur sélectionné. La déliaison supprime le fournisseur afin que l'utilisateur revienne à la connexion par mot de passe/TOTP jusqu'à ce qu'il se relie.",
+      "searchLabel": "Rechercher des utilisateurs internes",
+      "searchPlaceholder": "Rechercher par e-mail ou par nom",
+      "noneSelected": "Aucun utilisateur sélectionné pour le moment.",
+      "selected_one": "{{count}} utilisateur sélectionné.",
+      "selected_other": "{{count}} utilisateurs sélectionnés.",
+      "clearSelection": "Effacer la sélection",
+      "loadingUsers": "Chargement des utilisateurs...",
+      "noMatch": "Aucun utilisateur ne correspond à cette recherche.",
+      "noUsers": "Aucun utilisateur interne trouvé.",
+      "clientPortalComing": "Les attributions en masse pour le portail client arrivent bientôt. Pour l'instant, cet outil ne s'applique qu'aux utilisateurs MSP internes.",
+      "loadUsersFailed": "Impossible de charger les utilisateurs assignables.",
+      "actions": {
+        "previewLink": "Aperçu de l'attribution",
+        "previewUnlink": "Aperçu de la déliaison",
+        "link": "Lier les comptes",
+        "unlink": "Délier les comptes",
+        "preparingPreview": "Préparation de l'aperçu…",
+        "linking": "Liaison des comptes…",
+        "unlinking": "Déliaison des comptes…",
+        "bulkLabel": "Actions SSO en masse {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Nom",
+        "status": "Statut",
+        "active": "Actif",
+        "inactive": "Inactif",
+        "linkedProviders": "Fournisseurs liés",
+        "unlinked": "Non lié",
+        "lastLogin": "Dernière connexion"
+      },
+      "toast": {
+        "providerRequiredTitle": "Fournisseur requis",
+        "providerRequiredDescription": "Sélectionnez un fournisseur configuré avant de continuer.",
+        "noUsersTitle": "Aucun utilisateur sélectionné",
+        "noUsersDescription": "Sélectionnez au moins un utilisateur dans le tableau.",
+        "failedTitle": "Échec de l'attribution en masse",
+        "failedDescription": "Impossible de traiter l'attribution SSO en masse.",
+        "linkCompleteTitle": "Liaison terminée",
+        "unlinkCompleteTitle": "Déliaison terminée",
+        "previewReadyTitle": "Aperçu prêt",
+        "linkedCount": "{{count}} comptes liés via {{provider}}.",
+        "unlinkedCount": "{{count}} comptes déliés via {{provider}}.",
+        "previewUnlink_one": "Aperçu prêt. Nous délierons {{count}} utilisateur sélectionné.",
+        "previewUnlink_other": "Aperçu prêt. Nous délierons {{count}} utilisateurs sélectionnés.",
+        "previewLink": "Aperçu prêt. Vérifiez le résumé avant de lier les comptes."
+      },
+      "results": {
+        "completeTitle": "Attribution terminée",
+        "previewTitle": "Résultats de l'aperçu",
+        "noneMatched": "Aucun des utilisateurs sélectionnés ne correspond aux filtres actuels.",
+        "processed_one": "{{count}} utilisateur traité.",
+        "processed_other": "{{count}} utilisateurs traités.",
+        "candidatesSelected": "{{count}} sélectionnés",
+        "unlinked": "Non liés",
+        "wouldUnlink": "Seraient déliés",
+        "linked": "Liés",
+        "wouldLink": "Seraient liés",
+        "alreadyUnlinked": "Déjà déliés",
+        "alreadyLinked": "Déjà liés",
+        "skippedInactive": "Ignorés (inactifs)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/it/msp/dashboard.json
+++ b/server/public/locales/it/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Bentornato",
     "descriptionCommunity": "Accedi rapidamente a ticket, pianificazione, progetti e report dalla dashboard."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Benvenuto in AlgaDesk",
+      "description": "Monitora il carico di ticket, lo stato dei canali e-mail e tieni sotto controllo ogni conversazione."
+    },
+    "metrics": {
+      "openTickets": "Ticket aperti",
+      "awaitingCustomer": "In attesa del cliente",
+      "awaitingInternal": "In attesa interna",
+      "activeEmailChannels": "Canali e-mail attivi"
+    },
+    "aging": {
+      "title": "Anzianità ticket",
+      "under2Days": "Meno di 2 giorni",
+      "days2To7": "Da 2 a 7 giorni",
+      "over7Days": "Oltre 7 giorni"
+    },
+    "emailHealth": {
+      "title": "Stato dei canali e-mail",
+      "summary": "{{healthy}} di {{active}} canali attivi sono connessi.",
+      "totalConfigured": "Canali configurati in totale: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Ticket aggiornati di recente",
+      "empty": "Nessuna attività recente sui ticket."
+    }
+  },
   "features": {
     "heading": "Funzionalità della piattaforma",
     "comingSoon": "In arrivo!",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "Caricamento strumenti di gestione SSO...",
       "sessions": "Caricamento sessioni attive..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "SSO",
-        "description": "Caricamento degli strumenti di assegnazione SSO in blocco..."
-      },
-      "autoLink": {
-        "title": "Configuri automaticamente l'SSO per i nuovi utenti interni",
-        "description": "Attivi questa opzione per provisionare immediatamente ogni nuovo account del personale con il Suo provider SSO aziendale, in modo che non sia mai necessario un accesso basato su password.",
-        "body": "Quando è attivata, gli utenti MSP appena aggiunti possono accedere con Google o Microsoft utilizzando la loro email aziendale. Non dovranno collegare manualmente il proprio account.",
-        "toggleLabel": "Attiva/disattiva la corrispondenza SSO automatica",
-        "disabledInfo": "Attivi questo interruttore per consentire al personale nuovo ed esistente di saltare il flusso “Connetti SSO” quando la loro email corrisponde già a un provider configurato. Registreremo comunque ogni collegamento automatico."
-      },
-      "bulk": {
-        "title": "Assegnazione SSO in blocco",
-        "description": "Selezioni gli utenti interni dall'elenco sottostante e li colleghi a un provider Google o Microsoft configurato. Utilizzi l'anteprima per verificare l'impatto prima dell'esecuzione.",
-        "noProviders": "Nessun provider SSO è ancora configurato. Aggiunga le credenziali OAuth per continuare con le assegnazioni in blocco."
-      },
-      "errors": {
-        "loadProviders": "Impossibile caricare la configurazione del provider SSO.",
-        "updatePreferences": "Impossibile aggiornare le preferenze SSO."
-      },
-      "form": {
-        "title": "Scelga il provider e selezioni gli utenti",
-        "description": "Selezioni il provider SSO configurato per il Suo personale, quindi cerchi e selezioni gli utenti che devono essere collegati.",
-        "providerLabel": "Provider",
-        "notConfigured": "Non configurato",
-        "providerNotConfiguredAlert": "Fornisca le credenziali OAuth per questo provider prima di collegare gli account.",
-        "actionLabel": "Azione",
-        "linkSelected": "Collega utenti selezionati",
-        "unlinkSelected": "Scollega utenti selezionati",
-        "actionPlaceholder": "Selezioni l'azione SSO in blocco",
-        "actionDescription": "Il collegamento aggiunge il provider a ciascun utente selezionato. Lo scollegamento rimuove il provider, quindi l'utente torna all'accesso con password/TOTP fino al prossimo collegamento.",
-        "searchLabel": "Trovi utenti interni",
-        "searchPlaceholder": "Cerchi per email o nome",
-        "noneSelected": "Nessun utente ancora selezionato.",
-        "selected_one": "{{count}} utente selezionato.",
-        "selected_other": "{{count}} utenti selezionati.",
-        "clearSelection": "Cancella selezione",
-        "loadingUsers": "Caricamento utenti...",
-        "noMatch": "Nessun utente corrisponde a questa ricerca.",
-        "noUsers": "Nessun utente interno trovato.",
-        "clientPortalComing": "Le assegnazioni in blocco per il portale clienti arriveranno presto. Per ora, questo strumento si applica solo agli utenti MSP interni.",
-        "loadUsersFailed": "Impossibile caricare gli utenti assegnabili.",
-        "actions": {
-          "previewLink": "Anteprima assegnazione",
-          "previewUnlink": "Anteprima scollegamento",
-          "link": "Collega account",
-          "unlink": "Scollega account",
-          "preparingPreview": "Preparazione anteprima…",
-          "linking": "Collegamento account…",
-          "unlinking": "Scollegamento account…",
-          "bulkLabel": "Azioni SSO in blocco {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Nome",
-          "status": "Stato",
-          "active": "Attivo",
-          "inactive": "Inattivo",
-          "linkedProviders": "Provider collegati",
-          "unlinked": "Scollegato",
-          "lastLogin": "Ultimo accesso"
-        },
-        "toast": {
-          "providerRequiredTitle": "Provider richiesto",
-          "providerRequiredDescription": "Selezioni un provider configurato prima di continuare.",
-          "noUsersTitle": "Nessun utente selezionato",
-          "noUsersDescription": "Selezioni almeno un utente dalla tabella.",
-          "failedTitle": "Assegnazione in blocco non riuscita",
-          "failedDescription": "Impossibile elaborare l'assegnazione SSO in blocco.",
-          "linkCompleteTitle": "Collegamento completato",
-          "unlinkCompleteTitle": "Scollegamento completato",
-          "previewReadyTitle": "Anteprima pronta",
-          "linkedCount": "Collegati {{count}} account tramite {{provider}}.",
-          "unlinkedCount": "Scollegati {{count}} account tramite {{provider}}.",
-          "previewUnlink_one": "Anteprima pronta. Scolleghemo {{count}} utente selezionato.",
-          "previewUnlink_other": "Anteprima pronta. Scolleghemo {{count}} utenti selezionati.",
-          "previewLink": "Anteprima pronta. Esamini il riepilogo prima di collegare gli account."
-        },
-        "results": {
-          "completeTitle": "Assegnazione completata",
-          "previewTitle": "Risultati anteprima",
-          "noneMatched": "Nessuno degli utenti selezionati corrisponde ai filtri attuali.",
-          "processed_one": "Elaborato {{count}} utente.",
-          "processed_other": "Elaborati {{count}} utenti.",
-          "candidatesSelected": "{{count}} selezionati",
-          "unlinked": "Scollegati",
-          "wouldUnlink": "Verrebbero scollegati",
-          "linked": "Collegati",
-          "wouldLink": "Verrebbero collegati",
-          "alreadyUnlinked": "Già scollegati",
-          "alreadyLinked": "Già collegati",
-          "skippedInactive": "Saltati (inattivi)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Assegna ruoli agli utenti",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Caricamento sessioni...",
         "noMatch": "Nessuna sessione corrisponde alla Sua ricerca",
         "noSessions": "Nessuna sessione attiva trovata"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "SSO",
+      "description": "Caricamento degli strumenti di assegnazione SSO in blocco..."
+    },
+    "autoLink": {
+      "title": "Configuri automaticamente l'SSO per i nuovi utenti interni",
+      "description": "Attivi questa opzione per provisionare immediatamente ogni nuovo account del personale con il Suo provider SSO aziendale, in modo che non sia mai necessario un accesso basato su password.",
+      "body": "Quando è attivata, gli utenti MSP appena aggiunti possono accedere con Google o Microsoft utilizzando la loro email aziendale. Non dovranno collegare manualmente il proprio account.",
+      "toggleLabel": "Attiva/disattiva la corrispondenza SSO automatica",
+      "disabledInfo": "Attivi questo interruttore per consentire al personale nuovo ed esistente di saltare il flusso “Connetti SSO” quando la loro email corrisponde già a un provider configurato. Registreremo comunque ogni collegamento automatico."
+    },
+    "bulk": {
+      "title": "Assegnazione SSO in blocco",
+      "description": "Selezioni gli utenti interni dall'elenco sottostante e li colleghi a un provider Google o Microsoft configurato. Utilizzi l'anteprima per verificare l'impatto prima dell'esecuzione.",
+      "noProviders": "Nessun provider SSO è ancora configurato. Aggiunga le credenziali OAuth per continuare con le assegnazioni in blocco."
+    },
+    "errors": {
+      "loadProviders": "Impossibile caricare la configurazione del provider SSO.",
+      "updatePreferences": "Impossibile aggiornare le preferenze SSO."
+    },
+    "form": {
+      "title": "Scelga il provider e selezioni gli utenti",
+      "description": "Selezioni il provider SSO configurato per il Suo personale, quindi cerchi e selezioni gli utenti che devono essere collegati.",
+      "providerLabel": "Provider",
+      "notConfigured": "Non configurato",
+      "providerNotConfiguredAlert": "Fornisca le credenziali OAuth per questo provider prima di collegare gli account.",
+      "actionLabel": "Azione",
+      "linkSelected": "Collega utenti selezionati",
+      "unlinkSelected": "Scollega utenti selezionati",
+      "actionPlaceholder": "Selezioni l'azione SSO in blocco",
+      "actionDescription": "Il collegamento aggiunge il provider a ciascun utente selezionato. Lo scollegamento rimuove il provider, quindi l'utente torna all'accesso con password/TOTP fino al prossimo collegamento.",
+      "searchLabel": "Trovi utenti interni",
+      "searchPlaceholder": "Cerchi per email o nome",
+      "noneSelected": "Nessun utente ancora selezionato.",
+      "selected_one": "{{count}} utente selezionato.",
+      "selected_other": "{{count}} utenti selezionati.",
+      "clearSelection": "Cancella selezione",
+      "loadingUsers": "Caricamento utenti...",
+      "noMatch": "Nessun utente corrisponde a questa ricerca.",
+      "noUsers": "Nessun utente interno trovato.",
+      "clientPortalComing": "Le assegnazioni in blocco per il portale clienti arriveranno presto. Per ora, questo strumento si applica solo agli utenti MSP interni.",
+      "loadUsersFailed": "Impossibile caricare gli utenti assegnabili.",
+      "actions": {
+        "previewLink": "Anteprima assegnazione",
+        "previewUnlink": "Anteprima scollegamento",
+        "link": "Collega account",
+        "unlink": "Scollega account",
+        "preparingPreview": "Preparazione anteprima…",
+        "linking": "Collegamento account…",
+        "unlinking": "Scollegamento account…",
+        "bulkLabel": "Azioni SSO in blocco {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Nome",
+        "status": "Stato",
+        "active": "Attivo",
+        "inactive": "Inattivo",
+        "linkedProviders": "Provider collegati",
+        "unlinked": "Scollegato",
+        "lastLogin": "Ultimo accesso"
+      },
+      "toast": {
+        "providerRequiredTitle": "Provider richiesto",
+        "providerRequiredDescription": "Selezioni un provider configurato prima di continuare.",
+        "noUsersTitle": "Nessun utente selezionato",
+        "noUsersDescription": "Selezioni almeno un utente dalla tabella.",
+        "failedTitle": "Assegnazione in blocco non riuscita",
+        "failedDescription": "Impossibile elaborare l'assegnazione SSO in blocco.",
+        "linkCompleteTitle": "Collegamento completato",
+        "unlinkCompleteTitle": "Scollegamento completato",
+        "previewReadyTitle": "Anteprima pronta",
+        "linkedCount": "Collegati {{count}} account tramite {{provider}}.",
+        "unlinkedCount": "Scollegati {{count}} account tramite {{provider}}.",
+        "previewUnlink_one": "Anteprima pronta. Scolleghemo {{count}} utente selezionato.",
+        "previewUnlink_other": "Anteprima pronta. Scolleghemo {{count}} utenti selezionati.",
+        "previewLink": "Anteprima pronta. Esamini il riepilogo prima di collegare gli account."
+      },
+      "results": {
+        "completeTitle": "Assegnazione completata",
+        "previewTitle": "Risultati anteprima",
+        "noneMatched": "Nessuno degli utenti selezionati corrisponde ai filtri attuali.",
+        "processed_one": "Elaborato {{count}} utente.",
+        "processed_other": "Elaborati {{count}} utenti.",
+        "candidatesSelected": "{{count}} selezionati",
+        "unlinked": "Scollegati",
+        "wouldUnlink": "Verrebbero scollegati",
+        "linked": "Collegati",
+        "wouldLink": "Verrebbero collegati",
+        "alreadyUnlinked": "Già scollegati",
+        "alreadyLinked": "Già collegati",
+        "skippedInactive": "Saltati (inattivi)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/nl/msp/dashboard.json
+++ b/server/public/locales/nl/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Welkom terug",
     "descriptionCommunity": "Ga vanaf je dashboard direct naar tickets, planning, projecten en rapportage."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Welkom bij AlgaDesk",
+      "description": "Houd de ticket-werklast, de e-mailkanaalstatus en elk gesprek in de gaten."
+    },
+    "metrics": {
+      "openTickets": "Openstaande tickets",
+      "awaitingCustomer": "Wacht op klant",
+      "awaitingInternal": "Wacht intern",
+      "activeEmailChannels": "Actieve e-mailkanalen"
+    },
+    "aging": {
+      "title": "Ouderdom tickets",
+      "under2Days": "Minder dan 2 dagen",
+      "days2To7": "2 tot 7 dagen",
+      "over7Days": "Meer dan 7 dagen"
+    },
+    "emailHealth": {
+      "title": "E-mailkanaalstatus",
+      "summary": "{{healthy}} van {{active}} actieve kanalen zijn verbonden.",
+      "totalConfigured": "Totaal geconfigureerde kanalen: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Recent bijgewerkte tickets",
+      "empty": "Geen recente ticketactiviteit."
+    }
+  },
   "features": {
     "heading": "Platformfuncties",
     "comingSoon": "Binnenkort beschikbaar!",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "SSO-beheertools laden...",
       "sessions": "Actieve sessies laden..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "Single sign-on",
-        "description": "SSO-tools voor bulktoewijzing laden..."
-      },
-      "autoLink": {
-        "title": "SSO automatisch instellen voor nieuwe interne gebruikers",
-        "description": "Schakel dit in om elk nieuw personeelsaccount direct te voorzien van uw zakelijke SSO-provider, zodat ze nooit een wachtwoordgebaseerde aanmelding nodig hebben.",
-        "body": "Wanneer ingeschakeld, kunnen nieuw toegevoegde MSP-gebruikers zich aanmelden met Google of Microsoft via hun zakelijk e-mailadres. Ze hoeven hun account niet handmatig te koppelen.",
-        "toggleLabel": "Automatische SSO-matching in-/uitschakelen",
-        "disabledInfo": "Schakel dit in om nieuw en bestaand personeel de “SSO koppelen”-flow over te laten slaan wanneer hun e-mailadres al overeenkomt met een geconfigureerde provider. We registreren nog steeds elke automatische koppeling."
-      },
-      "bulk": {
-        "title": "Bulk Single sign-on-toewijzing",
-        "description": "Selecteer interne gebruikers uit de onderstaande lijst en koppel ze aan een geconfigureerde Google- of Microsoft-provider. Gebruik voorbeeld om de impact te dubbelchecken voordat u uitvoert.",
-        "noProviders": "Er zijn nog geen SSO-providers geconfigureerd. Voeg OAuth-inloggegevens toe om door te gaan met bulktoewijzingen."
-      },
-      "errors": {
-        "loadProviders": "Kan SSO-providerconfiguratie niet laden.",
-        "updatePreferences": "Kan SSO-voorkeuren niet bijwerken."
-      },
-      "form": {
-        "title": "Provider kiezen en gebruikers selecteren",
-        "description": "Kies de geconfigureerde SSO-provider voor uw personeel, zoek vervolgens en selecteer de gebruikers die gekoppeld moeten worden.",
-        "providerLabel": "Provider",
-        "notConfigured": "Niet geconfigureerd",
-        "providerNotConfiguredAlert": "Voer OAuth-inloggegevens voor deze provider in voordat u accounts koppelt.",
-        "actionLabel": "Actie",
-        "linkSelected": "Geselecteerde gebruikers koppelen",
-        "unlinkSelected": "Koppeling van geselecteerde gebruikers verwijderen",
-        "actionPlaceholder": "Selecteer SSO-bulkactie",
-        "actionDescription": "Koppelen voegt de provider toe aan elke geselecteerde gebruiker. Ontkoppelen verwijdert de provider zodat de gebruiker terugkeert naar wachtwoord/TOTP-aanmelding totdat hij opnieuw koppelt.",
-        "searchLabel": "Interne gebruikers zoeken",
-        "searchPlaceholder": "Zoek op e-mail of naam",
-        "noneSelected": "Nog geen gebruikers geselecteerd.",
-        "selected_one": "{{count}} gebruiker geselecteerd.",
-        "selected_other": "{{count}} gebruikers geselecteerd.",
-        "clearSelection": "Selectie wissen",
-        "loadingUsers": "Gebruikers laden...",
-        "noMatch": "Geen gebruikers komen overeen met deze zoekopdracht.",
-        "noUsers": "Geen interne gebruikers gevonden.",
-        "clientPortalComing": "Bulktoewijzingen voor het klantenportaal komen binnenkort. Voorlopig is deze tool alleen van toepassing op interne MSP-gebruikers.",
-        "loadUsersFailed": "Kan toewijsbare gebruikers niet laden.",
-        "actions": {
-          "previewLink": "Toewijzing voorbeeld",
-          "previewUnlink": "Ontkoppeling voorbeeld",
-          "link": "Accounts koppelen",
-          "unlink": "Accounts ontkoppelen",
-          "preparingPreview": "Voorbeeld voorbereiden…",
-          "linking": "Accounts koppelen…",
-          "unlinking": "Accounts ontkoppelen…",
-          "bulkLabel": "SSO-bulkacties {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Naam",
-          "status": "Status",
-          "active": "Actief",
-          "inactive": "Inactief",
-          "linkedProviders": "Gekoppelde providers",
-          "unlinked": "Ontkoppeld",
-          "lastLogin": "Laatste aanmelding"
-        },
-        "toast": {
-          "providerRequiredTitle": "Provider vereist",
-          "providerRequiredDescription": "Selecteer een geconfigureerde provider voordat u doorgaat.",
-          "noUsersTitle": "Geen gebruikers geselecteerd",
-          "noUsersDescription": "Selecteer ten minste één gebruiker uit de tabel.",
-          "failedTitle": "Bulktoewijzing mislukt",
-          "failedDescription": "Kan SSO-bulktoewijzing niet verwerken.",
-          "linkCompleteTitle": "Koppeling voltooid",
-          "unlinkCompleteTitle": "Ontkoppeling voltooid",
-          "previewReadyTitle": "Voorbeeld klaar",
-          "linkedCount": "{{count}} accounts gekoppeld via {{provider}}.",
-          "unlinkedCount": "{{count}} accounts ontkoppeld via {{provider}}.",
-          "previewUnlink_one": "Voorbeeld klaar. We ontkoppelen {{count}} geselecteerde gebruiker.",
-          "previewUnlink_other": "Voorbeeld klaar. We ontkoppelen {{count}} geselecteerde gebruikers.",
-          "previewLink": "Voorbeeld klaar. Bekijk het overzicht voordat u accounts koppelt."
-        },
-        "results": {
-          "completeTitle": "Toewijzing voltooid",
-          "previewTitle": "Voorbeeldresultaten",
-          "noneMatched": "Geen van de geselecteerde gebruikers kwam overeen met de huidige filters.",
-          "processed_one": "{{count}} gebruiker verwerkt.",
-          "processed_other": "{{count}} gebruikers verwerkt.",
-          "candidatesSelected": "{{count}} geselecteerd",
-          "unlinked": "Ontkoppeld",
-          "wouldUnlink": "Zou ontkoppelen",
-          "linked": "Gekoppeld",
-          "wouldLink": "Zou koppelen",
-          "alreadyUnlinked": "Al ontkoppeld",
-          "alreadyLinked": "Al gekoppeld",
-          "skippedInactive": "Overgeslagen (inactief)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Rollen toewijzen aan gebruikers",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Sessies laden...",
         "noMatch": "Geen sessies gevonden die overeenkomen met uw zoekopdracht",
         "noSessions": "Geen actieve sessies gevonden"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "Single sign-on",
+      "description": "SSO-tools voor bulktoewijzing laden..."
+    },
+    "autoLink": {
+      "title": "SSO automatisch instellen voor nieuwe interne gebruikers",
+      "description": "Schakel dit in om elk nieuw personeelsaccount direct te voorzien van uw zakelijke SSO-provider, zodat ze nooit een wachtwoordgebaseerde aanmelding nodig hebben.",
+      "body": "Wanneer ingeschakeld, kunnen nieuw toegevoegde MSP-gebruikers zich aanmelden met Google of Microsoft via hun zakelijk e-mailadres. Ze hoeven hun account niet handmatig te koppelen.",
+      "toggleLabel": "Automatische SSO-matching in-/uitschakelen",
+      "disabledInfo": "Schakel dit in om nieuw en bestaand personeel de “SSO koppelen”-flow over te laten slaan wanneer hun e-mailadres al overeenkomt met een geconfigureerde provider. We registreren nog steeds elke automatische koppeling."
+    },
+    "bulk": {
+      "title": "Bulk Single sign-on-toewijzing",
+      "description": "Selecteer interne gebruikers uit de onderstaande lijst en koppel ze aan een geconfigureerde Google- of Microsoft-provider. Gebruik voorbeeld om de impact te dubbelchecken voordat u uitvoert.",
+      "noProviders": "Er zijn nog geen SSO-providers geconfigureerd. Voeg OAuth-inloggegevens toe om door te gaan met bulktoewijzingen."
+    },
+    "errors": {
+      "loadProviders": "Kan SSO-providerconfiguratie niet laden.",
+      "updatePreferences": "Kan SSO-voorkeuren niet bijwerken."
+    },
+    "form": {
+      "title": "Provider kiezen en gebruikers selecteren",
+      "description": "Kies de geconfigureerde SSO-provider voor uw personeel, zoek vervolgens en selecteer de gebruikers die gekoppeld moeten worden.",
+      "providerLabel": "Provider",
+      "notConfigured": "Niet geconfigureerd",
+      "providerNotConfiguredAlert": "Voer OAuth-inloggegevens voor deze provider in voordat u accounts koppelt.",
+      "actionLabel": "Actie",
+      "linkSelected": "Geselecteerde gebruikers koppelen",
+      "unlinkSelected": "Koppeling van geselecteerde gebruikers verwijderen",
+      "actionPlaceholder": "Selecteer SSO-bulkactie",
+      "actionDescription": "Koppelen voegt de provider toe aan elke geselecteerde gebruiker. Ontkoppelen verwijdert de provider zodat de gebruiker terugkeert naar wachtwoord/TOTP-aanmelding totdat hij opnieuw koppelt.",
+      "searchLabel": "Interne gebruikers zoeken",
+      "searchPlaceholder": "Zoek op e-mail of naam",
+      "noneSelected": "Nog geen gebruikers geselecteerd.",
+      "selected_one": "{{count}} gebruiker geselecteerd.",
+      "selected_other": "{{count}} gebruikers geselecteerd.",
+      "clearSelection": "Selectie wissen",
+      "loadingUsers": "Gebruikers laden...",
+      "noMatch": "Geen gebruikers komen overeen met deze zoekopdracht.",
+      "noUsers": "Geen interne gebruikers gevonden.",
+      "clientPortalComing": "Bulktoewijzingen voor het klantenportaal komen binnenkort. Voorlopig is deze tool alleen van toepassing op interne MSP-gebruikers.",
+      "loadUsersFailed": "Kan toewijsbare gebruikers niet laden.",
+      "actions": {
+        "previewLink": "Toewijzing voorbeeld",
+        "previewUnlink": "Ontkoppeling voorbeeld",
+        "link": "Accounts koppelen",
+        "unlink": "Accounts ontkoppelen",
+        "preparingPreview": "Voorbeeld voorbereiden…",
+        "linking": "Accounts koppelen…",
+        "unlinking": "Accounts ontkoppelen…",
+        "bulkLabel": "SSO-bulkacties {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Naam",
+        "status": "Status",
+        "active": "Actief",
+        "inactive": "Inactief",
+        "linkedProviders": "Gekoppelde providers",
+        "unlinked": "Ontkoppeld",
+        "lastLogin": "Laatste aanmelding"
+      },
+      "toast": {
+        "providerRequiredTitle": "Provider vereist",
+        "providerRequiredDescription": "Selecteer een geconfigureerde provider voordat u doorgaat.",
+        "noUsersTitle": "Geen gebruikers geselecteerd",
+        "noUsersDescription": "Selecteer ten minste één gebruiker uit de tabel.",
+        "failedTitle": "Bulktoewijzing mislukt",
+        "failedDescription": "Kan SSO-bulktoewijzing niet verwerken.",
+        "linkCompleteTitle": "Koppeling voltooid",
+        "unlinkCompleteTitle": "Ontkoppeling voltooid",
+        "previewReadyTitle": "Voorbeeld klaar",
+        "linkedCount": "{{count}} accounts gekoppeld via {{provider}}.",
+        "unlinkedCount": "{{count}} accounts ontkoppeld via {{provider}}.",
+        "previewUnlink_one": "Voorbeeld klaar. We ontkoppelen {{count}} geselecteerde gebruiker.",
+        "previewUnlink_other": "Voorbeeld klaar. We ontkoppelen {{count}} geselecteerde gebruikers.",
+        "previewLink": "Voorbeeld klaar. Bekijk het overzicht voordat u accounts koppelt."
+      },
+      "results": {
+        "completeTitle": "Toewijzing voltooid",
+        "previewTitle": "Voorbeeldresultaten",
+        "noneMatched": "Geen van de geselecteerde gebruikers kwam overeen met de huidige filters.",
+        "processed_one": "{{count}} gebruiker verwerkt.",
+        "processed_other": "{{count}} gebruikers verwerkt.",
+        "candidatesSelected": "{{count}} geselecteerd",
+        "unlinked": "Ontkoppeld",
+        "wouldUnlink": "Zou ontkoppelen",
+        "linked": "Gekoppeld",
+        "wouldLink": "Zou koppelen",
+        "alreadyUnlinked": "Al ontkoppeld",
+        "alreadyLinked": "Al gekoppeld",
+        "skippedInactive": "Overgeslagen (inactief)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/pl/msp/dashboard.json
+++ b/server/public/locales/pl/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Witamy ponownie",
     "descriptionCommunity": "Przechodź z pulpitu bezpośrednio do zgłoszeń, harmonogramu, projektów i raportów."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Witamy w AlgaDesk",
+      "description": "Monitoruj obciążenie zgłoszeniami, kondycję kanałów e-mail i bądź na bieżąco z każdą rozmową."
+    },
+    "metrics": {
+      "openTickets": "Otwarte zgłoszenia",
+      "awaitingCustomer": "Oczekuje na klienta",
+      "awaitingInternal": "Oczekuje wewnętrznie",
+      "activeEmailChannels": "Aktywne kanały e-mail"
+    },
+    "aging": {
+      "title": "Wiek zgłoszeń",
+      "under2Days": "Poniżej 2 dni",
+      "days2To7": "Od 2 do 7 dni",
+      "over7Days": "Powyżej 7 dni"
+    },
+    "emailHealth": {
+      "title": "Kondycja kanałów e-mail",
+      "summary": "Połączonych jest {{healthy}} z {{active}} aktywnych kanałów.",
+      "totalConfigured": "Łącznie skonfigurowanych kanałów: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Ostatnio zaktualizowane zgłoszenia",
+      "empty": "Brak ostatniej aktywności w zgłoszeniach."
+    }
+  },
   "features": {
     "heading": "Funkcje platformy",
     "comingSoon": "Wkrótce!",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -1358,113 +1358,6 @@
       "sso": "Ładowanie narzędzi zarządzania SSO...",
       "sessions": "Ładowanie aktywnych sesji..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "Single Sign-On",
-        "description": "Ładowanie narzędzi do masowego przypisywania SSO..."
-      },
-      "autoLink": {
-        "title": "Automatyczne konfigurowanie SSO dla nowych użytkowników wewnętrznych",
-        "description": "Włącz tę opcję, aby każde nowe konto pracownika było natychmiast udostępniane Państwa korporacyjnemu dostawcy SSO, dzięki czemu nigdy nie będzie wymagane logowanie hasłem.",
-        "body": "Po włączeniu nowo dodani użytkownicy MSP mogą logować się przez Google lub Microsoft, używając swojego służbowego adresu Email. Nie będą musieli ręcznie łączyć swojego konta.",
-        "toggleLabel": "Przełącz automatyczne dopasowywanie SSO",
-        "disabledInfo": "Włącz ten przełącznik, aby nowi i obecni pracownicy mogli pominąć proces „Połącz SSO”, gdy ich Email pasuje już do skonfigurowanego dostawcy. Każde automatyczne powiązanie nadal będzie rejestrowane."
-      },
-      "bulk": {
-        "title": "Masowe przypisanie Single Sign-On",
-        "description": "Wybierz wewnętrznych użytkowników z listy poniżej i powiąż ich ze skonfigurowanym dostawcą Google lub Microsoft. Skorzystaj z podglądu, aby dwukrotnie sprawdzić wpływ przed wykonaniem.",
-        "noProviders": "Nie skonfigurowano jeszcze żadnych dostawców SSO. Dodaj poświadczenia OAuth, aby kontynuować masowe przypisywanie."
-      },
-      "errors": {
-        "loadProviders": "Nie udało się wczytać konfiguracji dostawcy SSO.",
-        "updatePreferences": "Nie udało się zaktualizować preferencji SSO."
-      },
-      "form": {
-        "title": "Wybierz dostawcę i wybierz użytkowników",
-        "description": "Wybierz skonfigurowanego dostawcę SSO dla swojego personelu, a następnie wyszukaj i wybierz użytkowników, którzy mają zostać powiązani.",
-        "providerLabel": "Dostawca",
-        "notConfigured": "Nie skonfigurowano",
-        "providerNotConfiguredAlert": "Podaj poświadczenia OAuth dla tego dostawcy przed powiązaniem kont.",
-        "actionLabel": "Akcja",
-        "linkSelected": "Powiąż wybranych użytkowników",
-        "unlinkSelected": "Odłącz wybranych użytkowników",
-        "actionPlaceholder": "Wybierz akcję masową SSO",
-        "actionDescription": "Powiązanie dodaje dostawcę do każdego wybranego użytkownika. Odłączenie usuwa dostawcę, więc użytkownik wraca do logowania hasłem/TOTP, dopóki ponownie nie połączy konta.",
-        "searchLabel": "Znajdź użytkowników wewnętrznych",
-        "searchPlaceholder": "Szukaj po Email lub nazwisku",
-        "noneSelected": "Nie wybrano jeszcze żadnych użytkowników.",
-        "selected_one": "Wybrano {{count}} użytkownika.",
-        "selected_few": "Wybrano {{count}} użytkowników.",
-        "selected_many": "Wybrano {{count}} użytkowników.",
-        "selected_other": "Wybrano {{count}} użytkowników.",
-        "clearSelection": "Wyczyść wybór",
-        "loadingUsers": "Ładowanie użytkowników...",
-        "noMatch": "Brak użytkowników pasujących do tego wyszukiwania.",
-        "noUsers": "Nie znaleziono użytkowników wewnętrznych.",
-        "clientPortalComing": "Masowe przypisania w portalu klienta będą dostępne wkrótce. Obecnie to narzędzie dotyczy tylko wewnętrznych użytkowników MSP.",
-        "loadUsersFailed": "Nie udało się wczytać użytkowników do przypisania.",
-        "actions": {
-          "previewLink": "Podgląd przypisania",
-          "previewUnlink": "Podgląd odłączenia",
-          "link": "Powiąż konta",
-          "unlink": "Odłącz konta",
-          "preparingPreview": "Przygotowywanie podglądu…",
-          "linking": "Powiązywanie kont…",
-          "unlinking": "Odłączanie kont…",
-          "bulkLabel": "Masowe akcje SSO {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Nazwa",
-          "status": "Status",
-          "active": "Aktywny",
-          "inactive": "Nieaktywny",
-          "linkedProviders": "Powiązani dostawcy",
-          "unlinked": "Odłączony",
-          "lastLogin": "Ostatnie logowanie"
-        },
-        "toast": {
-          "providerRequiredTitle": "Wymagany dostawca",
-          "providerRequiredDescription": "Wybierz skonfigurowanego dostawcę przed kontynuacją.",
-          "noUsersTitle": "Nie wybrano użytkowników",
-          "noUsersDescription": "Wybierz co najmniej jednego użytkownika z tabeli.",
-          "failedTitle": "Masowe przypisanie nie powiodło się",
-          "failedDescription": "Nie udało się przetworzyć masowego przypisania SSO.",
-          "linkCompleteTitle": "Powiązanie zakończone",
-          "unlinkCompleteTitle": "Odłączenie zakończone",
-          "previewReadyTitle": "Podgląd gotowy",
-          "linkedCount": "Powiązano {{count}} kont przez {{provider}}.",
-          "unlinkedCount": "Odłączono {{count}} kont przez {{provider}}.",
-          "previewUnlink_one": "Podgląd gotowy. Odłączymy {{count}} wybranego użytkownika.",
-          "previewUnlink_few": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
-          "previewUnlink_many": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
-          "previewUnlink_other": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
-          "previewLink": "Podgląd gotowy. Przejrzyj podsumowanie przed powiązaniem kont."
-        },
-        "results": {
-          "completeTitle": "Przypisanie zakończone",
-          "previewTitle": "Wyniki podglądu",
-          "noneMatched": "Żaden z wybranych użytkowników nie pasował do bieżących filtrów.",
-          "processed_one": "Przetworzono {{count}} użytkownika.",
-          "processed_few": "Przetworzono {{count}} użytkowników.",
-          "processed_many": "Przetworzono {{count}} użytkowników.",
-          "processed_other": "Przetworzono {{count}} użytkowników.",
-          "candidatesSelected": "wybrano {{count}}",
-          "unlinked": "Odłączono",
-          "wouldUnlink": "Zostałoby odłączonych",
-          "linked": "Powiązano",
-          "wouldLink": "Zostałoby powiązanych",
-          "alreadyUnlinked": "Już odłączeni",
-          "alreadyLinked": "Już powiązani",
-          "skippedInactive": "Pominięto (nieaktywny)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Przypisywanie ról użytkownikom",
       "description": {
@@ -1543,6 +1436,113 @@
         "loading": "Ładowanie sesji...",
         "noMatch": "Żadne sesje nie pasują do wyszukiwania",
         "noSessions": "Nie znaleziono aktywnych sesji"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "Single Sign-On",
+      "description": "Ładowanie narzędzi do masowego przypisywania SSO..."
+    },
+    "autoLink": {
+      "title": "Automatyczne konfigurowanie SSO dla nowych użytkowników wewnętrznych",
+      "description": "Włącz tę opcję, aby każde nowe konto pracownika było natychmiast udostępniane Państwa korporacyjnemu dostawcy SSO, dzięki czemu nigdy nie będzie wymagane logowanie hasłem.",
+      "body": "Po włączeniu nowo dodani użytkownicy MSP mogą logować się przez Google lub Microsoft, używając swojego służbowego adresu Email. Nie będą musieli ręcznie łączyć swojego konta.",
+      "toggleLabel": "Przełącz automatyczne dopasowywanie SSO",
+      "disabledInfo": "Włącz ten przełącznik, aby nowi i obecni pracownicy mogli pominąć proces „Połącz SSO”, gdy ich Email pasuje już do skonfigurowanego dostawcy. Każde automatyczne powiązanie nadal będzie rejestrowane."
+    },
+    "bulk": {
+      "title": "Masowe przypisanie Single Sign-On",
+      "description": "Wybierz wewnętrznych użytkowników z listy poniżej i powiąż ich ze skonfigurowanym dostawcą Google lub Microsoft. Skorzystaj z podglądu, aby dwukrotnie sprawdzić wpływ przed wykonaniem.",
+      "noProviders": "Nie skonfigurowano jeszcze żadnych dostawców SSO. Dodaj poświadczenia OAuth, aby kontynuować masowe przypisywanie."
+    },
+    "errors": {
+      "loadProviders": "Nie udało się wczytać konfiguracji dostawcy SSO.",
+      "updatePreferences": "Nie udało się zaktualizować preferencji SSO."
+    },
+    "form": {
+      "title": "Wybierz dostawcę i wybierz użytkowników",
+      "description": "Wybierz skonfigurowanego dostawcę SSO dla swojego personelu, a następnie wyszukaj i wybierz użytkowników, którzy mają zostać powiązani.",
+      "providerLabel": "Dostawca",
+      "notConfigured": "Nie skonfigurowano",
+      "providerNotConfiguredAlert": "Podaj poświadczenia OAuth dla tego dostawcy przed powiązaniem kont.",
+      "actionLabel": "Akcja",
+      "linkSelected": "Powiąż wybranych użytkowników",
+      "unlinkSelected": "Odłącz wybranych użytkowników",
+      "actionPlaceholder": "Wybierz akcję masową SSO",
+      "actionDescription": "Powiązanie dodaje dostawcę do każdego wybranego użytkownika. Odłączenie usuwa dostawcę, więc użytkownik wraca do logowania hasłem/TOTP, dopóki ponownie nie połączy konta.",
+      "searchLabel": "Znajdź użytkowników wewnętrznych",
+      "searchPlaceholder": "Szukaj po Email lub nazwisku",
+      "noneSelected": "Nie wybrano jeszcze żadnych użytkowników.",
+      "selected_one": "Wybrano {{count}} użytkownika.",
+      "selected_few": "Wybrano {{count}} użytkowników.",
+      "selected_many": "Wybrano {{count}} użytkowników.",
+      "selected_other": "Wybrano {{count}} użytkowników.",
+      "clearSelection": "Wyczyść wybór",
+      "loadingUsers": "Ładowanie użytkowników...",
+      "noMatch": "Brak użytkowników pasujących do tego wyszukiwania.",
+      "noUsers": "Nie znaleziono użytkowników wewnętrznych.",
+      "clientPortalComing": "Masowe przypisania w portalu klienta będą dostępne wkrótce. Obecnie to narzędzie dotyczy tylko wewnętrznych użytkowników MSP.",
+      "loadUsersFailed": "Nie udało się wczytać użytkowników do przypisania.",
+      "actions": {
+        "previewLink": "Podgląd przypisania",
+        "previewUnlink": "Podgląd odłączenia",
+        "link": "Powiąż konta",
+        "unlink": "Odłącz konta",
+        "preparingPreview": "Przygotowywanie podglądu…",
+        "linking": "Powiązywanie kont…",
+        "unlinking": "Odłączanie kont…",
+        "bulkLabel": "Masowe akcje SSO {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Nazwa",
+        "status": "Status",
+        "active": "Aktywny",
+        "inactive": "Nieaktywny",
+        "linkedProviders": "Powiązani dostawcy",
+        "unlinked": "Odłączony",
+        "lastLogin": "Ostatnie logowanie"
+      },
+      "toast": {
+        "providerRequiredTitle": "Wymagany dostawca",
+        "providerRequiredDescription": "Wybierz skonfigurowanego dostawcę przed kontynuacją.",
+        "noUsersTitle": "Nie wybrano użytkowników",
+        "noUsersDescription": "Wybierz co najmniej jednego użytkownika z tabeli.",
+        "failedTitle": "Masowe przypisanie nie powiodło się",
+        "failedDescription": "Nie udało się przetworzyć masowego przypisania SSO.",
+        "linkCompleteTitle": "Powiązanie zakończone",
+        "unlinkCompleteTitle": "Odłączenie zakończone",
+        "previewReadyTitle": "Podgląd gotowy",
+        "linkedCount": "Powiązano {{count}} kont przez {{provider}}.",
+        "unlinkedCount": "Odłączono {{count}} kont przez {{provider}}.",
+        "previewUnlink_one": "Podgląd gotowy. Odłączymy {{count}} wybranego użytkownika.",
+        "previewUnlink_few": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
+        "previewUnlink_many": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
+        "previewUnlink_other": "Podgląd gotowy. Odłączymy {{count}} wybranych użytkowników.",
+        "previewLink": "Podgląd gotowy. Przejrzyj podsumowanie przed powiązaniem kont."
+      },
+      "results": {
+        "completeTitle": "Przypisanie zakończone",
+        "previewTitle": "Wyniki podglądu",
+        "noneMatched": "Żaden z wybranych użytkowników nie pasował do bieżących filtrów.",
+        "processed_one": "Przetworzono {{count}} użytkownika.",
+        "processed_few": "Przetworzono {{count}} użytkowników.",
+        "processed_many": "Przetworzono {{count}} użytkowników.",
+        "processed_other": "Przetworzono {{count}} użytkowników.",
+        "candidatesSelected": "wybrano {{count}}",
+        "unlinked": "Odłączono",
+        "wouldUnlink": "Zostałoby odłączonych",
+        "linked": "Powiązano",
+        "wouldLink": "Zostałoby powiązanych",
+        "alreadyUnlinked": "Już odłączeni",
+        "alreadyLinked": "Już powiązani",
+        "skippedInactive": "Pominięto (nieaktywny)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/pt/msp/dashboard.json
+++ b/server/public/locales/pt/msp/dashboard.json
@@ -5,6 +5,33 @@
     "titleCommunity": "Welcome back",
     "descriptionCommunity": "Jump into tickets, scheduling, projects, and reporting from your dashboard."
   },
+  "algadesk": {
+    "welcome": {
+      "title": "Bem-vindo ao AlgaDesk",
+      "description": "Acompanhe a carga de tickets, a saúde dos canais de e-mail e cada conversa."
+    },
+    "metrics": {
+      "openTickets": "Tickets abertos",
+      "awaitingCustomer": "Aguardando cliente",
+      "awaitingInternal": "Aguardando internamente",
+      "activeEmailChannels": "Canais de e-mail ativos"
+    },
+    "aging": {
+      "title": "Idade dos tickets",
+      "under2Days": "Menos de 2 dias",
+      "days2To7": "De 2 a 7 dias",
+      "over7Days": "Mais de 7 dias"
+    },
+    "emailHealth": {
+      "title": "Saúde dos canais de e-mail",
+      "summary": "{{healthy}} de {{active}} canais ativos estão conectados.",
+      "totalConfigured": "Canais configurados no total: {{total}}"
+    },
+    "recentTickets": {
+      "title": "Tickets atualizados recentemente",
+      "empty": "Sem atividade recente em tickets."
+    }
+  },
   "features": {
     "heading": "Platform Features",
     "comingSoon": "Coming soon!",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "Loading SSO management tools...",
       "sessions": "Loading active sessions..."
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "SSO",
-        "description": "A carregar ferramentas de atribuição em massa de SSO..."
-      },
-      "autoLink": {
-        "title": "Configurar SSO automaticamente para novos utilizadores internos",
-        "description": "Ative esta opção para aprovisionar imediatamente cada nova conta de colaborador com o seu fornecedor de SSO empresarial, dispensando o início de sessão por palavra-passe.",
-        "body": "Quando ativado, os novos utilizadores MSP podem iniciar sessão com Google ou Microsoft utilizando o seu email profissional. Não terão de associar manualmente a conta.",
-        "toggleLabel": "Alternar associação automática de SSO",
-        "disabledInfo": "Ative esta opção para que colaboradores novos e existentes possam dispensar o fluxo \"Conectar SSO\" quando o seu email já corresponde a um fornecedor configurado. Continuaremos a registar todas as associações automáticas."
-      },
-      "bulk": {
-        "title": "Atribuição em Massa de SSO",
-        "description": "Selecione utilizadores internos da lista abaixo e associe-os a um fornecedor Google ou Microsoft configurado. Use a pré-visualização para confirmar o impacto antes de executar.",
-        "noProviders": "Ainda não existem fornecedores SSO configurados. Adicione credenciais OAuth para continuar com as atribuições em massa."
-      },
-      "errors": {
-        "loadProviders": "Não foi possível carregar a configuração do fornecedor SSO.",
-        "updatePreferences": "Não foi possível atualizar as preferências de SSO."
-      },
-      "form": {
-        "title": "Escolher fornecedor e selecionar utilizadores",
-        "description": "Escolha o fornecedor SSO configurado para a sua equipa e, em seguida, pesquise e selecione os utilizadores a associar.",
-        "providerLabel": "Fornecedor",
-        "notConfigured": "Não configurado",
-        "providerNotConfiguredAlert": "Forneça credenciais OAuth para este fornecedor antes de associar contas.",
-        "actionLabel": "Ação",
-        "linkSelected": "Associar utilizadores selecionados",
-        "unlinkSelected": "Desassociar utilizadores selecionados",
-        "actionPlaceholder": "Selecionar ação em massa de SSO",
-        "actionDescription": "Associar adiciona o fornecedor a cada utilizador selecionado. Desassociar remove o fornecedor para que o utilizador volte ao início de sessão por palavra-passe/TOTP até voltar a associar.",
-        "searchLabel": "Procurar utilizadores internos",
-        "searchPlaceholder": "Pesquisar por email ou nome",
-        "noneSelected": "Ainda não há utilizadores selecionados.",
-        "selected_one": "{{count}} utilizador selecionado.",
-        "selected_other": "{{count}} utilizadores selecionados.",
-        "clearSelection": "Limpar seleção",
-        "loadingUsers": "A carregar utilizadores...",
-        "noMatch": "Nenhum utilizador corresponde a esta pesquisa.",
-        "noUsers": "Não foram encontrados utilizadores internos.",
-        "clientPortalComing": "As atribuições em massa do portal do cliente estarão disponíveis em breve. Por agora, esta ferramenta aplica-se apenas a utilizadores MSP internos.",
-        "loadUsersFailed": "Não foi possível carregar os utilizadores atribuíveis.",
-        "actions": {
-          "previewLink": "Pré-visualizar atribuição",
-          "previewUnlink": "Pré-visualizar desassociação",
-          "link": "Associar contas",
-          "unlink": "Desassociar contas",
-          "preparingPreview": "A preparar pré-visualização…",
-          "linking": "A associar contas…",
-          "unlinking": "A desassociar contas…",
-          "bulkLabel": "Ações de SSO em massa {{location}}"
-        },
-        "table": {
-          "email": "Email",
-          "id": "ID",
-          "name": "Nome",
-          "status": "Estado",
-          "active": "Ativo",
-          "inactive": "Inativo",
-          "linkedProviders": "Fornecedores associados",
-          "unlinked": "Não associado",
-          "lastLogin": "Último início de sessão"
-        },
-        "toast": {
-          "providerRequiredTitle": "Fornecedor obrigatório",
-          "providerRequiredDescription": "Selecione um fornecedor configurado antes de continuar.",
-          "noUsersTitle": "Nenhum utilizador selecionado",
-          "noUsersDescription": "Selecione pelo menos um utilizador da tabela.",
-          "failedTitle": "Atribuição em massa falhou",
-          "failedDescription": "Não foi possível processar a atribuição em massa de SSO.",
-          "linkCompleteTitle": "Associação concluída",
-          "unlinkCompleteTitle": "Desassociação concluída",
-          "previewReadyTitle": "Pré-visualização pronta",
-          "linkedCount": "Associadas {{count}} contas via {{provider}}.",
-          "unlinkedCount": "Desassociadas {{count}} contas via {{provider}}.",
-          "previewUnlink_one": "Pré-visualização pronta. Iremos desassociar {{count}} utilizador selecionado.",
-          "previewUnlink_other": "Pré-visualização pronta. Iremos desassociar {{count}} utilizadores selecionados.",
-          "previewLink": "Pré-visualização pronta. Reveja o resumo antes de associar contas."
-        },
-        "results": {
-          "completeTitle": "Atribuição concluída",
-          "previewTitle": "Resultados da pré-visualização",
-          "noneMatched": "Nenhum dos utilizadores selecionados corresponde aos filtros atuais.",
-          "processed_one": "Processado {{count}} utilizador.",
-          "processed_other": "Processados {{count}} utilizadores.",
-          "candidatesSelected": "{{count}} selecionados",
-          "unlinked": "Desassociados",
-          "wouldUnlink": "Seriam desassociados",
-          "linked": "Associados",
-          "wouldLink": "Seriam associados",
-          "alreadyUnlinked": "Já não associados",
-          "alreadyLinked": "Já associados",
-          "skippedInactive": "Ignorados (inativos)"
-        },
-        "providerNames": {
-          "google": "Google Workspace",
-          "microsoft": "Microsoft 365"
-        }
-      }
-    },
     "userRoles": {
       "title": "Assign Roles to Users",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "Loading sessions...",
         "noMatch": "No sessions match your search",
         "noSessions": "No active sessions found"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "SSO",
+      "description": "A carregar ferramentas de atribuição em massa de SSO..."
+    },
+    "autoLink": {
+      "title": "Configurar SSO automaticamente para novos utilizadores internos",
+      "description": "Ative esta opção para aprovisionar imediatamente cada nova conta de colaborador com o seu fornecedor de SSO empresarial, dispensando o início de sessão por palavra-passe.",
+      "body": "Quando ativado, os novos utilizadores MSP podem iniciar sessão com Google ou Microsoft utilizando o seu email profissional. Não terão de associar manualmente a conta.",
+      "toggleLabel": "Alternar associação automática de SSO",
+      "disabledInfo": "Ative esta opção para que colaboradores novos e existentes possam dispensar o fluxo \"Conectar SSO\" quando o seu email já corresponde a um fornecedor configurado. Continuaremos a registar todas as associações automáticas."
+    },
+    "bulk": {
+      "title": "Atribuição em Massa de SSO",
+      "description": "Selecione utilizadores internos da lista abaixo e associe-os a um fornecedor Google ou Microsoft configurado. Use a pré-visualização para confirmar o impacto antes de executar.",
+      "noProviders": "Ainda não existem fornecedores SSO configurados. Adicione credenciais OAuth para continuar com as atribuições em massa."
+    },
+    "errors": {
+      "loadProviders": "Não foi possível carregar a configuração do fornecedor SSO.",
+      "updatePreferences": "Não foi possível atualizar as preferências de SSO."
+    },
+    "form": {
+      "title": "Escolher fornecedor e selecionar utilizadores",
+      "description": "Escolha o fornecedor SSO configurado para a sua equipa e, em seguida, pesquise e selecione os utilizadores a associar.",
+      "providerLabel": "Fornecedor",
+      "notConfigured": "Não configurado",
+      "providerNotConfiguredAlert": "Forneça credenciais OAuth para este fornecedor antes de associar contas.",
+      "actionLabel": "Ação",
+      "linkSelected": "Associar utilizadores selecionados",
+      "unlinkSelected": "Desassociar utilizadores selecionados",
+      "actionPlaceholder": "Selecionar ação em massa de SSO",
+      "actionDescription": "Associar adiciona o fornecedor a cada utilizador selecionado. Desassociar remove o fornecedor para que o utilizador volte ao início de sessão por palavra-passe/TOTP até voltar a associar.",
+      "searchLabel": "Procurar utilizadores internos",
+      "searchPlaceholder": "Pesquisar por email ou nome",
+      "noneSelected": "Ainda não há utilizadores selecionados.",
+      "selected_one": "{{count}} utilizador selecionado.",
+      "selected_other": "{{count}} utilizadores selecionados.",
+      "clearSelection": "Limpar seleção",
+      "loadingUsers": "A carregar utilizadores...",
+      "noMatch": "Nenhum utilizador corresponde a esta pesquisa.",
+      "noUsers": "Não foram encontrados utilizadores internos.",
+      "clientPortalComing": "As atribuições em massa do portal do cliente estarão disponíveis em breve. Por agora, esta ferramenta aplica-se apenas a utilizadores MSP internos.",
+      "loadUsersFailed": "Não foi possível carregar os utilizadores atribuíveis.",
+      "actions": {
+        "previewLink": "Pré-visualizar atribuição",
+        "previewUnlink": "Pré-visualizar desassociação",
+        "link": "Associar contas",
+        "unlink": "Desassociar contas",
+        "preparingPreview": "A preparar pré-visualização…",
+        "linking": "A associar contas…",
+        "unlinking": "A desassociar contas…",
+        "bulkLabel": "Ações de SSO em massa {{location}}"
+      },
+      "table": {
+        "email": "Email",
+        "id": "ID",
+        "name": "Nome",
+        "status": "Estado",
+        "active": "Ativo",
+        "inactive": "Inativo",
+        "linkedProviders": "Fornecedores associados",
+        "unlinked": "Não associado",
+        "lastLogin": "Último início de sessão"
+      },
+      "toast": {
+        "providerRequiredTitle": "Fornecedor obrigatório",
+        "providerRequiredDescription": "Selecione um fornecedor configurado antes de continuar.",
+        "noUsersTitle": "Nenhum utilizador selecionado",
+        "noUsersDescription": "Selecione pelo menos um utilizador da tabela.",
+        "failedTitle": "Atribuição em massa falhou",
+        "failedDescription": "Não foi possível processar a atribuição em massa de SSO.",
+        "linkCompleteTitle": "Associação concluída",
+        "unlinkCompleteTitle": "Desassociação concluída",
+        "previewReadyTitle": "Pré-visualização pronta",
+        "linkedCount": "Associadas {{count}} contas via {{provider}}.",
+        "unlinkedCount": "Desassociadas {{count}} contas via {{provider}}.",
+        "previewUnlink_one": "Pré-visualização pronta. Iremos desassociar {{count}} utilizador selecionado.",
+        "previewUnlink_other": "Pré-visualização pronta. Iremos desassociar {{count}} utilizadores selecionados.",
+        "previewLink": "Pré-visualização pronta. Reveja o resumo antes de associar contas."
+      },
+      "results": {
+        "completeTitle": "Atribuição concluída",
+        "previewTitle": "Resultados da pré-visualização",
+        "noneMatched": "Nenhum dos utilizadores selecionados corresponde aos filtros atuais.",
+        "processed_one": "Processado {{count}} utilizador.",
+        "processed_other": "Processados {{count}} utilizadores.",
+        "candidatesSelected": "{{count}} selecionados",
+        "unlinked": "Desassociados",
+        "wouldUnlink": "Seriam desassociados",
+        "linked": "Associados",
+        "wouldLink": "Seriam associados",
+        "alreadyUnlinked": "Já não associados",
+        "alreadyLinked": "Já associados",
+        "skippedInactive": "Ignorados (inativos)"
+      },
+      "providerNames": {
+        "google": "Google Workspace",
+        "microsoft": "Microsoft 365"
       }
     }
   },

--- a/server/public/locales/xx/msp/dashboard.json
+++ b/server/public/locales/xx/msp/dashboard.json
@@ -10,6 +10,33 @@
     "titleCommunity": "11111",
     "descriptionCommunity": "11111"
   },
+  "algadesk": {
+    "welcome": {
+      "title": "11111",
+      "description": "11111"
+    },
+    "metrics": {
+      "openTickets": "11111",
+      "awaitingCustomer": "11111",
+      "awaitingInternal": "11111",
+      "activeEmailChannels": "11111"
+    },
+    "aging": {
+      "title": "11111",
+      "under2Days": "11111",
+      "days2To7": "11111",
+      "over7Days": "11111"
+    },
+    "emailHealth": {
+      "title": "11111",
+      "summary": "11111 {{healthy}} 11111 {{active}} 11111",
+      "totalConfigured": "11111 {{total}} 11111"
+    },
+    "recentTickets": {
+      "title": "11111",
+      "empty": "11111"
+    }
+  },
   "features": {
     "heading": "11111",
     "comingSoon": "11111",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "11111",
       "sessions": "11111"
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "11111",
-        "description": "11111"
-      },
-      "autoLink": {
-        "title": "11111",
-        "description": "11111",
-        "body": "11111",
-        "toggleLabel": "11111",
-        "disabledInfo": "11111"
-      },
-      "bulk": {
-        "title": "11111",
-        "description": "11111",
-        "noProviders": "11111"
-      },
-      "errors": {
-        "loadProviders": "11111",
-        "updatePreferences": "11111"
-      },
-      "form": {
-        "title": "11111",
-        "description": "11111",
-        "providerLabel": "11111",
-        "notConfigured": "11111",
-        "providerNotConfiguredAlert": "11111",
-        "actionLabel": "11111",
-        "linkSelected": "11111",
-        "unlinkSelected": "11111",
-        "actionPlaceholder": "11111",
-        "actionDescription": "11111",
-        "searchLabel": "11111",
-        "searchPlaceholder": "11111",
-        "noneSelected": "11111",
-        "selected_one": "11111 {{count}} 11111",
-        "selected_other": "11111 {{count}} 11111",
-        "clearSelection": "11111",
-        "loadingUsers": "11111",
-        "noMatch": "11111",
-        "noUsers": "11111",
-        "clientPortalComing": "11111",
-        "loadUsersFailed": "11111",
-        "actions": {
-          "previewLink": "11111",
-          "previewUnlink": "11111",
-          "link": "11111",
-          "unlink": "11111",
-          "preparingPreview": "11111",
-          "linking": "11111",
-          "unlinking": "11111",
-          "bulkLabel": "11111 {{location}} 11111"
-        },
-        "table": {
-          "email": "11111",
-          "id": "11111",
-          "name": "11111",
-          "status": "11111",
-          "active": "11111",
-          "inactive": "11111",
-          "linkedProviders": "11111",
-          "unlinked": "11111",
-          "lastLogin": "11111"
-        },
-        "toast": {
-          "providerRequiredTitle": "11111",
-          "providerRequiredDescription": "11111",
-          "noUsersTitle": "11111",
-          "noUsersDescription": "11111",
-          "failedTitle": "11111",
-          "failedDescription": "11111",
-          "linkCompleteTitle": "11111",
-          "unlinkCompleteTitle": "11111",
-          "previewReadyTitle": "11111",
-          "linkedCount": "11111 {{count}} 11111 {{provider}} 11111",
-          "unlinkedCount": "11111 {{count}} 11111 {{provider}} 11111",
-          "previewUnlink_one": "11111 {{count}} 11111",
-          "previewUnlink_other": "11111 {{count}} 11111",
-          "previewLink": "11111"
-        },
-        "results": {
-          "completeTitle": "11111",
-          "previewTitle": "11111",
-          "noneMatched": "11111",
-          "processed_one": "11111 {{count}} 11111",
-          "processed_other": "11111 {{count}} 11111",
-          "candidatesSelected": "11111 {{count}} 11111",
-          "unlinked": "11111",
-          "wouldUnlink": "11111",
-          "linked": "11111",
-          "wouldLink": "11111",
-          "alreadyUnlinked": "11111",
-          "alreadyLinked": "11111",
-          "skippedInactive": "11111"
-        },
-        "providerNames": {
-          "google": "11111",
-          "microsoft": "11111"
-        }
-      }
-    },
     "userRoles": {
       "title": "11111",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "11111",
         "noMatch": "11111",
         "noSessions": "11111"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "11111",
+      "description": "11111"
+    },
+    "autoLink": {
+      "title": "11111",
+      "description": "11111",
+      "body": "11111",
+      "toggleLabel": "11111",
+      "disabledInfo": "11111"
+    },
+    "bulk": {
+      "title": "11111",
+      "description": "11111",
+      "noProviders": "11111"
+    },
+    "errors": {
+      "loadProviders": "11111",
+      "updatePreferences": "11111"
+    },
+    "form": {
+      "title": "11111",
+      "description": "11111",
+      "providerLabel": "11111",
+      "notConfigured": "11111",
+      "providerNotConfiguredAlert": "11111",
+      "actionLabel": "11111",
+      "linkSelected": "11111",
+      "unlinkSelected": "11111",
+      "actionPlaceholder": "11111",
+      "actionDescription": "11111",
+      "searchLabel": "11111",
+      "searchPlaceholder": "11111",
+      "noneSelected": "11111",
+      "selected_one": "11111 {{count}} 11111",
+      "selected_other": "11111 {{count}} 11111",
+      "clearSelection": "11111",
+      "loadingUsers": "11111",
+      "noMatch": "11111",
+      "noUsers": "11111",
+      "clientPortalComing": "11111",
+      "loadUsersFailed": "11111",
+      "actions": {
+        "previewLink": "11111",
+        "previewUnlink": "11111",
+        "link": "11111",
+        "unlink": "11111",
+        "preparingPreview": "11111",
+        "linking": "11111",
+        "unlinking": "11111",
+        "bulkLabel": "11111 {{location}} 11111"
+      },
+      "table": {
+        "email": "11111",
+        "id": "11111",
+        "name": "11111",
+        "status": "11111",
+        "active": "11111",
+        "inactive": "11111",
+        "linkedProviders": "11111",
+        "unlinked": "11111",
+        "lastLogin": "11111"
+      },
+      "toast": {
+        "providerRequiredTitle": "11111",
+        "providerRequiredDescription": "11111",
+        "noUsersTitle": "11111",
+        "noUsersDescription": "11111",
+        "failedTitle": "11111",
+        "failedDescription": "11111",
+        "linkCompleteTitle": "11111",
+        "unlinkCompleteTitle": "11111",
+        "previewReadyTitle": "11111",
+        "linkedCount": "11111 {{count}} 11111 {{provider}} 11111",
+        "unlinkedCount": "11111 {{count}} 11111 {{provider}} 11111",
+        "previewUnlink_one": "11111 {{count}} 11111",
+        "previewUnlink_other": "11111 {{count}} 11111",
+        "previewLink": "11111"
+      },
+      "results": {
+        "completeTitle": "11111",
+        "previewTitle": "11111",
+        "noneMatched": "11111",
+        "processed_one": "11111 {{count}} 11111",
+        "processed_other": "11111 {{count}} 11111",
+        "candidatesSelected": "11111 {{count}} 11111",
+        "unlinked": "11111",
+        "wouldUnlink": "11111",
+        "linked": "11111",
+        "wouldLink": "11111",
+        "alreadyUnlinked": "11111",
+        "alreadyLinked": "11111",
+        "skippedInactive": "11111"
+      },
+      "providerNames": {
+        "google": "11111",
+        "microsoft": "11111"
       }
     }
   },

--- a/server/public/locales/yy/msp/dashboard.json
+++ b/server/public/locales/yy/msp/dashboard.json
@@ -10,6 +10,33 @@
     "titleCommunity": "55555",
     "descriptionCommunity": "55555"
   },
+  "algadesk": {
+    "welcome": {
+      "title": "55555",
+      "description": "55555"
+    },
+    "metrics": {
+      "openTickets": "55555",
+      "awaitingCustomer": "55555",
+      "awaitingInternal": "55555",
+      "activeEmailChannels": "55555"
+    },
+    "aging": {
+      "title": "55555",
+      "under2Days": "55555",
+      "days2To7": "55555",
+      "over7Days": "55555"
+    },
+    "emailHealth": {
+      "title": "55555",
+      "summary": "55555 {{healthy}} 55555 {{active}} 55555",
+      "totalConfigured": "55555 {{total}} 55555"
+    },
+    "recentTickets": {
+      "title": "55555",
+      "empty": "55555"
+    }
+  },
   "features": {
     "heading": "55555",
     "comingSoon": "55555",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -1358,107 +1358,6 @@
       "sso": "55555",
       "sessions": "55555"
     },
-    "ssoBulk": {
-      "loading": {
-        "title": "55555",
-        "description": "55555"
-      },
-      "autoLink": {
-        "title": "55555",
-        "description": "55555",
-        "body": "55555",
-        "toggleLabel": "55555",
-        "disabledInfo": "55555"
-      },
-      "bulk": {
-        "title": "55555",
-        "description": "55555",
-        "noProviders": "55555"
-      },
-      "errors": {
-        "loadProviders": "55555",
-        "updatePreferences": "55555"
-      },
-      "form": {
-        "title": "55555",
-        "description": "55555",
-        "providerLabel": "55555",
-        "notConfigured": "55555",
-        "providerNotConfiguredAlert": "55555",
-        "actionLabel": "55555",
-        "linkSelected": "55555",
-        "unlinkSelected": "55555",
-        "actionPlaceholder": "55555",
-        "actionDescription": "55555",
-        "searchLabel": "55555",
-        "searchPlaceholder": "55555",
-        "noneSelected": "55555",
-        "selected_one": "55555 {{count}} 55555",
-        "selected_other": "55555 {{count}} 55555",
-        "clearSelection": "55555",
-        "loadingUsers": "55555",
-        "noMatch": "55555",
-        "noUsers": "55555",
-        "clientPortalComing": "55555",
-        "loadUsersFailed": "55555",
-        "actions": {
-          "previewLink": "55555",
-          "previewUnlink": "55555",
-          "link": "55555",
-          "unlink": "55555",
-          "preparingPreview": "55555",
-          "linking": "55555",
-          "unlinking": "55555",
-          "bulkLabel": "55555 {{location}} 55555"
-        },
-        "table": {
-          "email": "55555",
-          "id": "55555",
-          "name": "55555",
-          "status": "55555",
-          "active": "55555",
-          "inactive": "55555",
-          "linkedProviders": "55555",
-          "unlinked": "55555",
-          "lastLogin": "55555"
-        },
-        "toast": {
-          "providerRequiredTitle": "55555",
-          "providerRequiredDescription": "55555",
-          "noUsersTitle": "55555",
-          "noUsersDescription": "55555",
-          "failedTitle": "55555",
-          "failedDescription": "55555",
-          "linkCompleteTitle": "55555",
-          "unlinkCompleteTitle": "55555",
-          "previewReadyTitle": "55555",
-          "linkedCount": "55555 {{count}} 55555 {{provider}} 55555",
-          "unlinkedCount": "55555 {{count}} 55555 {{provider}} 55555",
-          "previewUnlink_one": "55555 {{count}} 55555",
-          "previewUnlink_other": "55555 {{count}} 55555",
-          "previewLink": "55555"
-        },
-        "results": {
-          "completeTitle": "55555",
-          "previewTitle": "55555",
-          "noneMatched": "55555",
-          "processed_one": "55555 {{count}} 55555",
-          "processed_other": "55555 {{count}} 55555",
-          "candidatesSelected": "55555 {{count}} 55555",
-          "unlinked": "55555",
-          "wouldUnlink": "55555",
-          "linked": "55555",
-          "wouldLink": "55555",
-          "alreadyUnlinked": "55555",
-          "alreadyLinked": "55555",
-          "skippedInactive": "55555"
-        },
-        "providerNames": {
-          "google": "55555",
-          "microsoft": "55555"
-        }
-      }
-    },
     "userRoles": {
       "title": "55555",
       "description": {
@@ -1537,6 +1436,107 @@
         "loading": "55555",
         "noMatch": "55555",
         "noSessions": "55555"
+      }
+    }
+  },
+  "ssoBulk": {
+    "loading": {
+      "title": "55555",
+      "description": "55555"
+    },
+    "autoLink": {
+      "title": "55555",
+      "description": "55555",
+      "body": "55555",
+      "toggleLabel": "55555",
+      "disabledInfo": "55555"
+    },
+    "bulk": {
+      "title": "55555",
+      "description": "55555",
+      "noProviders": "55555"
+    },
+    "errors": {
+      "loadProviders": "55555",
+      "updatePreferences": "55555"
+    },
+    "form": {
+      "title": "55555",
+      "description": "55555",
+      "providerLabel": "55555",
+      "notConfigured": "55555",
+      "providerNotConfiguredAlert": "55555",
+      "actionLabel": "55555",
+      "linkSelected": "55555",
+      "unlinkSelected": "55555",
+      "actionPlaceholder": "55555",
+      "actionDescription": "55555",
+      "searchLabel": "55555",
+      "searchPlaceholder": "55555",
+      "noneSelected": "55555",
+      "selected_one": "55555 {{count}} 55555",
+      "selected_other": "55555 {{count}} 55555",
+      "clearSelection": "55555",
+      "loadingUsers": "55555",
+      "noMatch": "55555",
+      "noUsers": "55555",
+      "clientPortalComing": "55555",
+      "loadUsersFailed": "55555",
+      "actions": {
+        "previewLink": "55555",
+        "previewUnlink": "55555",
+        "link": "55555",
+        "unlink": "55555",
+        "preparingPreview": "55555",
+        "linking": "55555",
+        "unlinking": "55555",
+        "bulkLabel": "55555 {{location}} 55555"
+      },
+      "table": {
+        "email": "55555",
+        "id": "55555",
+        "name": "55555",
+        "status": "55555",
+        "active": "55555",
+        "inactive": "55555",
+        "linkedProviders": "55555",
+        "unlinked": "55555",
+        "lastLogin": "55555"
+      },
+      "toast": {
+        "providerRequiredTitle": "55555",
+        "providerRequiredDescription": "55555",
+        "noUsersTitle": "55555",
+        "noUsersDescription": "55555",
+        "failedTitle": "55555",
+        "failedDescription": "55555",
+        "linkCompleteTitle": "55555",
+        "unlinkCompleteTitle": "55555",
+        "previewReadyTitle": "55555",
+        "linkedCount": "55555 {{count}} 55555 {{provider}} 55555",
+        "unlinkedCount": "55555 {{count}} 55555 {{provider}} 55555",
+        "previewUnlink_one": "55555 {{count}} 55555",
+        "previewUnlink_other": "55555 {{count}} 55555",
+        "previewLink": "55555"
+      },
+      "results": {
+        "completeTitle": "55555",
+        "previewTitle": "55555",
+        "noneMatched": "55555",
+        "processed_one": "55555 {{count}} 55555",
+        "processed_other": "55555 {{count}} 55555",
+        "candidatesSelected": "55555 {{count}} 55555",
+        "unlinked": "55555",
+        "wouldUnlink": "55555",
+        "linked": "55555",
+        "wouldLink": "55555",
+        "alreadyUnlinked": "55555",
+        "alreadyLinked": "55555",
+        "skippedInactive": "55555"
+      },
+      "providerNames": {
+        "google": "55555",
+        "microsoft": "55555"
       }
     }
   },

--- a/server/scripts/create-tenant.ts
+++ b/server/scripts/create-tenant.ts
@@ -4,7 +4,7 @@
  * CLI script to create a new tenant with onboarding seeds
  */
 
-import { createTenantComplete } from '@enterprise/lib/testing/tenant-creation';
+import { createTenantComplete } from '../../ee/server/src/lib/testing/tenant-creation';
 import knex from 'knex';
 import { parse } from 'ts-command-line-args';
 import * as dotenv from 'dotenv';
@@ -25,6 +25,7 @@ interface Args {
   clientName?: string;
   companyName?: string;
   password?: string;
+  productCode?: string;
   help?: boolean;
 }
 
@@ -37,6 +38,7 @@ const args = parse<Args>(
     clientName: { type: String, optional: true, description: 'Client name (defaults to tenant name)' },
     companyName: { type: String, optional: true, description: 'Company name (defaults to tenant name)' },
     password: { type: String, optional: true, description: 'Admin password (generated if not provided)' },
+    productCode: { type: String, optional: true, description: 'Product code: psa (default) or algadesk' },
     help: { type: Boolean, optional: true, alias: 'h', description: 'Show help' }
   },
   {
@@ -73,6 +75,14 @@ async function main() {
     const resolvedCompanyName = args.companyName ?? args.clientName ?? args.tenant;
     const resolvedClientName = args.clientName ?? args.companyName ?? args.tenant;
 
+    let productCode: 'psa' | 'algadesk' | undefined;
+    if (args.productCode !== undefined) {
+      if (args.productCode !== 'psa' && args.productCode !== 'algadesk') {
+        throw new Error(`Invalid productCode "${args.productCode}". Must be "psa" or "algadesk".`);
+      }
+      productCode = args.productCode;
+    }
+
     const result = await createTenantComplete(db, {
       tenantName: args.tenant,
       adminUser: {
@@ -81,7 +91,8 @@ async function main() {
         email: args.email
       },
       companyName: resolvedCompanyName,
-      clientName: resolvedClientName
+      clientName: resolvedClientName,
+      productCode
     });
 
     console.log('\n✅ Tenant created successfully!');
@@ -89,6 +100,7 @@ async function main() {
     console.log(`Admin User ID: ${result.adminUserId}`);
     console.log(`Client ID: ${result.clientId}`);
     console.log(`Admin Email: ${args.email}`);
+    console.log(`Product Code: ${productCode ?? '(default)'}`);
     console.log(`Temporary Password: ${result.temporaryPassword}`);
 
   } catch (error) {

--- a/server/scripts/rollback-tenant.ts
+++ b/server/scripts/rollback-tenant.ts
@@ -4,7 +4,7 @@
  * CLI script to rollback/delete a tenant
  */
 
-import { rollbackTenant } from '@enterprise/lib/testing/tenant-creation';
+import { rollbackTenant } from '../../ee/server/src/lib/testing/tenant-creation';
 import knex from 'knex';
 import { parse } from 'ts-command-line-args';
 import * as dotenv from 'dotenv';

--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -62,7 +62,7 @@ export function MspLayoutClient({
             <ClientUIStateProvider
               initialPageState={{
                 id: 'msp-portal',
-                title: isAlgadesk ? 'Algadesk MSP' : 'MSP Portal',
+                title: isAlgadesk ? 'AlgaDesk MSP' : 'MSP Portal',
                 components: []
               }}
             >

--- a/server/src/components/dashboard/AlgadeskDashboard.tsx
+++ b/server/src/components/dashboard/AlgadeskDashboard.tsx
@@ -1,5 +1,10 @@
+'use client';
+
 import Link from 'next/link';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { AlgadeskDashboardSummary } from '@/lib/actions/algadeskDashboardActions';
+import WelcomeBanner from '@/components/dashboard/WelcomeBanner';
+import { isEnterprise } from '@/lib/features';
 
 interface AlgadeskDashboardProps {
   summary: AlgadeskDashboardSummary;
@@ -17,46 +22,88 @@ function MetricCard({ title, value, href }: { title: string; value: number; href
 }
 
 export default function AlgadeskDashboard({ summary }: AlgadeskDashboardProps) {
+  const { t } = useTranslation('msp/dashboard');
+
   return (
     <div className="min-h-screen p-6" data-automation-id="algadesk-dashboard">
       <div className="mx-auto max-w-7xl space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold text-[rgb(var(--color-text-900))]">Algadesk Dashboard</h1>
-          <p className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
-            Ticket workload and email-channel health.
-          </p>
-        </div>
+        <WelcomeBanner
+          variant={isEnterprise ? 'gradient' : 'plain'}
+          title={t('algadesk.welcome.title', { defaultValue: 'Welcome to AlgaDesk' })}
+          description={t('algadesk.welcome.description', {
+            defaultValue:
+              'Track ticket workload, monitor email-channel health, and stay on top of every conversation.',
+          })}
+        />
 
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <MetricCard title="Open tickets" value={summary.openTickets} href="/msp/tickets?statusId=open" />
-          <MetricCard title="Awaiting customer" value={summary.awaitingCustomer} href="/msp/tickets?responseState=awaiting_client" />
-          <MetricCard title="Awaiting internal" value={summary.awaitingInternal} href="/msp/tickets?responseState=awaiting_internal" />
-          <MetricCard title="Active email channels" value={summary.emailHealth.activeChannels} href="/msp/settings?tab=email" />
+          <MetricCard
+            title={t('algadesk.metrics.openTickets', { defaultValue: 'Open tickets' })}
+            value={summary.openTickets}
+            href="/msp/tickets?statusId=open"
+          />
+          <MetricCard
+            title={t('algadesk.metrics.awaitingCustomer', { defaultValue: 'Awaiting customer' })}
+            value={summary.awaitingCustomer}
+            href="/msp/tickets?responseState=awaiting_client"
+          />
+          <MetricCard
+            title={t('algadesk.metrics.awaitingInternal', { defaultValue: 'Awaiting internal' })}
+            value={summary.awaitingInternal}
+            href="/msp/tickets?responseState=awaiting_internal"
+          />
+          <MetricCard
+            title={t('algadesk.metrics.activeEmailChannels', { defaultValue: 'Active email channels' })}
+            value={summary.emailHealth.activeChannels}
+            href="/msp/settings?tab=email"
+          />
         </section>
 
         <section className="grid gap-4 lg:grid-cols-2">
           <div className="rounded-lg border border-[rgb(var(--color-border-200))] bg-white p-4">
-            <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">Ticket aging</h2>
+            <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
+              {t('algadesk.aging.title', { defaultValue: 'Ticket aging' })}
+            </h2>
             <div className="mt-3 grid grid-cols-3 gap-3">
-              <MetricCard title="Under 2 days" value={summary.aging.under2Days} />
-              <MetricCard title="2 to 7 days" value={summary.aging.days2To7} />
-              <MetricCard title="Over 7 days" value={summary.aging.over7Days} />
+              <MetricCard
+                title={t('algadesk.aging.under2Days', { defaultValue: 'Under 2 days' })}
+                value={summary.aging.under2Days}
+              />
+              <MetricCard
+                title={t('algadesk.aging.days2To7', { defaultValue: '2 to 7 days' })}
+                value={summary.aging.days2To7}
+              />
+              <MetricCard
+                title={t('algadesk.aging.over7Days', { defaultValue: 'Over 7 days' })}
+                value={summary.aging.over7Days}
+              />
             </div>
           </div>
 
           <div className="rounded-lg border border-[rgb(var(--color-border-200))] bg-white p-4">
-            <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">Email channel health</h2>
+            <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
+              {t('algadesk.emailHealth.title', { defaultValue: 'Email channel health' })}
+            </h2>
             <p className="mt-2 text-sm text-[rgb(var(--color-text-500))]">
-              {summary.emailHealth.healthyChannels} of {summary.emailHealth.activeChannels} active channels are connected.
+              {t('algadesk.emailHealth.summary', {
+                defaultValue: '{{healthy}} of {{active}} active channels are connected.',
+                healthy: summary.emailHealth.healthyChannels,
+                active: summary.emailHealth.activeChannels,
+              })}
             </p>
             <p className="mt-1 text-sm text-[rgb(var(--color-text-500))]">
-              Total configured channels: {summary.emailHealth.totalChannels}
+              {t('algadesk.emailHealth.totalConfigured', {
+                defaultValue: 'Total configured channels: {{total}}',
+                total: summary.emailHealth.totalChannels,
+              })}
             </p>
           </div>
         </section>
 
         <section className="rounded-lg border border-[rgb(var(--color-border-200))] bg-white p-4">
-          <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">Recently updated tickets</h2>
+          <h2 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
+            {t('algadesk.recentTickets.title', { defaultValue: 'Recently updated tickets' })}
+          </h2>
           <ul className="mt-3 space-y-2">
             {summary.recentTickets.map((ticket) => (
               <li key={ticket.ticketId}>
@@ -66,7 +113,9 @@ export default function AlgadeskDashboard({ summary }: AlgadeskDashboardProps) {
               </li>
             ))}
             {summary.recentTickets.length === 0 ? (
-              <li className="text-sm text-[rgb(var(--color-text-500))]">No recent ticket activity.</li>
+              <li className="text-sm text-[rgb(var(--color-text-500))]">
+                {t('algadesk.recentTickets.empty', { defaultValue: 'No recent ticket activity.' })}
+              </li>
             ) : null}
           </ul>
         </section>

--- a/server/src/components/dashboard/DashboardContainer.tsx
+++ b/server/src/components/dashboard/DashboardContainer.tsx
@@ -8,21 +8,14 @@ import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContai
 import { Button } from '@alga-psa/ui/components/Button';
 import { usePerformanceTracking } from '@alga-psa/analytics/client';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { HiddenCardsExtrasProvider, type ExtraHiddenItem } from '@alga-psa/onboarding/components';
 import { isEnterprise } from '@/lib/features';
 import MobileAppCard from '@/components/dashboard/MobileAppCard';
+import WelcomeBanner from '@/components/dashboard/WelcomeBanner';
 import {
   dismissDashboardMobileAppCardAction,
   restoreDashboardMobileAppCardAction,
 } from '@/lib/actions/dashboardMobileAppActions';
-
-function getGreetingKey(): 'morning' | 'afternoon' | 'evening' {
-  const hour = new Date().getHours();
-  if (hour < 12) return 'morning';
-  if (hour < 18) return 'afternoon';
-  return 'evening';
-}
 
 // App shell: dashboard landing container (server-owned, uses analytics).
 import {
@@ -32,7 +25,6 @@ import {
   HeartPulse,
   ClipboardList,
   Calendar,
-  Sparkles,
   RotateCcw,
 } from 'lucide-react';
 
@@ -152,66 +144,9 @@ const FeatureCard = ({ icon: Icon, title, description, analyticsName }: FeatureC
   );
 };
 
-interface BannerProps {
-  greeting?: string;
-  title: string;
-  description: string;
-}
-
-function EnterpriseWelcomeBanner({ greeting, title, description }: BannerProps) {
-  return (
-    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-r from-violet-600 to-cyan-500 px-6 py-5 shadow-[0_10px_30px_rgba(2,6,23,0.12)]">
-      <div className="flex items-start gap-4">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/15 ring-1 ring-white/20">
-          <Sparkles className="h-5 w-5 text-white" />
-        </div>
-        <div className="min-w-0">
-          {greeting && (
-            <div className="text-xs font-medium uppercase tracking-wider text-white/80">
-              {greeting}
-            </div>
-          )}
-          <h1 className="text-xl font-semibold tracking-tight text-white sm:text-2xl">
-            {title}
-          </h1>
-          <p className="mt-1 text-sm text-white/80">
-            {description}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function CommunityWelcomeBanner({ greeting, title, description }: BannerProps) {
-  return (
-    <div className="overflow-hidden rounded-2xl border border-[rgb(var(--color-border-200))] bg-white px-6 py-5 shadow-sm">
-      <div className="flex items-start gap-4">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl ring-1 ring-[rgb(var(--color-border-200))] bg-[rgb(var(--color-primary-50))]">
-          <Sparkles className="h-5 w-5" style={{ color: 'rgb(var(--color-primary-500))' }} />
-        </div>
-        <div className="min-w-0">
-          {greeting && (
-            <div className="text-xs font-medium uppercase tracking-wider" style={{ color: 'rgb(var(--color-text-500))' }}>
-              {greeting}
-            </div>
-          )}
-          <h1 className="text-xl font-semibold tracking-tight" style={{ color: 'rgb(var(--color-text-900))' }}>
-            {title}
-          </h1>
-          <p className="mt-1 text-sm" style={{ color: 'rgb(var(--color-text-500))' }}>
-            {description}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 const WelcomeDashboard = ({ onboardingSection, initialMobileAppCardDismissed = false }: DashboardContainerProps) => {
   const posthog = usePostHog();
   const { t } = useTranslation('msp/dashboard');
-  const [firstName, setFirstName] = useState<string>('');
   const [mobileDismissed, setMobileDismissed] = useState(initialMobileAppCardDismissed);
   const [isMobilePending, startMobileTransition] = useTransition();
 
@@ -271,30 +206,6 @@ const WelcomeDashboard = ({ onboardingSection, initialMobileAppCardDismissed = f
     });
   }, [posthog]);
 
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const user = await getCurrentUser();
-        if (mounted) setFirstName(user?.first_name || '');
-      } catch {
-        /* ignore — banner falls back to non-personalized greeting */
-      }
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  const greetingPart = t(`greeting.${getGreetingKey()}`, {
-    defaultValue: getGreetingKey() === 'morning'
-      ? 'Good morning'
-      : getGreetingKey() === 'afternoon'
-        ? 'Good afternoon'
-        : 'Good evening',
-  });
-  const greetingLine = firstName ? `${greetingPart}, ${firstName}` : greetingPart;
-
   const translatedFeatureCards = featureCards.map((feature) => ({
     ...feature,
     title: t(feature.titleKey, { defaultValue: feature.titleDefault }),
@@ -319,19 +230,11 @@ const WelcomeDashboard = ({ onboardingSection, initialMobileAppCardDismissed = f
       <div className="min-h-screen p-6">
         <div className="max-w-7xl mx-auto">
           <div className="flex flex-col gap-8">
-              {isEnterprise ? (
-                <EnterpriseWelcomeBanner
-                  greeting={greetingLine}
-                  title={welcomeTitle}
-                  description={welcomeDescription}
-                />
-              ) : (
-                <CommunityWelcomeBanner
-                  greeting={greetingLine}
-                  title={welcomeCommunityTitle}
-                  description={welcomeCommunityDescription}
-                />
-              )}
+              <WelcomeBanner
+                variant={isEnterprise ? 'gradient' : 'plain'}
+                title={isEnterprise ? welcomeTitle : welcomeCommunityTitle}
+                description={isEnterprise ? welcomeDescription : welcomeCommunityDescription}
+              />
 
               {isEnterprise ? (
                 <HiddenCardsExtrasProvider value={mobileExtras}>

--- a/server/src/components/dashboard/WelcomeBanner.tsx
+++ b/server/src/components/dashboard/WelcomeBanner.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { getCurrentUser } from '@alga-psa/user-composition/actions';
+
+export type WelcomeBannerVariant = 'gradient' | 'plain';
+
+interface WelcomeBannerProps {
+  title: string;
+  description: string;
+  variant?: WelcomeBannerVariant;
+}
+
+function getGreetingKey(): 'morning' | 'afternoon' | 'evening' {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'morning';
+  if (hour < 18) return 'afternoon';
+  return 'evening';
+}
+
+export default function WelcomeBanner({ title, description, variant = 'plain' }: WelcomeBannerProps) {
+  const { t } = useTranslation('msp/dashboard');
+  const [firstName, setFirstName] = useState<string>('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const user = await getCurrentUser();
+        if (mounted) setFirstName(user?.first_name || '');
+      } catch {
+        /* ignore — banner falls back to non-personalized greeting */
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const greetingKey = getGreetingKey();
+  const greetingPart = t(`greeting.${greetingKey}`, {
+    defaultValue:
+      greetingKey === 'morning'
+        ? 'Good morning'
+        : greetingKey === 'afternoon'
+          ? 'Good afternoon'
+          : 'Good evening',
+  });
+  const greetingLine = firstName ? `${greetingPart}, ${firstName}` : greetingPart;
+
+  if (variant === 'gradient') {
+    return (
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-r from-violet-600 to-cyan-500 px-6 py-5 shadow-[0_10px_30px_rgba(2,6,23,0.12)]">
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/15 ring-1 ring-white/20">
+            <Sparkles className="h-5 w-5 text-white" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs font-medium uppercase tracking-wider text-white/80">
+              {greetingLine}
+            </div>
+            <h1 className="text-xl font-semibold tracking-tight text-white sm:text-2xl">{title}</h1>
+            <p className="mt-1 text-sm text-white/80">{description}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-[rgb(var(--color-border-200))] bg-white px-6 py-5 shadow-sm">
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl ring-1 ring-[rgb(var(--color-border-200))] bg-[rgb(var(--color-primary-50))]">
+          <Sparkles className="h-5 w-5" style={{ color: 'rgb(var(--color-primary-500))' }} />
+        </div>
+        <div className="min-w-0">
+          <div
+            className="text-xs font-medium uppercase tracking-wider"
+            style={{ color: 'rgb(var(--color-text-500))' }}
+          >
+            {greetingLine}
+          </div>
+          <h1
+            className="text-xl font-semibold tracking-tight"
+            style={{ color: 'rgb(var(--color-text-900))' }}
+          >
+            {title}
+          </h1>
+          <p className="mt-1 text-sm" style={{ color: 'rgb(var(--color-text-500))' }}>
+            {description}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/src/components/layout/Header.tsx
+++ b/server/src/components/layout/Header.tsx
@@ -33,6 +33,7 @@ import type { JobMetrics } from '@alga-psa/jobs/actions';
 import { getQueueMetricsAction } from '@alga-psa/jobs/actions';
 import { analytics } from '@alga-psa/analytics/client';
 import { QuickCreateDialog, QuickCreateType } from './QuickCreateDialog';
+import { useProduct } from '@/context/ProductContext';
 import { ThemeToggle } from '@alga-psa/ui/components/ThemeToggle';
 import { TrialBanner } from './TrialBanner';
 import { PaymentFailedBanner } from './PaymentFailedBanner';
@@ -179,9 +180,19 @@ const TenantBadge: React.FC<{
   );
 };
 
+const ALGADESK_QUICK_CREATE_TYPES: ReadonlySet<QuickCreateType> = new Set([
+  'ticket',
+  'client',
+  'contact',
+]);
+
 const QuickCreateMenu: React.FC<{ t: HeaderTranslator }> = ({ t }) => {
   const [activeQuickCreate, setActiveQuickCreate] = useState<QuickCreateType>(null);
-  const translatedOptions = quickCreateOptions.map((option) => ({
+  const { isAlgadesk } = useProduct();
+  const visibleOptions = isAlgadesk
+    ? quickCreateOptions.filter((option) => ALGADESK_QUICK_CREATE_TYPES.has(option.type))
+    : quickCreateOptions;
+  const translatedOptions = visibleOptions.map((option) => ({
     ...option,
     label: t(option.labelKey, { defaultValue: option.labelDefault }),
     description: t(option.descriptionKey, { defaultValue: option.descriptionDefault }),

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -129,8 +129,8 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
       {...props}
       menuSections={menuSections}
       bottomMenuItems={bottomMenuItems}
-      appDisplayName={isAlgadesk ? 'Algadesk' : 'AlgaPSA'}
-      appLogoAlt={isAlgadesk ? 'Algadesk Logo' : 'AlgaPSA Logo'}
+      appDisplayName={isAlgadesk ? 'AlgaDesk' : 'AlgaPSA'}
+      appLogoAlt={isAlgadesk ? 'AlgaDesk Logo' : 'AlgaPSA Logo'}
       settingsSectionsOverride={settingsSections}
     />
   );

--- a/server/src/components/product/ProductRouteBoundary.tsx
+++ b/server/src/components/product/ProductRouteBoundary.tsx
@@ -19,9 +19,9 @@ export function ProductRouteBoundary({ behavior, scope }: ProductRouteBoundaryPr
   const isUpgradeBoundary = behavior === 'upgrade_boundary';
   const title = isUpgradeBoundary ? 'Available in Alga PSA' : 'Page not available';
   const description = isUpgradeBoundary
-    ? 'This area is part of the full Alga PSA product. Algadesk includes focused help desk functionality only.'
+    ? 'This area is part of the full Alga PSA product. AlgaDesk includes focused help desk functionality only.'
     : 'This page is not available in your current product experience.';
-  const cta = isUpgradeBoundary ? 'Return to Algadesk dashboard' : 'Go to dashboard';
+  const cta = isUpgradeBoundary ? 'Return to AlgaDesk dashboard' : 'Go to dashboard';
   const homeHref = SCOPE_HOME[scope];
 
   return (

--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -40,6 +40,7 @@ import {
   DropdownMenuItem,
 } from '@alga-psa/ui/components/DropdownMenu';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useProduct } from '@/context/ProductContext';
 
 type TicketStatusSeedMode = 'copy_existing' | 'create_inline';
 type ManagedTicketStatus = {
@@ -139,6 +140,7 @@ const TICKET_STATUS_VALIDATION_KEYS: Record<ManagedTicketStatusValidationCode, s
 
 const BoardsSettings: React.FC = () => {
   const { t } = useTranslation('msp/settings');
+  const { isAlgadesk } = useProduct();
   const createEmptyFormData = () => ({
     board_name: '',
     description: '',
@@ -1091,25 +1093,27 @@ const BoardsSettings: React.FC = () => {
                 {t('ticketing.boards.fields.defaultAssignedAgent.help')}
               </p>
             </div>
-            <div>
-              <Label htmlFor="sla-policy-picker">{t('ticketing.boards.fields.slaPolicy.label')}</Label>
-              <CustomSelect
-                id="sla-policy-picker"
-                value={formData.sla_policy_id}
-                onValueChange={(value) => setFormData({ ...formData, sla_policy_id: value })}
-                options={[
-                  { value: '', label: t('ticketing.boards.fields.slaPolicy.none') },
-                  ...slaPolicies.map((policy): SelectOption => ({
-                    value: policy.sla_policy_id,
-                    label: policy.policy_name + (policy.is_default ? ' (Default)' : '')
-                  }))
-                ]}
-                placeholder={t('ticketing.boards.fields.slaPolicy.placeholder')}
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                {t('ticketing.boards.fields.slaPolicy.help')}
-              </p>
-            </div>
+            {!isAlgadesk && (
+              <div>
+                <Label htmlFor="sla-policy-picker">{t('ticketing.boards.fields.slaPolicy.label')}</Label>
+                <CustomSelect
+                  id="sla-policy-picker"
+                  value={formData.sla_policy_id}
+                  onValueChange={(value) => setFormData({ ...formData, sla_policy_id: value })}
+                  options={[
+                    { value: '', label: t('ticketing.boards.fields.slaPolicy.none') },
+                    ...slaPolicies.map((policy): SelectOption => ({
+                      value: policy.sla_policy_id,
+                      label: policy.policy_name + (policy.is_default ? ' (Default)' : '')
+                    }))
+                  ]}
+                  placeholder={t('ticketing.boards.fields.slaPolicy.placeholder')}
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('ticketing.boards.fields.slaPolicy.help')}
+                </p>
+              </div>
+            )}
             <div>
               <Label htmlFor="board-manager-picker">{t('ticketing.boards.fields.boardManager.label')}</Label>
               <UserPicker

--- a/server/src/components/settings/profile/UserProfile.tsx
+++ b/server/src/components/settings/profile/UserProfile.tsx
@@ -30,6 +30,7 @@ import { PasswordChangeForm, UserAvatarUpload } from '@alga-psa/users/components
 import { SessionManagement } from '@alga-psa/auth/components';
 import ApiKeysSetup from './ApiKeysSetup';
 import { isCalendarEnterpriseEdition, resolveUserProfileTab } from '@alga-psa/integrations/lib/calendarAvailability';
+import { useProduct } from '@/context/ProductContext';
 import { toast } from 'react-hot-toast';
 import { validateContactName, validateEmailAddress, validatePhoneNumber } from '@alga-psa/validation';
 import SettingsTabSkeleton from '@alga-psa/ui/components/skeletons/SettingsTabSkeleton';
@@ -88,7 +89,8 @@ export default function UserProfile({ userId }: UserProfileProps) {
   const { t } = useTranslation('msp/profile');
   const searchParams = useSearchParams();
   const tabParam = searchParams?.get('tab');
-  const isCalendarTabAvailable = isCalendarEnterpriseEdition();
+  const { isAlgadesk } = useProduct();
+  const isCalendarTabAvailable = isCalendarEnterpriseEdition() && !isAlgadesk;
   
   const [user, setUser] = useState<IUserWithRoles | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
  - Move ssoBulk locale keys out of `security` to the top of every msp/settings.json so the Single Sign-On tab renders real translations instead of raw keys.
  - Constrain the SSO action ViewSwitcher to content width (`w-fit`) and drop the redundant native `title` tooltip from ViewSwitcher.
  - Extract WelcomeBanner from DashboardContainer, reuse it on AlgadeskDashboard, and add the `algadesk.*` dashboard locale keys.
  - Assorted touch-ups to tenant create/rollback scripts, seed-tenant-onboarding, layout (Header, MspLayoutClient, SidebarWithFeatureFlags, ProductRouteBoundary), and settings (BoardsSettings, UserProfile).

  And so the ssoBulk keys, having long lurked beneath `security` like Cheshire
  grins shut in the wrong cupboard, climbed at last to the top shelf — while
  the ViewSwitcher, no longer announcing itself with a paper sign reading
  "Switch to X view," shrank from the full breadth of the table to the width
  of two polite buttons. 🎩🃏✨