### PR TITLE
Update sidebar nav icons for Tickets and Projects

### DIFF
--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -28,6 +28,7 @@ import {
   Layers,
   LayoutDashboard,
   LayoutTemplate,
+  ListTodo,
   ListTree,
   Mail,
   MapPin,
@@ -43,11 +44,13 @@ import {
   Settings,
   Shield,
   SlidersHorizontal,
+  SquareDashedKanban,
   Timer,
   User,
   UserCog,
   Users,
-  Star
+  Star,
+  Ticket
 } from 'lucide-react';
 
 // Navigation modes for the unified sidebar
@@ -88,7 +91,7 @@ export const navigationSections: NavigationSection[] = [
       {
         name: 'Tickets',
         translationKey: 'nav.tickets',
-        icon: MessageSquare,
+        icon: Ticket,
         href: '/msp/tickets'
       },
       {
@@ -106,10 +109,10 @@ export const navigationSections: NavigationSection[] = [
       {
         name: 'Projects',
         translationKey: 'nav.projects',
-        icon: Layers,
+        icon: ListTodo,
         subItems: [
-          { name: 'All Projects', translationKey: 'nav.projectsAll', icon: Layers, href: '/msp/projects' },
-          { name: 'Templates', translationKey: 'nav.projectsTemplates', icon: FileText, href: '/msp/projects/templates' }
+          { name: 'All Projects', translationKey: 'nav.projectsAll', icon: ListTodo, href: '/msp/projects' },
+          { name: 'Templates', translationKey: 'nav.projectsTemplates', icon: SquareDashedKanban, href: '/msp/projects/templates' }
         ]
       },
       {


### PR DESCRIPTION
## Summary
- **Tickets**: `MessageSquare` → `Ticket` (more recognizable for a ticketing item)
- **Projects**: `Layers` → `ListTodo` (also applied to the "All Projects" subitem)
- **Project Templates**: `FileText` → `SquareDashedKanban`

All changes are in `server/src/config/menuConfig.ts`.

## Test plan
- [ ] Sidebar shows a ticket icon next to "Tickets"
- [ ] Sidebar shows a checklist icon next to "Projects" and "All Projects"
- [ ] Sidebar shows a dashed-square kanban icon next to "Templates" under Projects