### PR TITLE
Add AI full-text business search workflow

### DIFF
--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -19,7 +19,9 @@ import { useAIChatContext } from '@product/chat/context';
 
 import {
   readAssistantContentFromSse,
+  type SseContinuationAvailable,
   type SseFunctionProposal,
+  type SseToolExecuted,
 } from './readAssistantContentFromSse';
 import { ChatMentionChip, type ChatMention } from './ChatMentionChip';
 import {
@@ -80,6 +82,12 @@ type PendingFunctionState = {
   assistantPreview: string;
   assistantReasoning?: string;
   functionCall: FunctionCallInfo;
+  nextMessages: ChatCompletionMessage[];
+  chatId?: string | null;
+};
+
+type PendingContinuationState = {
+  reason: string;
   nextMessages: ChatCompletionMessage[];
   chatId?: string | null;
 };
@@ -183,6 +191,16 @@ const buildFunctionCallMeta = (
   status: FunctionCallMeta['status'],
 ): FunctionCallMeta => {
   const httpDetails = determineHttpDetails(fn);
+  const rawDetails = {
+    ...(fn.metadata?.arguments ?? {}),
+    ...(fn.functionCall?.arguments ?? {}),
+  };
+  const details = Object.fromEntries(
+    Object.entries(rawDetails).filter(
+      ([key, value]) => value !== undefined && !['method', 'path'].includes(key),
+    ),
+  );
+
   return {
     displayName: fn.metadata.displayName ?? fn.functionCall?.name ?? t('chat.defaultFunctionName'),
     method: httpDetails.method,
@@ -191,6 +209,7 @@ const buildFunctionCallMeta = (
     status,
     timestamp: new Date().toISOString(),
     preview: sanitizeThinking(fn.assistantPreview ?? ''),
+    details: Object.keys(details).length > 0 ? details : undefined,
     notice:
       fn.functionCall.toolResultTruncated && action === 'approve'
         ? t('chat.resultTruncated')
@@ -321,6 +340,7 @@ export const Chat: React.FC<ChatProps> = ({
   const [pendingFunctionStatus, setPendingFunctionStatus] = useState<'idle' | 'awaiting' | 'executing'>('idle');
   const [pendingFunctionAction, setPendingFunctionAction] = useState<'none' | 'approve' | 'decline'>('none');
   const [functionError, setFunctionError] = useState<string | null>(null);
+  const [pendingContinuation, setPendingContinuation] = useState<PendingContinuationState | null>(null);
   const [autoApprovedMethods, setAutoApprovedMethods] = useState<string[]>([]);
   const [mentions, setMentions] = useState<ChatMention[]>([]);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
@@ -380,6 +400,21 @@ export const Chat: React.FC<ChatProps> = ({
         functionCallMeta: meta,
       },
     ]);
+  };
+
+  const appendAutoExecutedToolMarker = (event: SseToolExecuted) => {
+    appendFunctionCallMarker(
+      {
+        metadata: event.function,
+        assistantPreview: event.assistantPreview,
+        assistantReasoning: event.assistantReasoning,
+        functionCall: event.functionCall,
+        nextMessages: event.modelMessages ?? event.nextMessages,
+        chatId,
+      },
+      'approve',
+      'success',
+    );
   };
 
   void accountId;
@@ -707,6 +742,7 @@ export const Chat: React.FC<ChatProps> = ({
   ) => {
     const reuseExistingUserMessage = options?.reuseExistingUserMessage ?? false;
     setFunctionError(null);
+    setPendingContinuation(null);
     setEditingMessageIndex(null);
     setFullMessageStatus(null);
     setFullMessageStatusDetail(null);
@@ -832,6 +868,7 @@ export const Chat: React.FC<ChatProps> = ({
       let sawToken = false;
       let shouldContinueStreaming = true;
       let streamedFunctionProposal: PendingFunctionState | null = null;
+      let streamedContinuation: PendingContinuationState | null = null;
       let streamedReasoning: string | null = null;
 
       const scheduleIncomingRender = () => {
@@ -880,6 +917,21 @@ export const Chat: React.FC<ChatProps> = ({
             };
             shouldContinueStreaming = false;
           },
+          onToolExecuted: (event: SseToolExecuted) => {
+            if (generationIdRef.current !== generationId) {
+              return;
+            }
+            appendAutoExecutedToolMarker(event);
+          },
+          onContinuationAvailable: (event: SseContinuationAvailable) => {
+            const modelMessages = (event.modelMessages ??
+              event.nextMessages) as ChatCompletionMessage[];
+            streamedContinuation = {
+              reason: event.reason,
+              nextMessages: modelMessages,
+              chatId: createdChatId ?? chatId,
+            };
+          },
         });
 
       if (generationIdRef.current !== generationId) {
@@ -893,6 +945,17 @@ export const Chat: React.FC<ChatProps> = ({
         setPendingFunctionAction('none');
         setIncomingMessage('');
         setIsFunction(true);
+        setGeneratingResponse(false);
+        streamingTextRef.current = null;
+        streamAbortControllerRef.current = null;
+        return;
+      }
+
+      if (streamedContinuation) {
+        setConversation(streamedContinuation.nextMessages);
+        setPendingContinuation(streamedContinuation);
+        setIncomingMessage('');
+        setIsFunction(false);
         setGeneratingResponse(false);
         streamingTextRef.current = null;
         streamAbortControllerRef.current = null;
@@ -979,6 +1042,22 @@ export const Chat: React.FC<ChatProps> = ({
     mentions,
     t,
   ]);
+
+  const handleContinueFromToolLimit = useCallback(async () => {
+    if (!pendingContinuation) {
+      return;
+    }
+    const lastUserMessage = [...pendingContinuation.nextMessages]
+      .reverse()
+      .find((message) => message.role === 'user' && typeof message.content === 'string');
+    const prompt = typeof lastUserMessage?.content === 'string' && lastUserMessage.content.trim().length > 0
+      ? lastUserMessage.content
+      : t('chat.continuation.defaultPrompt');
+    await handleSend(prompt, {
+      reuseExistingUserMessage: true,
+      baseConversation: pendingContinuation.nextMessages,
+    });
+  }, [handleSend, pendingContinuation, t]);
 
   useEffect(() => {
     if (!autoSendPrompt) {
@@ -1385,7 +1464,7 @@ export const Chat: React.FC<ChatProps> = ({
   }, [autoResizeTextarea]);
 
   const canModifyHistory =
-    !generatingResponse && !isFunction && !isExecutingFunction && !pendingFunction;
+    !generatingResponse && !isFunction && !isExecutingFunction && !pendingFunction && !pendingContinuation;
   const canStop = generatingResponse || isExecutingFunction;
 
   const handleChatScroll = useCallback(() => {
@@ -1614,6 +1693,40 @@ export const Chat: React.FC<ChatProps> = ({
                   reasoning={fullReasoning ?? undefined}
                   showStreamingCursor={generatingResponse && !isFunction}
                 />
+              )}
+              {pendingContinuation && (
+                <div className="function-approval-wrapper">
+                  <Image
+                    className="chat-img"
+                    src="/avatar-purple-no-shadow.svg"
+                    alt={t('chat.avatarAlt')}
+                    width={18}
+                    height={18}
+                  />
+                  <div className="function-approval-bubble function-approval-bubble--continuation">
+                    <div className="function-approval-header">
+                      <span className="function-approval-badge">{t('chat.continuation.badge')}</span>
+                      <span className="function-approval-endpoint">{t('chat.continuation.endpoint')}</span>
+                    </div>
+                    <h3 className="function-approval-title">{t('chat.continuation.title')}</h3>
+                    <p className="function-approval-preview">
+                      {pendingContinuation.reason || t('chat.continuation.description')}
+                    </p>
+                    <div className="function-approval-status">{t('chat.continuation.status')}</div>
+                    <div className="function-approval-actions">
+                      <Button
+                        id="chat-continue-tool-chain"
+                        label={t('chat.continuation.continueAriaLabel')}
+                        size="sm"
+                        variant="default"
+                        onClick={() => void handleContinueFromToolLimit()}
+                        disabled={generatingResponse || isFunction}
+                      >
+                        {t('chat.continuation.continue')}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
               )}
               {pendingFunction && (
                 <div className="function-approval-wrapper">

--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -422,7 +422,7 @@ export const Chat: React.FC<ChatProps> = ({
         assistantPreview: event.assistantPreview,
         assistantReasoning: event.assistantReasoning,
         functionCall: event.functionCall,
-        nextMessages: event.modelMessages ?? event.nextMessages,
+        nextMessages: (event.modelMessages ?? event.nextMessages) as ChatCompletionMessage[],
         chatId,
       },
       'approve',

--- a/ee/server/src/components/chat/Chat.tsx
+++ b/ee/server/src/components/chat/Chat.tsx
@@ -217,6 +217,18 @@ const buildFunctionCallMeta = (
   };
 };
 
+const buildAutoToolBundleMeta = (items: FunctionCallMeta[]): FunctionCallMeta => ({
+  displayName: `Ran ${items.length} read-only calls`,
+  method: 'AUTO',
+  endpoint: `${items.length} searches/API calls`,
+  action: 'approve',
+  status: items.some((item) => item.status === 'error') ? 'error' : 'success',
+  timestamp: items.at(-1)?.timestamp ?? new Date().toISOString(),
+  preview: 'Alga automatically gathered read-only context. Expand to inspect each call.',
+  autoExecuted: true,
+  bundleItems: items,
+});
+
 type ChatProps = {
   clientUrl: string;
   accountId: string;
@@ -403,7 +415,8 @@ export const Chat: React.FC<ChatProps> = ({
   };
 
   const appendAutoExecutedToolMarker = (event: SseToolExecuted) => {
-    appendFunctionCallMarker(
+    const meta = buildFunctionCallMeta(
+      t,
       {
         metadata: event.function,
         assistantPreview: event.assistantPreview,
@@ -415,6 +428,32 @@ export const Chat: React.FC<ChatProps> = ({
       'approve',
       'success',
     );
+    meta.autoExecuted = true;
+
+    setNewChatMessages((prev) => {
+      const last = prev.at(-1);
+      const lastMeta = last?.functionCallMeta;
+      if (last?.role !== 'function-call' || !lastMeta?.autoExecuted) {
+        return [
+          ...prev,
+          {
+            _id: resolveMessageId(),
+            role: 'function-call',
+            content: '',
+            functionCallMeta: meta,
+          },
+        ];
+      }
+
+      const bundleItems = lastMeta.bundleItems ? [...lastMeta.bundleItems, meta] : [lastMeta, meta];
+      return [
+        ...prev.slice(0, -1),
+        {
+          ...last,
+          functionCallMeta: buildAutoToolBundleMeta(bundleItems),
+        },
+      ];
+    });
   };
 
   void accountId;

--- a/ee/server/src/components/chat/readAssistantContentFromSse.ts
+++ b/ee/server/src/components/chat/readAssistantContentFromSse.ts
@@ -26,7 +26,26 @@ type StreamFunctionProposalPayload = {
   modelMessages?: Array<Record<string, unknown>>;
 };
 
+type StreamToolExecutedPayload = {
+  type: 'tool_executed';
+  function: StreamFunctionMetadata;
+  assistantPreview: string;
+  assistantReasoning?: string;
+  functionCall: StreamFunctionCallInfo;
+  nextMessages: Array<Record<string, unknown>>;
+  modelMessages?: Array<Record<string, unknown>>;
+};
+
+type StreamContinuationPayload = {
+  type: 'continuation_available';
+  reason: string;
+  nextMessages: Array<Record<string, unknown>>;
+  modelMessages?: Array<Record<string, unknown>>;
+};
+
 export type SseFunctionProposal = StreamFunctionProposalPayload;
+export type SseToolExecuted = StreamToolExecutedPayload;
+export type SseContinuationAvailable = StreamContinuationPayload;
 
 type StreamEventPayload = {
   type?: unknown;
@@ -46,6 +65,8 @@ export type SseReadHandlers = {
   onToken?: (token: string, accumulated: string) => void;
   onReasoning?: (token: string, accumulated: string) => void;
   onToolCalls?: (proposal: StreamFunctionProposalPayload) => void;
+  onToolExecuted?: (event: StreamToolExecutedPayload) => void;
+  onContinuationAvailable?: (event: StreamContinuationPayload) => void;
   onDone?: (accumulated: string) => void;
 };
 
@@ -100,7 +121,7 @@ export async function readAssistantContentFromSse(
         continue;
       }
 
-      if (eventType === 'function_proposed') {
+      if (eventType === 'function_proposed' || eventType === 'tool_executed') {
         const fn = payload.function;
         const functionCall = payload.functionCall;
         const nextMessages = payload.nextMessages;
@@ -113,7 +134,19 @@ export async function readAssistantContentFromSse(
           !Array.isArray(functionCall) &&
           Array.isArray(nextMessages)
         ) {
-          handlers.onToolCalls?.(payload as StreamFunctionProposalPayload);
+          if (eventType === 'function_proposed') {
+            handlers.onToolCalls?.(payload as StreamFunctionProposalPayload);
+          } else {
+            handlers.onToolExecuted?.(payload as StreamToolExecutedPayload);
+          }
+        }
+        continue;
+      }
+
+      if (eventType === 'continuation_available') {
+        const nextMessages = payload.nextMessages;
+        if (Array.isArray(nextMessages)) {
+          handlers.onContinuationAvailable?.(payload as StreamContinuationPayload);
         }
         continue;
       }

--- a/ee/server/src/components/message/Message.tsx
+++ b/ee/server/src/components/message/Message.tsx
@@ -18,6 +18,8 @@ export type FunctionCallMeta = {
   preview?: string;
   notice?: string;
   details?: Record<string, unknown>;
+  autoExecuted?: boolean;
+  bundleItems?: FunctionCallMeta[];
 };
 
 type MessageProps = {
@@ -176,6 +178,7 @@ export const Message: React.FC<MessageProps> = ({
     const preview =
       previewRaw && previewRaw.length > 220 ? `${previewRaw.slice(0, 217)}…` : previewRaw;
     const notice = functionCallMeta.notice?.trim();
+    const bundleItems = functionCallMeta.bundleItems ?? [];
     const detailEntries = Object.entries(functionCallMeta.details ?? {}).filter(
       ([, value]) => value !== undefined,
     );
@@ -212,9 +215,59 @@ export const Message: React.FC<MessageProps> = ({
               <span className="function-card__badge">{functionCallMeta.method}</span>
               <span className="function-card__endpoint">{functionCallMeta.endpoint}</span>
             </div>
+            {bundleItems.length > 0 ? (
+              <div className="function-card__bundle-strip" aria-label="Executed calls">
+                {bundleItems.slice(0, 6).map((item, index) => (
+                  <span key={`${item.method}-${item.endpoint}-${index}`} className="function-card__bundle-chip">
+                    <span>{item.method}</span>
+                    {item.endpoint}
+                  </span>
+                ))}
+                {bundleItems.length > 6 ? (
+                  <span className="function-card__bundle-more">+{bundleItems.length - 6} more</span>
+                ) : null}
+              </div>
+            ) : null}
             {preview ? <p className="function-card__preview">{preview}</p> : null}
             {notice ? <p className="function-card__preview">{notice}</p> : null}
-            {detailEntries.length > 0 ? (
+            {bundleItems.length > 0 ? (
+              <details className="function-card__details">
+                <summary>{t('chat.viewDetails')}</summary>
+                <div className="function-card__bundle-list">
+                  {bundleItems.map((item, index) => {
+                    const itemDetailEntries = Object.entries(item.details ?? {}).filter(
+                      ([, value]) => value !== undefined,
+                    );
+                    return (
+                      <section key={`${item.method}-${item.endpoint}-${index}`} className="function-card__bundle-item">
+                        <div className="function-card__bundle-item-header">
+                          <span className="function-card__badge">{item.method}</span>
+                          <span className="function-card__endpoint">{item.endpoint}</span>
+                        </div>
+                        <div className="function-card__bundle-item-title">{item.displayName}</div>
+                        {item.preview ? <p className="function-card__preview">{item.preview}</p> : null}
+                        {itemDetailEntries.length > 0 ? (
+                          <dl className="function-card__detail-list">
+                            {itemDetailEntries.map(([key, value]) => {
+                              const formatted = formatDetailValue(value);
+                              const isStructured = formatted.includes('\n') || formatted.length > 90;
+                              return (
+                                <div key={key} className="function-card__detail-row">
+                                  <dt>{formatDetailKey(key)}</dt>
+                                  <dd>
+                                    {isStructured ? <pre>{formatted}</pre> : <span>{formatted}</span>}
+                                  </dd>
+                                </div>
+                              );
+                            })}
+                          </dl>
+                        ) : null}
+                      </section>
+                    );
+                  })}
+                </div>
+              </details>
+            ) : detailEntries.length > 0 ? (
               <details className="function-card__details">
                 <summary>{t('chat.viewDetails')}</summary>
                 <dl className="function-card__detail-list">

--- a/ee/server/src/components/message/Message.tsx
+++ b/ee/server/src/components/message/Message.tsx
@@ -17,6 +17,7 @@ export type FunctionCallMeta = {
   timestamp: string;
   preview?: string;
   notice?: string;
+  details?: Record<string, unknown>;
 };
 
 type MessageProps = {
@@ -94,6 +95,25 @@ const FunctionStatusIcon: React.FC<{ status: FunctionCallMeta['status'] }> = ({ 
   );
 };
 
+const formatDetailValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') {
+    return '—';
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const formatDetailKey = (key: string) =>
+  key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
 const formatTimestamp = (timestamp?: string) => {
   if (!timestamp) {
     return '';
@@ -156,6 +176,9 @@ export const Message: React.FC<MessageProps> = ({
     const preview =
       previewRaw && previewRaw.length > 220 ? `${previewRaw.slice(0, 217)}…` : previewRaw;
     const notice = functionCallMeta.notice?.trim();
+    const detailEntries = Object.entries(functionCallMeta.details ?? {}).filter(
+      ([, value]) => value !== undefined,
+    );
     const statusLabel =
       functionCallMeta.status === 'success'
         ? t('message.functionStatus.success')
@@ -191,6 +214,25 @@ export const Message: React.FC<MessageProps> = ({
             </div>
             {preview ? <p className="function-card__preview">{preview}</p> : null}
             {notice ? <p className="function-card__preview">{notice}</p> : null}
+            {detailEntries.length > 0 ? (
+              <details className="function-card__details">
+                <summary>{t('chat.viewDetails')}</summary>
+                <dl className="function-card__detail-list">
+                  {detailEntries.map(([key, value]) => {
+                    const formatted = formatDetailValue(value);
+                    const isStructured = formatted.includes('\n') || formatted.length > 90;
+                    return (
+                      <div key={key} className="function-card__detail-row">
+                        <dt>{formatDetailKey(key)}</dt>
+                        <dd>
+                          {isStructured ? <pre>{formatted}</pre> : <span>{formatted}</span>}
+                        </dd>
+                      </div>
+                    );
+                  })}
+                </dl>
+              </details>
+            ) : null}
             <span className="function-card__timestamp">
               {formatTimestamp(functionCallMeta.timestamp)}
             </span>

--- a/ee/server/src/components/message/message.css
+++ b/ee/server/src/components/message/message.css
@@ -433,6 +433,79 @@
   line-height: 1.45;
 }
 
+.function-card__details {
+  margin-top: 0.1rem;
+  border-top: 1px solid rgba(var(--color-border-200), 0.85);
+  padding-top: 0.45rem;
+}
+
+.function-card__details summary {
+  cursor: pointer;
+  width: fit-content;
+  color: rgb(var(--color-primary-600));
+  font-size: 0.78rem;
+  font-weight: 650;
+  list-style: none;
+}
+
+.function-card__details summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.35rem;
+  transition: transform 120ms ease;
+}
+
+.function-card__details[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.function-card__details summary::-webkit-details-marker {
+  display: none;
+}
+
+.function-card__detail-list {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0.55rem 0 0;
+}
+
+.function-card__detail-row {
+  display: grid;
+  grid-template-columns: minmax(6rem, 0.32fr) 1fr;
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.function-card__detail-row dt {
+  color: rgb(var(--color-text-500));
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.function-card__detail-row dd {
+  min-width: 0;
+  margin: 0;
+  color: rgb(var(--color-text-700));
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.function-card__detail-row pre {
+  max-height: 13rem;
+  overflow: auto;
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(var(--color-border-200), 0.9);
+  background: rgba(var(--color-card), 0.7);
+  color: rgb(var(--color-text-800));
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
 .function-card__timestamp {
   font-size: 0.74rem;
   color: rgba(var(--color-text-500), 0.85);

--- a/ee/server/src/components/message/message.css
+++ b/ee/server/src/components/message/message.css
@@ -289,6 +289,60 @@
   text-decoration: underline;
 }
 
+.message-content table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0.75rem 0;
+  border: 1px solid rgba(var(--color-border-200), 0.95);
+  border-radius: 0.65rem;
+  border-spacing: 0;
+  border-collapse: separate;
+  background: rgba(var(--color-card), 0.7);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.message-content thead {
+  background: rgba(var(--color-primary-50), 0.9);
+}
+
+.message-content th,
+.message-content td {
+  padding: 0.55rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(var(--color-border-200), 0.75);
+}
+
+.message-content th {
+  color: rgb(var(--color-text-800));
+  font-size: 0.73rem;
+  font-weight: 750;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.message-content td {
+  color: rgb(var(--color-text-800));
+}
+
+.message-content tbody tr:nth-child(even) {
+  background: rgba(var(--color-border-50), 0.55);
+}
+
+.message-content tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.message-content th:first-child,
+.message-content td:first-child,
+.message-content th:last-child,
+.message-content td:last-child {
+  white-space: nowrap;
+}
+
 .message-bubble--user .message-content a {
   color: rgb(var(--color-primary-600));
   text-decoration: underline;
@@ -461,6 +515,66 @@
 
 .function-card__details summary::-webkit-details-marker {
   display: none;
+}
+
+.function-card__bundle-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.05rem;
+}
+
+.function-card__bundle-chip,
+.function-card__bundle-more {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+  padding: 0.22rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--color-border-200), 0.95);
+  background: rgba(var(--color-card), 0.72);
+  color: rgb(var(--color-text-600));
+  font-size: 0.73rem;
+}
+
+.function-card__bundle-chip span {
+  color: rgb(var(--color-primary-700));
+  font-weight: 750;
+  letter-spacing: 0.04em;
+}
+
+.function-card__bundle-more {
+  color: rgb(var(--color-text-500));
+  font-weight: 650;
+}
+
+.function-card__bundle-list {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.55rem;
+}
+
+.function-card__bundle-item {
+  display: grid;
+  gap: 0.38rem;
+  padding: 0.65rem;
+  border: 1px solid rgba(var(--color-border-200), 0.9);
+  border-radius: 0.55rem;
+  background: rgba(var(--color-card), 0.58);
+}
+
+.function-card__bundle-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.function-card__bundle-item-title {
+  color: rgb(var(--color-text-800));
+  font-size: 0.82rem;
+  font-weight: 700;
 }
 
 .function-card__detail-list {

--- a/ee/server/src/lib/chat-actions/chatActions.tsx
+++ b/ee/server/src/lib/chat-actions/chatActions.tsx
@@ -1,6 +1,6 @@
 'use server'
 
-import { createTenantKnex } from '@/lib/db';
+import { createTenantKnex, runWithTenant } from '@/lib/db';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { IChat } from '../../interfaces/chat.interface';
 import { IMessage } from '../../interfaces/message.interface';
@@ -76,7 +76,12 @@ export async function createNewChatAction(data: Omit<IChat, 'tenant'>) {
   }
 
   try {
-    const conversation = await Chat.insert(chatPayload as IChat);
+    const user = await getCurrentUser();
+    const tenant = user?.tenant;
+    if (!tenant) {
+      throw new Error('Missing tenant for chat persistence');
+    }
+    const conversation = await runWithTenant(tenant, () => Chat.insert(chatPayload as IChat));
     return { _id: conversation.id, persisted: true };
   } catch (error) {
     if (isMissingRelationError(error)) {
@@ -97,28 +102,37 @@ export async function addMessageToChatAction(data: Omit<IMessage, 'tenant'>) {
   }
 
   try {
-    const message = await Message.insert(data);
-    if (data.chat_id) {
-      try {
-        const { knex } = await createTenantKnex();
-        await knex<IChat>('chats')
-          .where({ id: data.chat_id })
-          .update({ updated_at: knex.fn.now() });
-      } catch (touchError) {
-        if (
-          typeof touchError === 'object' &&
-          touchError !== null &&
-          'code' in touchError &&
-          (touchError as { code?: string }).code === '42703'
-        ) {
-          console.warn(
-            '[chatActions] chats.updated_at column missing; skipping chat recency update.',
-          );
-        } else {
-          throw touchError;
+    const user = await getCurrentUser();
+    const tenant = user?.tenant;
+    if (!tenant) {
+      throw new Error('Missing tenant for chat persistence');
+    }
+
+    const message = await runWithTenant(tenant, async () => {
+      const inserted = await Message.insert(data);
+      if (data.chat_id) {
+        try {
+          const { knex } = await createTenantKnex();
+          await knex<IChat>('chats')
+            .where({ id: data.chat_id })
+            .update({ updated_at: knex.fn.now() });
+        } catch (touchError) {
+          if (
+            typeof touchError === 'object' &&
+            touchError !== null &&
+            'code' in touchError &&
+            (touchError as { code?: string }).code === '42703'
+          ) {
+            console.warn(
+              '[chatActions] chats.updated_at column missing; skipping chat recency update.',
+            );
+          } else {
+            throw touchError;
+          }
         }
       }
-    }
+      return inserted;
+    });
     return { _id: message.id, persisted: true };
   } catch (error) {
     if (isMissingRelationError(error)) {

--- a/ee/server/src/services/chatCompletionsService.ts
+++ b/ee/server/src/services/chatCompletionsService.ts
@@ -1621,7 +1621,7 @@ export class ChatCompletionsService {
             iteration,
             toolNames: toolCalls.map((toolCall) => toolCall.function?.name ?? 'unknown'),
           });
-          conversation = autoConversation;
+          conversation = autoConversation.conversation;
           continue;
         }
 

--- a/ee/server/src/services/chatCompletionsService.ts
+++ b/ee/server/src/services/chatCompletionsService.ts
@@ -8,11 +8,24 @@ import { getProject } from '@alga-psa/projects/actions/projectActions';
 import { getTicketById } from '@alga-psa/tickets/actions/ticketActions';
 import { findCommentsByTicketId } from '@alga-psa/tickets/actions/comment-actions';
 import { getCurrentUser, findUserById } from '@alga-psa/user-composition/actions';
+import { createTenantKnex, runWithTenant } from '@/lib/db';
 import { getRegistry } from '../chat/registry/apiRegistry.indexer';
 import {
   ChatApiRegistryEntry,
 } from '../chat/registry/apiRegistry.schema';
 import { searchRegistryEntries, type RegistrySearchResult } from '../chat/registry/search';
+import {
+  resolveSearchAclPrincipal,
+  verifyResultVisibility,
+  type ClientAccess,
+} from '@/lib/search/acl';
+import {
+  countSearchMatches,
+  countSearchMatchesByType,
+  encodeSearchCursor,
+  runSearchQuery,
+} from '@/lib/search/query';
+import { SEARCH_OBJECT_TYPES, type SearchObjectType } from '@alga-psa/types';
 import { TemporaryApiKeyService } from './temporaryApiKeyService';
 import { parseAssistantContent, ParsedAssistantContent } from '../utils/chatContent';
 import { reprovisionExtension } from '../lib/actions/extensionDomainActions';
@@ -37,6 +50,7 @@ const RATE_LIMIT_BASE_DELAY_MS = 500;
 const RATE_LIMIT_MAX_DELAY_MS = 5000;
 const MIN_RATE_LIMIT_DELAY_MS = 100;
 const SEARCH_TOOL_NAME = 'search_api_registry';
+const BUSINESS_SEARCH_TOOL_NAME = 'search_business_data';
 const EXECUTE_TOOL_NAME = 'call_api_endpoint';
 const FINISH_TOOL_NAME = 'finish_response';
 const MAX_TOOL_ITERATIONS = 6;
@@ -148,6 +162,21 @@ export type ChatCompletionStreamEvent =
       type: 'function_proposed';
     } & FunctionProposedResponse)
   | {
+      type: 'tool_executed';
+      function: FunctionMetadata;
+      assistantPreview: string;
+      assistantReasoning?: string;
+      functionCall: FunctionCallInfo;
+      nextMessages: ChatCompletionMessage[];
+      modelMessages: ChatCompletionMessage[];
+    }
+  | {
+      type: 'continuation_available';
+      reason: string;
+      nextMessages: ChatCompletionMessage[];
+      modelMessages: ChatCompletionMessage[];
+    }
+  | {
       type: 'done';
     };
 
@@ -157,6 +186,7 @@ interface InitialCompletionParams {
   baseUrl: string;
   tenantId: string;
   userId: string;
+  cookieHeader?: string;
   uiContext?: ChatUiContext;
 }
 
@@ -199,6 +229,11 @@ type ToolArgumentParseContext = {
   source: 'stream' | 'non_stream';
   functionName?: string;
   toolCallId?: string;
+};
+
+type AutoToolAppendResult = {
+  conversation: ChatCompletionMessage[];
+  events: ChatCompletionStreamEvent[];
 };
 
 type StreamedToolCallState = {
@@ -269,11 +304,26 @@ export class ChatCompletionsService {
 
   static async *createStructuredCompletionStream(
     messages: ChatCompletionMessage[],
-    options: { signal?: AbortSignal; uiContext?: ChatUiContext; mentions?: ChatMention[] } = {},
+    options: {
+      signal?: AbortSignal;
+      uiContext?: ChatUiContext;
+      mentions?: ChatMention[];
+      baseUrl?: string;
+      tenantId?: string;
+      userId?: string;
+      chatId?: string | null;
+      cookieHeader?: string;
+      currentUser?: Record<string, unknown>;
+    } = {},
   ): AsyncGenerator<ChatCompletionStreamEvent> {
     const provider = await resolveChatProvider();
     let conversation = this.normalizeConversationHistory(messages);
     const promptContext = await this.buildPromptContext(options.uiContext, options.mentions);
+    const currentUser = options.currentUser ?? ((await getCurrentUser()) as unknown as Record<string, unknown> | null);
+    const tenantId = options.tenantId ?? (typeof currentUser?.tenant === 'string' ? currentUser.tenant : undefined);
+    const userId = options.userId ?? (typeof currentUser?.user_id === 'string' ? currentUser.user_id : undefined);
+    const baseUrl = options.baseUrl ?? '';
+    const chatId = options.chatId ?? null;
 
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
       if (options.signal?.aborted) {
@@ -323,6 +373,30 @@ export class ChatCompletionsService {
       const toolCalls = this.materializeStreamedToolCalls(streamedToolCalls);
 
       if (toolCalls.length > 1) {
+        const autoConversation = await this.tryAppendAutoToolResultsForMultipleCalls({
+          conversation,
+          parsedContent,
+          toolCalls,
+          source: 'stream',
+          baseUrl,
+          tenantId,
+          userId,
+          chatId,
+          cookieHeader: options.cookieHeader,
+          currentUser: currentUser ?? undefined,
+        });
+        if (autoConversation) {
+          this.logDebug('stream_tool_multiple_auto_executed', {
+            iteration,
+            toolNames: toolCalls.map((toolCall) => toolCall.function?.name ?? 'unknown'),
+          });
+          for (const event of autoConversation.events) {
+            yield event;
+          }
+          conversation = autoConversation.conversation;
+          continue;
+        }
+
         this.logWarn('stream_retry_multiple_tool_calls', {
           iteration,
           toolNames: toolCalls.map((toolCall) => toolCall.function?.name ?? 'unknown'),
@@ -402,6 +476,46 @@ export class ChatCompletionsService {
               tool_call_id: toolCallId,
             },
           ];
+          yield this.buildAutoToolExecutedEvent({
+            toolName: SEARCH_TOOL_NAME,
+            parsedArgs,
+            parsedContent,
+            toolCallId,
+            conversation,
+          });
+          continue;
+        }
+
+        if (functionName === BUSINESS_SEARCH_TOOL_NAME) {
+          this.logDebug('stream_tool_search_business_data', {
+            iteration,
+            query: typeof parsedArgs.query === 'string' ? parsedArgs.query : undefined,
+            types: parsedArgs.types,
+            limit: parsedArgs.limit,
+          });
+          const results = await this.searchBusinessData(parsedArgs, {
+            tenantId,
+            userId,
+            currentUser: currentUser ?? undefined,
+          });
+          const replay = this.serializeToolResultForConversation(results);
+          conversation = [
+            ...conversation,
+            assistantMessage,
+            {
+              role: 'function',
+              name: BUSINESS_SEARCH_TOOL_NAME,
+              content: replay.content,
+              tool_call_id: toolCallId,
+            },
+          ];
+          yield this.buildAutoToolExecutedEvent({
+            toolName: BUSINESS_SEARCH_TOOL_NAME,
+            parsedArgs,
+            parsedContent,
+            toolCallId,
+            conversation,
+          });
           continue;
         }
 
@@ -445,6 +559,62 @@ export class ChatCompletionsService {
             method: entry.method.toUpperCase(),
             path: entry.path,
           });
+
+          if (this.isReadOnlyRegistryEntry(entry, preparedArgs) && baseUrl && tenantId && userId) {
+            try {
+              this.logDebug('stream_tool_execute_auto_get', {
+                iteration,
+                entryId: entry.id,
+                path: entry.path,
+              });
+              const resultPayload = await this.executeReadOnlyApiCall({
+                entry,
+                args: preparedArgs,
+                baseUrl,
+                tenantId,
+                userId,
+                chatId,
+                cookieHeader: options.cookieHeader,
+              });
+              const replay = this.serializeToolResultForConversation(resultPayload);
+              conversation = [
+                ...conversation,
+                {
+                  role: 'function',
+                  name: EXECUTE_TOOL_NAME,
+                  content: replay.content,
+                  tool_call_id: toolCallId,
+                },
+              ];
+              yield this.buildAutoToolExecutedEvent({
+                toolName: EXECUTE_TOOL_NAME,
+                parsedArgs: preparedArgs,
+                parsedContent,
+                toolCallId,
+                conversation,
+                entry,
+              });
+              continue;
+            } catch (error) {
+              const message = error instanceof Error ? error.message : 'Read-only API call failed.';
+              this.logWarn('stream_tool_execute_auto_get_failed', {
+                iteration,
+                entryId: entry.id,
+                error: message,
+              });
+              conversation = [
+                ...conversation,
+                {
+                  role: 'function',
+                  name: EXECUTE_TOOL_NAME,
+                  content: JSON.stringify({ error: message }),
+                  tool_call_id: toolCallId,
+                },
+              ];
+              continue;
+            }
+          }
+
           const metadata = this.buildFunctionMetadata(entry, preparedArgs);
           const assistantPreview = this.buildFunctionPreview(parsedContent, entry);
           yield {
@@ -536,6 +706,12 @@ export class ChatCompletionsService {
       maxIterations: MAX_TOOL_ITERATIONS,
       ...this.summarizeConversation(conversation),
     });
+    yield {
+      type: 'continuation_available',
+      reason: `Reached the ${MAX_TOOL_ITERATIONS}-step tool limit while gathering information.`,
+      nextMessages: this.sanitizeMessagesForClient(conversation),
+      modelMessages: conversation,
+    };
     yield { type: 'done' };
   }
 
@@ -579,6 +755,7 @@ export class ChatCompletionsService {
         baseUrl: req.nextUrl.origin,
         tenantId: user.tenant,
         userId: user.user_id,
+        cookieHeader: req.headers.get('cookie') ?? undefined,
         uiContext,
       });
 
@@ -697,6 +874,7 @@ export class ChatCompletionsService {
       tenantId: params.tenantId,
       userId: params.userId,
       uiContext: params.uiContext,
+      cookieHeader: params.cookieHeader,
     });
   }
 
@@ -761,6 +939,7 @@ export class ChatCompletionsService {
       tenantId,
       userId,
       uiContext,
+      cookieHeader,
     });
 
     if (response.type === 'assistant_message') {
@@ -806,9 +985,48 @@ export class ChatCompletionsService {
       {
         type: 'function' as const,
         function: {
+          name: BUSINESS_SEARCH_TOOL_NAME,
+          description:
+            'Search tenant-scoped business data across tickets, projects, clients, contacts, assets, companies, invoices, services, and knowledge/reference records. This is read-only and executes automatically. Use this to find relevant business records before calling exact API endpoints for details. Query should be a concise full-text search expression made from likely record words, identifiers, names, or quoted phrases — not a full sentence. If restricting types, omit redundant object-type words from the query. Use OR for alternatives, e.g. "laptop OR workstation OR desktop" with types=["ticket"], not "tickets related to laptops or workstations".',
+          parameters: {
+            type: 'object',
+            properties: {
+              query: {
+                type: 'string',
+                description: 'Concise full-text query for business records. Use likely record words, identifiers, names, quoted phrases, and OR alternatives. Avoid filler phrases like "related to", "about", "show me", or redundant type words when types is set. Good: "laptop OR workstation OR desktop" with types=["ticket"]; bad: "tickets related to laptops or workstations".'
+              },
+              types: {
+                type: 'array',
+                description: 'Optional object types to restrict the search. Omit to search all visible business data.',
+                items: isVertex
+                  ? { type: 'string' }
+                  : { type: 'string', enum: [...SEARCH_OBJECT_TYPES] },
+              },
+              limit: {
+                type: isVertex ? 'number' : 'integer',
+                description: 'Maximum number of results to return (default 10, max 25).',
+              },
+              cursor: {
+                type: 'string',
+                description: 'Optional cursor from a prior search_business_data result.',
+              },
+              sort: {
+                type: 'string',
+                description: 'Sort by "relevance" or "recent" (default relevance).',
+                ...(isVertex ? {} : { enum: ['relevance', 'recent'] }),
+              },
+            },
+            required: ['query'],
+            ...(isVertex ? {} : { additionalProperties: false }),
+          },
+        },
+      },
+      {
+        type: 'function' as const,
+        function: {
           name: EXECUTE_TOOL_NAME,
           description:
-            'Invoke a documented API endpoint by its registry identifier. Include any path, query, header, or body parameters required by that endpoint. Prefer narrow list calls with limit/fields, then use detail endpoints when you have an ID. For large text fields, request byte windows with query parameters such as field_ranges[comment_text]=0-4095.',
+            'Invoke a documented API endpoint by its registry identifier. GET endpoints execute automatically and return results to you; POST/PUT/PATCH/DELETE endpoints are proposed to the user for approval. Include any path, query, header, or body parameters required by that endpoint. Prefer narrow list calls with limit/fields, then use detail endpoints when you have an ID. For large text fields, request byte windows with query parameters such as field_ranges[comment_text]=0-4095.',
           parameters: {
             type: 'object',
             properties: {
@@ -985,6 +1203,283 @@ export class ChatCompletionsService {
     return top;
   }
 
+  private static async searchBusinessData(args: Record<string, unknown>, context: {
+    tenantId?: string;
+    userId?: string;
+    currentUser?: Record<string, unknown>;
+  }) {
+    const query = typeof args.query === 'string' ? args.query.trim() : '';
+    if (!query) {
+      return { error: 'search_business_data requires a non-empty query string.' };
+    }
+
+    const tenantId = context.tenantId;
+    const userId = context.userId;
+    if (!tenantId || !userId) {
+      return { error: 'Unable to search business data without an authenticated tenant and user.' };
+    }
+
+    const requestedTypes = Array.isArray(args.types)
+      ? args.types.filter((value): value is SearchObjectType =>
+          typeof value === 'string' && (SEARCH_OBJECT_TYPES as readonly string[]).includes(value),
+        )
+      : [];
+    const allowedTypes = requestedTypes.length > 0 ? requestedTypes : [...SEARCH_OBJECT_TYPES];
+    const limit = Math.max(
+      1,
+      Math.min(
+        typeof args.limit === 'number' ? Math.floor(args.limit) : parseInt(String(args.limit ?? ''), 10) || 10,
+        25,
+      ),
+    );
+    const sort = args.sort === 'recent' ? 'recent' : 'relevance';
+    const cursor = typeof args.cursor === 'string' ? args.cursor : undefined;
+
+    try {
+      return await runWithTenant(tenantId, async () => {
+        const { knex } = await createTenantKnex(tenantId);
+        const currentUser =
+          context.currentUser && context.currentUser.user_id === userId && context.currentUser.tenant === tenantId
+            ? context.currentUser
+            : await getCurrentUser();
+        if (!currentUser || currentUser.user_id !== userId || currentUser.tenant !== tenantId) {
+          return { error: 'Unable to search business data without a matching authenticated user.' };
+        }
+
+        const clientAccess = this.resolveSearchClientAccess(currentUser as unknown as Record<string, unknown>);
+        const principal = await resolveSearchAclPrincipal(knex, currentUser as any, clientAccess);
+        const [hits, totalCount, countsByType] = await Promise.all([
+          runSearchQuery({
+            knex,
+            tenant: tenantId,
+            query,
+            allowedTypes,
+            limit: limit + 1,
+            cursor,
+            sort,
+            includeSnippets: true,
+            acl: principal,
+          }),
+          countSearchMatches({
+            knex,
+            tenant: tenantId,
+            query,
+            allowedTypes,
+            acl: principal,
+          }),
+          countSearchMatchesByType({
+            knex,
+            tenant: tenantId,
+            query,
+            allowedTypes,
+            acl: principal,
+          }),
+        ]);
+
+        const visible = await verifyResultVisibility(knex, principal, hits);
+        const pageHits = visible.slice(0, limit);
+        const last = pageHits[pageHits.length - 1];
+        const nextCursor = visible.length > limit && last ? encodeSearchCursor(last) : undefined;
+
+        return {
+          query,
+          sort,
+          totalCount,
+          countsByType: Object.fromEntries(
+            Object.entries(countsByType).filter(([, count]) => typeof count === 'number' && count > 0),
+          ),
+          results: pageHits.map((hit) => ({
+            id: hit.id,
+            type: hit.type,
+            parentId: hit.parentId,
+            title: hit.title,
+            subtitle: hit.subtitle,
+            preview: hit.snippet,
+            url: hit.url,
+            updatedAt: hit.updatedAt.toISOString(),
+            score: typeof hit.score === 'number' ? Number(hit.score.toFixed(4)) : hit.score,
+            metadata: hit.metadata ?? {},
+          })),
+          nextCursor,
+        };
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Business search failed.';
+      this.logWarn('tool_search_business_data_failed', { error: message });
+      return { error: message };
+    }
+  }
+
+  private static resolveSearchClientAccess(user: Record<string, unknown>): ClientAccess {
+    const clientId =
+      typeof user.clientId === 'string'
+        ? user.clientId
+        : typeof user.client_id === 'string'
+          ? user.client_id
+          : undefined;
+    if (user.user_type === 'client') {
+      return clientId ? { mode: 'scoped', clientIds: [clientId] } : { mode: 'scoped', clientIds: [] };
+    }
+    return { mode: 'all' };
+  }
+
+  private static async tryAppendAutoToolResultsForMultipleCalls(params: {
+    conversation: ChatCompletionMessage[];
+    parsedContent: ParsedAssistantContent;
+    toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[];
+    source: ToolArgumentParseContext['source'];
+    baseUrl: string;
+    tenantId?: string;
+    userId?: string;
+    chatId: string | null;
+    cookieHeader?: string;
+    currentUser?: Record<string, unknown>;
+  }): Promise<AutoToolAppendResult | null> {
+    const nextConversation = [...params.conversation];
+    const events: ChatCompletionStreamEvent[] = [];
+
+    for (const [index, toolCall] of params.toolCalls.entries()) {
+      const functionName = toolCall.function?.name;
+      const toolCallId = toolCall.id ?? uuid();
+      if (!functionName) {
+        return null;
+      }
+
+      const parsedArgsResult = this.parseToolArguments(toolCall.function?.arguments, {
+        source: params.source,
+        functionName,
+        toolCallId,
+      });
+      if (parsedArgsResult.ok === false) {
+        return null;
+      }
+
+      const parsedArgs = parsedArgsResult.value;
+      const assistantMessage = this.buildAssistantToolCallMessage(
+        functionName,
+        index === 0
+          ? params.parsedContent
+          : { raw: '', display: '', reasoning: undefined },
+        parsedArgs,
+        toolCallId,
+      );
+
+      if (functionName === SEARCH_TOOL_NAME) {
+        const results = this.searchRegistry(parsedArgs.query, parsedArgs.limit);
+        nextConversation.push(assistantMessage, {
+          role: 'function',
+          name: SEARCH_TOOL_NAME,
+          content: JSON.stringify({ results }),
+          tool_call_id: toolCallId,
+        });
+        events.push(this.buildAutoToolExecutedEvent({
+          toolName: SEARCH_TOOL_NAME,
+          parsedArgs,
+          parsedContent: index === 0 ? params.parsedContent : { raw: '', display: '', reasoning: undefined },
+          toolCallId,
+          conversation: [...nextConversation],
+        }));
+        continue;
+      }
+
+      if (functionName === BUSINESS_SEARCH_TOOL_NAME) {
+        const results = await this.searchBusinessData(parsedArgs, {
+          tenantId: params.tenantId,
+          userId: params.userId,
+          currentUser: params.currentUser,
+        });
+        const replay = this.serializeToolResultForConversation(results);
+        nextConversation.push(assistantMessage, {
+          role: 'function',
+          name: BUSINESS_SEARCH_TOOL_NAME,
+          content: replay.content,
+          tool_call_id: toolCallId,
+        });
+        events.push(this.buildAutoToolExecutedEvent({
+          toolName: BUSINESS_SEARCH_TOOL_NAME,
+          parsedArgs,
+          parsedContent: index === 0 ? params.parsedContent : { raw: '', display: '', reasoning: undefined },
+          toolCallId,
+          conversation: [...nextConversation],
+        }));
+        continue;
+      }
+
+      if (functionName === EXECUTE_TOOL_NAME) {
+        if (!params.baseUrl || !params.tenantId || !params.userId) {
+          return null;
+        }
+        const entry = this.resolveRegistryEntry(
+          parsedArgs.entryId ?? parsedArgs.id ?? parsedArgs.name,
+          parsedArgs,
+        );
+        if (!entry) {
+          return null;
+        }
+        const preparedArgs = { ...parsedArgs };
+        this.populatePathParameters(entry, preparedArgs);
+        assistantMessage.function_call!.arguments = preparedArgs;
+        if (!this.isReadOnlyRegistryEntry(entry, preparedArgs)) {
+          return null;
+        }
+        const resultPayload = await this.executeReadOnlyApiCall({
+          entry,
+          args: preparedArgs,
+          baseUrl: params.baseUrl,
+          tenantId: params.tenantId,
+          userId: params.userId,
+          chatId: params.chatId,
+          cookieHeader: params.cookieHeader,
+        });
+        const replay = this.serializeToolResultForConversation(resultPayload);
+        nextConversation.push(assistantMessage, {
+          role: 'function',
+          name: EXECUTE_TOOL_NAME,
+          content: replay.content,
+          tool_call_id: toolCallId,
+        });
+        events.push(this.buildAutoToolExecutedEvent({
+          toolName: EXECUTE_TOOL_NAME,
+          parsedArgs: preparedArgs,
+          parsedContent: index === 0 ? params.parsedContent : { raw: '', display: '', reasoning: undefined },
+          toolCallId,
+          conversation: [...nextConversation],
+          entry,
+        }));
+        continue;
+      }
+
+      return null;
+    }
+
+    return { conversation: nextConversation, events };
+  }
+
+  private static isReadOnlyRegistryEntry(entry: ChatApiRegistryEntry, args: Record<string, unknown>): boolean {
+    const requestedMethod = typeof args.method === 'string' ? args.method.toLowerCase() : undefined;
+    return (requestedMethod ?? entry.method.toLowerCase()) === 'get';
+  }
+
+  private static async executeReadOnlyApiCall(params: {
+    entry: ChatApiRegistryEntry;
+    args: Record<string, unknown>;
+    baseUrl: string;
+    tenantId: string;
+    userId: string;
+    chatId: string | null;
+    cookieHeader?: string;
+  }) {
+    return this.executeFunctionCall({
+      entry: params.entry,
+      args: params.args,
+      baseUrl: params.baseUrl,
+      tenantId: params.tenantId,
+      userId: params.userId,
+      chatId: params.chatId,
+      cookieHeader: params.cookieHeader,
+    });
+  }
+
   private static buildAssistantToolCallMessage(
     functionName: string,
     parsedContent: ParsedAssistantContent,
@@ -1036,7 +1531,7 @@ export class ChatCompletionsService {
       role: 'user',
       content:
         `${reason} Retry now with exactly one function call. ` +
-        `Use ${SEARCH_TOOL_NAME} to look up registry entries, ${EXECUTE_TOOL_NAME} to propose an API call, or ${FINISH_TOOL_NAME} when you are ready to respond to the user. ` +
+        `Use ${BUSINESS_SEARCH_TOOL_NAME} to search business data, ${SEARCH_TOOL_NAME} to look up registry entries, ${EXECUTE_TOOL_NAME} to call API endpoints, or ${FINISH_TOOL_NAME} when you are ready to respond to the user. ` +
         `Do not send plain assistant text outside ${FINISH_TOOL_NAME}. Put the final user-visible reply in ${FINISH_TOOL_NAME}.message.`,
     });
     return nextConversation;
@@ -1075,8 +1570,9 @@ export class ChatCompletionsService {
     tenantId: string;
     userId: string;
     uiContext?: ChatUiContext;
+    cookieHeader?: string;
   }): Promise<CompletionResponse> {
-    const { messages, chatId, baseUrl, tenantId, userId, uiContext } = params;
+    const { messages, chatId, baseUrl, tenantId, userId, uiContext, cookieHeader } = params;
     const provider = await resolveChatProvider();
     let conversation = this.normalizeConversationHistory(messages);
     const promptContext = await this.buildPromptContext(uiContext);
@@ -1109,6 +1605,26 @@ export class ChatCompletionsService {
       }
 
       if (toolCalls.length > 1) {
+        const autoConversation = await this.tryAppendAutoToolResultsForMultipleCalls({
+          conversation,
+          parsedContent,
+          toolCalls,
+          source: 'non_stream',
+          baseUrl,
+          tenantId,
+          userId,
+          chatId,
+          cookieHeader,
+        });
+        if (autoConversation) {
+          this.logDebug('tool_multiple_auto_executed', {
+            iteration,
+            toolNames: toolCalls.map((toolCall) => toolCall.function?.name ?? 'unknown'),
+          });
+          conversation = autoConversation;
+          continue;
+        }
+
         this.logWarn('retry_multiple_tool_calls', {
           iteration,
           toolNames: toolCalls.map((toolCall) => toolCall.function?.name ?? 'unknown'),
@@ -1187,6 +1703,25 @@ export class ChatCompletionsService {
           continue;
         }
 
+        if (functionName === BUSINESS_SEARCH_TOOL_NAME) {
+          this.logDebug('tool_search_business_data', {
+            iteration,
+            query: typeof parsedArgs.query === 'string' ? parsedArgs.query : undefined,
+            types: parsedArgs.types,
+            limit: parsedArgs.limit,
+          });
+          const results = await this.searchBusinessData(parsedArgs, { tenantId, userId });
+          const replay = this.serializeToolResultForConversation(results);
+          const functionMessage: ChatCompletionMessage = {
+            role: 'function',
+            name: BUSINESS_SEARCH_TOOL_NAME,
+            content: replay.content,
+            tool_call_id: toolCallId,
+          };
+          conversation = [...conversation, assistantMessage, functionMessage];
+          continue;
+        }
+
         if (functionName === EXECUTE_TOOL_NAME) {
           conversation = [...conversation, assistantMessage];
           this.logDebug('tool_execute_requested', {
@@ -1227,6 +1762,54 @@ export class ChatCompletionsService {
             method: entry.method.toUpperCase(),
             path: entry.path,
           });
+
+          if (this.isReadOnlyRegistryEntry(entry, preparedArgs)) {
+            try {
+              this.logDebug('tool_execute_auto_get', {
+                iteration,
+                entryId: entry.id,
+                path: entry.path,
+              });
+              const resultPayload = await this.executeReadOnlyApiCall({
+                entry,
+                args: preparedArgs,
+                baseUrl,
+                tenantId,
+                userId,
+                chatId,
+                cookieHeader,
+              });
+              const replay = this.serializeToolResultForConversation(resultPayload);
+              conversation = [
+                ...conversation,
+                {
+                  role: 'function',
+                  name: EXECUTE_TOOL_NAME,
+                  content: replay.content,
+                  tool_call_id: toolCallId,
+                },
+              ];
+              continue;
+            } catch (error) {
+              const message = error instanceof Error ? error.message : 'Read-only API call failed.';
+              this.logWarn('tool_execute_auto_get_failed', {
+                iteration,
+                entryId: entry.id,
+                error: message,
+              });
+              conversation = [
+                ...conversation,
+                {
+                  role: 'function',
+                  name: EXECUTE_TOOL_NAME,
+                  content: JSON.stringify({ error: message }),
+                  tool_call_id: toolCallId,
+                },
+              ];
+              continue;
+            }
+          }
+
           const metadata = this.buildFunctionMetadata(entry, preparedArgs);
           const assistantPreview = this.buildFunctionPreview(parsedContent, entry);
           return {
@@ -1531,6 +2114,29 @@ export class ChatCompletionsService {
           value: parsed as Record<string, unknown>,
         };
       } catch (error) {
+        const repairedArgs =
+          context.source === 'stream' ? this.tryRepairTruncatedJsonObjectString(args) : null;
+        if (repairedArgs) {
+          try {
+            const repairedParsed = JSON.parse(repairedArgs);
+            if (repairedParsed && typeof repairedParsed === 'object' && !Array.isArray(repairedParsed)) {
+              this.logWarn('repaired_truncated_tool_arguments', {
+                source: context.source,
+                functionName: context.functionName,
+                toolCallId: context.toolCallId,
+                rawArgumentsLength: args.length,
+                repairedArgumentsLength: repairedArgs.length,
+              });
+              return {
+                ok: true,
+                value: repairedParsed as Record<string, unknown>,
+              };
+            }
+          } catch {
+            // Fall through to the normal parse failure path below.
+          }
+        }
+
         this.logToolArgumentParseFailure(
           context,
           args,
@@ -1557,6 +2163,59 @@ export class ChatCompletionsService {
       message:
         'Tool arguments must be a valid JSON object. Retry the same function call with a JSON object only.',
     };
+  }
+
+  private static tryRepairTruncatedJsonObjectString(args: string): string | null {
+    const trimmed = args.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+      return null;
+    }
+
+    let inString = false;
+    let escaped = false;
+    const stack: string[] = [];
+
+    for (const char of trimmed) {
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (char === '\\') {
+          escaped = true;
+          continue;
+        }
+        if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === '{') {
+        stack.push('}');
+        continue;
+      }
+      if (char === '[') {
+        stack.push(']');
+        continue;
+      }
+      if (char === '}' || char === ']') {
+        const expected = stack.pop();
+        if (expected !== char) {
+          return null;
+        }
+      }
+    }
+
+    if (inString || escaped || stack.length === 0) {
+      return null;
+    }
+
+    return `${trimmed}${stack.reverse().join('')}`;
   }
 
   private static isLikelyTruncatedJsonObjectString(args: string): boolean {
@@ -2079,10 +2738,13 @@ export class ChatCompletionsService {
       role: 'system' as const,
       content:
         'You are Alga, an assistant that helps users manage PSA workflows. ' +
-        `Every assistant turn must contain exactly one function call: ${SEARCH_TOOL_NAME}, ${EXECUTE_TOOL_NAME}, or ${FINISH_TOOL_NAME}. ` +
+        `Every assistant turn must contain exactly one function call: ${SEARCH_TOOL_NAME}, ${BUSINESS_SEARCH_TOOL_NAME}, ${EXECUTE_TOOL_NAME}, or ${FINISH_TOOL_NAME}. ` +
         `Do not return plain assistant text without a function call. When you are ready to answer the user, call ${FINISH_TOOL_NAME} and put the final user-visible reply in ${FINISH_TOOL_NAME}.message. ` +
+        `${BUSINESS_SEARCH_TOOL_NAME} searches tenant-scoped business data and is best for discovery questions like finding records, tickets, clients, projects, assets, invoices, or KB/reference content by natural language. ${SEARCH_TOOL_NAME} searches only the API registry and is best for discovering which endpoint to call. ` +
+        `${BUSINESS_SEARCH_TOOL_NAME} uses full-text search syntax. Build concise search queries from words likely to appear in records: nouns, product names, client names, ticket numbers, asset names, identifiers, and short quoted phrases. Do not send the user's whole sentence. Remove filler such as "show me", "give me", "related to", "about", "we've done", and redundant object type words when you set types. Use OR for synonyms/alternatives, e.g. query="laptop OR workstation OR desktop" with types=["ticket"], not query="tickets related to laptops or workstations". If the first search is too narrow, broaden with synonyms; if too broad, add a client/name/status term or quoted phrase. ` +
+        `Read-only ${BUSINESS_SEARCH_TOOL_NAME} calls and GET ${EXECUTE_TOOL_NAME} calls execute automatically; mutating API calls (POST, PUT, PATCH, DELETE) are proposed for user approval. ` +
         'Always consult the enterprise API registry before executing actions so you understand every required parameter. ' +
-        'When the registry or endpoint descriptions mention prerequisite data (such as IDs for boards, clients, categories, priorities, or other related resources): for write operations (create, update, delete), proactively call the appropriate lookup endpoints to gather that information instead of asking the user; for read operations (list, get), call the endpoint directly and only look up prerequisite data if the user explicitly asks to filter by it. ' +
+        'When the registry or endpoint descriptions mention prerequisite data (such as IDs for boards, clients, categories, priorities, or other related resources): for write operations (create, update, delete), proactively call the appropriate lookup endpoints to gather that information instead of asking the user; for read operations (list, get), use search_business_data for broad discovery or call the endpoint directly when you already know the exact registry entry and only look up prerequisite data if the user explicitly asks to filter by it. ' +
         'For ticket-creation calls, first use search_api_registry to locate the list endpoints you need, gather current data (e.g. call GET /api/v1/tickets to sample board_id/status_id/priority_id combinations and GET /api/v1/clients to confirm client_id), and do not proceed until you have concrete UUIDs for board_id, client_id, status_id, and priority_id collected from prior API responses. When sampling GET /api/v1/tickets, pick the first record with non-null board_id, status_id, and priority_id and reuse those UUIDs unless the user specifies different values. ' +
         'Never invent field names for a fields query parameter. Only send fields values that are explicitly documented in the registry description, parameters, or examples for that exact endpoint. If the registry does not enumerate exact field names, omit fields entirely. For GET /api/v1/tickets specifically, the only valid fields values are ticket_id, ticket_number, title, status_id, status_name, status_is_closed, priority_name, assigned_to_name, client_name, contact_name, updated_at, entered_at, closed_at, and mobile_list. Do not use aliases like id, subject, status, priority, client, created_at, or description. ' +
         'When you only need discovery data, prefer list endpoints with small limits and explicit fields instead of full payloads. Once you have a resource ID, prefer the detail endpoint over repeatedly expanding list responses. ' +
@@ -2573,6 +3235,65 @@ export class ChatCompletionsService {
         suggestions,
       }),
       tool_call_id: toolCallId,
+    };
+  }
+
+  private static buildAutoToolExecutedEvent(params: {
+    toolName: string;
+    parsedArgs: Record<string, unknown>;
+    parsedContent: ParsedAssistantContent;
+    toolCallId: string;
+    conversation: ChatCompletionMessage[];
+    entry?: ChatApiRegistryEntry;
+  }): ChatCompletionStreamEvent {
+    const metadata = params.entry
+      ? this.buildFunctionMetadata(params.entry, params.parsedArgs)
+      : this.buildSearchToolMetadata(params.toolName, params.parsedArgs);
+    const assistantPreview =
+      (params.parsedContent.display ?? '').trim() ||
+      (params.parsedContent.reasoning ?? '').trim() ||
+      `Automatically ran ${metadata.displayName}.`;
+
+    return {
+      type: 'tool_executed',
+      function: metadata,
+      assistantPreview,
+      assistantReasoning: params.parsedContent.reasoning,
+      functionCall: {
+        name: params.toolName,
+        arguments: params.parsedArgs,
+        toolCallId: params.toolCallId,
+        entryId: params.entry?.id ?? params.toolName,
+      },
+      nextMessages: this.sanitizeMessagesForClient(params.conversation),
+      modelMessages: params.conversation,
+    };
+  }
+
+  private static buildSearchToolMetadata(toolName: string, args: Record<string, unknown>): FunctionMetadata {
+    const query = typeof args.query === 'string' ? args.query.trim() : '';
+    const limit = typeof args.limit === 'number' || typeof args.limit === 'string' ? String(args.limit) : undefined;
+    const isBusinessSearch = toolName === BUSINESS_SEARCH_TOOL_NAME;
+    const displayName = isBusinessSearch ? 'Search business data' : 'Search API registry';
+    const path = query
+      ? `${isBusinessSearch ? 'business data' : 'API registry'}: ${query}`
+      : isBusinessSearch
+        ? 'business data'
+        : 'API registry';
+
+    return {
+      id: toolName,
+      displayName,
+      description: isBusinessSearch
+        ? 'Searches tenant-scoped business records with full-text search.'
+        : 'Searches available API operations.',
+      approvalRequired: false,
+      arguments: {
+        ...args,
+        method: 'SEARCH',
+        path,
+        ...(limit ? { limit } : {}),
+      },
     };
   }
 

--- a/server/public/locales/de/msp/chat.json
+++ b/server/public/locales/de/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Überprüfen und genehmigen, sobald Sie bereit sind.",
       "completedNoDetails": "Die Aktion wurde ohne weitere Details abgeschlossen.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "FORTSETZEN",
+      "endpoint": "Such-/Tool-Kette",
+      "title": "Weitere Ergebnisse abrufen?",
+      "description": "Alga hat beim Sammeln von Informationen das Tool-Schrittlimit erreicht.",
+      "status": "Die oben gezeigten Suchen und schreibgeschützten Aufrufe wurden abgeschlossen. Fahren Sie an derselben Stelle fort, um mehr zu sammeln oder die Antwort abzuschließen.",
+      "continue": "Fortsetzen",
+      "continueAriaLabel": "KI-Antwort ab dem Tool-Limit fortsetzen",
+      "defaultPrompt": "Fortsetzen"
     }
   },
   "quickAsk": {

--- a/server/public/locales/en/msp/chat.json
+++ b/server/public/locales/en/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Review and approve when you are ready.",
       "completedNoDetails": "The action completed without additional details.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "CONTINUE",
+      "endpoint": "search/tool chain",
+      "title": "Continue gathering results?",
+      "description": "Alga reached the tool step limit while gathering information.",
+      "status": "The searches and read-only calls above were completed. Continue from the same point to gather more or finish the answer.",
+      "continue": "Continue",
+      "continueAriaLabel": "Continue the AI response from the tool limit",
+      "defaultPrompt": "Continue"
     }
   },
   "quickAsk": {

--- a/server/public/locales/es/msp/chat.json
+++ b/server/public/locales/es/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Revisa y aprueba cuando estés listo.",
       "completedNoDetails": "La acción se completó sin detalles adicionales.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "CONTINUAR",
+      "endpoint": "cadena de búsqueda/herramientas",
+      "title": "¿Continuar recopilando resultados?",
+      "description": "Alga alcanzó el límite de pasos de herramientas mientras recopilaba información.",
+      "status": "Las búsquedas y llamadas de solo lectura anteriores se completaron. Continúa desde el mismo punto para recopilar más información o terminar la respuesta.",
+      "continue": "Continuar",
+      "continueAriaLabel": "Continuar la respuesta de IA desde el límite de herramientas",
+      "defaultPrompt": "Continuar"
     }
   },
   "quickAsk": {

--- a/server/public/locales/fr/msp/chat.json
+++ b/server/public/locales/fr/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Examinez et approuvez lorsque vous êtes prêt.",
       "completedNoDetails": "L'action s'est terminée sans détails supplémentaires.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "CONTINUER",
+      "endpoint": "chaîne de recherche/outils",
+      "title": "Continuer à collecter les résultats ?",
+      "description": "Alga a atteint la limite d’étapes d’outils pendant la collecte d’informations.",
+      "status": "Les recherches et appels en lecture seule ci-dessus sont terminés. Continuez depuis le même point pour collecter davantage d’informations ou finaliser la réponse.",
+      "continue": "Continuer",
+      "continueAriaLabel": "Continuer la réponse IA depuis la limite d’outils",
+      "defaultPrompt": "Continuer"
     }
   },
   "quickAsk": {

--- a/server/public/locales/it/msp/chat.json
+++ b/server/public/locales/it/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Rivedi e approva quando sei pronto.",
       "completedNoDetails": "L'azione è stata completata senza ulteriori dettagli.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "CONTINUA",
+      "endpoint": "catena ricerca/strumenti",
+      "title": "Continuare a raccogliere risultati?",
+      "description": "Alga ha raggiunto il limite di passaggi degli strumenti durante la raccolta delle informazioni.",
+      "status": "Le ricerche e le chiamate in sola lettura sopra sono state completate. Continua dallo stesso punto per raccogliere altro o completare la risposta.",
+      "continue": "Continua",
+      "continueAriaLabel": "Continua la risposta IA dal limite degli strumenti",
+      "defaultPrompt": "Continua"
     }
   },
   "quickAsk": {

--- a/server/public/locales/nl/msp/chat.json
+++ b/server/public/locales/nl/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Beoordeel en keur goed wanneer u klaar bent.",
       "completedNoDetails": "De actie is voltooid zonder aanvullende details.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "DOORGAAN",
+      "endpoint": "zoek-/toolketen",
+      "title": "Doorgaan met resultaten verzamelen?",
+      "description": "Alga heeft de limiet voor toolstappen bereikt tijdens het verzamelen van informatie.",
+      "status": "De bovenstaande zoekopdrachten en alleen-lezen aanroepen zijn voltooid. Ga verder vanaf hetzelfde punt om meer te verzamelen of het antwoord af te ronden.",
+      "continue": "Doorgaan",
+      "continueAriaLabel": "AI-antwoord voortzetten vanaf de toollimiet",
+      "defaultPrompt": "Doorgaan"
     }
   },
   "quickAsk": {

--- a/server/public/locales/pl/msp/chat.json
+++ b/server/public/locales/pl/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Przejrzyj i zatwierdź, gdy będziesz gotowy.",
       "completedNoDetails": "Akcja została zakończona bez dodatkowych szczegółów.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "KONTYNUUJ",
+      "endpoint": "łańcuch wyszukiwania/narzędzi",
+      "title": "Kontynuować zbieranie wyników?",
+      "description": "Alga osiągnęła limit kroków narzędzi podczas zbierania informacji.",
+      "status": "Powyższe wyszukiwania i wywołania tylko do odczytu zostały zakończone. Kontynuuj od tego samego miejsca, aby zebrać więcej danych lub dokończyć odpowiedź.",
+      "continue": "Kontynuuj",
+      "continueAriaLabel": "Kontynuuj odpowiedź AI od limitu narzędzi",
+      "defaultPrompt": "Kontynuuj"
     }
   },
   "quickAsk": {

--- a/server/public/locales/pt/msp/chat.json
+++ b/server/public/locales/pt/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "Revise e aprove quando estiver pronto.",
       "completedNoDetails": "A ação foi concluída sem detalhes adicionais.",
       "emDash": "—"
+    },
+    "continuation": {
+      "badge": "CONTINUAR",
+      "endpoint": "cadeia de pesquisa/ferramentas",
+      "title": "Continuar coletando resultados?",
+      "description": "Alga atingiu o limite de etapas de ferramentas enquanto coletava informações.",
+      "status": "As pesquisas e chamadas somente leitura acima foram concluídas. Continue do mesmo ponto para coletar mais ou finalizar a resposta.",
+      "continue": "Continuar",
+      "continueAriaLabel": "Continuar a resposta da IA a partir do limite de ferramentas",
+      "defaultPrompt": "Continuar"
     }
   },
   "quickAsk": {

--- a/server/public/locales/xx/msp/chat.json
+++ b/server/public/locales/xx/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "11111",
       "completedNoDetails": "11111",
       "emDash": "11111"
+    },
+    "continuation": {
+      "badge": "11111",
+      "endpoint": "11111",
+      "title": "11111",
+      "description": "11111",
+      "status": "11111",
+      "continue": "11111",
+      "continueAriaLabel": "11111",
+      "defaultPrompt": "11111"
     }
   },
   "quickAsk": {

--- a/server/public/locales/yy/msp/chat.json
+++ b/server/public/locales/yy/msp/chat.json
@@ -107,6 +107,16 @@
       "reviewAndApprove": "55555",
       "completedNoDetails": "55555",
       "emDash": "55555"
+    },
+    "continuation": {
+      "badge": "55555",
+      "endpoint": "55555",
+      "title": "55555",
+      "description": "55555",
+      "status": "55555",
+      "continue": "55555",
+      "continueAriaLabel": "55555",
+      "defaultPrompt": "55555"
     }
   },
   "quickAsk": {

--- a/server/src/app/api/chat/v1/completions/stream/route.ts
+++ b/server/src/app/api/chat/v1/completions/stream/route.ts
@@ -2,6 +2,7 @@ import { env } from 'node:process';
 import { NextRequest } from 'next/server';
 
 import { isExperimentalFeatureEnabled } from '@alga-psa/tenancy/actions';
+import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { assertPsaChatProductAccess } from '../../../productAccess';
 
 const isEnterpriseEdition =
@@ -52,7 +53,16 @@ type RawCompletionChunk = {
 type ChatCompletionsServiceLike = {
   createStructuredCompletionStream: (
     conversation: IncomingChatMessage[],
-    options?: { signal?: AbortSignal; uiContext?: IncomingUiContext; mentions?: IncomingMention[] },
+    options?: {
+      signal?: AbortSignal;
+      uiContext?: IncomingUiContext;
+      mentions?: IncomingMention[];
+      baseUrl?: string;
+      tenantId?: string;
+      userId?: string;
+      cookieHeader?: string;
+      currentUser?: Record<string, unknown>;
+    },
   ) => Promise<AsyncIterable<RawCompletionChunk>>;
 };
 
@@ -302,6 +312,14 @@ export async function POST(req: NextRequest) {
     });
   }
 
+  const user = await getCurrentUser();
+  if (!user?.tenant || !user.user_id) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   const aiAssistantEnabled = await isExperimentalFeatureEnabled('aiAssistant');
   if (!aiAssistantEnabled) {
     return new Response(
@@ -326,7 +344,16 @@ export async function POST(req: NextRequest) {
         };
         const completionStream = await mod.ChatCompletionsService.createStructuredCompletionStream(
           messages,
-          { signal: req.signal, uiContext, mentions: mentions.length > 0 ? mentions : undefined },
+          {
+            signal: req.signal,
+            uiContext,
+            mentions: mentions.length > 0 ? mentions : undefined,
+            baseUrl: req.nextUrl.origin,
+            tenantId: user.tenant,
+            userId: user.user_id,
+            currentUser: user as unknown as Record<string, unknown>,
+            cookieHeader: req.headers.get('cookie') ?? undefined,
+          },
         );
 
         for await (const event of completionStream) {
@@ -367,7 +394,11 @@ export async function POST(req: NextRequest) {
             continue;
           }
 
-          if (eventType === 'function_proposed') {
+          if (
+            eventType === 'function_proposed' ||
+            eventType === 'tool_executed' ||
+            eventType === 'continuation_available'
+          ) {
             tryEnqueue(controller, controllerState, encodeSseData(encoder, event));
             continue;
           }

--- a/server/src/lib/api/services/ticketRichRender.ts
+++ b/server/src/lib/api/services/ticketRichRender.ts
@@ -22,7 +22,16 @@ function fallbackTicketHtml(content: unknown): string {
   return `<p>${escapeHtml(plainText)}</p>`;
 }
 
+function isLikelySerializedRichText(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed.startsWith('{') || trimmed.startsWith('[');
+}
+
 export function renderTicketRichTextHtml(content: unknown): string {
+  if (typeof content === 'string' && !isLikelySerializedRichText(content)) {
+    return fallbackTicketHtml(content);
+  }
+
   try {
     const html = convertBlockContentToHTML(content);
     if (

--- a/server/src/test/unit/api/chatCompletionsStream.route.events.test.ts
+++ b/server/src/test/unit/api/chatCompletionsStream.route.events.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 const isExperimentalFeatureEnabledMock = vi.hoisted(() =>
   vi.fn<(featureKey: string) => Promise<boolean>>(),
 );
+const getCurrentUserMock = vi.hoisted(() => vi.fn());
 
 const createStructuredCompletionStreamMock = vi.hoisted(() =>
   vi.fn<
@@ -23,6 +24,14 @@ const createStructuredCompletionStreamMock = vi.hoisted(() =>
 
 vi.mock('@alga-psa/tenancy/actions', () => ({
   isExperimentalFeatureEnabled: isExperimentalFeatureEnabledMock,
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: getCurrentUserMock,
+}));
+
+vi.mock('@/app/api/chat/productAccess', () => ({
+  assertPsaChatProductAccess: () => Promise.resolve(null),
 }));
 
 vi.mock('@product/chat/entry', () => ({
@@ -61,6 +70,8 @@ describe('POST /api/chat/v1/completions/stream (structured events)', () => {
 
   beforeEach(() => {
     isExperimentalFeatureEnabledMock.mockReset();
+    getCurrentUserMock.mockReset();
+    getCurrentUserMock.mockResolvedValue({ tenant: 'tenant-1', user_id: 'user-1' });
     createStructuredCompletionStreamMock.mockReset();
     process.env.EDITION = 'ee';
     delete process.env.NEXT_PUBLIC_EDITION;
@@ -310,6 +321,67 @@ describe('POST /api/chat/v1/completions/stream (structured events)', () => {
             name: 'call_api_endpoint',
             toolCallId: 'tool-call-1',
           }),
+        }),
+      ]),
+    );
+  });
+
+  it('emits auto-executed tool and continuation SSE events', async () => {
+    isExperimentalFeatureEnabledMock.mockResolvedValue(true);
+    createStructuredCompletionStreamMock.mockResolvedValue(
+      (async function* () {
+        yield {
+          type: 'tool_executed',
+          function: {
+            id: 'search_business_data',
+            displayName: 'Search business data',
+            approvalRequired: false,
+            arguments: { method: 'SEARCH', path: 'business data: laptops' },
+          },
+          assistantPreview: 'Searching business data.',
+          functionCall: {
+            name: 'search_business_data',
+            arguments: { query: 'laptops' },
+            toolCallId: 'tool-call-search-1',
+            entryId: 'search_business_data',
+          },
+          nextMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+          modelMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+        };
+        yield {
+          type: 'continuation_available',
+          reason: 'Reached the 6-step tool limit while gathering information.',
+          nextMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+          modelMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+        };
+        yield { type: 'done' };
+      })(),
+    );
+
+    vi.resetModules();
+    const { POST } = await import('@/app/api/chat/v1/completions/stream/route');
+
+    const response = await POST(
+      makeRequest({
+        messages: [{ role: 'user', content: 'Find laptop tickets' }],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payloads = await readSsePayloads(response);
+
+    expect(payloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tool_executed',
+          functionCall: expect.objectContaining({
+            name: 'search_business_data',
+            toolCallId: 'tool-call-search-1',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'continuation_available',
+          reason: 'Reached the 6-step tool limit while gathering information.',
         }),
       ]),
     );

--- a/server/src/test/unit/api/chatCompletionsStream.route.exists.test.ts
+++ b/server/src/test/unit/api/chatCompletionsStream.route.exists.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 const isExperimentalFeatureEnabledMock = vi.hoisted(() =>
   vi.fn<(featureKey: string) => Promise<boolean>>(),
 );
+const getCurrentUserMock = vi.hoisted(() => vi.fn());
 
 const createStructuredCompletionStreamMock = vi.hoisted(() =>
   vi.fn<
@@ -18,6 +19,10 @@ vi.mock('@alga-psa/tenancy/actions', () => ({
   isExperimentalFeatureEnabled: isExperimentalFeatureEnabledMock,
 }));
 
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: getCurrentUserMock,
+}));
+
 vi.mock('@product/chat/entry', () => ({
   ChatCompletionsService: {
     createStructuredCompletionStream: createStructuredCompletionStreamMock,
@@ -30,6 +35,8 @@ describe('POST /api/chat/v1/completions/stream', () => {
 
   beforeEach(() => {
     isExperimentalFeatureEnabledMock.mockReset();
+    getCurrentUserMock.mockReset();
+    getCurrentUserMock.mockResolvedValue({ tenant: 'tenant-1', user_id: 'user-1' });
     createStructuredCompletionStreamMock.mockReset();
     process.env.EDITION = 'ee';
     delete process.env.NEXT_PUBLIC_EDITION;

--- a/server/src/test/unit/api/ticketRichRender.helper.test.ts
+++ b/server/src/test/unit/api/ticketRichRender.helper.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   renderTicketDescriptionHtml,
   renderTicketRichTextHtml,
@@ -12,6 +12,10 @@ function readHelperSource(): string {
 }
 
 describe('ticketRichRender helper', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('derives HTML for serialized BlockNote JSON using the shared formatting package', () => {
     const source = readHelperSource();
     expect(source).toContain("import { convertBlockContentToHTML } from '@alga-psa/formatting';");
@@ -53,11 +57,14 @@ describe('ticketRichRender helper', () => {
     expect(html).toBe('<p>Hello from ProseMirror</p>');
   });
 
-  it('derives description HTML from ticket attributes for mobile detail responses', () => {
+  it('derives description HTML from ticket attributes for mobile detail responses without parsing plain text as JSON', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
     const html = renderTicketDescriptionHtml({
       description: 'Legacy plain text description',
     });
 
     expect(html).toBe('<p>Legacy plain text description</p>');
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/src/test/unit/readAssistantContentFromSse.test.ts
+++ b/server/src/test/unit/readAssistantContentFromSse.test.ts
@@ -145,6 +145,59 @@ describe('readAssistantContentFromSse()', () => {
     });
   });
 
+  it('invokes callbacks for auto-executed tool and continuation events', async () => {
+    const sse = createControlledSseResponse();
+    const executedTools: Array<Record<string, unknown>> = [];
+    const continuations: Array<Record<string, unknown>> = [];
+
+    const readPromise = readAssistantContentFromSse(sse.response, {
+      onToolExecuted: (event) => {
+        executedTools.push(event as unknown as Record<string, unknown>);
+      },
+      onContinuationAvailable: (event) => {
+        continuations.push(event as unknown as Record<string, unknown>);
+      },
+    });
+
+    sse.send(
+      `data: ${JSON.stringify({
+        type: 'tool_executed',
+        function: {
+          id: 'search_business_data',
+          displayName: 'Search business data',
+          approvalRequired: false,
+          arguments: { method: 'SEARCH', path: 'business data: laptops' },
+        },
+        assistantPreview: 'Searching business data.',
+        functionCall: {
+          name: 'search_business_data',
+          arguments: { query: 'laptops' },
+          toolCallId: 'tool-search-1',
+        },
+        nextMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+      })}\n\n`,
+    );
+    sse.send(
+      `data: ${JSON.stringify({
+        type: 'continuation_available',
+        reason: 'Reached the tool limit.',
+        nextMessages: [{ role: 'function', name: 'search_business_data', content: '{}' }],
+      })}\n\n`,
+    );
+    sse.send('data: {"type":"done","done":true}\n\n');
+    sse.close();
+
+    await expect(readPromise).resolves.toEqual({ content: '', doneReceived: true });
+    expect(executedTools).toHaveLength(1);
+    expect(executedTools[0]).toMatchObject({
+      type: 'tool_executed',
+      functionCall: { name: 'search_business_data', toolCallId: 'tool-search-1' },
+    });
+    expect(continuations).toEqual([
+      expect.objectContaining({ type: 'continuation_available', reason: 'Reached the tool limit.' }),
+    ]);
+  });
+
   it('returns doneReceived=true when a typed done event arrives', async () => {
     const sse = createControlledSseResponse();
 

--- a/server/src/test/unit/services/chatCompletionsService.unit.test.ts
+++ b/server/src/test/unit/services/chatCompletionsService.unit.test.ts
@@ -614,6 +614,28 @@ describe('ChatCompletionsService (unit)', () => {
     expect(systemPrompt.content).toContain('null file_id');
   });
 
+  it('defines and explains search_business_data as a first-class tool', async () => {
+    const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
+
+    const tools = (ChatCompletionsService as any).buildToolDefinitions('openrouter');
+    expect(tools.map((tool: any) => tool.function.name)).toContain('search_business_data');
+
+    const converted = (ChatCompletionsService as any).buildOpenAiMessages(
+      [{ role: 'user', content: 'Find Acme tickets' }],
+      'openrouter',
+    );
+    const systemPrompt = converted[0] as Record<string, unknown>;
+    expect(systemPrompt.content).toContain('search_business_data searches tenant-scoped business data');
+    expect(systemPrompt.content).toContain('GET call_api_endpoint calls execute automatically');
+    expect(systemPrompt.content).toContain('query="laptop OR workstation OR desktop"');
+    expect(systemPrompt.content).toContain('not query="tickets related to laptops or workstations"');
+    const businessSearchTool = tools.find((tool: any) => tool.function.name === 'search_business_data');
+    expect(businessSearchTool.function.description).toContain('concise full-text search expression');
+    expect(businessSearchTool.function.parameters.properties.query.description).toContain(
+      'Avoid filler phrases',
+    );
+  });
+
   it('builds prompt context with current user and resolved ticket details', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-09T17:50:00Z'));
@@ -809,6 +831,65 @@ describe('ChatCompletionsService (unit)', () => {
     expect(Array.isArray(parsedContent.suggestions)).toBe(true);
   });
 
+  it('auto-executes streamed GET call_api_endpoint calls and continues streaming the final response', async () => {
+    process.env.AI_CHAT_PROVIDER = 'openrouter';
+    setSecrets({
+      OPENROUTER_API_KEY: 'openrouter-key',
+      OPENROUTER_CHAT_MODEL: 'openrouter/model',
+    });
+
+    openAiCreateSpy
+      .mockResolvedValueOnce(
+        buildChunkStream([
+          {
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'tool-call-stream-auto-get',
+                      type: 'function',
+                      function: {
+                        name: 'call_api_endpoint',
+                        arguments: JSON.stringify({ entryId: 'tickets.list' }),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(buildFinishResponseChunkStream('Streamed ticket result.'));
+
+    const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
+    const executeFunctionCallSpy = vi
+      .spyOn(ChatCompletionsService as any, 'executeFunctionCall')
+      .mockResolvedValue({ status: 200, ok: true, data: [{ ticket_id: 'ticket-1' }] });
+
+    const streamedEvents: Array<{ type: string; delta?: string }> = [];
+    for await (const event of ChatCompletionsService.createStructuredCompletionStream(
+      [{ role: 'user', content: 'List tickets' }],
+      {
+        baseUrl: 'https://example.invalid',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    )) {
+      streamedEvents.push(event as { type: string; delta?: string });
+    }
+
+    expect(executeFunctionCallSpy).toHaveBeenCalledTimes(1);
+    expect(streamedEvents).toEqual([
+      { type: 'content_delta', delta: 'Streamed ticket result.' },
+      { type: 'done' },
+    ]);
+    expect(openAiCreateSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('retries streamed tool calls when the model emits invalid JSON arguments', async () => {
     process.env.AI_CHAT_PROVIDER = 'openrouter';
     setSecrets({
@@ -932,12 +1013,22 @@ describe('ChatCompletionsService (unit)', () => {
     );
   });
 
-  it('appends assistant reasoning_content during tool-call proposal turns', async () => {
+  it('appends assistant reasoning_content during mutating tool-call proposal turns', async () => {
     process.env.AI_CHAT_PROVIDER = 'openrouter';
     setSecrets({
       OPENROUTER_API_KEY: 'openrouter-key',
       OPENROUTER_CHAT_MODEL: 'openrouter/model',
     });
+    getRegistryMock.mockReturnValue([
+      buildRegistryEntry({
+        id: 'tickets.create',
+        method: 'post',
+        path: '/api/v1/tickets',
+        displayName: 'Create ticket',
+        summary: 'Create ticket',
+        description: 'Creates a ticket.',
+      }),
+    ]);
 
     openAiCreateSpy.mockResolvedValueOnce(
       buildCompletion({
@@ -951,7 +1042,7 @@ describe('ChatCompletionsService (unit)', () => {
             type: 'function',
             function: {
               name: 'call_api_endpoint',
-              arguments: JSON.stringify({ entryId: 'tickets.list' }),
+              arguments: JSON.stringify({ entryId: 'tickets.create', body: { title: 'New ticket' } }),
             },
           },
         ],
@@ -961,7 +1052,7 @@ describe('ChatCompletionsService (unit)', () => {
     const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
 
     const result = await (ChatCompletionsService as any).processModelInteraction({
-      messages: [{ role: 'user', content: 'List tickets' }],
+      messages: [{ role: 'user', content: 'Create a ticket' }],
       chatId: 'chat-1',
       baseUrl: 'https://example.invalid',
       tenantId: 'tenant-1',
@@ -1211,12 +1302,23 @@ describe('ChatCompletionsService (unit)', () => {
     expect(request.tool_choice).toBeUndefined();
   });
 
-  it('returns function_proposed with nextMessages/modelMessages preserving reasoning context', async () => {
+  it('returns function_proposed with nextMessages/modelMessages preserving reasoning context for mutating calls', async () => {
     process.env.AI_CHAT_PROVIDER = 'openrouter';
     setSecrets({
       OPENROUTER_API_KEY: 'openrouter-key',
       OPENROUTER_CHAT_MODEL: 'openrouter/model',
     });
+    getRegistryMock.mockReturnValue([
+      buildRegistryEntry({
+        id: 'tickets.update',
+        method: 'patch',
+        path: '/api/v1/tickets/{id}',
+        displayName: 'Update ticket',
+        summary: 'Update ticket',
+        description: 'Updates a ticket.',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      }),
+    ]);
 
     openAiCreateSpy.mockResolvedValueOnce(
       buildCompletion({
@@ -1228,7 +1330,7 @@ describe('ChatCompletionsService (unit)', () => {
             type: 'function',
             function: {
               name: 'call_api_endpoint',
-              arguments: JSON.stringify({ entryId: 'tickets.list' }),
+              arguments: JSON.stringify({ entryId: 'tickets.update', path: { id: 'ticket-1' }, body: { title: 'Updated' } }),
             },
           },
         ],
@@ -1238,7 +1340,7 @@ describe('ChatCompletionsService (unit)', () => {
     const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
 
     const result = await (ChatCompletionsService as any).processModelInteraction({
-      messages: [{ role: 'user', content: 'Execute tickets list' }],
+      messages: [{ role: 'user', content: 'Update a ticket' }],
       chatId: 'chat-1',
       baseUrl: 'https://example.invalid',
       tenantId: 'tenant-1',
@@ -1260,6 +1362,63 @@ describe('ChatCompletionsService (unit)', () => {
           role: 'assistant',
           reasoning_content: 'Need to execute endpoint now',
         }),
+      ]),
+    );
+  });
+
+  it('auto-executes GET call_api_endpoint calls and continues to the final response', async () => {
+    process.env.AI_CHAT_PROVIDER = 'openrouter';
+    setSecrets({
+      OPENROUTER_API_KEY: 'openrouter-key',
+      OPENROUTER_CHAT_MODEL: 'openrouter/model',
+    });
+
+    openAiCreateSpy
+      .mockResolvedValueOnce(
+        buildCompletion({
+          content: 'Fetching tickets',
+          tool_calls: [
+            {
+              id: 'tool-call-auto-get',
+              type: 'function',
+              function: {
+                name: 'call_api_endpoint',
+                arguments: JSON.stringify({ entryId: 'tickets.list' }),
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(buildFinishResponseCompletion('Found one ticket.'));
+
+    const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
+    const executeFunctionCallSpy = vi
+      .spyOn(ChatCompletionsService as any, 'executeFunctionCall')
+      .mockResolvedValue({ status: 200, ok: true, data: [{ ticket_id: 'ticket-1' }] });
+
+    const result = await (ChatCompletionsService as any).processModelInteraction({
+      messages: [{ role: 'user', content: 'List tickets' }],
+      chatId: 'chat-1',
+      baseUrl: 'https://example.invalid',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    });
+
+    expect(executeFunctionCallSpy).toHaveBeenCalledTimes(1);
+    expect(executeFunctionCallSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.objectContaining({ id: 'tickets.list', method: 'get' }),
+        args: expect.objectContaining({ entryId: 'tickets.list' }),
+      }),
+    );
+    expect(result).toMatchObject({
+      type: 'assistant_message',
+      message: expect.objectContaining({ content: 'Found one ticket.' }),
+    });
+    const followUpRequest = openAiCreateSpy.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(followUpRequest.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'tool', content: expect.stringContaining('ticket-1') }),
       ]),
     );
   });
@@ -1636,6 +1795,27 @@ describe('ChatCompletionsService (unit)', () => {
       functionCall: expect.objectContaining({
         toolCallId: 'stable-id-123',
       }),
+    });
+  });
+
+  it('repairs stream-truncated tool argument objects when braces are missing', async () => {
+    const { ChatCompletionsService } = await import('@ee/services/chatCompletionsService');
+
+    const parsed = (ChatCompletionsService as any).parseToolArguments(
+      '{"entryId":"get-_api_v1_tickets_id","path":{"id":"ticket-1"}',
+      {
+        source: 'stream',
+        functionName: 'call_api_endpoint',
+        toolCallId: 'tool-1',
+      },
+    );
+
+    expect(parsed).toEqual({
+      ok: true,
+      value: {
+        entryId: 'get-_api_v1_tickets_id',
+        path: { id: 'ticket-1' },
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- add first-class `search_business_data` support with tenant-scoped ACL-backed full-text search
- auto-execute read-only search/API GET chains and surface auto-run tool calls in chat
- add continuation UI for max tool-iteration cases, bundled read-only call cards, expandable call details, and improved table styling
- fix chat persistence tenant context and reduce plain-text ticket rich-render parse noise

## Validation
- `cd server && npx vitest run src/test/unit/readAssistantContentFromSse.test.ts src/test/unit/api/chatCompletionsStream.route.events.test.ts --coverage.enabled=false`
- `cd server && npx vitest run src/test/unit/services/chatCompletionsService.unit.test.ts -t "defines and explains search_business_data" --coverage.enabled=false`
- `cd server && npx vitest run src/test/unit/services/chatCompletionsService.unit.test.ts -t "repairs stream-truncated" --coverage.enabled=false`
- `NODE_OPTIONS=--max-old-space-size=12288 npm --prefix server run typecheck`
- manual Quick Ask validation via algadev for Northstar and laptop/workstation searches
