### PR TITLE
docs: add secrets/tenants directory to setup guide

### DIFF
--- a/docs/getting-started/setup_guide.md
+++ b/docs/getting-started/setup_guide.md
@@ -38,7 +38,7 @@ This guide provides step-by-step instructions for setting up the PSA system usin
    This checks for a published CE image matching the current `HEAD` short SHA. If it exists, the script pulls it and writes `.env.image` alongside `server/.env` with `ALGA_IMAGE_TAG=<sha>`. If no matching image exists, the script builds the CE image locally from the current checkout, tags it with that same SHA, and writes `.env.image`. If the worktree has uncommitted changes, the script builds locally with a `<sha>-local` tag so the image cannot be confused with the published commit image. Re-run the script whenever you upgrade or switch commits. If the local image build needs a larger Node.js heap, run `NEXT_BUILD_MAX_OLD_SPACE_SIZE=16384 ./scripts/set-image-tag.sh`.
 2. Create required directories:
    ```bash
-   mkdir -p secrets
+   mkdir -p secrets/tenants
    ```
 
 ## Secrets Configuration


### PR DESCRIPTION
## Problem

The CE prebuilt docker-compose bind-mounts `./secrets/tenants` as a directory on both the `server` and `email-service` containers, but the setup guide only instructs users to create individual secret files under `secrets/`. Without `secrets/tenants/`, Docker fails to start containers with:

```
Error response from daemon: invalid mount config for type "bind":
bind source path does not exist: /srv/alga-psa/secrets/tenants
```

## Fix

Changed `mkdir -p secrets` to `mkdir -p secrets/tenants` in the Initial Setup section. Since `mkdir -p` creates parent directories, this still creates `secrets/` as well.

## Reproduced

Both issues were reproduced locally against `release/1.0.0`:

1. ✅ `version` obsolete warnings confirmed (both yaml files)
2. ✅ `secrets/tenants` directory confirmed missing — the bind mount error is deterministic

Closes the `secrets/tenants` bind mount error for anyone following the setup guide verbatim.