### PR TITLE
Tidy ticket Assets section header (rename, icon, responsive)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16897,6 +16897,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
+      }
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.11",
       "license": "MIT",
@@ -42995,7 +43005,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -43344,6 +43354,7 @@
         "@alga-psa/documents": "*",
         "@alga-psa/formatting": "*",
         "@alga-psa/projects": "*",
+        "@alga-psa/reporting": "*",
         "@alga-psa/scheduling": "*",
         "@alga-psa/sla": "*",
         "@alga-psa/surveys": "*",
@@ -44025,7 +44036,6 @@
         "@alga-psa/core": "*",
         "@alga-psa/db": "*",
         "@alga-psa/formatting": "*",
-        "@alga-psa/reporting": "*",
         "@alga-psa/types": "*",
         "@blocknote/core": "^0.47.3",
         "@blocknote/mantine": "^0.47.3",
@@ -44186,11 +44196,7 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -47923,7 +47929,7 @@
       }
     },
     "server": {
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",
@@ -48090,6 +48096,7 @@
       "devDependencies": {
         "@eslint/js": "^9.18.0",
         "@faker-js/faker": "^9.9.0",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.2.0",

--- a/packages/assets/src/components/AssociatedAssets.tsx
+++ b/packages/assets/src/components/AssociatedAssets.tsx
@@ -406,13 +406,13 @@ export default function AssociatedAssets({ id, entityId, entityType, clientId, d
     };
 
     return (
-        <ReflectionContainer id={id} label={t('associatedAssets.title', { defaultValue: 'Associated Assets' })}>
+        <ReflectionContainer id={id} label={t('associatedAssets.title', { defaultValue: 'Assets' })}>
             <ContentCard
                 id={id}
                 collapsible
                 defaultExpanded={false}
-                title={t('associatedAssets.title', { defaultValue: 'Associated Assets' })}
-                headerIcon={<Boxes className="w-5 h-5" />}
+                title={t('associatedAssets.title', { defaultValue: 'Assets' })}
+                headerIcon={<Monitor className="w-5 h-5" />}
                 count={associatedAssets.length}
                 addButton={{
                     id: 'add-asset-button',

--- a/packages/ui/src/components/ContentCard.tsx
+++ b/packages/ui/src/components/ContentCard.tsx
@@ -90,12 +90,12 @@ export function ContentCard({
   if (collapsible && title) {
     return (
       <div id={id} className={`${styles['card']} p-6 space-y-4 ${className}`}>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-3">
           <Button
             id={`${id || 'content-card'}-toggle`}
             variant="ghost"
             size="sm"
-            className="flex items-center gap-1 p-0 h-auto hover:bg-transparent"
+            className="flex items-center gap-1 p-0 h-auto min-w-0 hover:bg-transparent"
             onClick={() => setIsExpanded(!isExpanded)}
           >
             {isExpanded ? (
@@ -103,12 +103,12 @@ export function ContentCard({
             ) : (
               <ChevronRight className="w-4 h-4 text-gray-500 flex-shrink-0" />
             )}
-            <h2 className={`${styles['panel-header']} flex items-center`}>
-              {headerIcon && <span className="mr-2 inline-flex">{headerIcon}</span>}
-              {title}
+            <h2 className={`${styles['panel-header']} flex items-center min-w-0`}>
+              {headerIcon && <span className="mr-2 inline-flex flex-shrink-0">{headerIcon}</span>}
+              <span className="truncate">{title}</span>
             </h2>
             {!isExpanded && count != null && count > 0 && (
-              <span className="ml-2 text-xs bg-gray-100 text-gray-600 rounded-full px-2 py-0.5">
+              <span className="ml-2 text-xs bg-gray-100 text-gray-600 rounded-full px-2 py-0.5 flex-shrink-0">
                 {count}
               </span>
             )}
@@ -118,12 +118,13 @@ export function ContentCard({
               id={addButton.id}
               variant="outline"
               size="sm"
+              className="flex-shrink-0 whitespace-nowrap"
               onClick={() => {
                 addButton.onClick();
                 if (!isExpanded) setIsExpanded(true);
               }}
             >
-              <Plus className="w-4 h-4 mr-1" />
+              <Plus className="w-4 h-4 mr-1 flex-shrink-0" />
               {addButton.label || 'Add'}
             </Button>
           )}

--- a/packages/ui/src/components/ContentCard.tsx
+++ b/packages/ui/src/components/ContentCard.tsx
@@ -90,12 +90,12 @@ export function ContentCard({
   if (collapsible && title) {
     return (
       <div id={id} className={`${styles['card']} p-6 space-y-4 ${className}`}>
-        <div className="flex items-center justify-between gap-3">
+        <div className="@container grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
           <Button
             id={`${id || 'content-card'}-toggle`}
             variant="ghost"
             size="sm"
-            className="flex items-center gap-1 p-0 h-auto min-w-0 hover:bg-transparent"
+            className="flex items-center gap-1 p-0 h-auto min-w-0 w-full justify-start hover:bg-transparent"
             onClick={() => setIsExpanded(!isExpanded)}
           >
             {isExpanded ? (
@@ -119,13 +119,15 @@ export function ContentCard({
               variant="outline"
               size="sm"
               className="flex-shrink-0 whitespace-nowrap"
+              title={addButton.label || 'Add'}
+              aria-label={addButton.label || 'Add'}
               onClick={() => {
                 addButton.onClick();
                 if (!isExpanded) setIsExpanded(true);
               }}
             >
-              <Plus className="w-4 h-4 mr-1 flex-shrink-0" />
-              {addButton.label || 'Add'}
+              <Plus className="w-4 h-4 @sm:mr-1 flex-shrink-0" />
+              <span className="hidden @sm:inline">{addButton.label || 'Add'}</span>
             </Button>
           )}
         </div>

--- a/server/package.json
+++ b/server/package.json
@@ -227,6 +227,7 @@
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@faker-js/faker": "^9.9.0",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.2.0",

--- a/server/public/locales/de/msp/assets.json
+++ b/server/public/locales/de/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Asset bearbeiten"
   },
   "associatedAssets": {
-    "title": "Zugehörige Vermögenswerte",
+    "title": "Vermögenswerte",
     "description": "Verwaltung der Beziehungen zwischen übergeordneten und untergeordneten Assets mit verknüpften Asset-Aktionen",
     "loading": {
       "assets": "Assets werden geladen..."

--- a/server/public/locales/en/msp/assets.json
+++ b/server/public/locales/en/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Edit Asset"
   },
   "associatedAssets": {
-    "title": "Associated Assets",
+    "title": "Assets",
     "description": "Parent and child asset relationship management with linked asset actions",
     "loading": {
       "assets": "Loading assets..."

--- a/server/public/locales/es/msp/assets.json
+++ b/server/public/locales/es/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Editar activo"
   },
   "associatedAssets": {
-    "title": "Activos asociados",
+    "title": "Activos",
     "description": "Gestión de relaciones de activos principales y secundarios con acciones de activos vinculados",
     "loading": {
       "assets": "Cargando recursos..."

--- a/server/public/locales/fr/msp/assets.json
+++ b/server/public/locales/fr/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Modifier l'actif"
   },
   "associatedAssets": {
-    "title": "Actifs associés",
+    "title": "Actifs",
     "description": "Gestion des relations entre les actifs parents et enfants avec des actions sur les actifs liés",
     "loading": {
       "assets": "Chargement des éléments..."

--- a/server/public/locales/it/msp/assets.json
+++ b/server/public/locales/it/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Modifica risorsa"
   },
   "associatedAssets": {
-    "title": "Beni associati",
+    "title": "Beni",
     "description": "Gestione delle relazioni tra asset padre e figlio con azioni sugli asset collegati",
     "loading": {
       "assets": "Caricamento risorse..."

--- a/server/public/locales/nl/msp/assets.json
+++ b/server/public/locales/nl/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Item bewerken"
   },
   "associatedAssets": {
-    "title": "Bijbehorende activa",
+    "title": "Activa",
     "description": "Relatiebeheer van bovenliggende en onderliggende activa met gekoppelde activaacties",
     "loading": {
       "assets": "Activa laden..."

--- a/server/public/locales/pl/msp/assets.json
+++ b/server/public/locales/pl/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Edytuj zasób"
   },
   "associatedAssets": {
-    "title": "Powiązane zasoby",
+    "title": "Zasoby",
     "description": "Zarządzanie relacjami zasobów nadrzędnych i podrzędnych z połączonymi działaniami dotyczącymi zasobów",
     "loading": {
       "assets": "Ładowanie zasobów..."

--- a/server/public/locales/pt/msp/assets.json
+++ b/server/public/locales/pt/msp/assets.json
@@ -699,7 +699,7 @@
     "pageTitle": "Editar Ativo"
   },
   "associatedAssets": {
-    "title": "Associated Assets",
+    "title": "Ativos",
     "description": "Parent and child asset relationship management with linked asset actions",
     "loading": {
       "assets": "Loading assets..."

--- a/server/tailwind.config.ts
+++ b/server/tailwind.config.ts
@@ -172,6 +172,7 @@ const config: Config = {
   plugins: [
     // require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
   ],
 };
 export default config;


### PR DESCRIPTION
## Summary
- Fix the ticket-detail ContentCard header so the Add button no longer wraps "+" and the label onto two lines in narrow columns (e.g. the right rail).
- Rename the "Associated Assets" section to "Assets" — the context already implies they're associated since you're viewing them on a ticket — and switch its icon from `Boxes` to `Monitor` to match the nav, dashboard, and asset detail views.
- Switch the ContentCard header to a `1fr auto` CSS grid so the title gets the leftover space and only truncates when actually cramped, and add `@tailwindcss/container-queries` so the Add button collapses to an icon-only `+` (with `aria-label`/`title`) when the header row is narrower than 24rem.

## Test plan
- [ ] Open a ticket in `/msp/tickets/[id]` at a wide viewport and confirm the Materials, Assets, Watch List, Email Notifications, and Properties sections all show their title plus the full `+ Add …` button on one line.
- [ ] Narrow the browser/right rail until the section header is under ~24rem and confirm the Add button collapses to `+` only while the title remains readable.
- [ ] Hover the collapsed `+` button and confirm the tooltip shows the original label (e.g. "Add Asset").
- [ ] Confirm the Assets section now reads "Assets" with the Monitor icon, matching the main nav.