### PR TITLE
Multi-select and bulk actions for project tasks

### DIFF
--- a/packages/projects/src/actions/projectTaskExportActions.ts
+++ b/packages/projects/src/actions/projectTaskExportActions.ts
@@ -298,6 +298,7 @@ export const exportProjectTasksToCSV = withAuth(async (
   projectId: string,
   selectedPhaseIds: string[],
   selectedFields?: string[],
+  taskIds?: string[],
 ): Promise<{ csv: string; count: number }> => {
   await assertPsaOnlyTenantAccess(tenant, 'project_actions');
   const { knex: db } = await createTenantKnex();
@@ -308,36 +309,57 @@ export const exportProjectTasksToCSV = withAuth(async (
       throwPermissionError('read project');
     }
 
-    // Get phases for this project, filtered to selected ones
-    const phases = await trx('project_phases')
-      .where({ project_id: projectId, tenant })
-      .whereIn('phase_id', selectedPhaseIds)
-      .select('phase_id');
+    let tasks: TaskRow[];
 
-    const phaseIds = phases.map(p => p.phase_id);
-    if (phaseIds.length === 0) {
-      return { csv: '', count: 0 };
+    if (taskIds && taskIds.length > 0) {
+      // Export only the explicitly selected tasks, scoped to this project's phases
+      const projectPhases = await trx('project_phases')
+        .where({ project_id: projectId, tenant })
+        .select('phase_id');
+
+      const projectPhaseIds = projectPhases.map(p => p.phase_id);
+      if (projectPhaseIds.length === 0) {
+        return { csv: '', count: 0 };
+      }
+
+      tasks = await trx('project_tasks')
+        .whereIn('task_id', taskIds)
+        .whereIn('phase_id', projectPhaseIds)
+        .andWhere('tenant', tenant)
+        .orderBy(['phase_id', 'order_key'])
+        .limit(MAX_EXPORT_ROWS);
+    } else {
+      // Get phases for this project, filtered to selected ones
+      const phases = await trx('project_phases')
+        .where({ project_id: projectId, tenant })
+        .whereIn('phase_id', selectedPhaseIds)
+        .select('phase_id');
+
+      const phaseIds = phases.map(p => p.phase_id);
+      if (phaseIds.length === 0) {
+        return { csv: '', count: 0 };
+      }
+
+      // Get all tasks for selected phases
+      tasks = await trx('project_tasks')
+        .whereIn('phase_id', phaseIds)
+        .andWhere('tenant', tenant)
+        .orderBy(['phase_id', 'order_key'])
+        .limit(MAX_EXPORT_ROWS);
     }
-
-    // Get all tasks for selected phases
-    const tasks: TaskRow[] = await trx('project_tasks')
-      .whereIn('phase_id', phaseIds)
-      .andWhere('tenant', tenant)
-      .orderBy(['phase_id', 'order_key'])
-      .limit(MAX_EXPORT_ROWS);
 
     if (tasks.length === 0) {
       return { csv: '', count: 0 };
     }
 
-    const taskIds = tasks.map(t => t.task_id);
+    const taskRowIds = tasks.map(t => t.task_id);
 
     // Resolve lookups, tags, and checklist counts in parallel
     const [lookups, tagsArray, checklistRows] = await Promise.all([
       resolveNameLookups(trx, tenant, tasks),
-      findTagsByEntityIds(taskIds, 'project_task').catch(() => []),
+      findTagsByEntityIds(taskRowIds, 'project_task').catch(() => []),
       trx('task_checklist_items')
-        .whereIn('task_id', taskIds)
+        .whereIn('task_id', taskRowIds)
         .andWhere('tenant', tenant)
         .select('task_id', 'completed'),
     ]);

--- a/packages/projects/src/components/BulkAssignDialog.tsx
+++ b/packages/projects/src/components/BulkAssignDialog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import UserPicker from '@alga-psa/ui/components/UserPicker';
+import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
+import type { IUserWithRoles } from '@alga-psa/types';
+import { useTranslation } from 'react-i18next';
+
+interface BulkAssignDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  taskCount: number;
+  users: IUserWithRoles[];
+  onConfirm: (userId: string | null) => Promise<void>;
+}
+
+export default function BulkAssignDialog({
+  isOpen,
+  onClose,
+  taskCount,
+  users,
+  onConfirm,
+}: BulkAssignDialogProps) {
+  const { t } = useTranslation(['features/projects', 'common']);
+  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedUserId('');
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true);
+    try {
+      await onConfirm(selectedUserId || null);
+    } catch (error) {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('dialogs.bulkAssign.title', 'Assign Tasks')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        <div className="mb-3 text-sm text-gray-600">
+          {t('dialogs.bulkAssign.message', 'Assign {{count}} selected task(s) to:', { count: taskCount })}
+        </div>
+
+        <div className="mb-6">
+          <UserPicker
+            value={selectedUserId}
+            onValueChange={setSelectedUserId}
+            users={users}
+            getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
+            buttonWidth="full"
+            labelStyle="none"
+            placeholder={t('dialogs.bulkAssign.unassigned', 'Not assigned')}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-2">
+          <Button id="cancel-bulk-assign-button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('common:actions.cancel', 'Cancel')}
+          </Button>
+          <Button id="confirm-bulk-assign-button" onClick={handleConfirm} disabled={isSubmitting}>
+            {isSubmitting
+              ? t('dialogs.bulkAssign.assigning', 'Assigning...')
+              : t('dialogs.bulkAssign.confirm', 'Assign Tasks')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/projects/src/components/BulkAssignDialog.tsx
+++ b/packages/projects/src/components/BulkAssignDialog.tsx
@@ -3,17 +3,23 @@
 import { useState, useEffect } from 'react';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
-import UserPicker from '@alga-psa/ui/components/UserPicker';
+import UserAndTeamPicker from '@alga-psa/ui/components/UserAndTeamPicker';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
-import type { IUserWithRoles } from '@alga-psa/types';
+import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
+import type { IUserWithRoles, ITeam } from '@alga-psa/types';
 import { useTranslation } from 'react-i18next';
+
+type BulkAssignSelection =
+  | { kind: 'user'; userId: string | null }
+  | { kind: 'team'; teamId: string };
 
 interface BulkAssignDialogProps {
   isOpen: boolean;
   onClose: () => void;
   taskCount: number;
   users: IUserWithRoles[];
-  onConfirm: (userId: string | null) => Promise<void>;
+  teams: ITeam[];
+  onConfirm: (selection: BulkAssignSelection) => Promise<void>;
 }
 
 export default function BulkAssignDialog({
@@ -21,23 +27,44 @@ export default function BulkAssignDialog({
   onClose,
   taskCount,
   users,
+  teams,
   onConfirm,
 }: BulkAssignDialogProps) {
   const { t } = useTranslation(['features/projects', 'common']);
-  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [pickerValue, setPickerValue] = useState<string>('');
+  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setSelectedUserId('');
+      setPickerValue('');
+      setPendingTeamId(null);
       setIsSubmitting(false);
     }
   }, [isOpen]);
 
+  // Only teams with a lead can be assigned — assignTeamToProjectTask requires
+  // a manager to fall back to as primary assignee for tasks with no assignee.
+  const assignableTeams = teams.filter((team) => !!team.manager_id);
+
+  const handleUserChange = (value: string) => {
+    setPickerValue(value);
+    setPendingTeamId(null);
+  };
+
+  const handleTeamSelect = (teamId: string) => {
+    setPendingTeamId(teamId);
+    setPickerValue(teamId);
+  };
+
   const handleConfirm = async () => {
     setIsSubmitting(true);
     try {
-      await onConfirm(selectedUserId || null);
+      if (pendingTeamId) {
+        await onConfirm({ kind: 'team', teamId: pendingTeamId });
+      } else {
+        await onConfirm({ kind: 'user', userId: pickerValue || null });
+      }
     } catch (error) {
       setIsSubmitting(false);
     }
@@ -55,17 +82,29 @@ export default function BulkAssignDialog({
           {t('dialogs.bulkAssign.message', 'Assign {{count}} selected task(s) to:', { count: taskCount })}
         </div>
 
-        <div className="mb-6">
-          <UserPicker
-            value={selectedUserId}
-            onValueChange={setSelectedUserId}
+        <div className="mb-3">
+          <UserAndTeamPicker
+            value={pickerValue}
+            onValueChange={handleUserChange}
+            onTeamSelect={handleTeamSelect}
             users={users}
+            teams={assignableTeams}
             getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
+            getTeamAvatarUrlsBatch={getTeamAvatarUrlsBatchAction}
             buttonWidth="full"
             labelStyle="none"
             placeholder={t('dialogs.bulkAssign.unassigned', 'Not assigned')}
           />
         </div>
+
+        {pendingTeamId && (
+          <p className="mb-6 text-xs text-gray-500">
+            {t(
+              'dialogs.bulkAssign.teamReplaceNotice',
+              'Tasks already assigned to a different team will have that team replaced.',
+            )}
+          </p>
+        )}
 
         <div className="flex justify-end space-x-2">
           <Button id="cancel-bulk-assign-button" variant="ghost" onClick={onClose} disabled={isSubmitting}>

--- a/packages/projects/src/components/BulkMoveTaskDialog.tsx
+++ b/packages/projects/src/components/BulkMoveTaskDialog.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import TreeSelect, { TreeSelectOption, TreeSelectPath } from '@alga-psa/ui/components/TreeSelect';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+interface BulkMoveTaskDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  taskCount: number;
+  projectTreeData: Array<TreeSelectOption<'project' | 'phase' | 'status'>>;
+  onConfirm: (targetPhaseId: string, targetStatusId: string | undefined) => Promise<void>;
+}
+
+export default function BulkMoveTaskDialog({
+  isOpen,
+  onClose,
+  taskCount,
+  projectTreeData,
+  onConfirm,
+}: BulkMoveTaskDialogProps) {
+  const { t } = useTranslation(['features/projects', 'common']);
+  const [selectedTargetPath, setSelectedTargetPath] = useState<TreeSelectPath | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedTargetPath(null);
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  const handleTreeSelect = (_value: string, _type: string, _excluded: boolean, path?: TreeSelectPath) => {
+    if (path && path['phase']) {
+      setSelectedTargetPath(path);
+    } else {
+      setSelectedTargetPath(null);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedTargetPath || !selectedTargetPath['phase']) {
+      toast.error(t('dialogs.moveTask.selectTargetError', 'Please select a target phase.'));
+      return;
+    }
+
+    const targetPhaseId = selectedTargetPath['phase'];
+    const targetStatusId = selectedTargetPath['status'] || undefined;
+
+    setIsSubmitting(true);
+    try {
+      await onConfirm(targetPhaseId, targetStatusId);
+    } catch (error) {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('dialogs.bulkMoveTask.title', 'Move Tasks')}
+      className="max-w-lg max-h-[90vh] overflow-y-auto"
+    >
+      <DialogContent>
+        <div className="mb-2 text-sm text-gray-600">
+          {t('dialogs.bulkMoveTask.message', 'Move {{count}} selected task(s) to a new phase/status:', {
+            count: taskCount,
+          })}
+        </div>
+
+        <div className="mb-6">
+          <TreeSelect<'project' | 'phase' | 'status'>
+            value={selectedTargetPath?.['status'] || selectedTargetPath?.['phase'] || ''}
+            onValueChange={handleTreeSelect}
+            options={projectTreeData}
+            placeholder={t('dialogs.moveTask.placeholder', 'Select target project/phase/status...')}
+            className="w-full"
+            multiSelect={false}
+            showExclude={false}
+            showReset={false}
+            allowEmpty={false}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-2">
+          <Button id="cancel-bulk-move-button" variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('common:actions.cancel', 'Cancel')}
+          </Button>
+          <Button
+            id="confirm-bulk-move-button"
+            onClick={handleConfirm}
+            disabled={!selectedTargetPath?.['phase'] || isSubmitting}
+          >
+            {isSubmitting
+              ? t('dialogs.moveTask.moving', 'Moving...')
+              : t('dialogs.bulkMoveTask.confirm', 'Move Tasks')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/projects/src/components/BulkTaskActionBar.tsx
+++ b/packages/projects/src/components/BulkTaskActionBar.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Button } from '@alga-psa/ui/components/Button';
+import { Move, UserPlus, Trash2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useTaskSelection } from './TaskSelectionContext';
+
+interface BulkTaskActionBarProps {
+  onMove: () => void;
+  onAssign: () => void;
+  onDelete: () => void;
+}
+
+export default function BulkTaskActionBar({ onMove, onAssign, onDelete }: BulkTaskActionBarProps) {
+  const { t } = useTranslation(['features/projects', 'common']);
+  const { selectedTaskIds, clearSelection } = useTaskSelection();
+  const count = selectedTaskIds.size;
+
+  if (count === 0) return null;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-white dark:bg-[rgb(var(--color-card))] border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg px-4 py-2.5">
+      <span className="text-sm font-medium text-gray-700 dark:text-[rgb(var(--color-text-200))] whitespace-nowrap">
+        {t('bulkActions.selectedCount', '{{count}} selected', { count })}
+      </span>
+      <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
+      <Button id="bulk-move-tasks-button" variant="outline" size="sm" onClick={onMove}>
+        <Move className="h-4 w-4 mr-1.5" />
+        {t('bulkActions.move', 'Move')}
+      </Button>
+      <Button id="bulk-assign-tasks-button" variant="outline" size="sm" onClick={onAssign}>
+        <UserPlus className="h-4 w-4 mr-1.5" />
+        {t('bulkActions.assign', 'Assign')}
+      </Button>
+      <Button
+        id="bulk-delete-tasks-button"
+        variant="outline"
+        size="sm"
+        onClick={onDelete}
+        className="text-destructive hover:text-destructive"
+      >
+        <Trash2 className="h-4 w-4 mr-1.5" />
+        {t('bulkActions.delete', 'Delete')}
+      </Button>
+      <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
+      <Button id="bulk-clear-selection-button" variant="ghost" size="sm" onClick={clearSelection}>
+        <X className="h-4 w-4 mr-1.5" />
+        {t('bulkActions.clear', 'Clear')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -1887,9 +1887,11 @@ export default function ProjectDetail({
     const sourcePhase = projectPhases.find(p => p.phase_id === task?.phase_id);
 
     if (task && sourcePhase && targetPhase.phase_id !== sourcePhase.phase_id) {
-      // Bulk drag: the dragged task is part of a multi-selection
+      // Bulk drag: the dragged task is part of a multi-selection. The selection is
+      // project-wide, so include selected tasks from every phase, not just the
+      // currently visible kanban board.
       if (selectedTaskIds.has(taskId) && selectedTaskIds.size > 1) {
-        const bulkTaskIds = projectTasks
+        const bulkTaskIds = allProjectTasks
           .filter(t => selectedTaskIds.has(t.task_id) && t.phase_id !== targetPhase.phase_id)
           .map(t => t.task_id);
         if (bulkTaskIds.length > 0) {
@@ -1924,7 +1926,9 @@ export default function ProjectDetail({
       const movedIds = new Set<string>();
 
       for (const id of bulkTaskIds) {
-        const task = projectTasks.find(t => t.task_id === id);
+        // Selected tasks may live in any phase, so look them up project-wide
+        const task = allProjectTasks.find(t => t.task_id === id)
+          || projectTasks.find(t => t.task_id === id);
         if (!task) {
           failed++;
           continue;
@@ -2620,16 +2624,22 @@ export default function ProjectDetail({
         continue;
       }
       try {
+        // A user assignment should become the primary assignee. The UI renders the
+        // team over the user, so any existing team assignment must be removed first.
+        if (task.assigned_team_id) {
+          await removeTeamFromProjectTask(taskId, { mode: 'remove_all' });
+        }
         const updatedTask = await updateTaskWithChecklist(taskId, {
           ...task,
           assigned_to: userId,
+          assigned_team_id: null,
           estimated_hours: Number(task.estimated_hours) || 0,
           actual_hours: Number(task.actual_hours) || 0,
           checklist_items: task.checklist_items,
         });
         if (updatedTask) {
           const checklistItems = await getTaskChecklistItems(taskId);
-          const taskWithChecklist = { ...updatedTask, checklist_items: checklistItems };
+          const taskWithChecklist = { ...updatedTask, assigned_team_id: null, checklist_items: checklistItems };
           setProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
           setAllProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
           success++;
@@ -3463,10 +3473,9 @@ export default function ProjectDetail({
             moveConfirmation.taskIds && moveConfirmation.taskIds.length > 1
               ? t(
                   'projectDetail.confirmMoveTasksMessage',
-                  'Are you sure you want to move {{count}} selected tasks from phase "{{sourcePhase}}" to "{{targetPhase}}"?',
+                  'Are you sure you want to move {{count}} selected tasks to phase "{{targetPhase}}"?',
                   {
                     count: moveConfirmation.taskIds.length,
-                    sourcePhase: moveConfirmation.sourcePhase.phase_name,
                     targetPhase: moveConfirmation.targetPhase.phase_name,
                   },
                 )
@@ -3619,6 +3628,9 @@ export default function ProjectDetail({
               setProjectTasks(prev => prev.filter(t => t.task_id !== taskToDelete.task_id));
               // Remove from allProjectTasks for filtered counts
               setAllProjectTasks(prev => prev.filter(t => t.task_id !== taskToDelete.task_id));
+              // Drop the deleted task from the multi-selection so bulk actions and
+              // selection-aware labels don't keep counting it
+              setTasksSelected([taskToDelete.task_id], false);
               toast.success(
                 t('projectDetail.taskDeletedSuccess', 'Task "{{taskName}}" deleted successfully!', {
                   taskName: taskToDelete.task_name,

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -1923,19 +1923,15 @@ export default function ProjectDetail({
       const { taskIds: bulkTaskIds, targetPhase } = moveConfirmation;
       let success = 0;
       let failed = 0;
-      const movedIds = new Set<string>();
+      const movedById = new Map<string, IProjectTask>();
 
       for (const id of bulkTaskIds) {
-        // Selected tasks may live in any phase, so look them up project-wide
-        const task = allProjectTasks.find(t => t.task_id === id)
-          || projectTasks.find(t => t.task_id === id);
-        if (!task) {
-          failed++;
-          continue;
-        }
         try {
-          await moveTaskToPhase(id, targetPhase.phase_id, task.project_status_mapping_id);
-          movedIds.add(id);
+          // Omit the status mapping so moveTaskToPhase performs phase-aware
+          // status remapping — passing the source status can land a task on a
+          // mapping that isn't valid for the target phase's status set.
+          const movedTask = await moveTaskToPhase(id, targetPhase.phase_id);
+          movedById.set(id, movedTask);
           success++;
         } catch (error) {
           console.error(`Failed to move task ${id}:`, error);
@@ -1943,11 +1939,20 @@ export default function ProjectDetail({
         }
       }
 
-      // Moved tasks leave the current kanban board
-      setProjectTasks(prev => prev.filter(t => !movedIds.has(t.task_id)));
-      setAllProjectTasks(prev => prev.map(t =>
-        movedIds.has(t.task_id) ? { ...t, phase_id: targetPhase.phase_id } : t
-      ));
+      // Moved tasks leave the current kanban board; apply the server-resolved
+      // phase + status mapping so the list view groups them correctly
+      setProjectTasks(prev => prev.filter(t => !movedById.has(t.task_id)));
+      setAllProjectTasks(prev => prev.map(t => {
+        const moved = movedById.get(t.task_id);
+        return moved
+          ? {
+              ...t,
+              phase_id: moved.phase_id,
+              project_status_mapping_id: moved.project_status_mapping_id,
+              order_key: moved.order_key,
+            }
+          : t;
+      }));
 
       if (failed === 0) {
         toast.success(
@@ -1969,29 +1974,38 @@ export default function ProjectDetail({
     }
 
     try {
-      // Get the current task to preserve its status
       const task = projectTasks.find(t => t.task_id === moveConfirmation.taskId);
       if (!task) {
         throw new Error('Task not found');
       }
 
+      // Omit the status mapping so moveTaskToPhase performs phase-aware status
+      // remapping — passing the source status can land the task on a mapping
+      // that isn't valid for the target phase's status set.
       const updatedTask = await moveTaskToPhase(
         moveConfirmation.taskId,
         moveConfirmation.targetPhase.phase_id,
-        task.project_status_mapping_id  // Pass the current status mapping ID
       );
-      
+
       const checklistItems = await getTaskChecklistItems(moveConfirmation.taskId);
       const taskWithChecklist = { ...updatedTask, checklist_items: checklistItems };
-      
+
       setProjectTasks(prevTasks =>
         prevTasks.map((task): IProjectTask =>
           task.task_id === updatedTask.task_id ? taskWithChecklist : task
         )
       );
-      // Update allProjectTasks for filtered counts
+      // Apply the server-resolved phase + status mapping so the list view
+      // groups the moved task correctly
       setAllProjectTasks(prev => prev.map(t =>
-        t.task_id === updatedTask.task_id ? { ...t, phase_id: moveConfirmation.targetPhase.phase_id } : t
+        t.task_id === updatedTask.task_id
+          ? {
+              ...t,
+              phase_id: updatedTask.phase_id,
+              project_status_mapping_id: updatedTask.project_status_mapping_id,
+              order_key: updatedTask.order_key,
+            }
+          : t
       ));
 
       toast.success(

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -991,18 +991,51 @@ export default function ProjectDetail({
   ) => {
     // Bulk move: when the dragged task is part of a multi-selection, move them all
     if (selectedTaskIds.has(taskId) && selectedTaskIds.size > 1) {
-      const tasksToMove = allProjectTasks.filter(t => selectedTaskIds.has(t.task_id));
+      // Sort selected tasks by current order_key so they land in their existing
+      // relative order. Tasks already in the target phase are repositioned;
+      // cross-phase tasks are moved in.
+      const tasksToMove = allProjectTasks
+        .filter(t => selectedTaskIds.has(t.task_id))
+        .sort((a, b) => {
+          const ka = a.order_key || '';
+          const kb = b.order_key || '';
+          return ka < kb ? -1 : ka > kb ? 1 : 0;
+        });
       if (tasksToMove.length === 0) return;
+
+      // Don't anchor positioning to tasks that are themselves being moved
+      const safeBefore = beforeTaskId && selectedTaskIds.has(beforeTaskId) ? null : beforeTaskId;
+      const safeAfter = afterTaskId && selectedTaskIds.has(afterTaskId) ? null : afterTaskId;
 
       let success = 0;
       let failed = 0;
+      let crossPhaseMoved = 0;
+      // Chain inserts so each subsequent task lands immediately after the
+      // previous one, preserving the relative order at the drop position.
+      let prevBefore: string | null = safeBefore;
+      const statusUpdatedById = new Map<string, IProjectTask>();
       for (const task of tasksToMove) {
         try {
           if (task.phase_id !== newPhaseId) {
-            await moveTaskToPhase(task.task_id, newPhaseId, newStatusMappingId);
+            await moveTaskToPhase(
+              task.task_id,
+              newPhaseId,
+              newStatusMappingId,
+              undefined,
+              prevBefore,
+              safeAfter,
+            );
+            crossPhaseMoved++;
           } else {
-            await updateTaskStatus(task.task_id, newStatusMappingId, null, null);
+            const updatedTask = await updateTaskStatus(
+              task.task_id,
+              newStatusMappingId,
+              prevBefore,
+              safeAfter,
+            );
+            statusUpdatedById.set(task.task_id, updatedTask);
           }
+          prevBefore = task.task_id;
           success++;
         } catch (error) {
           console.error(`Failed to move task ${task.task_id}:`, error);
@@ -1010,17 +1043,33 @@ export default function ProjectDetail({
         }
       }
 
-      setAllProjectTasks(prev => prev.map(t =>
-        selectedTaskIds.has(t.task_id)
-          ? { ...t, phase_id: newPhaseId, project_status_mapping_id: newStatusMappingId }
-          : t
-      ));
-      setProjectTasks(prev => prev.flatMap(t => {
-        if (!selectedTaskIds.has(t.task_id)) return [t];
-        // Drop from the current kanban view if moved out of the selected phase
-        if (selectedPhase && newPhaseId !== selectedPhase.phase_id) return [];
-        return [{ ...t, project_status_mapping_id: newStatusMappingId }];
-      }));
+      if (crossPhaseMoved > 0) {
+        // Cross-phase movement changes which list buckets a task belongs to and
+        // can invalidate cached ordering for the target status. Bump the version
+        // so the board reloads with correct grouping/ordering.
+        setAllProjectTasks(prev => prev.map(t => {
+          const u = statusUpdatedById.get(t.task_id);
+          if (u) {
+            return { ...t, project_status_mapping_id: u.project_status_mapping_id, order_key: u.order_key };
+          }
+          if (selectedTaskIds.has(t.task_id) && t.phase_id !== newPhaseId) {
+            return { ...t, phase_id: newPhaseId, project_status_mapping_id: newStatusMappingId };
+          }
+          return t;
+        }));
+        setStatusVersion(v => v + 1);
+      } else {
+        // Pure same-phase reorder/status change — apply server-returned
+        // order_key/status so the list reflects the exact drop position.
+        const applyUpdate = (taskItem: IProjectTask): IProjectTask => {
+          const u = statusUpdatedById.get(taskItem.task_id);
+          return u
+            ? { ...taskItem, project_status_mapping_id: u.project_status_mapping_id, order_key: u.order_key }
+            : taskItem;
+        };
+        setProjectTasks(prev => prev.map(applyUpdate));
+        setAllProjectTasks(prev => prev.map(applyUpdate));
+      }
 
       if (failed === 0) {
         toast.success(
@@ -2246,6 +2295,10 @@ export default function ProjectDetail({
     setProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
     setAllProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
     setPhaseTaskResources(prev => ({ ...prev, [taskId]: resources }));
+    // List view + project-wide agent filter read from the project-wide map.
+    // Keep it in sync so team-member additions/removals are reflected without
+    // a page reload.
+    setAllProjectTaskResources(prev => ({ ...prev, [taskId]: resources }));
   };
 
   const performTeamAssign = async (taskId: string, teamId: string) => {
@@ -2622,61 +2675,142 @@ export default function ProjectDetail({
     setIsBulkDeleteOpen(false);
   };
 
-  // Handler for bulk assign confirmation
-  const handleBulkAssignConfirm = async (userId: string | null) => {
+  // Handler for bulk assign confirmation — dispatches to user- or team-assign
+  // based on the dialog's selection.
+  const handleBulkAssignConfirm = async (
+    selection: { kind: 'user'; userId: string | null } | { kind: 'team'; teamId: string },
+  ) => {
     const ids = Array.from(selectedTaskIds);
     if (ids.length === 0) return;
 
     let success = 0;
     let failed = 0;
 
-    for (const taskId of ids) {
-      const task = projectTasks.find(t => t.task_id === taskId)
-        || allProjectTasks.find(t => t.task_id === taskId);
-      if (!task) {
-        failed++;
-        continue;
-      }
-      try {
-        // A user assignment should become the primary assignee. The UI renders the
-        // team over the user, so any existing team assignment must be removed first.
-        if (task.assigned_team_id) {
-          await removeTeamFromProjectTask(taskId, { mode: 'remove_all' });
+    if (selection.kind === 'user') {
+      const userId = selection.userId;
+      // Tasks whose team_member resource rows were just wiped — their cached
+      // resources need to be refetched so list-view and the agent filter no
+      // longer count the removed members.
+      const resourcesToRefresh: string[] = [];
+
+      for (const taskId of ids) {
+        const task = projectTasks.find(t => t.task_id === taskId)
+          || allProjectTasks.find(t => t.task_id === taskId);
+        if (!task) {
+          failed++;
+          continue;
         }
-        const updatedTask = await updateTaskWithChecklist(taskId, {
-          ...task,
-          assigned_to: userId,
-          assigned_team_id: null,
-          estimated_hours: Number(task.estimated_hours) || 0,
-          actual_hours: Number(task.actual_hours) || 0,
-          checklist_items: task.checklist_items,
-        });
-        if (updatedTask) {
-          const checklistItems = await getTaskChecklistItems(taskId);
-          const taskWithChecklist = { ...updatedTask, assigned_team_id: null, checklist_items: checklistItems };
-          setProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
-          setAllProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
-          success++;
-        } else {
+        try {
+          // A user assignment should become the primary assignee. The UI renders the
+          // team over the user, so any existing team assignment must be removed first.
+          if (task.assigned_team_id) {
+            await removeTeamFromProjectTask(taskId, { mode: 'remove_all' });
+            resourcesToRefresh.push(taskId);
+          }
+          const updatedTask = await updateTaskWithChecklist(taskId, {
+            ...task,
+            assigned_to: userId,
+            assigned_team_id: null,
+            estimated_hours: Number(task.estimated_hours) || 0,
+            actual_hours: Number(task.actual_hours) || 0,
+            checklist_items: task.checklist_items,
+          });
+          if (updatedTask) {
+            const checklistItems = await getTaskChecklistItems(taskId);
+            const taskWithChecklist = { ...updatedTask, assigned_team_id: null, checklist_items: checklistItems };
+            setProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
+            setAllProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
+            success++;
+          } else {
+            failed++;
+          }
+        } catch (error) {
+          console.error(`Failed to assign task ${taskId}:`, error);
           failed++;
         }
-      } catch (error) {
-        console.error(`Failed to assign task ${taskId}:`, error);
-        failed++;
       }
-    }
 
-    if (failed === 0) {
-      toast.success(
-        t('projectDetail.bulkAssignSuccess', '{{count}} task(s) assigned successfully!', { count: success }),
-      );
+      if (resourcesToRefresh.length > 0) {
+        const refreshed = await Promise.all(
+          resourcesToRefresh.map(async (id) => {
+            try {
+              return [id, await getTaskResourcesAction(id)] as const;
+            } catch (error) {
+              console.error(`Failed to refresh resources for task ${id}:`, error);
+              return null;
+            }
+          }),
+        );
+        const updates = refreshed.filter((r): r is readonly [string, ITaskResource[]] => r !== null);
+        if (updates.length > 0) {
+          setPhaseTaskResources(prev => {
+            const next = { ...prev };
+            for (const [id, resources] of updates) next[id] = resources;
+            return next;
+          });
+          setAllProjectTaskResources(prev => {
+            const next = { ...prev };
+            for (const [id, resources] of updates) next[id] = resources;
+            return next;
+          });
+        }
+      }
+
+      if (failed === 0) {
+        toast.success(
+          t('projectDetail.bulkAssignSuccess', '{{count}} task(s) assigned successfully!', { count: success }),
+        );
+      } else {
+        toast.error(
+          t('projectDetail.bulkAssignPartial', 'Assigned {{success}} task(s), {{failed}} failed.', {
+            success,
+            failed,
+          }),
+        );
+      }
     } else {
-      toast.error(
-        t('projectDetail.bulkAssignPartial', 'Assigned {{success}} task(s), {{failed}} failed.', {
-          success,
-          failed,
-        }),
-      );
+      const teamId = selection.teamId;
+      for (const taskId of ids) {
+        const task = projectTasks.find(t => t.task_id === taskId)
+          || allProjectTasks.find(t => t.task_id === taskId);
+        if (!task) {
+          failed++;
+          continue;
+        }
+        if (task.assigned_team_id === teamId) {
+          // Already assigned to this team — nothing to do, count as success.
+          success++;
+          continue;
+        }
+
+        try {
+          // If a different team is currently assigned, drop it first. Bulk mode
+          // can't surface the per-task keep/remove prompt, so we mirror the
+          // single-user-assign path (which always removes the prior team).
+          if (task.assigned_team_id) {
+            await removeTeamFromProjectTask(taskId, { mode: 'remove_all' });
+          }
+          await assignTeamToProjectTask(taskId, teamId);
+          await refreshTaskAfterTeamChange(taskId);
+          success++;
+        } catch (error) {
+          console.error(`Failed to assign team to task ${taskId}:`, error);
+          failed++;
+        }
+      }
+
+      if (failed === 0) {
+        toast.success(
+          t('projectDetail.bulkAssignTeamSuccess', '{{count}} task(s) assigned to team successfully!', { count: success }),
+        );
+      } else {
+        toast.error(
+          t('projectDetail.bulkAssignTeamPartial', 'Assigned {{success}} task(s) to team, {{failed}} failed.', {
+            success,
+            failed,
+          }),
+        );
+      }
     }
 
     clearSelection();
@@ -3602,13 +3736,14 @@ export default function ProjectDetail({
         />
       )}
 
-      {/* Bulk Assign Dialog */}
+      {/* Bulk Assign Dialog (users + teams) */}
       {isBulkAssignOpen && (
         <BulkAssignDialog
           isOpen={isBulkAssignOpen}
           onClose={() => setIsBulkAssignOpen(false)}
           taskCount={selectedTaskIds.size}
           users={users}
+          teams={teams}
           onConfirm={handleBulkAssignConfirm}
         />
       )}

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -34,6 +34,10 @@ import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHand
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import DuplicateTaskDialog, { DuplicateOptions } from './DuplicateTaskDialog';
 import MoveTaskDialog from './MoveTaskDialog';
+import BulkMoveTaskDialog from './BulkMoveTaskDialog';
+import BulkAssignDialog from './BulkAssignDialog';
+import BulkTaskActionBar from './BulkTaskActionBar';
+import { useTaskSelection } from './TaskSelectionContext';
 import ProjectPhases from './ProjectPhases';
 import PhaseTaskImportDialog from './PhaseTaskImportDialog';
 import KanbanBoard from './KanbanBoard';
@@ -222,6 +226,8 @@ export default function ProjectDetail({
   const [moveConfirmation, setMoveConfirmation] = useState<{
     taskId: string;
     taskName: string;
+    /** When present, this is a bulk move of all these task IDs (taskId is the grabbed one). */
+    taskIds?: string[];
     sourcePhase: IProjectPhase;
     targetPhase: IProjectPhase;
   } | null>(null);
@@ -242,6 +248,13 @@ export default function ProjectDetail({
   // State for the Move Task Dialog
   const [isMoveTaskDialogOpen, setIsMoveTaskDialogOpen] = useState(false);
   const [taskToMove, setTaskToMove] = useState<IProjectTask | null>(null);
+
+  // Bulk task selection / actions
+  const { selectedTaskIds, clearSelection } = useTaskSelection();
+  const [isBulkMoveOpen, setIsBulkMoveOpen] = useState(false);
+  const [isBulkAssignOpen, setIsBulkAssignOpen] = useState(false);
+  const [isBulkDeleteOpen, setIsBulkDeleteOpen] = useState(false);
+
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
   const [taskToDuplicate, setTaskToDuplicate] = useState<IProjectTask | null>(null);
   const [animatingTasks, setAnimatingTasks] = useState<Set<string>>(new Set());
@@ -975,6 +988,54 @@ export default function ProjectDetail({
     beforeTaskId: string | null,
     afterTaskId: string | null
   ) => {
+    // Bulk move: when the dragged task is part of a multi-selection, move them all
+    if (selectedTaskIds.has(taskId) && selectedTaskIds.size > 1) {
+      const tasksToMove = allProjectTasks.filter(t => selectedTaskIds.has(t.task_id));
+      if (tasksToMove.length === 0) return;
+
+      let success = 0;
+      let failed = 0;
+      for (const task of tasksToMove) {
+        try {
+          if (task.phase_id !== newPhaseId) {
+            await moveTaskToPhase(task.task_id, newPhaseId, newStatusMappingId);
+          } else {
+            await updateTaskStatus(task.task_id, newStatusMappingId, null, null);
+          }
+          success++;
+        } catch (error) {
+          console.error(`Failed to move task ${task.task_id}:`, error);
+          failed++;
+        }
+      }
+
+      setAllProjectTasks(prev => prev.map(t =>
+        selectedTaskIds.has(t.task_id)
+          ? { ...t, phase_id: newPhaseId, project_status_mapping_id: newStatusMappingId }
+          : t
+      ));
+      setProjectTasks(prev => prev.flatMap(t => {
+        if (!selectedTaskIds.has(t.task_id)) return [t];
+        // Drop from the current kanban view if moved out of the selected phase
+        if (selectedPhase && newPhaseId !== selectedPhase.phase_id) return [];
+        return [{ ...t, project_status_mapping_id: newStatusMappingId }];
+      }));
+
+      if (failed === 0) {
+        toast.success(
+          t('projectDetail.bulkTasksMovedSuccess', '{{count}} tasks moved', { count: success }),
+        );
+      } else {
+        toast.error(
+          t('projectDetail.bulkMovePartial', 'Moved {{moved}} task(s), {{failed}} failed.', {
+            moved: success,
+            failed,
+          }),
+        );
+      }
+      return;
+    }
+
     try {
       const task = allProjectTasks.find(t => t.task_id === taskId);
       if (!task) {
@@ -1005,7 +1066,7 @@ export default function ProjectDetail({
     } catch (error) {
       handleError(error, 'Failed to move task');
     }
-  }, [allProjectTasks, t]);
+  }, [allProjectTasks, selectedTaskIds, selectedPhase, t]);
   
   // Handle tag changes
   const handleProjectTagsChange = (tags: ITag[]) => {
@@ -1352,7 +1413,16 @@ export default function ProjectDetail({
 
   const handleDragStart = (e: React.DragEvent, taskId: string) => {
     e.dataTransfer.setData('text/plain', taskId);
-    if (e.target instanceof HTMLElement) {
+    const isBulkDrag = selectedTaskIds.has(taskId) && selectedTaskIds.size > 1;
+    if (isBulkDrag) {
+      // Dim every selected card so it's clear they all move together
+      document.querySelectorAll('[data-task-id]').forEach((el) => {
+        const id = el.getAttribute('data-task-id');
+        if (id && selectedTaskIds.has(id)) {
+          el.classList.add('opacity-50');
+        }
+      });
+    } else if (e.target instanceof HTMLElement) {
       e.target.classList.add('opacity-50');
     }
     document.body.classList.add('dragging-task');
@@ -1362,6 +1432,9 @@ export default function ProjectDetail({
     if (e.target instanceof HTMLElement) {
       e.target.classList.remove('opacity-50');
     }
+    document.querySelectorAll('[data-task-id]').forEach((el) => {
+      el.classList.remove('opacity-50');
+    });
     document.body.classList.remove('dragging-task');
     setPhaseDropTarget(null);
     setTaskDraggingOverPhaseId(null); // Clear task dragging over phase
@@ -1374,10 +1447,131 @@ export default function ProjectDetail({
     }
   };
 
+  // Move every selected task into the target status of the current kanban phase.
+  // Selected tasks already in this phase are repositioned at the drop point;
+  // selected tasks from other phases are moved into this phase + target status.
+  const handleBulkKanbanDrop = async (
+    targetStatusId: string,
+    beforeTaskId: string | null,
+    afterTaskId: string | null,
+  ) => {
+    const currentPhaseId = selectedPhase?.phase_id;
+    if (!currentPhaseId) return;
+
+    // Selected tasks across every phase (not just the current board)
+    const allSelected = allProjectTasks.filter(t => selectedTaskIds.has(t.task_id));
+    if (allSelected.length === 0) return;
+
+    const samePhaseTasks = allSelected
+      .filter(t => t.phase_id === currentPhaseId)
+      .sort((a, b) => {
+        const ka = a.order_key || '';
+        const kb = b.order_key || '';
+        return ka < kb ? -1 : ka > kb ? 1 : 0;
+      });
+    const otherPhaseTasks = allSelected.filter(t => t.phase_id !== currentPhaseId);
+
+    try {
+      const statusUpdatedById = new Map<string, IProjectTask>();
+      let movedInCount = 0;
+      let failed = 0;
+
+      // Reposition same-phase tasks at the drop location, grouped consecutively
+      let prevBefore = beforeTaskId;
+      for (const task of samePhaseTasks) {
+        try {
+          const updatedTask = await updateTaskStatus(task.task_id, targetStatusId, prevBefore, afterTaskId);
+          statusUpdatedById.set(task.task_id, updatedTask);
+          prevBefore = task.task_id;
+        } catch (error) {
+          console.error(`Failed to move task ${task.task_id}:`, error);
+          failed++;
+        }
+      }
+
+      // Move cross-phase tasks into the current phase at the target status
+      for (const task of otherPhaseTasks) {
+        try {
+          await moveTaskToPhase(task.task_id, currentPhaseId, targetStatusId);
+          movedInCount++;
+        } catch (error) {
+          console.error(`Failed to move task ${task.task_id}:`, error);
+          failed++;
+        }
+      }
+
+      if (otherPhaseTasks.length > 0) {
+        // Cross-phase tasks now belong to this phase. Update the project-wide list
+        // optimistically, then reload the board so they appear with correct
+        // ordering, ticket links, resources, etc.
+        setAllProjectTasks(prev => prev.map(t => {
+          const u = statusUpdatedById.get(t.task_id);
+          if (u) {
+            return { ...t, project_status_mapping_id: u.project_status_mapping_id, order_key: u.order_key };
+          }
+          if (selectedTaskIds.has(t.task_id) && t.phase_id !== currentPhaseId) {
+            return { ...t, phase_id: currentPhaseId, project_status_mapping_id: targetStatusId };
+          }
+          return t;
+        }));
+        setStatusVersion(v => v + 1);
+      } else {
+        // Pure same-phase status change — update in place to avoid a reload flicker
+        const applyUpdate = (t: IProjectTask): IProjectTask => {
+          const u = statusUpdatedById.get(t.task_id);
+          return u
+            ? { ...t, project_status_mapping_id: u.project_status_mapping_id, order_key: u.order_key }
+            : t;
+        };
+        setProjectTasks(prev => prev.map(applyUpdate));
+        setAllProjectTasks(prev => prev.map(applyUpdate));
+
+        setAnimatingTasks(prev => {
+          const next = new Set(prev);
+          statusUpdatedById.forEach((_, id) => next.add(id));
+          return next;
+        });
+        setTimeout(() => {
+          setAnimatingTasks(prev => {
+            const next = new Set(prev);
+            statusUpdatedById.forEach((_, id) => next.delete(id));
+            return next;
+          });
+        }, 500);
+      }
+
+      const total = statusUpdatedById.size + movedInCount;
+      if (failed === 0) {
+        toast.success(
+          t('projectDetail.bulkTasksMovedSuccess', '{{count}} tasks moved', { count: total }),
+        );
+      } else {
+        toast.error(
+          t('projectDetail.bulkMovePartial', 'Moved {{moved}} task(s), {{failed}} failed.', {
+            moved: total,
+            failed,
+          }),
+        );
+      }
+    } catch (error) {
+      handleError(error, 'Failed to move tasks');
+    }
+  };
+
   const handleDrop = async (e: React.DragEvent, targetStatusId: string, draggedTaskId: string, beforeTaskId: string | null, afterTaskId: string | null) => {
     e.preventDefault();
+
+    // Bulk drag: when the dragged task is part of a multi-selection, move them all
+    if (selectedTaskIds.has(draggedTaskId) && selectedTaskIds.size > 1) {
+      // Don't anchor positioning to tasks that are themselves being moved
+      const safeBefore = beforeTaskId && selectedTaskIds.has(beforeTaskId) ? null : beforeTaskId;
+      const safeAfter = afterTaskId && selectedTaskIds.has(afterTaskId) ? null : afterTaskId;
+      await handleBulkKanbanDrop(targetStatusId, safeBefore, safeAfter);
+      return;
+    }
+
     const task = projectTasks.find(t => t.task_id === draggedTaskId);
-    
+
     if (!task) {
       console.error('Task not found');
       return;
@@ -1690,8 +1884,25 @@ export default function ProjectDetail({
     const taskId = plainData;
     const task = projectTasks.find(t => t.task_id === taskId);
     const sourcePhase = projectPhases.find(p => p.phase_id === task?.phase_id);
-    
+
     if (task && sourcePhase && targetPhase.phase_id !== sourcePhase.phase_id) {
+      // Bulk drag: the dragged task is part of a multi-selection
+      if (selectedTaskIds.has(taskId) && selectedTaskIds.size > 1) {
+        const bulkTaskIds = projectTasks
+          .filter(t => selectedTaskIds.has(t.task_id) && t.phase_id !== targetPhase.phase_id)
+          .map(t => t.task_id);
+        if (bulkTaskIds.length > 0) {
+          setMoveConfirmation({
+            taskId,
+            taskName: task.task_name,
+            taskIds: bulkTaskIds,
+            sourcePhase,
+            targetPhase,
+          });
+        }
+        return;
+      }
+
       setMoveConfirmation({
         taskId,
         taskName: task.task_name,
@@ -1703,7 +1914,55 @@ export default function ProjectDetail({
 
   const handleMoveConfirm = async () => {
     if (!moveConfirmation) return;
-    
+
+    // Bulk move: move every selected task to the target phase
+    if (moveConfirmation.taskIds && moveConfirmation.taskIds.length > 0) {
+      const { taskIds: bulkTaskIds, targetPhase } = moveConfirmation;
+      let success = 0;
+      let failed = 0;
+      const movedIds = new Set<string>();
+
+      for (const id of bulkTaskIds) {
+        const task = projectTasks.find(t => t.task_id === id);
+        if (!task) {
+          failed++;
+          continue;
+        }
+        try {
+          await moveTaskToPhase(id, targetPhase.phase_id, task.project_status_mapping_id);
+          movedIds.add(id);
+          success++;
+        } catch (error) {
+          console.error(`Failed to move task ${id}:`, error);
+          failed++;
+        }
+      }
+
+      // Moved tasks leave the current kanban board
+      setProjectTasks(prev => prev.filter(t => !movedIds.has(t.task_id)));
+      setAllProjectTasks(prev => prev.map(t =>
+        movedIds.has(t.task_id) ? { ...t, phase_id: targetPhase.phase_id } : t
+      ));
+
+      if (failed === 0) {
+        toast.success(
+          t('projectDetail.bulkTasksMovedToPhase', '{{count}} tasks moved to {{phaseName}}', {
+            count: success,
+            phaseName: targetPhase.phase_name,
+          }),
+        );
+      } else {
+        toast.error(
+          t('projectDetail.bulkMovePartial', 'Moved {{moved}} task(s), {{failed}} failed.', {
+            moved: success,
+            failed,
+          }),
+        );
+      }
+      setMoveConfirmation(null);
+      return;
+    }
+
     try {
       // Get the current task to preserve its status
       const task = projectTasks.find(t => t.task_id === moveConfirmation.taskId);
@@ -2245,6 +2504,158 @@ export default function ProjectDetail({
       setIsMoveTaskDialogOpen(false);
       setTaskToMove(null);
     }
+  };
+
+  // Handler for bulk move confirmation
+  const handleBulkMoveConfirm = async (targetPhaseId: string, targetStatusId: string | undefined) => {
+    const ids = Array.from(selectedTaskIds);
+    if (ids.length === 0) return;
+
+    const moved: IProjectTask[] = [];
+    const failed: string[] = [];
+
+    for (const taskId of ids) {
+      try {
+        const movedTask = await moveTaskToPhase(taskId, targetPhaseId, targetStatusId);
+        if (movedTask) {
+          moved.push(movedTask);
+        } else {
+          failed.push(taskId);
+        }
+      } catch (error) {
+        console.error(`Failed to move task ${taskId}:`, error);
+        failed.push(taskId);
+      }
+    }
+
+    if (moved.length > 0) {
+      const movedMap = new Map(moved.map(m => [m.task_id, m]));
+      setProjectTasks(prev => prev.flatMap(t => {
+        const m = movedMap.get(t.task_id);
+        if (!m) return [t];
+        // Drop from the current kanban view when moved out of the selected phase
+        if (selectedPhase && m.phase_id !== selectedPhase.phase_id) return [];
+        return [{ ...t, ...m }];
+      }));
+      setAllProjectTasks(prev => prev.map(t => {
+        const m = movedMap.get(t.task_id);
+        return m
+          ? { ...t, phase_id: m.phase_id, project_status_mapping_id: m.project_status_mapping_id }
+          : t;
+      }));
+    }
+
+    if (failed.length === 0) {
+      toast.success(
+        t('projectDetail.bulkMoveSuccess', '{{count}} task(s) moved successfully!', { count: moved.length }),
+      );
+    } else {
+      toast.error(
+        t('projectDetail.bulkMovePartial', 'Moved {{moved}} task(s), {{failed}} failed.', {
+          moved: moved.length,
+          failed: failed.length,
+        }),
+      );
+    }
+
+    clearSelection();
+    setIsBulkMoveOpen(false);
+  };
+
+  // Handler for bulk delete confirmation
+  const handleBulkDeleteConfirm = async () => {
+    const ids = Array.from(selectedTaskIds);
+    if (ids.length === 0) return;
+
+    const deleted: string[] = [];
+    const failed: string[] = [];
+
+    for (const taskId of ids) {
+      try {
+        await deleteTaskAction(taskId);
+        deleted.push(taskId);
+      } catch (error) {
+        console.error(`Failed to delete task ${taskId}:`, error);
+        failed.push(taskId);
+      }
+    }
+
+    if (deleted.length > 0) {
+      const deletedSet = new Set(deleted);
+      setProjectTasks(prev => prev.filter(t => !deletedSet.has(t.task_id)));
+      setAllProjectTasks(prev => prev.filter(t => !deletedSet.has(t.task_id)));
+    }
+
+    if (failed.length === 0) {
+      toast.success(
+        t('projectDetail.bulkDeleteSuccess', '{{count}} task(s) deleted successfully!', { count: deleted.length }),
+      );
+    } else {
+      toast.error(
+        t('projectDetail.bulkDeletePartial', 'Deleted {{deleted}} task(s), {{failed}} failed.', {
+          deleted: deleted.length,
+          failed: failed.length,
+        }),
+      );
+    }
+
+    clearSelection();
+    setIsBulkDeleteOpen(false);
+  };
+
+  // Handler for bulk assign confirmation
+  const handleBulkAssignConfirm = async (userId: string | null) => {
+    const ids = Array.from(selectedTaskIds);
+    if (ids.length === 0) return;
+
+    let success = 0;
+    let failed = 0;
+
+    for (const taskId of ids) {
+      const task = projectTasks.find(t => t.task_id === taskId)
+        || allProjectTasks.find(t => t.task_id === taskId);
+      if (!task) {
+        failed++;
+        continue;
+      }
+      try {
+        const updatedTask = await updateTaskWithChecklist(taskId, {
+          ...task,
+          assigned_to: userId,
+          estimated_hours: Number(task.estimated_hours) || 0,
+          actual_hours: Number(task.actual_hours) || 0,
+          checklist_items: task.checklist_items,
+        });
+        if (updatedTask) {
+          const checklistItems = await getTaskChecklistItems(taskId);
+          const taskWithChecklist = { ...updatedTask, checklist_items: checklistItems };
+          setProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
+          setAllProjectTasks(prev => prev.map(t => (t.task_id === taskId ? taskWithChecklist : t)));
+          success++;
+        } else {
+          failed++;
+        }
+      } catch (error) {
+        console.error(`Failed to assign task ${taskId}:`, error);
+        failed++;
+      }
+    }
+
+    if (failed === 0) {
+      toast.success(
+        t('projectDetail.bulkAssignSuccess', '{{count}} task(s) assigned successfully!', { count: success }),
+      );
+    } else {
+      toast.error(
+        t('projectDetail.bulkAssignPartial', 'Assigned {{success}} task(s), {{failed}} failed.', {
+          success,
+          failed,
+        }),
+      );
+    }
+
+    clearSelection();
+    setIsBulkAssignOpen(false);
   };
 
   // Render the sticky header with title, view switcher, search, and filters
@@ -3025,16 +3436,32 @@ export default function ProjectDetail({
           isOpen={true}
           onClose={() => setMoveConfirmation(null)}
           onConfirm={handleMoveConfirm}
-          title={t('dialogs.moveTask.title', 'Move Task')}
-          message={t(
-            'projectDetail.confirmMoveTaskMessage',
-            'Are you sure you want to move task "{{taskName}}" from phase "{{sourcePhase}}" to "{{targetPhase}}"?',
-            {
-              taskName: moveConfirmation.taskName,
-              sourcePhase: moveConfirmation.sourcePhase.phase_name,
-              targetPhase: moveConfirmation.targetPhase.phase_name,
-            },
-          )}
+          title={
+            moveConfirmation.taskIds && moveConfirmation.taskIds.length > 1
+              ? t('projectDetail.moveTasksTitle', 'Move Tasks')
+              : t('dialogs.moveTask.title', 'Move Task')
+          }
+          message={
+            moveConfirmation.taskIds && moveConfirmation.taskIds.length > 1
+              ? t(
+                  'projectDetail.confirmMoveTasksMessage',
+                  'Are you sure you want to move {{count}} selected tasks from phase "{{sourcePhase}}" to "{{targetPhase}}"?',
+                  {
+                    count: moveConfirmation.taskIds.length,
+                    sourcePhase: moveConfirmation.sourcePhase.phase_name,
+                    targetPhase: moveConfirmation.targetPhase.phase_name,
+                  },
+                )
+              : t(
+                  'projectDetail.confirmMoveTaskMessage',
+                  'Are you sure you want to move task "{{taskName}}" from phase "{{sourcePhase}}" to "{{targetPhase}}"?',
+                  {
+                    taskName: moveConfirmation.taskName,
+                    sourcePhase: moveConfirmation.sourcePhase.phase_name,
+                    targetPhase: moveConfirmation.targetPhase.phase_name,
+                  },
+                )
+          }
           confirmLabel={t('common:actions.confirm', 'Confirm')}
           cancelLabel={t('common:actions.cancel', 'Cancel')}
         />
@@ -3113,6 +3540,52 @@ export default function ProjectDetail({
           currentProjectId={project.project_id}
           projectTreeData={projectTreeData}
           onConfirm={handleDialogMoveConfirm}
+        />
+      )}
+
+      {/* Bulk task action bar */}
+      <BulkTaskActionBar
+        onMove={() => setIsBulkMoveOpen(true)}
+        onAssign={() => setIsBulkAssignOpen(true)}
+        onDelete={() => setIsBulkDeleteOpen(true)}
+      />
+
+      {/* Bulk Move Task Dialog */}
+      {isBulkMoveOpen && (
+        <BulkMoveTaskDialog
+          isOpen={isBulkMoveOpen}
+          onClose={() => setIsBulkMoveOpen(false)}
+          taskCount={selectedTaskIds.size}
+          projectTreeData={projectTreeData}
+          onConfirm={handleBulkMoveConfirm}
+        />
+      )}
+
+      {/* Bulk Assign Dialog */}
+      {isBulkAssignOpen && (
+        <BulkAssignDialog
+          isOpen={isBulkAssignOpen}
+          onClose={() => setIsBulkAssignOpen(false)}
+          taskCount={selectedTaskIds.size}
+          users={users}
+          onConfirm={handleBulkAssignConfirm}
+        />
+      )}
+
+      {/* Bulk Delete Confirmation Dialog */}
+      {isBulkDeleteOpen && (
+        <ConfirmationDialog
+          isOpen={isBulkDeleteOpen}
+          onClose={() => setIsBulkDeleteOpen(false)}
+          onConfirm={handleBulkDeleteConfirm}
+          title={t('projectDetail.bulkDeleteTitle', 'Delete Tasks')}
+          message={t(
+            'projectDetail.bulkDeleteMessage',
+            'Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.',
+            { count: selectedTaskIds.size },
+          )}
+          confirmLabel={t('common:actions.delete', 'Delete')}
+          cancelLabel={t('common:actions.cancel', 'Cancel')}
         />
       )}
 

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -46,8 +46,9 @@ import KanbanZoomControl, { calculateColumnWidth } from './KanbanZoomControl';
 import DonutChart from './DonutChart';
 import { calculateProjectCompletion } from '@alga-psa/projects/lib/projectUtils';
 import { IClient } from '@alga-psa/types';
-import { HelpCircle, LayoutGrid, List, Search, Pin, X, XCircle, CheckSquare, Bug, Sparkles, TrendingUp, Flag, BookOpen, Columns3, Plus } from 'lucide-react';
+import { HelpCircle, LayoutGrid, List, Search, Pin, X, XCircle, ClipboardList, Bug, Sparkles, TrendingUp, Flag, BookOpen, Columns3, Plus } from 'lucide-react';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { generateKeyBetween } from 'fractional-indexing';
 import KanbanBoardSkeleton from '@alga-psa/ui/components/skeletons/KanbanBoardSkeleton';
 import { useUserPreferencesBatch } from '@alga-psa/user-composition/hooks';
@@ -70,7 +71,7 @@ const STATUS_FALLBACK_BORDERS = ['#d1d5db', '#a5b4fc', '#86efac', '#fde047'];
 
 // Task type icons for the filter dropdown
 const taskTypeIcons: Record<string, React.ComponentType<any>> = {
-  task: CheckSquare,
+  task: ClipboardList,
   bug: Bug,
   feature: Sparkles,
   improvement: TrendingUp,
@@ -250,7 +251,7 @@ export default function ProjectDetail({
   const [taskToMove, setTaskToMove] = useState<IProjectTask | null>(null);
 
   // Bulk task selection / actions
-  const { selectedTaskIds, clearSelection } = useTaskSelection();
+  const { selectedTaskIds, clearSelection, setTasksSelected } = useTaskSelection();
   const [isBulkMoveOpen, setIsBulkMoveOpen] = useState(false);
   const [isBulkAssignOpen, setIsBulkAssignOpen] = useState(false);
   const [isBulkDeleteOpen, setIsBulkDeleteOpen] = useState(false);
@@ -2813,7 +2814,7 @@ export default function ProjectDetail({
               options={[
                 { value: 'all', label: t('projectDetail.allTypes', 'All Types') },
                 ...taskTypes.map(t => {
-                  const Icon = taskTypeIcons[t.type_key] || CheckSquare;
+                  const Icon = taskTypeIcons[t.type_key] || ClipboardList;
                   return {
                     value: t.type_key,
                     label: (
@@ -3041,7 +3042,7 @@ export default function ProjectDetail({
               options={[
                 { value: 'all', label: t('projectDetail.allTypes', 'All Types') },
                 ...taskTypes.map(t => {
-                  const Icon = taskTypeIcons[t.type_key] || CheckSquare;
+                  const Icon = taskTypeIcons[t.type_key] || ClipboardList;
                   return {
                     value: t.type_key,
                     label: (
@@ -3348,6 +3349,12 @@ export default function ProjectDetail({
                   <div className={styles.kanbanStatusStripTrack}>
                     {visibleKanbanStatuses.map((status, index) => {
                       const { itemStyle, countStyle } = getStatusStripStyles(status, index);
+                      const stripTaskIds = filteredTasks
+                        .filter(t => t.project_status_mapping_id === status.project_status_mapping_id)
+                        .map(t => t.task_id);
+                      const stripAllSelected = stripTaskIds.length > 0
+                        && stripTaskIds.every(id => selectedTaskIds.has(id));
+                      const stripSomeSelected = stripTaskIds.some(id => selectedTaskIds.has(id));
                       return (
                         <div
                           key={status.project_status_mapping_id}
@@ -3360,6 +3367,17 @@ export default function ProjectDetail({
                           }}
                           title={status.custom_name || status.name}
                         >
+                          {stripTaskIds.length > 0 && (
+                            <Checkbox
+                              id={`select-sticky-status-${status.project_status_mapping_id}`}
+                              checked={stripAllSelected}
+                              indeterminate={stripSomeSelected && !stripAllSelected}
+                              onChange={() => setTasksSelected(stripTaskIds, !stripAllSelected)}
+                              size="sm"
+                              containerClassName="mb-0 flex-shrink-0"
+                              skipRegistration
+                            />
+                          )}
                           <span className={styles.kanbanStatusStripName}>
                             {status.custom_name || status.name}
                           </span>

--- a/packages/projects/src/components/ProjectInfo.tsx
+++ b/packages/projects/src/components/ProjectInfo.tsx
@@ -265,7 +265,7 @@ export default function ProjectInfo({
 }
 
 function ProjectTasksShareMenu() {
-  const { t } = useTranslation('projects');
+  const { t } = useTranslation('features/projects');
   const { t: tCommon } = useTranslation('common');
   const { registration } = useTaskShareActions();
   const { selectedTaskIds } = useTaskSelection();
@@ -278,7 +278,7 @@ function ProjectTasksShareMenu() {
       id: 'project-tasks-share-print',
       icon: Printer,
       label: selectedTaskCount > 0
-        ? t('export.printSelected', { defaultValue: 'Print {{count}} Selected', count: selectedTaskCount })
+        ? tCommon('actions.printSelected', { defaultValue: 'Print selected ({{count}})', count: selectedTaskCount })
         : tCommon('actions.print', { defaultValue: 'Print' }),
       onSelect: () => { void registration.triggerPrint(); },
       disabled: registration.isPrinting,

--- a/packages/projects/src/components/ProjectInfo.tsx
+++ b/packages/projects/src/components/ProjectInfo.tsx
@@ -268,6 +268,8 @@ function ProjectTasksShareMenu() {
   const { t } = useTranslation('projects');
   const { t: tCommon } = useTranslation('common');
   const { registration } = useTaskShareActions();
+  const { selectedTaskIds } = useTaskSelection();
+  const selectedTaskCount = selectedTaskIds.size;
 
   if (!registration) return null;
 
@@ -275,7 +277,9 @@ function ProjectTasksShareMenu() {
     {
       id: 'project-tasks-share-print',
       icon: Printer,
-      label: tCommon('actions.print', { defaultValue: 'Print' }),
+      label: selectedTaskCount > 0
+        ? t('export.printSelected', { defaultValue: 'Print {{count}} Selected', count: selectedTaskCount })
+        : tCommon('actions.print', { defaultValue: 'Print' }),
       onSelect: () => { void registration.triggerPrint(); },
       disabled: registration.isPrinting,
     },

--- a/packages/projects/src/components/ProjectInfo.tsx
+++ b/packages/projects/src/components/ProjectInfo.tsx
@@ -17,6 +17,7 @@ import CreateTemplateDialog from './project-templates/CreateTemplateDialog';
 import ProjectMaterialsDrawer from './ProjectMaterialsDrawer';
 import ProjectTaskExportDialog from './ProjectTaskExportDialog';
 import { useTaskShareActions } from './TaskShareActionsContext';
+import { useTaskSelection } from './TaskSelectionContext';
 import { useTranslation } from 'react-i18next';
 
 interface ProjectInfoProps {
@@ -52,6 +53,8 @@ export default function ProjectInfo({
 }: ProjectInfoProps) {
   const { t } = useTranslation(['features/projects', 'common']);
   const { openDrawer, closeDrawer } = useDrawer();
+  const { selectedTaskIds } = useTaskSelection();
+  const selectedTaskCount = selectedTaskIds.size;
 
   const [currentProject, setCurrentProject] = useState(project);
   const [showTemplateDialog, setShowTemplateDialog] = useState(false);
@@ -160,7 +163,9 @@ export default function ProjectInfo({
             onClick={() => setShowExportDialog(true)}
           >
             <Download className="h-4 w-4 mr-2" />
-            {t('export.exportTasks', 'Export Tasks')}
+            {selectedTaskCount > 0
+              ? t('export.exportSelected', 'Export {{count}} Selected', { count: selectedTaskCount })
+              : t('export.exportTasks', 'Export Tasks')}
           </Button>
           <ProjectTasksShareMenu />
           <Button
@@ -253,6 +258,7 @@ export default function ProjectInfo({
         onClose={() => setShowExportDialog(false)}
         projectId={currentProject.project_id}
         phases={phases}
+        selectedTaskIds={selectedTaskIds}
       />
     </div>
   );

--- a/packages/projects/src/components/ProjectPage.tsx
+++ b/packages/projects/src/components/ProjectPage.tsx
@@ -4,6 +4,7 @@ import { getProjectMetadata, updateProject } from '../actions/projectActions';
 import ProjectInfo from './ProjectInfo';
 import ProjectDetail from './ProjectDetail';
 import { TaskShareActionsProvider } from './TaskShareActionsContext';
+import { TaskSelectionProvider } from './TaskSelectionContext';
 import { useEffect, useState, useCallback } from 'react';
 import { useSearchParams, usePathname } from 'next/navigation';
 import type { IClient, IProject, IProjectPhase, IProjectTask, IProjectTicketLinkWithDetails, ITag, IUserWithRoles, ProjectStatus } from '@alga-psa/types';
@@ -147,6 +148,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
 
   return (
     <TaskShareActionsProvider>
+    <TaskSelectionProvider>
     <div>
       <ProjectInfo
         project={projectMetadata.project}
@@ -174,6 +176,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
         onUrlUpdate={handleUrlUpdate}
       />
     </div>
+    </TaskSelectionProvider>
     </TaskShareActionsProvider>
   );
 }

--- a/packages/projects/src/components/ProjectTaskExportDialog.tsx
+++ b/packages/projects/src/components/ProjectTaskExportDialog.tsx
@@ -16,6 +16,8 @@ interface ProjectTaskExportDialogProps {
   onClose: () => void;
   projectId: string;
   phases: IProjectPhase[];
+  /** When non-empty, the export is scoped to exactly these task IDs and the phase picker is hidden. */
+  selectedTaskIds?: Set<string>;
 }
 
 type ExportStep = 'configure' | 'exporting' | 'complete';
@@ -46,10 +48,12 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
   onClose,
   projectId,
   phases,
+  selectedTaskIds,
 }) => {
   const { t } = useTranslation(['features/projects', 'common']);
   const exportT = useCallback((key: string, fallback: string, options?: Record<string, unknown>) =>
     t(`export.${key}`, { defaultValue: fallback, ...(options ?? {}) }), [t]);
+  const isSelectionMode = (selectedTaskIds?.size ?? 0) > 0;
   const [step, setStep] = useState<ExportStep>('configure');
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(ALL_FIELD_KEYS));
   const [selectedPhaseIds, setSelectedPhaseIds] = useState<Set<string>>(
@@ -119,8 +123,9 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
       const orderedFields = ALL_FIELD_KEYS.filter(k => selectedFields.has(k));
       const { csv, count } = await exportProjectTasksToCSV(
         projectId,
-        Array.from(selectedPhaseIds),
+        isSelectionMode ? [] : Array.from(selectedPhaseIds),
         orderedFields,
+        isSelectionMode ? Array.from(selectedTaskIds!) : undefined,
       );
 
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -141,7 +146,7 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
       setStep('configure');
       handleError(err, exportT('failed', 'Failed to export tasks'));
     }
-  }, [projectId, selectedFields, selectedPhaseIds, exportT]);
+  }, [projectId, selectedFields, selectedPhaseIds, isSelectionMode, selectedTaskIds, exportT]);
 
   const footer =
     step === 'configure' ? (
@@ -156,7 +161,7 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
         <Button
           id="export-tasks-btn"
           onClick={() => void handleExport()}
-          disabled={noPhasesSelected || noFieldsSelected}
+          disabled={(!isSelectionMode && noPhasesSelected) || noFieldsSelected}
           className="flex items-center gap-2"
         >
           <Download className="h-4 w-4" />
@@ -192,7 +197,20 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
         {/* Step 1: Configure */}
         {step === 'configure' && (
           <div>
+            {/* Selection-mode notice */}
+            {isSelectionMode && (
+              <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50 dark:border-[rgb(var(--color-primary-700))] dark:bg-[rgb(var(--color-primary-900))] p-3">
+                <p className="text-sm text-primary-700 dark:text-[rgb(var(--color-primary-200))]">
+                  {exportT('selectedTasksNotice', 'Exporting {{count}} selected task{{plural}}.', {
+                    count: selectedTaskIds!.size,
+                    plural: selectedTaskIds!.size === 1 ? '' : 's',
+                  })}
+                </p>
+              </div>
+            )}
+
             {/* Phase selection */}
+            {!isSelectionMode && (
             <div className="mb-4">
               <div className="flex items-center justify-between mb-2">
                 <h3 className="text-sm font-medium text-gray-700 dark:text-[rgb(var(--color-text-200))]">
@@ -232,6 +250,7 @@ const ProjectTaskExportDialog: React.FC<ProjectTaskExportDialogProps> = ({
                 })}
               </p>
             </div>
+            )}
 
             {/* Field selection */}
             <div>

--- a/packages/projects/src/components/StatusColumn.tsx
+++ b/packages/projects/src/components/StatusColumn.tsx
@@ -4,6 +4,7 @@ import { IProjectTask, ProjectStatus, IProjectTicketLinkWithDetails, ITaskType, 
 import { ITag } from '@alga-psa/types';
 import { IPriority, IStandardPriority } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Circle, Plus } from 'lucide-react';
 import TaskCard from './TaskCard';
 import styles from './ProjectDetail.module.css';
@@ -11,6 +12,7 @@ import { IUserWithRoles } from '@alga-psa/types';
 import { useState, useRef } from 'react';
 import { useTheme } from 'next-themes';
 import { darkenColor } from '@alga-psa/ui/lib/colorUtils';
+import { useTaskSelection } from './TaskSelectionContext';
 
 interface StatusColumnProps {
   status: ProjectStatus;
@@ -113,6 +115,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
 }) => {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
+  const { isSelected, setTasksSelected } = useTaskSelection();
   const [isDraggedOver, setIsDraggedOver] = useState(false);
   const [dragOverTaskId, setDragOverTaskId] = useState<string | null>(null);
   const [dropPosition, setDropPosition] = useState<'before' | 'after' | null>(null);
@@ -308,6 +311,11 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
     return keyA < keyB ? -1 : keyA > keyB ? 1 : 0;
   });
 
+  // Select-all state for this status column
+  const statusTaskIds = displayTasks.map(t => t.task_id);
+  const allTasksSelected = statusTaskIds.length > 0 && statusTaskIds.every(id => isSelected(id));
+  const someTasksSelected = statusTaskIds.some(id => isSelected(id));
+
   // Helper to lighten hex color (for background)
   const lightenColor = (hex: string, percent: number) => {
     const num = parseInt(hex.replace('#', ''), 16);
@@ -341,6 +349,17 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
       {!hideHeader && (
         <div className={`font-bold ${zoomLevel <= 30 ? 'text-xs p-2' : 'text-sm p-3'} rounded-t-lg`}>
           <div className="flex items-center justify-between gap-2">
+            {statusTaskIds.length > 0 && (
+              <Checkbox
+                id={`select-status-column-${status.project_status_mapping_id}`}
+                checked={allTasksSelected}
+                indeterminate={someTasksSelected && !allTasksSelected}
+                onChange={() => setTasksSelected(statusTaskIds, !allTasksSelected)}
+                size="sm"
+                containerClassName="mb-0 flex-shrink-0"
+                skipRegistration
+              />
+            )}
             <div
               className={`flex ${configuredColor ? '' : darkBackgroundColor} ${zoomLevel <= 30 ? 'rounded-xl border px-2 py-1.5' : 'rounded-2xl border-2 ps-3 py-3 pe-4'} ${configuredColor ? '' : borderColor} shadow-sm items-center min-w-0 flex-1`}
               style={configuredColor ? {

--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -6,7 +6,7 @@ import { IProjectTask, IProjectTicketLinkWithDetails, ITaskType, IProjectTaskDep
 import { IUserWithRoles } from '@alga-psa/types';
 import { IPriority, IStandardPriority } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
-import { CheckSquare, Square, Ticket, MoreVertical, Move, Copy, Edit, Trash2, Bug, Sparkles, TrendingUp, Flag, BookOpen, Paperclip, Ban, GitBranch, Link2, Tag, MessageSquare } from 'lucide-react';
+import { CheckSquare, Square, Ticket, MoreVertical, Move, Copy, Edit, Trash2, Bug, Sparkles, TrendingUp, Flag, BookOpen, Paperclip, Ban, GitBranch, Link2, Tag, MessageSquare, ClipboardList } from 'lucide-react';
 import { extractTaskDescriptionText } from '../lib/taskRichText';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import UserAndTeamPicker from '@alga-psa/ui/components/UserAndTeamPicker';
@@ -65,7 +65,7 @@ interface TaskCardProps {
 }
 
 const taskTypeIcons: Record<string, React.ComponentType<any>> = {
-  task: CheckSquare,
+  task: ClipboardList,
   bug: Bug,
   feature: Sparkles,
   improvement: TrendingUp,
@@ -170,7 +170,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
     }
   }, [providedDocumentCount]);
 
-  const Icon = taskTypeIcons[task.task_type_key || 'task'] || CheckSquare;
+  const Icon = taskTypeIcons[task.task_type_key || 'task'] || ClipboardList;
 
   // Sync ticket links from props when they change
   useEffect(() => {
@@ -307,7 +307,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
     >
       {/* Selection checkbox */}
       <div
-        className={`absolute ${zoomLevel <= 15 ? 'top-1 right-6' : 'top-1.5 right-8'} z-10 flex items-center`}
+        className={`absolute ${zoomLevel <= 15 ? 'top-1 left-1' : 'top-1.5 left-2'} z-10 flex items-center`}
         onClick={(e) => e.stopPropagation()}
       >
         <input
@@ -321,7 +321,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
       </div>
 
       {/* Task type indicator */}
-      <div className={`absolute ${zoomLevel <= 15 ? 'top-1 left-1' : 'top-2 left-2'}`} title={taskType?.type_name || t('task', 'Task')}>
+      <div className={`absolute ${zoomLevel <= 15 ? 'top-1 right-6' : 'top-2 right-8'}`} title={taskType?.type_name || t('task', 'Task')}>
         <Icon
           className={zoomLevel <= 15 ? 'w-3 h-3' : 'w-4 h-4'}
           style={{ color: taskType?.color || '#6B7280' }}

--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -327,7 +327,13 @@ export const TaskCard: React.FC<TaskCardProps> = ({
           style={{ color: taskType?.color || '#6B7280' }}
         />
       </div>
-      
+
+      {/* Header strip — clicks here (around the checkbox / action menu) should not open the task */}
+      <div
+        className={`absolute top-0 left-0 right-0 cursor-default ${zoomLevel <= 15 ? 'h-5' : 'h-7'}`}
+        onClick={(e) => e.stopPropagation()}
+        aria-hidden="true"
+      />
 
       {/* Action Menu Button */}
       <div className={`absolute ${zoomLevel <= 15 ? 'top-0.5 right-0.5' : 'top-1 right-1'} z-10`}>

--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -28,6 +28,7 @@ import styles from './ProjectDetail.module.css';
 import { highlightSearchMatch } from '../lib/searchUtils';
 import { calculateZoomScales } from './KanbanZoomControl';
 import { useTranslation } from 'react-i18next';
+import { useTaskSelection } from './TaskSelectionContext';
 
 interface TaskCardProps {
   task: IProjectTask;
@@ -106,6 +107,8 @@ export const TaskCard: React.FC<TaskCardProps> = ({
   teamAvatarUrls = {},
 }) => {
   const { t } = useTranslation(['features/projects', 'common']);
+  const { isSelected, toggleTask, selectedTaskIds } = useTaskSelection();
+  const selected = isSelected(task.task_id);
   // Use data from props — parent (StatusColumn) always provides arrays from batch-loaded data
   const [taskTickets, setTaskTickets] = useState<IProjectTicketLinkWithDetails[]>(
     task.ticket_links ?? ticketLinks ?? []
@@ -217,6 +220,29 @@ export const TaskCard: React.FC<TaskCardProps> = ({
       dragImage.style.height = `${rect.height}px`;
       dragImage.style.transform = 'translateY(-1000px)';
       dragImage.classList.add('drag-image');
+
+      // When dragging as part of a multi-selection, show a count badge on the drag image
+      if (selected && selectedTaskIds.size > 1) {
+        const badge = document.createElement('div');
+        badge.textContent = String(selectedTaskIds.size);
+        badge.style.position = 'absolute';
+        badge.style.top = '-10px';
+        badge.style.right = '-10px';
+        badge.style.minWidth = '24px';
+        badge.style.height = '24px';
+        badge.style.padding = '0 6px';
+        badge.style.borderRadius = '9999px';
+        badge.style.background = 'rgb(var(--color-primary-500))';
+        badge.style.color = '#fff';
+        badge.style.fontSize = '12px';
+        badge.style.fontWeight = '600';
+        badge.style.display = 'flex';
+        badge.style.alignItems = 'center';
+        badge.style.justifyContent = 'center';
+        badge.style.boxShadow = '0 1px 3px rgba(0,0,0,0.3)';
+        dragImage.appendChild(badge);
+      }
+
       document.body.appendChild(dragImage);
       e.dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2);
       setTimeout(() => document.body.removeChild(dragImage), 0);
@@ -269,7 +295,9 @@ export const TaskCard: React.FC<TaskCardProps> = ({
         console.log('Using cached project tree data when selecting task for editing');
         onTaskSelected(task);
       }}
-      className={`${styles.taskCard} relative bg-white ${zoomScales.cardPadding} rounded-lg shadow-sm cursor-pointer hover:shadow-md transition-all duration-200 border border-gray-200 flex flex-col ${zoomScales.cardGap} ${
+      className={`${styles.taskCard} relative bg-white ${zoomScales.cardPadding} rounded-lg shadow-sm cursor-pointer hover:shadow-md transition-all duration-200 border flex flex-col ${zoomScales.cardGap} ${
+        selected ? 'border-primary-500 ring-2 ring-primary-500' : 'border-gray-200'
+      } ${
         isDragging ? styles.dragging : ''
       } ${isAnimating ? styles.entering : ''}`}
       aria-grabbed={isDragging}
@@ -277,6 +305,21 @@ export const TaskCard: React.FC<TaskCardProps> = ({
         taskName: task.task_name,
       })}
     >
+      {/* Selection checkbox */}
+      <div
+        className={`absolute ${zoomLevel <= 15 ? 'top-1 right-6' : 'top-1.5 right-8'} z-10 flex items-center`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => toggleTask(task.task_id)}
+          aria-label={t('projectDetail.selectTaskAria', 'Select task {{taskName}}', { taskName: task.task_name })}
+          className={`alga-checkbox ${zoomLevel <= 15 ? 'h-3 w-3' : 'h-4 w-4'} rounded cursor-pointer`}
+          style={{ accentColor: 'rgb(var(--color-primary-500))' }}
+        />
+      </div>
+
       {/* Task type indicator */}
       <div className={`absolute ${zoomLevel <= 15 ? 'top-1 left-1' : 'top-2 left-2'}`} title={taskType?.type_name || t('task', 'Task')}>
         <Icon

--- a/packages/projects/src/components/TaskListView.tsx
+++ b/packages/projects/src/components/TaskListView.tsx
@@ -28,6 +28,8 @@ import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions
 import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
 import { highlightSearchMatch } from '../lib/searchUtils';
 import { useTranslation } from 'react-i18next';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import { useTaskSelection } from './TaskSelectionContext';
 
 // Auto-scroll configuration for drag operations
 const SCROLL_THRESHOLD = 80; // Pixels from edge to start scrolling
@@ -137,6 +139,7 @@ export default function TaskListView({
   searchCaseSensitive = false
 }: TaskListViewProps) {
   const { t } = useTranslation(['features/projects', 'common']);
+  const { isSelected, toggleTask, setTasksSelected, selectedTaskIds } = useTaskSelection();
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedStatuses, setExpandedStatuses] = useState<Set<string>>(new Set());
   const [expandedTitles, setExpandedTitles] = useState<Set<string>>(new Set());
@@ -510,10 +513,19 @@ export default function TaskListView({
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', task.task_id);
     // Add a visual cue that we're dragging
-    if (e.currentTarget) {
+    const isBulkDrag = selectedTaskIds.has(task.task_id) && selectedTaskIds.size > 1;
+    if (isBulkDrag) {
+      // Dim every selected row so it's clear they all move together
+      document.querySelectorAll('[data-task-row-id]').forEach((el) => {
+        const id = el.getAttribute('data-task-row-id');
+        if (id && selectedTaskIds.has(id)) {
+          (el as HTMLElement).style.opacity = '0.5';
+        }
+      });
+    } else if (e.currentTarget) {
       e.currentTarget.style.opacity = '0.5';
     }
-  }, []);
+  }, [selectedTaskIds]);
 
   const handleDragEnd = useCallback((e: React.DragEvent<HTMLTableRowElement>) => {
     setDraggedTask(null);
@@ -523,6 +535,9 @@ export default function TaskListView({
     if (e.currentTarget) {
       e.currentTarget.style.opacity = '1';
     }
+    document.querySelectorAll('[data-task-row-id]').forEach((el) => {
+      (el as HTMLElement).style.opacity = '1';
+    });
     // Clear scroll interval
     scrollSpeedRef.current = 0;
     if (scrollIntervalRef.current) {
@@ -873,7 +888,7 @@ export default function TaskListView({
       {/* Column headers - sticky */}
       <div className="bg-white border-b border-gray-200 flex-shrink-0">
         <table className="w-full table-fixed">
-          <colgroup><col style={{ width: '40px' }} /><col />{isColumnVisible('deps') && <col style={{ width: '5%' }} />}{isColumnVisible('checklist') && <col style={{ width: '6%' }} />}{isColumnVisible('tags') && <col style={{ width: '10%' }} />}{isColumnVisible('assignee') && <col style={{ width: '17%' }} />}{isColumnVisible('est_hours') && <col style={{ width: '6%' }} />}{isColumnVisible('actual_hours') && <col style={{ width: '7%' }} />}{isColumnVisible('due_date') && <col style={{ width: '9%' }} />}{isColumnVisible('attachments') && <col style={{ width: '6%' }} />}<col style={{ width: '8%' }} /></colgroup>
+          <colgroup><col style={{ width: '64px' }} /><col />{isColumnVisible('deps') && <col style={{ width: '5%' }} />}{isColumnVisible('checklist') && <col style={{ width: '6%' }} />}{isColumnVisible('tags') && <col style={{ width: '10%' }} />}{isColumnVisible('assignee') && <col style={{ width: '17%' }} />}{isColumnVisible('est_hours') && <col style={{ width: '6%' }} />}{isColumnVisible('actual_hours') && <col style={{ width: '7%' }} />}{isColumnVisible('due_date') && <col style={{ width: '9%' }} />}{isColumnVisible('attachments') && <col style={{ width: '6%' }} />}<col style={{ width: '8%' }} /></colgroup>
           <thead>
             <tr>
               <th className="w-10 px-3 py-3" />
@@ -958,7 +973,7 @@ export default function TaskListView({
           return (
             <div key={phaseGroup.phase.phase_id}>
               <table className="w-full table-fixed">
-                <colgroup><col style={{ width: '40px' }} /><col />{isColumnVisible('deps') && <col style={{ width: '5%' }} />}{isColumnVisible('checklist') && <col style={{ width: '6%' }} />}{isColumnVisible('tags') && <col style={{ width: '10%' }} />}{isColumnVisible('assignee') && <col style={{ width: '17%' }} />}{isColumnVisible('est_hours') && <col style={{ width: '6%' }} />}{isColumnVisible('actual_hours') && <col style={{ width: '7%' }} />}{isColumnVisible('due_date') && <col style={{ width: '9%' }} />}{isColumnVisible('attachments') && <col style={{ width: '6%' }} />}<col style={{ width: '8%' }} /></colgroup>
+                <colgroup><col style={{ width: '64px' }} /><col />{isColumnVisible('deps') && <col style={{ width: '5%' }} />}{isColumnVisible('checklist') && <col style={{ width: '6%' }} />}{isColumnVisible('tags') && <col style={{ width: '10%' }} />}{isColumnVisible('assignee') && <col style={{ width: '17%' }} />}{isColumnVisible('est_hours') && <col style={{ width: '6%' }} />}{isColumnVisible('actual_hours') && <col style={{ width: '7%' }} />}{isColumnVisible('due_date') && <col style={{ width: '9%' }} />}{isColumnVisible('attachments') && <col style={{ width: '6%' }} />}<col style={{ width: '8%' }} /></colgroup>
 
                 {/* Phase header row */}
                 <thead>
@@ -1058,6 +1073,9 @@ export default function TaskListView({
                     {phaseGroup.statusGroups.map(statusGroup => {
                       const statusKey = `${phaseGroup.phase.phase_id}:${statusGroup.status.project_status_mapping_id}`;
                       const isStatusExpanded = expandedStatuses.has(statusKey);
+                      const statusTaskIds = statusGroup.tasks.map(t => t.task_id);
+                      const allStatusSelected = statusTaskIds.length > 0 && statusTaskIds.every(id => isSelected(id));
+                      const someStatusSelected = statusTaskIds.some(id => isSelected(id));
                       const isDropTarget = draggedTask &&
                         dragOverStatus === statusGroup.status.project_status_mapping_id &&
                         dragOverPhase === phaseGroup.phase.phase_id;
@@ -1087,6 +1105,19 @@ export default function TaskListView({
                                   <ChevronDown className="h-3.5 w-3.5 text-gray-400" />
                                 ) : (
                                   <ChevronRight className="h-3.5 w-3.5 text-gray-400" />
+                                )}
+                                {statusTaskIds.length > 0 && (
+                                  <div onClick={(e) => e.stopPropagation()}>
+                                    <Checkbox
+                                      id={`select-status-${statusKey}`}
+                                      checked={allStatusSelected}
+                                      indeterminate={someStatusSelected && !allStatusSelected}
+                                      onChange={() => setTasksSelected(statusTaskIds, !allStatusSelected)}
+                                      size="sm"
+                                      containerClassName="mb-0"
+                                      skipRegistration
+                                    />
+                                  </div>
                                 )}
                                 <span
                                   className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
@@ -1131,6 +1162,7 @@ export default function TaskListView({
                                   </tr>
                                 )}
                                 <tr
+                                data-task-row-id={task.task_id}
                                 className={`${taskIndex % 2 === 0 ? 'bg-gray-50 dark:bg-[rgb(var(--color-border-100))]' : 'bg-white dark:bg-[rgb(var(--color-card))]'} hover:bg-primary/10 group transition-colors ${
                                   isDragging ? 'opacity-50' : ''
                                 } ${showDropIndicator ? 'bg-primary-50' : ''}`}
@@ -1141,11 +1173,23 @@ export default function TaskListView({
                                 onDragLeave={handleDragLeave}
                                 onDrop={(e) => handleDrop(e, statusGroup.status.project_status_mapping_id, phaseGroup.phase.phase_id, statusGroup.tasks, taskIndex)}
                               >
-                                {/* Drag handle and indent spacer */}
-                                <td className="py-3 px-3 w-10">
-                                  {onTaskMove && (
-                                    <GripVertical className="h-4 w-4 text-gray-400 cursor-grab opacity-0 group-hover:opacity-100 transition-opacity" />
-                                  )}
+                                {/* Selection checkbox and drag handle */}
+                                <td className="py-3 px-3">
+                                  <div className="flex items-center gap-1">
+                                    <div onClick={(e) => e.stopPropagation()}>
+                                      <Checkbox
+                                        id={`select-task-${task.task_id}`}
+                                        checked={isSelected(task.task_id)}
+                                        onChange={() => toggleTask(task.task_id)}
+                                        size="sm"
+                                        containerClassName="mb-0"
+                                        skipRegistration
+                                      />
+                                    </div>
+                                    {onTaskMove && (
+                                      <GripVertical className="h-4 w-4 text-gray-400 cursor-grab opacity-0 group-hover:opacity-100 transition-opacity" />
+                                    )}
+                                  </div>
                                 </td>
 
                                 {/* Task Name */}

--- a/packages/projects/src/components/TaskListView.tsx
+++ b/packages/projects/src/components/TaskListView.tsx
@@ -717,7 +717,7 @@ export default function TaskListView({
   const visibleColumnCount = COLUMN_CONFIG.filter(c => isColumnVisible(c.key ?? '')).length;
 
   const printRows = useMemo(() => {
-    return phaseGroups.flatMap((phaseGroup) =>
+    const rows = phaseGroups.flatMap((phaseGroup) =>
       phaseGroup.statusGroups.flatMap((statusGroup) =>
         statusGroup.tasks.map((task) => ({
           task,
@@ -726,7 +726,12 @@ export default function TaskListView({
         }))
       )
     );
-  }, [phaseGroups]);
+    // When tasks are selected, scope the print to just those
+    if (selectedTaskIds.size > 0) {
+      return rows.filter((row) => selectedTaskIds.has(row.task.task_id));
+    }
+    return rows;
+  }, [phaseGroups, selectedTaskIds]);
 
   const printColumns = useMemo<PrintColumnOption<typeof printRows[number]>[]>(() => [
     {
@@ -852,9 +857,15 @@ export default function TaskListView({
       <div className="app-print-root app-print-only">
         <PrintableTable
           title={t('projectPrint.tasks.title', 'Project Tasks')}
-          subtitle={t('projectPrint.tasks.subtitle', '{{count}} tasks', {
-            count: printRows.length,
-          })}
+          subtitle={
+            selectedTaskIds.size > 0
+              ? t('projectPrint.tasks.subtitleSelected', '{{count}} selected tasks', {
+                  count: printRows.length,
+                })
+              : t('projectPrint.tasks.subtitle', '{{count}} tasks', {
+                  count: printRows.length,
+                })
+          }
           rows={printRows}
           columns={selectedTaskPrintColumns}
           getRowKey={({ task }) => task.task_id}

--- a/packages/projects/src/components/TaskSelectionContext.tsx
+++ b/packages/projects/src/components/TaskSelectionContext.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+export interface TaskSelectionContextValue {
+  selectedTaskIds: Set<string>;
+  isSelected: (taskId: string) => boolean;
+  toggleTask: (taskId: string) => void;
+  setTasksSelected: (taskIds: string[], selected: boolean) => void;
+  clearSelection: () => void;
+}
+
+const noopContext: TaskSelectionContextValue = {
+  selectedTaskIds: new Set<string>(),
+  isSelected: () => false,
+  toggleTask: () => {},
+  setTasksSelected: () => {},
+  clearSelection: () => {},
+};
+
+const TaskSelectionContext = createContext<TaskSelectionContextValue>(noopContext);
+
+export function TaskSelectionProvider({ children }: { children: React.ReactNode }) {
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
+
+  const toggleTask = useCallback((taskId: string) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  }, []);
+
+  const setTasksSelected = useCallback((taskIds: string[], selected: boolean) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      for (const id of taskIds) {
+        if (selected) {
+          next.add(id);
+        } else {
+          next.delete(id);
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedTaskIds(new Set());
+  }, []);
+
+  const isSelected = useCallback(
+    (taskId: string) => selectedTaskIds.has(taskId),
+    [selectedTaskIds],
+  );
+
+  const value = useMemo<TaskSelectionContextValue>(
+    () => ({ selectedTaskIds, isSelected, toggleTask, setTasksSelected, clearSelection }),
+    [selectedTaskIds, isSelected, toggleTask, setTasksSelected, clearSelection],
+  );
+
+  return <TaskSelectionContext.Provider value={value}>{children}</TaskSelectionContext.Provider>;
+}
+
+export function useTaskSelection(): TaskSelectionContextValue {
+  return useContext(TaskSelectionContext);
+}

--- a/packages/projects/src/components/TaskTypeSelector.tsx
+++ b/packages/projects/src/components/TaskTypeSelector.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { ITaskType } from '@alga-psa/types';
 import { useTranslation } from 'react-i18next';
-import { CheckSquare, Bug, Sparkles, TrendingUp, Flag, BookOpen, GitBranch } from 'lucide-react';
+import { ClipboardList, Bug, Sparkles, TrendingUp, Flag, BookOpen, GitBranch } from 'lucide-react';
 
 interface TaskTypeSelectorProps {
   value: string;
@@ -14,7 +14,7 @@ interface TaskTypeSelectorProps {
 }
 
 const taskTypeIcons: Record<string, React.ComponentType<any>> = {
-  task: CheckSquare,
+  task: ClipboardList,
   bug: Bug,
   feature: Sparkles,
   improvement: TrendingUp,
@@ -30,7 +30,7 @@ export const TaskTypeSelector: React.FC<TaskTypeSelectorProps> = ({
 }) => {
   const { t } = useTranslation(['features/projects', 'common']);
   const options = taskTypes.map(type => {
-    const Icon = taskTypeIcons[type.type_key] || CheckSquare;
+    const Icon = taskTypeIcons[type.type_key] || ClipboardList;
     return {
       value: type.type_key,
       label: (

--- a/packages/projects/src/components/project-templates/TemplateEditor.tsx
+++ b/packages/projects/src/components/project-templates/TemplateEditor.tsx
@@ -24,6 +24,7 @@ import {
   GripVertical,
   Settings,
   CheckSquare,
+  ClipboardList,
   Bug,
   Sparkles,
   TrendingUp,
@@ -114,7 +115,7 @@ const lightenColor = (hex: string, percent: number) => {
 };
 
 const taskTypeIcons: Record<string, React.ComponentType<{ className?: string; style?: React.CSSProperties }>> = {
-  task: CheckSquare,
+  task: ClipboardList,
   bug: Bug,
   feature: Sparkles,
   improvement: TrendingUp,
@@ -2079,7 +2080,7 @@ function TaskCard({
 
   // Get task type icon and color from database, with fallback
   const taskTypeKey = task.task_type_key || 'task';
-  const Icon = taskTypeIcons[taskTypeKey] || CheckSquare;
+  const Icon = taskTypeIcons[taskTypeKey] || ClipboardList;
   const iconColor = taskType?.color || '#6B7280';
 
   // Get priority info

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "{{deleted}} Aufgabe(n) gelöscht, {{failed}} fehlgeschlagen.",
     "bulkAssignSuccess": "{{count}} Aufgabe(n) erfolgreich zugewiesen!",
     "bulkAssignPartial": "{{success}} Aufgabe(n) zugewiesen, {{failed}} fehlgeschlagen.",
+    "bulkAssignTeamSuccess": "{{count}} Aufgabe(n) erfolgreich einem Team zugewiesen!",
+    "bulkAssignTeamPartial": "{{success}} Aufgabe(n) einem Team zugewiesen, {{failed}} fehlgeschlagen.",
     "bulkDeleteTitle": "Aufgaben löschen",
     "bulkDeleteMessage": "Möchten Sie {{count}} ausgewählte Aufgabe(n) wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
     "bulkTasksMovedSuccess": "{{count}} Aufgaben verschoben",
@@ -534,7 +536,6 @@
       "updatedAt": "Aktualisiert am"
     },
     "exportSelected": "{{count}} ausgewählte exportieren",
-    "printSelected": "{{count}} ausgewählte drucken",
     "selectedTasksNotice": "{{count}} ausgewählte Aufgabe{{plural}} werden exportiert."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "{{count}} ausgewählte Aufgabe(n) zuweisen an:",
       "unassigned": "Nicht zugewiesen",
       "assigning": "Wird zugewiesen...",
-      "confirm": "Aufgaben zuweisen"
+      "confirm": "Aufgaben zuweisen",
+      "teamReplaceNotice": "Aufgaben, die bereits einem anderen Team zugewiesen sind, werden auf das neue Team umgestellt."
     }
   },
   "filters": {

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Fällig",
     "noDueDate": "Kein Fälligkeitsdatum",
     "hideTags": "Tags ausblenden",
-    "criticalPath": "Kritischer Pfad"
+    "criticalPath": "Kritischer Pfad",
+    "selectTaskAria": "Aufgabe {{taskName}} auswählen",
+    "bulkMoveSuccess": "{{count}} Aufgabe(n) erfolgreich verschoben!",
+    "bulkMovePartial": "{{moved}} Aufgabe(n) verschoben, {{failed}} fehlgeschlagen.",
+    "bulkDeleteSuccess": "{{count}} Aufgabe(n) erfolgreich gelöscht!",
+    "bulkDeletePartial": "{{deleted}} Aufgabe(n) gelöscht, {{failed}} fehlgeschlagen.",
+    "bulkAssignSuccess": "{{count}} Aufgabe(n) erfolgreich zugewiesen!",
+    "bulkAssignPartial": "{{success}} Aufgabe(n) zugewiesen, {{failed}} fehlgeschlagen.",
+    "bulkDeleteTitle": "Aufgaben löschen",
+    "bulkDeleteMessage": "Möchten Sie {{count}} ausgewählte Aufgabe(n) wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "bulkTasksMovedSuccess": "{{count}} Aufgaben verschoben",
+    "bulkTasksMovedToPhase": "{{count}} Aufgaben nach {{phaseName}} verschoben",
+    "moveTasksTitle": "Aufgaben verschieben",
+    "confirmMoveTasksMessage": "Möchten Sie {{count}} ausgewählte Aufgaben wirklich in die Phase „{{targetPhase}}“ verschieben?"
   },
   "taskForm": {
     "addTitle": "Aufgabe hinzufügen",
@@ -519,7 +532,10 @@
       "tags": "Tags",
       "createdAt": "Erstellt am",
       "updatedAt": "Aktualisiert am"
-    }
+    },
+    "exportSelected": "{{count}} ausgewählte exportieren",
+    "printSelected": "{{count}} ausgewählte drucken",
+    "selectedTasksNotice": "{{count}} ausgewählte Aufgabe{{plural}} werden exportiert."
   },
   "import": {
     "title": "Phasen und Aufgaben importieren",
@@ -709,6 +725,18 @@
       "tasks": "Aufgaben",
       "badgeCount": "{{count}} Aufgabe",
       "badgeCount_other": "{{count}} Aufgaben"
+    },
+    "bulkMoveTask": {
+      "title": "Aufgaben verschieben",
+      "message": "{{count}} ausgewählte Aufgabe(n) in eine neue Phase/einen neuen Status verschieben:",
+      "confirm": "Aufgaben verschieben"
+    },
+    "bulkAssign": {
+      "title": "Aufgaben zuweisen",
+      "message": "{{count}} ausgewählte Aufgabe(n) zuweisen an:",
+      "unassigned": "Nicht zugewiesen",
+      "assigning": "Wird zugewiesen...",
+      "confirm": "Aufgaben zuweisen"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Geschätzte Stunden",
         "wbsCode": "PSP-Code",
         "description": "Beschreibung"
-      }
+      },
+      "subtitleSelected": "{{count}} ausgewählte Aufgaben"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} ausgewählt",
+    "move": "Verschieben",
+    "assign": "Zuweisen",
+    "delete": "Löschen",
+    "clear": "Zurücksetzen"
   }
 }

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "Deleted {{deleted}} task(s), {{failed}} failed.",
     "bulkAssignSuccess": "{{count}} task(s) assigned successfully!",
     "bulkAssignPartial": "Assigned {{success}} task(s), {{failed}} failed.",
+    "bulkAssignTeamSuccess": "{{count}} task(s) assigned to team successfully!",
+    "bulkAssignTeamPartial": "Assigned {{success}} task(s) to team, {{failed}} failed.",
     "bulkDeleteTitle": "Delete Tasks",
     "bulkDeleteMessage": "Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.",
     "bulkTasksMovedSuccess": "{{count}} tasks moved",
@@ -534,7 +536,6 @@
       "updatedAt": "Updated At"
     },
     "exportSelected": "Export {{count}} Selected",
-    "printSelected": "Print {{count}} Selected",
     "selectedTasksNotice": "Exporting {{count}} selected task{{plural}}."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Assign {{count}} selected task(s) to:",
       "unassigned": "Not assigned",
       "assigning": "Assigning...",
-      "confirm": "Assign Tasks"
+      "confirm": "Assign Tasks",
+      "teamReplaceNotice": "Tasks already assigned to a different team will have that team replaced."
     }
   },
   "filters": {

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Due",
     "noDueDate": "No due date",
     "hideTags": "Hide tags",
-    "criticalPath": "Critical Path"
+    "criticalPath": "Critical Path",
+    "selectTaskAria": "Select task {{taskName}}",
+    "bulkMoveSuccess": "{{count}} task(s) moved successfully!",
+    "bulkMovePartial": "Moved {{moved}} task(s), {{failed}} failed.",
+    "bulkDeleteSuccess": "{{count}} task(s) deleted successfully!",
+    "bulkDeletePartial": "Deleted {{deleted}} task(s), {{failed}} failed.",
+    "bulkAssignSuccess": "{{count}} task(s) assigned successfully!",
+    "bulkAssignPartial": "Assigned {{success}} task(s), {{failed}} failed.",
+    "bulkDeleteTitle": "Delete Tasks",
+    "bulkDeleteMessage": "Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.",
+    "bulkTasksMovedSuccess": "{{count}} tasks moved",
+    "bulkTasksMovedToPhase": "{{count}} tasks moved to {{phaseName}}",
+    "moveTasksTitle": "Move Tasks",
+    "confirmMoveTasksMessage": "Are you sure you want to move {{count}} selected tasks to phase \"{{targetPhase}}\"?"
   },
   "taskForm": {
     "addTitle": "Add New Task",
@@ -519,7 +532,10 @@
       "tags": "Tags",
       "createdAt": "Created At",
       "updatedAt": "Updated At"
-    }
+    },
+    "exportSelected": "Export {{count}} Selected",
+    "printSelected": "Print {{count}} Selected",
+    "selectedTasksNotice": "Exporting {{count}} selected task{{plural}}."
   },
   "import": {
     "title": "Import Phases & Tasks",
@@ -709,6 +725,18 @@
       "tasks": "Tasks",
       "badgeCount": "{{count}} Task",
       "badgeCount_other": "{{count}} Tasks"
+    },
+    "bulkMoveTask": {
+      "title": "Move Tasks",
+      "message": "Move {{count}} selected task(s) to a new phase/status:",
+      "confirm": "Move Tasks"
+    },
+    "bulkAssign": {
+      "title": "Assign Tasks",
+      "message": "Assign {{count}} selected task(s) to:",
+      "unassigned": "Not assigned",
+      "assigning": "Assigning...",
+      "confirm": "Assign Tasks"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Estimated Hours",
         "wbsCode": "WBS Code",
         "description": "Description"
-      }
+      },
+      "subtitleSelected": "{{count}} selected tasks"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} selected",
+    "move": "Move",
+    "assign": "Assign",
+    "delete": "Delete",
+    "clear": "Clear"
   }
 }

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "{{deleted}} tarea(s) eliminada(s), {{failed}} con errores.",
     "bulkAssignSuccess": "¡{{count}} tarea(s) asignada(s) correctamente!",
     "bulkAssignPartial": "{{success}} tarea(s) asignada(s), {{failed}} con errores.",
+    "bulkAssignTeamSuccess": "¡{{count}} tarea(s) asignada(s) al equipo correctamente!",
+    "bulkAssignTeamPartial": "{{success}} tarea(s) asignada(s) al equipo, {{failed}} con errores.",
     "bulkDeleteTitle": "Eliminar tareas",
     "bulkDeleteMessage": "¿Seguro que quieres eliminar {{count}} tarea(s) seleccionada(s)? Esta acción no se puede deshacer.",
     "bulkTasksMovedSuccess": "{{count}} tareas movidas",
@@ -534,7 +536,6 @@
       "updatedAt": "Actualizado el"
     },
     "exportSelected": "Exportar {{count}} seleccionada(s)",
-    "printSelected": "Imprimir {{count}} seleccionada(s)",
     "selectedTasksNotice": "Exportando {{count}} tarea{{plural}} seleccionada(s)."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Asignar {{count}} tarea(s) seleccionada(s) a:",
       "unassigned": "Sin asignar",
       "assigning": "Asignando...",
-      "confirm": "Asignar tareas"
+      "confirm": "Asignar tareas",
+      "teamReplaceNotice": "Las tareas ya asignadas a otro equipo se reasignarán al equipo seleccionado."
     }
   },
   "filters": {

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Vencimiento",
     "noDueDate": "Sin fecha de vencimiento",
     "hideTags": "Ocultar etiquetas",
-    "criticalPath": "Ruta crítica"
+    "criticalPath": "Ruta crítica",
+    "selectTaskAria": "Seleccionar tarea {{taskName}}",
+    "bulkMoveSuccess": "¡{{count}} tarea(s) movida(s) correctamente!",
+    "bulkMovePartial": "{{moved}} tarea(s) movida(s), {{failed}} con errores.",
+    "bulkDeleteSuccess": "¡{{count}} tarea(s) eliminada(s) correctamente!",
+    "bulkDeletePartial": "{{deleted}} tarea(s) eliminada(s), {{failed}} con errores.",
+    "bulkAssignSuccess": "¡{{count}} tarea(s) asignada(s) correctamente!",
+    "bulkAssignPartial": "{{success}} tarea(s) asignada(s), {{failed}} con errores.",
+    "bulkDeleteTitle": "Eliminar tareas",
+    "bulkDeleteMessage": "¿Seguro que quieres eliminar {{count}} tarea(s) seleccionada(s)? Esta acción no se puede deshacer.",
+    "bulkTasksMovedSuccess": "{{count}} tareas movidas",
+    "bulkTasksMovedToPhase": "{{count}} tareas movidas a {{phaseName}}",
+    "moveTasksTitle": "Mover tareas",
+    "confirmMoveTasksMessage": "¿Seguro que quieres mover {{count}} tareas seleccionadas a la fase \"{{targetPhase}}\"?"
   },
   "taskForm": {
     "addTitle": "Agregar tarea",
@@ -519,7 +532,10 @@
       "tags": "Etiquetas",
       "createdAt": "Creado el",
       "updatedAt": "Actualizado el"
-    }
+    },
+    "exportSelected": "Exportar {{count}} seleccionada(s)",
+    "printSelected": "Imprimir {{count}} seleccionada(s)",
+    "selectedTasksNotice": "Exportando {{count}} tarea{{plural}} seleccionada(s)."
   },
   "import": {
     "title": "Importar fases y tareas",
@@ -709,6 +725,18 @@
       "tasks": "Tareas",
       "badgeCount": "{{count}} Tarea",
       "badgeCount_other": "{{count}} Tareas"
+    },
+    "bulkMoveTask": {
+      "title": "Mover tareas",
+      "message": "Mover {{count}} tarea(s) seleccionada(s) a una nueva fase/estado:",
+      "confirm": "Mover tareas"
+    },
+    "bulkAssign": {
+      "title": "Asignar tareas",
+      "message": "Asignar {{count}} tarea(s) seleccionada(s) a:",
+      "unassigned": "Sin asignar",
+      "assigning": "Asignando...",
+      "confirm": "Asignar tareas"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Horas estimadas",
         "wbsCode": "Código WBS",
         "description": "Descripción"
-      }
+      },
+      "subtitleSelected": "{{count}} tareas seleccionadas"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} seleccionada(s)",
+    "move": "Mover",
+    "assign": "Asignar",
+    "delete": "Eliminar",
+    "clear": "Borrar"
   }
 }

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "{{deleted}} tâche(s) supprimée(s), {{failed}} en échec.",
     "bulkAssignSuccess": "{{count}} tâche(s) affectée(s) avec succès !",
     "bulkAssignPartial": "{{success}} tâche(s) affectée(s), {{failed}} en échec.",
+    "bulkAssignTeamSuccess": "{{count}} tâche(s) affectée(s) à une équipe avec succès !",
+    "bulkAssignTeamPartial": "{{success}} tâche(s) affectée(s) à l’équipe, {{failed}} en échec.",
     "bulkDeleteTitle": "Supprimer les tâches",
     "bulkDeleteMessage": "Voulez-vous vraiment supprimer {{count}} tâche(s) sélectionnée(s) ? Cette action est irréversible.",
     "bulkTasksMovedSuccess": "{{count}} tâches déplacées",
@@ -534,7 +536,6 @@
       "updatedAt": "Mis à jour le"
     },
     "exportSelected": "Exporter {{count}} sélectionnée(s)",
-    "printSelected": "Imprimer {{count}} sélectionnée(s)",
     "selectedTasksNotice": "Export de {{count}} tâche{{plural}} sélectionnée(s)."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Affecter {{count}} tâche(s) sélectionnée(s) à :",
       "unassigned": "Non affecté",
       "assigning": "Affectation...",
-      "confirm": "Affecter les tâches"
+      "confirm": "Affecter les tâches",
+      "teamReplaceNotice": "Les tâches déjà affectées à une autre équipe seront réaffectées à l’équipe sélectionnée."
     }
   },
   "filters": {

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Échéance",
     "noDueDate": "Pas d'échéance",
     "hideTags": "Masquer les étiquettes",
-    "criticalPath": "Chemin critique"
+    "criticalPath": "Chemin critique",
+    "selectTaskAria": "Sélectionner la tâche {{taskName}}",
+    "bulkMoveSuccess": "{{count}} tâche(s) déplacée(s) avec succès !",
+    "bulkMovePartial": "{{moved}} tâche(s) déplacée(s), {{failed}} en échec.",
+    "bulkDeleteSuccess": "{{count}} tâche(s) supprimée(s) avec succès !",
+    "bulkDeletePartial": "{{deleted}} tâche(s) supprimée(s), {{failed}} en échec.",
+    "bulkAssignSuccess": "{{count}} tâche(s) affectée(s) avec succès !",
+    "bulkAssignPartial": "{{success}} tâche(s) affectée(s), {{failed}} en échec.",
+    "bulkDeleteTitle": "Supprimer les tâches",
+    "bulkDeleteMessage": "Voulez-vous vraiment supprimer {{count}} tâche(s) sélectionnée(s) ? Cette action est irréversible.",
+    "bulkTasksMovedSuccess": "{{count}} tâches déplacées",
+    "bulkTasksMovedToPhase": "{{count}} tâches déplacées vers {{phaseName}}",
+    "moveTasksTitle": "Déplacer les tâches",
+    "confirmMoveTasksMessage": "Voulez-vous vraiment déplacer {{count}} tâches sélectionnées vers la phase « {{targetPhase}} » ?"
   },
   "taskForm": {
     "addTitle": "Ajouter une tâche",
@@ -519,7 +532,10 @@
       "tags": "Étiquettes",
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le"
-    }
+    },
+    "exportSelected": "Exporter {{count}} sélectionnée(s)",
+    "printSelected": "Imprimer {{count}} sélectionnée(s)",
+    "selectedTasksNotice": "Export de {{count}} tâche{{plural}} sélectionnée(s)."
   },
   "import": {
     "title": "Importer des phases et des tâches",
@@ -709,6 +725,18 @@
       "tasks": "Tâches",
       "badgeCount": "{{count}} Tâche",
       "badgeCount_other": "{{count}} Tâches"
+    },
+    "bulkMoveTask": {
+      "title": "Déplacer les tâches",
+      "message": "Déplacer {{count}} tâche(s) sélectionnée(s) vers une nouvelle phase/un nouveau statut :",
+      "confirm": "Déplacer les tâches"
+    },
+    "bulkAssign": {
+      "title": "Affecter les tâches",
+      "message": "Affecter {{count}} tâche(s) sélectionnée(s) à :",
+      "unassigned": "Non affecté",
+      "assigning": "Affectation...",
+      "confirm": "Affecter les tâches"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Heures estimées",
         "wbsCode": "Code WBS",
         "description": "Description"
-      }
+      },
+      "subtitleSelected": "{{count}} tâches sélectionnées"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} sélectionné(s)",
+    "move": "Déplacer",
+    "assign": "Affecter",
+    "delete": "Supprimer",
+    "clear": "Effacer"
   }
 }

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Scadenza",
     "noDueDate": "Nessuna data di scadenza",
     "hideTags": "Nascondi tag",
-    "criticalPath": "Percorso critico"
+    "criticalPath": "Percorso critico",
+    "selectTaskAria": "Seleziona attività {{taskName}}",
+    "bulkMoveSuccess": "{{count}} attività spostata/e con successo!",
+    "bulkMovePartial": "{{moved}} attività spostata/e, {{failed}} non riuscite.",
+    "bulkDeleteSuccess": "{{count}} attività eliminata/e con successo!",
+    "bulkDeletePartial": "{{deleted}} attività eliminata/e, {{failed}} non riuscite.",
+    "bulkAssignSuccess": "{{count}} attività assegnata/e con successo!",
+    "bulkAssignPartial": "{{success}} attività assegnata/e, {{failed}} non riuscite.",
+    "bulkDeleteTitle": "Elimina attività",
+    "bulkDeleteMessage": "Sei sicuro di voler eliminare {{count}} attività selezionata/e? Questa azione non può essere annullata.",
+    "bulkTasksMovedSuccess": "{{count}} attività spostate",
+    "bulkTasksMovedToPhase": "{{count}} attività spostate in {{phaseName}}",
+    "moveTasksTitle": "Sposta attività",
+    "confirmMoveTasksMessage": "Sei sicuro di voler spostare {{count}} attività selezionate nella fase \"{{targetPhase}}\"?"
   },
   "taskForm": {
     "addTitle": "Aggiungi attività",
@@ -519,7 +532,10 @@
       "tags": "Tag",
       "createdAt": "Creato il",
       "updatedAt": "Aggiornato il"
-    }
+    },
+    "exportSelected": "Esporta {{count}} selezionata/e",
+    "printSelected": "Stampa {{count}} selezionata/e",
+    "selectedTasksNotice": "Esportazione di {{count}} attività selezionat{{plural}}."
   },
   "import": {
     "title": "Importa fasi e attività",
@@ -709,6 +725,18 @@
       "tasks": "Attività",
       "badgeCount": "{{count}} Attività",
       "badgeCount_other": "{{count}} Attività"
+    },
+    "bulkMoveTask": {
+      "title": "Sposta attività",
+      "message": "Sposta {{count}} attività selezionata/e in una nuova fase/stato:",
+      "confirm": "Sposta attività"
+    },
+    "bulkAssign": {
+      "title": "Assegna attività",
+      "message": "Assegna {{count}} attività selezionata/e a:",
+      "unassigned": "Non assegnato",
+      "assigning": "Assegnazione...",
+      "confirm": "Assegna attività"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Ore stimate",
         "wbsCode": "Codice WBS",
         "description": "Descrizione"
-      }
+      },
+      "subtitleSelected": "{{count}} attività selezionate"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} selezionata/e",
+    "move": "Sposta",
+    "assign": "Assegna",
+    "delete": "Elimina",
+    "clear": "Cancella"
   }
 }

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "{{deleted}} attività eliminata/e, {{failed}} non riuscite.",
     "bulkAssignSuccess": "{{count}} attività assegnata/e con successo!",
     "bulkAssignPartial": "{{success}} attività assegnata/e, {{failed}} non riuscite.",
+    "bulkAssignTeamSuccess": "{{count}} attività assegnata/e al team con successo!",
+    "bulkAssignTeamPartial": "{{success}} attività assegnata/e al team, {{failed}} non riuscite.",
     "bulkDeleteTitle": "Elimina attività",
     "bulkDeleteMessage": "Sei sicuro di voler eliminare {{count}} attività selezionata/e? Questa azione non può essere annullata.",
     "bulkTasksMovedSuccess": "{{count}} attività spostate",
@@ -534,7 +536,6 @@
       "updatedAt": "Aggiornato il"
     },
     "exportSelected": "Esporta {{count}} selezionata/e",
-    "printSelected": "Stampa {{count}} selezionata/e",
     "selectedTasksNotice": "Esportazione di {{count}} attività selezionat{{plural}}."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Assegna {{count}} attività selezionata/e a:",
       "unassigned": "Non assegnato",
       "assigning": "Assegnazione...",
-      "confirm": "Assegna attività"
+      "confirm": "Assegna attività",
+      "teamReplaceNotice": "Le attività già assegnate a un altro team verranno riassegnate al team selezionato."
     }
   },
   "filters": {

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "{{deleted}} taak/taken verwijderd, {{failed}} mislukt.",
     "bulkAssignSuccess": "{{count}} taak/taken succesvol toegewezen!",
     "bulkAssignPartial": "{{success}} taak/taken toegewezen, {{failed}} mislukt.",
+    "bulkAssignTeamSuccess": "{{count}} taak/taken succesvol aan team toegewezen!",
+    "bulkAssignTeamPartial": "{{success}} taak/taken aan team toegewezen, {{failed}} mislukt.",
     "bulkDeleteTitle": "Taken verwijderen",
     "bulkDeleteMessage": "Weet je zeker dat je {{count}} geselecteerde taak/taken wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
     "bulkTasksMovedSuccess": "{{count}} taken verplaatst",
@@ -534,7 +536,6 @@
       "updatedAt": "Bijgewerkt op"
     },
     "exportSelected": "{{count}} geselecteerde exporteren",
-    "printSelected": "{{count}} geselecteerde afdrukken",
     "selectedTasksNotice": "{{count}} geselecteerde taak{{plural}} exporteren."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "{{count}} geselecteerde taak/taken toewijzen aan:",
       "unassigned": "Niet toegewezen",
       "assigning": "Toewijzen...",
-      "confirm": "Taken toewijzen"
+      "confirm": "Taken toewijzen",
+      "teamReplaceNotice": "Taken die al aan een ander team zijn toegewezen, worden aan het nieuwe team toegewezen."
     }
   },
   "filters": {

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Vervaldatum",
     "noDueDate": "Geen vervaldatum",
     "hideTags": "Tags verbergen",
-    "criticalPath": "Kritiek pad"
+    "criticalPath": "Kritiek pad",
+    "selectTaskAria": "Taak {{taskName}} selecteren",
+    "bulkMoveSuccess": "{{count}} taak/taken succesvol verplaatst!",
+    "bulkMovePartial": "{{moved}} taak/taken verplaatst, {{failed}} mislukt.",
+    "bulkDeleteSuccess": "{{count}} taak/taken succesvol verwijderd!",
+    "bulkDeletePartial": "{{deleted}} taak/taken verwijderd, {{failed}} mislukt.",
+    "bulkAssignSuccess": "{{count}} taak/taken succesvol toegewezen!",
+    "bulkAssignPartial": "{{success}} taak/taken toegewezen, {{failed}} mislukt.",
+    "bulkDeleteTitle": "Taken verwijderen",
+    "bulkDeleteMessage": "Weet je zeker dat je {{count}} geselecteerde taak/taken wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+    "bulkTasksMovedSuccess": "{{count}} taken verplaatst",
+    "bulkTasksMovedToPhase": "{{count}} taken verplaatst naar {{phaseName}}",
+    "moveTasksTitle": "Taken verplaatsen",
+    "confirmMoveTasksMessage": "Weet je zeker dat je {{count}} geselecteerde taken naar fase \"{{targetPhase}}\" wilt verplaatsen?"
   },
   "taskForm": {
     "addTitle": "Nieuwe taak toevoegen",
@@ -519,7 +532,10 @@
       "tags": "Labels",
       "createdAt": "Gemaakt op",
       "updatedAt": "Bijgewerkt op"
-    }
+    },
+    "exportSelected": "{{count}} geselecteerde exporteren",
+    "printSelected": "{{count}} geselecteerde afdrukken",
+    "selectedTasksNotice": "{{count}} geselecteerde taak{{plural}} exporteren."
   },
   "import": {
     "title": "Fasen en taken importeren",
@@ -709,6 +725,18 @@
       "tasks": "Taken",
       "badgeCount": "{{count}} Taak",
       "badgeCount_other": "{{count}} Taken"
+    },
+    "bulkMoveTask": {
+      "title": "Taken verplaatsen",
+      "message": "{{count}} geselecteerde taak/taken naar een nieuwe fase/status verplaatsen:",
+      "confirm": "Taken verplaatsen"
+    },
+    "bulkAssign": {
+      "title": "Taken toewijzen",
+      "message": "{{count}} geselecteerde taak/taken toewijzen aan:",
+      "unassigned": "Niet toegewezen",
+      "assigning": "Toewijzen...",
+      "confirm": "Taken toewijzen"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Geschatte uren",
         "wbsCode": "WBS-code",
         "description": "Beschrijving"
-      }
+      },
+      "subtitleSelected": "{{count}} geselecteerde taken"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} geselecteerd",
+    "move": "Verplaatsen",
+    "assign": "Toewijzen",
+    "delete": "Verwijderen",
+    "clear": "Wissen"
   }
 }

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Termin",
     "noDueDate": "Brak terminu",
     "hideTags": "Ukryj tagi",
-    "criticalPath": "Ścieżka krytyczna"
+    "criticalPath": "Ścieżka krytyczna",
+    "selectTaskAria": "Zaznacz zadanie {{taskName}}",
+    "bulkMoveSuccess": "Przeniesiono {{count}} zadania!",
+    "bulkMovePartial": "Przeniesiono {{moved}} zadania, nie powiodło się: {{failed}}.",
+    "bulkDeleteSuccess": "Usunięto {{count}} zadania!",
+    "bulkDeletePartial": "Usunięto {{deleted}} zadania, nie powiodło się: {{failed}}.",
+    "bulkAssignSuccess": "Przypisano {{count}} zadania!",
+    "bulkAssignPartial": "Przypisano {{success}} zadania, nie powiodło się: {{failed}}.",
+    "bulkDeleteTitle": "Usuń zadania",
+    "bulkDeleteMessage": "Czy na pewno chcesz usunąć {{count}} wybrane zadania? Tej operacji nie można cofnąć.",
+    "bulkTasksMovedSuccess": "Przeniesiono {{count}} zadania",
+    "bulkTasksMovedToPhase": "Przeniesiono {{count}} zadania do {{phaseName}}",
+    "moveTasksTitle": "Przenieś zadania",
+    "confirmMoveTasksMessage": "Czy na pewno chcesz przenieść {{count}} wybrane zadania do fazy „{{targetPhase}}”?"
   },
   "taskForm": {
     "addTitle": "Dodaj nowe zadanie",
@@ -519,7 +532,10 @@
       "tags": "Tagi",
       "createdAt": "Utworzono o godz",
       "updatedAt": "Zaktualizowano o godz"
-    }
+    },
+    "exportSelected": "Eksportuj {{count}} wybrane",
+    "printSelected": "Drukuj {{count}} wybrane",
+    "selectedTasksNotice": "Eksportowanie {{count}} wybranego zadania{{plural}}."
   },
   "import": {
     "title": "Importuj fazy i zadania",
@@ -709,6 +725,18 @@
       "tasks": "Zadania",
       "badgeCount": "{{count}} Zadanie",
       "badgeCount_other": "{{count}} Zadania"
+    },
+    "bulkMoveTask": {
+      "title": "Przenieś zadania",
+      "message": "Przenieś {{count}} wybrane zadania do nowej fazy/statusu:",
+      "confirm": "Przenieś zadania"
+    },
+    "bulkAssign": {
+      "title": "Przypisz zadania",
+      "message": "Przypisz {{count}} wybrane zadania do:",
+      "unassigned": "Nieprzypisane",
+      "assigning": "Przypisywanie...",
+      "confirm": "Przypisz zadania"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Szacowane godziny",
         "wbsCode": "Kod WBS",
         "description": "Opis"
-      }
+      },
+      "subtitleSelected": "{{count}} wybrane zadania"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "Wybrano: {{count}}",
+    "move": "Przenieś",
+    "assign": "Przypisz",
+    "delete": "Usuń",
+    "clear": "Wyczyść"
   }
 }

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "Usunięto {{deleted}} zadania, nie powiodło się: {{failed}}.",
     "bulkAssignSuccess": "Przypisano {{count}} zadania!",
     "bulkAssignPartial": "Przypisano {{success}} zadania, nie powiodło się: {{failed}}.",
+    "bulkAssignTeamSuccess": "Przypisano {{count}} zadania do zespołu!",
+    "bulkAssignTeamPartial": "Przypisano {{success}} zadania do zespołu, nie powiodło się: {{failed}}.",
     "bulkDeleteTitle": "Usuń zadania",
     "bulkDeleteMessage": "Czy na pewno chcesz usunąć {{count}} wybrane zadania? Tej operacji nie można cofnąć.",
     "bulkTasksMovedSuccess": "Przeniesiono {{count}} zadania",
@@ -534,7 +536,6 @@
       "updatedAt": "Zaktualizowano o godz"
     },
     "exportSelected": "Eksportuj {{count}} wybrane",
-    "printSelected": "Drukuj {{count}} wybrane",
     "selectedTasksNotice": "Eksportowanie {{count}} wybranego zadania{{plural}}."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Przypisz {{count}} wybrane zadania do:",
       "unassigned": "Nieprzypisane",
       "assigning": "Przypisywanie...",
-      "confirm": "Przypisz zadania"
+      "confirm": "Przypisz zadania",
+      "teamReplaceNotice": "Zadania już przypisane do innego zespołu zostaną przeniesione do wybranego zespołu."
     }
   },
   "filters": {

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "Deleted {{deleted}} task(s), {{failed}} failed.",
     "bulkAssignSuccess": "{{count}} task(s) assigned successfully!",
     "bulkAssignPartial": "Assigned {{success}} task(s), {{failed}} failed.",
+    "bulkAssignTeamSuccess": "{{count}} task(s) assigned to team successfully!",
+    "bulkAssignTeamPartial": "Assigned {{success}} task(s) to team, {{failed}} failed.",
     "bulkDeleteTitle": "Delete Tasks",
     "bulkDeleteMessage": "Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.",
     "bulkTasksMovedSuccess": "{{count}} tasks moved",
@@ -534,7 +536,6 @@
       "updatedAt": "Updated At"
     },
     "exportSelected": "Export {{count}} Selected",
-    "printSelected": "Print {{count}} Selected",
     "selectedTasksNotice": "Exporting {{count}} selected task{{plural}}."
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "Assign {{count}} selected task(s) to:",
       "unassigned": "Not assigned",
       "assigning": "Assigning...",
-      "confirm": "Assign Tasks"
+      "confirm": "Assign Tasks",
+      "teamReplaceNotice": "Tasks already assigned to a different team will have that team replaced."
     }
   },
   "filters": {

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "Due",
     "noDueDate": "No due date",
     "hideTags": "Hide tags",
-    "criticalPath": "Critical Path"
+    "criticalPath": "Critical Path",
+    "selectTaskAria": "Select task {{taskName}}",
+    "bulkMoveSuccess": "{{count}} task(s) moved successfully!",
+    "bulkMovePartial": "Moved {{moved}} task(s), {{failed}} failed.",
+    "bulkDeleteSuccess": "{{count}} task(s) deleted successfully!",
+    "bulkDeletePartial": "Deleted {{deleted}} task(s), {{failed}} failed.",
+    "bulkAssignSuccess": "{{count}} task(s) assigned successfully!",
+    "bulkAssignPartial": "Assigned {{success}} task(s), {{failed}} failed.",
+    "bulkDeleteTitle": "Delete Tasks",
+    "bulkDeleteMessage": "Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.",
+    "bulkTasksMovedSuccess": "{{count}} tasks moved",
+    "bulkTasksMovedToPhase": "{{count}} tasks moved to {{phaseName}}",
+    "moveTasksTitle": "Move Tasks",
+    "confirmMoveTasksMessage": "Are you sure you want to move {{count}} selected tasks to phase \"{{targetPhase}}\"?"
   },
   "taskForm": {
     "addTitle": "Add New Task",
@@ -519,7 +532,10 @@
       "tags": "Tags",
       "createdAt": "Created At",
       "updatedAt": "Updated At"
-    }
+    },
+    "exportSelected": "Export {{count}} Selected",
+    "printSelected": "Print {{count}} Selected",
+    "selectedTasksNotice": "Exporting {{count}} selected task{{plural}}."
   },
   "import": {
     "title": "Import Phases & Tasks",
@@ -709,6 +725,18 @@
       "tasks": "Tasks",
       "badgeCount": "{{count}} Task",
       "badgeCount_other": "{{count}} Tasks"
+    },
+    "bulkMoveTask": {
+      "title": "Move Tasks",
+      "message": "Move {{count}} selected task(s) to a new phase/status:",
+      "confirm": "Move Tasks"
+    },
+    "bulkAssign": {
+      "title": "Assign Tasks",
+      "message": "Assign {{count}} selected task(s) to:",
+      "unassigned": "Not assigned",
+      "assigning": "Assigning...",
+      "confirm": "Assign Tasks"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "Horas estimadas",
         "wbsCode": "Código EAP",
         "description": "Descrição"
-      }
+      },
+      "subtitleSelected": "{{count}} selected tasks"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "{{count}} selected",
+    "move": "Move",
+    "assign": "Assign",
+    "delete": "Delete",
+    "clear": "Clear"
   }
 }

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "11111",
     "noDueDate": "11111",
     "hideTags": "11111",
-    "criticalPath": "11111"
+    "criticalPath": "11111",
+    "selectTaskAria": "11111 {{taskName}} 11111",
+    "bulkMoveSuccess": "11111 {{count}} 11111",
+    "bulkMovePartial": "11111 {{moved}} 11111 {{failed}} 11111",
+    "bulkDeleteSuccess": "11111 {{count}} 11111",
+    "bulkDeletePartial": "11111 {{deleted}} 11111 {{failed}} 11111",
+    "bulkAssignSuccess": "11111 {{count}} 11111",
+    "bulkAssignPartial": "11111 {{success}} 11111 {{failed}} 11111",
+    "bulkDeleteTitle": "11111",
+    "bulkDeleteMessage": "11111 {{count}} 11111",
+    "bulkTasksMovedSuccess": "11111 {{count}} 11111",
+    "bulkTasksMovedToPhase": "11111 {{count}} 11111 {{phaseName}} 11111",
+    "moveTasksTitle": "11111",
+    "confirmMoveTasksMessage": "11111 {{count}} 11111 {{targetPhase}} 11111"
   },
   "taskForm": {
     "addTitle": "11111",
@@ -519,7 +532,10 @@
       "tags": "11111",
       "createdAt": "11111",
       "updatedAt": "11111"
-    }
+    },
+    "exportSelected": "11111 {{count}} 11111",
+    "printSelected": "11111 {{count}} 11111",
+    "selectedTasksNotice": "11111 {{count}} 11111 {{plural}} 11111"
   },
   "import": {
     "title": "11111",
@@ -709,6 +725,18 @@
       "tasks": "11111",
       "badgeCount": "11111 {{count}} 11111",
       "badgeCount_other": "11111 {{count}} 11111"
+    },
+    "bulkMoveTask": {
+      "title": "11111",
+      "message": "11111 {{count}} 11111",
+      "confirm": "11111"
+    },
+    "bulkAssign": {
+      "title": "11111",
+      "message": "11111 {{count}} 11111",
+      "unassigned": "11111",
+      "assigning": "11111",
+      "confirm": "11111"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "11111",
         "wbsCode": "11111",
         "description": "11111"
-      }
+      },
+      "subtitleSelected": "11111 {{count}} 11111"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "11111 {{count}} 11111",
+    "move": "11111",
+    "assign": "11111",
+    "delete": "11111",
+    "clear": "11111"
   }
 }

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "11111 {{deleted}} 11111 {{failed}} 11111",
     "bulkAssignSuccess": "11111 {{count}} 11111",
     "bulkAssignPartial": "11111 {{success}} 11111 {{failed}} 11111",
+    "bulkAssignTeamSuccess": "11111 {{count}} 11111",
+    "bulkAssignTeamPartial": "11111 {{success}} 11111 {{failed}} 11111",
     "bulkDeleteTitle": "11111",
     "bulkDeleteMessage": "11111 {{count}} 11111",
     "bulkTasksMovedSuccess": "11111 {{count}} 11111",
@@ -534,7 +536,6 @@
       "updatedAt": "11111"
     },
     "exportSelected": "11111 {{count}} 11111",
-    "printSelected": "11111 {{count}} 11111",
     "selectedTasksNotice": "11111 {{count}} 11111 {{plural}} 11111"
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "11111 {{count}} 11111",
       "unassigned": "11111",
       "assigning": "11111",
-      "confirm": "11111"
+      "confirm": "11111",
+      "teamReplaceNotice": "11111"
     }
   },
   "filters": {

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -248,6 +248,8 @@
     "bulkDeletePartial": "55555 {{deleted}} 55555 {{failed}} 55555",
     "bulkAssignSuccess": "55555 {{count}} 55555",
     "bulkAssignPartial": "55555 {{success}} 55555 {{failed}} 55555",
+    "bulkAssignTeamSuccess": "55555 {{count}} 55555",
+    "bulkAssignTeamPartial": "55555 {{success}} 55555 {{failed}} 55555",
     "bulkDeleteTitle": "55555",
     "bulkDeleteMessage": "55555 {{count}} 55555",
     "bulkTasksMovedSuccess": "55555 {{count}} 55555",
@@ -534,7 +536,6 @@
       "updatedAt": "55555"
     },
     "exportSelected": "55555 {{count}} 55555",
-    "printSelected": "55555 {{count}} 55555",
     "selectedTasksNotice": "55555 {{count}} 55555 {{plural}} 55555"
   },
   "import": {
@@ -736,7 +737,8 @@
       "message": "55555 {{count}} 55555",
       "unassigned": "55555",
       "assigning": "55555",
-      "confirm": "55555"
+      "confirm": "55555",
+      "teamReplaceNotice": "55555"
     }
   },
   "filters": {

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -240,7 +240,20 @@
     "dueLabel": "55555",
     "noDueDate": "55555",
     "hideTags": "55555",
-    "criticalPath": "55555"
+    "criticalPath": "55555",
+    "selectTaskAria": "55555 {{taskName}} 55555",
+    "bulkMoveSuccess": "55555 {{count}} 55555",
+    "bulkMovePartial": "55555 {{moved}} 55555 {{failed}} 55555",
+    "bulkDeleteSuccess": "55555 {{count}} 55555",
+    "bulkDeletePartial": "55555 {{deleted}} 55555 {{failed}} 55555",
+    "bulkAssignSuccess": "55555 {{count}} 55555",
+    "bulkAssignPartial": "55555 {{success}} 55555 {{failed}} 55555",
+    "bulkDeleteTitle": "55555",
+    "bulkDeleteMessage": "55555 {{count}} 55555",
+    "bulkTasksMovedSuccess": "55555 {{count}} 55555",
+    "bulkTasksMovedToPhase": "55555 {{count}} 55555 {{phaseName}} 55555",
+    "moveTasksTitle": "55555",
+    "confirmMoveTasksMessage": "55555 {{count}} 55555 {{targetPhase}} 55555"
   },
   "taskForm": {
     "addTitle": "55555",
@@ -519,7 +532,10 @@
       "tags": "55555",
       "createdAt": "55555",
       "updatedAt": "55555"
-    }
+    },
+    "exportSelected": "55555 {{count}} 55555",
+    "printSelected": "55555 {{count}} 55555",
+    "selectedTasksNotice": "55555 {{count}} 55555 {{plural}} 55555"
   },
   "import": {
     "title": "55555",
@@ -709,6 +725,18 @@
       "tasks": "55555",
       "badgeCount": "55555 {{count}} 55555",
       "badgeCount_other": "55555 {{count}} 55555"
+    },
+    "bulkMoveTask": {
+      "title": "55555",
+      "message": "55555 {{count}} 55555",
+      "confirm": "55555"
+    },
+    "bulkAssign": {
+      "title": "55555",
+      "message": "55555 {{count}} 55555",
+      "unassigned": "55555",
+      "assigning": "55555",
+      "confirm": "55555"
     }
   },
   "filters": {
@@ -1411,7 +1439,15 @@
         "estimatedHours": "55555",
         "wbsCode": "55555",
         "description": "55555"
-      }
+      },
+      "subtitleSelected": "55555 {{count}} 55555"
     }
+  },
+  "bulkActions": {
+    "selectedCount": "55555 {{count}} 55555",
+    "move": "55555",
+    "assign": "55555",
+    "delete": "55555",
+    "clear": "55555"
   }
 }


### PR DESCRIPTION
## Summary

Adds the ability to select multiple project tasks and act on them in bulk, across both the Kanban and List views.

### Selection
- Shared `TaskSelectionContext` tracks selected task IDs across the project page.
- Per-task selection checkboxes on Kanban cards (top-left) and List view rows.
- Select-all checkboxes on Kanban status column headers (and the sticky status strip) and List view status groups, with indeterminate state.

### Bulk actions
- A floating bulk action bar appears when tasks are selected, with **Move**, **Assign**, and **Delete** actions.
- **Export** and **Print** become selection-aware — the header Export button, the export dialog, and the share menu's Print action scope to the selected tasks when a selection is active.

### Bulk drag-and-drop
- Dragging any selected task moves the whole selection at once.
- Kanban: bulk status changes within a phase, and cross-phase moves — including selections that span multiple phases (other-phase tasks are pulled into the current phase at the drop status).
- Dragging a selected card onto a phase shows a bulk move confirmation.
- List view bulk drag moves the whole selection across phases/statuses.

### Card polish
- A transparent header strip prevents clicks near the checkbox / 3-dots menu from opening the task.
- Swapped the checkbox (now top-left) and task type icon (now top-right) so per-task checkboxes line up with the column header control.
- Changed the "task" task type icon from a checkbox-style icon to a clipboard icon so it's not confused with selection checkboxes.

## Test plan
- [ ] Select tasks in Kanban and List views; verify checkboxes, select-all, and indeterminate states
- [ ] Bulk move / assign / delete via the action bar
- [ ] Export with a selection active (header button + dialog scope to selected tasks)
- [ ] Print with a selection active (share menu label + print output scope to selected tasks)
- [ ] Bulk drag in Kanban: within-phase status change, onto another phase, and a selection spanning multiple phases
- [ ] Bulk drag in List view across phases/statuses
- [ ] Single-task drag and click-to-open still work unchanged
- [ ] Verify card layout at different Kanban zoom levels