### PR TITLE
Fix client delete RBAC + unify delete UX paths

### DIFF
--- a/packages/auth/src/lib/preCheckDeletion.ts
+++ b/packages/auth/src/lib/preCheckDeletion.ts
@@ -17,7 +17,6 @@ function buildPermissionDenied(message: string): DeletionValidationResult {
 }
 
 function permissionEntityFor(entityType: string): string {
-  if (entityType === 'client') return 'company';
   if (entityType === 'schedule_entry') return 'user_schedule';
   if (entityType === 'survey_template') return 'settings';
   if (entityType === 'status') return 'settings';

--- a/packages/clients/src/actions/clientActions.deletion.test.ts
+++ b/packages/clients/src/actions/clientActions.deletion.test.ts
@@ -1,0 +1,343 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createTenantKnexMock = vi.hoisted(() => vi.fn());
+const withTransactionMock = vi.hoisted(() => vi.fn());
+const deleteEntityWithValidationMock = vi.hoisted(() => vi.fn());
+const preCheckDeletionMock = vi.hoisted(() => vi.fn());
+const hasPermissionAsyncMock = vi.hoisted(() => vi.fn());
+const deleteEntityTagsMock = vi.hoisted(() => vi.fn());
+const isEnterpriseRef = vi.hoisted(() => ({ value: false }));
+
+type ServerAction = (...args: unknown[]) => unknown;
+type LookupTransaction = (table: string) => {
+  where: ReturnType<typeof vi.fn>;
+};
+type TransactionCallback = (trx: LookupTransaction) => Promise<unknown>;
+
+vi.mock('@alga-psa/auth', () => ({
+  preCheckDeletion: preCheckDeletionMock,
+  withAuth: (fn: ServerAction) => (...args: unknown[]) =>
+    fn({ user_id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  deleteEntityWithValidation: deleteEntityWithValidationMock,
+  unparseCSV: vi.fn(),
+  get isEnterprise() {
+    return isEnterpriseRef.value;
+  },
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: createTenantKnexMock,
+  withTransaction: withTransactionMock,
+}));
+
+vi.mock('../lib/authHelpers', () => ({
+  hasPermissionAsync: hasPermissionAsyncMock,
+}));
+
+vi.mock('../lib/billingHelpers', () => ({
+  createDefaultTaxSettingsAsync: vi.fn(),
+}));
+
+vi.mock('../lib/documentsHelpers', () => ({
+  getClientLogoUrlAsync: vi.fn(),
+  getClientLogoUrlsBatchAsync: vi.fn(),
+}));
+
+vi.mock('@alga-psa/storage', () => ({
+  uploadEntityImage: vi.fn(),
+  deleteEntityImage: vi.fn(),
+}));
+
+vi.mock('@alga-psa/tags/actions', () => ({
+  createTag: vi.fn(),
+}));
+
+vi.mock('@alga-psa/tags/lib/tagCleanup', () => ({
+  deleteEntityTags: deleteEntityTagsMock,
+}));
+
+vi.mock('@alga-psa/shared/models/clientModel', () => ({
+  ClientModel: {},
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(),
+}));
+
+vi.mock('@alga-psa/workflow-streams', () => ({
+  buildClientArchivedPayload: vi.fn(),
+  buildClientCreatedPayload: vi.fn(),
+  buildClientOwnerAssignedPayload: vi.fn(),
+  buildClientStatusChangedPayload: vi.fn(),
+  buildClientUpdatedPayload: vi.fn(),
+  buildContactPrimarySetPayload: vi.fn(),
+}));
+
+vi.mock('@alga-psa/shared/billingClients/defaultContract', () => ({
+  ensureDefaultContractForClientIfBillingConfigured: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function createLookupTrx(input: {
+  client?: { client_id: string; is_inactive?: boolean } | null;
+  isDefaultClient?: boolean;
+}): LookupTransaction {
+  return ((table: string) => {
+    if (table === 'clients') {
+      return {
+        where: vi.fn(() => ({
+          first: vi.fn(async () => input.client ?? null),
+        })),
+      };
+    }
+
+    if (table === 'tenant_companies') {
+      return {
+        where: vi.fn(() => ({
+          first: vi.fn(async () => (input.isDefaultClient ? { client_id: 'client-1' } : null)),
+        })),
+      };
+    }
+
+    throw new Error(`Unexpected lookup table ${table}`);
+  }) as LookupTransaction;
+}
+
+function primeClientLookup(input: {
+  client?: { client_id: string; is_inactive?: boolean } | null;
+  isDefaultClient?: boolean;
+}) {
+  createTenantKnexMock.mockResolvedValue({ knex: {} });
+  withTransactionMock.mockImplementation(async (_db: unknown, callback: TransactionCallback) =>
+    callback(createLookupTrx(input))
+  );
+}
+
+describe('client deletion actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isEnterpriseRef.value = false;
+    hasPermissionAsyncMock.mockResolvedValue(true);
+    preCheckDeletionMock.mockResolvedValue({
+      canDelete: true,
+      dependencies: [],
+      alternatives: [],
+    });
+    deleteEntityWithValidationMock.mockResolvedValue({
+      canDelete: true,
+      deleted: true,
+      dependencies: [],
+      alternatives: [],
+    });
+  });
+
+  describe('validateClientDeletion', () => {
+    it('returns PERMISSION_DENIED before opening tenant DB access when delete permission is missing', async () => {
+      hasPermissionAsyncMock.mockResolvedValue(false);
+
+      const { validateClientDeletion } = await import('./clientActions');
+      const result = await validateClientDeletion('client-1');
+
+      expect(result).toMatchObject({
+        canDelete: false,
+        code: 'PERMISSION_DENIED',
+        dependencies: [],
+        alternatives: [],
+      });
+      expect(createTenantKnexMock).not.toHaveBeenCalled();
+      expect(preCheckDeletionMock).not.toHaveBeenCalled();
+    });
+
+    it('returns NOT_FOUND without running dependency precheck when the client does not exist', async () => {
+      primeClientLookup({ client: null });
+
+      const { validateClientDeletion } = await import('./clientActions');
+      const result = await validateClientDeletion('missing-client');
+
+      expect(result).toMatchObject({
+        canDelete: false,
+        code: 'NOT_FOUND',
+        message: 'Client not found.',
+      });
+      expect(preCheckDeletionMock).not.toHaveBeenCalled();
+    });
+
+    it('returns IS_DEFAULT without running dependency precheck for the default client', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: false },
+        isDefaultClient: true,
+      });
+
+      const { validateClientDeletion } = await import('./clientActions');
+      const result = await validateClientDeletion('client-1');
+
+      expect(result).toMatchObject({
+        canDelete: false,
+        code: 'IS_DEFAULT',
+      });
+      expect(preCheckDeletionMock).not.toHaveBeenCalled();
+    });
+
+    it('runs client dependency precheck and splits deactivate alternatives when active contacts block deletion', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: false },
+        isDefaultClient: false,
+      });
+      preCheckDeletionMock.mockResolvedValue({
+        canDelete: false,
+        code: 'DEPENDENCIES_EXIST',
+        message: 'Blocked',
+        dependencies: [{ type: 'contact', count: 2, label: 'contacts' }],
+        alternatives: [{ action: 'deactivate', label: 'Mark as Inactive', warning: 'Keeps data' }],
+      });
+
+      const { validateClientDeletion } = await import('./clientActions');
+      const result = await validateClientDeletion('client-1');
+
+      expect(preCheckDeletionMock).toHaveBeenCalledWith('client', 'client-1');
+      expect(result.alternatives).toEqual([
+        {
+          action: 'deactivate_client_only',
+          label: 'Client Only',
+          description: 'Deactivate the client but leave its contacts active.',
+          warning: 'Keeps data',
+        },
+        {
+          action: 'deactivate',
+          label: 'Client & Contacts',
+          warning: 'Keeps data',
+        },
+      ]);
+    });
+
+    it('removes no-op deactivate alternatives when the client is already inactive', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: true },
+        isDefaultClient: false,
+      });
+      preCheckDeletionMock.mockResolvedValue({
+        canDelete: false,
+        code: 'DEPENDENCIES_EXIST',
+        message: 'Blocked',
+        dependencies: [{ type: 'ticket', count: 1, label: 'ticket' }],
+        alternatives: [{ action: 'deactivate', label: 'Mark as Inactive' }],
+      });
+
+      const { validateClientDeletion } = await import('./clientActions');
+      const result = await validateClientDeletion('client-1');
+
+      expect(result.alternatives).toEqual([]);
+    });
+  });
+
+  describe('deleteClient', () => {
+    it('throws before opening tenant DB access when delete permission is missing', async () => {
+      hasPermissionAsyncMock.mockResolvedValue(false);
+
+      const { deleteClient } = await import('./clientActions');
+
+      await expect(deleteClient('client-1')).rejects.toThrow('Permission denied: Cannot delete clients');
+      expect(createTenantKnexMock).not.toHaveBeenCalled();
+      expect(deleteEntityWithValidationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns NOT_FOUND without invoking atomic deletion when the client does not exist', async () => {
+      primeClientLookup({ client: null });
+
+      const { deleteClient } = await import('./clientActions');
+      const result = await deleteClient('missing-client');
+
+      expect(result).toMatchObject({
+        success: false,
+        canDelete: false,
+        code: 'NOT_FOUND',
+      });
+      expect(deleteEntityWithValidationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns IS_DEFAULT without invoking atomic deletion for the default client', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: false },
+        isDefaultClient: true,
+      });
+
+      const { deleteClient } = await import('./clientActions');
+      const result = await deleteClient('client-1');
+
+      expect(result).toMatchObject({
+        success: false,
+        canDelete: false,
+        code: 'IS_DEFAULT',
+      });
+      expect(deleteEntityWithValidationMock).not.toHaveBeenCalled();
+    });
+
+    it('uses atomic deletion and returns success with dependency counts when deletion passes', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: false },
+        isDefaultClient: false,
+      });
+      deleteEntityWithValidationMock.mockResolvedValue({
+        canDelete: true,
+        deleted: true,
+        dependencies: [
+          { type: 'contact', count: 0, label: 'contacts' },
+          { type: 'ticket', count: 0, label: 'tickets' },
+        ],
+        alternatives: [],
+      });
+
+      const { deleteClient } = await import('./clientActions');
+      const result = await deleteClient('client-1');
+
+      expect(deleteEntityWithValidationMock).toHaveBeenCalledWith(
+        'client',
+        'client-1',
+        {},
+        'tenant-1',
+        expect.any(Function)
+      );
+      expect(result).toMatchObject({
+        success: true,
+        deleted: true,
+        counts: { contact: 0, ticket: 0 },
+      });
+    });
+
+    it('returns blocked validation result and tailored alternatives when atomic deletion finds dependencies', async () => {
+      primeClientLookup({
+        client: { client_id: 'client-1', is_inactive: false },
+        isDefaultClient: false,
+      });
+      deleteEntityWithValidationMock.mockResolvedValue({
+        canDelete: false,
+        deleted: false,
+        code: 'DEPENDENCIES_EXIST',
+        message: 'Blocked',
+        dependencies: [{ type: 'contact', count: 1, label: 'contact' }],
+        alternatives: [{ action: 'deactivate', label: 'Mark as Inactive' }],
+      });
+
+      const { deleteClient } = await import('./clientActions');
+      const result = await deleteClient('client-1');
+
+      expect(result).toMatchObject({
+        success: false,
+        deleted: false,
+        canDelete: false,
+        code: 'DEPENDENCIES_EXIST',
+        counts: { contact: 1 },
+      });
+      expect(result.alternatives.map((alternative) => alternative.action)).toEqual([
+        'deactivate_client_only',
+        'deactivate',
+      ]);
+    });
+  });
+});

--- a/packages/clients/src/actions/clientActions.ts
+++ b/packages/clients/src/actions/clientActions.ts
@@ -887,8 +887,41 @@ export const validateClientDeletion = withAuth(async (
     };
   }
 
-  return preCheckDeletion('client', clientId);
+  const result = await preCheckDeletion('client', clientId);
+  return tailorClientDeleteAlternatives(result, client.is_inactive);
 });
+
+// Tailor the generic "Mark as Inactive" alternative for client-specific UX:
+// - drop it when the client is already inactive (no-op)
+// - split into "Client Only" + "Client & Contacts" when active contacts exist
+// Applied to both validateClientDeletion (precheck) and deleteClient (post-check)
+// so dependency surfaces always get the right buttons.
+function tailorClientDeleteAlternatives(
+  result: DeletionValidationResult,
+  clientIsInactive: boolean
+): DeletionValidationResult {
+  const contactDependency = result.dependencies.find((d) => d.type === 'contact');
+  const hasContacts = (contactDependency?.count ?? 0) > 0;
+
+  const alternatives = result.alternatives.flatMap((alt) => {
+    if (alt.action !== 'deactivate') return [alt];
+    if (clientIsInactive) return [];
+    if (hasContacts) {
+      return [
+        {
+          action: 'deactivate_client_only',
+          label: 'Client Only',
+          description: 'Deactivate the client but leave its contacts active.',
+          warning: alt.warning
+        },
+        { ...alt, label: 'Client & Contacts' }
+      ];
+    }
+    return [alt];
+  });
+
+  return { ...result, alternatives };
+}
 
 export const deleteClient = withAuth(async (user, { tenant }, clientId: string): Promise<DeletionValidationResult & {
   success: boolean;
@@ -1039,8 +1072,10 @@ export const deleteClient = withAuth(async (user, { tenant }, clientId: string):
       return acc;
     }, {});
 
+    const tailored = tailorClientDeleteAlternatives(result, client.is_inactive);
+
     return {
-      ...result,
+      ...tailored,
       deleted: result.deleted,
       success: result.deleted === true,
       counts

--- a/packages/clients/src/components/clients/ClientDetails.tsx
+++ b/packages/clients/src/components/clients/ClientDetails.tsx
@@ -325,12 +325,89 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
     };
   }, [entraSyncRunId, fetchEntraSyncRunStatus]);
 
+  const localizeClientDeleteValidation = useCallback((result: DeletionValidationResult): DeletionValidationResult => {
+    const hasClientOnlyAlternative = result.alternatives.some((alternative) => alternative.action === 'deactivate_client_only');
+    const dependencyLabel = (type: string, count: number, fallback: string) => {
+      const dependencyKeys: Record<string, [string, string, string, string]> = {
+        contact: ['clientsPage.dependency.contact', 'contact', 'clientsPage.dependency.contacts', 'contacts'],
+        ticket: ['clientsPage.dependency.ticket', 'ticket', 'clientsPage.dependency.tickets', 'tickets'],
+        project: ['clientsPage.dependency.project', 'project', 'clientsPage.dependency.projects', 'projects'],
+        invoice: ['clientsPage.dependency.invoice', 'invoice', 'clientsPage.dependency.invoices', 'invoices'],
+        document: ['clientsPage.dependency.document', 'document', 'clientsPage.dependency.documents', 'documents'],
+        interaction: ['clientsPage.dependency.interaction', 'interaction', 'clientsPage.dependency.interactions', 'interactions'],
+        asset: ['clientsPage.dependency.asset', 'asset', 'clientsPage.dependency.assets', 'assets'],
+        usage: ['clientsPage.dependency.serviceUsageRecord', 'service usage record', 'clientsPage.dependency.serviceUsageRecords', 'service usage records'],
+        bucket_usage: ['clientsPage.dependency.bucketUsageRecord', 'bucket usage record', 'clientsPage.dependency.bucketUsageRecords', 'bucket usage records'],
+      };
+      const keys = dependencyKeys[type];
+      if (!keys) return fallback;
+      const [singularKey, singularDefault, pluralKey, pluralDefault] = keys;
+      return count === 1
+        ? t(singularKey, { defaultValue: singularDefault })
+        : t(pluralKey, { defaultValue: pluralDefault });
+    };
+
+    const message = (() => {
+      if (result.code === 'DEPENDENCIES_EXIST') {
+        return t('clientsPage.deleteClientUnable', { defaultValue: 'Unable to delete this client.' });
+      }
+      if (result.code === 'IS_DEFAULT') {
+        return t('clientsPage.defaultClientDeleteError', {
+          defaultValue: 'Cannot delete the default client. Please set another client as default in General Settings first.',
+        });
+      }
+      if (result.code === 'NOT_FOUND') {
+        return t('clientsPage.clientNotFound', { defaultValue: 'Client not found.' });
+      }
+      if (result.code === 'PERMISSION_DENIED') {
+        return t('clientsPage.deletePermissionDenied', {
+          defaultValue: 'Permission denied: Cannot delete clients.',
+        });
+      }
+      return result.message;
+    })();
+
+    return {
+      ...result,
+      message,
+      dependencies: result.dependencies.map((dependency) => ({
+        ...dependency,
+        label: dependencyLabel(dependency.type, dependency.count, dependency.label),
+      })),
+      alternatives: result.alternatives.map((alternative) => {
+        if (alternative.action === 'deactivate_client_only') {
+          return {
+            ...alternative,
+            label: t('clientDetails.clientOnly', { defaultValue: 'Client Only' }),
+            description: t('clientDetails.deactivateClientOnlyDescription', {
+              defaultValue: 'Deactivate the client but leave its contacts active.',
+            }),
+          };
+        }
+
+        if (alternative.action === 'deactivate') {
+          return {
+            ...alternative,
+            label: hasClientOnlyAlternative
+              ? t('clientDetails.clientAndContacts', { defaultValue: 'Client & Contacts' })
+              : t('clientsPage.markAsInactive', { defaultValue: 'Mark as Inactive' }),
+            description: t('clientDetails.deactivateClientDescription', {
+              defaultValue: 'Deactivates the record without deleting its data.',
+            }),
+          };
+        }
+
+        return alternative;
+      }),
+    };
+  }, [t]);
+
 
   const runDeleteValidation = useCallback(async () => {
     setIsDeleteValidating(true);
     try {
       const result = await validateClientDeletion(editedClient.client_id);
-      setDeleteValidation(result);
+      setDeleteValidation(localizeClientDeleteValidation(result));
     } catch (error: any) {
       console.error('Failed to validate client deletion:', error);
       setDeleteValidation({
@@ -345,7 +422,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
     } finally {
       setIsDeleteValidating(false);
     }
-  }, [editedClient.client_id]);
+  }, [editedClient.client_id, localizeClientDeleteValidation, t]);
 
   const handleDeleteClient = () => {
     setIsDeleteDialogOpen(true);
@@ -358,7 +435,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
       const result = await deleteClient(editedClient.client_id);
 
       if (!result.success) {
-        setDeleteValidation(result);
+        setDeleteValidation(localizeClientDeleteValidation(result));
         return;
       }
 
@@ -381,13 +458,13 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
   };
 
   const handleDeleteAlternativeAction = async (action: string) => {
-    if (action !== 'deactivate') {
-      return;
-    }
-
     setIsDeleteProcessing(true);
     try {
-      await handleMarkClientInactiveAll();
+      if (action === 'deactivate') {
+        await handleMarkClientInactiveAll();
+      } else if (action === 'deactivate_client_only') {
+        await handleMarkClientInactiveOnly();
+      }
     } finally {
       setIsDeleteProcessing(false);
     }

--- a/packages/clients/src/components/clients/Clients.tsx
+++ b/packages/clients/src/components/clients/Clients.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useState, useEffect, useCallback, memo } from 'react';
-import type { IClient } from '@alga-psa/types';
+import type { DeletionValidationResult, IClient } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
@@ -9,6 +9,7 @@ import { getAllClients } from '@alga-psa/clients/actions';
 import {
   getAllClientsPaginated,
   deleteClient,
+  validateClientDeletion,
   importClientsFromCSV,
   exportClientsToCSV,
   markClientInactiveWithContacts,
@@ -33,7 +34,7 @@ import Drawer from '@alga-psa/ui/components/Drawer';
 import ClientDetails from './ClientDetails';
 import { useAutomationIdAndRegister } from '@alga-psa/ui/ui-reflection/useAutomationIdAndRegister';
 import toast from 'react-hot-toast';
-import { handleError, useClientDrawer } from '@alga-psa/ui';
+import { DeleteEntityDialog, handleError, useClientDrawer } from '@alga-psa/ui';
 import { useTagPermissions } from '@alga-psa/tags/hooks';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -371,24 +372,14 @@ const Clients: React.FC = () => {
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
   const [isMultiDeleteDialogOpen, setIsMultiDeleteDialogOpen] = useState(false);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [multiDeleteError, setMultiDeleteError] = useState<string | null>(null);
   const [multiDeleteResults, setMultiDeleteResults] = useState<{
     successCount: number;
     failedClients: Array<{ clientId: string; clientName: string; reason: string }>;
   } | null>(null);
-  const [showDeactivateOption, setShowDeactivateOption] = useState(false);
-  const [deleteDependencies, setDeleteDependencies] = useState<{
-    contacts?: number;
-    tickets?: number;
-    projects?: number;
-    invoices?: number;
-    documents?: number;
-    interactions?: number;
-    assets?: number;
-    service_usage?: number;
-    bucket_usage?: number;
-  } | null>(null);
+  const [deleteValidation, setDeleteValidation] = useState<DeletionValidationResult | null>(null);
+  const [isDeleteValidating, setIsDeleteValidating] = useState(false);
+  const [isDeleteProcessing, setIsDeleteProcessing] = useState(false);
 
 
   // Quick View state
@@ -440,105 +431,82 @@ const Clients: React.FC = () => {
     });
   }, [t]);
 
-  const formatDependencyItem = useCallback((
-    count: number,
-    singularKey: string,
-    singularDefault: string,
-    pluralKey: string,
-    pluralDefault: string,
-  ) => {
-    const label = count === 1
-      ? t(singularKey, { defaultValue: singularDefault })
-      : t(pluralKey, { defaultValue: pluralDefault });
+  const localizeClientDeleteValidation = useCallback((result: DeletionValidationResult): DeletionValidationResult => {
+    const hasClientOnlyAlternative = result.alternatives.some((alternative) => alternative.action === 'deactivate_client_only');
+    const dependencyLabel = (type: string, count: number, fallback: string) => {
+      const dependencyKeys: Record<string, [string, string, string, string]> = {
+        contact: ['clientsPage.dependency.contact', 'contact', 'clientsPage.dependency.contacts', 'contacts'],
+        ticket: ['clientsPage.dependency.ticket', 'ticket', 'clientsPage.dependency.tickets', 'tickets'],
+        project: ['clientsPage.dependency.project', 'project', 'clientsPage.dependency.projects', 'projects'],
+        invoice: ['clientsPage.dependency.invoice', 'invoice', 'clientsPage.dependency.invoices', 'invoices'],
+        document: ['clientsPage.dependency.document', 'document', 'clientsPage.dependency.documents', 'documents'],
+        interaction: ['clientsPage.dependency.interaction', 'interaction', 'clientsPage.dependency.interactions', 'interactions'],
+        asset: ['clientsPage.dependency.asset', 'asset', 'clientsPage.dependency.assets', 'assets'],
+        usage: ['clientsPage.dependency.serviceUsageRecord', 'service usage record', 'clientsPage.dependency.serviceUsageRecords', 'service usage records'],
+        bucket_usage: ['clientsPage.dependency.bucketUsageRecord', 'bucket usage record', 'clientsPage.dependency.bucketUsageRecords', 'bucket usage records'],
+      };
+      const keys = dependencyKeys[type];
+      if (!keys) return fallback;
+      const [singularKey, singularDefault, pluralKey, pluralDefault] = keys;
+      return count === 1
+        ? t(singularKey, { defaultValue: singularDefault })
+        : t(pluralKey, { defaultValue: pluralDefault });
+    };
 
-    return `${count} ${label}`;
+    const message = (() => {
+      if (result.code === 'DEPENDENCIES_EXIST') {
+        return t('clientsPage.deleteClientUnable', { defaultValue: 'Unable to delete this client.' });
+      }
+      if (result.code === 'IS_DEFAULT') {
+        return t('clientsPage.defaultClientDeleteError', {
+          defaultValue: 'Cannot delete the default client. Please set another client as default in General Settings first.',
+        });
+      }
+      if (result.code === 'NOT_FOUND') {
+        return t('clientsPage.clientNotFound', { defaultValue: 'Client not found.' });
+      }
+      if (result.code === 'PERMISSION_DENIED') {
+        return t('clientsPage.deletePermissionDenied', {
+          defaultValue: 'Permission denied: Cannot delete clients.',
+        });
+      }
+      return result.message;
+    })();
+
+    return {
+      ...result,
+      message,
+      dependencies: result.dependencies.map((dependency) => ({
+        ...dependency,
+        label: dependencyLabel(dependency.type, dependency.count, dependency.label),
+      })),
+      alternatives: result.alternatives.map((alternative) => {
+        if (alternative.action === 'deactivate_client_only') {
+          return {
+            ...alternative,
+            label: t('clientDetails.clientOnly', { defaultValue: 'Client Only' }),
+            description: t('clientDetails.deactivateClientOnlyDescription', {
+              defaultValue: 'Deactivate the client but leave its contacts active.',
+            }),
+          };
+        }
+
+        if (alternative.action === 'deactivate') {
+          return {
+            ...alternative,
+            label: hasClientOnlyAlternative
+              ? t('clientDetails.clientAndContacts', { defaultValue: 'Client & Contacts' })
+              : t('clientsPage.markAsInactive', { defaultValue: 'Mark as Inactive' }),
+            description: t('clientDetails.deactivateClientDescription', {
+              defaultValue: 'Deactivates the record without deleting its data.',
+            }),
+          };
+        }
+
+        return alternative;
+      }),
+    };
   }, [t]);
-
-  const renderDependencyItems = useCallback((dependencies: NonNullable<typeof deleteDependencies>) => {
-    return [
-      dependencies.contacts
-        ? formatDependencyItem(
-            dependencies.contacts,
-            'clientsPage.dependency.contact',
-            'contact',
-            'clientsPage.dependency.contacts',
-            'contacts',
-          )
-        : null,
-      dependencies.tickets
-        ? formatDependencyItem(
-            dependencies.tickets,
-            'clientsPage.dependency.ticket',
-            'ticket',
-            'clientsPage.dependency.tickets',
-            'tickets',
-          )
-        : null,
-      dependencies.projects
-        ? formatDependencyItem(
-            dependencies.projects,
-            'clientsPage.dependency.project',
-            'project',
-            'clientsPage.dependency.projects',
-            'projects',
-          )
-        : null,
-      dependencies.invoices
-        ? formatDependencyItem(
-            dependencies.invoices,
-            'clientsPage.dependency.invoice',
-            'invoice',
-            'clientsPage.dependency.invoices',
-            'invoices',
-          )
-        : null,
-      dependencies.documents
-        ? formatDependencyItem(
-            dependencies.documents,
-            'clientsPage.dependency.document',
-            'document',
-            'clientsPage.dependency.documents',
-            'documents',
-          )
-        : null,
-      dependencies.interactions
-        ? formatDependencyItem(
-            dependencies.interactions,
-            'clientsPage.dependency.interaction',
-            'interaction',
-            'clientsPage.dependency.interactions',
-            'interactions',
-          )
-        : null,
-      dependencies.assets
-        ? formatDependencyItem(
-            dependencies.assets,
-            'clientsPage.dependency.asset',
-            'asset',
-            'clientsPage.dependency.assets',
-            'assets',
-          )
-        : null,
-      dependencies.service_usage
-        ? formatDependencyItem(
-            dependencies.service_usage,
-            'clientsPage.dependency.serviceUsageRecord',
-            'service usage record',
-            'clientsPage.dependency.serviceUsageRecords',
-            'service usage records',
-          )
-        : null,
-      dependencies.bucket_usage
-        ? formatDependencyItem(
-            dependencies.bucket_usage,
-            'clientsPage.dependency.bucketUsageRecord',
-            'bucket usage record',
-            'clientsPage.dependency.bucketUsageRecords',
-            'bucket usage records',
-          )
-        : null,
-    ].filter(Boolean) as string[];
-  }, [formatDependencyItem]);
 
 
   // Debounce search input
@@ -688,43 +656,72 @@ const Clients: React.FC = () => {
 
 
 
+  const runDeleteValidation = useCallback(async (clientId: string) => {
+    setIsDeleteValidating(true);
+    try {
+      const result = await validateClientDeletion(clientId);
+      setDeleteValidation(localizeClientDeleteValidation(result));
+    } catch (error) {
+      console.error('Failed to validate client deletion:', error);
+      setDeleteValidation({
+        canDelete: false,
+        code: 'VALIDATION_FAILED',
+        message: t('clientsPage.singleDeleteError', {
+          defaultValue: 'An error occurred while deleting the client. Please try again.',
+        }),
+        dependencies: [],
+        alternatives: []
+      });
+    } finally {
+      setIsDeleteValidating(false);
+    }
+  }, [localizeClientDeleteValidation, t]);
+
   const handleDeleteClient = async (client: IClient) => {
     setClientToDelete(client);
-    setDeleteError(null);
-    setShowDeactivateOption(false);
+    setDeleteValidation(null);
     setIsDeleteDialogOpen(true);
+    void runDeleteValidation(client.client_id);
   };
 
   const confirmDelete = async () => {
     if (!clientToDelete) return;
-    
+    setIsDeleteProcessing(true);
     try {
       const result = await deleteClient(clientToDelete.client_id);
-      
+
       if (!result.success) {
-        if (!result.canDelete && result.dependencies.length > 0) {
-          handleDependencyError(result);
-          setShowDeactivateOption(result.alternatives.length > 0);
-          return;
-        }
-        throw new Error(result.message || t('clientDetails.deleteError', {
-          defaultValue: 'Failed to delete client. Please try again.',
-        }));
+        setDeleteValidation(localizeClientDeleteValidation(result));
+        return;
       }
 
-      // Show success toast
       toast.success(t('clientsPage.deleteSingleSuccess', {
         defaultValue: '{{name}} has been deleted successfully.',
         name: clientToDelete.client_name,
       }));
-      
+
       setRefreshKey(prev => prev + 1);
       resetDeleteState();
     } catch (error) {
       console.error('Error deleting client:', error);
-      setDeleteError(t('clientsPage.singleDeleteError', {
+      toast.error(t('clientsPage.singleDeleteError', {
         defaultValue: 'An error occurred while deleting the client. Please try again.',
       }));
+    } finally {
+      setIsDeleteProcessing(false);
+    }
+  };
+
+  const handleDeleteAlternativeAction = async (action: string) => {
+    setIsDeleteProcessing(true);
+    try {
+      if (action === 'deactivate') {
+        await handleMarkClientInactiveAll();
+      } else if (action === 'deactivate_client_only') {
+        await handleMarkClientInactiveOnly();
+      }
+    } finally {
+      setIsDeleteProcessing(false);
     }
   };
 
@@ -975,7 +972,7 @@ const Clients: React.FC = () => {
               ? client.client_name
               : t('clientsPage.unknownClient', { defaultValue: 'Unknown Client' });
 
-          if ('code' in result && result.code === 'COMPANY_HAS_DEPENDENCIES') {
+          if ('code' in result && result.code === 'DEPENDENCIES_EXIST' && result.dependencies?.length > 0) {
             const reason = formatDependencyText(result);
             failedClients.push({ clientId, clientName, reason });
           } else {
@@ -1080,83 +1077,16 @@ const Clients: React.FC = () => {
     }
   };
 
-  interface DependencyResult {
-    dependencies?: Array<{ count: number; label: string } | string>;
-    counts?: Record<string, number>; // Changed from string to number to match backend
-    code?: string;
-    message?: string;
-  }
-
-  const formatDependencyText = (result: DependencyResult): string => {
-    const dependencies = result.dependencies || [];
-    const counts = result.counts || {};
-
-    if (dependencies.length > 0 && typeof dependencies[0] !== 'string') {
-      return dependencies
-        .map((dep) => {
-          if (typeof dep === 'string') return dep;
-          return `${dep.count} ${dep.label}`;
-        })
-        .join(', ');
-    }
-    
-    // Map the base keys to their full dependency names
-    const keyMap: Record<string, string> = {
-      'contact': 'contacts',
-      'ticket': 'active tickets',
-      'project': 'active projects',
-      'document': 'documents',
-      'invoice': 'invoices',
-      'interaction': 'interactions',
-      'location': 'locations',
-      'service_usage': 'service usage records',
-      'bucket_usage': 'bucket usage records',
-      'contract_line': 'contract lines',
-      'tax_rate': 'tax rates',
-      'tax_setting': 'tax settings'
-    };
-
-    // Create a reverse mapping from full names to base keys
-    const reverseKeyMap: Record<string, string> = {};
-    Object.entries(keyMap).forEach(([key, value]) => {
-      reverseKeyMap[value] = key;
-    });
-
-    return dependencies
-    .map((dep): string => {
-      const depStr = typeof dep === 'string' ? dep : dep.label;
-      // Get the base key for this dependency
-      const baseKey = reverseKeyMap[depStr];
-      const count = baseKey ? counts[baseKey] || 0 : (typeof dep !== 'string' ? dep.count : 0);
-      return `${count} ${depStr}`;
-    })
-    .join(', ');
+  const formatDependencyText = (result: DeletionValidationResult): string => {
+    return result.dependencies.map((dep) => `${dep.count} ${dep.label}`).join(', ');
   };
-
-  const handleDependencyError = (result: DependencyResult) => {
-    // Store the dependency counts for structured display
-    // Only include counts that are > 0
-    const counts = result.counts || {};
-    setDeleteDependencies({
-      contacts: counts['contact'] > 0 ? counts['contact'] : undefined,
-      tickets: counts['ticket'] > 0 ? counts['ticket'] : undefined,
-      projects: counts['project'] > 0 ? counts['project'] : undefined,
-      invoices: counts['invoice'] > 0 ? counts['invoice'] : undefined,
-      documents: counts['document'] > 0 ? counts['document'] : undefined,
-      interactions: counts['interaction'] > 0 ? counts['interaction'] : undefined,
-      assets: counts['asset'] > 0 ? counts['asset'] : undefined,
-      service_usage: counts['service_usage'] > 0 ? counts['service_usage'] : undefined,
-      bucket_usage: counts['bucket_usage'] > 0 ? counts['bucket_usage'] : undefined,
-    });
-  };
-
 
   const resetDeleteState = () => {
     setIsDeleteDialogOpen(false);
     setClientToDelete(null);
-    setDeleteError(null);
-    setShowDeactivateOption(false);
-    setDeleteDependencies(null);
+    setDeleteValidation(null);
+    setIsDeleteValidating(false);
+    setIsDeleteProcessing(false);
   };
 
   const handleExportToCSV = async () => {
@@ -1576,144 +1506,17 @@ const Clients: React.FC = () => {
       </Dialog>
 
       {/* Single client delete confirmation dialog */}
-      <Dialog
+      <DeleteEntityDialog
+        id="single-delete-confirmation-dialog"
         isOpen={isDeleteDialogOpen}
         onClose={resetDeleteState}
-        id="single-delete-confirmation-dialog"
-        title={t('clientsPage.deleteClient', { defaultValue: 'Delete Client' })}
-      >
-        <DialogContent>
-          <div className="space-y-4">
-            {clientToDelete?.is_inactive && showDeactivateOption && deleteDependencies ? (
-              <>
-                <Alert variant="warning">
-                  <AlertDescription>
-                    {t('clientsPage.alreadyInactive', {
-                      defaultValue: 'This client is already marked as inactive.',
-                    })}
-                  </AlertDescription>
-                </Alert>
-                <p className="text-gray-700">
-                  {t('clientsPage.deleteBlockedSingle', {
-                    defaultValue: 'Unable to delete this client due to the following associated records:',
-                  })}
-                </p>
-                <div>
-                  <ul className="list-disc list-inside space-y-1 text-gray-700">
-                    {renderDependencyItems(deleteDependencies).map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-                <p className="text-gray-700">
-                  {t('clientsPage.deleteBlockedHelp', {
-                    defaultValue: 'Please remove or reassign these items before the client can be deleted.',
-                  })}
-                </p>
-              </>
-            ) : showDeactivateOption && deleteDependencies ? (
-              <>
-                <p className="text-gray-700">
-                  {t('clientsPage.deleteClientUnable', {
-                    defaultValue: 'Unable to delete this client.',
-                  })}
-                </p>
-                <div>
-                  <p className="text-gray-700 mb-2">
-                    {t('clientsPage.singleDeletePrompt', {
-                      defaultValue: 'This client has the following associated records:',
-                    })}
-                  </p>
-                  <ul className="list-disc list-inside space-y-1 text-gray-700">
-                    {renderDependencyItems(deleteDependencies).map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-                <Alert variant="info">
-                  <AlertDescription>
-                    <p>
-                      {t('clientsPage.inactiveAlternative', {
-                        defaultValue: 'You can mark this client as inactive instead. Inactive clients are hidden from most views but retain all their data and can be marked as active later.',
-                      })}
-                    </p>
-                    {deleteDependencies.contacts && deleteDependencies.contacts > 0 && (
-                      <p className="mt-2">
-                        {t('clientsPage.deactivateContactsPrompt', {
-                          defaultValue: 'Would you like to also deactivate the {{count}} associated contact(s)?',
-                          count: deleteDependencies.contacts,
-                        })}
-                      </p>
-                    )}
-                  </AlertDescription>
-                </Alert>
-              </>
-            ) : deleteError ? (
-              <div className="text-gray-600 whitespace-pre-line">
-                {deleteError}
-              </div>
-            ) : (
-              <p className="text-gray-600">
-                {t('clientsPage.deleteSinglePrompt', {
-                  defaultValue: 'Are you sure you want to delete {{name}}? This action cannot be undone.',
-                  name: clientToDelete?.client_name ?? '',
-                })}
-              </p>
-            )}
-          </div>
-
-          <DialogFooter>
-            <div className="mt-4 flex justify-end space-x-2">
-              <Button
-                variant="outline"
-                onClick={resetDeleteState}
-                id="single-delete-cancel"
-              >
-                {t('common.actions.cancel', { defaultValue: 'Cancel' })}
-              </Button>
-
-              {clientToDelete?.is_inactive && showDeactivateOption ? (
-                <Button
-                  variant="default"
-                  onClick={resetDeleteState}
-                  id="single-delete-close"
-                >
-                  {t('common.actions.close', { defaultValue: 'Close' })}
-                </Button>
-              ) : showDeactivateOption ? (
-                <>
-                  {deleteDependencies?.contacts && deleteDependencies.contacts > 0 && (
-                    <Button
-                      variant="outline"
-                      onClick={() => void handleMarkClientInactiveOnly()}
-                      id="single-delete-client-only"
-                    >
-                      {t('clientDetails.clientOnly', { defaultValue: 'Client Only' })}
-                    </Button>
-                  )}
-                  <Button
-                    variant="default"
-                    onClick={() => void handleMarkClientInactiveAll()}
-                    id="single-delete-mark-inactive"
-                  >
-                    {deleteDependencies?.contacts && deleteDependencies.contacts > 0
-                      ? t('clientDetails.clientAndContacts', { defaultValue: 'Client & Contacts' })
-                      : t('clientsPage.markAsInactive', { defaultValue: 'Mark as Inactive' })}
-                  </Button>
-                </>
-              ) : !deleteError && (
-                <Button
-                  onClick={() => void confirmDelete()}
-                  id="single-delete-confirm"
-                  variant="destructive"
-                >
-                  {t('common.actions.delete', { defaultValue: 'Delete' })}
-                </Button>
-              )}
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onConfirmDelete={confirmDelete}
+        onAlternativeAction={handleDeleteAlternativeAction}
+        entityName={clientToDelete?.client_name ?? ''}
+        validationResult={deleteValidation}
+        isValidating={isDeleteValidating}
+        isDeleting={isDeleteProcessing}
+      />
 
       {/* CSV Import Dialog */}
       <ClientsImportDialog

--- a/packages/ui/src/components/DeleteEntityDialog.tsx
+++ b/packages/ui/src/components/DeleteEntityDialog.tsx
@@ -4,9 +4,10 @@ import React, { useMemo } from 'react';
 import { Dialog, DialogContent, DialogFooter } from './Dialog';
 import { Button } from './Button';
 import Spinner from './Spinner';
-import type { DeletionAlternative, DeletionDependency, DeletionValidationResult } from '@alga-psa/types';
+import type { DeletionDependency, DeletionValidationResult } from '@alga-psa/types';
 import { withDataAutomationId } from '../ui-reflection/withDataAutomationId';
 import type { AutomationProps } from '../ui-reflection/types';
+import { useTranslation } from '../lib/i18n/client';
 
 export interface DeleteEntityDialogProps extends AutomationProps {
   isOpen: boolean;
@@ -21,7 +22,7 @@ export interface DeleteEntityDialogProps extends AutomationProps {
   id?: string;
 }
 
-function renderDependencyRow(dependency: DeletionDependency) {
+function renderDependencyRow(dependency: DeletionDependency, viewLabel: string) {
   return (
     <li key={dependency.type} className="flex items-center justify-between text-sm text-[rgb(var(--color-text-700))]">
       <span>
@@ -32,7 +33,7 @@ function renderDependencyRow(dependency: DeletionDependency) {
           href={dependency.viewUrl}
           className="text-[rgb(var(--color-primary-600))] hover:text-[rgb(var(--color-primary-700))] underline"
         >
-          View
+          {viewLabel}
         </a>
       ) : null}
     </li>
@@ -51,28 +52,74 @@ export const DeleteEntityDialog = ({
   isDeleting = false,
   id
 }: DeleteEntityDialogProps) => {
+  const { t } = useTranslation('common');
   const canDelete = validationResult?.canDelete ?? false;
-  const dependencies = validationResult?.dependencies ?? [];
-  const alternatives = validationResult?.alternatives ?? [];
-  const blockMessage = validationResult?.message ?? 'Please remove or reassign these items before deleting.';
+  const dependencies = useMemo(() => validationResult?.dependencies ?? [], [validationResult?.dependencies]);
+  const alternatives = useMemo(() => (validationResult?.alternatives ?? []).map((alternative) => {
+    if (alternative.action === 'deactivate' && alternative.label === 'Mark as Inactive') {
+      return {
+        ...alternative,
+        label: t('deleteEntity.alternatives.deactivate.label', { defaultValue: 'Mark as Inactive' }),
+        description: alternative.description
+          ? t('deleteEntity.alternatives.deactivate.description', {
+              defaultValue: 'Deactivates the record without deleting its data.',
+            })
+          : alternative.description,
+        warning: alternative.warning
+          ? t('deleteEntity.alternatives.deactivate.warning', {
+              defaultValue: 'Inactive records will no longer be selectable in new workflows.',
+            })
+          : alternative.warning,
+      };
+    }
+
+    if (alternative.action === 'archive' && alternative.label === 'Archive') {
+      return {
+        ...alternative,
+        label: t('deleteEntity.alternatives.archive.label', { defaultValue: 'Archive' }),
+        description: alternative.description
+          ? t('deleteEntity.alternatives.archive.description', {
+              defaultValue: 'Moves the record out of active use while preserving history.',
+            })
+          : alternative.description,
+        warning: alternative.warning
+          ? t('deleteEntity.alternatives.archive.warning', {
+              defaultValue: 'Archived records are hidden from default views.',
+            })
+          : alternative.warning,
+      };
+    }
+
+    return alternative;
+  }), [validationResult?.alternatives, t]);
+  const viewLabel = t('actions.view', { defaultValue: 'View' });
+  const blockMessage = validationResult?.message ?? t('deleteEntity.fallbackBlockMessage', {
+    defaultValue: 'Please remove or reassign these items before deleting.',
+  });
 
   const primaryAlternative = alternatives[0];
   const secondaryAlternatives = alternatives.slice(1);
 
   const title = isValidating
-    ? 'Checking Dependencies'
+    ? t('deleteEntity.checkingDependenciesTitle', { defaultValue: 'Checking Dependencies' })
     : canDelete
-      ? `Delete ${entityName}`
-      : 'Cannot Delete';
+      ? t('deleteEntity.deleteTitle', { defaultValue: 'Delete {{entityName}}', entityName })
+      : t('deleteEntity.cannotDeleteTitle', { defaultValue: 'Cannot Delete' });
 
-  const confirmLabel = isDeleting ? 'Deleting...' : 'Delete';
+  const confirmLabel = isDeleting
+    ? t('deleteEntity.deleting', { defaultValue: 'Deleting...' })
+    : t('actions.delete', { defaultValue: 'Delete' });
 
   const dialogBody = useMemo(() => {
     if (isValidating) {
       return (
         <div className="flex items-center gap-3 text-[rgb(var(--color-text-600))]">
           <Spinner size="xs" />
-          <span>Checking for dependencies...</span>
+          <span>
+            {t('deleteEntity.checkingDependenciesMessage', {
+              defaultValue: 'Checking for dependencies...',
+            })}
+          </span>
         </div>
       );
     }
@@ -80,7 +127,10 @@ export const DeleteEntityDialog = ({
     if (canDelete) {
       return (
         <p className="text-[rgb(var(--color-text-700))]">
-          {confirmationMessage ?? `Are you sure you want to delete "${entityName}"? This action cannot be undone.`}
+          {confirmationMessage ?? t('deleteEntity.confirmationMessage', {
+            defaultValue: 'Are you sure you want to delete "{{entityName}}"? This action cannot be undone.',
+            entityName,
+          })}
         </p>
       );
     }
@@ -89,11 +139,13 @@ export const DeleteEntityDialog = ({
       <div className="space-y-3">
         <p className="text-[rgb(var(--color-text-700))]">{blockMessage}</p>
         {dependencies.length > 0 && (
-          <ul className="space-y-2">{dependencies.map(renderDependencyRow)}</ul>
+          <ul className="space-y-2">
+            {dependencies.map((dependency) => renderDependencyRow(dependency, viewLabel))}
+          </ul>
         )}
       </div>
     );
-  }, [isValidating, canDelete, blockMessage, confirmationMessage, dependencies, entityName]);
+  }, [isValidating, canDelete, blockMessage, confirmationMessage, dependencies, entityName, t, viewLabel]);
 
   return (
     <Dialog
@@ -113,7 +165,7 @@ export const DeleteEntityDialog = ({
               id={`${id || 'delete-entity-dialog'}-cancel`}
               disabled={isDeleting}
             >
-              Cancel
+              {t('actions.cancel', { defaultValue: 'Cancel' })}
             </Button>
             {!isValidating && !canDelete && primaryAlternative && onAlternativeAction && (
               <Button

--- a/server/public/locales/de/common.json
+++ b/server/public/locales/de/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Bitte geben Sie Feedback"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Abhängigkeiten werden geprüft",
+    "deleteTitle": "{{entityName}} löschen",
+    "cannotDeleteTitle": "Kann nicht gelöscht werden",
+    "deleting": "Wird gelöscht...",
+    "checkingDependenciesMessage": "Abhängigkeiten werden geprüft...",
+    "fallbackBlockMessage": "Bitte entfernen Sie diese Elemente oder weisen Sie sie neu zu, bevor Sie löschen.",
+    "confirmationMessage": "Sind Sie sicher, dass Sie \"{{entityName}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Als inaktiv markieren",
+        "description": "Deaktiviert den Datensatz, ohne seine Daten zu löschen.",
+        "warning": "Inaktive Datensätze können in neuen Workflows nicht mehr ausgewählt werden."
+      },
+      "archive": {
+        "label": "Archivieren",
+        "description": "Entfernt den Datensatz aus der aktiven Nutzung und bewahrt den Verlauf auf.",
+        "warning": "Archivierte Datensätze werden in Standardansichten ausgeblendet."
+      }
+    }
   }
 }

--- a/server/public/locales/de/msp/clients.json
+++ b/server/public/locales/de/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "Sind Sie sicher, dass Sie {{count}} ausgewählte {{clientsLabel}} löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
     "singleInactiveWithContactsSuccess_one": "{{name}} und {{count}} Kontakt wurden erfolgreich deaktiviert.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} und {{count}} Kontakte wurden erfolgreich deaktiviert."
+    "singleInactiveWithContactsSuccess_other": "{{name}} und {{count}} Kontakte wurden erfolgreich deaktiviert.",
+    "defaultClientDeleteError": "Der Standardkunde kann nicht gelöscht werden. Legen Sie zuerst in den allgemeinen Einstellungen einen anderen Kunden als Standard fest.",
+    "clientNotFound": "Kunde nicht gefunden.",
+    "deletePermissionDenied": "Berechtigung verweigert: Kunden können nicht gelöscht werden."
   },
   "clientDetails": {
     "title": "Kundendaten",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Eingehende E-Mail-Domäne hinzugefügt",
     "inboundDomainAddFailed": "Domäne konnte nicht hinzugefügt werden",
     "inboundDomainRemoved": "Eingehende E-Mail-Domäne entfernt",
-    "inboundDomainRemoveFailed": "Domäne konnte nicht entfernt werden"
+    "inboundDomainRemoveFailed": "Domäne konnte nicht entfernt werden",
+    "deactivateClientDescription": "Deaktiviert den Datensatz, ohne seine Daten zu löschen.",
+    "deactivateClientOnlyDescription": "Deaktiviert den Kunden, lässt seine Kontakte aber aktiv."
   },
   "quickAddClient": {
     "title": "Neuen Kunden hinzufügen",

--- a/server/public/locales/en/common.json
+++ b/server/public/locales/en/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Please provide feedback"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Checking Dependencies",
+    "deleteTitle": "Delete {{entityName}}",
+    "cannotDeleteTitle": "Cannot Delete",
+    "deleting": "Deleting...",
+    "checkingDependenciesMessage": "Checking for dependencies...",
+    "fallbackBlockMessage": "Please remove or reassign these items before deleting.",
+    "confirmationMessage": "Are you sure you want to delete \"{{entityName}}\"? This action cannot be undone.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Mark as Inactive",
+        "description": "Deactivates the record without deleting its data.",
+        "warning": "Inactive records will no longer be selectable in new workflows."
+      },
+      "archive": {
+        "label": "Archive",
+        "description": "Moves the record out of active use while preserving history.",
+        "warning": "Archived records are hidden from default views."
+      }
+    }
   }
 }

--- a/server/public/locales/en/msp/clients.json
+++ b/server/public/locales/en/msp/clients.json
@@ -132,7 +132,10 @@
       "bucketUsageRecord": "bucket usage record",
       "bucketUsageRecords": "bucket usage records"
     },
-    "deleteSelectedPrompt": "Are you sure you want to delete {{count}} selected {{clientsLabel}}? This action cannot be undone."
+    "deleteSelectedPrompt": "Are you sure you want to delete {{count}} selected {{clientsLabel}}? This action cannot be undone.",
+    "defaultClientDeleteError": "Cannot delete the default client. Please set another client as default in General Settings first.",
+    "clientNotFound": "Client not found.",
+    "deletePermissionDenied": "Permission denied: Cannot delete clients."
   },
   "clientDetails": {
     "title": "Client Details",
@@ -216,7 +219,9 @@
     "status": {
       "label": "Status",
       "helper": "Set client status as active or inactive"
-    }
+    },
+    "deactivateClientDescription": "Deactivates the record without deleting its data.",
+    "deactivateClientOnlyDescription": "Deactivate the client but leave its contacts active."
   },
   "quickAddClient": {
     "title": "Add New Client",

--- a/server/public/locales/es/common.json
+++ b/server/public/locales/es/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Por favor, proporcione comentarios"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Comprobando dependencias",
+    "deleteTitle": "Eliminar {{entityName}}",
+    "cannotDeleteTitle": "No se puede eliminar",
+    "deleting": "Eliminando...",
+    "checkingDependenciesMessage": "Comprobando dependencias...",
+    "fallbackBlockMessage": "Elimine o reasigne estos elementos antes de eliminar.",
+    "confirmationMessage": "¿Está seguro de que desea eliminar \"{{entityName}}\"? Esta acción no se puede deshacer.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Marcar como inactivo",
+        "description": "Desactiva el registro sin eliminar sus datos.",
+        "warning": "Los registros inactivos ya no se podrán seleccionar en nuevos flujos de trabajo."
+      },
+      "archive": {
+        "label": "Archivar",
+        "description": "Mueve el registro fuera del uso activo y conserva el historial.",
+        "warning": "Los registros archivados se ocultan en las vistas predeterminadas."
+      }
+    }
   }
 }

--- a/server/public/locales/es/msp/clients.json
+++ b/server/public/locales/es/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "¿Está seguro de que desea eliminar {{count}} seleccionado {{clientsLabel}}? Esta acción no se puede deshacer.",
     "singleInactiveWithContactsSuccess_one": "{{name}} y {{count}} contacto han sido desactivados correctamente.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} y {{count}} contactos han sido desactivados correctamente."
+    "singleInactiveWithContactsSuccess_other": "{{name}} y {{count}} contactos han sido desactivados correctamente.",
+    "defaultClientDeleteError": "No se puede eliminar el cliente predeterminado. Primero establezca otro cliente como predeterminado en Configuración general.",
+    "clientNotFound": "Cliente no encontrado.",
+    "deletePermissionDenied": "Permiso denegado: no se pueden eliminar clientes."
   },
   "clientDetails": {
     "title": "Detalles del cliente",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Dominio de correo entrante añadido",
     "inboundDomainAddFailed": "Error al añadir el dominio",
     "inboundDomainRemoved": "Dominio de correo entrante eliminado",
-    "inboundDomainRemoveFailed": "Error al eliminar el dominio"
+    "inboundDomainRemoveFailed": "Error al eliminar el dominio",
+    "deactivateClientDescription": "Desactiva el registro sin eliminar sus datos.",
+    "deactivateClientOnlyDescription": "Desactiva el cliente, pero deja activos sus contactos."
   },
   "quickAddClient": {
     "title": "Agregar nuevo cliente",

--- a/server/public/locales/fr/common.json
+++ b/server/public/locales/fr/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Veuillez fournir un commentaire"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Vérification des dépendances",
+    "deleteTitle": "Supprimer {{entityName}}",
+    "cannotDeleteTitle": "Suppression impossible",
+    "deleting": "Suppression...",
+    "checkingDependenciesMessage": "Vérification des dépendances...",
+    "fallbackBlockMessage": "Veuillez supprimer ou réaffecter ces éléments avant la suppression.",
+    "confirmationMessage": "Êtes-vous sûr de vouloir supprimer \"{{entityName}}\" ? Cette action ne peut pas être annulée.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Marquer comme inactif",
+        "description": "Désactive l’enregistrement sans supprimer ses données.",
+        "warning": "Les enregistrements inactifs ne pourront plus être sélectionnés dans les nouveaux flux de travail."
+      },
+      "archive": {
+        "label": "Archiver",
+        "description": "Retire l’enregistrement de l’usage actif tout en conservant l’historique.",
+        "warning": "Les enregistrements archivés sont masqués dans les vues par défaut."
+      }
+    }
   }
 }

--- a/server/public/locales/fr/msp/clients.json
+++ b/server/public/locales/fr/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "Êtes-vous sûr de vouloir supprimer {{count}} sélectionné {{clientsLabel}} ? Cette action ne peut pas être annulée.",
     "singleInactiveWithContactsSuccess_one": "{{name}} et {{count}} contact ont été désactivés avec succès.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} et {{count}} contacts ont été désactivés avec succès."
+    "singleInactiveWithContactsSuccess_other": "{{name}} et {{count}} contacts ont été désactivés avec succès.",
+    "defaultClientDeleteError": "Impossible de supprimer le client par défaut. Définissez d’abord un autre client comme client par défaut dans les paramètres généraux.",
+    "clientNotFound": "Client introuvable.",
+    "deletePermissionDenied": "Autorisation refusée : impossible de supprimer des clients."
   },
   "clientDetails": {
     "title": "Détails du client",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Domaine de courrier entrant ajouté",
     "inboundDomainAddFailed": "Échec de l'ajout du domaine",
     "inboundDomainRemoved": "Domaine de courrier entrant supprimé",
-    "inboundDomainRemoveFailed": "Échec de la suppression du domaine"
+    "inboundDomainRemoveFailed": "Échec de la suppression du domaine",
+    "deactivateClientDescription": "Désactive l’enregistrement sans supprimer ses données.",
+    "deactivateClientOnlyDescription": "Désactive le client, mais laisse ses contacts actifs."
   },
   "quickAddClient": {
     "title": "Ajouter un nouveau client",

--- a/server/public/locales/it/common.json
+++ b/server/public/locales/it/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Per favore fornisci un feedback"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Verifica delle dipendenze",
+    "deleteTitle": "Elimina {{entityName}}",
+    "cannotDeleteTitle": "Impossibile eliminare",
+    "deleting": "Eliminazione...",
+    "checkingDependenciesMessage": "Verifica delle dipendenze...",
+    "fallbackBlockMessage": "Rimuovi o riassegna questi elementi prima di eliminare.",
+    "confirmationMessage": "Sei sicuro di voler eliminare \"{{entityName}}\"? Questa azione non può essere annullata.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Segna come inattivo",
+        "description": "Disattiva il record senza eliminarne i dati.",
+        "warning": "I record inattivi non saranno più selezionabili nei nuovi flussi di lavoro."
+      },
+      "archive": {
+        "label": "Archivia",
+        "description": "Sposta il record fuori dall’uso attivo preservando la cronologia.",
+        "warning": "I record archiviati sono nascosti nelle viste predefinite."
+      }
+    }
   }
 }

--- a/server/public/locales/it/msp/clients.json
+++ b/server/public/locales/it/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "Sei sicuro di voler eliminare {{count}} selezionato {{clientsLabel}}? Questa azione non può essere annullata.",
     "singleInactiveWithContactsSuccess_one": "{{name}} e {{count}} contatto sono stati disattivati con successo.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} e {{count}} contatti sono stati disattivati con successo."
+    "singleInactiveWithContactsSuccess_other": "{{name}} e {{count}} contatti sono stati disattivati con successo.",
+    "defaultClientDeleteError": "Impossibile eliminare il cliente predefinito. Imposta prima un altro cliente come predefinito nelle impostazioni generali.",
+    "clientNotFound": "Cliente non trovato.",
+    "deletePermissionDenied": "Autorizzazione negata: impossibile eliminare i clienti."
   },
   "clientDetails": {
     "title": "Dettagli del cliente",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Dominio email in entrata aggiunto",
     "inboundDomainAddFailed": "Impossibile aggiungere il dominio",
     "inboundDomainRemoved": "Dominio email in entrata rimosso",
-    "inboundDomainRemoveFailed": "Impossibile rimuovere il dominio"
+    "inboundDomainRemoveFailed": "Impossibile rimuovere il dominio",
+    "deactivateClientDescription": "Disattiva il record senza eliminarne i dati.",
+    "deactivateClientOnlyDescription": "Disattiva il cliente ma lascia attivi i suoi contatti."
   },
   "quickAddClient": {
     "title": "Aggiungi nuovo cliente",

--- a/server/public/locales/nl/common.json
+++ b/server/public/locales/nl/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Geef feedback"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Afhankelijkheden controleren",
+    "deleteTitle": "{{entityName}} verwijderen",
+    "cannotDeleteTitle": "Kan niet worden verwijderd",
+    "deleting": "Verwijderen...",
+    "checkingDependenciesMessage": "Afhankelijkheden controleren...",
+    "fallbackBlockMessage": "Verwijder deze items of wijs ze opnieuw toe voordat u verwijdert.",
+    "confirmationMessage": "Weet u zeker dat u \"{{entityName}}\" wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Markeer als inactief",
+        "description": "Deactiveert de record zonder de gegevens te verwijderen.",
+        "warning": "Inactieve records zijn niet meer selecteerbaar in nieuwe workflows."
+      },
+      "archive": {
+        "label": "Archiveren",
+        "description": "Verplaatst de record uit actief gebruik en bewaart de geschiedenis.",
+        "warning": "Gearchiveerde records worden verborgen in standaardweergaven."
+      }
+    }
   }
 }

--- a/server/public/locales/nl/msp/clients.json
+++ b/server/public/locales/nl/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "Weet u zeker dat u {{count}} geselecteerde {{clientsLabel}} wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
     "singleInactiveWithContactsSuccess_one": "{{name}} en {{count}} contact zijn succesvol gedeactiveerd.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} en {{count}} contacten zijn succesvol gedeactiveerd."
+    "singleInactiveWithContactsSuccess_other": "{{name}} en {{count}} contacten zijn succesvol gedeactiveerd.",
+    "defaultClientDeleteError": "De standaardklant kan niet worden verwijderd. Stel eerst een andere klant als standaard in bij Algemene instellingen.",
+    "clientNotFound": "Klant niet gevonden.",
+    "deletePermissionDenied": "Toestemming geweigerd: klanten kunnen niet worden verwijderd."
   },
   "clientDetails": {
     "title": "Klantgegevens",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Inkomend e-maildomein toegevoegd",
     "inboundDomainAddFailed": "Kan domein niet toevoegen",
     "inboundDomainRemoved": "Inkomend e-maildomein verwijderd",
-    "inboundDomainRemoveFailed": "Kan domein niet verwijderen"
+    "inboundDomainRemoveFailed": "Kan domein niet verwijderen",
+    "deactivateClientDescription": "Deactiveert de record zonder de gegevens te verwijderen.",
+    "deactivateClientOnlyDescription": "Deactiveer de klant maar laat de contacten actief."
   },
   "quickAddClient": {
     "title": "Nieuwe klant toevoegen",

--- a/server/public/locales/pl/common.json
+++ b/server/public/locales/pl/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Prosimy o przekazanie opinii"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Sprawdzanie zależności",
+    "deleteTitle": "Usuń {{entityName}}",
+    "cannotDeleteTitle": "Nie można usunąć",
+    "deleting": "Usuwanie...",
+    "checkingDependenciesMessage": "Sprawdzanie zależności...",
+    "fallbackBlockMessage": "Usuń lub ponownie przypisz te elementy przed usunięciem.",
+    "confirmationMessage": "Czy na pewno chcesz usunąć \"{{entityName}}\"? Tej akcji nie można cofnąć.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Oznacz jako nieaktywne",
+        "description": "Dezaktywuje rekord bez usuwania jego danych.",
+        "warning": "Nieaktywne rekordy nie będą już dostępne do wyboru w nowych przepływach pracy."
+      },
+      "archive": {
+        "label": "Archiwizuj",
+        "description": "Przenosi rekord poza aktywne użycie, zachowując historię.",
+        "warning": "Zarchiwizowane rekordy są ukryte w widokach domyślnych."
+      }
+    }
   }
 }

--- a/server/public/locales/pl/msp/clients.json
+++ b/server/public/locales/pl/msp/clients.json
@@ -132,7 +132,10 @@
     },
     "deleteSelectedPrompt": "Czy na pewno chcesz usunąć {{count}} wybrane {{clientsLabel}}? Tej akcji nie można cofnąć.",
     "singleInactiveWithContactsSuccess_one": "{{name}} i {{count}} kontakt zostały pomyślnie dezaktywowane.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} i {{count}} kontaktów zostało pomyślnie dezaktywowanych."
+    "singleInactiveWithContactsSuccess_other": "{{name}} i {{count}} kontaktów zostało pomyślnie dezaktywowanych.",
+    "defaultClientDeleteError": "Nie można usunąć domyślnego klienta. Najpierw ustaw innego klienta jako domyślnego w Ustawieniach ogólnych.",
+    "clientNotFound": "Nie znaleziono klienta.",
+    "deletePermissionDenied": "Odmowa uprawnień: nie można usuwać klientów."
   },
   "clientDetails": {
     "title": "Dane Klienta",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Dodano przychodzącą domenę e-mail",
     "inboundDomainAddFailed": "Nie udało się dodać domeny",
     "inboundDomainRemoved": "Usunięto przychodzącą domenę e-mail",
-    "inboundDomainRemoveFailed": "Nie udało się usunąć domeny"
+    "inboundDomainRemoveFailed": "Nie udało się usunąć domeny",
+    "deactivateClientDescription": "Dezaktywuje rekord bez usuwania jego danych.",
+    "deactivateClientOnlyDescription": "Dezaktywuj klienta, ale pozostaw jego kontakty aktywne."
   },
   "quickAddClient": {
     "title": "Dodaj nowego klienta",

--- a/server/public/locales/pt/common.json
+++ b/server/public/locales/pt/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "Por favor, forneça um comentário"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "Verificando dependências",
+    "deleteTitle": "Excluir {{entityName}}",
+    "cannotDeleteTitle": "Não é possível excluir",
+    "deleting": "Excluindo...",
+    "checkingDependenciesMessage": "Verificando dependências...",
+    "fallbackBlockMessage": "Remova ou reatribua estes itens antes de excluir.",
+    "confirmationMessage": "Tem certeza de que deseja excluir \"{{entityName}}\"? Esta ação não pode ser desfeita.",
+    "alternatives": {
+      "deactivate": {
+        "label": "Marcar como inativo",
+        "description": "Desativa o registro sem excluir seus dados.",
+        "warning": "Registros inativos não poderão mais ser selecionados em novos fluxos de trabalho."
+      },
+      "archive": {
+        "label": "Arquivar",
+        "description": "Move o registro para fora do uso ativo preservando o histórico.",
+        "warning": "Registros arquivados ficam ocultos nas visualizações padrão."
+      }
+    }
   }
 }

--- a/server/public/locales/pt/msp/clients.json
+++ b/server/public/locales/pt/msp/clients.json
@@ -132,7 +132,10 @@
     "deleteSelectedPrompt": "Are you sure you want to delete {{count}} selected {{clientsLabel}}? This action cannot be undone.",
     "singleInactiveSuccess": "{{name}} foi marcado como inativo com sucesso.",
     "singleInactiveWithContactsSuccess_one": "{{name}} e {{count}} contato foram desativados com sucesso.",
-    "singleInactiveWithContactsSuccess_other": "{{name}} e {{count}} contatos foram desativados com sucesso."
+    "singleInactiveWithContactsSuccess_other": "{{name}} e {{count}} contatos foram desativados com sucesso.",
+    "defaultClientDeleteError": "Não é possível excluir o cliente padrão. Primeiro defina outro cliente como padrão em Configurações gerais.",
+    "clientNotFound": "Cliente não encontrado.",
+    "deletePermissionDenied": "Permissão negada: não é possível excluir clientes."
   },
   "clientDetails": {
     "title": "Client Details",
@@ -216,7 +219,9 @@
     "inboundDomainAdded": "Domínio de e-mail de entrada adicionado",
     "inboundDomainAddFailed": "Falha ao adicionar o domínio",
     "inboundDomainRemoved": "Domínio de e-mail de entrada removido",
-    "inboundDomainRemoveFailed": "Falha ao remover o domínio"
+    "inboundDomainRemoveFailed": "Falha ao remover o domínio",
+    "deactivateClientDescription": "Desativa o registro sem excluir seus dados.",
+    "deactivateClientOnlyDescription": "Desative o cliente, mas mantenha seus contatos ativos."
   },
   "quickAddClient": {
     "title": "Add New Client",

--- a/server/public/locales/xx/common.json
+++ b/server/public/locales/xx/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "11111"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "11111",
+    "deleteTitle": "11111 {{entityName}}",
+    "cannotDeleteTitle": "11111",
+    "deleting": "11111",
+    "checkingDependenciesMessage": "11111",
+    "fallbackBlockMessage": "11111",
+    "confirmationMessage": "11111 {{entityName}} 11111",
+    "alternatives": {
+      "deactivate": {
+        "label": "11111",
+        "description": "11111",
+        "warning": "11111"
+      },
+      "archive": {
+        "label": "11111",
+        "description": "11111",
+        "warning": "11111"
+      }
+    }
   }
 }

--- a/server/public/locales/xx/msp/clients.json
+++ b/server/public/locales/xx/msp/clients.json
@@ -132,7 +132,10 @@
       "bucketUsageRecord": "11111",
       "bucketUsageRecords": "11111"
     },
-    "deleteSelectedPrompt": "11111 {{count}} 11111 {{clientsLabel}} 11111"
+    "deleteSelectedPrompt": "11111 {{count}} 11111 {{clientsLabel}} 11111",
+    "defaultClientDeleteError": "11111",
+    "clientNotFound": "11111",
+    "deletePermissionDenied": "11111"
   },
   "clientDetails": {
     "title": "11111",
@@ -216,7 +219,9 @@
     "status": {
       "label": "11111",
       "helper": "11111"
-    }
+    },
+    "deactivateClientDescription": "11111",
+    "deactivateClientOnlyDescription": "11111"
   },
   "quickAddClient": {
     "title": "11111",

--- a/server/public/locales/yy/common.json
+++ b/server/public/locales/yy/common.json
@@ -1122,5 +1122,26 @@
   },
   "feedback": {
     "providePlaceholder": "55555"
+  },
+  "deleteEntity": {
+    "checkingDependenciesTitle": "55555",
+    "deleteTitle": "55555 {{entityName}}",
+    "cannotDeleteTitle": "55555",
+    "deleting": "55555",
+    "checkingDependenciesMessage": "55555",
+    "fallbackBlockMessage": "55555",
+    "confirmationMessage": "55555 {{entityName}} 55555",
+    "alternatives": {
+      "deactivate": {
+        "label": "55555",
+        "description": "55555",
+        "warning": "55555"
+      },
+      "archive": {
+        "label": "55555",
+        "description": "55555",
+        "warning": "55555"
+      }
+    }
   }
 }

--- a/server/public/locales/yy/msp/clients.json
+++ b/server/public/locales/yy/msp/clients.json
@@ -132,7 +132,10 @@
       "bucketUsageRecord": "55555",
       "bucketUsageRecords": "55555"
     },
-    "deleteSelectedPrompt": "55555 {{count}} 55555 {{clientsLabel}} 55555"
+    "deleteSelectedPrompt": "55555 {{count}} 55555 {{clientsLabel}} 55555",
+    "defaultClientDeleteError": "55555",
+    "clientNotFound": "55555",
+    "deletePermissionDenied": "55555"
   },
   "clientDetails": {
     "title": "55555",
@@ -216,7 +219,9 @@
     "status": {
       "label": "55555",
       "helper": "55555"
-    }
+    },
+    "deactivateClientDescription": "55555",
+    "deactivateClientOnlyDescription": "55555"
   },
   "quickAddClient": {
     "title": "55555",


### PR DESCRIPTION
  Drop the stale 'client' → 'company' permission alias in preCheckDeletion
  so post-rename installs find their seeded client:delete permission again
  and the dialog stops returning a blanket "no permission" denial.

  Unify the two single-client delete buttons on packages/ui's shared
  DeleteEntityDialog + validateClientDeletion precheck pattern. The list
  view's bespoke dialog (with its dead handleDependencyError / counts-map
  indirection) is gone, the legacy COMPANY_HAS_DEPENDENCIES code branch is
  retired, and the empty "associated records:" render is fixed.

  Restore the Client Only vs Client & Contacts choice via
  tailorClientDeleteAlternatives in clientActions, applied to both the
  precheck and the deleteClient post-check so a race that surfaces fresh
  dependencies still gets the right buttons. Already-inactive clients no
  longer get offered a meaningless second Mark as Inactive.

  Add localization for dependency labels, validation messages, and
  alternative button labels in ClientDetails, plus i18n keys across all
  locales and a DeleteEntityDialog test for the new behavior.

  "Off with their head!" cried the Queen of Hearts — but the precheck
  kept asking for a 'company' that had long since vanished from
  Wonderland. Now both Delete buttons speak the same tongue, and a
  client harboring contacts may choose to lose its head alone or invite
  the entire tea party along. 🃏🐇🎩