### PR TITLE
Persist client-portal notification toggles

### DIFF
--- a/packages/client-portal/src/components/profile/ClientProfile.tsx
+++ b/packages/client-portal/src/components/profile/ClientProfile.tsx
@@ -19,6 +19,7 @@ import { useContactAvatar, invalidateContactAvatar } from '@alga-psa/user-compos
 import {
   getCategoriesAction,
   getCategoryWithSubtypesAction,
+  getUserPreferencesAction,
   updateUserPreferenceAction
 } from '@alga-psa/notifications/actions';
 import type { NotificationCategory, NotificationSubtype, UserNotificationPreference } from '@alga-psa/notifications';
@@ -89,18 +90,38 @@ export function ClientProfile() {
         setCurrentEffectiveLocale(inherited.locale);
         setInheritedSource(inherited.source);
 
-        // Get notification categories and subtypes
+        // Get notification categories, subtypes, and saved user email preferences
         const notificationCategories = await getCategoriesAction();
-        setCategories(notificationCategories);
+        const emailPreferences = await getUserPreferencesAction(currentUser.tenant, currentUser.user_id);
+        const emailPreferenceBySubtype = new Map(
+          emailPreferences.map((preference: UserNotificationPreference) => [
+            preference.subtype_id,
+            preference.is_enabled
+          ])
+        );
 
         // Get subtypes for each category
         const subtypes: Record<number, NotificationSubtype[]> = {};
         await Promise.all(
           notificationCategories.map(async (category: NotificationCategory): Promise<void> => {
             const { subtypes: categorySubtypes } = await getCategoryWithSubtypesAction(category.id);
-            subtypes[category.id] = categorySubtypes;
+            subtypes[category.id] = categorySubtypes.map((subtype: NotificationSubtype) => ({
+              ...subtype,
+              is_enabled: subtype.is_enabled && (emailPreferenceBySubtype.get(subtype.id) ?? true)
+            }));
           })
         );
+        setCategories(notificationCategories.map((category: NotificationCategory) => {
+          const categorySubtypes = subtypes[category.id] ?? [];
+          if (categorySubtypes.length === 0) {
+            return category;
+          }
+
+          return {
+            ...category,
+            is_enabled: categorySubtypes.every((subtype: NotificationSubtype) => subtype.is_enabled)
+          };
+        }));
         setSubtypesByCategory(subtypes);
 
       } catch (err) {
@@ -149,21 +170,78 @@ export function ClientProfile() {
     }
   };
 
-  const handleCategoryToggle = (categoryId: number, enabled: boolean) => {
-    setCategories(prev => 
-      prev.map((cat):NotificationCategory => 
-        cat.id === categoryId ? { ...cat, is_enabled: enabled } : cat
-      )
-    );
+  const handleCategoryToggle = async (categoryId: number, enabled: boolean) => {
+    if (!user) return;
+
+    const categorySubtypes = subtypesByCategory[categoryId] ?? [];
+
+    try {
+      await Promise.all(
+        categorySubtypes.map((subtype: NotificationSubtype) =>
+          updateUserPreferenceAction(user.tenant, user.user_id, {
+            subtype_id: subtype.id,
+            is_enabled: enabled
+          })
+        )
+      );
+
+      setSubtypesByCategory(prev => ({
+        ...prev,
+        [categoryId]: (prev[categoryId] ?? []).map((subtype): NotificationSubtype => ({
+          ...subtype,
+          is_enabled: enabled
+        }))
+      }));
+
+      setCategories(prev =>
+        prev.map((cat): NotificationCategory =>
+          cat.id === categoryId ? { ...cat, is_enabled: enabled } : cat
+        )
+      );
+    } catch (err) {
+      toast.error(tProfile('notifications.preferences.saveError', 'Failed to save preference'));
+      handleError(err, tProfile('notifications.preferences.saveError', 'Failed to save preference'));
+    }
   };
 
-  const handleSubtypeToggle = (categoryId: number, subtypeId: number, enabled: boolean) => {
-    setSubtypesByCategory(prev => ({
-      ...prev,
-      [categoryId]: prev[categoryId].map((subtype):NotificationSubtype =>
-        subtype.id === subtypeId ? { ...subtype, is_enabled: enabled } : subtype
-      )
-    }));
+  const handleSubtypeToggle = async (categoryId: number, subtypeId: number, enabled: boolean) => {
+    if (!user) return;
+
+    try {
+      await updateUserPreferenceAction(user.tenant, user.user_id, {
+        subtype_id: subtypeId,
+        is_enabled: enabled
+      });
+
+      setSubtypesByCategory(prev => ({
+        ...prev,
+        [categoryId]: (prev[categoryId] ?? []).map((subtype): NotificationSubtype =>
+          subtype.id === subtypeId ? { ...subtype, is_enabled: enabled } : subtype
+        )
+      }));
+
+      setCategories(prev =>
+        prev.map((category): NotificationCategory => {
+          if (category.id !== categoryId) {
+            return category;
+          }
+
+          const updatedSubtypes = (subtypesByCategory[categoryId] ?? []).map((subtype): NotificationSubtype =>
+            subtype.id === subtypeId ? { ...subtype, is_enabled: enabled } : subtype
+          );
+
+          return {
+            ...category,
+            is_enabled: updatedSubtypes.length > 0
+              ? updatedSubtypes.every((subtype: NotificationSubtype) => subtype.is_enabled)
+              : enabled
+          };
+        })
+      );
+    } catch (err) {
+      toast.error(tProfile('notifications.preferences.saveError', 'Failed to save preference'));
+      handleError(err, tProfile('notifications.preferences.saveError', 'Failed to save preference'));
+    }
   };
 
   // Define tab labels (must be before early returns to maintain hook order)

--- a/server/public/locales/pt/client-portal.json
+++ b/server/public/locales/pt/client-portal.json
@@ -12,7 +12,7 @@
     "signOut": "Sign out",
     "clientPortal": "Client Portal",
     "portal": "Portal",
-    "notifications": "Notifications",
+    "notifications": "Notificações",
     "documents": "Documents",
     "knowledgeBase": "Knowledge Base",
     "requestServices": "Pedidos de serviço",
@@ -392,7 +392,7 @@
     "preferences": "Preferences",
     "security": "Security",
     "activity": "Activity",
-    "notificationSettings": "Notification Settings",
+    "notificationSettings": "Definições de notificações",
     "fields": {
       "firstName": "First Name",
       "lastName": "Last Name",
@@ -434,14 +434,14 @@
       "disabled": "Disabled"
     },
     "notifications": {
-      "title": "Notification Settings",
-      "email": "Email Notifications",
+      "title": "Definições de notificações",
+      "email": "Notificações por email",
       "ticketUpdates": "Ticket Updates",
       "projectUpdates": "Project Updates",
       "invoices": "Invoice Notifications",
       "announcements": "System Announcements",
       "emailPreferences": "Email",
-      "internalPreferences": "Internal"
+      "internalPreferences": "Internas"
     },
     "actions": {
       "save": "Save Changes",
@@ -602,7 +602,7 @@
       "save": "Save group",
       "create": "Create group",
       "nameRequired": "Visibility group name is required",
-      "saveError": "Unable to save visibility group",
+      "saveError": "Não foi possível guardar o grupo de visibilidade",
       "updateSuccess": "Visibility group updated",
       "createSuccess": "Visibility group created",
       "assignmentsTitle": "Contact assignments",
@@ -616,11 +616,11 @@
     }
   },
   "notifications": {
-    "title": "Notifications",
+    "title": "Notificações",
     "markAsRead": "Mark as read",
     "markAllAsRead": "Mark all as read",
     "noNotifications": "No new notifications",
-    "settings": "Notification Settings",
+    "settings": "Definições de notificações",
     "viewAll": "View all notifications",
     "tabs": {
       "unread": "Unread",
@@ -628,14 +628,14 @@
       "read": "Read"
     },
     "preferences": {
-      "title": "Notification Preferences",
-      "description": "Manage which internal notifications you receive",
-      "loading": "Loading preferences...",
-      "loadError": "Failed to load preferences",
-      "saveError": "Failed to save preference",
-      "noCategories": "No notification categories available",
-      "emailPreferences": "Email preferences",
-      "internalPreferences": "Internal preferences"
+      "title": "Preferências de notificações",
+      "description": "Gerir as notificações internas que recebe",
+      "loading": "A carregar preferências...",
+      "loadError": "Falha ao carregar as preferências",
+      "saveError": "Falha ao guardar a preferência",
+      "noCategories": "Não há categorias de notificação disponíveis",
+      "emailPreferences": "Preferências de email",
+      "internalPreferences": "Preferências internas"
     },
     "categories": {
       "tickets": "Tickets",


### PR DESCRIPTION
  Client profile notification toggles were UI-only — no save call,
  nothing reloaded from server. Wire handleCategoryToggle and
  handleSubtypeToggle to updateUserPreferenceAction (per-subtype) and
  hydrate state on mount via getUserPreferencesAction so saved settings
  survive a refresh. Category toggle fans out to every subtype; subtype
  toggle recomputes the category checkbox from its children. Also fix
  half-untranslated pt strings on the same screen (notifications,
  notification settings, preference labels, visibility-group save error).

    "I should hardly have thought my preferences would persist," sighed
    Alice, "for they vanished the moment I looked away — but lo, the
    emailPreferenceBySubtype map remembered, the Map of Wonderland did
    recall, and the Cheshire toggle stayed put with a small Portuguese
    smile." 📬🐈