### PR TITLE
Fix billing quote and contract navigation

### DIFF
--- a/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
+++ b/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
@@ -101,8 +101,12 @@ const BillingDashboard: React.FC<BillingDashboardProps> = ({
     router.push(`/msp/billing?${params.toString()}`);
   };
 
-  // Get current tab from URL or default to overview
-  const requestedTab = searchParams?.get('tab') as BillingTabValue | null;
+  // Get current tab from URL or default to overview.
+  // Preserve compatibility with old consolidated contracts URLs so they do not fall through to Quotes.
+  const requestedTabParam = searchParams?.get('tab');
+  const requestedTab = requestedTabParam === 'contracts'
+    ? (searchParams?.get('subtab') === 'templates' ? 'contract-templates' : 'client-contracts')
+    : (requestedTabParam as BillingTabValue | null);
   const availableValues = tabDefinitions.map((tab) => tab.value);
   const currentTab = availableValues.includes(requestedTab as BillingTabValue)
     ? (requestedTab as BillingTabValue)

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -436,10 +436,11 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
     updateContractViewParam(value);
   }, [updateContractViewParam]);
 
-  const contractsListUrl = useMemo(() => {
-    const targetSubtab = contract?.is_template ? 'templates' : 'client-contracts';
-    return `/msp/billing?tab=contracts&subtab=${targetSubtab}`;
-  }, [contract?.is_template]);
+  const contractsListUrl = useMemo(() => (
+    contract?.is_template
+      ? '/msp/billing?tab=contract-templates'
+      : '/msp/billing?tab=client-contracts'
+  ), [contract?.is_template]);
 
   // Track if there are unsaved changes
   const hasUnsavedChanges = useMemo(() => {
@@ -621,10 +622,7 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
     setIsDeleting(true);
     try {
       await deleteContract(detailContractId);
-      const params = new URLSearchParams();
-      params.set('tab', 'contracts');
-      params.set('subtab', 'client-contracts');
-      router.push(`/msp/billing?${params.toString()}`);
+      router.push('/msp/billing?tab=client-contracts');
     } catch (err) {
       console.error('Error deleting contract:', err);
       setError(err instanceof Error ? err.message : 'Failed to delete contract');

--- a/packages/billing/src/components/billing-dashboard/quotes/QuoteDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuoteDetail.tsx
@@ -21,6 +21,7 @@ import { approveQuote, convertQuoteToBoth, convertQuoteToContract, convertQuoteT
 import { getQuoteDocumentTemplates } from '../../../actions/quoteDocumentTemplates';
 import { getContactsForPicker } from '@alga-psa/user-composition/actions';
 import QuoteStatusBadge from './QuoteStatusBadge';
+import { ArrowLeft } from 'lucide-react';
 import { QuoteSendRecipientsField, type QuoteRecipient } from './QuoteSendRecipientsField';
 
 interface QuoteDetailProps {
@@ -844,7 +845,10 @@ const QuoteDetail: React.FC<QuoteDetailProps> = ({ quoteId, onBack, onEdit, onSe
     return (
       <Card size="2">
         <Box p="4" className="space-y-4">
-          <Button id="quote-detail-back-error" variant="outline" onClick={onBack}>{t('quoteDetail.actions.backToQuotes', { defaultValue: 'Back to Quotes' })}</Button>
+          <Button id="quote-detail-back-error" variant="soft" size="sm" onClick={onBack} className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            {t('quoteDetail.actions.back', { defaultValue: 'Back' })}
+          </Button>
           <Alert variant="destructive">
             <AlertTitle>{t('quoteDetail.title', { defaultValue: 'Quote Detail' })}</AlertTitle>
             <AlertDescription>{error || t('quoteDetail.errors.notFound', { defaultValue: 'Quote not found' })}</AlertDescription>
@@ -857,6 +861,11 @@ const QuoteDetail: React.FC<QuoteDetailProps> = ({ quoteId, onBack, onEdit, onSe
   return (
     <Card size="2">
       <Box p="4" className="space-y-6">
+        <Button id="quote-detail-back" variant="soft" size="sm" onClick={onBack} className="gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          {t('quoteDetail.actions.back', { defaultValue: 'Back' })}
+        </Button>
+
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">{formatQuoteNumber(quote, t('quoteDetail.labels.templateQuote', { defaultValue: 'Template quote' }))}</div>
@@ -866,7 +875,6 @@ const QuoteDetail: React.FC<QuoteDetailProps> = ({ quoteId, onBack, onEdit, onSe
             </div>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button id="quote-detail-back" variant="outline" onClick={onBack}>{t('common.actions.back', { defaultValue: 'Back' })}</Button>
             {renderPrimaryActions()}
             {!quote.is_template ? (
               <>

--- a/packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@alga-psa/ui/components/DropdownMenu';
-import { ChevronDown, ChevronRight, MoreVertical } from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronRight, MoreVertical } from 'lucide-react';
 import { CURRENCY_OPTIONS } from '@alga-psa/core';
 import type { IClient, IContact, IQuote, IQuoteDocumentTemplate, IQuoteListItem, QuoteConversionPreview, QuoteStatus } from '@alga-psa/types';
 import { isActionPermissionError, getErrorMessage } from '@alga-psa/ui/lib/errorHandling';
@@ -392,23 +392,24 @@ const QuoteForm: React.FC<QuoteFormProps> = ({ quoteId, initialIsTemplate = fals
   };
 
   const handleSubmit = async () => {
+    setError(null);
+
+    if (!isTemplate && !form.client_id) {
+      setError(t('quoteForm.validation.clientRequired', { defaultValue: 'Client is required' }));
+      return;
+    }
+
+    if (!form.title && !form.template_id) {
+      setError(
+        t('quoteForm.validation.titleRequired', {
+          defaultValue: 'Title is required unless creating from template',
+        }),
+      );
+      return;
+    }
+
     try {
       setIsSaving(true);
-      setError(null);
-
-      if (!isTemplate && !form.client_id) {
-        throw new Error(
-          t('quoteForm.validation.clientRequired', { defaultValue: 'Client is required' }),
-        );
-      }
-
-      if (!form.title && !form.template_id) {
-        throw new Error(
-          t('quoteForm.validation.titleRequired', {
-            defaultValue: 'Title is required unless creating from template',
-          }),
-        );
-      }
 
       const payload = {
         client_id: form.client_id || null,
@@ -1135,6 +1136,19 @@ const QuoteForm: React.FC<QuoteFormProps> = ({ quoteId, initialIsTemplate = fals
   return (
     <Card size="2">
       <Box p="4" className="space-y-6">
+        <Button
+          id="quote-form-back-to-list"
+          variant="soft"
+          size="sm"
+          onClick={onCancel}
+          className="gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {isTemplate
+            ? t('quoteForm.actions.backToTemplates', { defaultValue: 'Back to Quote Templates' })
+            : t('quoteForm.actions.backToQuotes', { defaultValue: 'Back to Quotes' })}
+        </Button>
+
         {/* ============ TOP HEADER BAR ============ */}
         <header className="flex flex-col gap-3 border-b border-border pb-4 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0 flex-1 space-y-2">
@@ -1189,9 +1203,6 @@ const QuoteForm: React.FC<QuoteFormProps> = ({ quoteId, initialIsTemplate = fals
                   </Button>
                 </>
               )}
-              <Button id="quote-form-cancel" variant="outline" onClick={onCancel}>
-                {t('quoteForm.actions.back', { defaultValue: 'Back' })}
-              </Button>
               {secondaryAction && (
                 <Button id={secondaryAction.id} variant="outline" onClick={secondaryAction.onClick} disabled={secondaryAction.disabled}>
                   {secondaryAction.label}

--- a/server/next.config.mjs
+++ b/server/next.config.mjs
@@ -230,6 +230,7 @@ const nextConfig = {
       '@alga-psa/types': '../packages/types/src',
       '@alga-psa/types/': '../packages/types/src/',
       '@alga-psa/core': '../packages/core/src',
+      '@alga-psa/core/rateLimit': '../packages/core/src/lib/rateLimit/index.ts',
       '@alga-psa/core/': '../packages/core/src/',
       '@alga-psa/validation': '../packages/validation/src',
       '@alga-psa/validation/': '../packages/validation/src/',
@@ -490,6 +491,9 @@ const nextConfig = {
       '@alga-psa/types': prebuiltDirAbs('types'),
       '@alga-psa/types/': `${prebuiltDirAbs('types')}/`,
       '@alga-psa/core': prebuiltDirAbs('core'),
+      '@alga-psa/core/rateLimit': usePrebuilt
+        ? path.join(prebuiltDirAbs('core'), 'lib/rateLimit/index.js')
+        : path.join(__dirname, '../packages/core/src/lib/rateLimit/index.ts'),
       '@alga-psa/core/': `${prebuiltDirAbs('core')}/`,
       '@alga-psa/validation': prebuiltDirAbs('validation'),
       '@alga-psa/validation/': `${prebuiltDirAbs('validation')}/`,

--- a/server/src/test/unit/billing/contractDetailNavigation.static.test.ts
+++ b/server/src/test/unit/billing/contractDetailNavigation.static.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const contractDetailPath = path.resolve(
+  process.cwd(),
+  '../packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx',
+);
+const billingDashboardPath = path.resolve(
+  process.cwd(),
+  '../packages/billing/src/components/billing-dashboard/BillingDashboard.tsx',
+);
+
+describe('contract detail navigation', () => {
+  it('routes back to concrete billing contract list tabs instead of the legacy contracts tab', () => {
+    const source = fs.readFileSync(contractDetailPath, 'utf8');
+
+    expect(source).toContain("? '/msp/billing?tab=contract-templates'");
+    expect(source).toContain(": '/msp/billing?tab=client-contracts'");
+    expect(source).toContain("router.push('/msp/billing?tab=client-contracts')");
+    expect(source).not.toContain("tab=contracts&subtab=");
+    expect(source).not.toContain("params.set('tab', 'contracts')");
+  });
+
+  it('keeps legacy consolidated contracts URLs from falling through to the Quotes tab', () => {
+    const source = fs.readFileSync(billingDashboardPath, 'utf8');
+
+    expect(source).toContain("requestedTabParam === 'contracts'");
+    expect(source).toContain("? (searchParams?.get('subtab') === 'templates' ? 'contract-templates' : 'client-contracts')");
+  });
+});

--- a/server/src/test/unit/billing/quoteBackNavigation.static.test.ts
+++ b/server/src/test/unit/billing/quoteBackNavigation.static.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const quoteFormPath = path.resolve(
+  process.cwd(),
+  '../packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx',
+);
+const quoteDetailPath = path.resolve(
+  process.cwd(),
+  '../packages/billing/src/components/billing-dashboard/quotes/QuoteDetail.tsx',
+);
+
+describe('quote back navigation affordances', () => {
+  it('shows a contract-detail-style back button on the quote form', () => {
+    const source = fs.readFileSync(quoteFormPath, 'utf8');
+
+    expect(source).toContain('id="quote-form-back-to-list"');
+    expect(source).toContain('variant="soft"');
+    expect(source).toContain('Back to Quotes');
+    expect(source).toContain('Back to Quote Templates');
+    expect(source).toContain('<ArrowLeft className="h-4 w-4" />');
+  });
+
+  it('shows a contract-detail-style back button on quote detail', () => {
+    const source = fs.readFileSync(quoteDetailPath, 'utf8');
+
+    expect(source).toContain('id="quote-detail-back"');
+    expect(source).toContain('variant="soft"');
+    expect(source).toContain('<ArrowLeft className="h-4 w-4" />');
+  });
+});

--- a/server/src/test/unit/billing/quoteFormValidation.static.test.ts
+++ b/server/src/test/unit/billing/quoteFormValidation.static.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const quoteFormPath = path.resolve(
+  process.cwd(),
+  '../packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx',
+);
+
+describe('quote form validation', () => {
+  it('handles missing client validation as UI state instead of throwing a console error', () => {
+    const source = fs.readFileSync(quoteFormPath, 'utf8');
+
+    expect(source).toContain("setError(t('quoteForm.validation.clientRequired'");
+    expect(source).not.toContain("throw new Error(\n          t('quoteForm.validation.clientRequired'");
+    expect(source).toMatch(/if \(!isTemplate && !form\.client_id\) \{\s+setError\([\s\S]*?\);\s+return;\s+\}/);
+  });
+});


### PR DESCRIPTION
## Summary
- Route contract detail back/delete navigation to concrete billing tabs instead of the legacy contracts tab
- Preserve compatibility for legacy tab=contracts URLs so they do not fall through to Quotes
- Add quote form/detail back buttons matching the contract detail pattern
- Show quote validation errors in UI state instead of throwing console errors
- Add explicit Next aliases for @alga-psa/core/rateLimit for local dev/Turbopack resolution

## Tests
- cd server && npx vitest run src/test/unit/billing/contractDetailNavigation.static.test.ts src/test/unit/billing/quoteFormValidation.static.test.ts src/test/unit/billing/quoteBackNavigation.static.test.ts --coverage=false