### PR TITLE
docs: add secrets/tenants directory to setup guide

### DIFF
--- a/docs/getting-started/setup_guide.md
+++ b/docs/getting-started/setup_guide.md
@@ -38,7 +38,7 @@ This guide provides step-by-step instructions for setting up the PSA system usin
    This checks for a published CE image matching the current `HEAD` short SHA. If it exists, the script pulls it and writes `.env.image` alongside `server/.env` with `ALGA_IMAGE_TAG=<sha>`. If no matching image exists, the script builds the CE image locally from the current checkout, tags it with that same SHA, and writes `.env.image`. If the worktree has uncommitted changes, the script builds locally with a `<sha>-local` tag so the image cannot be confused with the published commit image. Re-run the script whenever you upgrade or switch commits. If the local image build needs a larger Node.js heap, run `NEXT_BUILD_MAX_OLD_SPACE_SIZE=16384 ./scripts/set-image-tag.sh`.
 2. Create required directories:
    ```bash
-   mkdir -p secrets
+   mkdir -p secrets/tenants
    ```
 
 ## Secrets Configuration


### PR DESCRIPTION
Same fix as #2515 — targeting main for the next release.

**Problem:** The CE prebuilt docker-compose bind-mounts `./secrets/tenants` as a directory on both the `server` and `email-service` containers, but the setup guide only creates `secrets/` with individual files. Missing `secrets/tenants/` blocks container startup.

**Fix:** `mkdir -p secrets` → `mkdir -p secrets/tenants` (creates both).