### PR TITLE
Add Algadesk onboarding wizard flow

### DIFF
--- a/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/PRD.md
+++ b/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/PRD.md
@@ -1,0 +1,77 @@
+# PRD — Algadesk Onboarding Wizard
+
+- Slug: `algadesk-onboarding-wizard`
+- Date: `2026-05-07`
+- Status: Draft
+
+## Summary
+
+Make the existing onboarding wizard product-aware so Algadesk tenants get a focused help-desk setup flow while PSA tenants retain the current full PSA onboarding flow. Algadesk onboarding must initialize the data needed for a working ticketing environment without creating PSA-only billing/service/contract setup data.
+
+## Problem
+
+Algadesk is a lightweight help-desk product variant. The current wizard is PSA-oriented and includes steps such as Billing that are not available in Algadesk. Sending Algadesk tenants through PSA setup creates confusing UX and risks initializing data for disabled surfaces. At the same time, Algadesk still needs a complete operational baseline: tenant/admin details, optional team and client/contact data, and ticketing defaults such as boards, statuses, priorities, and ticket numbering.
+
+## Goals
+
+1. Detect the tenant product and render an Algadesk-specific wizard for `product_code = algadesk`.
+2. Preserve the current 6-step PSA wizard unchanged for `product_code = psa`.
+3. Remove PSA-only setup steps from Algadesk onboarding, especially Billing.
+4. Keep help-desk-relevant setup available for Algadesk: workspace/admin info, team members, first client, client contact, and ticketing configuration.
+5. Ensure Algadesk onboarding completion still validates ticketing defaults needed for a functional help desk.
+6. Avoid initializing PSA-only billing/service/contract data during Algadesk onboarding.
+7. Keep a future PSA upgrade path clean by leaving PSA default initialization to a separate upgrade initializer when a tenant upgrades.
+
+## Non-goals
+
+1. Building a separate onboarding route or deployment for Algadesk.
+2. Changing tenant creation or `product_code` assignment flows.
+3. Creating PSA billing/service/contract defaults for Algadesk tenants.
+4. Implementing the future Algadesk-to-PSA upgrade initializer in this work.
+5. Redesigning the ticketing configuration step.
+6. Adding the PSA dashboard onboarding checklist to Algadesk dashboards.
+
+## Users and Primary Flows
+
+- Algadesk admin:
+  - signs into a new Algadesk tenant,
+  - is redirected to `/msp/onboarding`,
+  - sees Algadesk-branded help-desk setup without Billing,
+  - configures a ticket board/status/priority baseline,
+  - completes onboarding and lands in the Algadesk dashboard.
+- PSA admin:
+  - experiences the existing onboarding flow with no product-specific regression.
+- Future upgrade operator:
+  - can upgrade an Algadesk tenant later without reverse-engineering hidden billing defaults created during help-desk onboarding.
+
+## UX / UI Notes
+
+- Use the same `/msp/onboarding` route and existing wizard shell.
+- Algadesk copy should refer to setting up Algadesk/help desk rather than a full PSA system.
+- Algadesk step list should hide Billing and keep only help-desk-relevant setup.
+- Optional steps remain skippable; required steps remain workspace/admin info and ticketing.
+- The ticketing step remains the source of board/status/priority setup for both products.
+
+## Data / API / Integration Notes
+
+- Product detection comes from the existing product seam (`session.user.product_code` surfaced through `ProductProvider`).
+- The wizard should receive a product code and derive its active step list from that product.
+- Existing server actions remain shared, but Algadesk navigation must not call `setupBilling` because the Billing step is not reachable.
+- Existing onboarding progress storage rules remain: do not persist user-specific fields in tenant-wide `onboarding_data`.
+- Completion still calls `completeOnboarding()` after ticketing validation/configuration.
+
+## Risks and Constraints
+
+- The current wizard uses numeric step indexes. Product filtering must distinguish display step positions from the original action indexes to avoid accidentally calling the wrong server action.
+- Tests should protect PSA step preservation and Algadesk Billing removal.
+- Existing partial `onboarding_data` from PSA or earlier flows may contain billing fields; Algadesk should ignore those in navigation rather than deleting them unexpectedly.
+
+## Acceptance Criteria / Definition of Done
+
+1. PSA tenants still see all current wizard steps, including Billing.
+2. Algadesk tenants do not see the Billing step and cannot trigger `setupBilling` from wizard navigation.
+3. Algadesk tenants can complete onboarding after required workspace/admin and ticketing setup.
+4. Algadesk optional help-desk setup steps remain available/skippable.
+5. Algadesk onboarding shell uses Algadesk/help-desk-oriented title/description copy.
+6. Existing tenant-wide onboarding data separation for user fields remains intact.
+7. Automated tests cover product-specific step derivation and route/page wiring where practical.

--- a/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/SCRATCHPAD.md
@@ -1,0 +1,45 @@
+# Scratchpad — Algadesk Onboarding Wizard
+
+## Decisions
+
+- Algadesk onboarding should not create PSA-only billing/service/contract setup data.
+- A future Algadesk-to-PSA upgrade should run a separate PSA initializer when the product changes to `psa`.
+- Use the existing `/msp/onboarding` route and shared wizard, made product-aware.
+- Keep help-desk-relevant optional setup in Algadesk; remove Billing.
+
+## Discoveries
+
+- `server/src/app/msp/layout.tsx` already resolves `productCode` and wraps MSP pages in `MspLayoutClient`.
+- `MspLayoutClient` wraps onboarding children in `AppSessionProvider` and `ProductProvider`, so the client onboarding page can read product context.
+- `packages/onboarding/src/components/OnboardingWizard.tsx` currently uses numeric step indexes directly for rendering, validation, and server action dispatch.
+- Billing setup is only invoked from step index 4 in `saveStepData`.
+- Ticketing defaults are handled through `configureTicketing` and `validateOnboardingDefaults` on step index 5.
+- Algadesk dashboard currently returns `AlgadeskDashboard` directly and does not render the PSA dashboard onboarding checklist slot.
+
+## Implementation Notes
+
+- Introduce product-aware active step index helpers in `OnboardingWizard.tsx`.
+- Keep `currentStep` and `completedSteps` as displayed positions, then map to original indexes for action/render/validation logic.
+- Add focused tests under `server/src/test/unit/onboarding`.
+
+## Validation
+
+- `cd server && npx vitest run src/test/unit/onboarding/algadeskOnboardingWizard.productSteps.test.ts src/test/unit/onboarding/onboardingWizardDataSeparation.test.tsx src/test/unit/onboarding/clientInfoStepRendering.test.tsx`
+- `cd server && npm run typecheck`
+
+## Implementation Summary
+
+- Added `packages/onboarding/src/lib/onboardingWizardSteps.ts` for product-specific wizard step derivation.
+- Wired `server/src/app/msp/onboarding/page.tsx` to read `productCode` from `ProductProvider` and pass it to `OnboardingWizard`.
+- Updated `OnboardingWizard` to keep displayed step positions separate from original server-action step indexes.
+- Algadesk active steps are Client Info/Workspace, Team Members, Add Client, Client Contact, and Ticketing. Billing remains PSA-only.
+- Added source/contract and helper tests for product-specific behavior.
+- Updated existing ClientInfoStep tests to mock `useI18n` and tolerate locale seeding updates while preserving tenantName/clientName separation assertions.
+
+## Review Follow-up
+
+- Ran builtin reviewer on the uncommitted diff.
+- Added Algadesk onboarding translation keys to all `server/public/locales/*/msp/onboarding.json` files.
+- Restored the stricter tenantName/clientName test assertion by clearing the locale-seeding update before typing.
+- Aligned `handleSkip` with displayed required step positions.
+- Added locale-key coverage to the Algadesk onboarding contract test.

--- a/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/features.json
+++ b/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/features.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "F001",
+    "description": "Pass the current tenant product code into the onboarding wizard from the MSP onboarding page.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals 1",
+      "Data / API / Integration Notes"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Derive wizard step lists by product while preserving the full existing PSA step list.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals 1",
+      "Goals 2",
+      "Acceptance Criteria 1"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Hide the Billing step for Algadesk tenants so setupBilling cannot be reached through wizard navigation.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals 3",
+      "Goals 6",
+      "Acceptance Criteria 2"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Map displayed step positions to original step action indexes so product filtering does not call the wrong save/validation/render logic.",
+    "implemented": true,
+    "prdRefs": [
+      "Risks and Constraints"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Keep Algadesk help-desk setup steps available and skippable where optional: team members, first client, client contact, and ticketing configuration.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals 4",
+      "Acceptance Criteria 4"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Use Algadesk/help-desk-oriented title and description copy in the onboarding shell for Algadesk tenants.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Acceptance Criteria 5"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Retain current onboarding completion and ticketing-default validation behavior for both PSA and Algadesk.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals 5",
+      "Data / API / Integration Notes",
+      "Acceptance Criteria 3"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Keep existing onboarding_data merge behavior and user-specific field separation unchanged.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integration Notes",
+      "Acceptance Criteria 6"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Add Algadesk onboarding wizard shell and step translation keys to all onboarding locale files.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Acceptance Criteria 5"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/tests.json
+++ b/ee/docs/plans/2026-05-07-algadesk-onboarding-wizard/tests.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit test product-specific step derivation: PSA includes all existing steps and Algadesk excludes Billing while keeping required workspace/ticketing positions correct.",
+    "implemented": true,
+    "featureIds": [
+      "F002",
+      "F003",
+      "F004",
+      "F005"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Contract/unit test the onboarding page passes productCode into OnboardingWizard from ProductProvider.",
+    "implemented": true,
+    "featureIds": [
+      "F001"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Source/contract test that Algadesk-specific wizard copy exists while PSA defaults remain available.",
+    "implemented": true,
+    "featureIds": [
+      "F006"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "Regression check existing onboarding data separation tests still pass for tenantName vs user-specific fields.",
+    "implemented": true,
+    "featureIds": [
+      "F008"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "Contract test every onboarding locale defines the Algadesk wizard shell and workspace step translation keys.",
+    "implemented": true,
+    "featureIds": [
+      "F006",
+      "F009"
+    ]
+  }
+]

--- a/packages/onboarding/src/components/OnboardingWizard.tsx
+++ b/packages/onboarding/src/components/OnboardingWizard.tsx
@@ -12,9 +12,8 @@ import { ClientContactStep } from './steps/ClientContactStep';
 import { BillingSetupStep } from './steps/BillingSetupStep';
 import { TicketingConfigStep } from './steps/TicketingConfigStep';
 import {
+  type ProductCode,
   type WizardData,
-  ONBOARDING_WIZARD_STEPS,
-  ONBOARDING_WIZARD_REQUIRED_STEP_INDEXES,
 } from '@alga-psa/types';
 import {
   saveClientInfo,
@@ -29,9 +28,10 @@ import {
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { updateTenantDefaultLocaleAction } from '@alga-psa/tenancy/actions';
 import { isSupportedLocale, type SupportedLocale } from '@alga-psa/core/i18n/config';
-
-const STEPS = ONBOARDING_WIZARD_STEPS;
-const REQUIRED_STEPS = ONBOARDING_WIZARD_REQUIRED_STEP_INDEXES;
+import {
+  getOnboardingWizardRequiredStepPositions,
+  getOnboardingWizardStepIndexes,
+} from '../lib/onboardingWizardSteps';
 
 interface OnboardingWizardProps {
   open?: boolean;
@@ -42,6 +42,7 @@ interface OnboardingWizardProps {
   onComplete?: (data: WizardData) => void;
   fullPage?: boolean;
   isRevisit?: boolean;
+  productCode?: ProductCode;
 }
 
 export function OnboardingWizard({
@@ -53,6 +54,7 @@ export function OnboardingWizard({
   onComplete,
   fullPage = false,
   isRevisit = false,
+  productCode = 'psa',
 }: OnboardingWizardProps) {
   const { t } = useTranslation('msp/onboarding');
   const [currentStep, setCurrentStep] = useState(0);
@@ -60,6 +62,11 @@ export function OnboardingWizard({
   const [errors, setErrors] = useState<Record<number, string>>({});
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
   const [attemptedSteps, setAttemptedSteps] = useState<Set<number>>(new Set());
+  const activeStepIndexes = getOnboardingWizardStepIndexes(productCode);
+  const requiredStepPositions = getOnboardingWizardRequiredStepPositions(productCode);
+  const currentOriginalStepIndex = activeStepIndexes[currentStep] ?? activeStepIndexes[0] ?? 0;
+  const isAlgadesk = productCode === 'algadesk';
+
   const [wizardData, setWizardData] = useState<WizardData>({
     // MSP Company Info
     firstName: '',
@@ -111,9 +118,9 @@ export function OnboardingWizard({
     setWizardData((prev) => ({ ...prev, ...data }));
   };
 
-  const translatedSteps = [
-    t('onboardingWizard.steps.clientInfo', {
-      defaultValue: 'Client Info'
+  const translatedStepLabelsByOriginalIndex = [
+    t(isAlgadesk ? 'onboardingWizard.steps.algadeskWorkspace' : 'onboardingWizard.steps.clientInfo', {
+      defaultValue: isAlgadesk ? 'Workspace' : 'Client Info'
     }),
     t('onboardingWizard.steps.teamMembers', {
       defaultValue: 'Team Members'
@@ -131,6 +138,9 @@ export function OnboardingWizard({
       defaultValue: 'Ticketing'
     })
   ];
+  const translatedSteps = activeStepIndexes.map(
+    (stepIndex) => translatedStepLabelsByOriginalIndex[stepIndex] ?? translatedStepLabelsByOriginalIndex[0]
+  );
 
   const saveStepData = async (stepIndex: number): Promise<boolean> => {
     if (testMode) return true;
@@ -287,8 +297,8 @@ export function OnboardingWizard({
     // Mark the current step as attempted
     setAttemptedSteps(prev => new Set([...prev, currentStep]));
     
-    if (currentStep < STEPS.length - 1) {
-      const saved = await saveStepData(currentStep);
+    if (currentStep < activeStepIndexes.length - 1) {
+      const saved = await saveStepData(currentOriginalStepIndex);
       if (saved) {
         setCompletedSteps(prev => new Set([...prev, currentStep]));
         setCurrentStep(currentStep + 1);
@@ -303,7 +313,7 @@ export function OnboardingWizard({
   };
 
   const handleSkip = () => {
-    if (currentStep < STEPS.length - 1 && !REQUIRED_STEPS.includes(currentStep)) {
+    if (currentStep < activeStepIndexes.length - 1 && !requiredStepPositions.includes(currentStep)) {
       // Don't mark as completed when skipping
       setCurrentStep(currentStep + 1);
     }
@@ -422,7 +432,7 @@ export function OnboardingWizard({
   };
 
   const hasAtLeastOneFieldFilled = () => {
-    switch (currentStep) {
+    switch (currentOriginalStepIndex) {
       case 1: // Team members
         return wizardData.teamMembers.some((member) => 
           member.firstName || member.lastName || member.email || member.role
@@ -451,11 +461,11 @@ export function OnboardingWizard({
   };
 
   const isStepValid = () => {
-    if (currentStep === 0) return isFirstStepValid();
-    if (currentStep === 5) return isTicketingStepValid();
+    if (currentOriginalStepIndex === 0) return isFirstStepValid();
+    if (currentOriginalStepIndex === 5) return isTicketingStepValid();
     
     // For optional steps with dependencies, check if the dependency was skipped
-    if (currentStep === 3) { // Contact step
+    if (currentOriginalStepIndex === 3) { // Contact step
       // If client step was skipped (no client data), this step is valid to proceed
       const hasClientInfo = !!(wizardData.clientName || wizardData.clientEmail || 
                              wizardData.clientPhone || wizardData.clientUrl || wizardData.clientId);
@@ -466,7 +476,7 @@ export function OnboardingWizard({
   };
 
   const renderStep = () => {
-    switch (currentStep) {
+    switch (currentOriginalStepIndex) {
       case 0:
         return <ClientInfoStep data={wizardData} updateData={updateData} isRevisit={isRevisit} />;
       case 1:
@@ -487,13 +497,13 @@ export function OnboardingWizard({
   const wizardNavigation = (
     <WizardNavigation
       currentStep={currentStep}
-      totalSteps={STEPS.length}
+      totalSteps={activeStepIndexes.length}
       onBack={handleBack}
       onNext={handleNext}
       onSkip={handleSkip}
       onFinish={handleFinish}
       isNextDisabled={!isStepValid() || isLoading}
-      isSkipDisabled={REQUIRED_STEPS.includes(currentStep)}
+      isSkipDisabled={requiredStepPositions.includes(currentStep)}
       isLoading={isLoading}
       backLabel={t('common.actions.back', {
         defaultValue: 'Back'
@@ -560,7 +570,7 @@ export function OnboardingWizard({
           <p>
             {t('onboardingWizard.debug.isRequired', {
               defaultValue: 'Is Required: {{value}}',
-              value: REQUIRED_STEPS.includes(currentStep)
+              value: requiredStepPositions.includes(currentStep)
                 ? t('common.yes', { defaultValue: 'Yes' })
                 : t('common.no', { defaultValue: 'No' })
             })}
@@ -578,9 +588,9 @@ export function OnboardingWizard({
         </div>
       )}
 
-      {errors[currentStep] && (
+      {errors[currentOriginalStepIndex] && (
         <Alert variant="destructive" className="mb-4">
-          <AlertDescription>{errors[currentStep]}</AlertDescription>
+          <AlertDescription>{errors[currentOriginalStepIndex]}</AlertDescription>
         </Alert>
       )}
     </>
@@ -592,13 +602,15 @@ export function OnboardingWizard({
         <div className="mx-auto max-w-5xl px-4 py-8">
           <div className="mb-8">
             <h1 className="text-3xl font-bold text-gray-900">
-              {t('onboardingWizard.shell.title', {
-                defaultValue: 'Setup Your System'
+              {t(isAlgadesk ? 'onboardingWizard.shell.algadeskTitle' : 'onboardingWizard.shell.title', {
+                defaultValue: isAlgadesk ? 'Set Up Algadesk' : 'Setup Your System'
               })}
             </h1>
             <p className="mt-2 text-lg text-gray-600">
-              {t('onboardingWizard.shell.description', {
-                defaultValue: 'Let\'s get your workspace configured and ready to use.'
+              {t(isAlgadesk ? 'onboardingWizard.shell.algadeskDescription' : 'onboardingWizard.shell.description', {
+                defaultValue: isAlgadesk
+                  ? 'Configure your help desk workspace, clients, and ticketing defaults.'
+                  : 'Let\'s get your workspace configured and ready to use.'
               })}
             </p>
           </div>
@@ -615,8 +627,8 @@ export function OnboardingWizard({
     <Dialog
       isOpen={open}
       onClose={() => onOpenChange?.(false)}
-      title={t('onboardingWizard.shell.title', {
-        defaultValue: 'Setup Your System'
+      title={t(isAlgadesk ? 'onboardingWizard.shell.algadeskTitle' : 'onboardingWizard.shell.title', {
+        defaultValue: isAlgadesk ? 'Set Up Algadesk' : 'Setup Your System'
       })}
       className="max-w-4xl"
       footer={wizardNavigation}

--- a/packages/onboarding/src/lib/index.ts
+++ b/packages/onboarding/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './stepDefinitions';
 export * from './deriveParentStepFromSubsteps';
 export * from './dashboardOnboardingDismissals';
+export * from './onboardingWizardSteps';

--- a/packages/onboarding/src/lib/onboardingWizardSteps.ts
+++ b/packages/onboarding/src/lib/onboardingWizardSteps.ts
@@ -1,0 +1,26 @@
+import {
+  type ProductCode,
+  ONBOARDING_WIZARD_REQUIRED_STEP_INDEXES,
+  ONBOARDING_WIZARD_STEPS,
+} from '@alga-psa/types';
+
+export const PSA_ONBOARDING_STEP_INDEXES = ONBOARDING_WIZARD_STEPS.map((_step, index) => index);
+export const ALGADESK_ONBOARDING_STEP_INDEXES = [0, 1, 2, 3, 5] as const;
+
+export function getOnboardingWizardStepIndexes(productCode: ProductCode): number[] {
+  return productCode === 'algadesk'
+    ? [...ALGADESK_ONBOARDING_STEP_INDEXES]
+    : [...PSA_ONBOARDING_STEP_INDEXES];
+}
+
+export function getOnboardingWizardRequiredStepPositions(productCode: ProductCode): number[] {
+  const activeStepIndexes = getOnboardingWizardStepIndexes(productCode);
+
+  return activeStepIndexes.reduce<number[]>((positions, originalStepIndex, displayPosition) => {
+    if (ONBOARDING_WIZARD_REQUIRED_STEP_INDEXES.includes(originalStepIndex)) {
+      positions.push(displayPosition);
+    }
+
+    return positions;
+  }, []);
+}

--- a/server/public/locales/de/msp/onboarding.json
+++ b/server/public/locales/de/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Kunden anlegen",
       "clientContact": "Kundenkontakt",
       "billing": "Abrechnung",
-      "ticketing": "Ticketing"
+      "ticketing": "Ticketing",
+      "algadeskWorkspace": "Arbeitsbereich"
     },
     "errors": {
       "saveClientInfo": "Kundeninfo konnte nicht gespeichert werden",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "System einrichten",
-      "description": "Lassen Sie uns Ihren Arbeitsbereich konfigurieren und einsatzbereit machen."
+      "description": "Lassen Sie uns Ihren Arbeitsbereich konfigurieren und einsatzbereit machen.",
+      "algadeskTitle": "Algadesk einrichten",
+      "algadeskDescription": "Konfigurieren Sie Ihren Helpdesk-Arbeitsbereich, Kunden und Ticketing-Standardeinstellungen."
     }
   },
   "addClientStep": {

--- a/server/public/locales/en/msp/onboarding.json
+++ b/server/public/locales/en/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Add Client",
       "clientContact": "Client Contact",
       "billing": "Billing",
-      "ticketing": "Ticketing"
+      "ticketing": "Ticketing",
+      "algadeskWorkspace": "Workspace"
     },
     "errors": {
       "saveClientInfo": "Failed to save client info",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Setup Your System",
-      "description": "Let's get your workspace configured and ready to use."
+      "description": "Let's get your workspace configured and ready to use.",
+      "algadeskTitle": "Set Up Algadesk",
+      "algadeskDescription": "Configure your help desk workspace, clients, and ticketing defaults."
     }
   },
   "addClientStep": {

--- a/server/public/locales/es/msp/onboarding.json
+++ b/server/public/locales/es/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Añadir cliente",
       "clientContact": "Contacto del cliente",
       "billing": "Facturación",
-      "ticketing": "Tickets"
+      "ticketing": "Tickets",
+      "algadeskWorkspace": "Espacio de trabajo"
     },
     "errors": {
       "saveClientInfo": "No se pudo guardar la información del cliente",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Configura tu sistema",
-      "description": "Vamos a configurar tu espacio de trabajo y dejarlo listo para usar."
+      "description": "Vamos a configurar tu espacio de trabajo y dejarlo listo para usar.",
+      "algadeskTitle": "Configurar Algadesk",
+      "algadeskDescription": "Configura tu espacio de trabajo de mesa de ayuda, clientes y valores predeterminados de tickets."
     }
   },
   "addClientStep": {

--- a/server/public/locales/fr/msp/onboarding.json
+++ b/server/public/locales/fr/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Ajouter un client",
       "clientContact": "Contact client",
       "billing": "Facturation",
-      "ticketing": "Gestion des tickets"
+      "ticketing": "Gestion des tickets",
+      "algadeskWorkspace": "Espace de travail"
     },
     "errors": {
       "saveClientInfo": "Impossible d'enregistrer les informations client",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Configurez votre système",
-      "description": "Configurons votre espace de travail et préparons-le à l'utilisation."
+      "description": "Configurons votre espace de travail et préparons-le à l'utilisation.",
+      "algadeskTitle": "Configurer Algadesk",
+      "algadeskDescription": "Configurez votre espace d’assistance, vos clients et les paramètres par défaut des tickets."
     }
   },
   "addClientStep": {

--- a/server/public/locales/it/msp/onboarding.json
+++ b/server/public/locales/it/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Aggiungi cliente",
       "clientContact": "Contatto cliente",
       "billing": "Fatturazione",
-      "ticketing": "Ticketing"
+      "ticketing": "Ticketing",
+      "algadeskWorkspace": "Area di lavoro"
     },
     "errors": {
       "saveClientInfo": "Impossibile salvare le informazioni del cliente",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Configura il tuo sistema",
-      "description": "Configuriamo il tuo workspace e lo rendiamo pronto all'uso."
+      "description": "Configuriamo il tuo workspace e lo rendiamo pronto all'uso.",
+      "algadeskTitle": "Configura Algadesk",
+      "algadeskDescription": "Configura l’area di lavoro dell’help desk, i clienti e le impostazioni predefinite dei ticket."
     }
   },
   "addClientStep": {

--- a/server/public/locales/nl/msp/onboarding.json
+++ b/server/public/locales/nl/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Klant toevoegen",
       "clientContact": "Klantcontact",
       "billing": "Facturatie",
-      "ticketing": "Tickets"
+      "ticketing": "Tickets",
+      "algadeskWorkspace": "Werkruimte"
     },
     "errors": {
       "saveClientInfo": "Klantinfo opslaan mislukt",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Stel je systeem in",
-      "description": "Laten we je werkruimte configureren en klaarzetten voor gebruik."
+      "description": "Laten we je werkruimte configureren en klaarzetten voor gebruik.",
+      "algadeskTitle": "Algadesk instellen",
+      "algadeskDescription": "Configureer je helpdeskomgeving, klanten en standaardinstellingen voor tickets."
     }
   },
   "addClientStep": {

--- a/server/public/locales/pl/msp/onboarding.json
+++ b/server/public/locales/pl/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Dodaj klienta",
       "clientContact": "Kontakt klienta",
       "billing": "Fakturowanie",
-      "ticketing": "Zgłoszenia"
+      "ticketing": "Zgłoszenia",
+      "algadeskWorkspace": "Obszar roboczy"
     },
     "errors": {
       "saveClientInfo": "Nie udało się zapisać informacji o kliencie",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Skonfiguruj swój system",
-      "description": "Skonfigurujmy Twoje środowisko i przygotujmy je do użycia."
+      "description": "Skonfigurujmy Twoje środowisko i przygotujmy je do użycia.",
+      "algadeskTitle": "Skonfiguruj Algadesk",
+      "algadeskDescription": "Skonfiguruj obszar roboczy helpdesku, klientów i domyślne ustawienia zgłoszeń."
     }
   },
   "addClientStep": {

--- a/server/public/locales/pt/msp/onboarding.json
+++ b/server/public/locales/pt/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "Add Client",
       "clientContact": "Client Contact",
       "billing": "Billing",
-      "ticketing": "Ticketing"
+      "ticketing": "Ticketing",
+      "algadeskWorkspace": "Espaço de trabalho"
     },
     "errors": {
       "saveClientInfo": "Failed to save client info",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "Setup Your System",
-      "description": "Let's get your workspace configured and ready to use."
+      "description": "Let's get your workspace configured and ready to use.",
+      "algadeskTitle": "Configurar o Algadesk",
+      "algadeskDescription": "Configure seu espaço de trabalho de help desk, clientes e padrões de tickets."
     }
   },
   "addClientStep": {

--- a/server/public/locales/xx/msp/onboarding.json
+++ b/server/public/locales/xx/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "11111",
       "clientContact": "11111",
       "billing": "11111",
-      "ticketing": "11111"
+      "ticketing": "11111",
+      "algadeskWorkspace": "11111"
     },
     "errors": {
       "saveClientInfo": "11111",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "11111",
-      "description": "11111"
+      "description": "11111",
+      "algadeskTitle": "11111",
+      "algadeskDescription": "11111"
     }
   },
   "addClientStep": {

--- a/server/public/locales/yy/msp/onboarding.json
+++ b/server/public/locales/yy/msp/onboarding.json
@@ -35,7 +35,8 @@
       "addClient": "55555",
       "clientContact": "55555",
       "billing": "55555",
-      "ticketing": "55555"
+      "ticketing": "55555",
+      "algadeskWorkspace": "55555"
     },
     "errors": {
       "saveClientInfo": "55555",
@@ -62,7 +63,9 @@
     },
     "shell": {
       "title": "55555",
-      "description": "55555"
+      "description": "55555",
+      "algadeskTitle": "55555",
+      "algadeskDescription": "55555"
     }
   },
   "addClientStep": {

--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -8,11 +8,12 @@ import { TagProvider } from "@alga-psa/tags/context";
 import { PostHogUserIdentifier } from "@alga-psa/ui/components/analytics/PostHogUserIdentifier";
 import { ClientUIStateProvider } from "@alga-psa/ui/ui-reflection/ClientUIStateProvider";
 import { I18nWrapper } from "@alga-psa/tenancy/components";
+import { getTenantSettings } from "@alga-psa/tenancy/actions";
 import { AIChatContextProvider } from '@product/chat/context';
 import { TierProvider } from "@/context/TierContext";
 import { ProductProvider } from "@/context/ProductContext";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { Session } from "next-auth";
 import type { SupportedLocale } from "@alga-psa/core/i18n/config";
 import type { ProductCode } from '@alga-psa/types';
@@ -40,14 +41,52 @@ export function MspLayoutClient({
   const pathname = usePathname();
   const isOnboardingPage = pathname === "/msp/onboarding";
   const routeBehavior = resolveProductRouteBehavior(productCode, pathname);
+  const sessionTenant = session?.user?.tenant;
+  const [clientNeedsOnboarding, setClientNeedsOnboarding] = useState(false);
+  const shouldForceOnboarding = needsOnboarding || clientNeedsOnboarding;
 
   useEffect(() => {
-    if (needsOnboarding && !isOnboardingPage) {
+    if (shouldForceOnboarding && !isOnboardingPage) {
       router.replace("/msp/onboarding");
     }
-  }, [needsOnboarding, isOnboardingPage, router]);
+  }, [shouldForceOnboarding, isOnboardingPage, router]);
 
-  if (needsOnboarding && !isOnboardingPage) {
+  useEffect(() => {
+    let isCancelled = false;
+
+    setClientNeedsOnboarding(false);
+
+    if (needsOnboarding || isOnboardingPage || !sessionTenant) {
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    void getTenantSettings()
+      .then((settings) => {
+        if (isCancelled || !settings) {
+          return;
+        }
+
+        const hasOnboardingFlags =
+          Object.prototype.hasOwnProperty.call(settings, 'onboarding_completed') &&
+          Object.prototype.hasOwnProperty.call(settings, 'onboarding_skipped');
+
+        if (hasOnboardingFlags && !settings.onboarding_completed && !settings.onboarding_skipped) {
+          setClientNeedsOnboarding(true);
+          router.replace('/msp/onboarding');
+        }
+      })
+      .catch((error) => {
+        console.error('Error checking onboarding status:', error);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [needsOnboarding, isOnboardingPage, sessionTenant, router]);
+
+  if (shouldForceOnboarding && !isOnboardingPage) {
     return null;
   }
 

--- a/server/src/app/msp/onboarding/page.tsx
+++ b/server/src/app/msp/onboarding/page.tsx
@@ -7,9 +7,11 @@ import { getTenantSettings } from '@alga-psa/tenancy/actions';
 import { getOnboardingInitialData } from '@alga-psa/onboarding/actions';
 import type { WizardData } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useProduct } from '@/context/ProductContext';
 
 export default function OnboardingPage() {
   const { t } = useTranslation('common');
+  const { productCode } = useProduct();
   const router = useRouter();
   const [initialData, setInitialData] = useState<Partial<WizardData>>({});
   const [isLoading, setIsLoading] = useState(true);
@@ -99,6 +101,7 @@ export default function OnboardingPage() {
         onComplete={handleComplete}
         fullPage={true}
         isRevisit={isRevisit}
+        productCode={productCode}
       />
     </div>
   );

--- a/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
+++ b/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MspLayoutClient } from '@/app/msp/MspLayoutClient';
+import { getTenantSettings } from '@alga-psa/tenancy/actions';
 
 const mockUsePathname = vi.fn(() => '/msp/tickets');
 const mockReplace = vi.fn();
@@ -32,6 +33,10 @@ vi.mock('@alga-psa/tenancy/components', () => ({
   I18nWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('@alga-psa/tenancy/actions', () => ({
+  getTenantSettings: vi.fn(),
+}));
+
 vi.mock('@/context/TierContext', () => ({
   TierProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -54,7 +59,10 @@ vi.mock('@/components/product/ProductRouteBoundary', () => ({
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
+
+const mockGetTenantSettings = vi.mocked(getTenantSettings);
 
 describe('MspLayoutClient product shell behavior', () => {
   it('RT006: renders Algadesk shell for allowed Algadesk MSP routes', () => {
@@ -88,5 +96,30 @@ describe('MspLayoutClient product shell behavior', () => {
 
     expect(screen.getByTestId('psa-default-layout')).toBeInTheDocument();
     expect(screen.queryByTestId('algadesk-shell')).not.toBeInTheDocument();
+  });
+
+  it('RT006: client fallback redirects Algadesk tenants when onboarding is incomplete', async () => {
+    mockGetTenantSettings.mockResolvedValue({
+      tenant: 'tenant-1',
+      onboarding_completed: false,
+      onboarding_skipped: false,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    render(
+      <MspLayoutClient
+        session={{ user: { tenant: 'tenant-1' } } as any}
+        productCode="algadesk"
+        needsOnboarding={false}
+        initialSidebarCollapsed={false}
+      >
+        <div>algadesk content</div>
+      </MspLayoutClient>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/msp/onboarding');
+    });
   });
 });

--- a/server/src/test/unit/onboarding/algadeskOnboardingWizard.productSteps.test.ts
+++ b/server/src/test/unit/onboarding/algadeskOnboardingWizard.productSteps.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { ONBOARDING_WIZARD_STEPS } from '@alga-psa/types';
+import {
+  getOnboardingWizardRequiredStepPositions,
+  getOnboardingWizardStepIndexes,
+} from '@alga-psa/onboarding/lib';
+
+describe('Algadesk onboarding wizard product steps', () => {
+  it('preserves the full PSA wizard step list', () => {
+    const stepIndexes = getOnboardingWizardStepIndexes('psa');
+
+    expect(stepIndexes).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(stepIndexes.map((index) => ONBOARDING_WIZARD_STEPS[index])).toEqual([
+      'Client Info',
+      'Team Members',
+      'Add Client',
+      'Client Contact',
+      'Billing',
+      'Ticketing',
+    ]);
+    expect(getOnboardingWizardRequiredStepPositions('psa')).toEqual([0, 5]);
+  });
+
+  it('removes Billing from Algadesk while keeping help-desk setup and required ticketing', () => {
+    const stepIndexes = getOnboardingWizardStepIndexes('algadesk');
+    const stepLabels = stepIndexes.map((index) => ONBOARDING_WIZARD_STEPS[index]);
+
+    expect(stepLabels).toEqual([
+      'Client Info',
+      'Team Members',
+      'Add Client',
+      'Client Contact',
+      'Ticketing',
+    ]);
+    expect(stepLabels).not.toContain('Billing');
+    expect(getOnboardingWizardRequiredStepPositions('algadesk')).toEqual([0, 4]);
+  });
+
+  it('keeps Algadesk-specific wizard shell copy in the shared wizard source', () => {
+    const source = readFileSync(
+      join(process.cwd(), '../packages/onboarding/src/components/OnboardingWizard.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain("onboardingWizard.shell.algadeskTitle");
+    expect(source).toContain('Set Up Algadesk');
+    expect(source).toContain('Configure your help desk workspace, clients, and ticketing defaults.');
+  });
+
+  it('defines Algadesk onboarding translation keys for every locale', () => {
+    const localesRoot = join(process.cwd(), 'public/locales');
+    const locales = readdirSync(localesRoot);
+
+    for (const locale of locales) {
+      const source = readFileSync(join(localesRoot, locale, 'msp/onboarding.json'), 'utf8');
+      const messages = JSON.parse(source);
+
+      expect(messages.onboardingWizard.steps.algadeskWorkspace, locale).toBeTruthy();
+      expect(messages.onboardingWizard.shell.algadeskTitle, locale).toBeTruthy();
+      expect(messages.onboardingWizard.shell.algadeskDescription, locale).toBeTruthy();
+    }
+  });
+
+  it('wires the MSP onboarding page to pass productCode into OnboardingWizard', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/app/msp/onboarding/page.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain("import { useProduct } from '@/context/ProductContext';");
+    expect(source).toContain('const { productCode } = useProduct();');
+    expect(source).toContain('productCode={productCode}');
+  });
+});

--- a/server/src/test/unit/onboarding/clientInfoStepRendering.test.tsx
+++ b/server/src/test/unit/onboarding/clientInfoStepRendering.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
       return interpolate(template, options);
     },
   }),
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: vi.fn(),
+  }),
 }));
 
 vi.mock('@alga-psa/validation', () => ({

--- a/server/src/test/unit/onboarding/onboardingWizardDataSeparation.test.tsx
+++ b/server/src/test/unit/onboarding/onboardingWizardDataSeparation.test.tsx
@@ -15,6 +15,10 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
     t: (key: string, options?: Record<string, unknown>) =>
       String(options?.defaultValue ?? key),
   }),
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: vi.fn(),
+  }),
 }));
 
 vi.mock('@alga-psa/validation', () => ({
@@ -86,6 +90,7 @@ describe('Onboarding wizard data separation: tenantName vs clientName', () => {
       const data = makeWizardData();
 
       render(<ClientInfoStep data={data} updateData={updateData} isRevisit />);
+      updateData.mockClear();
 
       const input = screen.getByPlaceholderText('Acme IT Solutions');
       await import('@testing-library/user-event').then(async ({ default: userEvent }) => {
@@ -93,6 +98,7 @@ describe('Onboarding wizard data separation: tenantName vs clientName', () => {
       });
 
       const calls = updateData.mock.calls.flat();
+      expect(calls.length).toBeGreaterThan(0);
       expect(calls.every((call: Record<string, unknown>) => 'tenantName' in call)).toBe(true);
       expect(calls.some((call: Record<string, unknown>) => 'clientName' in call)).toBe(false);
     });


### PR DESCRIPTION
## Summary
- Add product-aware onboarding wizard steps so Algadesk uses a shortened help-desk setup flow without Billing
- Pass tenant product code into the onboarding wizard and update Algadesk-specific onboarding copy/locales
- Add client-side onboarding enforcement fallback for Algadesk/PSA layouts when server props are stale
- Add plan docs and focused unit coverage for product-specific wizard steps and layout redirect behavior

## Smoke validation
Using Alga Dev against http://localhost:3234:
- Algadesk wizard shows Set Up Algadesk and steps: Workspace, Team Members, Add Client, Client Contact, Ticketing
- Algadesk skips optional setup directly to Ticketing without Billing
- Algadesk blocks completion until board/default open status/priority exist, then lands in Algadesk shell
- Algadesk /msp/billing shows upgrade boundary while tickets remain functional without service catalog setup
- PSA wizard still shows full flow with Billing between Client Contact and Ticketing
- PSA Billing step saves a service and advances to Ticketing

## Tests
- cd server && npx vitest run src/test/unit/layout/MspLayoutClient.productShell.test.tsx src/test/unit/onboarding/algadeskOnboardingWizard.productSteps.test.ts src/test/unit/onboarding/clientInfoStepRendering.test.tsx src/test/unit/onboarding/onboardingWizardDataSeparation.test.tsx --coverage.enabled=false