### PR TITLE
Fix tenant args and deletion gates for time periods, services, tax rates

### DIFF
--- a/packages/auth/src/lib/preCheckDeletion.test.ts
+++ b/packages/auth/src/lib/preCheckDeletion.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getCurrentUserMock = vi.fn();
+const hasPermissionMock = vi.fn();
+const getDeletionConfigMock = vi.fn();
+const validateDeletionMock = vi.fn();
+const createTenantKnexMock = vi.fn();
+const withTransactionMock = vi.fn();
+
+vi.mock('./getCurrentUser', () => ({
+  getCurrentUser: (...args: any[]) => getCurrentUserMock(...args)
+}));
+
+vi.mock('./rbac', () => ({
+  hasPermission: (...args: any[]) => hasPermissionMock(...args)
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  getDeletionConfig: (...args: any[]) => getDeletionConfigMock(...args),
+  validateDeletion: (...args: any[]) => validateDeletionMock(...args)
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: (...args: any[]) => createTenantKnexMock(...args),
+  withTransaction: (...args: any[]) => withTransactionMock(...args)
+}));
+
+import { preCheckDeletion } from './preCheckDeletion';
+
+describe('preCheckDeletion permission mapping', () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockReset();
+    hasPermissionMock.mockReset();
+    getDeletionConfigMock.mockReset();
+    validateDeletionMock.mockReset();
+    createTenantKnexMock.mockReset();
+    withTransactionMock.mockReset();
+
+    getCurrentUserMock.mockResolvedValue({ user_id: 'u1', tenant: 't1' });
+    getDeletionConfigMock.mockReturnValue({ entityType: 'tax_rate', dependencies: [] });
+    hasPermissionMock.mockResolvedValue(true);
+    createTenantKnexMock.mockResolvedValue({ knex: {}, tenant: 't1' });
+    withTransactionMock.mockImplementation(async (_knex: unknown, fn: any) => fn({}));
+    validateDeletionMock.mockResolvedValue({ canDelete: true, dependencies: [], alternatives: [] });
+  });
+
+  it('checks billing:delete (not tax_rate:delete) when validating tax_rate deletion', async () => {
+    await preCheckDeletion('tax_rate', 'rate-1');
+
+    expect(hasPermissionMock).toHaveBeenCalledTimes(1);
+    const [, resource, action] = hasPermissionMock.mock.calls[0];
+    expect(resource).toBe('billing');
+    expect(action).toBe('delete');
+  });
+
+  it('returns PERMISSION_DENIED for tax_rate when user lacks billing:delete', async () => {
+    hasPermissionMock.mockResolvedValueOnce(false);
+
+    const result = await preCheckDeletion('tax_rate', 'rate-1');
+
+    expect(result.canDelete).toBe(false);
+    expect(result.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('still uses the entity type as resource for unmapped entities', async () => {
+    getDeletionConfigMock.mockReturnValueOnce({ entityType: 'project', dependencies: [] });
+
+    await preCheckDeletion('project', 'p-1');
+
+    const [, resource] = hasPermissionMock.mock.calls[0];
+    expect(resource).toBe('project');
+  });
+});

--- a/packages/auth/src/lib/preCheckDeletion.ts
+++ b/packages/auth/src/lib/preCheckDeletion.ts
@@ -22,6 +22,7 @@ function permissionEntityFor(entityType: string): string {
   if (entityType === 'status') return 'settings';
   if (entityType === 'role') return 'security_settings';
   if (entityType === 'invoice_template') return 'invoice';
+  if (entityType === 'tax_rate') return 'billing';
   return entityType;
 }
 

--- a/packages/billing/src/models/contractLine.ts
+++ b/packages/billing/src/models/contractLine.ts
@@ -56,6 +56,14 @@ const ContractLine = {
         throw new Error('Cannot delete contract line that is in use by clients');
       }
 
+      await knexOrTrx('contract_line_service_configuration')
+        .where({ contract_line_id: planId, tenant })
+        .delete();
+
+      await knexOrTrx('contract_line_services')
+        .where({ contract_line_id: planId, tenant })
+        .delete();
+
       const deletedCount = await knexOrTrx('contract_lines')
         .where({
           contract_line_id: planId,

--- a/packages/billing/tests/contractLineDelete.cascade.test.ts
+++ b/packages/billing/tests/contractLineDelete.cascade.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/db', () => ({
+  requireTenantId: vi.fn(async () => 'tenant-1')
+}));
+
+import ContractLine from '../src/models/contractLine';
+
+type Op = { table: string; type: 'count' | 'delete'; where: Record<string, unknown> };
+
+function makeKnex(rows: Record<string, number>) {
+  const ops: Op[] = [];
+
+  function builder(table: string) {
+    const state: { where: Record<string, unknown> } = { where: {} };
+    const b: any = {};
+    b.where = (filters: Record<string, unknown>) => {
+      state.where = { ...state.where, ...filters };
+      return b;
+    };
+    b.count = (_col: string) => {
+      ops.push({ table, type: 'count', where: state.where });
+      return {
+        first: async () => ({ count: String(rows[table] ?? 0) })
+      };
+    };
+    b.delete = async () => {
+      ops.push({ table, type: 'delete', where: state.where });
+      return rows[table] === undefined ? 1 : rows[table];
+    };
+    return b;
+  }
+
+  const knex: any = (table: string) => builder(table);
+  return { knex, ops };
+}
+
+describe('ContractLine.delete cascade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes contract_line_service_configuration and contract_line_services before contract_lines', async () => {
+    const { knex, ops } = makeKnex({
+      client_contract_lines: 0,
+      contract_lines: 1
+    });
+
+    await ContractLine.delete(knex, 'cl-1');
+
+    const deletes = ops.filter((op) => op.type === 'delete').map((op) => op.table);
+
+    expect(deletes).toEqual([
+      'contract_line_service_configuration',
+      'contract_line_services',
+      'contract_lines'
+    ]);
+
+    const configDelete = ops.find((op) => op.table === 'contract_line_service_configuration' && op.type === 'delete');
+    expect(configDelete?.where).toEqual({ contract_line_id: 'cl-1', tenant: 'tenant-1' });
+
+    const servicesDelete = ops.find((op) => op.table === 'contract_line_services' && op.type === 'delete');
+    expect(servicesDelete?.where).toEqual({ contract_line_id: 'cl-1', tenant: 'tenant-1' });
+  });
+
+  it('refuses to delete when contract line is in use by a client', async () => {
+    const { knex, ops } = makeKnex({
+      client_contract_lines: 1,
+      contract_lines: 1
+    });
+
+    await expect(ContractLine.delete(knex, 'cl-2')).rejects.toThrow(/in use by clients/i);
+
+    expect(ops.some((op) => op.type === 'delete')).toBe(false);
+  });
+
+  it('throws when contract line does not exist', async () => {
+    const { knex } = makeKnex({
+      client_contract_lines: 0,
+      contract_lines: 0
+    });
+
+    await expect(ContractLine.delete(knex, 'cl-missing')).rejects.toThrow(/not found/i);
+  });
+});

--- a/packages/core/src/config/deletion/index.ts
+++ b/packages/core/src/config/deletion/index.ts
@@ -32,6 +32,21 @@ const countPortalUsers = async (
   return Number(result?.count ?? 0);
 };
 
+const countContractLineServiceDeps = async (
+  trx: Knex | Knex.Transaction,
+  options: { tenant: string; entityId: string }
+): Promise<number> => {
+  const result = await trx('contract_line_services as cls')
+    .innerJoin('contract_lines as cl', function () {
+      this.on('cl.tenant', '=', 'cls.tenant').andOn('cl.contract_line_id', '=', 'cls.contract_line_id');
+    })
+    .where({ 'cls.tenant': options.tenant, 'cls.service_id': options.entityId })
+    .count<{ count: string }>('* as count')
+    .first();
+
+  return Number(result?.count ?? 0);
+};
+
 const countTimeEntryBilling = async (
   trx: Knex | Knex.Transaction,
   options: { tenant: string; entityId: string }
@@ -385,7 +400,9 @@ export const DELETION_CONFIGS: Record<string, EntityDeletionConfig> = {
         type: 'contract_line_service',
         table: 'contract_line_services',
         foreignKey: 'service_id',
-        label: 'contract line configuration'
+        countQuery: countContractLineServiceDeps,
+        label: 'contract line configuration',
+        viewUrlTemplate: '/msp/billing?tab=contract-lines'
       },
       { type: 'contract_template_line_default', table: 'contract_template_line_defaults', foreignKey: 'service_id', label: 'contract template default' },
       { type: 'contract_template_line_service', table: 'contract_template_line_services', foreignKey: 'service_id', label: 'contract template service' },

--- a/packages/core/src/server/deletion/contractLineServiceCount.test.ts
+++ b/packages/core/src/server/deletion/contractLineServiceCount.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DELETION_CONFIGS } from '../../config/deletion/index';
+
+function findCountQuery() {
+  const dep = DELETION_CONFIGS.service.dependencies.find((d) => d.type === 'contract_line_service');
+  if (!dep || !dep.countQuery) {
+    throw new Error('contract_line_service dependency is missing its countQuery');
+  }
+  return dep.countQuery;
+}
+
+function makeBuilder(count: number) {
+  const builder: any = {};
+  builder.innerJoin = vi.fn().mockReturnValue(builder);
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.count = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockResolvedValue({ count: String(count) });
+  return builder;
+}
+
+describe('DELETION_CONFIGS.service contract_line_service countQuery', () => {
+  it('joins contract_lines so orphan rows are excluded from the count', async () => {
+    const countQuery = findCountQuery();
+    const builder = makeBuilder(3);
+    const trx = vi.fn().mockReturnValue(builder) as any;
+
+    const count = await countQuery(trx, { tenant: 't-1', entityId: 'svc-1' });
+
+    expect(trx).toHaveBeenCalledWith('contract_line_services as cls');
+    expect(builder.innerJoin).toHaveBeenCalledTimes(1);
+    expect(builder.innerJoin.mock.calls[0][0]).toBe('contract_lines as cl');
+    expect(builder.where).toHaveBeenCalledWith({
+      'cls.tenant': 't-1',
+      'cls.service_id': 'svc-1'
+    });
+    expect(count).toBe(3);
+  });
+
+  it('returns 0 when no live contract-line references exist', async () => {
+    const countQuery = findCountQuery();
+    const builder = makeBuilder(0);
+    const trx = vi.fn().mockReturnValue(builder) as any;
+
+    const count = await countQuery(trx, { tenant: 't-1', entityId: 'svc-orphan-only' });
+
+    expect(count).toBe(0);
+  });
+});

--- a/packages/scheduling/src/actions/timePeriodsActions.ts
+++ b/packages/scheduling/src/actions/timePeriodsActions.ts
@@ -371,18 +371,18 @@ export const deleteTimePeriod = withAuth(async (_user, { tenant }, periodId: str
   try {
     const { knex } = await createTenantKnex();
     // Check if period exists and has no associated time records
-    const period = await TimePeriod.findById(knex, periodId);
+    const period = await TimePeriod.findById(knex, tenant, periodId);
     if (!period) {
       throw new Error('Time period not found');
     }
 
-    const isEditable = await TimePeriod.isEditable(knex, periodId);
+    const isEditable = await TimePeriod.isEditable(knex, tenant, periodId);
     if (!isEditable) {
       throw new Error('Cannot delete time period with associated time sheets');
     }
 
     try {
-      await TimePeriod.delete(knex, periodId);
+      await TimePeriod.delete(knex, tenant, periodId);
       revalidatePath('/msp/time-entry');
     } catch (error: any) {
       if (error.message.includes('belongs to different tenant')) {
@@ -412,12 +412,12 @@ export const updateTimePeriod = withAuth(async (
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
       // Check if period exists and has no associated time records
-      const period = await TimePeriod.findById(trx, periodId);
+      const period = await TimePeriod.findById(trx, tenant, periodId);
       if (!period) {
         throw new Error('Time period not found');
       }
 
-      const isEditable = await TimePeriod.isEditable(trx, periodId);
+      const isEditable = await TimePeriod.isEditable(trx, tenant, periodId);
       if (!isEditable) {
         throw new Error('Cannot update time period with associated time sheets');
       }
@@ -426,14 +426,14 @@ export const updateTimePeriod = withAuth(async (
       if (updates.start_date || updates.end_date) {
         const startDate = updates.start_date || period.start_date;
         const endDate = updates.end_date || period.end_date;
-        const overlappingPeriod = await TimePeriod.findOverlapping(trx, startDate, endDate, periodId);
+        const overlappingPeriod = await TimePeriod.findOverlapping(trx, tenant, startDate, endDate, periodId);
         if (overlappingPeriod) {
           throw new Error('Cannot update time period: overlaps with existing period');
         }
       }
 
       try {
-        const updatedPeriod = await TimePeriod.update(trx, periodId, updates);
+        const updatedPeriod = await TimePeriod.update(trx, tenant, periodId, updates);
         const validatedPeriod = validateData(timePeriodSchema, updatedPeriod);
 
         revalidatePath('/msp/time-entry');
@@ -464,6 +464,7 @@ export const generateAndSaveTimePeriods = withAuth(async (_user, { tenant }, sta
       for (const period of generatedPeriods) {
         const overlappingPeriod = await TimePeriod.findOverlapping(
           trx,
+          tenant,
           toPlainDate(period.start_date),
           toPlainDate(period.end_date)
         );
@@ -475,7 +476,7 @@ export const generateAndSaveTimePeriods = withAuth(async (_user, { tenant }, sta
       // Save generated periods to the database
       const savedPeriods = await Promise.all(generatedPeriods.map((period: ITimePeriodView): Promise<ITimePeriod> => {
         // Convert string dates to Temporal.PlainDate for database
-        return TimePeriod.create(trx, {
+        return TimePeriod.create(trx, tenant, {
           ...period,
           start_date: toPlainDate(period.start_date),
           end_date: toPlainDate(period.end_date)


### PR DESCRIPTION
  - timePeriodsActions: pass `tenant` to nine TimePeriod.findById/isEditable/ delete/update/findOverlapping/create calls so periodId is no longer fed in as tenant (root cause of the "Undefined column: [period_id]" error on /msp/settings).
  - deletion config: add viewUrlTemplate for the `contract_line_service` dependency so the service-deletion dialog can link straight to the Contract Lines tab.
  - preCheckDeletion: map `tax_rate` to the `billing` RBAC resource so users with `billing:delete` can actually delete tax rates (no `tax_rate` resource is seeded anywhere).

  "Curiouser and curiouser!" cried the tenant, finding itself stuffed into
  a period_id binding, while a tax_rate wandered the rabbit-hole asking
  strangers for permission to disappear. 🐇🫖 🪄