### PR TITLE
fix(contract-wizard): layout, alignment, and summary polish

### DIFF
--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ContractBasicsStep.tsx
@@ -713,8 +713,8 @@ export function ContractBasicsStep({
 
             <div className="space-y-2">
               <Label htmlFor="po_amount">{t('wizardBasics.po.amountLabel', { defaultValue: 'PO Amount' })}</Label>
-              <div className="flex h-10 items-center rounded-md border border-[rgb(var(--color-border-400))] shadow-sm focus-within:border-transparent focus-within:ring-2 focus-within:ring-[rgb(var(--color-primary-500))]">
-                <span className="shrink-0 pl-3 pr-1 text-[rgb(var(--color-text-400))]">
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[rgb(var(--color-text-400))]">
                   {currencySymbol}
                 </span>
                 <Input
@@ -743,7 +743,7 @@ export function ContractBasicsStep({
                   placeholder={
                     currencyMeta.fractionDigits === 0 ? '0' : `0.${'0'.repeat(currencyMeta.fractionDigits)}`
                   }
-                  className="h-full rounded-none border-0 py-0 pl-1 pr-3 shadow-none focus:border-transparent focus:ring-0"
+                  className="pl-10"
                 />
               </div>
               <p className="text-xs text-[rgb(var(--color-text-400))]">

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/FixedFeeServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/FixedFeeServicesStep.tsx
@@ -16,6 +16,7 @@ import { BillingFrequencyOverrideSelect } from '../BillingFrequencyOverrideSelec
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { getRecurringAuthoringPreview } from '../recurringAuthoringPreview';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useFormatBillingFrequency } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 
 interface FixedFeeServicesStepProps {
   data: ContractWizardData;
@@ -108,6 +109,11 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
     billingFrequency: data.fixed_billing_frequency ?? data.billing_frequency,
     enableProration: data.enable_proration,
   }, t);
+
+  const formatBillingFrequency = useFormatBillingFrequency();
+  const hasAlternateBillingFrequency =
+    data.fixed_billing_frequency !== undefined &&
+    data.fixed_billing_frequency !== data.billing_frequency;
 
   return (
     <ReflectionContainer id="fixed-fee-services-step">
@@ -281,6 +287,15 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
         )}
 
         {data.fixed_services.length > 0 && (
+          <BillingFrequencyOverrideSelect
+            contractBillingFrequency={data.billing_frequency}
+            value={data.fixed_billing_frequency}
+            onChange={(value) => updateData({ fixed_billing_frequency: value })}
+            label={t('wizardFixed.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
+          />
+        )}
+
+        {data.fixed_services.length > 0 && (
           <Alert variant="info" className="mt-6">
             <AlertDescription>
               <h4 className="text-sm font-semibold mb-2">
@@ -309,8 +324,28 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
                 <p>{recurringPreview.billingTimingSummary}</p>
                 <p>{recurringPreview.firstInvoiceSummary}</p>
                 <p>{recurringPreview.partialPeriodSummary}</p>
+                {hasAlternateBillingFrequency && data.fixed_billing_frequency && (
+                  <p>
+                    <strong>
+                      {t('wizardFixed.preview.labels.alternateFrequency', {
+                        defaultValue: 'Alternate Billing Frequency:',
+                      })}
+                    </strong>{' '}
+                    {formatBillingFrequency(data.fixed_billing_frequency)}
+                  </p>
+                )}
                 <div className="pt-2">
-                  <p><strong>{recurringPreview.materializedPeriodsHeading}:</strong></p>
+                  <p className="flex items-center gap-1">
+                    <strong>{recurringPreview.materializedPeriodsHeading}:</strong>
+                    <Tooltip
+                      content={t('wizardFixed.preview.materializedPeriods.tooltip', {
+                        defaultValue:
+                          'A preview of the next few service periods and the invoice windows that would be generated for them based on the current settings. These help you sanity-check the cadence before saving — actual invoices are produced later by the billing run.',
+                      })}
+                    >
+                      <HelpCircle className="h-3.5 w-3.5 text-[rgb(var(--color-text-300))] cursor-help" />
+                    </Tooltip>
+                  </p>
                   <p>{recurringPreview.materializedPeriodsSummary}</p>
                   <ul className="list-disc pl-5 space-y-1">
                     {recurringPreview.materializedPeriods.map((period) => (
@@ -330,15 +365,6 @@ export function FixedFeeServicesStep({ data, updateData }: FixedFeeServicesStepP
               </div>
             </AlertDescription>
           </Alert>
-        )}
-
-        {data.fixed_services.length > 0 && (
-          <BillingFrequencyOverrideSelect
-            contractBillingFrequency={data.billing_frequency}
-            value={data.fixed_billing_frequency}
-            onChange={(value) => updateData({ fixed_billing_frequency: value })}
-            label={t('wizardFixed.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
-          />
         )}
       </div>
     </ReflectionContainer>

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
@@ -13,6 +13,7 @@ import { BucketOverlayFields } from '../BucketOverlayFields';
 import { BillingFrequencyOverrideSelect } from '../BillingFrequencyOverrideSelect';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useFormatBillingFrequency } from '@alga-psa/billing/hooks/useBillingEnumOptions';
 
 interface HourlyServicesStepProps {
   data: ContractWizardData;
@@ -105,6 +106,11 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
     if (!cents) return `${currencySymbol}0.00`;
     return `${currencySymbol}${(cents / 100).toFixed(2)}`;
   };
+
+  const formatBillingFrequency = useFormatBillingFrequency();
+  const hasAlternateBillingFrequency =
+    data.hourly_billing_frequency !== undefined &&
+    data.hourly_billing_frequency !== data.billing_frequency;
 
   return (
     <div className="space-y-6">
@@ -307,6 +313,15 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
       )}
 
       {data.hourly_services.length > 0 && (
+        <BillingFrequencyOverrideSelect
+          contractBillingFrequency={data.billing_frequency}
+          value={data.hourly_billing_frequency}
+          onChange={(value) => updateData({ hourly_billing_frequency: value })}
+          label={t('wizardHourly.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
+        />
+      )}
+
+      {data.hourly_services.length > 0 && (
         <Alert variant="info" className="mt-6">
           <AlertDescription>
             <h4 className="text-sm font-semibold mb-2">
@@ -335,18 +350,79 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
                   })}
                 </p>
               )}
+              {hasAlternateBillingFrequency && data.hourly_billing_frequency && (
+                <p>
+                  <strong>
+                    {t('wizardHourly.summary.labels.alternateFrequency', {
+                      defaultValue: 'Alternate Billing Frequency:',
+                    })}
+                  </strong>{' '}
+                  {formatBillingFrequency(data.hourly_billing_frequency)}
+                </p>
+              )}
+              {data.hourly_services.some((service) => service.bucket_overlay) && (
+                <div className="pt-2">
+                  <p className="font-semibold">
+                    {t('wizardHourly.summary.labels.bucketsHeading', { defaultValue: 'Buckets:' })}
+                  </p>
+                  <ul className="list-disc pl-5 space-y-1">
+                    {data.hourly_services.map((service, index) => {
+                      if (!service.bucket_overlay) return null;
+                      const overlay = service.bucket_overlay;
+                      const includedHours =
+                        overlay.total_minutes !== undefined ? overlay.total_minutes / 60 : undefined;
+                      const serviceLabel =
+                        service.service_name ||
+                        t('wizardHourly.summary.labels.serviceFallback', {
+                          defaultValue: 'Service {{index}}',
+                          index: index + 1,
+                        });
+                      return (
+                        <li key={`hourly-bucket-summary-${index}`}>
+                          <span className="block">
+                            <strong>{serviceLabel}</strong>
+                          </span>
+                          {includedHours !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.includedHours', { defaultValue: 'Included Hours:' })}
+                              </strong>{' '}
+                              {t('wizardHourly.summary.values.hours', {
+                                defaultValue: '{{count}} hours',
+                                count: includedHours,
+                              })}
+                            </span>
+                          )}
+                          {overlay.overage_rate !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.overageRate', { defaultValue: 'Overage Rate:' })}
+                              </strong>{' '}
+                              {t('wizardHourly.summary.values.overageRatePerHour', {
+                                defaultValue: '{{rate}}/hour',
+                                rate: formatCurrency(overlay.overage_rate),
+                              })}
+                            </span>
+                          )}
+                          {overlay.allow_rollover !== undefined && (
+                            <span className="block">
+                              <strong>
+                                {t('wizardHourly.summary.labels.rollover', { defaultValue: 'Rollover:' })}
+                              </strong>{' '}
+                              {overlay.allow_rollover
+                                ? t('wizardHourly.summary.values.rolloverEnabled', { defaultValue: 'Enabled' })
+                                : t('wizardHourly.summary.values.rolloverDisabled', { defaultValue: 'Disabled' })}
+                            </span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
             </div>
           </AlertDescription>
         </Alert>
-      )}
-
-      {data.hourly_services.length > 0 && (
-        <BillingFrequencyOverrideSelect
-          contractBillingFrequency={data.billing_frequency}
-          value={data.hourly_billing_frequency}
-          onChange={(value) => updateData({ hourly_billing_frequency: value })}
-          label={t('wizardHourly.alternateFrequencyLabel', { defaultValue: 'Alternate Billing Frequency (Optional)' })}
-        />
       )}
     </div>
   );

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
@@ -161,7 +161,7 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
                     />
                   </div>
 
-                  <div className="flex items-end gap-4 flex-wrap">
+                  <div className="flex items-start gap-4 flex-wrap">
                     <div className="space-y-2">
                       <Label htmlFor={`product-quantity-${index}`} className="text-sm">
                         {t('wizardProducts.labels.quantity', { defaultValue: 'Quantity' })}

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
@@ -168,7 +168,7 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor={`unit-rate-${index}`} className="text-sm flex items-center gap-2">
+                  <Label htmlFor={`unit-rate-${index}`} className="text-sm flex items-center gap-2 h-5">
                     <Coins className="h-3 w-3" />
                     {t('wizardUsage.labels.ratePerUnit', { defaultValue: 'Rate per Unit' })}
                   </Label>
@@ -216,7 +216,7 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor={`unit-measure-${index}`} className="text-sm">
+                  <Label htmlFor={`unit-measure-${index}`} className="text-sm flex items-center gap-2 h-5">
                     {t('wizardUsage.labels.unitOfMeasure', { defaultValue: 'Unit of Measure' })}
                   </Label>
                   <Input

--- a/server/public/locales/de/msp/contracts.json
+++ b/server/public/locales/de/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Festgebühren-Services",
     "preview": {
       "labels": {
+        "alternateFrequency": "Alternative Abrechnungsfrequenz:",
         "billingTiming": "Abrechnungszeitpunkt:",
         "cadenceOwner": "Rhythmus-Eigentümer:",
         "invoiceWindow": "Rechnungsfenster:",
         "recurringRate": "Wiederkehrender Tarif:",
         "service": "Dienst:",
         "services": "Dienste:"
+      },
+      "materializedPeriods": {
+        "tooltip": "Eine Vorschau der nächsten Servicezeiträume und der Rechnungsfenster, die auf Grundlage der aktuellen Einstellungen für sie erzeugt würden. Damit lässt sich die Kadenz vor dem Speichern überprüfen – die tatsächlichen Rechnungen werden später vom Abrechnungslauf erstellt."
       },
       "title": "Wiederkehrende Vorschau vor dem Speichern"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Alternative Abrechnungsfrequenz:",
+        "bucketsHeading": "Stundenkontingente:",
+        "includedHours": "Inkludierte Stunden:",
         "minimumTime": "Minimale Zeit:",
+        "overageRate": "Überschreitungssatz:",
+        "rollover": "Übertrag:",
         "roundUp": "Aufrunden:",
+        "serviceFallback": "Service {{index}}",
         "services": "Dienste:"
       },
       "title": "Zusammenfassung der Stunden-Services",
       "values": {
         "everyMinutes": "Alle {{count}} Minuten",
-        "minutes": "{{count}} Minuten"
+        "hours": "{{count}} Stunden",
+        "minutes": "{{count}} Minuten",
+        "overageRatePerHour": "{{rate}}/Stunde",
+        "rolloverDisabled": "Deaktiviert",
+        "rolloverEnabled": "Aktiviert"
       }
     }
   },

--- a/server/public/locales/en/msp/contracts.json
+++ b/server/public/locales/en/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Fixed Fee Services",
     "preview": {
       "labels": {
+        "alternateFrequency": "Alternate Billing Frequency:",
         "billingTiming": "Billing Timing:",
         "cadenceOwner": "Cadence Owner:",
         "invoiceWindow": "Invoice window:",
         "recurringRate": "Recurring Rate:",
         "service": "Service:",
         "services": "Services:"
+      },
+      "materializedPeriods": {
+        "tooltip": "A preview of the next few service periods and the invoice windows that would be generated for them based on the current settings. These help you sanity-check the cadence before saving — actual invoices are produced later by the billing run."
       },
       "title": "Recurring Preview Before Save"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Alternate Billing Frequency:",
+        "bucketsHeading": "Buckets:",
+        "includedHours": "Included Hours:",
         "minimumTime": "Minimum Time:",
+        "overageRate": "Overage Rate:",
+        "rollover": "Rollover:",
         "roundUp": "Round Up:",
+        "serviceFallback": "Service {{index}}",
         "services": "Services:"
       },
       "title": "Hourly Services Summary",
       "values": {
         "everyMinutes": "Every {{count}} minutes",
-        "minutes": "{{count}} minutes"
+        "hours": "{{count}} hours",
+        "minutes": "{{count}} minutes",
+        "overageRatePerHour": "{{rate}}/hour",
+        "rolloverDisabled": "Disabled",
+        "rolloverEnabled": "Enabled"
       }
     }
   },

--- a/server/public/locales/es/msp/contracts.json
+++ b/server/public/locales/es/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Servicios de tarifa fija",
     "preview": {
       "labels": {
+        "alternateFrequency": "Frecuencia de facturación alternativa:",
         "billingTiming": "Momento de facturación:",
         "cadenceOwner": "Propietario de la cadencia:",
         "invoiceWindow": "Ventana de facturación:",
         "recurringRate": "Tarifa recurrente:",
         "service": "Servicio:",
         "services": "Servicios:"
+      },
+      "materializedPeriods": {
+        "tooltip": "Vista previa de los próximos periodos de servicio y las ventanas de facturación que se generarían para ellos según la configuración actual. Permiten verificar la cadencia antes de guardar — las facturas reales se generan después en la ejecución de facturación."
       },
       "title": "Vista previa recurrente antes de guardar"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Frecuencia de facturación alternativa:",
+        "bucketsHeading": "Bloques:",
+        "includedHours": "Horas incluidas:",
         "minimumTime": "Tiempo mínimo:",
+        "overageRate": "Tarifa de exceso:",
+        "rollover": "Traslado:",
         "roundUp": "Redondear:",
+        "serviceFallback": "Servicio {{index}}",
         "services": "Servicios:"
       },
       "title": "Resumen de servicios por hora",
       "values": {
         "everyMinutes": "Cada {{count}} minutos",
-        "minutes": "{{count}} minutos"
+        "hours": "{{count}} horas",
+        "minutes": "{{count}} minutos",
+        "overageRatePerHour": "{{rate}}/hora",
+        "rolloverDisabled": "Deshabilitado",
+        "rolloverEnabled": "Habilitado"
       }
     }
   },

--- a/server/public/locales/fr/msp/contracts.json
+++ b/server/public/locales/fr/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Services à frais fixes",
     "preview": {
       "labels": {
+        "alternateFrequency": "Fréquence de facturation alternative :",
         "billingTiming": "Moment de facturation :",
         "cadenceOwner": "Propriétaire de la cadence :",
         "invoiceWindow": "Fenêtre de facturation :",
         "recurringRate": "Tarif récurrent :",
         "service": "Service :",
         "services": "Services :"
+      },
+      "materializedPeriods": {
+        "tooltip": "Aperçu des prochaines périodes de service et des fenêtres de facturation qui seraient générées pour elles selon les paramètres actuels. Ces données permettent de vérifier la cadence avant l'enregistrement — les factures réelles sont produites plus tard lors de l'exécution de facturation."
       },
       "title": "Aperçu récurrent avant enregistrement"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Fréquence de facturation alternative :",
+        "bucketsHeading": "Banques :",
+        "includedHours": "Heures incluses :",
         "minimumTime": "Temps minimum :",
+        "overageRate": "Tarif de dépassement :",
+        "rollover": "Report :",
         "roundUp": "Arrondi :",
+        "serviceFallback": "Service {{index}}",
         "services": "Services :"
       },
       "title": "Résumé des services horaires",
       "values": {
         "everyMinutes": "Toutes les {{count}} minutes",
-        "minutes": "{{count}} minutes"
+        "hours": "{{count}} heures",
+        "minutes": "{{count}} minutes",
+        "overageRatePerHour": "{{rate}}/heure",
+        "rolloverDisabled": "Désactivé",
+        "rolloverEnabled": "Activé"
       }
     }
   },

--- a/server/public/locales/it/msp/contracts.json
+++ b/server/public/locales/it/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Servizi a tariffa fissa",
     "preview": {
       "labels": {
+        "alternateFrequency": "Frequenza di fatturazione alternativa:",
         "billingTiming": "Tempistiche di fatturazione:",
         "cadenceOwner": "Proprietario della cadenza:",
         "invoiceWindow": "Finestra di fatturazione:",
         "recurringRate": "Tariffa ricorrente:",
         "service": "Servizio:",
         "services": "Servizi:"
+      },
+      "materializedPeriods": {
+        "tooltip": "Anteprima dei prossimi periodi di servizio e delle finestre di fatturazione che verrebbero generate per essi in base alle impostazioni attuali. Permettono di verificare la cadenza prima del salvataggio — le fatture effettive vengono prodotte successivamente dall'esecuzione di fatturazione."
       },
       "title": "Anteprima ricorrente prima del salvataggio"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Frequenza di fatturazione alternativa:",
+        "bucketsHeading": "Pacchetti:",
+        "includedHours": "Ore incluse:",
         "minimumTime": "Tempo minimo:",
+        "overageRate": "Tariffa di superamento:",
+        "rollover": "Riporto:",
         "roundUp": "Arrotondamento per eccesso:",
+        "serviceFallback": "Servizio {{index}}",
         "services": "Servizi:"
       },
       "title": "Riepilogo dei servizi orari",
       "values": {
         "everyMinutes": "Ogni {{count}} minuti",
-        "minutes": "{{count}} minuti"
+        "hours": "{{count}} ore",
+        "minutes": "{{count}} minuti",
+        "overageRatePerHour": "{{rate}}/ora",
+        "rolloverDisabled": "Disabilitato",
+        "rolloverEnabled": "Abilitato"
       }
     }
   },

--- a/server/public/locales/nl/msp/contracts.json
+++ b/server/public/locales/nl/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Vaste-vergoedingsservices",
     "preview": {
       "labels": {
+        "alternateFrequency": "Alternatieve factureerfrequentie:",
         "billingTiming": "Facturatietiming:",
         "cadenceOwner": "Cadanseigenaar:",
         "invoiceWindow": "Factuurvenster:",
         "recurringRate": "Terugkerend tarief:",
         "service": "Service:",
         "services": "Services:"
+      },
+      "materializedPeriods": {
+        "tooltip": "Een voorbeeld van de volgende serviceperioden en de factureringsvensters die op basis van de huidige instellingen zouden worden gegenereerd. Hiermee kunt u de cadans controleren voordat u opslaat — de daadwerkelijke facturen worden later door de factureringsrun geproduceerd."
       },
       "title": "Terugkerend voorbeeld vóór opslaan"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Alternatieve factureerfrequentie:",
+        "bucketsHeading": "Bundels:",
+        "includedHours": "Inbegrepen uren:",
         "minimumTime": "Minimale tijd:",
+        "overageRate": "Overschrijdingstarief:",
+        "rollover": "Overdracht:",
         "roundUp": "Naar boven afronden:",
+        "serviceFallback": "Service {{index}}",
         "services": "Services:"
       },
       "title": "Samenvatting uurservices",
       "values": {
         "everyMinutes": "Elke {{count}} minuten",
-        "minutes": "{{count}} minuten"
+        "hours": "{{count}} uur",
+        "minutes": "{{count}} minuten",
+        "overageRatePerHour": "{{rate}}/uur",
+        "rolloverDisabled": "Uitgeschakeld",
+        "rolloverEnabled": "Ingeschakeld"
       }
     }
   },

--- a/server/public/locales/pl/msp/contracts.json
+++ b/server/public/locales/pl/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Usługi z opłatą stałą",
     "preview": {
       "labels": {
+        "alternateFrequency": "Alternatywna częstotliwość rozliczeń:",
         "billingTiming": "Termin rozliczeń:",
         "cadenceOwner": "Właściciel rytmu:",
         "invoiceWindow": "Okno fakturowania:",
         "recurringRate": "Stawka cykliczna:",
         "service": "Usługa:",
         "services": "Usługi:"
+      },
+      "materializedPeriods": {
+        "tooltip": "Podgląd kilku następnych okresów świadczenia usług i okien fakturowania, które zostałyby wygenerowane dla nich w oparciu o bieżące ustawienia. Pomaga zweryfikować cykl przed zapisaniem — rzeczywiste faktury są generowane później podczas uruchomienia rozliczeń."
       },
       "title": "Podgląd cyklu przed zapisaniem"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Alternatywna częstotliwość rozliczeń:",
+        "bucketsHeading": "Pakiety:",
+        "includedHours": "Godziny w pakiecie:",
         "minimumTime": "Minimalny czas:",
+        "overageRate": "Stawka za przekroczenie:",
+        "rollover": "Przeniesienie:",
         "roundUp": "Zaokrąglij w górę:",
+        "serviceFallback": "Usługa {{index}}",
         "services": "Usługi:"
       },
       "title": "Podsumowanie usług godzinowych",
       "values": {
         "everyMinutes": "Co {{count}} minut",
-        "minutes": "{{count}} min"
+        "hours": "{{count}} godz.",
+        "minutes": "{{count}} min",
+        "overageRatePerHour": "{{rate}}/godz.",
+        "rolloverDisabled": "Wyłączone",
+        "rolloverEnabled": "Włączone"
       }
     }
   },

--- a/server/public/locales/pt/msp/contracts.json
+++ b/server/public/locales/pt/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "Fixed Fee Services",
     "preview": {
       "labels": {
+        "alternateFrequency": "Alternate Billing Frequency:",
         "billingTiming": "Billing Timing:",
         "cadenceOwner": "Cadence Owner:",
         "invoiceWindow": "Invoice window:",
         "recurringRate": "Recurring Rate:",
         "service": "Service:",
         "services": "Services:"
+      },
+      "materializedPeriods": {
+        "tooltip": "A preview of the next few service periods and the invoice windows that would be generated for them based on the current settings. These help you sanity-check the cadence before saving — actual invoices are produced later by the billing run."
       },
       "title": "Recurring Preview Before Save"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "Alternate Billing Frequency:",
+        "bucketsHeading": "Buckets:",
+        "includedHours": "Included Hours:",
         "minimumTime": "Minimum Time:",
+        "overageRate": "Overage Rate:",
+        "rollover": "Rollover:",
         "roundUp": "Round Up:",
+        "serviceFallback": "Service {{index}}",
         "services": "Services:"
       },
       "title": "Hourly Services Summary",
       "values": {
         "everyMinutes": "Every {{count}} minutes",
-        "minutes": "{{count}} minutes"
+        "hours": "{{count}} hours",
+        "minutes": "{{count}} minutes",
+        "overageRatePerHour": "{{rate}}/hour",
+        "rolloverDisabled": "Disabled",
+        "rolloverEnabled": "Enabled"
       }
     }
   },

--- a/server/public/locales/xx/msp/contracts.json
+++ b/server/public/locales/xx/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "11111",
     "preview": {
       "labels": {
+        "alternateFrequency": "11111",
         "billingTiming": "11111",
         "cadenceOwner": "11111",
         "invoiceWindow": "11111",
         "recurringRate": "11111",
         "service": "11111",
         "services": "11111"
+      },
+      "materializedPeriods": {
+        "tooltip": "11111"
       },
       "title": "11111"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "11111",
+        "bucketsHeading": "11111",
+        "includedHours": "11111",
         "minimumTime": "11111",
+        "overageRate": "11111",
+        "rollover": "11111",
         "roundUp": "11111",
+        "serviceFallback": "11111",
         "services": "11111"
       },
       "title": "11111",
       "values": {
         "everyMinutes": "11111 {{count}} 11111",
-        "minutes": "11111 {{count}} 11111"
+        "hours": "11111",
+        "minutes": "11111 {{count}} 11111",
+        "overageRatePerHour": "11111",
+        "rolloverDisabled": "11111",
+        "rolloverEnabled": "11111"
       }
     }
   },

--- a/server/public/locales/yy/msp/contracts.json
+++ b/server/public/locales/yy/msp/contracts.json
@@ -1463,12 +1463,16 @@
     "heading": "55555",
     "preview": {
       "labels": {
+        "alternateFrequency": "55555",
         "billingTiming": "55555",
         "cadenceOwner": "55555",
         "invoiceWindow": "55555",
         "recurringRate": "55555",
         "service": "55555",
         "services": "55555"
+      },
+      "materializedPeriods": {
+        "tooltip": "55555"
       },
       "title": "55555"
     },
@@ -1538,14 +1542,24 @@
     },
     "summary": {
       "labels": {
+        "alternateFrequency": "55555",
+        "bucketsHeading": "55555",
+        "includedHours": "55555",
         "minimumTime": "55555",
+        "overageRate": "55555",
+        "rollover": "55555",
         "roundUp": "55555",
+        "serviceFallback": "55555",
         "services": "55555"
       },
       "title": "55555",
       "values": {
         "everyMinutes": "55555 {{count}} 55555",
-        "minutes": "55555 {{count}} 55555"
+        "hours": "55555",
+        "minutes": "55555 {{count}} 55555",
+        "overageRatePerHour": "55555",
+        "rolloverDisabled": "55555",
+        "rolloverEnabled": "55555"
       }
     }
   },


### PR DESCRIPTION
## Summary

Aesthetic-only subset of the original `fix/contract-wizard-preview-and-layout` branch. Touches only the wizard step components — no engine, no preview-resolution logic, no persistence path.

- **ContractBasicsStep**: PO Amount field switched to the codebase's standard currency-prefixed input pattern (relative wrapper + absolute-positioned currency span + `Input` with `pl-10`), matching `ContractLineEditDialog`, `EditContractLineServiceQuantityDialog`, and `FixedFeeServicesStep`. Fixes the double-border / double-ring rendering and preserves `useAutomationIdAndRegister` registration.
- **ProductsStep**: Quantity / Override row switched from `items-end` to `items-start` so the two inputs align at the top instead of being staggered by the trailing helper text under Override.
- **UsageBasedServicesStep**: Rate per Unit and Unit of Measure labels both render at a consistent fixed height (`flex items-center gap-2 h-5`), so the inputs line up whether or not a label has an icon.
- **FixedFeeServicesStep**: "Recurring Preview Before Save" panel renders below the Alternate Billing Frequency selector instead of above it. Summary includes a dedicated "Alternate Billing Frequency:" line when an override differs from the contract frequency. Added a HelpCircle tooltip on "Illustrative future materialized periods" explaining what the preview is for.
- **HourlyServicesStep**: Hourly Services Summary panel renders below the Alternate Billing Frequency selector. Summary now lists each bucket-enabled hourly service with Included Hours, Overage Rate, and Rollover status. Alternate billing frequency shown on its own line when set.

## What this PR intentionally does NOT include

The original branch also touched `recurringAuthoringPreview.ts` (and the i18n / test files supporting it) to change how the preview resolves billing frequencies per cadence owner. Those commits are **excluded** here — they patch a symptom of an upstream UX problem in `ContractBasicsStep` where the wizard offers cadence-owner / billing-frequency combinations the engine has coded as unsupported. That work is tracked separately and should be approached as a wizard-control fix rather than a preview-helper fix.

## Test plan

- [ ] Contract wizard → Contract Basics step: PO Amount field renders with a single border / single focus ring; currency symbol is positioned correctly; field accepts numeric input and the automation registry still picks it up.
- [ ] Contract wizard → Products step: Quantity and Override unit price inputs align at the top of their row regardless of whether the Override helper text is present.
- [ ] Contract wizard → Usage-Based step: Rate per Unit (with Coins icon) and Unit of Measure (no icon) labels and their inputs are vertically aligned.
- [ ] Contract wizard → Fixed Fee step: with services added, the Alternate Billing Frequency selector appears above the Recurring Preview panel; tooltip on the materialized-periods heading renders on hover; the "Alternate Billing Frequency:" summary line appears only when an override is set and differs from the contract frequency.
- [ ] Contract wizard → Hourly Services step: with services added, the Alternate Billing Frequency selector appears above the summary panel; bucket-enabled services list Included Hours / Overage Rate / Rollover in the summary; the "Alternate Billing Frequency:" line appears only when an override is set.