### PR TITLE
Update README workflow automation content

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,7 +20,7 @@ Alga PSA is built around the way MSPs operate with clients:
 - **Time and approvals connected to billing** so billable work can move toward invoices with less duplicate entry.
 - **Contracts, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
-- **Workflow automation and an event bus** for teams that need repeatable handoffs, notifications, and business processes.
+- **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
 - **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
 
 ## Features at a glance
@@ -47,8 +47,8 @@ Alga PSA is built around the way MSPs operate with clients:
 
 ### Automation, reporting, and controls
 
-- Automation Hub for TypeScript-based workflows with event-driven triggers
-- Workflow editor with code completion, versioning, history, and templates
+- Workflow Automation with an Event Catalog for ticket, billing, scheduling, email, project, CRM, asset, document, and integration triggers
+- Visual workflow designer for event-driven, one-time scheduled, recurring scheduled, and manual runs, with versioning and run history
 - Redis-backed event processing for asynchronous work and system events
 - Reporting and analytics for operational visibility
 - Role-based access control (RBAC) and attribute-based access control (ABAC)
@@ -58,7 +58,7 @@ Some capabilities may depend on edition, deployment configuration, or enabled fe
 
 ## Product screenshots
 
-These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features).
+These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features) and the [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers).
 
 | Service desk | Billing and time |
 | --- | --- |
@@ -66,8 +66,8 @@ These images link directly to screenshots from the [Alga PSA feature tour](https
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
-| <img src="https://www.nineminds.com/imported-media/Workflows.png" alt="Alga PSA workflows screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Assets%20Asset%20workspace%20overview.png" alt="Alga PSA asset workspace overview" width="420"> |
-| Workflow tools for repeatable processes and handoffs. | Asset views for client equipment and service context. |
+| <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
+| Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
 ## Quick start
 
@@ -113,7 +113,7 @@ Alga PSA is a TypeScript monorepo with a Next.js application, shared domain pack
 | Backend | Next.js API routes running on Node.js, shared domain packages, and a dedicated workflow worker service |
 | Database | PostgreSQL with row-level security for tenant isolation |
 | Event processing | Redis-backed event bus with Zod schema validation for asynchronous system events |
-| Workflow execution | Dedicated workflow worker service for processing workflow jobs outside the request path |
+| Workflow execution | Temporal-backed workflow runtime and worker services for event-triggered, scheduled, and manual workflow runs |
 | Real-time collaboration | Hocuspocus/Yjs for collaborative document editing |
 | Authentication | NextAuth.js with separate MSP and client portal access surfaces |
 | Packages | npm workspaces and Nx-managed `@alga-psa/*` packages for billing, clients, tickets, documents, scheduling, reporting, integrations, and shared infrastructure |
@@ -149,9 +149,10 @@ Useful technical docs:
 - [Asset Management](../docs/features/asset_management.md)
 - [SLA Management](../docs/features/sla.md)
 - [Time Entry Guide](../docs/features/time_entry.md)
-- [Workflow System](../docs/workflow/workflow-system.md)
-- [TypeScript Workflow Creation](../docs/workflow/typescript-workflow-creation.md)
-- [Automation Hub Guide](../docs/workflow/automation-hub-workflow-guide.md)
+- [Workflow Automation for MSPs](https://www.nineminds.com/documentation/151-workflow-automation-for-msps)
+- [Choosing Workflow Triggers](https://www.nineminds.com/documentation/152-choosing-workflow-triggers)
+- [Building Your First MSP Workflow](https://www.nineminds.com/documentation/153-building-your-first-msp-workflow)
+- [Publishing and Monitoring Workflows](https://www.nineminds.com/documentation/156-publishing-monitoring-workflows)
 
 ### Development and contribution
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -21,7 +21,9 @@ Alga PSA is built around the way MSPs operate with clients:
 - **Contracts, sales quotes, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
 - **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
-- **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
+- **Open-source core with self-hosting support** so MSPs and technical teams can keep control over deployment, data, and code review.
+
+Community Edition is the self-hostable AGPL core. Enterprise Edition covers commercially licensed modules and larger deployment needs. See [Editions and licensing](#editions-and-licensing) for details.
 
 ## Features at a glance
 
@@ -34,6 +36,7 @@ Alga PSA is built around the way MSPs operate with clients:
 - Document management with version control
 - Asset management for client equipment, maintenance schedules, and relationships
 - Project and task management for longer-running client work
+- Scheduling and dispatch views for planned work and technician coordination
 
 ### Time, contracts, billing, and invoicing
 
@@ -41,11 +44,11 @@ Alga PSA is built around the way MSPs operate with clients:
 - Automatic interval tracking for ticket work, stored in the browser with IndexedDB
 - Conversion of tracked intervals into time entries
 - Flexible billing cycles by company, including weekly, bi-weekly, monthly, and quarterly billing
-- Proration support, approval-based time billing, and unapproved time rollover
-- Contract purchase order support, including PO numbers on invoices and advisory PO limits
+- Billing-period support for proration and unapproved time rollover
+- Contract purchase order support with PO numbers and advisory PO limits
 - Sales quotes for pricing proposals, optional line items, approvals, client portal acceptance, and conversion to contracts or invoices
 - Graphical invoice and quote designer for branded PDF layouts, data-bound fields, line-item tables, preview, and per-document template overrides
-- International tax support, including composite taxes, threshold-based rates, tax holidays, and reverse charge scenarios
+- International tax support with composite rates, thresholds, tax holidays, and reverse charge scenarios
 
 ### Automation, reporting, and controls
 
@@ -55,29 +58,30 @@ Alga PSA is built around the way MSPs operate with clients:
 - Reporting and analytics for operational visibility
 - Role-based access control (RBAC) and attribute-based access control (ABAC)
 - Multi-portal authentication for MSP users and client portal users
+- API, OpenAPI registry material, and extension SDK support for integrations and custom workflows
 
-Some capabilities may depend on edition, deployment configuration, or enabled feature flags. See the setup and architecture docs for implementation details.
+Feature availability varies by edition, deployment configuration, and enabled feature flags. See the setup and architecture docs for implementation details.
 
 ## Product screenshots
 
 These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features), [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers), and [Invoice Designer docs](https://www.nineminds.com/documentation/1410-bind-invoice-data-to-your-layout).
 
-| Service desk | Billing and time |
+| Core workflow | Business operations |
 | --- | --- |
 | <img src="https://www.nineminds.com/imported-media/Ticketing-1.gif" alt="Alga PSA ticketing screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Billing%20dashboard.png" alt="Alga PSA billing dashboard" width="420"> |
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
-| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/invoice-designer-fields.png" alt="Alga PSA invoice designer fields tab" width="420"> |
-| Drag-and-drop invoice and quote layout designer with palette, canvas, and inspector. | Data bindings for customer, invoice, quote, line-item, and tenant fields. |
-| <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
-| Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
+| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
+| Drag-and-drop invoice and quote layout designer for branded PDFs. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
 ## Quick start
 
 For a full installation, use the [Complete Setup Guide](../docs/getting-started/setup_guide.md). It covers release selection, secrets, environment configuration, Docker Compose, initial login credentials, persistence, backups, and production notes.
 
 The current CE prebuilt Docker Compose path is below. Before running these commands, follow the setup guide to create the required `secrets/` directory and `server/.env` file.
+
+The stack boots PostgreSQL, the Next.js application server, and the workflow worker. On first start, the server creates a seeded workspace admin account; tail the logs below to retrieve the credentials.
 
 ```bash
 git clone https://github.com/nine-minds/alga-psa.git
@@ -108,6 +112,8 @@ docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.c
 For Windows-specific setup, see the [Windows Setup Guide](../docs/getting-started/setup_guide_windows.md).
 
 ## Technical architecture
+
+The following details are for teams evaluating the technical stack. For deployment requirements, see [Quick start](#quick-start).
 
 Alga PSA is a TypeScript monorepo with a Next.js application, shared domain packages, worker services, and Docker-based deployment paths.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -18,7 +18,7 @@ Alga PSA is built around the way MSPs operate with clients:
 
 - **Tickets tied to clients, contacts, assets, and service history** so the team has context before work starts.
 - **Time and approvals connected to billing** so billable work can move toward invoices with less duplicate entry.
-- **Contracts, recurring services, tax, and invoice workflows** for the financial side of service delivery.
+- **Contracts, sales quotes, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
 - **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
 - **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
@@ -43,6 +43,8 @@ Alga PSA is built around the way MSPs operate with clients:
 - Flexible billing cycles by company, including weekly, bi-weekly, monthly, and quarterly billing
 - Proration support, approval-based time billing, and unapproved time rollover
 - Contract purchase order support, including PO numbers on invoices and advisory PO limits
+- Sales quotes for pricing proposals, optional line items, approvals, client portal acceptance, and conversion to contracts or invoices
+- Graphical invoice and quote designer for branded PDF layouts, data-bound fields, line-item tables, preview, and per-document template overrides
 - International tax support, including composite taxes, threshold-based rates, tax holidays, and reverse charge scenarios
 
 ### Automation, reporting, and controls
@@ -58,7 +60,7 @@ Some capabilities may depend on edition, deployment configuration, or enabled fe
 
 ## Product screenshots
 
-These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features) and the [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers).
+These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features), [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers), and [Invoice Designer docs](https://www.nineminds.com/documentation/1410-bind-invoice-data-to-your-layout).
 
 | Service desk | Billing and time |
 | --- | --- |
@@ -66,6 +68,8 @@ These images link directly to screenshots from the [Alga PSA feature tour](https
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
+| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/invoice-designer-fields.png" alt="Alga PSA invoice designer fields tab" width="420"> |
+| Drag-and-drop invoice and quote layout designer with palette, canvas, and inspector. | Data bindings for customer, invoice, quote, line-item, and tenant fields. |
 | <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
 | Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
@@ -145,6 +149,8 @@ Useful technical docs:
 ### MSP feature areas
 
 - [Billing System](../docs/billing/billing.md)
+- [Invoice Templates](../docs/billing/invoice_templates.md)
+- [Quoting System](../docs/billing/quoting-system.md)
 - [International Tax Support](../docs/billing/tax/international_tax_support.md)
 - [Asset Management](../docs/features/asset_management.md)
 - [SLA Management](../docs/features/sla.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Alga PSA is built around the way MSPs operate with clients:
 - **Contracts, sales quotes, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
 - **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
-- **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
+- **Open-source core with self-hosting support** so MSPs and technical teams can keep control over deployment, data, and code review.
+
+Community Edition is the self-hostable AGPL core. Enterprise Edition covers commercially licensed modules and larger deployment needs. See [Editions and licensing](#editions-and-licensing) for details.
 
 ## Features at a glance
 
@@ -34,6 +36,7 @@ Alga PSA is built around the way MSPs operate with clients:
 - Document management with version control
 - Asset management for client equipment, maintenance schedules, and relationships
 - Project and task management for longer-running client work
+- Scheduling and dispatch views for planned work and technician coordination
 
 ### Time, contracts, billing, and invoicing
 
@@ -41,11 +44,11 @@ Alga PSA is built around the way MSPs operate with clients:
 - Automatic interval tracking for ticket work, stored in the browser with IndexedDB
 - Conversion of tracked intervals into time entries
 - Flexible billing cycles by company, including weekly, bi-weekly, monthly, and quarterly billing
-- Proration support, approval-based time billing, and unapproved time rollover
-- Contract purchase order support, including PO numbers on invoices and advisory PO limits
+- Billing-period support for proration and unapproved time rollover
+- Contract purchase order support with PO numbers and advisory PO limits
 - Sales quotes for pricing proposals, optional line items, approvals, client portal acceptance, and conversion to contracts or invoices
 - Graphical invoice and quote designer for branded PDF layouts, data-bound fields, line-item tables, preview, and per-document template overrides
-- International tax support, including composite taxes, threshold-based rates, tax holidays, and reverse charge scenarios
+- International tax support with composite rates, thresholds, tax holidays, and reverse charge scenarios
 
 ### Automation, reporting, and controls
 
@@ -55,29 +58,30 @@ Alga PSA is built around the way MSPs operate with clients:
 - Reporting and analytics for operational visibility
 - Role-based access control (RBAC) and attribute-based access control (ABAC)
 - Multi-portal authentication for MSP users and client portal users
+- API, OpenAPI registry material, and extension SDK support for integrations and custom workflows
 
-Some capabilities may depend on edition, deployment configuration, or enabled feature flags. See the setup and architecture docs for implementation details.
+Feature availability varies by edition, deployment configuration, and enabled feature flags. See the setup and architecture docs for implementation details.
 
 ## Product screenshots
 
 These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features), [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers), and [Invoice Designer docs](https://www.nineminds.com/documentation/1410-bind-invoice-data-to-your-layout).
 
-| Service desk | Billing and time |
+| Core workflow | Business operations |
 | --- | --- |
 | <img src="https://www.nineminds.com/imported-media/Ticketing-1.gif" alt="Alga PSA ticketing screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Billing%20dashboard.png" alt="Alga PSA billing dashboard" width="420"> |
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
-| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/invoice-designer-fields.png" alt="Alga PSA invoice designer fields tab" width="420"> |
-| Drag-and-drop invoice and quote layout designer with palette, canvas, and inspector. | Data bindings for customer, invoice, quote, line-item, and tenant fields. |
-| <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
-| Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
+| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
+| Drag-and-drop invoice and quote layout designer for branded PDFs. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
 ## Quick start
 
 For a full installation, use the [Complete Setup Guide](docs/getting-started/setup_guide.md). It covers release selection, secrets, environment configuration, Docker Compose, initial login credentials, persistence, backups, and production notes.
 
 The current CE prebuilt Docker Compose path is below. Before running these commands, follow the setup guide to create the required `secrets/` directory and `server/.env` file.
+
+The stack boots PostgreSQL, the Next.js application server, and the workflow worker. On first start, the server creates a seeded workspace admin account; tail the logs below to retrieve the credentials.
 
 ```bash
 git clone https://github.com/nine-minds/alga-psa.git
@@ -108,6 +112,8 @@ docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.c
 For Windows-specific setup, see the [Windows Setup Guide](docs/getting-started/setup_guide_windows.md).
 
 ## Technical architecture
+
+The following details are for teams evaluating the technical stack. For deployment requirements, see [Quick start](#quick-start).
 
 Alga PSA is a TypeScript monorepo with a Next.js application, shared domain packages, worker services, and Docker-based deployment paths.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alga PSA is built around the way MSPs operate with clients:
 
 - **Tickets tied to clients, contacts, assets, and service history** so the team has context before work starts.
 - **Time and approvals connected to billing** so billable work can move toward invoices with less duplicate entry.
-- **Contracts, recurring services, tax, and invoice workflows** for the financial side of service delivery.
+- **Contracts, sales quotes, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
 - **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
 - **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
@@ -43,6 +43,8 @@ Alga PSA is built around the way MSPs operate with clients:
 - Flexible billing cycles by company, including weekly, bi-weekly, monthly, and quarterly billing
 - Proration support, approval-based time billing, and unapproved time rollover
 - Contract purchase order support, including PO numbers on invoices and advisory PO limits
+- Sales quotes for pricing proposals, optional line items, approvals, client portal acceptance, and conversion to contracts or invoices
+- Graphical invoice and quote designer for branded PDF layouts, data-bound fields, line-item tables, preview, and per-document template overrides
 - International tax support, including composite taxes, threshold-based rates, tax holidays, and reverse charge scenarios
 
 ### Automation, reporting, and controls
@@ -58,7 +60,7 @@ Some capabilities may depend on edition, deployment configuration, or enabled fe
 
 ## Product screenshots
 
-These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features) and the [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers).
+These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features), [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers), and [Invoice Designer docs](https://www.nineminds.com/documentation/1410-bind-invoice-data-to-your-layout).
 
 | Service desk | Billing and time |
 | --- | --- |
@@ -66,6 +68,8 @@ These images link directly to screenshots from the [Alga PSA feature tour](https
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
+| <img src="https://www.nineminds.com/docs-images/invoice-designer-workspace.png" alt="Alga PSA invoice and quote designer workspace" width="420"> | <img src="https://www.nineminds.com/docs-images/invoice-designer-fields.png" alt="Alga PSA invoice designer fields tab" width="420"> |
+| Drag-and-drop invoice and quote layout designer with palette, canvas, and inspector. | Data bindings for customer, invoice, quote, line-item, and tenant fields. |
 | <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
 | Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
@@ -145,6 +149,8 @@ Useful technical docs:
 ### MSP feature areas
 
 - [Billing System](docs/billing/billing.md)
+- [Invoice Templates](docs/billing/invoice_templates.md)
+- [Quoting System](docs/billing/quoting-system.md)
 - [International Tax Support](docs/billing/tax/international_tax_support.md)
 - [Asset Management](docs/features/asset_management.md)
 - [SLA Management](docs/features/sla.md)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alga PSA is built around the way MSPs operate with clients:
 - **Time and approvals connected to billing** so billable work can move toward invoices with less duplicate entry.
 - **Contracts, recurring services, tax, and invoice workflows** for the financial side of service delivery.
 - **Client portal and document workflows** so clients have a clearer place to submit requests, view information, and follow progress.
-- **Workflow automation and an event bus** for teams that need repeatable handoffs, notifications, and business processes.
+- **Workflow automation** for turning repeatable ticket, billing, notification, and approval steps into managed processes with Event Catalog triggers and scheduled runs.
 - **Open-source core with self-hosting support** for MSPs and technical teams that want deployment and data control.
 
 ## Features at a glance
@@ -47,8 +47,8 @@ Alga PSA is built around the way MSPs operate with clients:
 
 ### Automation, reporting, and controls
 
-- Automation Hub for TypeScript-based workflows with event-driven triggers
-- Workflow editor with code completion, versioning, history, and templates
+- Workflow Automation with an Event Catalog for ticket, billing, scheduling, email, project, CRM, asset, document, and integration triggers
+- Visual workflow designer for event-driven, one-time scheduled, recurring scheduled, and manual runs, with versioning and run history
 - Redis-backed event processing for asynchronous work and system events
 - Reporting and analytics for operational visibility
 - Role-based access control (RBAC) and attribute-based access control (ABAC)
@@ -58,7 +58,7 @@ Some capabilities may depend on edition, deployment configuration, or enabled fe
 
 ## Product screenshots
 
-These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features).
+These images link directly to screenshots from the [Alga PSA feature tour](https://www.nineminds.com/AlgaPSA-features) and the [Workflow Automation docs](https://www.nineminds.com/documentation/152-choosing-workflow-triggers).
 
 | Service desk | Billing and time |
 | --- | --- |
@@ -66,8 +66,8 @@ These images link directly to screenshots from the [Alga PSA feature tour](https
 | Ticketing views for client requests, assignment, attachments, and follow-up. | Contracts, billing, and invoice-related workflows in one billing area. |
 | <img src="https://www.nineminds.com/imported-media/time%20entry%20select%20time%20period.png" alt="Alga PSA time entry screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Schedule%20view.png" alt="Alga PSA schedule view" width="420"> |
 | Time entry views for recording and reviewing work before billing. | Schedule views for dispatch and calendar-based work planning. |
-| <img src="https://www.nineminds.com/imported-media/Workflows.png" alt="Alga PSA workflows screen" width="420"> | <img src="https://www.nineminds.com/imported-media/Assets%20Asset%20workspace%20overview.png" alt="Alga PSA asset workspace overview" width="420"> |
-| Workflow tools for repeatable processes and handoffs. | Asset views for client equipment and service context. |
+| <img src="https://www.nineminds.com/docs-images/workflow-event-catalog.png" alt="Alga PSA workflow event catalog" width="420"> | <img src="https://www.nineminds.com/docs-images/workflow-designer-ticket-triage.png" alt="Alga PSA visual workflow designer" width="420"> |
+| Event Catalog triggers for choosing the business moment that should start a workflow. | Visual workflow designer for ticket triage, notifications, approvals, and other repeatable processes. |
 
 ## Quick start
 
@@ -113,7 +113,7 @@ Alga PSA is a TypeScript monorepo with a Next.js application, shared domain pack
 | Backend | Next.js API routes running on Node.js, shared domain packages, and a dedicated workflow worker service |
 | Database | PostgreSQL with row-level security for tenant isolation |
 | Event processing | Redis-backed event bus with Zod schema validation for asynchronous system events |
-| Workflow execution | Dedicated workflow worker service for processing workflow jobs outside the request path |
+| Workflow execution | Temporal-backed workflow runtime and worker services for event-triggered, scheduled, and manual workflow runs |
 | Real-time collaboration | Hocuspocus/Yjs for collaborative document editing |
 | Authentication | NextAuth.js with separate MSP and client portal access surfaces |
 | Packages | npm workspaces and Nx-managed `@alga-psa/*` packages for billing, clients, tickets, documents, scheduling, reporting, integrations, and shared infrastructure |
@@ -149,9 +149,10 @@ Useful technical docs:
 - [Asset Management](docs/features/asset_management.md)
 - [SLA Management](docs/features/sla.md)
 - [Time Entry Guide](docs/features/time_entry.md)
-- [Workflow System](docs/workflow/workflow-system.md)
-- [TypeScript Workflow Creation](docs/workflow/typescript-workflow-creation.md)
-- [Automation Hub Guide](docs/workflow/automation-hub-workflow-guide.md)
+- [Workflow Automation for MSPs](https://www.nineminds.com/documentation/151-workflow-automation-for-msps)
+- [Choosing Workflow Triggers](https://www.nineminds.com/documentation/152-choosing-workflow-triggers)
+- [Building Your First MSP Workflow](https://www.nineminds.com/documentation/153-building-your-first-msp-workflow)
+- [Publishing and Monitoring Workflows](https://www.nineminds.com/documentation/156-publishing-monitoring-workflows)
 
 ### Development and contribution
 


### PR DESCRIPTION
## Summary
- Update README workflow wording to match the current Workflow Automation system
- Replace older TypeScript/code-editor framing with Event Catalog triggers, visual designer, scheduled/manual runs, versioning, and run history
- Add workflow documentation screenshots from the Nine Minds documentation site
- Replace stale workflow doc links with current documentation pages

## Validation
- Used subagents to inspect the current workflow implementation and docs
- Used Alga Dev browser to inspect https://www.nineminds.com/documentation/152-choosing-workflow-triggers
- Verified embedded image and documentation URLs return 200
- Ran git diff --check