### PR TITLE
Route Teams deep links to real PSA pages

### DIFF
--- a/ee/packages/microsoft-teams/src/lib/teams/buildTeamsFullPsaUrl.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/buildTeamsFullPsaUrl.ts
@@ -4,10 +4,8 @@ export function buildTeamsFullPsaUrl(destination: TeamsTabDestination): string |
   switch (destination.type) {
     case 'ticket':
       return `/msp/tickets/${destination.ticketId}`;
-    case 'project_task': {
-      const query = new URLSearchParams({ taskId: destination.taskId });
-      return `/msp/projects/${destination.projectId}?${query.toString()}`;
-    }
+    case 'project_task':
+      return `/msp/projects/${destination.projectId}/tasks/${destination.taskId}`;
     case 'approval': {
       const query = new URLSearchParams({ approvalId: destination.approvalId });
       return `/msp/time-sheet-approvals?${query.toString()}`;

--- a/ee/packages/microsoft-teams/src/lib/teams/resolveTeamsTabDestination.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/resolveTeamsTabDestination.ts
@@ -104,6 +104,10 @@ export function resolveTeamsTabDestinationFromPsaUrl(psaUrl: string | undefined)
   }
 
   if (segments[1] === 'projects' && segments[2]) {
+    if (segments[3] === 'tasks' && segments[4]) {
+      return { type: 'project_task', projectId: segments[2], taskId: segments[4] };
+    }
+
     const taskId = parsed.searchParams.get('taskId')?.trim();
     return taskId ? { type: 'project_task', projectId: segments[2], taskId } : { type: 'my_work' };
   }

--- a/ee/packages/microsoft-teams/src/lib/teams/teamsDeepLinks.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/teamsDeepLinks.ts
@@ -11,24 +11,21 @@ export type TeamsDeepLinkDestination =
 export type TeamsDeepLinkSurface = 'tab' | 'notification' | 'bot' | 'message_extension';
 
 function buildTeamsTabWebUrl(baseUrl: string, destination: TeamsDeepLinkDestination): string {
-  // Build a Teams-tab URL with query params that resolveTeamsTabDestination()
-  // can read server-side. Using the tab URL (instead of the raw PSA URL)
-  // ensures the destination context survives regardless of how Teams delivers
-  // the deep link to the tab page.
-  const tabBase = `${baseUrl}/teams/tab`;
+  // Keep Teams tab context for in-Teams routing, but let browser fallback opens
+  // land on actual PSA pages instead of the Teams tab shell.
   switch (destination.type) {
     case 'my_work':
-      return tabBase;
+      return `${baseUrl}/msp/dashboard`;
     case 'ticket':
-      return `${tabBase}?page=ticket&ticketId=${encodeURIComponent(destination.ticketId)}`;
+      return `${baseUrl}/msp/tickets/${destination.ticketId}`;
     case 'project_task':
-      return `${tabBase}?page=project_task&projectId=${encodeURIComponent(destination.projectId)}&taskId=${encodeURIComponent(destination.taskId)}`;
+      return `${baseUrl}/msp/projects/${destination.projectId}/tasks/${destination.taskId}`;
     case 'approval':
-      return `${tabBase}?page=approval&approvalId=${encodeURIComponent(destination.approvalId)}`;
+      return `${baseUrl}/msp/time-sheet-approvals?approvalId=${encodeURIComponent(destination.approvalId)}`;
     case 'time_entry':
-      return `${tabBase}?page=time_entry&entryId=${encodeURIComponent(destination.entryId)}`;
+      return `${baseUrl}/msp/time-entry?entryId=${encodeURIComponent(destination.entryId)}`;
     case 'contact':
-      return `${tabBase}?page=contact&contactId=${encodeURIComponent(destination.contactId)}`;
+      return `${baseUrl}/msp/contacts/${destination.contactId}`;
     default: {
       const exhaustive: never = destination;
       throw new Error(`Unsupported Teams deep-link destination: ${(exhaustive as any).type}`);
@@ -90,6 +87,10 @@ function resolveTeamsDeepLinkDestinationFromPsaUrl(psaUrl: string): TeamsDeepLin
   }
 
   if (segments[1] === 'projects' && segments[2]) {
+    if (segments[3] === 'tasks' && segments[4]) {
+      return { type: 'project_task', projectId: segments[2], taskId: segments[4] };
+    }
+
     const taskId = parsed.searchParams.get('taskId')?.trim();
     return taskId ? { type: 'project_task', projectId: segments[2], taskId } : { type: 'my_work' };
   }

--- a/packages/integrations/src/actions/integrations/teamsDeepLinks.ts
+++ b/packages/integrations/src/actions/integrations/teamsDeepLinks.ts
@@ -13,15 +13,15 @@ type TeamsDeepLinkSurface = 'tab' | 'notification' | 'bot' | 'message_extension'
 function buildTeamsTabWebUrl(baseUrl: string, destination: TeamsDeepLinkDestination): string {
   switch (destination.type) {
     case 'my_work':
-      return `${baseUrl}/teams/tab`;
+      return `${baseUrl}/msp/dashboard`;
     case 'ticket':
       return `${baseUrl}/msp/tickets/${destination.ticketId}`;
     case 'project_task':
-      return `${baseUrl}/msp/projects/${destination.projectId}?taskId=${encodeURIComponent(destination.taskId)}`;
+      return `${baseUrl}/msp/projects/${destination.projectId}/tasks/${destination.taskId}`;
     case 'approval':
-      return `${baseUrl}/msp/approvals/${destination.approvalId}`;
+      return `${baseUrl}/msp/time-sheet-approvals?approvalId=${encodeURIComponent(destination.approvalId)}`;
     case 'time_entry':
-      return `${baseUrl}/msp/time?entryId=${encodeURIComponent(destination.entryId)}`;
+      return `${baseUrl}/msp/time-entry?entryId=${encodeURIComponent(destination.entryId)}`;
     case 'contact':
       return `${baseUrl}/msp/contacts/${destination.contactId}`;
   }

--- a/packages/integrations/src/actions/integrations/teamsPackageActions.test.ts
+++ b/packages/integrations/src/actions/integrations/teamsPackageActions.test.ts
@@ -262,9 +262,11 @@ describe('Teams app package actions', () => {
       },
     });
     expect(JSON.stringify(result.package?.manifest)).not.toContain('channel-routing');
+    expect(result.package?.deepLinks.myWork).toContain(encodeURIComponent('https://tenant.example.com/msp/dashboard'));
     expect(result.package?.deepLinks.ticketTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/tickets/{ticketId}'));
-    expect(result.package?.deepLinks.projectTaskTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/projects/{projectId}?taskId=%7BtaskId%7D'));
-    expect(result.package?.deepLinks.approvalTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/approvals/{approvalId}'));
+    expect(result.package?.deepLinks.projectTaskTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/projects/{projectId}/tasks/{taskId}'));
+    expect(result.package?.deepLinks.approvalTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/time-sheet-approvals?approvalId=%7BapprovalId%7D'));
+    expect(result.package?.deepLinks.timeEntryTemplate).toContain(encodeURIComponent('https://tenant.example.com/msp/time-entry?entryId=%7BentryId%7D'));
     expect(teamsIntegrations[0]).toMatchObject({
       tenant: 'tenant-1',
       selected_profile_id: 'profile-1',
@@ -340,29 +342,33 @@ describe('Teams app package actions', () => {
   });
 
   it('T211/T301: converts notification-style PSA record URLs into Teams personal-tab deep links so activity-feed notifications can target the correct destination without duplicating record-link rules', () => {
-    expect(
-      buildTeamsPersonalTabDeepLinkFromPsaUrl(
-        'https://tenant.example.com',
-        'teams-client-id',
-        '/msp/tickets/ticket-123'
-      )
-    ).toContain(encodeURIComponent('{"page":"ticket","ticketId":"ticket-123"}'));
+    const ticketDeepLink = buildTeamsPersonalTabDeepLinkFromPsaUrl(
+      'https://tenant.example.com',
+      'teams-client-id',
+      '/msp/tickets/ticket-123'
+    );
 
-    expect(
-      buildTeamsPersonalTabDeepLinkFromPsaUrl(
-        'https://tenant.example.com',
-        'teams-client-id',
-        '/msp/projects/project-44?taskId=task-88'
-      )
-    ).toContain(encodeURIComponent('{"page":"project_task","projectId":"project-44","taskId":"task-88"}'));
+    expect(ticketDeepLink).toContain(encodeURIComponent('{"page":"ticket","ticketId":"ticket-123"}'));
+    expect(ticketDeepLink).toContain(encodeURIComponent('https://tenant.example.com/msp/tickets/ticket-123'));
+    expect(ticketDeepLink).not.toContain(encodeURIComponent('https://tenant.example.com/teams/tab?page=ticket'));
 
-    expect(
-      buildTeamsPersonalTabDeepLinkFromPsaUrl(
-        'https://tenant.example.com',
-        'teams-client-id',
-        '/msp/time-sheet-approvals?approvalId=approval-2'
-      )
-    ).toContain(encodeURIComponent('{"page":"approval","approvalId":"approval-2"}'));
+    const projectTaskDeepLink = buildTeamsPersonalTabDeepLinkFromPsaUrl(
+      'https://tenant.example.com',
+      'teams-client-id',
+      '/msp/projects/project-44?taskId=task-88'
+    );
+
+    expect(projectTaskDeepLink).toContain(encodeURIComponent('{"page":"project_task","projectId":"project-44","taskId":"task-88"}'));
+    expect(projectTaskDeepLink).toContain(encodeURIComponent('https://tenant.example.com/msp/projects/project-44/tasks/task-88'));
+
+    const approvalDeepLink = buildTeamsPersonalTabDeepLinkFromPsaUrl(
+      'https://tenant.example.com',
+      'teams-client-id',
+      '/msp/time-sheet-approvals?approvalId=approval-2'
+    );
+
+    expect(approvalDeepLink).toContain(encodeURIComponent('{"page":"approval","approvalId":"approval-2"}'));
+    expect(approvalDeepLink).toContain(encodeURIComponent('https://tenant.example.com/msp/time-sheet-approvals?approvalId=approval-2'));
   });
 
   it('T212/T302: falls back notification-style Teams deep links to my-work when the PSA URL is malformed or not a supported Teams destination', () => {

--- a/server/src/test/unit/lib/teams/buildTeamsFullPsaUrl.test.ts
+++ b/server/src/test/unit/lib/teams/buildTeamsFullPsaUrl.test.ts
@@ -13,7 +13,7 @@ describe('buildTeamsFullPsaUrl', () => {
 
     expect(urls).toEqual([
       '/msp/tickets/ticket-123',
-      '/msp/projects/project-44?taskId=task-88',
+      '/msp/projects/project-44/tasks/task-88',
       '/msp/time-sheet-approvals?approvalId=approval-2',
       '/msp/time-entry?entryId=entry-9',
       '/msp/contacts/contact-5',
@@ -27,7 +27,7 @@ describe('buildTeamsFullPsaUrl', () => {
     });
   });
 
-  it('T204/T210: omits the full-PSA handoff for the default my-work landing destination so unsupported or fallback states stay on the safe Teams shell', () => {
-    expect(buildTeamsFullPsaUrl({ type: 'my_work' })).toBeNull();
+  it('T204/T210: returns the dashboard for the default my-work landing destination', () => {
+    expect(buildTeamsFullPsaUrl({ type: 'my_work' })).toBe('/msp/dashboard');
   });
 });

--- a/server/src/test/unit/lib/teams/resolveTeamsTabDestination.test.ts
+++ b/server/src/test/unit/lib/teams/resolveTeamsTabDestination.test.ts
@@ -144,6 +144,11 @@ describe('resolveTeamsTabDestination', () => {
       projectId: 'project-44',
       taskId: 'task-88',
     });
+    expect(resolveTeamsTabDestinationFromPsaUrl('/msp/projects/project-44/tasks/task-88')).toEqual({
+      type: 'project_task',
+      projectId: 'project-44',
+      taskId: 'task-88',
+    });
     expect(resolveTeamsTabDestinationFromPsaUrl('/msp/time-sheet-approvals?approvalId=approval-2')).toEqual({
       type: 'approval',
       approvalId: 'approval-2',


### PR DESCRIPTION
  Replace the Teams tab shell handoff with direct PSA routes so browser
  fallback opens land on actual pages. Project tasks now use path-style
  URLs (/msp/projects/{projectId}/tasks/{taskId}) instead of a taskId
  query param, my_work resolves to /msp/dashboard, and approval/time-entry
  links point at /msp/time-sheet-approvals and /msp/time-entry. Path-style
  project-task URLs are now parsed back in both resolvers, with tests
  updated to match.

  "But I don't want to go among Teams-tab shells," said Alice. "Oh, you
  can't help that," said the Cat, "we're all routed to /msp/dashboard
  here." And down the project_task path she fell, no longer clutching her
  ?taskId query string. 🐇🔗🎩