### PR TITLE
fix: shared HOCUSPOCUS_JWT_SECRET + ticket subscriber reconnect

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -232,6 +232,13 @@ spec:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: AI_DOCUMENT_API_KEY
 
+          # ----------- HOCUSPOCUS JWT ----------------
+          - name: HOCUSPOCUS_JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: HOCUSPOCUS_JWT_SECRET
+
           # ----------- TEMPORAL ----------------
           - name: TEMPORAL_ADDRESS
             value: "{{ .Values.temporal.address }}"

--- a/helm/templates/hocuspocus/deployment.yaml
+++ b/helm/templates/hocuspocus/deployment.yaml
@@ -155,6 +155,12 @@ spec:
               secretKeyRef:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: AI_DOCUMENT_API_KEY
+          # ----------- HOCUSPOCUS JWT ----------------
+          - name: HOCUSPOCUS_JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: HOCUSPOCUS_JWT_SECRET
           ports:
             - name: http
               containerPort: {{ .Values.hocuspocus.service.port }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -20,6 +20,7 @@ data:
   TOKEN_SECRET_KEY: {{ if and .Values.secrets .Values.secrets.TOKEN_SECRET_KEY }}{{ .Values.secrets.TOKEN_SECRET_KEY | b64enc | quote }}{{ else }}{{ index $existing.data "TOKEN_SECRET_KEY" }}{{ end }}
   IMAP_WEBHOOK_SECRET: {{ if and .Values.secrets .Values.secrets.IMAP_WEBHOOK_SECRET }}{{ .Values.secrets.IMAP_WEBHOOK_SECRET | b64enc | quote }}{{ else }}{{ index $existing.data "IMAP_WEBHOOK_SECRET" }}{{ end }}
   AI_DOCUMENT_API_KEY: {{ if and .Values.secrets .Values.secrets.AI_DOCUMENT_API_KEY }}{{ .Values.secrets.AI_DOCUMENT_API_KEY | b64enc | quote }}{{ else }}{{ index $existing.data "AI_DOCUMENT_API_KEY" }}{{ end }}
+  HOCUSPOCUS_JWT_SECRET: {{ if and .Values.secrets .Values.secrets.HOCUSPOCUS_JWT_SECRET }}{{ .Values.secrets.HOCUSPOCUS_JWT_SECRET | b64enc | quote }}{{ else }}{{ index $existing.data "HOCUSPOCUS_JWT_SECRET" }}{{ end }}
   {{- if and .Values.secrets .Values.secrets.stripe_secret_key }}
   stripe_secret_key: {{ .Values.secrets.stripe_secret_key | b64enc | quote }}
   {{- else if index $existing.data "stripe_secret_key" }}
@@ -113,6 +114,7 @@ data:
   TOKEN_SECRET_KEY: {{ (.Values.secrets.TOKEN_SECRET_KEY | default (randAlphaNum 32)) | b64enc | quote }}
   IMAP_WEBHOOK_SECRET: {{ (.Values.secrets.IMAP_WEBHOOK_SECRET | default (randAlphaNum 48)) | b64enc | quote }}
   AI_DOCUMENT_API_KEY: {{ (.Values.secrets.AI_DOCUMENT_API_KEY | default (randAlphaNum 64)) | b64enc | quote }}
+  HOCUSPOCUS_JWT_SECRET: {{ (.Values.secrets.HOCUSPOCUS_JWT_SECRET | default (randAlphaNum 64)) | b64enc | quote }}
   {{- if .Values.secrets.stripe_secret_key }}
   stripe_secret_key: {{ .Values.secrets.stripe_secret_key | b64enc | quote }}
   {{- end }}
@@ -170,5 +172,6 @@ data:
   TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   IMAP_WEBHOOK_SECRET: {{ randAlphaNum 48 | b64enc | quote }}
   AI_DOCUMENT_API_KEY: {{ randAlphaNum 64 | b64enc | quote }}
+  HOCUSPOCUS_JWT_SECRET: {{ randAlphaNum 64 | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/hocuspocus/TicketUpdatesExtension.js
+++ b/hocuspocus/TicketUpdatesExtension.js
@@ -52,6 +52,9 @@ export class TicketUpdatesExtension {
     })
 
     this.subscriber.on('ready', async () => {
+      // Redis drops server-side subscriptions on every reconnect; treat each
+      // 'ready' as a fresh session and re-issue pSubscribe.
+      this.hasPatternSubscription = false
       await this.ensurePatternSubscription()
     })
 


### PR DESCRIPTION
Wire HOCUSPOCUS_JWT_SECRET via secretKeyRef in both sebastian and hocuspocus deployment templates and add it to the helm-managed Secret (preserve on upgrade, generate randAlphaNum 64 when not provided). Without it /api/tickets/[id]/live-token throws "HOCUSPOCUS_JWT_SECRET is required in production" and hocuspocus falls back to a fixed dev secret, so JWTs never verify and clients stay stuck on "Live updates offline".

TicketUpdatesExtension: reset hasPatternSubscription on Redis 'ready' so reconnects re-issue pSubscribe. node-redis fires error -> reconnecting -> ready on transient disconnect (not 'end'), and Redis drops server-side pattern subscriptions on every reconnect, so the guard flag must clear on each 'ready'.