### PR TITLE
Fix 500 on NM store rate limit config lookup

### DIFF
--- a/server/src/lib/api/rateLimit/__tests__/configGetter.fallback.test.ts
+++ b/server/src/lib/api/rateLimit/__tests__/configGetter.fallback.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const KEY_UUID = '11111111-1111-1111-1111-111111111111';
+
 describe('resolveApiRateLimitConfig', () => {
   let readOps: typeof import('@/lib/api/rateLimit/apiRateLimitSettingsModel').apiRateLimitSettingsReadOps;
 
@@ -14,7 +16,7 @@ describe('resolveApiRateLimitConfig', () => {
     const getForKeySpy = vi.spyOn(readOps, 'getForKey');
 
     getForKeySpy.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
-    await expect(resolveApiRateLimitConfig('t1', 'k1')).resolves.toEqual({
+    await expect(resolveApiRateLimitConfig('t1', KEY_UUID)).resolves.toEqual({
       maxTokens: 120,
       refillRate: 1,
     });
@@ -30,7 +32,7 @@ describe('resolveApiRateLimitConfig', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       });
-    await expect(resolveApiRateLimitConfig('t1', 'k1')).resolves.toEqual({
+    await expect(resolveApiRateLimitConfig('t1', KEY_UUID)).resolves.toEqual({
       maxTokens: 240,
       refillRate: 2,
     });
@@ -38,15 +40,42 @@ describe('resolveApiRateLimitConfig', () => {
     getForKeySpy.mockReset();
     getForKeySpy.mockResolvedValueOnce({
       tenant: 't1',
-      apiKeyId: 'k1',
+      apiKeyId: KEY_UUID,
       maxTokens: 30,
       refillPerMin: 15,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    await expect(resolveApiRateLimitConfig('t1', 'k1')).resolves.toEqual({
+    await expect(resolveApiRateLimitConfig('t1', KEY_UUID)).resolves.toEqual({
       maxTokens: 30,
       refillRate: 0.25,
     });
+  });
+
+  it('skips the per-key lookup when the key is not a uuid', async () => {
+    const module = await import('@/lib/api/rateLimit/apiRateLimitSettingsModel');
+    const { resolveApiRateLimitConfig } = module;
+    readOps = module.apiRateLimitSettingsReadOps;
+    const getForKeySpy = vi.spyOn(readOps, 'getForKey');
+
+    getForKeySpy.mockResolvedValueOnce({
+      tenant: 't1',
+      apiKeyId: null,
+      maxTokens: 240,
+      refillPerMin: 120,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // 'nm_store' is the NM store bucket sentinel, not a uuid; querying the
+    // uuid api_key_id column with it would raise a Postgres cast error.
+    await expect(resolveApiRateLimitConfig('t1', 'nm_store')).resolves.toEqual({
+      maxTokens: 240,
+      refillRate: 2,
+    });
+
+    expect(getForKeySpy).toHaveBeenCalledTimes(1);
+    expect(getForKeySpy).toHaveBeenCalledWith('t1', null);
+    expect(getForKeySpy).not.toHaveBeenCalledWith('t1', 'nm_store');
   });
 });

--- a/server/src/lib/api/rateLimit/__tests__/enforce.test.ts
+++ b/server/src/lib/api/rateLimit/__tests__/enforce.test.ts
@@ -62,6 +62,27 @@ describe('enforceApiRateLimit', () => {
     });
   });
 
+  it('uses a non-uuid subject for the bucket identity but not for the config lookup', async () => {
+    tryConsumeMock.mockResolvedValue({
+      allowed: true,
+      remaining: 100,
+    });
+
+    const { enforceApiRateLimit } = await import('@/lib/api/rateLimit/enforce');
+
+    const decision = await enforceApiRateLimit('http://example.com/api/v1/tickets', {
+      tenant: 'tenant-1',
+      userId: '00000000-0000-0000-0000-000000000000',
+      rateLimitSubjectId: 'nm_store',
+    });
+
+    // 'nm_store' must never reach the config getter (api_key_id is a uuid
+    // column); it is only the token-bucket identity.
+    expect(apiRateLimitConfigGetterMock).toHaveBeenCalledWith('tenant-1', undefined);
+    expect(tryConsumeMock).toHaveBeenCalledWith('api', 'tenant-1', 'nm_store');
+    expect(decision).toMatchObject({ limit: 120, remaining: 100 });
+  });
+
   it('throws TooManyRequestsError with retry headers when RATE_LIMIT_ENFORCE is true', async () => {
     process.env.RATE_LIMIT_ENFORCE = 'true';
     tryConsumeMock.mockResolvedValue({

--- a/server/src/lib/api/rateLimit/apiRateLimitSettingsModel.ts
+++ b/server/src/lib/api/rateLimit/apiRateLimitSettingsModel.ts
@@ -40,6 +40,16 @@ function toBucketConfig(row: ApiRateLimitSettingsRow): BucketConfig {
   };
 }
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// api_key_id is a uuid column; querying it with a non-uuid string (e.g. the
+// 'nm_store' bucket sentinel) raises a Postgres cast error that surfaces as a
+// 500. Treat non-uuid keys as "no per-key override" instead.
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
 async function loadForKey(
   tenant: string,
   apiKeyId?: string | null,
@@ -193,7 +203,7 @@ export async function resolveApiRateLimitConfig(
   tenant: string,
   apiKeyId?: string,
 ): Promise<BucketConfig> {
-  if (apiKeyId) {
+  if (apiKeyId && isUuid(apiKeyId)) {
     const perKey = await apiRateLimitSettingsReadOps.getForKey(tenant, apiKeyId);
     if (perKey) {
       return toBucketConfig(perKey);

--- a/server/src/lib/api/rateLimit/enforce.ts
+++ b/server/src/lib/api/rateLimit/enforce.ts
@@ -78,7 +78,12 @@ export async function enforceApiRateLimit(
   }
 
   const subjectId = context.rateLimitSubjectId ?? context.apiKeyId;
-  const bucketConfig = await apiRateLimitConfigGetter(context.tenant, subjectId);
+  // The config lookup keys off api_key_id (a uuid column). rateLimitSubjectId
+  // is a free-form bucket identity (e.g. 'nm_store' for the NM store global
+  // key) and is not a uuid, so only the real apiKeyId may drive the config
+  // lookup. When absent, resolveApiRateLimitConfig() falls back to the tenant
+  // default. subjectId remains the token-bucket identity string.
+  const bucketConfig = await apiRateLimitConfigGetter(context.tenant, context.apiKeyId);
   const result = await TokenBucketRateLimiter.getInstance().tryConsume('api', context.tenant, subjectId);
 
   const retryAfterMs = result.retryAfterMs;


### PR DESCRIPTION
  "But I don't want to go among uuid people," said 'nm_store'. "Oh, you
  can't help that," grinned the Postgres Cat, "we're all cast-errors here
  — though now the looking-glass column lets you slip back to the tenant
  default and vanish, all but the grin." 🐈🔑🎩