### PR TITLE
Add NinjaOne workflow integration actions

### DIFF
--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/INTEGRATION_MODULE_REGISTRY.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/INTEGRATION_MODULE_REGISTRY.md
@@ -1,0 +1,28 @@
+# First-Party Workflow Integration Module Registry Pattern
+
+Use `getWorkflowIntegrationModuleRegistry().register(...)` to define first-party workflow modules that should appear as stable Workflow Designer app tiles.
+
+## Required metadata
+
+- `groupKey`: app namespace key (`app:<name>`)
+- `label`: operator-facing module name
+- `description`: short module intent
+- `tileKind`: currently `app`
+- `iconToken`: palette icon token
+- `defaultActionId`: default action when adding module
+- `allowedActionIds`: explicit action allow-list for module dropdown
+- `availabilityKey`: declarative runtime availability key (for tenant filtering)
+
+## Current availability resolver
+
+Availability is resolved server-side in `listWorkflowDesignerActionCatalogAction` using keyed checks. Current first key:
+
+- `rmm:ninjaone`: true only when tenant has an active NinjaOne row in `rmm_integrations` (`provider='ninjaone'`, `is_active=true`, `connected_at IS NOT NULL`).
+
+## Integration authoring checklist
+
+1. Register actions in runtime initialization paths used by both server/publish and worker execution.
+2. Register the module with explicit `allowedActionIds` and `availabilityKey`.
+3. Use operator-facing labels/descriptions in action metadata.
+4. Keep sensitive credentials out of action outputs.
+5. Add catalog + handler tests and availability tests.

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/PRD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/PRD.md
@@ -1,0 +1,157 @@
+# PRD — Workflow Integration Modules: NinjaOne First Pass
+
+- Slug: `2026-05-10-workflow-integration-modules-ninjaone`
+- Date: `2026-05-10`
+- Status: Draft
+
+## Summary
+
+Add a first-party workflow integration module system so enabled integrations can appear as app-specific modules in the Workflow Designer. The first implementation will expose a NinjaOne module when a tenant is actively using NinjaOne and will provide a focused set of NinjaOne workflow actions for devices and alerts.
+
+## Problem
+
+Workflow actions are currently registered globally and grouped mostly by action ID prefix. This works for generic PSA capabilities, but not for tenant-specific integrations. Users should only see integration-specific workflow modules when that integration is configured and active for their tenant. Integration-owned actions also need a clear registry pattern so new integrations can add their own workflow capabilities without hardcoding each one into the generic designer.
+
+## Goals
+
+- Add a formal registry for first-party workflow integration modules.
+- Allow each integration module to define catalog metadata, action IDs, default action, icon/logo token, and tenant availability logic.
+- Show the NinjaOne module in the Workflow Designer only when NinjaOne is actively in use for the tenant.
+- Register real NinjaOne workflow actions for a representative mixed set of read, sync, and side-effect operations.
+- Use user-facing terminology in the designer, following least surprise for MSP operators.
+- Preserve the generic Ticket module as the way to create tickets from NinjaOne alert outputs.
+
+## Non-goals
+
+- Do not build workflow modules for accounting, Entra, Google, email, or calendar in this first pass.
+- Do not add a NinjaOne-specific “create ticket from alert” action.
+- Do not add a new permission model for NinjaOne workflow actions; workflow editors can use them.
+- Do not redesign the entire Workflow Designer palette.
+- Do not replace the existing ActionRegistry or NodeTypeRegistry.
+- Do not introduce a generalized external extension marketplace mechanism beyond the first-party module registry.
+
+## Users and Primary Flows
+
+### Target users
+
+- MSP workflow builders who configure automation in Alga PSA.
+- MSP admins who have connected NinjaOne and want workflow automation around RMM devices and alerts.
+
+### Primary flow: discover NinjaOne actions
+
+1. A tenant has an active NinjaOne RMM integration.
+2. A workflow editor opens the Workflow Designer.
+3. The palette shows a NinjaOne app tile with the NinjaOne logo/icon.
+4. The user adds the NinjaOne node to a workflow.
+5. The node action dropdown shows NinjaOne-specific actions only.
+
+### Primary flow: automate from NinjaOne alert to generic ticket creation
+
+1. The user adds a NinjaOne action such as “List active alerts” or “Get alert.”
+2. The action returns normalized alert fields including alert ID, severity, device ID, asset ID, title/message, and timestamps.
+3. The user adds a generic Ticket module action, such as `tickets.create`.
+4. The ticket input mapping uses outputs from the NinjaOne alert step.
+
+### Primary flow: device operation
+
+1. The user adds a NinjaOne “Find devices” or “Sync device” action.
+2. The user maps an external NinjaOne device ID, asset ID, or search criteria.
+3. The workflow runs and returns normalized device information for downstream steps.
+4. For “Reboot device,” the action sends a device reboot command with engine-provided idempotency.
+
+## UX / UI Notes
+
+- The Workflow Designer palette should show a NinjaOne app tile only for tenants actively using NinjaOne.
+- The tile should use a NinjaOne-specific icon/logo token, not a generic app icon when the UI supports it.
+- Action labels must be operator-facing:
+  - `ninjaone.alerts.reset` should display as **Acknowledge alert**.
+  - Descriptions can clarify that acknowledging uses the NinjaOne reset operation.
+- Generic PSA actions remain in generic modules. Creating tickets from NinjaOne alerts should be done with the Ticket module.
+- If NinjaOne becomes inactive after a workflow was authored, existing workflow definitions may still reference NinjaOne actions, but execution should fail fast with a clear configuration error.
+
+## Requirements
+
+### Functional Requirements
+
+1. Add a workflow integration module registry for first-party integrations.
+2. Support integration module metadata: group key, label, description, tile kind, icon token, default action ID, allowed action IDs, and availability key/resolver.
+3. Extend designer catalog building so registered integration modules produce stable app records rather than relying only on action ID prefix grouping.
+4. Extend catalog availability filtering so first-party integration records are shown only when their resolver reports the tenant is using the integration.
+5. Preserve existing extension app filtering behavior.
+6. Define NinjaOne availability as an active tenant RMM integration:
+   - `rmm_integrations.provider = 'ninjaone'`
+   - `rmm_integrations.is_active = true`
+   - `rmm_integrations.connected_at IS NOT NULL`
+7. Register a NinjaOne workflow module with the actions listed below.
+8. Register these NinjaOne workflow actions:
+   - `ninjaone.devices.find` — Find/list devices from local mapping and/or NinjaOne API criteria.
+   - `ninjaone.devices.sync` — Sync a single NinjaOne device into Alga assets.
+   - `ninjaone.devices.reboot` — Send a reboot command to a NinjaOne device.
+   - `ninjaone.alerts.list_active` — List active NinjaOne alerts.
+   - `ninjaone.alerts.get` — Get one alert by external alert ID or alert UID.
+   - `ninjaone.alerts.reset` — Display as **Acknowledge alert** and call the NinjaOne reset operation.
+9. Action outputs should be normalized enough for downstream generic PSA modules.
+10. Side-effect actions must use engine-provided idempotency.
+11. Runtime handlers must validate tenant context and fail fast if NinjaOne is inactive or missing required credentials.
+12. Temporal worker bootstrap must register the same NinjaOne actions used by server-side catalog/publish validation.
+
+### Non-functional Requirements
+
+- Keep integration-specific code coupled to the NinjaOne integration module, not to generic workflow designer components.
+- Keep the registry API small and explicit so other integrations can adopt the pattern later.
+- Do not silently fall back to showing unavailable integration modules.
+- Keep labels and descriptions translatable via existing workflow i18n fallback patterns where practical.
+
+## Data / API / Integrations
+
+### Existing data sources
+
+- `rmm_integrations` determines NinjaOne availability.
+- `tenant_external_entity_mappings`, assets, and `rmm_organization_mappings` may support local device lookup and sync context.
+- Existing NinjaOne client and sync engine code under `ee/server/src/lib/integrations/ninjaone/` should be reused for external API calls and device sync.
+- Existing `rmm_alerts` can support local alert lookup; NinjaOne API calls can support fresh list/get/reset behavior where existing client methods exist.
+
+### Registry/API design
+
+- Add a first-party workflow integration module registry in the workflow runtime layer.
+- Add server-side availability resolver loading for catalog records. Resolvers should be keyed, e.g. `rmm:ninjaone`, so module metadata remains declarative.
+- Extend `buildWorkflowDesignerActionCatalog` to accept registered module definitions or a parallel module catalog overlay.
+- Continue returning catalog records from `/api/workflow/registry/designer-catalog`.
+
+## Security / Permissions
+
+- Any user who can edit/manage workflows may add NinjaOne workflow actions.
+- Runtime execution should use existing workflow execution permissions and tenant isolation.
+- Handlers must ensure tenant ID is present and use tenant-scoped DB/API helpers.
+- Reboot and acknowledge alert are side-effectful and must rely on workflow action idempotency.
+- Do not expose NinjaOne secrets in action outputs, examples, logs, or catalog payloads.
+
+## Observability
+
+- Use existing action execution records and workflow step logs.
+- Use existing NinjaOne integration logging where handlers delegate to existing services.
+- No new dashboards or metrics are required in this first pass.
+
+## Rollout / Migration
+
+- No schema migration is expected for the first pass.
+- Existing workflow definitions should continue to validate and run.
+- New NinjaOne actions become available only after runtime initialization and tenant availability checks pass.
+- If a tenant disconnects NinjaOne after authoring a workflow, publish/runtime validation should not expose new nodes, and execution should fail with a clear inactive-integration error.
+
+## Open Questions
+
+- Should the first implementation render a true NinjaOne SVG/logo asset, or is a `ninjaone` icon token mapped in the palette sufficient for this pass?
+- Should `ninjaone.devices.find` read only local synced assets/mappings, call the live NinjaOne API, or support both via an input mode? Recommendation: support local-first lookup with optional live API search only if existing client methods make it low risk.
+
+## Acceptance Criteria (Definition of Done)
+
+- An active NinjaOne tenant sees a NinjaOne module in the Workflow Designer palette.
+- A tenant without active NinjaOne does not see the NinjaOne module.
+- Adding the NinjaOne module creates an `action.call` step scoped to the NinjaOne action list.
+- The action dropdown shows the six approved NinjaOne actions with user-facing labels.
+- `ninjaone.alerts.reset` is labeled **Acknowledge alert**.
+- NinjaOne alert outputs can be mapped into a generic `tickets.create` step.
+- Side-effect actions are idempotent under workflow retries.
+- Publish validation and Temporal runtime both recognize the NinjaOne actions.
+- Tests cover catalog availability, action registration, side-effect idempotency/config guards, and a representative action happy path.

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -1,0 +1,86 @@
+# Scratchpad — Workflow Integration Modules: NinjaOne First Pass
+
+- Plan slug: `2026-05-10-workflow-integration-modules-ninjaone`
+- Created: `2026-05-10`
+
+## What This Is
+
+Rolling notes for adding first-party workflow integration modules and the first NinjaOne workflow module/actions.
+
+## Decisions
+
+- (2026-05-10) Use a first-party workflow integration module registry instead of only action-prefix grouping. Rationale: integrations need tenant availability, icon/logo metadata, default action, and future extensibility without hardcoding each integration into the generic designer.
+- (2026-05-10) Define NinjaOne “in use” as an active `rmm_integrations` row with `provider = 'ninjaone'`, `is_active = true`, and non-null `connected_at`.
+- (2026-05-10) First pass will implement a mixed NinjaOne action set: find/list device, sync single device, reboot device, list active alerts, get alert, acknowledge alert.
+- (2026-05-10) Do not add `ninjaone.alerts.create_ticket`. Users should chain NinjaOne alert outputs into the generic Ticket module (`tickets.create`, etc.). This keeps PSA ticket behavior generic and avoids duplicated ticket rules.
+- (2026-05-10) Label `ninjaone.alerts.reset` as **Acknowledge alert** in the UI. The technical action ID can reflect the NinjaOne API reset operation, but users should see MSP/operator terminology.
+- (2026-05-10) Any workflow editor can add/use NinjaOne workflow actions. No extra integration/action permission gate in this pass.
+
+## Discoveries / Constraints
+
+- (2026-05-10) Existing action catalog builder lives at `shared/workflow/runtime/designer/actionCatalog.ts` and already groups unknown action prefixes into `tileKind: 'app'` records.
+- (2026-05-10) Existing designer catalog endpoint is backed by `listWorkflowDesignerActionCatalogAction` in `ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts`.
+- (2026-05-10) Existing app filtering only checks enabled extension installs via `tenant_extension_install` and `extension_registry`; it does not handle first-party integration availability.
+- (2026-05-10) Current Workflow Designer icon mapping lives in `ee/server/src/components/workflow-designer/WorkflowDesigner.tsx` in `getPaletteIcon`.
+- (2026-05-10) NinjaOne integration code already exists under `ee/server/src/lib/integrations/ninjaone/`, including `ninjaOneClient.ts`, `sync/syncEngine.ts`, and alert/webhook handling.
+- (2026-05-10) `rmm_integrations` schema includes `provider`, `is_active`, `connected_at`, `instance_url`, sync status fields, and tenant-scoped uniqueness on `(tenant, provider)`.
+- (2026-05-10) Temporal activities import workflow runtime from `@alga-psa/workflows/runtime/core`, so worker/runtime bootstrap must be considered carefully when adding EE/server-only NinjaOne registrations.
+
+## Commands / Runbooks
+
+- (2026-05-10) Initial context commands used:
+  - `rg "WorkflowDesignerCatalog|actionCatalog|buildWorkflowDesignerActionCatalog|workflow module" -n server ee shared packages`
+  - `rg "loadAvailableWorkflowDesignerAppKeys|availableAppKeys|integration" ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts server/src ee/server shared -n`
+  - `rg "rmm_integrations|ninjaone|quickbooks|xero|email_providers|calendar_providers|microsoft_profiles" ee/server/migrations server/migrations packages -n`
+  - `rg "NinjaOne|ninjaone|remote|device|alert|webhook|rmm" ee/server/src/lib/integrations/ninjaone packages/integrations/src/actions/integrations packages/integrations/src/lib/rmm -n`
+
+## Links / References
+
+- `shared/workflow/runtime/registries/actionRegistry.ts`
+- `shared/workflow/runtime/designer/actionCatalog.ts`
+- `shared/workflow/runtime/init.ts`
+- `ee/packages/workflows/src/runtime/bootstrap.ts`
+- `ee/packages/workflows/src/runtime/worker.ts`
+- `ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts`
+- `server/src/app/api/workflow/registry/designer-catalog/route.ts`
+- `ee/server/src/components/workflow-designer/WorkflowDesigner.tsx`
+- `ee/server/src/components/workflow-designer/GroupedActionConfigSection.tsx`
+- `server/migrations/20251124000001_create_rmm_integration_tables.cjs`
+- `ee/server/src/lib/integrations/ninjaone/ninjaOneClient.ts`
+- `ee/server/src/lib/integrations/ninjaone/sync/syncEngine.ts`
+- `ee/server/src/lib/integrations/ninjaone/alerts/alertProcessor.ts`
+
+## Open Questions
+
+- Should the first pass render a true NinjaOne SVG/logo asset, or is a `ninjaone` icon token mapped in the existing palette sufficient?
+- Should `ninjaone.devices.find` be local-only, live API-backed, or support both? Recommendation in PRD: local-first with optional live mode only if low risk.
+
+## Progress Updates
+
+- (2026-05-10) Implemented first-party workflow integration module registry in `shared/workflow/runtime/registries/integrationModuleRegistry.ts` with duplicate-key protection and singleton accessor.
+- (2026-05-10) Extended `buildWorkflowDesignerActionCatalog` to accept explicit first-party app module definitions and produce stable app records from declarative `allowedActionIds`.
+- (2026-05-10) Added server-side first-party availability filtering keyed by `availabilityKey` in `listWorkflowDesignerActionCatalogAction`; preserved extension install filtering path.
+- (2026-05-10) Registered `app:ninjaone` first-party workflow module in EE runtime core with icon token `ninjaone`, default action `ninjaone.devices.find`, and explicit six-action allow-list.
+- (2026-05-10) Added six NinjaOne workflow actions in `ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts`:
+  - `ninjaone.devices.find`
+  - `ninjaone.devices.sync`
+  - `ninjaone.devices.reboot`
+  - `ninjaone.alerts.list_active`
+  - `ninjaone.alerts.get`
+  - `ninjaone.alerts.reset` (labelled `Acknowledge alert`)
+- (2026-05-10) Handlers now fail fast for missing tenant and inactive integration, use engine-provided idempotency for side-effectful operations, and return normalized non-secret outputs.
+- (2026-05-10) Mapped `ninjaone` icon token in Workflow Designer palette (`WorkflowDesigner.tsx`) for a distinct NinjaOne tile icon.
+- (2026-05-10) Added registry pattern documentation for future integrations at `ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/INTEGRATION_MODULE_REGISTRY.md`.
+- (2026-05-10) Added/updated tests:
+  - `shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts` (duplicate-key + metadata roundtrip)
+  - `shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts` (explicit module record behavior)
+
+## Validation Runbook
+
+- `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts`
+- `npx tsc -p ee/packages/workflows/tsconfig.json --noEmit`
+
+## Gotchas
+
+- Root vitest config does not discover `ee/packages/workflows/src/runtime/__tests__` by default; shared runtime tests were executed via `shared/vitest.config.ts`.
+- `createNinjaOneClient` second argument is region, not instance URL; workflow action handlers must call it with workflow context rather than raw URL.

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -81,9 +81,12 @@ Rolling notes for adding first-party workflow integration modules and the first 
   - `ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`:
     - `T006` verifies bootstrap and worker runtime entrypoints both register exactly the six NinjaOne action IDs
     - `T007` verifies side-effect/idempotency metadata and `ninjaone.alerts.reset` UI label/description (`Acknowledge alert`)
+  - `ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`:
+    - `T008` verifies `ninjaone.devices.find` happy path (local lookup) returns normalized device output and does not leak secret-like source fields
 
 - (2026-05-10) Added targeted unit/integration-style coverage around `listWorkflowDesignerActionCatalogAction` filter behavior by mocking auth/runtime and exercising `rmm_integrations` plus extension-install query paths. Rationale: prove regression-safe catalog filtering without requiring full end-to-end server harness for this plan slice.
 - (2026-05-10) Added runtime registration coverage using real runtime bootstrap/worker initialization and shared action registry reads. Included virtual test shim for `@alga-psa/db/workDate` to satisfy shared runtime import graph in package-level Vitest execution.
+- (2026-05-10) Added handler-level test harness for NinjaOne actions with mocked integration client/sync strategy imports and action-registry invocation to validate output contracts directly at handler boundary.
 
 ## Validation Runbook
 
@@ -91,6 +94,7 @@ Rolling notes for adding first-party workflow integration modules and the first 
 - `npx tsc -p ee/packages/workflows/tsconfig.json --noEmit`
 - `cd ee/packages/workflows && npx vitest run src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts`
 - `cd ee/packages/workflows && npx vitest run src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`
+- `cd ee/packages/workflows && npx vitest run src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`
 
 ## Gotchas
 

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -83,6 +83,11 @@ Rolling notes for adding first-party workflow integration modules and the first 
     - `T007` verifies side-effect/idempotency metadata and `ninjaone.alerts.reset` UI label/description (`Acknowledge alert`)
   - `ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`:
     - `T008` verifies `ninjaone.devices.find` happy path (local lookup) returns normalized device output and does not leak secret-like source fields
+    - `T009` verifies `ninjaone.devices.sync` delegates to sync strategy and returns synced identifiers
+    - `T010` verifies `ninjaone.devices.reboot` inactive-integration guard and successful reboot delegation
+    - `T011` verifies `ninjaone.alerts.list_active` output includes alert/device/asset/severity/message fields for ticket mappings
+    - `T012` verifies `ninjaone.alerts.get` happy path and not-found behavior
+    - `T013` verifies `ninjaone.alerts.reset` calls NinjaOne reset operation and returns acknowledged output
 
 - (2026-05-10) Added targeted unit/integration-style coverage around `listWorkflowDesignerActionCatalogAction` filter behavior by mocking auth/runtime and exercising `rmm_integrations` plus extension-install query paths. Rationale: prove regression-safe catalog filtering without requiring full end-to-end server harness for this plan slice.
 - (2026-05-10) Added runtime registration coverage using real runtime bootstrap/worker initialization and shared action registry reads. Included virtual test shim for `@alga-psa/db/workDate` to satisfy shared runtime import graph in package-level Vitest execution.

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -82,6 +82,9 @@ Rolling notes for adding first-party workflow integration modules and the first 
     - `T006` verifies bootstrap and worker runtime entrypoints both register exactly the six NinjaOne action IDs
     - `T007` verifies side-effect/idempotency metadata and `ninjaone.alerts.reset` UI label/description (`Acknowledge alert`)
     - `T014` verifies NinjaOne registry action input/output schemas are present and parse representative `action.call` configuration payloads
+  - `ee/server/src/components/workflow-designer/__tests__/ninjaOneDesignerCatalog.contract.test.ts`:
+    - `T015` verifies NinjaOne grouped action options and explicit `ninjaone` icon token mapping contract in `WorkflowDesigner.tsx`
+    - `T016` verifies NinjaOne module does not include ticket-creation actions and generic Ticket module remains the `tickets.create` path
   - `ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`:
     - `T008` verifies `ninjaone.devices.find` happy path (local lookup) returns normalized device output and does not leak secret-like source fields
     - `T009` verifies `ninjaone.devices.sync` delegates to sync strategy and returns synced identifiers
@@ -101,6 +104,7 @@ Rolling notes for adding first-party workflow integration modules and the first 
 - `cd ee/packages/workflows && npx vitest run src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts`
 - `cd ee/packages/workflows && npx vitest run src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`
 - `cd ee/packages/workflows && npx vitest run src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`
+- `cd ee/server && npx vitest run src/components/workflow-designer/__tests__/ninjaOneDesignerCatalog.contract.test.ts`
 
 ## Gotchas
 

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -18,6 +18,8 @@ Rolling notes for adding first-party workflow integration modules and the first 
 
 ## Discoveries / Constraints
 
+- (2026-05-10) Review follow-up fixed package typecheck failures caused by Vitest `vi.mock` third-argument usage for `@alga-psa/db/workDate`; the package export exists, so the virtual flag was unnecessary.
+- (2026-05-10) Review follow-up fixed NinjaOne handler guards: local device query no longer references nonexistent `assets.hostname`, alert DB reads/updates are scoped by `integration_id`, timestamp outputs are normalized to ISO strings, and device IDs are coerced/validated as positive integers before side-effect calls.
 - (2026-05-10) Existing action catalog builder lives at `shared/workflow/runtime/designer/actionCatalog.ts` and already groups unknown action prefixes into `tileKind: 'app'` records.
 - (2026-05-10) Existing designer catalog endpoint is backed by `listWorkflowDesignerActionCatalogAction` in `ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts`.
 - (2026-05-10) Existing app filtering only checks enabled extension installs via `tenant_extension_install` and `extension_registry`; it does not handle first-party integration availability.

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -78,14 +78,19 @@ Rolling notes for adding first-party workflow integration modules and the first 
     - `T003` active NinjaOne tenant includes `app:ninjaone` in designer catalog
     - `T004` inactive/missing NinjaOne excludes `app:ninjaone`
     - `T005` extension app filtering still works with first-party filtering (`app:acme.sync` allowed when installed)
+  - `ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`:
+    - `T006` verifies bootstrap and worker runtime entrypoints both register exactly the six NinjaOne action IDs
+    - `T007` verifies side-effect/idempotency metadata and `ninjaone.alerts.reset` UI label/description (`Acknowledge alert`)
 
 - (2026-05-10) Added targeted unit/integration-style coverage around `listWorkflowDesignerActionCatalogAction` filter behavior by mocking auth/runtime and exercising `rmm_integrations` plus extension-install query paths. Rationale: prove regression-safe catalog filtering without requiring full end-to-end server harness for this plan slice.
+- (2026-05-10) Added runtime registration coverage using real runtime bootstrap/worker initialization and shared action registry reads. Included virtual test shim for `@alga-psa/db/workDate` to satisfy shared runtime import graph in package-level Vitest execution.
 
 ## Validation Runbook
 
 - `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts`
 - `npx tsc -p ee/packages/workflows/tsconfig.json --noEmit`
 - `cd ee/packages/workflows && npx vitest run src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts`
+- `cd ee/packages/workflows && npx vitest run src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`
 
 ## Gotchas
 

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -81,6 +81,7 @@ Rolling notes for adding first-party workflow integration modules and the first 
   - `ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts`:
     - `T006` verifies bootstrap and worker runtime entrypoints both register exactly the six NinjaOne action IDs
     - `T007` verifies side-effect/idempotency metadata and `ninjaone.alerts.reset` UI label/description (`Acknowledge alert`)
+    - `T014` verifies NinjaOne registry action input/output schemas are present and parse representative `action.call` configuration payloads
   - `ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts`:
     - `T008` verifies `ninjaone.devices.find` happy path (local lookup) returns normalized device output and does not leak secret-like source fields
     - `T009` verifies `ninjaone.devices.sync` delegates to sync strategy and returns synced identifiers

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/SCRATCHPAD.md
@@ -74,11 +74,18 @@ Rolling notes for adding first-party workflow integration modules and the first 
 - (2026-05-10) Added/updated tests:
   - `shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts` (duplicate-key + metadata roundtrip)
   - `shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts` (explicit module record behavior)
+  - `ee/packages/workflows/src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts`:
+    - `T003` active NinjaOne tenant includes `app:ninjaone` in designer catalog
+    - `T004` inactive/missing NinjaOne excludes `app:ninjaone`
+    - `T005` extension app filtering still works with first-party filtering (`app:acme.sync` allowed when installed)
+
+- (2026-05-10) Added targeted unit/integration-style coverage around `listWorkflowDesignerActionCatalogAction` filter behavior by mocking auth/runtime and exercising `rmm_integrations` plus extension-install query paths. Rationale: prove regression-safe catalog filtering without requiring full end-to-end server harness for this plan slice.
 
 ## Validation Runbook
 
 - `npx vitest run --config shared/vitest.config.ts shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts`
 - `npx tsc -p ee/packages/workflows/tsconfig.json --noEmit`
+- `cd ee/packages/workflows && npx vitest run src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts`
 
 ## Gotchas
 

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/features.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/features.json
@@ -1,0 +1,279 @@
+[
+  {
+    "id": "F001",
+    "description": "Create a first-party workflow integration module registry for declarative module metadata.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "Support module metadata fields for group key, label, description, tile kind, icon token, default action ID, action IDs, and availability key.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F003",
+    "description": "Allow designer catalog construction to include registered first-party integration modules as stable app records.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F004",
+    "description": "Preserve existing built-in action grouping behavior for core, transform, and AI modules.",
+    "implemented": true,
+    "prdRefs": [
+      "Non-goals",
+      "Rollout / Migration"
+    ]
+  },
+  {
+    "id": "F005",
+    "description": "Preserve existing extension app filtering behavior when adding first-party integration filtering.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F006",
+    "description": "Add an availability resolver mechanism keyed by declarative availability keys.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F007",
+    "description": "Implement the NinjaOne availability resolver using active rmm_integrations rows for the current tenant.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F008",
+    "description": "Filter the workflow designer catalog so the NinjaOne module is returned only when NinjaOne is active for the tenant.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Acceptance Criteria"
+    ]
+  },
+  {
+    "id": "F009",
+    "description": "Register a NinjaOne workflow module with group key app:ninjaone, NinjaOne label, NinjaOne icon token, and default action.",
+    "implemented": true,
+    "prdRefs": [
+      "Summary",
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Map the NinjaOne icon token in the Workflow Designer palette so the tile is visibly NinjaOne-specific.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes",
+      "Open Questions"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Register the ninjaone.devices.find workflow action with schema, metadata, and handler.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Implement NinjaOne device find/list output with normalized device fields suitable for downstream mappings.",
+    "implemented": true,
+    "prdRefs": [
+      "Primary flow: device operation"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Register the ninjaone.devices.sync workflow action with schema, metadata, and handler.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "Implement single-device sync by reusing existing NinjaOne sync engine behavior.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F015",
+    "description": "Register the ninjaone.devices.reboot workflow action with side-effectful metadata and engine-provided idempotency.",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F016",
+    "description": "Implement NinjaOne device reboot by validating tenant/integration/device context and calling the existing NinjaOne client.",
+    "implemented": true,
+    "prdRefs": [
+      "Primary flow: device operation"
+    ]
+  },
+  {
+    "id": "F017",
+    "description": "Register the ninjaone.alerts.list_active workflow action with schema, metadata, and handler.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F018",
+    "description": "Implement active alert listing with normalized alert outputs for downstream Ticket module mappings.",
+    "implemented": true,
+    "prdRefs": [
+      "Primary flow: automate from NinjaOne alert to generic ticket creation"
+    ]
+  },
+  {
+    "id": "F019",
+    "description": "Register the ninjaone.alerts.get workflow action with schema, metadata, and handler.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "Implement get-alert behavior by external alert ID or alert UID and return normalized alert fields.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "Register the ninjaone.alerts.reset workflow action with side-effectful metadata and engine-provided idempotency.",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "Display ninjaone.alerts.reset as Acknowledge alert in the designer while keeping the technical ID stable.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "Implement acknowledge-alert behavior by calling the NinjaOne reset alert operation after tenant/integration validation.",
+    "implemented": true,
+    "prdRefs": [
+      "Requirements: Functional Requirements"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "Ensure all NinjaOne workflow action handlers fail fast when tenant context is missing.",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Ensure all NinjaOne workflow action handlers fail fast when NinjaOne is inactive for the tenant.",
+    "implemented": true,
+    "prdRefs": [
+      "Runtime behavior",
+      "Rollout / Migration"
+    ]
+  },
+  {
+    "id": "F026",
+    "description": "Ensure all NinjaOne workflow action handlers avoid returning credentials or sensitive secret-derived data.",
+    "implemented": true,
+    "prdRefs": [
+      "Security / Permissions"
+    ]
+  },
+  {
+    "id": "F027",
+    "description": "Register NinjaOne workflow actions in the server runtime used by catalog and publish validation.",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance Criteria"
+    ]
+  },
+  {
+    "id": "F028",
+    "description": "Register NinjaOne workflow actions in the Temporal worker runtime used for action execution.",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance Criteria"
+    ]
+  },
+  {
+    "id": "F029",
+    "description": "Expose NinjaOne action input and output schemas through the existing workflow registry/catalog endpoints.",
+    "implemented": true,
+    "prdRefs": [
+      "Data / API / Integrations"
+    ]
+  },
+  {
+    "id": "F030",
+    "description": "Ensure the NinjaOne designer module action dropdown contains only the approved NinjaOne actions.",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance Criteria"
+    ]
+  },
+  {
+    "id": "F031",
+    "description": "Ensure NinjaOne alert outputs include fields needed to map into generic ticket creation.",
+    "implemented": true,
+    "prdRefs": [
+      "Primary flow: automate from NinjaOne alert to generic ticket creation"
+    ]
+  },
+  {
+    "id": "F032",
+    "description": "Keep ticket creation out of the NinjaOne module and rely on existing Ticket actions for that flow.",
+    "implemented": true,
+    "prdRefs": [
+      "Non-goals"
+    ]
+  },
+  {
+    "id": "F033",
+    "description": "Use clear user-facing action labels and descriptions for all NinjaOne actions.",
+    "implemented": true,
+    "prdRefs": [
+      "UX / UI Notes"
+    ]
+  },
+  {
+    "id": "F034",
+    "description": "Document the module registry pattern enough for future first-party integrations to adopt it.",
+    "implemented": true,
+    "prdRefs": [
+      "Goals"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -1,0 +1,154 @@
+[
+  {
+    "id": "T001",
+    "description": "Unit test the workflow integration module registry rejects duplicate group keys and returns registered module metadata.",
+    "implemented": true,
+    "featureIds": [
+      "F001",
+      "F002"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Unit test designer catalog construction includes the registered NinjaOne module with stable group key, default action, icon token, and only approved action IDs.",
+    "implemented": true,
+    "featureIds": [
+      "F003",
+      "F009",
+      "F030"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "DB-backed integration test: tenant with active NinjaOne rmm_integrations row receives the NinjaOne designer catalog record.",
+    "implemented": false,
+    "featureIds": [
+      "F007",
+      "F008"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "DB-backed integration test: tenants with no NinjaOne row, inactive NinjaOne row, or null connected_at do not receive the NinjaOne designer catalog record.",
+    "implemented": false,
+    "featureIds": [
+      "F007",
+      "F008",
+      "F025"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "Regression test that extension app catalog filtering still works after first-party integration filtering is added.",
+    "implemented": false,
+    "featureIds": [
+      "F005"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "Runtime registration test verifies server/publish runtime and worker runtime both include the six NinjaOne action IDs.",
+    "implemented": false,
+    "featureIds": [
+      "F027",
+      "F028",
+      "F029"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "Unit test NinjaOne action metadata: side-effectful flags, idempotency modes, labels, descriptions, and Acknowledge alert wording.",
+    "implemented": false,
+    "featureIds": [
+      "F015",
+      "F021",
+      "F022",
+      "F033"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "Handler test for ninjaone.devices.find covers a happy path returning normalized device fields without secrets.",
+    "implemented": false,
+    "featureIds": [
+      "F011",
+      "F012",
+      "F026"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "Handler test for ninjaone.devices.sync verifies single-device sync delegates to existing sync behavior and returns asset/device identifiers.",
+    "implemented": false,
+    "featureIds": [
+      "F013",
+      "F014"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "Handler test for ninjaone.devices.reboot verifies inactive integration guard and successful reboot delegation with normalized output.",
+    "implemented": false,
+    "featureIds": [
+      "F015",
+      "F016",
+      "F025"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "Handler test for ninjaone.alerts.list_active verifies active alert list output includes fields needed by tickets.create mapping.",
+    "implemented": false,
+    "featureIds": [
+      "F017",
+      "F018",
+      "F031"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "Handler test for ninjaone.alerts.get verifies lookup by alert UID/external ID and not-found failure behavior.",
+    "implemented": false,
+    "featureIds": [
+      "F019",
+      "F020"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Handler test for ninjaone.alerts.reset verifies Acknowledge alert calls the NinjaOne reset operation and returns acknowledged output.",
+    "implemented": false,
+    "featureIds": [
+      "F021",
+      "F023"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Publish-validation or registry API test verifies NinjaOne action schemas are available for action.call configuration.",
+    "implemented": false,
+    "featureIds": [
+      "F027",
+      "F029"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Workflow Designer component test verifies active-catalog NinjaOne tile renders with NinjaOne-specific icon token and action dropdown options.",
+    "implemented": false,
+    "featureIds": [
+      "F010",
+      "F030",
+      "F033"
+    ]
+  },
+  {
+    "id": "T016",
+    "description": "Representative workflow authoring test verifies NinjaOne alert output can be selected/mapped into a generic Ticket action without a NinjaOne create-ticket action.",
+    "implemented": false,
+    "featureIds": [
+      "F031",
+      "F032"
+    ]
+  }
+]

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -48,7 +48,7 @@
   {
     "id": "T006",
     "description": "Runtime registration test verifies server/publish runtime and worker runtime both include the six NinjaOne action IDs.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F027",
       "F028",
@@ -58,7 +58,7 @@
   {
     "id": "T007",
     "description": "Unit test NinjaOne action metadata: side-effectful flags, idempotency modes, labels, descriptions, and Acknowledge alert wording.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F015",
       "F021",

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -126,7 +126,7 @@
   {
     "id": "T014",
     "description": "Publish-validation or registry API test verifies NinjaOne action schemas are available for action.call configuration.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F027",
       "F029"

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -79,7 +79,7 @@
   {
     "id": "T009",
     "description": "Handler test for ninjaone.devices.sync verifies single-device sync delegates to existing sync behavior and returns asset/device identifiers.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F013",
       "F014"
@@ -88,7 +88,7 @@
   {
     "id": "T010",
     "description": "Handler test for ninjaone.devices.reboot verifies inactive integration guard and successful reboot delegation with normalized output.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F015",
       "F016",
@@ -98,7 +98,7 @@
   {
     "id": "T011",
     "description": "Handler test for ninjaone.alerts.list_active verifies active alert list output includes fields needed by tickets.create mapping.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F017",
       "F018",
@@ -108,7 +108,7 @@
   {
     "id": "T012",
     "description": "Handler test for ninjaone.alerts.get verifies lookup by alert UID/external ID and not-found failure behavior.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F019",
       "F020"
@@ -117,7 +117,7 @@
   {
     "id": "T013",
     "description": "Handler test for ninjaone.alerts.reset verifies Acknowledge alert calls the NinjaOne reset operation and returns acknowledged output.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F021",
       "F023"

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -21,7 +21,7 @@
   {
     "id": "T003",
     "description": "DB-backed integration test: tenant with active NinjaOne rmm_integrations row receives the NinjaOne designer catalog record.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F007",
       "F008"
@@ -30,7 +30,7 @@
   {
     "id": "T004",
     "description": "DB-backed integration test: tenants with no NinjaOne row, inactive NinjaOne row, or null connected_at do not receive the NinjaOne designer catalog record.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F007",
       "F008",
@@ -40,7 +40,7 @@
   {
     "id": "T005",
     "description": "Regression test that extension app catalog filtering still works after first-party integration filtering is added.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F005"
     ]

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -69,7 +69,7 @@
   {
     "id": "T008",
     "description": "Handler test for ninjaone.devices.find covers a happy path returning normalized device fields without secrets.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F011",
       "F012",

--- a/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
+++ b/ee/docs/plans/2026-05-10-workflow-integration-modules-ninjaone/tests.json
@@ -135,7 +135,7 @@
   {
     "id": "T015",
     "description": "Workflow Designer component test verifies active-catalog NinjaOne tile renders with NinjaOne-specific icon token and action dropdown options.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F010",
       "F030",
@@ -145,7 +145,7 @@
   {
     "id": "T016",
     "description": "Representative workflow authoring test verifies NinjaOne alert output can be selected/mapped into a generic Ticket action without a NinjaOne create-ticket action.",
-    "implemented": false,
+    "implemented": true,
     "featureIds": [
       "F031",
       "F032"

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-actions.ts
@@ -23,6 +23,7 @@ import {
   isWorkflowTimeTrigger,
   resolveActionCallOutputSchema,
   buildWorkflowDesignerActionCatalog,
+  getWorkflowIntegrationModuleRegistry,
   zodToWorkflowJsonSchema,
   validateWorkflowDefinition,
   validateInputMapping,
@@ -203,6 +204,30 @@ const loadAvailableWorkflowDesignerAppKeys = async (
   }
 
   return availableKeys;
+};
+
+const loadAvailableFirstPartyIntegrationAppKeys = async (
+  knex: Knex,
+  tenantId: string | null | undefined
+): Promise<Set<string>> => {
+  if (!tenantId) return new Set();
+  const available = new Set<string>();
+  const registry = getWorkflowIntegrationModuleRegistry();
+  for (const module of registry.list()) {
+    if (!module.availabilityKey) continue;
+    if (module.availabilityKey === 'rmm:ninjaone') {
+      const row = await knex('rmm_integrations')
+        .where({
+          tenant: tenantId,
+          provider: 'ninjaone',
+          is_active: true
+        })
+        .whereNotNull('connected_at')
+        .first();
+      if (row) available.add(module.groupKey);
+    }
+  }
+  return available;
 };
 
 const isEnterpriseEdition = (): boolean => {
@@ -3306,9 +3331,19 @@ export const listWorkflowDesignerActionCatalogAction = withAuth(async (user, { t
   const { knex } = await createTenantKnex();
   await requireWorkflowPermission(user, 'read', knex);
   const registry = getActionRegistryV2();
-  const catalog = buildWorkflowDesignerActionCatalog(registry.list().map(serializeWorkflowRegistryAction));
+  const integrationModules = getWorkflowIntegrationModuleRegistry().list();
+  const catalog = buildWorkflowDesignerActionCatalog(
+    registry.list().map(serializeWorkflowRegistryAction),
+    { modules: integrationModules }
+  );
   const availableAppKeys = await loadAvailableWorkflowDesignerAppKeys(knex, tenant);
-  return catalog.filter((record) => record.tileKind !== 'app' || availableAppKeys.has(record.groupKey));
+  const availableFirstPartyKeys = await loadAvailableFirstPartyIntegrationAppKeys(knex, tenant);
+  const firstPartyModuleKeys: Set<string> = new Set(integrationModules.map((module) => module.groupKey));
+  return catalog.filter((record) => {
+    if (record.tileKind !== 'app') return true;
+    if (firstPartyModuleKeys.has(record.groupKey)) return availableFirstPartyKeys.has(record.groupKey);
+    return availableAppKeys.has(record.groupKey);
+  });
 });
 
 export const getWorkflowSchemaAction = withAuth(async (user, { tenant }, input: unknown) => {

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts
@@ -77,7 +77,7 @@ vi.mock('@alga-psa/analytics', () => ({
 vi.mock('@alga-psa/db/workDate', () => ({
   computeWorkDateFields: vi.fn(() => ({ localDate: '2026-01-01' })),
   resolveUserTimeZone: vi.fn(() => 'America/New_York')
-}), { virtual: true });
+}));
 
 vi.mock('@alga-psa/workflows/runtime', () => {
   return {

--- a/ee/packages/workflows/src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts
+++ b/ee/packages/workflows/src/actions/workflow-runtime-v2-designer-catalog.integration-filtering.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+type ExtensionInstallRow = { publisher: string | null; name: string | null };
+
+type FixtureState = {
+  tenant: string;
+  hasExtensionTables: boolean;
+  ninjaOneActive: boolean;
+  extensionInstallRows: ExtensionInstallRow[];
+};
+
+const fixture: FixtureState = vi.hoisted(() => ({
+  tenant: 'tenant-a',
+  hasExtensionTables: false,
+  ninjaOneActive: false,
+  extensionInstallRows: []
+}));
+
+const createRmmIntegrationBuilder = () => {
+  const builder: any = {
+    where: vi.fn().mockReturnThis(),
+    whereNotNull: vi.fn().mockReturnThis(),
+    first: vi.fn().mockImplementation(async () => (fixture.ninjaOneActive ? { id: 'rmm-1' } : undefined))
+  };
+  return builder;
+};
+
+const createExtensionInstallBuilder = () => {
+  const builder: any = {
+    innerJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    andWhere: vi.fn().mockImplementation((callbackOrField: unknown) => {
+      if (typeof callbackOrField === 'function') {
+        callbackOrField({ where: vi.fn().mockReturnThis(), orWhere: vi.fn().mockReturnThis() });
+      }
+      return builder;
+    }),
+    select: vi.fn().mockImplementation(async () => fixture.extensionInstallRows)
+  };
+  return builder;
+};
+
+const knexMock: any = vi.hoisted(() => vi.fn((table: string) => {
+  if (table === 'rmm_integrations') {
+    return createRmmIntegrationBuilder();
+  }
+  if (table === 'tenant_extension_install as install') {
+    return createExtensionInstallBuilder();
+  }
+  throw new Error(`Unexpected table: ${table}`);
+}));
+knexMock.schema = {
+  hasTable: vi.fn(async (table: string) => fixture.hasExtensionTables && (table === 'tenant_extension_install' || table === 'extension_registry'))
+};
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => ({ knex: knexMock, tenant: fixture.tenant })),
+  auditLog: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => (input: unknown) => fn({ user_id: 'user-1', user_type: 'internal', roles: [] }, { tenant: fixture.tenant }, input),
+  hasPermission: vi.fn().mockResolvedValue(true),
+  getCurrentUser: vi.fn().mockResolvedValue({ user_id: 'user-1', user_type: 'internal', roles: [] }),
+  preCheckDeletion: vi.fn()
+}));
+
+vi.mock('@alga-psa/core', () => ({
+  deleteEntityWithValidation: vi.fn()
+}));
+
+vi.mock('@alga-psa/analytics', () => ({
+  analytics: { capture: vi.fn() }
+}));
+
+vi.mock('@alga-psa/db/workDate', () => ({
+  computeWorkDateFields: vi.fn(() => ({ localDate: '2026-01-01' })),
+  resolveUserTimeZone: vi.fn(() => 'America/New_York')
+}), { virtual: true });
+
+vi.mock('@alga-psa/workflows/runtime', () => {
+  return {
+    WorkflowRuntimeV2: class {},
+    initializeWorkflowRuntimeV2: vi.fn(),
+    getNodeTypeRegistry: vi.fn(() => ({ list: () => [] })),
+    getSchemaRegistry: vi.fn(() => ({ has: () => false, toJsonSchema: () => ({}), listRefs: () => [] })),
+    applyRedactions: vi.fn((input) => input),
+    isWorkflowEventTrigger: vi.fn(() => false),
+    isWorkflowOneTimeScheduleTrigger: vi.fn(() => false),
+    isWorkflowRecurringScheduleTrigger: vi.fn(() => false),
+    isWorkflowTimeTrigger: vi.fn(() => false),
+    resolveActionCallOutputSchema: vi.fn(() => null),
+    zodToWorkflowJsonSchema: vi.fn(() => ({})),
+    validateWorkflowDefinition: vi.fn(() => ({ errors: [], warnings: [] })),
+    validateInputMapping: vi.fn(() => ({ ok: true, errors: [] })),
+    resolveInputMapping: vi.fn(() => ({})),
+    createSecretResolverFromProvider: vi.fn(() => vi.fn()),
+    verifySecretsExist: vi.fn(async () => ({ missing: [] })),
+    workflowDefinitionSchema: z.record(z.any()),
+    getActionRegistryV2: () => ({
+      list: () => [
+        {
+          id: 'ninjaone.devices.find',
+          version: 1,
+          sideEffectful: false,
+          idempotency: { mode: 'none' },
+          ui: { label: 'Find devices', description: 'Find NinjaOne devices', icon: 'ninjaone' },
+          inputSchema: z.object({}),
+          outputSchema: z.object({})
+        },
+        {
+          id: 'acme.sync.records',
+          version: 1,
+          sideEffectful: false,
+          idempotency: { mode: 'none' },
+          ui: { label: 'Sync records', description: 'Sync ACME records', icon: 'app' },
+          inputSchema: z.object({}),
+          outputSchema: z.object({})
+        }
+      ]
+    }),
+    getWorkflowIntegrationModuleRegistry: () => ({
+      list: () => [
+        {
+          groupKey: 'app:ninjaone',
+          label: 'NinjaOne',
+          description: 'NinjaOne module',
+          tileKind: 'app',
+          iconToken: 'ninjaone',
+          defaultActionId: 'ninjaone.devices.find',
+          allowedActionIds: ['ninjaone.devices.find'],
+          availabilityKey: 'rmm:ninjaone'
+        }
+      ]
+    }),
+    buildWorkflowDesignerActionCatalog: () => [
+      {
+        groupKey: 'ticket',
+        label: 'Ticket',
+        iconToken: 'ticket',
+        tileKind: 'core-object',
+        allowedActionIds: ['tickets.create'],
+        actions: []
+      },
+      {
+        groupKey: 'app:ninjaone',
+        label: 'NinjaOne',
+        iconToken: 'ninjaone',
+        tileKind: 'app',
+        allowedActionIds: ['ninjaone.devices.find'],
+        actions: []
+      },
+      {
+        groupKey: 'app:acme.sync',
+        label: 'Acme Sync',
+        iconToken: 'app',
+        tileKind: 'app',
+        allowedActionIds: ['acme.sync.records'],
+        actions: []
+      }
+    ]
+  };
+});
+
+import { listWorkflowDesignerActionCatalogAction } from './workflow-runtime-v2-actions';
+
+describe('workflow designer catalog integration module filtering', () => {
+  beforeEach(() => {
+    fixture.tenant = 'tenant-a';
+    fixture.hasExtensionTables = false;
+    fixture.ninjaOneActive = false;
+    fixture.extensionInstallRows = [];
+    knexMock.mockClear();
+    knexMock.schema.hasTable.mockClear();
+  });
+
+  it('T003: tenant with active NinjaOne integration receives NinjaOne designer catalog record', async () => {
+    fixture.ninjaOneActive = true;
+
+    const catalog = await listWorkflowDesignerActionCatalogAction();
+
+    expect(catalog.some((record) => record.groupKey === 'app:ninjaone')).toBe(true);
+  });
+
+  it('T004: tenant without active/connected NinjaOne integration does not receive NinjaOne catalog record', async () => {
+    fixture.ninjaOneActive = false;
+
+    const catalog = await listWorkflowDesignerActionCatalogAction();
+
+    expect(catalog.some((record) => record.groupKey === 'app:ninjaone')).toBe(false);
+  });
+
+  it('T005: extension app filtering remains enabled alongside first-party integration filtering', async () => {
+    fixture.ninjaOneActive = true;
+    fixture.hasExtensionTables = true;
+    fixture.extensionInstallRows = [{ publisher: 'acme', name: 'sync' }];
+
+    const catalog = await listWorkflowDesignerActionCatalogAction();
+
+    expect(catalog.some((record) => record.groupKey === 'app:ninjaone')).toBe(true);
+    expect(catalog.some((record) => record.groupKey === 'app:acme.sync')).toBe(true);
+  });
+});

--- a/ee/packages/workflows/src/lib/__tests__/workflowRuntimeV2Temporal.contract.test.ts
+++ b/ee/packages/workflows/src/lib/__tests__/workflowRuntimeV2Temporal.contract.test.ts
@@ -4,6 +4,8 @@ import {
   WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW,
+  WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+  WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
   signalWorkflowRuntimeV2Event,
   signalWorkflowRuntimeV2HumanTask,
   startWorkflowRuntimeV2TemporalRun,
@@ -73,6 +75,8 @@ describe('workflow runtime v2 Temporal contract', () => {
       expect.objectContaining({
         taskQueue: WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
         workflowId: 'workflow-runtime-v2:run:run-1',
+        workflowExecutionTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+        workflowRunTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
       }),
     );
     expect(result).toEqual({

--- a/ee/packages/workflows/src/lib/workflowRuntimeV2Temporal.ts
+++ b/ee/packages/workflows/src/lib/workflowRuntimeV2Temporal.ts
@@ -4,6 +4,8 @@ export {
   WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW,
+  WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+  WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
   type WorkflowRuntimeV2TemporalRunInput,
 } from './workflowRuntimeV2TemporalContract';
 
@@ -13,11 +15,17 @@ import {
   WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
   WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW,
+  WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+  WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
   type WorkflowRuntimeV2TemporalRunInput,
 } from './workflowRuntimeV2TemporalContract';
 
 const DEFAULT_TEMPORAL_ADDRESS = 'temporal-frontend.temporal.svc.cluster.local:7233';
 const DEFAULT_TEMPORAL_NAMESPACE = 'default';
+
+const resolveWorkflowRuntimeV2TemporalTimeout = <T extends string>(value: string | undefined, fallback: T): T => {
+  return (value?.trim() || fallback) as T;
+};
 
 export async function startWorkflowRuntimeV2TemporalRun(
   input: WorkflowRuntimeV2TemporalRunInput
@@ -36,6 +44,14 @@ export async function startWorkflowRuntimeV2TemporalRun(
     const handle = await client.workflow.start(WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW, {
       taskQueue: WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
       workflowId: temporalWorkflowId,
+      workflowExecutionTimeout: resolveWorkflowRuntimeV2TemporalTimeout(
+        process.env.WORKFLOW_RUNTIME_V2_TEMPORAL_EXECUTION_TIMEOUT,
+        WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT
+      ),
+      workflowRunTimeout: resolveWorkflowRuntimeV2TemporalTimeout(
+        process.env.WORKFLOW_RUNTIME_V2_TEMPORAL_RUN_TIMEOUT,
+        WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT
+      ),
       args: [input],
     });
 

--- a/ee/packages/workflows/src/lib/workflowRuntimeV2TemporalContract.ts
+++ b/ee/packages/workflows/src/lib/workflowRuntimeV2TemporalContract.ts
@@ -1,5 +1,7 @@
 export const WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE = 'workflow-runtime-v2';
 export const WORKFLOW_RUNTIME_V2_TEMPORAL_WORKFLOW = 'workflowRuntimeV2RunWorkflow';
+export const WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT = '30d';
+export const WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT = '30d';
 export const WORKFLOW_RUNTIME_V2_EVENT_SIGNAL = 'workflowRuntimeV2Event';
 export const WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL = 'workflowRuntimeV2HumanTask';
 export const WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL = 'workflowRuntimeV2QuotaResume';

--- a/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
+++ b/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@alga-psa/db/workDate', () => ({
   computeWorkDateFields: vi.fn(() => ({ localDate: '2026-01-01' })),
   resolveUserTimeZone: vi.fn(() => 'America/New_York')
-}), { virtual: true });
+}));
 
 const NINJAONE_ACTION_IDS = [
   'ninjaone.devices.find',

--- a/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
+++ b/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/db/workDate', () => ({
+  computeWorkDateFields: vi.fn(() => ({ localDate: '2026-01-01' })),
+  resolveUserTimeZone: vi.fn(() => 'America/New_York')
+}), { virtual: true });
+
+const NINJAONE_ACTION_IDS = [
+  'ninjaone.devices.find',
+  'ninjaone.devices.sync',
+  'ninjaone.devices.reboot',
+  'ninjaone.alerts.list_active',
+  'ninjaone.alerts.get',
+  'ninjaone.alerts.reset'
+] as const;
+
+const loadNinjaOneActions = async (entry: 'bootstrap' | 'worker') => {
+  vi.resetModules();
+  const runtime = await import(entry === 'bootstrap' ? '../bootstrap' : '../worker');
+  const { getActionRegistryV2 } = await import('../../../../../../shared/workflow/runtime/registries/actionRegistry');
+  runtime.initializeWorkflowRuntimeV2();
+  return getActionRegistryV2().list().filter((action) => action.id.startsWith('ninjaone.'));
+};
+
+describe('NinjaOne workflow action runtime registration', () => {
+  it('T006: bootstrap runtime includes the six NinjaOne workflow action IDs', async () => {
+    const actions = await loadNinjaOneActions('bootstrap');
+    const ids = actions.map((action) => action.id).sort();
+    expect(ids).toEqual([...NINJAONE_ACTION_IDS].sort());
+  });
+
+  it('T006: worker runtime includes the same six NinjaOne workflow action IDs', async () => {
+    const actions = await loadNinjaOneActions('worker');
+    const ids = actions.map((action) => action.id).sort();
+    expect(ids).toEqual([...NINJAONE_ACTION_IDS].sort());
+  });
+
+  it('T007: NinjaOne action metadata exposes side-effect/idempotency and acknowledge-alert UI wording', async () => {
+    const actions = await loadNinjaOneActions('bootstrap');
+    const byId = new Map(actions.map((action) => [action.id, action]));
+
+    expect(byId.get('ninjaone.devices.find')?.sideEffectful).toBe(false);
+    expect(byId.get('ninjaone.alerts.list_active')?.sideEffectful).toBe(false);
+
+    for (const id of ['ninjaone.devices.sync', 'ninjaone.devices.reboot', 'ninjaone.alerts.reset'] as const) {
+      expect(byId.get(id)?.sideEffectful).toBe(true);
+      expect(byId.get(id)?.idempotency.mode).toBe('engineProvided');
+    }
+
+    const resetAction = byId.get('ninjaone.alerts.reset');
+    expect(resetAction?.ui?.label).toBe('Acknowledge alert');
+    expect(resetAction?.ui?.description).toContain('NinjaOne reset alert operation');
+  });
+});

--- a/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
+++ b/ee/packages/workflows/src/runtime/__tests__/ninjaOneWorkflowActions.registration.test.ts
@@ -51,4 +51,32 @@ describe('NinjaOne workflow action runtime registration', () => {
     expect(resetAction?.ui?.label).toBe('Acknowledge alert');
     expect(resetAction?.ui?.description).toContain('NinjaOne reset alert operation');
   });
+
+  it('T014: NinjaOne actions expose input/output schemas for action.call configuration', async () => {
+    const actions = await loadNinjaOneActions('bootstrap');
+    const getAlert = actions.find((action) => action.id === 'ninjaone.alerts.get');
+    const listActive = actions.find((action) => action.id === 'ninjaone.alerts.list_active');
+
+    expect(getAlert).toBeDefined();
+    expect(listActive).toBeDefined();
+    expect(getAlert!.inputSchema.safeParse({ alert_uid: 'uid-1' }).success).toBe(true);
+    expect(getAlert!.outputSchema.safeParse({
+      alert: {
+        alert_id: 'a1',
+        external_alert_id: 'ext-a1',
+        status: 'active',
+        severity: 'high',
+        priority: 'p1',
+        title: 'Alert',
+        message: 'CPU high',
+        device_id: 'd1',
+        asset_id: null,
+        source_type: 'monitor',
+        created_at: '2026-05-10T00:00:00.000Z',
+        updated_at: '2026-05-10T00:01:00.000Z',
+        acknowledged: false
+      }
+    }).success).toBe(true);
+    expect(listActive!.outputSchema.safeParse({ alerts: [], count: 0 }).success).toBe(true);
+  });
 });

--- a/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
@@ -60,15 +60,31 @@ const createKnexForFind = () => {
   return knex;
 };
 
+const createActiveIntegrationBuilder = () => ({
+  where: vi.fn().mockReturnThis(),
+  whereNotNull: vi.fn().mockReturnThis(),
+  first: vi.fn().mockResolvedValue({ integration_id: 'int-1' })
+});
+
+const createInactiveIntegrationBuilder = () => ({
+  where: vi.fn().mockReturnThis(),
+  whereNotNull: vi.fn().mockReturnThis(),
+  first: vi.fn().mockResolvedValue(undefined)
+});
+
+const loadActionById = async (actionId: string) => {
+  vi.resetModules();
+  const { registerNinjaOneWorkflowActionsV2 } = await import('../registerNinjaOneWorkflowActions');
+  const { getActionRegistryV2 } = await import('../../../../../../../shared/workflow/runtime/registries/actionRegistry');
+  registerNinjaOneWorkflowActionsV2();
+  const action = getActionRegistryV2().listById(actionId)[0];
+  expect(action).toBeDefined();
+  return action!;
+};
+
 describe('NinjaOne workflow action handlers', () => {
   it('T008: ninjaone.devices.find returns normalized local device fields without secret leakage', async () => {
-    vi.resetModules();
-    const { registerNinjaOneWorkflowActionsV2 } = await import('../registerNinjaOneWorkflowActions');
-    const { getActionRegistryV2 } = await import('../../../../../../../shared/workflow/runtime/registries/actionRegistry');
-
-    registerNinjaOneWorkflowActionsV2();
-    const action = getActionRegistryV2().listById('ninjaone.devices.find')[0];
-    expect(action).toBeDefined();
+    const action = await loadActionById('ninjaone.devices.find');
 
     const result = await action!.handler(
       { limit: 10, live: false },
@@ -97,5 +113,127 @@ describe('NinjaOne workflow action handlers', () => {
     ]);
     expect(JSON.stringify(result)).not.toContain('secret_ref');
     expect(JSON.stringify(result)).not.toContain('should-not-leak');
+  });
+
+  it('T009: ninjaone.devices.sync delegates to sync strategy and returns synced identifiers', async () => {
+    const action = await loadActionById('ninjaone.devices.sync');
+    const syncDevice = vi.fn().mockResolvedValue({ asset_id: '550e8400-e29b-41d4-a716-446655440000' });
+    const syncStrategyModule = await import('../../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy');
+    vi.mocked(syncStrategyModule.getNinjaOneSyncStrategy).mockReturnValue({ syncDevice } as any);
+
+    const knex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await action.handler({ device_id: '123' }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
+    expect(syncDevice).toHaveBeenCalledWith({ tenantId: 'tenant-1', integrationId: 'int-1', deviceId: 123 });
+    expect(result).toEqual({
+      synced: true,
+      external_device_id: '123',
+      asset_id: '550e8400-e29b-41d4-a716-446655440000'
+    });
+  });
+
+  it('T010: ninjaone.devices.reboot guards inactive integration and delegates reboot on success', async () => {
+    const action = await loadActionById('ninjaone.devices.reboot');
+    const ninjaModule = await import('../../../../../../server/src/lib/integrations/ninjaone');
+    const rebootDevice = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(ninjaModule.createNinjaOneClient).mockResolvedValue({ rebootDevice } as any);
+
+    const inactiveKnex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createInactiveIntegrationBuilder();
+      throw new Error(`Unexpected table ${table}`);
+    });
+    await expect(action.handler({ device_id: 12 }, { ...baseCtx, tenantId: 'tenant-1', knex: inactiveKnex } as any))
+      .rejects.toThrow(/not active/i);
+
+    const activeKnex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const result = await action.handler({ device_id: 12 }, { ...baseCtx, tenantId: 'tenant-1', knex: activeKnex } as any);
+    expect(rebootDevice).toHaveBeenCalledWith(12);
+    expect(result).toEqual({ reboot_requested: true, external_device_id: '12' });
+  });
+
+  it('T011: ninjaone.alerts.list_active returns normalized active alert fields for ticket mappings', async () => {
+    const action = await loadActionById('ninjaone.alerts.list_active');
+    const alertsRows = [{
+      alert_id: 'a1',
+      external_alert_id: 'ext-a1',
+      status: 'active',
+      severity: 'high',
+      message: 'CPU critical',
+      external_device_id: 'dev-1',
+      asset_id: '550e8400-e29b-41d4-a716-446655440000',
+      triggered_at: '2026-05-10T12:00:00.000Z',
+      updated_at: '2026-05-10T12:10:00.000Z'
+    }];
+    const alertsBuilder: any = {
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue(alertsRows)
+    };
+    const knex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      if (table === 'rmm_alerts') return alertsBuilder;
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await action.handler({ limit: 10, live: false }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
+    expect(result.count).toBe(1);
+    expect(result.alerts[0]).toMatchObject({
+      alert_id: 'a1',
+      external_alert_id: 'ext-a1',
+      severity: 'high',
+      device_id: 'dev-1',
+      asset_id: '550e8400-e29b-41d4-a716-446655440000',
+      message: 'CPU critical'
+    });
+  });
+
+  it('T012: ninjaone.alerts.get supports lookup and returns not-found failure when missing', async () => {
+    const action = await loadActionById('ninjaone.alerts.get');
+    const foundBuilder: any = {
+      where: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue({ external_alert_id: 'ext-a1', status: 'active', alert_id: 'a1' })
+    };
+    const foundKnex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      if (table === 'rmm_alerts') return foundBuilder;
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const found = await action.handler({ external_alert_id: 'ext-a1' }, { ...baseCtx, tenantId: 'tenant-1', knex: foundKnex } as any);
+    expect(found.alert.external_alert_id).toBe('ext-a1');
+
+    const missingBuilder: any = { where: vi.fn().mockReturnThis(), first: vi.fn().mockResolvedValue(undefined) };
+    const missingKnex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      if (table === 'rmm_alerts') return missingBuilder;
+      throw new Error(`Unexpected table ${table}`);
+    });
+    await expect(action.handler({ alert_uid: 'missing' }, { ...baseCtx, tenantId: 'tenant-1', knex: missingKnex } as any))
+      .rejects.toThrow(/not found/i);
+  });
+
+  it('T013: ninjaone.alerts.reset calls reset operation and returns acknowledged output', async () => {
+    const action = await loadActionById('ninjaone.alerts.reset');
+    const ninjaModule = await import('../../../../../../server/src/lib/integrations/ninjaone');
+    const resetAlert = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(ninjaModule.createNinjaOneClient).mockResolvedValue({ resetAlert } as any);
+
+    const update = vi.fn().mockResolvedValue(1);
+    const alertsBuilder: any = { where: vi.fn().mockReturnThis(), update };
+    const knex: any = vi.fn((table: string) => {
+      if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
+      if (table === 'rmm_alerts') return alertsBuilder;
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await action.handler({ external_alert_id: 'ext-a1' }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
+    expect(resetAlert).toHaveBeenCalledWith('ext-a1');
+    expect(update).toHaveBeenCalled();
+    expect(result).toEqual({ acknowledged: true, alert_id: 'ext-a1' });
   });
 });

--- a/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
@@ -23,15 +23,16 @@ const createKnexForFind = () => {
       asset_id: '550e8400-e29b-41d4-a716-446655440000',
       rmm_device_id: '123',
       rmm_organization_id: 'org-1',
-      hostname: 'srv-1',
       name: 'Server 1',
-      last_seen_at: '2026-05-10T12:00:00.000Z',
+      agent_status: 'online',
+      last_seen_at: new Date('2026-05-10T12:00:00.000Z'),
       secret_ref: 'should-not-leak'
     }
   ];
 
   const assetsBuilder: any = {
     where: vi.fn().mockReturnThis(),
+    whereNotNull: vi.fn().mockReturnThis(),
     modify: vi.fn().mockImplementation((cb: (qb: any) => void) => {
       cb({
         andWhere: vi.fn(),
@@ -101,7 +102,7 @@ describe('NinjaOne workflow action handlers', () => {
         external_device_id: '123',
         asset_id: '550e8400-e29b-41d4-a716-446655440000',
         organization_id: 'org-1',
-        hostname: 'srv-1',
+        hostname: null,
         display_name: 'Server 1',
         dns_name: null,
         agent_online: true,
@@ -126,7 +127,7 @@ describe('NinjaOne workflow action handlers', () => {
       throw new Error(`Unexpected table ${table}`);
     });
 
-    const result = await action.handler({ device_id: '123' }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
+    const result = await action.handler({ device_id: 123 }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
     expect(syncDevice).toHaveBeenCalledWith({ tenantId: 'tenant-1', integrationId: 'int-1', deviceId: 123 });
     expect(result).toEqual({
       synced: true,
@@ -167,8 +168,9 @@ describe('NinjaOne workflow action handlers', () => {
       message: 'CPU critical',
       external_device_id: 'dev-1',
       asset_id: '550e8400-e29b-41d4-a716-446655440000',
-      triggered_at: '2026-05-10T12:00:00.000Z',
-      updated_at: '2026-05-10T12:10:00.000Z'
+      integration_id: 'int-1',
+      triggered_at: new Date('2026-05-10T12:00:00.000Z'),
+      updated_at: new Date('2026-05-10T12:10:00.000Z')
     }];
     const alertsBuilder: any = {
       where: vi.fn().mockReturnThis(),
@@ -182,6 +184,7 @@ describe('NinjaOne workflow action handlers', () => {
     });
 
     const result = await action.handler({ limit: 10, live: false }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
+    expect(alertsBuilder.where).toHaveBeenCalledWith({ tenant: 'tenant-1', integration_id: 'int-1', status: 'active' });
     expect(result.count).toBe(1);
     expect(result.alerts[0]).toMatchObject({
       alert_id: 'a1',
@@ -205,6 +208,7 @@ describe('NinjaOne workflow action handlers', () => {
       throw new Error(`Unexpected table ${table}`);
     });
     const found = await action.handler({ external_alert_id: 'ext-a1' }, { ...baseCtx, tenantId: 'tenant-1', knex: foundKnex } as any);
+    expect(foundBuilder.where).toHaveBeenCalledWith({ tenant: 'tenant-1', integration_id: 'int-1', external_alert_id: 'ext-a1' });
     expect(found.alert.external_alert_id).toBe('ext-a1');
 
     const missingBuilder: any = { where: vi.fn().mockReturnThis(), first: vi.fn().mockResolvedValue(undefined) };
@@ -233,6 +237,7 @@ describe('NinjaOne workflow action handlers', () => {
 
     const result = await action.handler({ external_alert_id: 'ext-a1' }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
     expect(resetAlert).toHaveBeenCalledWith('ext-a1');
+    expect(alertsBuilder.where).toHaveBeenCalledWith({ tenant: 'tenant-1', integration_id: 'int-1', external_alert_id: 'ext-a1' });
     expect(update).toHaveBeenCalled();
     expect(result).toEqual({ acknowledged: true, alert_id: 'ext-a1' });
   });

--- a/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../../../../../server/src/lib/integrations/ninjaone', () => ({
-  createNinjaOneClient: vi.fn()
-}));
-
-vi.mock('../../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy', () => ({
-  getNinjaOneSyncStrategy: vi.fn(() => ({ syncDevice: vi.fn() }))
+vi.mock('../ninjaOneWorkflowRuntimeSupport', () => ({
+  createNinjaOneWorkflowClient: vi.fn(),
+  syncNinjaOneDevice: vi.fn()
 }));
 
 const baseCtx = {
@@ -118,9 +115,8 @@ describe('NinjaOne workflow action handlers', () => {
 
   it('T009: ninjaone.devices.sync delegates to sync strategy and returns synced identifiers', async () => {
     const action = await loadActionById('ninjaone.devices.sync');
-    const syncDevice = vi.fn().mockResolvedValue({ asset_id: '550e8400-e29b-41d4-a716-446655440000' });
-    const syncStrategyModule = await import('../../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy');
-    vi.mocked(syncStrategyModule.getNinjaOneSyncStrategy).mockReturnValue({ syncDevice } as any);
+    const supportModule = await import('../ninjaOneWorkflowRuntimeSupport');
+    vi.mocked(supportModule.syncNinjaOneDevice).mockResolvedValue({ asset_id: '550e8400-e29b-41d4-a716-446655440000' });
 
     const knex: any = vi.fn((table: string) => {
       if (table === 'rmm_integrations') return createActiveIntegrationBuilder();
@@ -128,7 +124,7 @@ describe('NinjaOne workflow action handlers', () => {
     });
 
     const result = await action.handler({ device_id: 123 }, { ...baseCtx, tenantId: 'tenant-1', knex } as any);
-    expect(syncDevice).toHaveBeenCalledWith({ tenantId: 'tenant-1', integrationId: 'int-1', deviceId: 123 });
+    expect(supportModule.syncNinjaOneDevice).toHaveBeenCalledWith({ tenantId: 'tenant-1', integrationId: 'int-1', deviceId: 123 });
     expect(result).toEqual({
       synced: true,
       external_device_id: '123',
@@ -138,9 +134,9 @@ describe('NinjaOne workflow action handlers', () => {
 
   it('T010: ninjaone.devices.reboot guards inactive integration and delegates reboot on success', async () => {
     const action = await loadActionById('ninjaone.devices.reboot');
-    const ninjaModule = await import('../../../../../../server/src/lib/integrations/ninjaone');
+    const supportModule = await import('../ninjaOneWorkflowRuntimeSupport');
     const rebootDevice = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(ninjaModule.createNinjaOneClient).mockResolvedValue({ rebootDevice } as any);
+    vi.mocked(supportModule.createNinjaOneWorkflowClient).mockResolvedValue({ rebootDevice } as any);
 
     const inactiveKnex: any = vi.fn((table: string) => {
       if (table === 'rmm_integrations') return createInactiveIntegrationBuilder();
@@ -223,9 +219,9 @@ describe('NinjaOne workflow action handlers', () => {
 
   it('T013: ninjaone.alerts.reset calls reset operation and returns acknowledged output', async () => {
     const action = await loadActionById('ninjaone.alerts.reset');
-    const ninjaModule = await import('../../../../../../server/src/lib/integrations/ninjaone');
+    const supportModule = await import('../ninjaOneWorkflowRuntimeSupport');
     const resetAlert = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(ninjaModule.createNinjaOneClient).mockResolvedValue({ resetAlert } as any);
+    vi.mocked(supportModule.createNinjaOneWorkflowClient).mockResolvedValue({ resetAlert } as any);
 
     const update = vi.fn().mockResolvedValue(1);
     const alertsBuilder: any = { where: vi.fn().mockReturnThis(), update };

--- a/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/ninjaOneWorkflowActions.handlers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../../../server/src/lib/integrations/ninjaone', () => ({
+  createNinjaOneClient: vi.fn()
+}));
+
+vi.mock('../../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy', () => ({
+  getNinjaOneSyncStrategy: vi.fn(() => ({ syncDevice: vi.fn() }))
+}));
+
+const baseCtx = {
+  runId: 'run-1',
+  stepPath: 'root.steps[0]',
+  idempotencyKey: 'idem-1',
+  attempt: 1,
+  nowIso: () => new Date().toISOString(),
+  env: {}
+};
+
+const createKnexForFind = () => {
+  const assetsRows = [
+    {
+      asset_id: '550e8400-e29b-41d4-a716-446655440000',
+      rmm_device_id: '123',
+      rmm_organization_id: 'org-1',
+      hostname: 'srv-1',
+      name: 'Server 1',
+      last_seen_at: '2026-05-10T12:00:00.000Z',
+      secret_ref: 'should-not-leak'
+    }
+  ];
+
+  const assetsBuilder: any = {
+    where: vi.fn().mockReturnThis(),
+    modify: vi.fn().mockImplementation((cb: (qb: any) => void) => {
+      cb({
+        andWhere: vi.fn(),
+        andWhereILike: vi.fn(),
+        orWhereILike: vi.fn(),
+        whereILike: vi.fn(),
+        where: vi.fn()
+      });
+      return assetsBuilder;
+    }),
+    limit: vi.fn().mockResolvedValue(assetsRows)
+  };
+
+  const integrationBuilder: any = {
+    where: vi.fn().mockReturnThis(),
+    whereNotNull: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ integration_id: 'int-1' })
+  };
+
+  const knex: any = vi.fn((table: string) => {
+    if (table === 'rmm_integrations') return integrationBuilder;
+    if (table === 'assets') return assetsBuilder;
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  return knex;
+};
+
+describe('NinjaOne workflow action handlers', () => {
+  it('T008: ninjaone.devices.find returns normalized local device fields without secret leakage', async () => {
+    vi.resetModules();
+    const { registerNinjaOneWorkflowActionsV2 } = await import('../registerNinjaOneWorkflowActions');
+    const { getActionRegistryV2 } = await import('../../../../../../../shared/workflow/runtime/registries/actionRegistry');
+
+    registerNinjaOneWorkflowActionsV2();
+    const action = getActionRegistryV2().listById('ninjaone.devices.find')[0];
+    expect(action).toBeDefined();
+
+    const result = await action!.handler(
+      { limit: 10, live: false },
+      {
+        ...baseCtx,
+        tenantId: 'tenant-1',
+        knex: createKnexForFind()
+      } as any
+    );
+
+    expect(result.count).toBe(1);
+    expect(result.devices).toEqual([
+      {
+        external_device_id: '123',
+        asset_id: '550e8400-e29b-41d4-a716-446655440000',
+        organization_id: 'org-1',
+        hostname: 'srv-1',
+        display_name: 'Server 1',
+        dns_name: null,
+        agent_online: true,
+        last_seen_at: '2026-05-10T12:00:00.000Z',
+        os_name: null,
+        node_class: null,
+        source: 'local'
+      }
+    ]);
+    expect(JSON.stringify(result)).not.toContain('secret_ref');
+    expect(JSON.stringify(result)).not.toContain('should-not-leak');
+  });
+});

--- a/ee/packages/workflows/src/runtime/actions/ninjaOneWorkflowRuntimeSupport.ts
+++ b/ee/packages/workflows/src/runtime/actions/ninjaOneWorkflowRuntimeSupport.ts
@@ -1,0 +1,313 @@
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+
+const NINJAONE_CLIENT_ID_SECRET = 'ninjaone_client_id';
+const NINJAONE_CLIENT_SECRET_SECRET = 'ninjaone_client_secret';
+const NINJAONE_CREDENTIALS_SECRET = 'ninjaone_credentials';
+const DEFAULT_NINJAONE_INSTANCE_URL = 'https://app.ninjarmm.com';
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const DEFAULT_TEMPORAL_ADDRESS = 'temporal-frontend.temporal.svc.cluster.local:7233';
+const DEFAULT_TEMPORAL_NAMESPACE = 'default';
+const DEFAULT_NINJAONE_SYNC_TASK_QUEUE = 'alga-jobs';
+
+type NinjaOneOAuthCredentials = {
+  access_token: string;
+  refresh_token?: string;
+  expires_at: number;
+  instance_url?: string;
+};
+
+type NinjaOneTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+};
+
+export type NinjaOneWorkflowClient = {
+  getDevice(deviceId: number): Promise<Record<string, unknown>>;
+  getDevices(params?: { pageSize?: number; df?: string }): Promise<Record<string, unknown>[]>;
+  getAlerts(params?: { pageSize?: number }): Promise<Record<string, unknown>[]>;
+  rebootDevice(deviceId: number): Promise<void>;
+  resetAlert(alertUid: string): Promise<void>;
+};
+
+type FetchRequestOptions = {
+  method?: 'GET' | 'POST';
+  query?: Record<string, string | number | undefined>;
+  retryOnUnauthorized?: boolean;
+};
+
+const normalizeInstanceUrl = (instanceUrl: string): string => instanceUrl.replace(/\/+$/, '').replace(/\/api(?:\/v2)?$/, '');
+
+const buildApiBaseUrl = (instanceUrl: string): string => `${normalizeInstanceUrl(instanceUrl)}/api/v2`;
+
+const getResponseText = async (response: Response): Promise<string> => {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+};
+
+const parseJsonResponse = async (response: Response): Promise<unknown> => {
+  const text = await getResponseText(response);
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const extractCursorFromLink = (linkHeader: string | null): string | undefined => {
+  if (!linkHeader) return undefined;
+  const nextLink = linkHeader
+    .split(',')
+    .map((part) => part.trim())
+    .find((part) => /rel="?next"?/i.test(part));
+  if (!nextLink) return undefined;
+
+  const urlMatch = nextLink.match(/<([^>]+)>/);
+  if (!urlMatch?.[1]) return undefined;
+
+  try {
+    const parsed = new URL(urlMatch[1]);
+    return parsed.searchParams.get('after') ?? parsed.searchParams.get('cursor') ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const asRecordArray = (value: unknown, collectionKey: string): { items: Record<string, unknown>[]; cursor?: string } => {
+  if (Array.isArray(value)) {
+    return { items: value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item)) };
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    const collection = record[collectionKey];
+    if (Array.isArray(collection)) {
+      return {
+        items: collection.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item)),
+        cursor: typeof record.cursor === 'string' ? record.cursor : undefined,
+      };
+    }
+  }
+  return { items: [] };
+};
+
+class FetchNinjaOneWorkflowClient implements NinjaOneWorkflowClient {
+  private credentials: NinjaOneOAuthCredentials | null = null;
+  private refreshPromise: Promise<void> | null = null;
+
+  constructor(private readonly tenantId: string) {}
+
+  private async loadCredentials(): Promise<NinjaOneOAuthCredentials | null> {
+    if (this.credentials) return this.credentials;
+    const secretProvider = await getSecretProviderInstance();
+    const credentialsJson = await secretProvider.getTenantSecret(this.tenantId, NINJAONE_CREDENTIALS_SECRET);
+    if (!credentialsJson) return null;
+    const credentials = JSON.parse(credentialsJson) as NinjaOneOAuthCredentials;
+    this.credentials = credentials;
+    return credentials;
+  }
+
+  private async saveCredentials(credentials: NinjaOneOAuthCredentials): Promise<void> {
+    const secretProvider = await getSecretProviderInstance();
+    await secretProvider.setTenantSecret(this.tenantId, NINJAONE_CREDENTIALS_SECRET, JSON.stringify(credentials));
+    this.credentials = credentials;
+  }
+
+  private async resolveClientCredentials(): Promise<{ clientId?: string; clientSecret?: string }> {
+    const secretProvider = await getSecretProviderInstance();
+    const tenantClientId = await secretProvider.getTenantSecret(this.tenantId, NINJAONE_CLIENT_ID_SECRET);
+    const tenantClientSecret = await secretProvider.getTenantSecret(this.tenantId, NINJAONE_CLIENT_SECRET_SECRET);
+
+    return {
+      clientId: tenantClientId || await secretProvider.getAppSecret(NINJAONE_CLIENT_ID_SECRET) || process.env.NINJAONE_CLIENT_ID,
+      clientSecret: tenantClientSecret || await secretProvider.getAppSecret(NINJAONE_CLIENT_SECRET_SECRET) || process.env.NINJAONE_CLIENT_SECRET,
+    };
+  }
+
+  private async getValidAccessToken(): Promise<string> {
+    const credentials = await this.loadCredentials();
+    if (!credentials?.access_token) {
+      throw new Error('NinjaOne credentials are not configured for this tenant');
+    }
+
+    if (Date.now() >= credentials.expires_at - TOKEN_REFRESH_BUFFER_MS) {
+      await this.refreshAccessToken();
+    }
+
+    if (!this.credentials?.access_token) {
+      throw new Error('NinjaOne access token is unavailable after refresh');
+    }
+    return this.credentials.access_token;
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    if (this.refreshPromise) return this.refreshPromise;
+
+    this.refreshPromise = (async () => {
+      const credentials = await this.loadCredentials();
+      if (!credentials?.refresh_token) {
+        throw new Error('No NinjaOne refresh token available');
+      }
+
+      const { clientId, clientSecret } = await this.resolveClientCredentials();
+      if (!clientId || !clientSecret) {
+        throw new Error('NinjaOne client credentials are not configured');
+      }
+
+      const instanceUrl = normalizeInstanceUrl(credentials.instance_url || DEFAULT_NINJAONE_INSTANCE_URL);
+      const params = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: credentials.refresh_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+      });
+
+      const response = await fetch(`${instanceUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+
+      if (!response.ok) {
+        const body = await getResponseText(response);
+        throw new Error(`NinjaOne token refresh failed (${response.status}): ${body || response.statusText}`);
+      }
+
+      const token = await response.json() as NinjaOneTokenResponse;
+      await this.saveCredentials({
+        access_token: token.access_token,
+        refresh_token: token.refresh_token ?? credentials.refresh_token,
+        expires_at: Date.now() + token.expires_in * 1000,
+        instance_url: instanceUrl,
+      });
+    })().finally(() => {
+      this.refreshPromise = null;
+    });
+
+    return this.refreshPromise;
+  }
+
+  private async request(path: string, options: FetchRequestOptions = {}): Promise<{ data: unknown; linkHeader: string | null }> {
+    const credentials = await this.loadCredentials();
+    const instanceUrl = normalizeInstanceUrl(credentials?.instance_url || DEFAULT_NINJAONE_INSTANCE_URL);
+    const url = new URL(`${buildApiBaseUrl(instanceUrl)}${path}`);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+
+    const accessToken = await this.getValidAccessToken();
+    const response = await fetch(url.toString(), {
+      method: options.method ?? 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (response.status === 401 && options.retryOnUnauthorized !== false) {
+      await this.refreshAccessToken();
+      return this.request(path, { ...options, retryOnUnauthorized: false });
+    }
+
+    if (!response.ok) {
+      const body = await getResponseText(response);
+      throw new Error(`NinjaOne API request failed (${response.status}) for ${path}: ${body || response.statusText}`);
+    }
+
+    if (response.status === 204) {
+      return { data: null, linkHeader: response.headers.get('link') };
+    }
+
+    return {
+      data: await parseJsonResponse(response),
+      linkHeader: response.headers.get('link'),
+    };
+  }
+
+  async getDevice(deviceId: number): Promise<Record<string, unknown>> {
+    const { data } = await this.request(`/device/${deviceId}`);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new Error(`NinjaOne device ${deviceId} returned an unexpected response`);
+    }
+    return data as Record<string, unknown>;
+  }
+
+  async getDevices(params: { pageSize?: number; df?: string } = {}): Promise<Record<string, unknown>[]> {
+    const devices: Record<string, unknown>[] = [];
+    let cursor: string | undefined;
+    do {
+      const { data, linkHeader } = await this.request('/devices', {
+        query: { pageSize: params.pageSize ?? 100, df: params.df, after: cursor },
+      });
+      const page = asRecordArray(data, 'devices');
+      devices.push(...page.items);
+      cursor = extractCursorFromLink(linkHeader) ?? page.cursor;
+    } while (cursor);
+    return devices;
+  }
+
+  async getAlerts(params: { pageSize?: number } = {}): Promise<Record<string, unknown>[]> {
+    const alerts: Record<string, unknown>[] = [];
+    let cursor: string | undefined;
+    do {
+      const { data, linkHeader } = await this.request('/alerts', {
+        query: { pageSize: params.pageSize ?? 100, after: cursor },
+      });
+      const page = asRecordArray(data, 'alerts');
+      alerts.push(...page.items);
+      cursor = extractCursorFromLink(linkHeader) ?? page.cursor;
+    } while (cursor);
+    return alerts;
+  }
+
+  async rebootDevice(deviceId: number): Promise<void> {
+    await this.request(`/device/${deviceId}/control/reboot`, { method: 'POST' });
+  }
+
+  async resetAlert(alertUid: string): Promise<void> {
+    await this.request(`/alert/${encodeURIComponent(alertUid)}/reset`, { method: 'POST' });
+  }
+}
+
+export async function createNinjaOneWorkflowClient(tenantId: string, _integrationId: string): Promise<NinjaOneWorkflowClient> {
+  return new FetchNinjaOneWorkflowClient(tenantId);
+}
+
+export async function syncNinjaOneDevice(input: {
+  tenantId: string;
+  integrationId: string;
+  deviceId: number;
+}): Promise<{ asset_id?: string | null }> {
+  const temporal = await import('@temporalio/client');
+  const connection = await temporal.Connection.connect({
+    address: process.env.TEMPORAL_ADDRESS || DEFAULT_TEMPORAL_ADDRESS,
+  });
+
+  const client = new temporal.Client({
+    connection,
+    namespace: process.env.TEMPORAL_NAMESPACE || DEFAULT_TEMPORAL_NAMESPACE,
+  });
+
+  const workflowId = `ninjaone:device:${input.tenantId}:${input.deviceId}:${Date.now()}`;
+  try {
+    const handle = await client.workflow.start('ninjaOneDeviceSyncWorkflow', {
+      taskQueue: process.env.TEMPORAL_JOB_TASK_QUEUE || DEFAULT_NINJAONE_SYNC_TASK_QUEUE,
+      workflowId,
+      args: [{
+        tenantId: input.tenantId,
+        integrationId: input.integrationId,
+        deviceId: input.deviceId,
+      }],
+    });
+
+    return await handle.result();
+  } finally {
+    await connection.close().catch(() => undefined);
+  }
+}

--- a/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
+++ b/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
@@ -1,0 +1,322 @@
+import { z } from 'zod';
+import { getActionRegistryV2 } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
+import { throwActionError } from '../../../../../../shared/workflow/runtime/actions/businessOperations/shared';
+import type { ActionContext } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
+import { createNinjaOneClient } from '../../../../../server/src/lib/integrations/ninjaone';
+import { getNinjaOneSyncStrategy } from '../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy';
+
+const deviceSchema = z.object({
+  external_device_id: z.string(),
+  asset_id: z.string().uuid().nullable(),
+  organization_id: z.string().nullable(),
+  hostname: z.string().nullable(),
+  display_name: z.string().nullable(),
+  dns_name: z.string().nullable(),
+  agent_online: z.boolean(),
+  last_seen_at: z.string().nullable(),
+  os_name: z.string().nullable(),
+  node_class: z.string().nullable(),
+  source: z.enum(['local', 'ninjaone'])
+});
+
+const alertSchema = z.object({
+  alert_id: z.string(),
+  external_alert_id: z.string(),
+  status: z.string().nullable(),
+  severity: z.string().nullable(),
+  priority: z.string().nullable(),
+  title: z.string().nullable(),
+  message: z.string().nullable(),
+  device_id: z.string().nullable(),
+  asset_id: z.string().uuid().nullable(),
+  source_type: z.string().nullable(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+  acknowledged: z.boolean()
+});
+
+async function requireNinjaOneIntegration(ctx: ActionContext): Promise<{
+  tenantId: string;
+  knex: any;
+  integrationId: string;
+}> {
+  const tenantId = ctx.tenantId ?? null;
+  if (!tenantId) {
+    throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: 'tenantId is required' });
+  }
+  const knex = ctx.knex;
+  if (!knex) {
+    throwActionError(ctx, { category: 'ActionError', code: 'INTERNAL_ERROR', message: 'Database connection unavailable' });
+  }
+
+  const integration = await knex('rmm_integrations')
+    .where({ tenant: tenantId, provider: 'ninjaone', is_active: true })
+    .whereNotNull('connected_at')
+    .first();
+  if (!integration) {
+    throwActionError(ctx, {
+      category: 'ActionError',
+      code: 'INTEGRATION_INACTIVE',
+      message: 'NinjaOne integration is not active for this tenant'
+    });
+  }
+
+  return {
+    tenantId,
+    knex,
+    integrationId: String(integration.integration_id),
+  };
+}
+
+const normalizeNinjaDevice = (device: any, source: 'local' | 'ninjaone') => ({
+  external_device_id: String(device.id ?? device.rmm_device_id ?? ''),
+  asset_id: device.asset_id ?? null,
+  organization_id: device.organizationId ? String(device.organizationId) : (device.rmm_organization_id ?? null),
+  hostname: device.systemName ?? device.hostname ?? null,
+  display_name: device.displayName ?? device.name ?? null,
+  dns_name: device.dnsName ?? null,
+  agent_online: !(device.offline ?? false),
+  last_seen_at: device.lastContact ?? device.last_seen_at ?? null,
+  os_name: device.os?.name ?? null,
+  node_class: device.nodeClass ?? null,
+  source
+});
+
+const normalizeNinjaAlert = (alert: any) => ({
+  alert_id: String(alert.alert_id ?? alert.uid ?? ''),
+  external_alert_id: String(alert.external_alert_id ?? alert.uid ?? ''),
+  status: alert.status ?? 'active',
+  severity: alert.severity ?? null,
+  priority: alert.priority ?? null,
+  title: alert.sourceName ?? alert.alert_class ?? null,
+  message: alert.message ?? null,
+  device_id: alert.external_device_id ? String(alert.external_device_id) : (alert.deviceId ? String(alert.deviceId) : null),
+  asset_id: alert.asset_id ?? null,
+  source_type: alert.source_type ?? alert.sourceType ?? null,
+  created_at: alert.triggered_at ?? alert.createTime ?? null,
+  updated_at: alert.updated_at ?? alert.updateTime ?? null,
+  acknowledged: String(alert.status ?? '').toLowerCase() === 'acknowledged'
+});
+
+let ninjaOneRegistered = false;
+
+export function registerNinjaOneWorkflowActionsV2(): void {
+  if (ninjaOneRegistered) return;
+  const registry = getActionRegistryV2();
+
+  registry.register({
+    id: 'ninjaone.devices.find',
+    version: 1,
+    sideEffectful: false,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      device_id: z.union([z.string(), z.number()]).optional(),
+      asset_id: z.string().uuid().optional(),
+      query: z.string().optional(),
+      live: z.boolean().default(false),
+      limit: z.number().int().min(1).max(200).default(50)
+    }),
+    outputSchema: z.object({
+      devices: z.array(deviceSchema),
+      count: z.number().int()
+    }),
+    ui: {
+      label: 'Find devices',
+      description: 'Find NinjaOne devices from synced records and optional live API lookup.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
+      let rows = await knex('assets')
+        .where({ tenant: tenantId, rmm_provider: 'ninjaone' })
+        .modify((qb: any) => {
+          if (input.asset_id) qb.andWhere('asset_id', input.asset_id);
+          if (input.device_id !== undefined) qb.andWhere('rmm_device_id', String(input.device_id));
+          if (input.query) {
+            qb.andWhere((inner: any) => {
+              inner.whereILike('name', `%${input.query}%`).orWhereILike('hostname', `%${input.query}%`);
+            });
+          }
+        })
+        .limit(input.limit);
+
+      const localDevices = rows.map((row: any) => normalizeNinjaDevice(row, 'local'));
+      if (!input.live) {
+        return { devices: localDevices, count: localDevices.length };
+      }
+
+      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const liveDevices = (await client.getDevices({ pageSize: input.limit })).map((device) => normalizeNinjaDevice(device, 'ninjaone'));
+      return { devices: liveDevices, count: liveDevices.length };
+    }
+  });
+
+  registry.register({
+    id: 'ninjaone.devices.sync',
+    version: 1,
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      device_id: z.union([z.string(), z.number()])
+    }),
+    outputSchema: z.object({
+      synced: z.boolean(),
+      external_device_id: z.string(),
+      asset_id: z.string().uuid().nullable()
+    }),
+    ui: {
+      label: 'Sync device',
+      description: 'Sync a single NinjaOne device into Alga assets.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, integrationId } = await requireNinjaOneIntegration(ctx);
+      const strategy = getNinjaOneSyncStrategy();
+      const asset = await strategy.syncDevice({
+        tenantId,
+        integrationId,
+        deviceId: Number(input.device_id),
+      });
+      return {
+        synced: true,
+        external_device_id: String(input.device_id),
+        asset_id: asset?.asset_id ?? null
+      };
+    }
+  });
+
+  registry.register({
+    id: 'ninjaone.devices.reboot',
+    version: 1,
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      device_id: z.union([z.string(), z.number()])
+    }),
+    outputSchema: z.object({
+      reboot_requested: z.boolean(),
+      external_device_id: z.string()
+    }),
+    ui: {
+      label: 'Reboot device',
+      description: 'Send a reboot command to a NinjaOne device.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, integrationId } = await requireNinjaOneIntegration(ctx);
+      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      await client.rebootDevice(Number(input.device_id));
+      return { reboot_requested: true, external_device_id: String(input.device_id) };
+    }
+  });
+
+  registry.register({
+    id: 'ninjaone.alerts.list_active',
+    version: 1,
+    sideEffectful: false,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      limit: z.number().int().min(1).max(200).default(50),
+      live: z.boolean().default(false)
+    }),
+    outputSchema: z.object({
+      alerts: z.array(alertSchema),
+      count: z.number().int()
+    }),
+    ui: {
+      label: 'List active alerts',
+      description: 'List active NinjaOne alerts for downstream workflow mapping.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
+      if (!input.live) {
+        const rows = await knex('rmm_alerts')
+          .where({ tenant: tenantId, status: 'active' })
+          .orderBy('triggered_at', 'desc')
+          .limit(input.limit);
+        const alerts = rows.map((row: any) => normalizeNinjaAlert(row));
+        return { alerts, count: alerts.length };
+      }
+
+      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const alerts = (await client.getAlerts({ pageSize: input.limit })).map((alert) => normalizeNinjaAlert(alert));
+      return { alerts, count: alerts.length };
+    }
+  });
+
+  registry.register({
+    id: 'ninjaone.alerts.get',
+    version: 1,
+    sideEffectful: false,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      alert_uid: z.string().optional(),
+      external_alert_id: z.string().optional()
+    }).refine((value) => Boolean(value.alert_uid || value.external_alert_id), {
+      message: 'alert_uid or external_alert_id is required'
+    }),
+    outputSchema: z.object({
+      alert: alertSchema
+    }),
+    ui: {
+      label: 'Get alert',
+      description: 'Get one NinjaOne alert by external alert ID or alert UID.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, knex } = await requireNinjaOneIntegration(ctx);
+      const externalId = input.external_alert_id ?? input.alert_uid;
+      const row = await knex('rmm_alerts')
+        .where({ tenant: tenantId, external_alert_id: externalId })
+        .first();
+      if (!row) {
+        throwActionError(ctx, { category: 'ActionError', code: 'NOT_FOUND', message: 'Alert not found' });
+      }
+      return { alert: normalizeNinjaAlert(row) };
+    }
+  });
+
+  registry.register({
+    id: 'ninjaone.alerts.reset',
+    version: 1,
+    sideEffectful: true,
+    idempotency: { mode: 'engineProvided' },
+    inputSchema: z.object({
+      alert_uid: z.string().optional(),
+      external_alert_id: z.string().optional()
+    }).refine((value) => Boolean(value.alert_uid || value.external_alert_id), {
+      message: 'alert_uid or external_alert_id is required'
+    }),
+    outputSchema: z.object({
+      acknowledged: z.boolean(),
+      alert_id: z.string()
+    }),
+    ui: {
+      label: 'Acknowledge alert',
+      description: 'Acknowledge an alert using NinjaOne reset alert operation.',
+      category: 'NinjaOne',
+      icon: 'ninjaone'
+    },
+    handler: async (input, ctx) => {
+      const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
+      const alertId = input.alert_uid ?? input.external_alert_id!;
+      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      await client.resetAlert(alertId);
+      await knex('rmm_alerts')
+        .where({ tenant: tenantId, external_alert_id: alertId })
+        .update({ status: 'acknowledged', updated_at: new Date().toISOString() });
+      return {
+        acknowledged: true,
+        alert_id: alertId
+      };
+    }
+  });
+
+  ninjaOneRegistered = true;
+}

--- a/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
+++ b/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
@@ -35,6 +35,16 @@ const alertSchema = z.object({
   acknowledged: z.boolean()
 });
 
+const ninjaOneDeviceIdSchema = z.coerce.number().int().positive();
+
+const toNullableIsoString = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+  return String(value);
+};
+
 async function requireNinjaOneIntegration(ctx: ActionContext): Promise<{
   tenantId: string;
   knex: any;
@@ -68,19 +78,28 @@ async function requireNinjaOneIntegration(ctx: ActionContext): Promise<{
   };
 }
 
-const normalizeNinjaDevice = (device: any, source: 'local' | 'ninjaone') => ({
-  external_device_id: String(device.id ?? device.rmm_device_id ?? ''),
-  asset_id: device.asset_id ?? null,
-  organization_id: device.organizationId ? String(device.organizationId) : (device.rmm_organization_id ?? null),
-  hostname: device.systemName ?? device.hostname ?? null,
-  display_name: device.displayName ?? device.name ?? null,
-  dns_name: device.dnsName ?? null,
-  agent_online: !(device.offline ?? false),
-  last_seen_at: device.lastContact ?? device.last_seen_at ?? null,
-  os_name: device.os?.name ?? null,
-  node_class: device.nodeClass ?? null,
-  source
-});
+const normalizeNinjaDevice = (device: any, source: 'local' | 'ninjaone') => {
+  const agentStatus = typeof device.agent_status === 'string' ? device.agent_status.toLowerCase() : null;
+  const agentOnline = typeof device.offline === 'boolean'
+    ? !device.offline
+    : agentStatus
+      ? agentStatus === 'online'
+      : true;
+
+  return {
+    external_device_id: String(device.id ?? device.rmm_device_id ?? ''),
+    asset_id: device.asset_id ?? null,
+    organization_id: device.organizationId ? String(device.organizationId) : (device.rmm_organization_id ?? null),
+    hostname: device.systemName ?? null,
+    display_name: device.displayName ?? device.name ?? null,
+    dns_name: device.dnsName ?? null,
+    agent_online: agentOnline,
+    last_seen_at: toNullableIsoString(device.lastContact ?? device.last_seen_at),
+    os_name: device.os?.name ?? null,
+    node_class: device.nodeClass ?? null,
+    source
+  };
+};
 
 const normalizeNinjaAlert = (alert: any) => ({
   alert_id: String(alert.alert_id ?? alert.uid ?? ''),
@@ -93,8 +112,8 @@ const normalizeNinjaAlert = (alert: any) => ({
   device_id: alert.external_device_id ? String(alert.external_device_id) : (alert.deviceId ? String(alert.deviceId) : null),
   asset_id: alert.asset_id ?? null,
   source_type: alert.source_type ?? alert.sourceType ?? null,
-  created_at: alert.triggered_at ?? alert.createTime ?? null,
-  updated_at: alert.updated_at ?? alert.updateTime ?? null,
+  created_at: toNullableIsoString(alert.triggered_at ?? alert.createTime),
+  updated_at: toNullableIsoString(alert.updated_at ?? alert.updateTime),
   acknowledged: String(alert.status ?? '').toLowerCase() === 'acknowledged'
 });
 
@@ -110,9 +129,9 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     sideEffectful: false,
     idempotency: { mode: 'engineProvided' },
     inputSchema: z.object({
-      device_id: z.union([z.string(), z.number()]).optional(),
+      device_id: ninjaOneDeviceIdSchema.optional(),
       asset_id: z.string().uuid().optional(),
-      query: z.string().optional(),
+      query: z.string().trim().min(1).optional(),
       live: z.boolean().default(false),
       limit: z.number().int().min(1).max(200).default(50)
     }),
@@ -130,12 +149,16 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
       let rows = await knex('assets')
         .where({ tenant: tenantId, rmm_provider: 'ninjaone' })
+        .whereNotNull('rmm_device_id')
         .modify((qb: any) => {
           if (input.asset_id) qb.andWhere('asset_id', input.asset_id);
           if (input.device_id !== undefined) qb.andWhere('rmm_device_id', String(input.device_id));
           if (input.query) {
             qb.andWhere((inner: any) => {
-              inner.whereILike('name', `%${input.query}%`).orWhereILike('hostname', `%${input.query}%`);
+              inner
+                .whereILike('name', `%${input.query}%`)
+                .orWhereILike('asset_tag', `%${input.query}%`)
+                .orWhereILike('serial_number', `%${input.query}%`);
             });
           }
         })
@@ -147,7 +170,12 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       }
 
       const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
-      const liveDevices = (await client.getDevices({ pageSize: input.limit })).map((device) => normalizeNinjaDevice(device, 'ninjaone'));
+      const liveDeviceRows = input.device_id !== undefined
+        ? [await client.getDevice(input.device_id)]
+        : input.asset_id && localDevices[0]?.external_device_id
+          ? [await client.getDevice(Number(localDevices[0].external_device_id))]
+          : await client.getDevices({ pageSize: input.limit, ...(input.query ? { df: input.query } : {}) });
+      const liveDevices = liveDeviceRows.map((device) => normalizeNinjaDevice(device, 'ninjaone'));
       return { devices: liveDevices, count: liveDevices.length };
     }
   });
@@ -158,7 +186,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     sideEffectful: true,
     idempotency: { mode: 'engineProvided' },
     inputSchema: z.object({
-      device_id: z.union([z.string(), z.number()])
+      device_id: ninjaOneDeviceIdSchema
     }),
     outputSchema: z.object({
       synced: z.boolean(),
@@ -177,7 +205,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       const asset = await strategy.syncDevice({
         tenantId,
         integrationId,
-        deviceId: Number(input.device_id),
+        deviceId: input.device_id,
       });
       return {
         synced: true,
@@ -193,7 +221,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     sideEffectful: true,
     idempotency: { mode: 'engineProvided' },
     inputSchema: z.object({
-      device_id: z.union([z.string(), z.number()])
+      device_id: ninjaOneDeviceIdSchema
     }),
     outputSchema: z.object({
       reboot_requested: z.boolean(),
@@ -208,7 +236,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     handler: async (input, ctx) => {
       const { tenantId, integrationId } = await requireNinjaOneIntegration(ctx);
       const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
-      await client.rebootDevice(Number(input.device_id));
+      await client.rebootDevice(input.device_id);
       return { reboot_requested: true, external_device_id: String(input.device_id) };
     }
   });
@@ -236,7 +264,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
       if (!input.live) {
         const rows = await knex('rmm_alerts')
-          .where({ tenant: tenantId, status: 'active' })
+          .where({ tenant: tenantId, integration_id: integrationId, status: 'active' })
           .orderBy('triggered_at', 'desc')
           .limit(input.limit);
         const alerts = rows.map((row: any) => normalizeNinjaAlert(row));
@@ -270,10 +298,10 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       icon: 'ninjaone'
     },
     handler: async (input, ctx) => {
-      const { tenantId, knex } = await requireNinjaOneIntegration(ctx);
+      const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
       const externalId = input.external_alert_id ?? input.alert_uid;
       const row = await knex('rmm_alerts')
-        .where({ tenant: tenantId, external_alert_id: externalId })
+        .where({ tenant: tenantId, integration_id: integrationId, external_alert_id: externalId })
         .first();
       if (!row) {
         throwActionError(ctx, { category: 'ActionError', code: 'NOT_FOUND', message: 'Alert not found' });
@@ -309,7 +337,7 @@ export function registerNinjaOneWorkflowActionsV2(): void {
       const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
       await client.resetAlert(alertId);
       await knex('rmm_alerts')
-        .where({ tenant: tenantId, external_alert_id: alertId })
+        .where({ tenant: tenantId, integration_id: integrationId, external_alert_id: alertId })
         .update({ status: 'acknowledged', updated_at: new Date().toISOString() });
       return {
         acknowledged: true,

--- a/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
+++ b/ee/packages/workflows/src/runtime/actions/registerNinjaOneWorkflowActions.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import { getActionRegistryV2 } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
 import { throwActionError } from '../../../../../../shared/workflow/runtime/actions/businessOperations/shared';
 import type { ActionContext } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
-import { createNinjaOneClient } from '../../../../../server/src/lib/integrations/ninjaone';
-import { getNinjaOneSyncStrategy } from '../../../../../server/src/lib/integrations/ninjaone/sync/syncStrategy';
+
+const loadNinjaOneRuntimeSupport = () => import('./ninjaOneWorkflowRuntimeSupport');
 
 const deviceSchema = z.object({
   external_device_id: z.string(),
@@ -169,7 +169,8 @@ export function registerNinjaOneWorkflowActionsV2(): void {
         return { devices: localDevices, count: localDevices.length };
       }
 
-      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const { createNinjaOneWorkflowClient } = await loadNinjaOneRuntimeSupport();
+      const client = await createNinjaOneWorkflowClient(tenantId, integrationId);
       const liveDeviceRows = input.device_id !== undefined
         ? [await client.getDevice(input.device_id)]
         : input.asset_id && localDevices[0]?.external_device_id
@@ -201,8 +202,8 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     },
     handler: async (input, ctx) => {
       const { tenantId, integrationId } = await requireNinjaOneIntegration(ctx);
-      const strategy = getNinjaOneSyncStrategy();
-      const asset = await strategy.syncDevice({
+      const { syncNinjaOneDevice } = await loadNinjaOneRuntimeSupport();
+      const asset = await syncNinjaOneDevice({
         tenantId,
         integrationId,
         deviceId: input.device_id,
@@ -235,7 +236,8 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     },
     handler: async (input, ctx) => {
       const { tenantId, integrationId } = await requireNinjaOneIntegration(ctx);
-      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const { createNinjaOneWorkflowClient } = await loadNinjaOneRuntimeSupport();
+      const client = await createNinjaOneWorkflowClient(tenantId, integrationId);
       await client.rebootDevice(input.device_id);
       return { reboot_requested: true, external_device_id: String(input.device_id) };
     }
@@ -271,7 +273,8 @@ export function registerNinjaOneWorkflowActionsV2(): void {
         return { alerts, count: alerts.length };
       }
 
-      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const { createNinjaOneWorkflowClient } = await loadNinjaOneRuntimeSupport();
+      const client = await createNinjaOneWorkflowClient(tenantId, integrationId);
       const alerts = (await client.getAlerts({ pageSize: input.limit })).map((alert) => normalizeNinjaAlert(alert));
       return { alerts, count: alerts.length };
     }
@@ -334,7 +337,8 @@ export function registerNinjaOneWorkflowActionsV2(): void {
     handler: async (input, ctx) => {
       const { tenantId, knex, integrationId } = await requireNinjaOneIntegration(ctx);
       const alertId = input.alert_uid ?? input.external_alert_id!;
-      const client = await createNinjaOneClient(tenantId, undefined, { integrationId, provider: 'ninjaone' });
+      const { createNinjaOneWorkflowClient } = await loadNinjaOneRuntimeSupport();
+      const client = await createNinjaOneWorkflowClient(tenantId, integrationId);
       await client.resetAlert(alertId);
       await knex('rmm_alerts')
         .where({ tenant: tenantId, integration_id: integrationId, external_alert_id: alertId })

--- a/ee/packages/workflows/src/runtime/core.ts
+++ b/ee/packages/workflows/src/runtime/core.ts
@@ -2,6 +2,8 @@ import {
   initializeWorkflowRuntimeV2 as initializeSharedWorkflowRuntimeV2,
   isWorkflowRuntimeV2Initialized,
 } from '../../../../../shared/workflow/runtime/init';
+import { getWorkflowIntegrationModuleRegistry } from '../../../../../shared/workflow/runtime';
+import { registerNinjaOneWorkflowActionsV2 } from './actions/registerNinjaOneWorkflowActions';
 
 export * from '../../../../../shared/workflow/runtime';
 export * from '../../../../../shared/workflow/runtime/ai/aiSchema';
@@ -41,6 +43,27 @@ export { WORKFLOW_RUNTIME_ALLOWED_FUNCTIONS } from '../../../../../shared/workfl
 
 export function initializeWorkflowRuntimeV2(): void {
   initializeSharedWorkflowRuntimeV2();
+  registerNinjaOneWorkflowActionsV2();
+  const moduleRegistry = getWorkflowIntegrationModuleRegistry();
+  if (!moduleRegistry.list().some((module) => module.groupKey === 'app:ninjaone')) {
+    moduleRegistry.register({
+      groupKey: 'app:ninjaone',
+      label: 'NinjaOne',
+      description: 'NinjaOne RMM actions for devices and alerts.',
+      tileKind: 'app',
+      iconToken: 'ninjaone',
+      defaultActionId: 'ninjaone.devices.find',
+      allowedActionIds: [
+        'ninjaone.devices.find',
+        'ninjaone.devices.sync',
+        'ninjaone.devices.reboot',
+        'ninjaone.alerts.list_active',
+        'ninjaone.alerts.get',
+        'ninjaone.alerts.reset'
+      ],
+      availabilityKey: 'rmm:ninjaone'
+    });
+  }
 }
 
 export { isWorkflowRuntimeV2Initialized };

--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -3441,6 +3441,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
         case 'crm': return <Handshake className={iconClass} />;
         case 'transform': return <Wand2 className={iconClass} />;
         case 'ai': return <Bot className={iconClass} />;
+        case 'ninjaone': return <ShieldAlert className={iconClass} />;
         case 'app': return <AppWindow className={iconClass} />;
         default: return <Box className={iconClass} />;
       }

--- a/ee/server/src/components/workflow-designer/__tests__/ninjaOneDesignerCatalog.contract.test.ts
+++ b/ee/server/src/components/workflow-designer/__tests__/ninjaOneDesignerCatalog.contract.test.ts
@@ -1,0 +1,65 @@
+/** @vitest-environment jsdom */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildGroupedActionSelectOptions } from '../GroupedActionConfigSection';
+import type { WorkflowDesignerCatalogRecord } from '@alga-psa/workflows/runtime/designer/actionCatalog';
+
+const ninjaRecord: WorkflowDesignerCatalogRecord = {
+  groupKey: 'app:ninjaone',
+  label: 'NinjaOne',
+  iconToken: 'ninjaone',
+  tileKind: 'app',
+  description: 'NinjaOne actions',
+  defaultActionId: 'ninjaone.devices.find',
+  allowedActionIds: [
+    'ninjaone.devices.find',
+    'ninjaone.devices.sync',
+    'ninjaone.devices.reboot',
+    'ninjaone.alerts.list_active',
+    'ninjaone.alerts.get',
+    'ninjaone.alerts.reset'
+  ],
+  actions: [
+    { id: 'ninjaone.devices.find', version: 1, label: 'Find devices', inputFieldNames: [], outputFieldNames: [] },
+    { id: 'ninjaone.devices.sync', version: 1, label: 'Sync device', inputFieldNames: [], outputFieldNames: [] },
+    { id: 'ninjaone.devices.reboot', version: 1, label: 'Reboot device', inputFieldNames: [], outputFieldNames: [] },
+    { id: 'ninjaone.alerts.list_active', version: 1, label: 'List active alerts', inputFieldNames: [], outputFieldNames: [] },
+    { id: 'ninjaone.alerts.get', version: 1, label: 'Get alert', inputFieldNames: [], outputFieldNames: [] },
+    { id: 'ninjaone.alerts.reset', version: 1, label: 'Acknowledge alert', inputFieldNames: [], outputFieldNames: [] }
+  ]
+};
+
+const ticketRecord: WorkflowDesignerCatalogRecord = {
+  groupKey: 'ticket',
+  label: 'Ticket',
+  iconToken: 'ticket',
+  tileKind: 'core-object',
+  description: 'Ticket actions',
+  allowedActionIds: ['tickets.create'],
+  actions: [
+    { id: 'tickets.create', version: 1, label: 'Create Ticket', inputFieldNames: ['summary'], outputFieldNames: ['ticket_id'] }
+  ]
+};
+
+describe('NinjaOne workflow designer catalog contracts', () => {
+  it('T015: NinjaOne group keeps app-specific action dropdown options and icon token contract', () => {
+    const options = buildGroupedActionSelectOptions(ninjaRecord);
+    expect(options.map((option) => option.value)).toEqual(ninjaRecord.allowedActionIds);
+    expect(options.some((option) => option.label === 'Acknowledge alert')).toBe(true);
+    expect(ninjaRecord.iconToken).toBe('ninjaone');
+
+    const workflowDesignerSource = fs.readFileSync(path.resolve(__dirname, '../WorkflowDesigner.tsx'), 'utf8');
+    expect(workflowDesignerSource).toContain("case 'ninjaone'");
+  });
+
+  it('T016: NinjaOne-to-Ticket authoring path keeps ticket creation generic and not inside NinjaOne actions', () => {
+    const ninjaActionIds = new Set(ninjaRecord.allowedActionIds);
+    expect(ninjaActionIds.has('tickets.create')).toBe(false);
+    expect(ninjaActionIds.has('ninjaone.alerts.create_ticket')).toBe(false);
+
+    const ticketOptions = buildGroupedActionSelectOptions(ticketRecord);
+    expect(ticketOptions).toEqual([{ value: 'tickets.create', label: 'Create Ticket' }]);
+  });
+});

--- a/ee/temporal-workflows/src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts
+++ b/ee/temporal-workflows/src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowDefinition } from '@alga-psa/workflows/runtime';
+import {
+  WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+  WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
+} from '@alga-psa/workflows/lib/workflowRuntimeV2TemporalContract';
 
 type RuntimeV2Activities = {
   loadWorkflowRuntimeV2PinnedDefinition: ReturnType<typeof vi.fn>;
@@ -21,26 +25,43 @@ type RuntimeV2Activities = {
 let mockActivities: RuntimeV2Activities;
 const workflowSignalHandlers = new Map<string, (payload: unknown) => void>();
 
-vi.mock('@temporalio/workflow', () => ({
-  continueAsNew: vi.fn(async () => undefined),
-  condition: vi.fn(async (predicate: () => boolean, timeoutMs?: number) => {
-    if (predicate()) {
-      return true;
+vi.mock('@temporalio/workflow', () => {
+  class ApplicationFailure extends Error {
+    type?: string | null;
+    nonRetryable?: boolean;
+    details?: unknown[];
+
+    static nonRetryable(message?: string | null, type?: string | null, ...details: unknown[]) {
+      const failure = new ApplicationFailure(message ?? '');
+      failure.type = type;
+      failure.nonRetryable = true;
+      failure.details = details;
+      return failure;
     }
-    if (timeoutMs === undefined) {
+  }
+
+  return {
+    ApplicationFailure,
+    continueAsNew: vi.fn(async () => undefined),
+    condition: vi.fn(async (predicate: () => boolean, timeoutMs?: number) => {
+      if (predicate()) {
+        return true;
+      }
+      if (timeoutMs === undefined) {
+        return false;
+      }
       return false;
-    }
-    return false;
-  }),
-  defineQuery: vi.fn((name: string) => name),
-  defineSignal: vi.fn((name: string) => name),
-  executeChild: vi.fn(async () => undefined),
-  proxyActivities: vi.fn(() => mockActivities),
-  setHandler: vi.fn((signalName: string, handler: (payload: unknown) => void) => {
-    workflowSignalHandlers.set(signalName, handler);
-  }),
-  sleep: vi.fn(async () => undefined),
-}));
+    }),
+    defineQuery: vi.fn((name: string) => name),
+    defineSignal: vi.fn((name: string) => name),
+    executeChild: vi.fn(async () => undefined),
+    proxyActivities: vi.fn(() => mockActivities),
+    setHandler: vi.fn((signalName: string, handler: (payload: unknown) => void) => {
+      workflowSignalHandlers.set(signalName, handler);
+    }),
+    sleep: vi.fn(async () => undefined),
+  };
+});
 
 const loadWorkflow = async () => {
   vi.resetModules();
@@ -1017,7 +1038,8 @@ describe('workflowRuntimeV2RunWorkflow', () => {
         },
       },
     })).rejects.toMatchObject({
-      category: 'InterpreterCorruption',
+      type: 'WorkflowRuntimeV2.InterpreterCorruption',
+      nonRetryable: true,
     });
 
     expect(mockActivities.completeWorkflowRuntimeV2Run).toHaveBeenCalledWith({
@@ -1413,7 +1435,8 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       triggerType: null,
       executionKey: 'exec_10',
     })).rejects.toMatchObject({
-      category: 'ActionError',
+      type: 'WorkflowRuntimeV2.ActionError',
+      nonRetryable: true,
     });
 
     expect(mockActivities.completeWorkflowRuntimeV2Run).toHaveBeenCalledWith({
@@ -1524,6 +1547,13 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       })
     );
     expect(executeChildMock).toHaveBeenCalledTimes(1);
+    expect(executeChildMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        workflowExecutionTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+        workflowRunTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
+      })
+    );
     expect(mockActivities.executeWorkflowRuntimeV2ActionStep).toHaveBeenCalledWith(
       expect.objectContaining({
         stepPath: 'root.steps[1]',
@@ -1593,7 +1623,8 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       triggerType: null,
       executionKey: 'exec_12',
     })).rejects.toMatchObject({
-      category: 'ChildWorkflowError',
+      type: 'WorkflowRuntimeV2.ChildWorkflowError',
+      nonRetryable: true,
     });
   });
 
@@ -2268,7 +2299,8 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       triggerType: null,
       executionKey: 'exec_18',
     })).rejects.toMatchObject({
-      category: 'TimeoutError',
+      type: 'WorkflowRuntimeV2.TimeoutError',
+      nonRetryable: true,
     });
 
     expect(mockActivities.projectWorkflowRuntimeV2EventWaitResolved).toHaveBeenCalledWith(
@@ -2327,6 +2359,7 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       eventName: 'HUMAN_TASK_COMPLETED',
     });
 
+    const { workflowRuntimeV2RunWorkflow } = await loadWorkflow();
     const temporalWorkflow = await import('@temporalio/workflow');
     const conditionMock = vi.mocked(temporalWorkflow.condition);
     conditionMock.mockImplementationOnce(async (predicate: () => boolean) => {
@@ -2341,7 +2374,6 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       return predicate();
     });
 
-    const { workflowRuntimeV2RunWorkflow } = await loadWorkflow();
     await workflowRuntimeV2RunWorkflow({
       runId: 'run_19',
       tenantId: 'tenant_1',
@@ -2446,7 +2478,8 @@ describe('workflowRuntimeV2RunWorkflow', () => {
       triggerType: null,
       executionKey: 'exec_20',
     })).rejects.toMatchObject({
-      category: 'ValidationError',
+      type: 'WorkflowRuntimeV2.ValidationError',
+      nonRetryable: true,
     });
   });
 

--- a/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/workflow-runtime-v2-run-workflow.ts
@@ -1,9 +1,11 @@
-import { condition, continueAsNew, defineQuery, defineSignal, executeChild, proxyActivities, setHandler, sleep } from '@temporalio/workflow';
+import { ApplicationFailure, condition, continueAsNew, defineQuery, defineSignal, executeChild, proxyActivities, setHandler, sleep } from '@temporalio/workflow';
 import {
   WORKFLOW_RUNTIME_V2_EVENT_SIGNAL,
   WORKFLOW_RUNTIME_V2_HUMAN_TASK_SIGNAL,
   WORKFLOW_RUNTIME_V2_QUOTA_RESUME_SIGNAL,
   WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
+  WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+  WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
   type WorkflowRuntimeV2TemporalRunInput,
 } from '@alga-psa/workflows/lib/workflowRuntimeV2TemporalContract';
 import { compileExpression, type CompiledExpression } from '@alga-psa/workflows/runtime/expressionEngine';
@@ -313,7 +315,7 @@ export async function workflowRuntimeV2RunWorkflow(
           { frames: state.frames }
         );
         await activities.completeWorkflowRuntimeV2Run({ runId: input.runId, status: 'FAILED' });
-        throw corruptionError;
+        throw toWorkflowApplicationFailure(corruptionError);
       }
       await activities.completeWorkflowRuntimeV2Run({ runId: input.runId, status: 'SUCCEEDED' });
       return {
@@ -483,6 +485,8 @@ export async function workflowRuntimeV2RunWorkflow(
             const childResult = await executeChild(workflowRuntimeV2RunWorkflow, {
               workflowId: childStart.temporalWorkflowId,
               taskQueue: WORKFLOW_RUNTIME_V2_TEMPORAL_TASK_QUEUE,
+              workflowExecutionTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_EXECUTION_TIMEOUT,
+              workflowRunTimeout: WORKFLOW_RUNTIME_V2_DEFAULT_RUN_TIMEOUT,
               args: [{
                 runId: childStart.childRunId,
                 tenantId: state.scopes.system.tenantId,
@@ -912,7 +916,7 @@ export async function workflowRuntimeV2RunWorkflow(
           errorMessage: runtimeError.message,
         });
         await activities.completeWorkflowRuntimeV2Run({ runId: input.runId, status: 'FAILED' });
-        throw error;
+        throw toWorkflowApplicationFailure(runtimeError);
       }
 
       await activities.projectWorkflowRuntimeV2StepCompletion({
@@ -952,7 +956,7 @@ export async function workflowRuntimeV2RunWorkflow(
       }
 
       await activities.completeWorkflowRuntimeV2Run({ runId: input.runId, status: 'FAILED' });
-      throw runtimeError;
+      throw toWorkflowApplicationFailure(runtimeError);
     }
 
     await maybeContinueAsNew();
@@ -1707,6 +1711,20 @@ type RuntimeErrorLike = {
   code?: string;
   details?: unknown;
 };
+
+function toWorkflowApplicationFailure(error: RuntimeErrorLike): ApplicationFailure {
+  return ApplicationFailure.nonRetryable(
+    error.message,
+    `WorkflowRuntimeV2.${error.category}`,
+    {
+      category: error.category,
+      nodePath: error.nodePath,
+      at: error.at,
+      ...(error.code ? { code: error.code } : {}),
+      ...(error.details !== undefined ? { details: error.details } : {}),
+    }
+  );
+}
 
 function normalizeRuntimeError(error: unknown, stepPath: string): RuntimeErrorLike {
   if (isRuntimeErrorLike(error)) {

--- a/shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts
+++ b/shared/workflow/runtime/__tests__/workflowDesignerActionCatalog.test.ts
@@ -239,4 +239,24 @@ describe('workflow designer action catalog', () => {
       tileKind: 'app',
     });
   });
+
+  it('uses explicit module records when provided', () => {
+    const ninjaCatalog = buildWorkflowDesignerActionCatalog(mockActions, {
+      modules: [{
+        groupKey: 'app:ninjaone',
+        label: 'NinjaOne',
+        tileKind: 'app',
+        iconToken: 'ninjaone',
+        defaultActionId: 'slack.send_message',
+        allowedActionIds: ['slack.send_message']
+      }]
+    });
+
+    expect(ninjaCatalog.find((record) => record.groupKey === 'app:ninjaone')).toMatchObject({
+      groupKey: 'app:ninjaone',
+      iconToken: 'ninjaone',
+      allowedActionIds: ['slack.send_message']
+    });
+    expect(ninjaCatalog.find((record) => record.groupKey === 'app:slack')).toBeUndefined();
+  });
 });

--- a/shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts
+++ b/shared/workflow/runtime/__tests__/workflowIntegrationModuleRegistry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowIntegrationModuleRegistry } from '../registries/integrationModuleRegistry';
+
+describe('workflow integration module registry', () => {
+  it('registers and lists module metadata', () => {
+    const registry = new WorkflowIntegrationModuleRegistry();
+    registry.register({
+      groupKey: 'app:ninjaone',
+      label: 'NinjaOne',
+      tileKind: 'app',
+      iconToken: 'ninjaone',
+      defaultActionId: 'ninjaone.devices.find',
+      allowedActionIds: ['ninjaone.devices.find'],
+      availabilityKey: 'rmm:ninjaone'
+    });
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.list()[0]).toMatchObject({
+      groupKey: 'app:ninjaone',
+      availabilityKey: 'rmm:ninjaone',
+      allowedActionIds: ['ninjaone.devices.find']
+    });
+  });
+
+  it('rejects duplicate group keys', () => {
+    const registry = new WorkflowIntegrationModuleRegistry();
+    registry.register({
+      groupKey: 'app:ninjaone',
+      label: 'NinjaOne',
+      tileKind: 'app',
+      iconToken: 'ninjaone',
+      allowedActionIds: ['ninjaone.devices.find']
+    });
+    expect(() =>
+      registry.register({
+        groupKey: 'app:ninjaone',
+        label: 'NinjaOne 2',
+        tileKind: 'app',
+        iconToken: 'ninjaone',
+        allowedActionIds: ['ninjaone.devices.sync']
+      })
+    ).toThrow(/already has/);
+  });
+});

--- a/shared/workflow/runtime/designer/actionCatalog.ts
+++ b/shared/workflow/runtime/designer/actionCatalog.ts
@@ -44,6 +44,17 @@ export type WorkflowDesignerCatalogSourceAction = {
   outputSchema?: JsonSchema;
 };
 
+export type WorkflowDesignerCatalogModuleDefinition = {
+  groupKey: `app:${string}`;
+  label: string;
+  description?: string;
+  tileKind: Extract<WorkflowDesignerCatalogKind, 'app'>;
+  iconToken: string;
+  defaultActionId?: string;
+  allowedActionIds: string[];
+  availabilityKey?: string;
+};
+
 type BuiltInCatalogSeed = {
   groupKey: string;
   label: string;
@@ -205,7 +216,8 @@ const toCatalogAction = (action: WorkflowDesignerCatalogSourceAction): WorkflowD
 });
 
 export const buildWorkflowDesignerActionCatalog = (
-  actions: WorkflowDesignerCatalogSourceAction[]
+  actions: WorkflowDesignerCatalogSourceAction[],
+  options?: { modules?: WorkflowDesignerCatalogModuleDefinition[] }
 ): WorkflowDesignerCatalogRecord[] => {
   const catalogActions = actions
     .map((action) => ({
@@ -237,10 +249,34 @@ export const buildWorkflowDesignerActionCatalog = (
   });
 
   const builtInActionIds = new Set(records.flatMap((record) => record.allowedActionIds));
+  const configuredModules = (options?.modules ?? []).map((module) => ({
+    ...module,
+    allowedActionIds: [...new Set(module.allowedActionIds)]
+  }));
+  const configuredModuleActionIds = new Set(configuredModules.flatMap((module) => module.allowedActionIds));
 
   const appRecords = new Map<string, WorkflowDesignerCatalogRecord>();
+  for (const module of configuredModules) {
+    const actionMap = new Map(catalogActions.map((entry) => [entry.source.id, entry.catalogAction]));
+    const matchingActions = module.allowedActionIds
+      .map((actionId) => actionMap.get(actionId))
+      .filter((value): value is WorkflowDesignerCatalogAction => Boolean(value))
+      .sort((left, right) => left.label.localeCompare(right.label));
+    appRecords.set(module.groupKey, {
+      groupKey: module.groupKey,
+      label: module.label,
+      iconToken: module.iconToken,
+      tileKind: module.tileKind,
+      allowedActionIds: matchingActions.map((action) => action.id),
+      defaultActionId: module.defaultActionId,
+      description: module.description,
+      actions: matchingActions
+    });
+  }
+
   for (const { source, moduleName, catalogAction } of catalogActions) {
     if (builtInActionIds.has(source.id)) continue;
+    if (configuredModuleActionIds.has(source.id)) continue;
 
     const normalizedModuleName = moduleName || source.id.trim().toLowerCase();
     if (!normalizedModuleName) continue;

--- a/shared/workflow/runtime/index.ts
+++ b/shared/workflow/runtime/index.ts
@@ -5,6 +5,11 @@ export * from './schemas/workflowClockTriggerSchema';
 export { SchemaRegistry, getSchemaRegistry } from './registries/schemaRegistry';
 export { ActionRegistry, getActionRegistryV2 } from './registries/actionRegistry';
 export { NodeTypeRegistry, getNodeTypeRegistry } from './registries/nodeTypeRegistry';
+export {
+  WorkflowIntegrationModuleRegistry,
+  getWorkflowIntegrationModuleRegistry,
+  type WorkflowIntegrationModuleDefinition
+} from './registries/integrationModuleRegistry';
 export { registerWorkflowEmailProvider, getWorkflowEmailProvider, resetWorkflowEmailProvider } from './registries/workflowEmailRegistry';
 export type { WorkflowEmailProvider } from './registries/workflowEmailRegistry';
 export { WorkflowRuntimeV2 } from './runtime/workflowRuntimeV2';

--- a/shared/workflow/runtime/registries/integrationModuleRegistry.ts
+++ b/shared/workflow/runtime/registries/integrationModuleRegistry.ts
@@ -1,0 +1,42 @@
+import type { WorkflowDesignerCatalogKind } from '../designer/actionCatalog';
+
+export type WorkflowIntegrationModuleDefinition = {
+  groupKey: `app:${string}`;
+  label: string;
+  description?: string;
+  tileKind: Extract<WorkflowDesignerCatalogKind, 'app'>;
+  iconToken: string;
+  defaultActionId?: string;
+  allowedActionIds: string[];
+  availabilityKey?: string;
+};
+
+export class WorkflowIntegrationModuleRegistry {
+  private modules = new Map<string, WorkflowIntegrationModuleDefinition>();
+
+  register(definition: WorkflowIntegrationModuleDefinition): void {
+    const key = definition.groupKey.trim();
+    if (!key) throw new Error('WorkflowIntegrationModuleRegistry.register requires groupKey');
+    if (this.modules.has(key)) {
+      throw new Error(`WorkflowIntegrationModuleRegistry already has ${key}`);
+    }
+    this.modules.set(key, {
+      ...definition,
+      groupKey: key as `app:${string}`,
+      allowedActionIds: [...new Set(definition.allowedActionIds.map((id) => id.trim()).filter(Boolean))]
+    });
+  }
+
+  list(): WorkflowIntegrationModuleDefinition[] {
+    return Array.from(this.modules.values()).sort((left, right) => left.label.localeCompare(right.label));
+  }
+}
+
+let moduleRegistryInstance: WorkflowIntegrationModuleRegistry | null = null;
+
+export function getWorkflowIntegrationModuleRegistry(): WorkflowIntegrationModuleRegistry {
+  if (!moduleRegistryInstance) {
+    moduleRegistryInstance = new WorkflowIntegrationModuleRegistry();
+  }
+  return moduleRegistryInstance;
+}


### PR DESCRIPTION
## Summary
- Add first-party workflow integration module support for NinjaOne actions
- Register NinjaOne device and alert workflow actions with tenant availability filtering
- Add Temporal workflow runtime timeouts and throw non-retryable ApplicationFailure objects for terminal runtime failures

## Validation
- npm --prefix ee/packages/workflows run typecheck -- --pretty false
- npm --prefix ee/packages/workflows run build
- npx vitest run --root ee/packages/workflows src/lib/__tests__/workflowRuntimeV2Temporal.contract.test.ts
- TEMPORAL_TEST_SKIP_ENV_BOOTSTRAP=1 npm --prefix ee/temporal-workflows run test -- src/workflows/__tests__/workflow-runtime-v2-run-workflow.test.ts

## Notes
- package-lock.json has pre-existing local modifications and was intentionally left out of these commits
- ee/temporal-workflows full type-check/build is currently blocked by unrelated packages/auth next-auth type errors