### PR TITLE
Remove runner labels from job monitoring UI

### DIFF
--- a/packages/jobs/src/components/monitoring/JobMetricsDisplay.tsx
+++ b/packages/jobs/src/components/monitoring/JobMetricsDisplay.tsx
@@ -16,17 +16,11 @@ export default function JobMetricsDisplay({ metrics }: JobMetricsDisplayProps) {
     : 0;
 
   const isMixedRunners = metrics.byRunner && metrics.byRunner.pgboss > 0 && metrics.byRunner.temporal > 0;
-  
-  let totalLabel = t('metrics.labels.totalJobs', { defaultValue: 'Total Jobs' });
-  if (metrics.byRunner && !isMixedRunners) {
-    if (metrics.byRunner.pgboss > 0) totalLabel = t('metrics.labels.totalJobsPgBoss', { defaultValue: 'Total Jobs (PG Boss)' });
-    if (metrics.byRunner.temporal > 0) totalLabel = t('metrics.labels.totalJobsTemporal', { defaultValue: 'Total Jobs (Temporal)' });
-  }
 
   const metricsData = [
     {
       id: 'total-jobs-metric',
-      label: totalLabel,
+      label: t('metrics.labels.totalJobs', { defaultValue: 'Total Jobs' }),
       value: metrics.total,
       icon: ListChecks,
       color: 'text-[rgb(var(--color-text-700))]',

--- a/packages/jobs/src/components/monitoring/RecentJobsDataTable.tsx
+++ b/packages/jobs/src/components/monitoring/RecentJobsDataTable.tsx
@@ -150,31 +150,6 @@ export default function RecentJobsDataTable({ initialData = [] }: RecentJobsData
       ),
     },
     {
-      title: t('recentTable.columns.runner', { defaultValue: 'Runner' }),
-      dataIndex: 'runner_type',
-      render: (runner: string, record: JobRecord) => (
-        <div className="flex flex-col items-start">
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-            runner === 'temporal' 
-              ? 'bg-purple-100 text-purple-700 border border-purple-200' 
-              : 'bg-blue-100 text-blue-700 border border-blue-200'
-          }`}>
-            {runner === 'temporal'
-              ? t('shared.runnerLabels.temporal', { defaultValue: 'Temporal' })
-              : t('shared.runnerLabels.pgboss', { defaultValue: 'PG Boss' })}
-          </span>
-          {record.external_id && (
-            <span className="text-[10px] text-[rgb(var(--color-text-400))] font-mono mt-0.5" title={record.external_id}>
-              {t('recentTable.externalId', {
-                defaultValue: 'ID: {{id}}...',
-                id: record.external_id.slice(0, 8),
-              })}
-            </span>
-          )}
-        </div>
-      ),
-    },
-    {
       title: t('recentTable.columns.status', { defaultValue: 'Status' }),
       dataIndex: 'status',
       render: (status: string) => <StatusBadge status={status} label={getStatusLabel(status)} />,
@@ -222,14 +197,6 @@ export default function RecentJobsDataTable({ initialData = [] }: RecentJobsData
       label: t('recentTable.print.columns.jobName', { defaultValue: 'Job Name' }),
       header: t('recentTable.print.columns.jobName', { defaultValue: 'Job Name' }),
       render: (job) => job.type,
-    },
-    {
-      key: 'runner',
-      label: t('recentTable.print.columns.runner', { defaultValue: 'Runner' }),
-      header: t('recentTable.print.columns.runner', { defaultValue: 'Runner' }),
-      render: (job) => job.runner_type === 'temporal'
-        ? t('shared.runnerLabels.temporal', { defaultValue: 'Temporal' })
-        : t('shared.runnerLabels.pgboss', { defaultValue: 'PG Boss' }),
     },
     {
       key: 'status',


### PR DESCRIPTION
## Summary
- Total Jobs card now always reads "Total Jobs" — dropped the conditional `(PG Boss)` / `(Temporal)` suffix
- Removed the Runner column from the recent jobs table (and from print column options)

## Test plan
- [ ] Open System monitoring → Job Monitoring
- [ ] Confirm the "Total Jobs" card has no runner suffix in either single-runner or mixed-runner environments
- [ ] Confirm the recent jobs table no longer has a Runner column
- [ ] Open Print options dialog and confirm Runner is no longer offered