### PR TITLE
 Publish domain events after transaction commit

### DIFF
--- a/server/src/lib/api/services/ContractLineService.ts
+++ b/server/src/lib/api/services/ContractLineService.ts
@@ -301,7 +301,7 @@ export class ContractLineService extends BaseService<IContractLine> {
         const [contractLine] = await trx('contract_lines').insert(planData).returning('*');
 
         return {
-          contractLine: await this.getById(contractLine.contract_line_id, context),
+          contractLineId: contractLine.contract_line_id,
           eventPayload: {
             contractLineId: contractLine.contract_line_id,
             contractLineName: data.contract_line_name,
@@ -322,7 +322,9 @@ export class ContractLineService extends BaseService<IContractLine> {
         }
       });
 
-      return result.contractLine;
+      // Re-fetch after commit so the read uses a committed, tenant-scoped
+      // connection (getById does not run on the transaction connection).
+      return this.getById(result.contractLineId, context);
     }
 
 

--- a/server/src/lib/api/services/ContractLineService.ts
+++ b/server/src/lib/api/services/ContractLineService.ts
@@ -272,7 +272,7 @@ export class ContractLineService extends BaseService<IContractLine> {
   async create(data: any, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const result = await withTransaction(knex, async (trx) => {
         const planData = this.addCreateAuditFields(data, context);
         planData.contract_line_id = uuidv4();
 
@@ -300,21 +300,29 @@ export class ContractLineService extends BaseService<IContractLine> {
 
         const [contractLine] = await trx('contract_lines').insert(planData).returning('*');
 
-        // Publish event
-        await publishEvent({
-          eventType: 'CONTRACT_LINE_CREATED',
-          payload: {
-            tenantId: context.tenant,
+        return {
+          contractLine: await this.getById(contractLine.contract_line_id, context),
+          eventPayload: {
             contractLineId: contractLine.contract_line_id,
             contractLineName: data.contract_line_name,
             contractLineType: data.contract_line_type,
-            userId: context.userId,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
-        return this.getById(contractLine.contract_line_id, context);
+          },
+        };
       });
+
+      await publishEvent({
+        eventType: 'CONTRACT_LINE_CREATED',
+        payload: {
+          tenantId: context.tenant,
+          contractLineId: result.eventPayload.contractLineId,
+          contractLineName: result.eventPayload.contractLineName,
+          contractLineType: result.eventPayload.contractLineType,
+          userId: context.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return result.contractLine;
     }
 
 

--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -384,7 +384,7 @@ export class InvoiceService extends BaseService<IInvoice> {
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
     
-    const invoice = await withTransaction(knex, async (trx) => {
+    const invoiceId = await withTransaction(knex, async (trx) => {
       // Generate invoice number
       const invoiceNumber = await generateInvoiceNumber(trx);
 
@@ -453,11 +453,14 @@ export class InvoiceService extends BaseService<IInvoice> {
         }
       }));
 
-      return this.getById(invoice.invoice_id, context) as Promise<IInvoice>;
+      return invoice.invoice_id;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(invoiceId, context) as Promise<IInvoice>;
   }
 
   /**
@@ -468,8 +471,8 @@ export class InvoiceService extends BaseService<IInvoice> {
 
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
-    
-    const invoice = await withTransaction(knex, async (trx) => {
+
+    await withTransaction(knex, async (trx) => {
       const existing = await trx('invoices')
         .where({ invoice_id: id, tenant: context.tenant })
         .first();
@@ -665,12 +668,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           timestamp: occurredAt
         }
       }));
-
-      return this.getById(id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(id, context) as Promise<IInvoice>;
   }
 
   /**
@@ -786,8 +790,8 @@ export class InvoiceService extends BaseService<IInvoice> {
 
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
-    
-    const invoice = await withTransaction(knex, async (trx) => {
+
+    await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -867,12 +871,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
       }));
-
-      return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(data.invoice_id, context) as Promise<IInvoice>;
   }
 
   /**
@@ -883,8 +888,8 @@ export class InvoiceService extends BaseService<IInvoice> {
 
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
-    
-    const invoice = await withTransaction(knex, async (trx) => {
+
+    await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -980,12 +985,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           },
         }));
       }
-
-      return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(data.invoice_id, context) as Promise<IInvoice>;
   }
 
   /**
@@ -996,8 +1002,8 @@ export class InvoiceService extends BaseService<IInvoice> {
 
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
-    
-    const invoice = await withTransaction(knex, async (trx) => {
+
+    await withTransaction(knex, async (trx) => {
       const occurredAt = new Date().toISOString();
 
       const invoice = await trx('invoices')
@@ -1139,11 +1145,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	        }
 	      }));
 
-      return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(data.invoice_id, context) as Promise<IInvoice>;
   }
 
   /**
@@ -1154,8 +1162,8 @@ export class InvoiceService extends BaseService<IInvoice> {
 
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
-    
-    const invoice = await withTransaction(knex, async (trx) => {
+
+    await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -1272,11 +1280,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	        }
 	      }));
 
-      return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(data.invoice_id, context) as Promise<IInvoice>;
   }
 
   /**
@@ -1289,7 +1299,7 @@ export class InvoiceService extends BaseService<IInvoice> {
     const { knex } = await this.getKnex();
     const deferredEvents: DeferredEvent[] = [];
 
-    const invoice = await withTransaction(knex, async (trx) => {
+    await withTransaction(knex, async (trx) => {
       const occurredAt = new Date().toISOString();
 
       const invoice = await trx('invoices')
@@ -1427,11 +1437,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	        }
 	      }));
 
-      return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
 
     await publishDeferredEvents(deferredEvents);
-    return invoice;
+
+    // Re-fetch after commit: getById runs on a pooled (non-transaction)
+    // connection, so it must read the row only after the tx commits.
+    return this.getById(data.invoice_id, context) as Promise<IInvoice>;
   }
 
   // ============================================================================

--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -83,6 +83,14 @@ import {
   updateInvoiceTotalsAndRecordTransaction
 } from '@alga-psa/billing/services/invoiceService';
 
+type DeferredEvent = () => Promise<void>;
+
+async function publishDeferredEvents(events: DeferredEvent[]): Promise<void> {
+  for (const publish of events) {
+    await publish();
+  }
+}
+
 export interface InvoiceServiceContext extends ServiceContext {
   permissions?: string[];
 }
@@ -374,8 +382,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'create');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       // Generate invoice number
       const invoiceNumber = await generateInvoiceNumber(trx);
 
@@ -433,7 +442,7 @@ export class InvoiceService extends BaseService<IInvoice> {
         details: { action: 'invoice.created' }
       });
 
-      await publishEvent({
+      deferredEvents.push(() => publishEvent({
         eventType: 'INVOICE_CREATED',
         payload: {
           tenantId: context.tenant,
@@ -442,10 +451,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           userId: context.userId,
           timestamp: new Date().toISOString()
         }
-      });
+      }));
 
       return this.getById(invoice.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -455,8 +467,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'update');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const existing = await trx('invoices')
         .where({ invoice_id: id, tenant: context.tenant })
         .first();
@@ -500,7 +513,7 @@ export class InvoiceService extends BaseService<IInvoice> {
           .del();
 
         for (const itemId of replacedItemIds) {
-          await publishEvent({
+          deferredEvents.push(() => publishEvent({
             eventType: 'INVOICE_ITEM_DELETED',
             payload: {
               tenantId: context.tenant,
@@ -509,7 +522,7 @@ export class InvoiceService extends BaseService<IInvoice> {
               userId: context.userId,
               timestamp: new Date().toISOString()
             }
-          });
+          }));
         }
         
       // Normalize header alias: prefer is_bundle_header, but accept is_bundle_header
@@ -548,7 +561,7 @@ export class InvoiceService extends BaseService<IInvoice> {
       const nextDueDate = updateData.due_date ? toIsoDateString(updateData.due_date) : previousDueDate;
 
       if (newStatus !== previousStatus) {
-        await publishWorkflowEvent({
+        deferredEvents.push(() => publishWorkflowEvent({
           eventType: 'INVOICE_STATUS_CHANGED',
           payload: buildInvoiceStatusChangedPayload({
             invoiceId: id,
@@ -562,11 +575,11 @@ export class InvoiceService extends BaseService<IInvoice> {
             occurredAt,
             actor: { actorType: 'USER', actorUserId: context.userId },
           },
-        });
+        }));
       }
 
       if (previousDueDate && nextDueDate && previousDueDate !== nextDueDate) {
-        await publishWorkflowEvent({
+        deferredEvents.push(() => publishWorkflowEvent({
           eventType: 'INVOICE_DUE_DATE_CHANGED',
           payload: buildInvoiceDueDateChangedPayload({
             invoiceId: id,
@@ -580,7 +593,7 @@ export class InvoiceService extends BaseService<IInvoice> {
             occurredAt,
             actor: { actorType: 'USER', actorUserId: context.userId },
           },
-        });
+        }));
       }
 
       if (newStatus === 'overdue' && previousStatus !== 'overdue') {
@@ -593,7 +606,7 @@ export class InvoiceService extends BaseService<IInvoice> {
           tenantId: context.tenant,
         });
 
-        await publishWorkflowEvent({
+        deferredEvents.push(() => publishWorkflowEvent({
           eventType: 'INVOICE_OVERDUE',
           payload: buildInvoiceOverduePayload({
             invoiceId: id,
@@ -609,7 +622,7 @@ export class InvoiceService extends BaseService<IInvoice> {
             occurredAt,
             actor: { actorType: 'USER', actorUserId: context.userId },
           },
-        });
+        }));
       }
 
       if (previousStatus === 'overdue' && newStatus === 'cancelled') {
@@ -623,7 +636,7 @@ export class InvoiceService extends BaseService<IInvoice> {
         });
 
         if (amountDue > 0) {
-          await publishWorkflowEvent({
+          deferredEvents.push(() => publishWorkflowEvent({
             eventType: 'INVOICE_WRITTEN_OFF',
             payload: buildInvoiceWrittenOffPayload({
               invoiceId: id,
@@ -637,11 +650,11 @@ export class InvoiceService extends BaseService<IInvoice> {
               occurredAt,
               actor: { actorType: 'USER', actorUserId: context.userId },
             },
-          });
+          }));
         }
       }
 
-      await publishEvent({
+      deferredEvents.push(() => publishEvent({
         eventType: 'INVOICE_UPDATED',
         payload: {
           tenantId: context.tenant,
@@ -651,10 +664,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           changes: data as Record<string, unknown>,
           timestamp: occurredAt
         }
-      });
+      }));
 
       return this.getById(id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -664,8 +680,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'delete');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: id, tenant: context.tenant })
         .first();
@@ -725,7 +742,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	      });
 
 	      if (softCancelled && String(invoice.status) !== 'cancelled') {
-	        await publishWorkflowEvent({
+	        deferredEvents.push(() => publishWorkflowEvent({
 	          eventType: 'INVOICE_STATUS_CHANGED',
 	          payload: buildInvoiceStatusChangedPayload({
 	            invoiceId: id,
@@ -739,11 +756,11 @@ export class InvoiceService extends BaseService<IInvoice> {
 	            occurredAt,
 	            actor: { actorType: 'USER', actorUserId: context.userId },
 	          },
-	        });
+	        }));
 	      }
 
 	      // Publish event
-	      await publishEvent({
+	      deferredEvents.push(() => publishEvent({
 	        eventType: 'INVOICE_DELETED',
 	        payload: {
 	          tenantId: context.tenant,
@@ -751,8 +768,10 @@ export class InvoiceService extends BaseService<IInvoice> {
 	          userId: context.userId,
 	          timestamp: occurredAt
 	        }
-	      });
+	      }));
     });
+
+    await publishDeferredEvents(deferredEvents);
   }
 
   // ============================================================================
@@ -766,8 +785,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'finalize');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -822,7 +842,7 @@ export class InvoiceService extends BaseService<IInvoice> {
       });
 
       // Publish event
-      await publishEvent({
+      deferredEvents.push(() => publishEvent({
         eventType: 'INVOICE_FINALIZED',
         payload: {
           tenantId: context.tenant,
@@ -831,9 +851,9 @@ export class InvoiceService extends BaseService<IInvoice> {
           userId: context.userId,
           timestamp: new Date().toISOString()
         }
-      });
+      }));
 
-      await publishWorkflowEvent({
+      deferredEvents.push(() => publishWorkflowEvent({
         eventType: 'INVOICE_STATUS_CHANGED',
         payload: buildInvoiceStatusChangedPayload({
           invoiceId: data.invoice_id,
@@ -846,10 +866,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           tenantId: context.tenant,
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
-      });
+      }));
 
       return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -859,8 +882,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'send');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -919,7 +943,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 
       // Publish event
       const sentAt = new Date().toISOString();
-      await publishWorkflowEvent({
+      deferredEvents.push(() => publishWorkflowEvent({
         eventType: 'INVOICE_SENT',
         payload: buildInvoiceSentPayload({
           invoiceId: data.invoice_id,
@@ -937,10 +961,10 @@ export class InvoiceService extends BaseService<IInvoice> {
           occurredAt: sentAt,
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
-      });
+      }));
 
       if (String(invoice.status) !== 'sent') {
-        await publishWorkflowEvent({
+        deferredEvents.push(() => publishWorkflowEvent({
           eventType: 'INVOICE_STATUS_CHANGED',
           payload: buildInvoiceStatusChangedPayload({
             invoiceId: data.invoice_id,
@@ -954,11 +978,14 @@ export class InvoiceService extends BaseService<IInvoice> {
             occurredAt: sentAt,
             actor: { actorType: 'USER', actorUserId: context.userId },
           },
-        });
+        }));
       }
 
       return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -968,8 +995,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'payment');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const occurredAt = new Date().toISOString();
 
       const invoice = await trx('invoices')
@@ -1000,7 +1028,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 
       await trx('invoice_payments').insert(paymentData);
 
-      await publishWorkflowEvent({
+      deferredEvents.push(() => publishWorkflowEvent({
         eventType: 'PAYMENT_RECORDED',
         payload: buildPaymentRecordedPayload({
           paymentId: paymentData.payment_id,
@@ -1018,9 +1046,9 @@ export class InvoiceService extends BaseService<IInvoice> {
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
         idempotencyKey: `payment_recorded:${paymentData.payment_id}`,
-      });
+      }));
 
-      await publishWorkflowEvent({
+      deferredEvents.push(() => publishWorkflowEvent({
         eventType: 'PAYMENT_APPLIED',
         payload: buildPaymentAppliedPayload({
           paymentId: paymentData.payment_id,
@@ -1034,7 +1062,7 @@ export class InvoiceService extends BaseService<IInvoice> {
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
         idempotencyKey: `payment_applied:${paymentData.payment_id}:${data.invoice_id}`,
-      });
+      }));
 
       // Calculate total payments
       const payments = await trx('invoice_payments')
@@ -1080,7 +1108,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	      });
 
 	      if (String(newStatus) !== String(invoice.status)) {
-	        await publishWorkflowEvent({
+	        deferredEvents.push(() => publishWorkflowEvent({
 	          eventType: 'INVOICE_STATUS_CHANGED',
 	          payload: buildInvoiceStatusChangedPayload({
 	            invoiceId: data.invoice_id,
@@ -1094,11 +1122,11 @@ export class InvoiceService extends BaseService<IInvoice> {
 	            occurredAt,
 	            actor: { actorType: 'USER', actorUserId: context.userId },
 	          },
-	        });
+	        }));
 	      }
 
 	      // Publish event
-	      await publishEvent({
+	      deferredEvents.push(() => publishEvent({
 	        eventType: 'INVOICE_PAYMENT_RECORDED',
 	        payload: {
 	          tenantId: context.tenant,
@@ -1109,10 +1137,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	          userId: context.userId,
 	          timestamp: new Date().toISOString()
 	        }
-	      });
+	      }));
 
       return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -1122,8 +1153,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'credit');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const invoice = await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
         .first();
@@ -1208,7 +1240,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 
 	      if (String(newStatus) !== String(invoice.status)) {
 	        const occurredAt = new Date().toISOString();
-	        await publishWorkflowEvent({
+	        deferredEvents.push(() => publishWorkflowEvent({
 	          eventType: 'INVOICE_STATUS_CHANGED',
 	          payload: buildInvoiceStatusChangedPayload({
 	            invoiceId: data.invoice_id,
@@ -1222,11 +1254,11 @@ export class InvoiceService extends BaseService<IInvoice> {
 	            occurredAt,
 	            actor: { actorType: 'USER', actorUserId: context.userId },
 	          },
-	        });
+	        }));
 	      }
 
 	      // Publish event
-	      await publishEvent({
+	      deferredEvents.push(() => publishEvent({
 	        eventType: 'INVOICE_CREDIT_APPLIED',
 	        payload: {
 	          tenantId: context.tenant,
@@ -1238,10 +1270,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	          userId: context.userId,
 	          timestamp: new Date().toISOString()
 	        }
-	      });
+	      }));
 
       return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   /**
@@ -1252,8 +1287,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'refund');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
 
-    return withTransaction(knex, async (trx) => {
+    const invoice = await withTransaction(knex, async (trx) => {
       const occurredAt = new Date().toISOString();
 
       const invoice = await trx('invoices')
@@ -1296,7 +1332,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 
       await trx('invoice_payments').insert(refundData);
 
-      await publishWorkflowEvent({
+      deferredEvents.push(() => publishWorkflowEvent({
         eventType: 'PAYMENT_REFUNDED',
         payload: buildPaymentRefundedPayload({
           paymentId: refundData.payment_id,
@@ -1312,7 +1348,7 @@ export class InvoiceService extends BaseService<IInvoice> {
           actor: { actorType: 'USER', actorUserId: context.userId },
         },
         idempotencyKey: `payment_refunded:${refundData.payment_id}`,
-      });
+      }));
 
       // Calculate net payments after refund
       const netPayments = await trx('invoice_payments')
@@ -1359,7 +1395,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	      });
 
 	      if (String(newStatus) !== String(invoice.status)) {
-	        await publishWorkflowEvent({
+	        deferredEvents.push(() => publishWorkflowEvent({
 	          eventType: 'INVOICE_STATUS_CHANGED',
 	          payload: buildInvoiceStatusChangedPayload({
 	            invoiceId: data.invoice_id,
@@ -1373,11 +1409,11 @@ export class InvoiceService extends BaseService<IInvoice> {
 	            occurredAt,
 	            actor: { actorType: 'USER', actorUserId: context.userId },
 	          },
-	        });
+	        }));
 	      }
 
 	      // Publish event
-	      await publishEvent({
+	      deferredEvents.push(() => publishEvent({
 	        eventType: 'INVOICE_REFUND_RECORDED',
 	        payload: {
 	          tenantId: context.tenant,
@@ -1389,10 +1425,13 @@ export class InvoiceService extends BaseService<IInvoice> {
 	          userId: context.userId,
 	          timestamp: new Date().toISOString()
 	        }
-	      });
+	      }));
 
       return this.getById(data.invoice_id, context) as Promise<IInvoice>;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return invoice;
   }
 
   // ============================================================================
@@ -1406,8 +1445,9 @@ export class InvoiceService extends BaseService<IInvoice> {
     await this.validatePermissions(context, 'invoice', 'bulk_update');
 
     const { knex } = await this.getKnex();
+    const deferredEvents: DeferredEvent[] = [];
     
-    return withTransaction(knex, async (trx) => {
+    const result = await withTransaction(knex, async (trx) => {
       const results: { updated_count: number; errors: string[] } = { updated_count: 0, errors: [] };
 
       for (const invoiceId of data.invoice_ids) {
@@ -1458,7 +1498,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	          const newStatus = String(data.status);
 
 	          if (newStatus !== previousStatus) {
-	            await publishWorkflowEvent({
+	            deferredEvents.push(() => publishWorkflowEvent({
 	              eventType: 'INVOICE_STATUS_CHANGED',
 	              payload: buildInvoiceStatusChangedPayload({
 	                invoiceId,
@@ -1472,7 +1512,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	                occurredAt,
 	                actor: { actorType: 'USER', actorUserId: context.userId },
 	              },
-	            });
+	            }));
 	          }
 
 	          if (newStatus === 'overdue' && previousStatus !== 'overdue') {
@@ -1483,7 +1523,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	              tenantId: context.tenant,
 	            });
 
-	            await publishWorkflowEvent({
+	            deferredEvents.push(() => publishWorkflowEvent({
 	              eventType: 'INVOICE_OVERDUE',
 	              payload: buildInvoiceOverduePayload({
 	                invoiceId,
@@ -1499,7 +1539,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	                occurredAt,
 	                actor: { actorType: 'USER', actorUserId: context.userId },
 	              },
-	            });
+	            }));
 	          }
 
 	          if (previousStatus === 'overdue' && newStatus === 'cancelled') {
@@ -1511,7 +1551,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	            });
 
 	            if (amountDue > 0) {
-	              await publishWorkflowEvent({
+	              deferredEvents.push(() => publishWorkflowEvent({
 	                eventType: 'INVOICE_WRITTEN_OFF',
 	                payload: buildInvoiceWrittenOffPayload({
 	                  invoiceId,
@@ -1525,7 +1565,7 @@ export class InvoiceService extends BaseService<IInvoice> {
 	                  occurredAt,
 	                  actor: { actorType: 'USER', actorUserId: context.userId },
 	                },
-	              });
+	              }));
 	            }
 	          }
 
@@ -1536,7 +1576,7 @@ export class InvoiceService extends BaseService<IInvoice> {
       }
 
       // Publish bulk event
-      await publishEvent({
+      deferredEvents.push(() => publishEvent({
         eventType: 'INVOICE_BULK_STATUS_UPDATE',
         payload: {
           tenantId: context.tenant,
@@ -1547,10 +1587,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           userId: context.userId,
           timestamp: new Date().toISOString()
         }
-      });
+      }));
 
       return results;
     });
+
+    await publishDeferredEvents(deferredEvents);
+    return result;
   }
 
   /**

--- a/server/src/lib/api/services/ProjectService.ts
+++ b/server/src/lib/api/services/ProjectService.ts
@@ -48,6 +48,11 @@ type InternalUpdateProjectTaskData = UpdateProjectTaskData & {
   description_rich_text?: string | null;
 };
 
+type DeferredWorkflowEvent = {
+  eventType: Parameters<typeof publishWorkflowEvent>[0]['eventType'];
+  payload: Record<string, unknown>;
+};
+
 async function resolveUserName(
   trx: Knex.Transaction,
   tenant: string,
@@ -251,7 +256,7 @@ export class ProjectService extends BaseService<IProject> {
   async createProject(data: CreateProjectData, context: ServiceContext): Promise<IProject> {
     const { knex } = await this.getKnex();
     
-    return withTransaction(knex, async (trx) => {
+    const project = await withTransaction(knex, async (trx) => {
       const projectNumber = data.project_number ?? await SharedNumberingService.getNextNumber('PROJECT', { knex: trx, tenant: context.tenant });
 
       // Generate WBS code
@@ -307,21 +312,22 @@ export class ProjectService extends BaseService<IProject> {
         });
       }
 
-      // Publish event
-      await publishEvent({
-        eventType: 'PROJECT_CREATED',
-        payload: {
-          tenantId: context.tenant,
-          projectId: project.project_id,
-          projectName: project.project_name,
-          clientId: project.client_id,
-          userId: context.userId,
-          timestamp: new Date().toISOString()
-        }
-      });
-
       return project;
     });
+
+    await publishEvent({
+      eventType: 'PROJECT_CREATED',
+      payload: {
+        tenantId: context.tenant,
+        projectId: project.project_id,
+        projectName: project.project_name,
+        clientId: project.client_id,
+        userId: context.userId,
+        timestamp: new Date().toISOString()
+      }
+    });
+
+    return project;
   }
 
   // Override for BaseService compatibility  
@@ -334,7 +340,7 @@ export class ProjectService extends BaseService<IProject> {
   async update(id: string, data: UpdateProjectData, context: ServiceContext): Promise<IProject> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const result = await withTransaction(knex, async (trx) => {
         const beforeProject = await trx(this.tableName)
           .where({ [this.primaryKey]: id, tenant: context.tenant })
           .first();
@@ -368,47 +374,66 @@ export class ProjectService extends BaseService<IProject> {
           project.status = data.status;
         }
   
-        const occurredAt = updateData.updated_at instanceof Date ? updateData.updated_at : new Date();
-        const ctx = {
-          tenantId: context.tenant,
-          occurredAt,
-          actor: { actorType: 'USER' as const, actorUserId: context.userId },
-        };
+        return { beforeProject, project, occurredAt: updateData.updated_at };
+      });
 
-        if ('status' in data && beforeProject.status !== project.status) {
-          await publishWorkflowEvent({
-            eventType: 'PROJECT_STATUS_CHANGED',
-            ctx,
-            payload: buildProjectStatusChangedPayload({
-              projectId: id,
-              previousStatus: beforeProject.status,
-              newStatus: project.status,
-              changedAt: occurredAt,
-            }),
-          });
-        }
+      const occurredAt = result.occurredAt instanceof Date ? result.occurredAt : new Date();
+      const ctx = {
+        tenantId: context.tenant,
+        occurredAt,
+        actor: { actorType: 'USER' as const, actorUserId: context.userId },
+      };
 
-        await publishWorkflowEvent({
-          eventType: 'PROJECT_UPDATED',
-          ctx,
-          payload: buildProjectUpdatedPayload({
+      if (
+        'assigned_to' in data &&
+        result.beforeProject.assigned_to !== result.project.assigned_to &&
+        result.project.assigned_to
+      ) {
+        await publishEvent({
+          eventType: 'PROJECT_ASSIGNED',
+          payload: {
+            tenantId: context.tenant,
             projectId: id,
-            before: beforeProject as unknown as Record<string, unknown> & { project_id: string },
-            after: project as unknown as Record<string, unknown> & { project_id: string },
-            updatedFieldKeys: Object.keys(data),
-            updatedAt: occurredAt,
+            userId: context.userId,
+            assignedTo: result.project.assigned_to,
+            timestamp: new Date().toISOString()
+          }
+        });
+      }
+
+      if ('status' in data && result.beforeProject.status !== result.project.status) {
+        await publishWorkflowEvent({
+          eventType: 'PROJECT_STATUS_CHANGED',
+          ctx,
+          payload: buildProjectStatusChangedPayload({
+            projectId: id,
+            previousStatus: result.beforeProject.status,
+            newStatus: result.project.status,
+            changedAt: occurredAt,
           }),
         });
-  
-        return project;
+      }
+
+      await publishWorkflowEvent({
+        eventType: 'PROJECT_UPDATED',
+        ctx,
+        payload: buildProjectUpdatedPayload({
+          projectId: id,
+          before: result.beforeProject as unknown as Record<string, unknown> & { project_id: string },
+          after: result.project as unknown as Record<string, unknown> & { project_id: string },
+          updatedFieldKeys: Object.keys(data),
+          updatedAt: occurredAt,
+        }),
       });
+
+      return result.project;
     }
 
 
   async delete(id: string, context: ServiceContext): Promise<void> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const result = await trx(this.tableName)
           .where({ [this.primaryKey]: id, tenant: context.tenant })
           .del();
@@ -416,17 +441,16 @@ export class ProjectService extends BaseService<IProject> {
         if (result === 0) {
           throw new NotFoundError('Project not found');
         }
-  
-        // Publish event
-        await publishEvent({
-          eventType: 'PROJECT_DELETED',
-          payload: {
-            tenantId: context.tenant,
-            projectId: id,
-            userId: context.userId,
-            timestamp: new Date().toISOString()
-          }
-        });
+      });
+
+      await publishEvent({
+        eventType: 'PROJECT_DELETED',
+        payload: {
+          tenantId: context.tenant,
+          projectId: id,
+          userId: context.userId,
+          timestamp: new Date().toISOString()
+        }
       });
     }
 
@@ -579,7 +603,7 @@ export class ProjectService extends BaseService<IProject> {
   async createTask(phaseId: string, data: CreateProjectTaskData, context: ServiceContext): Promise<IProjectTask> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const result = await withTransaction(knex, async (trx) => {
         const phase = await trx('project_phases')
           .where({ phase_id: phaseId, tenant: context.tenant })
           .first();
@@ -640,25 +664,25 @@ export class ProjectService extends BaseService<IProject> {
 
         const statusInfo = await resolveProjectStatusInfo(trx, context.tenant, task.project_status_mapping_id);
 
-        await publishWorkflowEvent({
-          eventType: 'PROJECT_TASK_CREATED',
-          ctx,
-          payload: buildProjectTaskCreatedPayload({
-            projectId: phase.project_id,
-            taskId: task.task_id,
-            title: task.task_name,
-            dueDate: task.due_date,
-            status: statusInfo.status,
-            createdByUserId: context.userId,
-            createdAt: occurredAt,
-          }),
-        });
+        const workflowEvents: DeferredWorkflowEvent[] = [
+          {
+            eventType: 'PROJECT_TASK_CREATED',
+            payload: buildProjectTaskCreatedPayload({
+              projectId: phase.project_id,
+              taskId: task.task_id,
+              title: task.task_name,
+              dueDate: task.due_date,
+              status: statusInfo.status,
+              createdByUserId: context.userId,
+              createdAt: occurredAt,
+            }),
+          },
+        ];
 
         if (task.assigned_to) {
           const assignedByName = await resolveUserName(trx, context.tenant, context.userId);
-          await publishWorkflowEvent({
+          workflowEvents.push({
             eventType: 'PROJECT_TASK_ASSIGNED',
-            ctx,
             payload: buildProjectTaskAssignedPayload({
               projectId: phase.project_id,
               taskId: task.task_id,
@@ -671,15 +695,25 @@ export class ProjectService extends BaseService<IProject> {
           });
         }
 
-        return task;
+        return { task, ctx, workflowEvents };
       });
+
+      for (const event of result.workflowEvents) {
+        await publishWorkflowEvent({
+          eventType: event.eventType,
+          ctx: result.ctx,
+          payload: event.payload,
+        });
+      }
+
+      return result.task;
     }
 
 
   async updateTask(taskId: string, data: InternalUpdateProjectTaskData, context: ServiceContext): Promise<IProjectTask> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const result = await withTransaction(knex, async (trx) => {
         const beforeTask = await trx<IProjectTask>('project_tasks')
           .where({ task_id: taskId, tenant: context.tenant })
           .first();
@@ -707,9 +741,16 @@ export class ProjectService extends BaseService<IProject> {
           .select('project_id')
           .first<{ project_id: string }>();
 
+        const workflowEvents: DeferredWorkflowEvent[] = [];
+        let ctx: {
+          tenantId: string;
+          occurredAt: Date;
+          actor: { actorType: 'USER'; actorUserId: string };
+        } | null = null;
+
         if (phase) {
           const occurredAt = task.updated_at instanceof Date ? task.updated_at : new Date();
-          const ctx = {
+          ctx = {
             tenantId: context.tenant,
             occurredAt,
             actor: { actorType: 'USER' as const, actorUserId: context.userId },
@@ -717,9 +758,8 @@ export class ProjectService extends BaseService<IProject> {
 
           if (beforeTask.assigned_to !== task.assigned_to && task.assigned_to) {
             const assignedByName = await resolveUserName(trx, context.tenant, context.userId);
-            await publishWorkflowEvent({
+            workflowEvents.push({
               eventType: 'PROJECT_TASK_ASSIGNED',
-              ctx,
               payload: buildProjectTaskAssignedPayload({
                 projectId: phase.project_id,
                 taskId: task.task_id,
@@ -738,9 +778,8 @@ export class ProjectService extends BaseService<IProject> {
               resolveProjectStatusInfo(trx, context.tenant, task.project_status_mapping_id),
             ]);
 
-            await publishWorkflowEvent({
+            workflowEvents.push({
               eventType: 'PROJECT_TASK_STATUS_CHANGED',
-              ctx,
               payload: buildProjectTaskStatusChangedPayload({
                 projectId: phase.project_id,
                 taskId: task.task_id,
@@ -751,9 +790,8 @@ export class ProjectService extends BaseService<IProject> {
             });
 
             if (!beforeStatus.isClosed && afterStatus.isClosed) {
-              await publishWorkflowEvent({
+              workflowEvents.push({
                 eventType: 'PROJECT_TASK_COMPLETED',
-                ctx,
                 payload: buildProjectTaskCompletedPayload({
                   projectId: phase.project_id,
                   taskId: task.task_id,
@@ -765,8 +803,20 @@ export class ProjectService extends BaseService<IProject> {
           }
         }
   
-        return task;
+        return { task, ctx, workflowEvents };
       });
+
+      if (result.ctx) {
+        for (const event of result.workflowEvents) {
+          await publishWorkflowEvent({
+            eventType: event.eventType,
+            ctx: result.ctx,
+            payload: event.payload,
+          });
+        }
+      }
+
+      return result.task;
     }
 
 

--- a/server/src/lib/api/services/TagService.ts
+++ b/server/src/lib/api/services/TagService.ts
@@ -175,7 +175,7 @@ export class TagService extends BaseService {
       ): Promise<TagResponse> {
         const { knex, tenant } = await this.getKnex();
 
-        return withTransaction(knex, async (trx) => {
+        const { created, definitionToPublish } = await withTransaction(knex, async (trx) => {
           const tagData: Omit<ITag, 'tenant' | 'tag_id'> = {
             tag_text: data.tag_text,
             tagged_id: data.tagged_id,
@@ -205,10 +205,6 @@ export class TagService extends BaseService {
             tagged_type: tagData.tagged_type
           }, context.userId);
 
-          if (createdDefinition) {
-            await this.publishTagDefinitionCreated(definition, context);
-          }
-          
           // Get the created tag for return
           const created = await trx('tag_mappings as tm')
             .join('tag_definitions as td', function() {
@@ -230,8 +226,19 @@ export class TagService extends BaseService {
             )
             .first();
 
-          return created as TagResponse;
+          return {
+            created: created as TagResponse,
+            definitionToPublish: createdDefinition ? definition : null,
+          };
         });
+
+        // Publish after the transaction commits so subscribers can read the
+        // newly-created tag definition on their own connections.
+        if (definitionToPublish) {
+          await this.publishTagDefinitionCreated(definitionToPublish, context);
+        }
+
+        return created;
       }
 
   /**
@@ -244,7 +251,7 @@ export class TagService extends BaseService {
   ): Promise<TagResponse> {
     const { knex, tenant } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const { updated, tagUpdate } = await withTransaction(knex, async (trx) => {
       const updateData = { ...data };
       if (updateData.tag_text) {
         updateData.tag_text = updateData.tag_text.toLowerCase().trim();
@@ -270,13 +277,6 @@ export class TagService extends BaseService {
         board_id: updateData.board_id
       });
 
-      await this.publishTagDefinitionUpdated(
-        mapping.tag_id,
-        previousDefinition?.tag_text,
-        updateData.tag_text ?? previousDefinition?.tag_text,
-        context,
-      );
-      
       // Get updated tag
       const updated = await trx('tag_mappings as tm')
         .join('tag_definitions as td', function() {
@@ -302,8 +302,26 @@ export class TagService extends BaseService {
         throw new Error('Tag not found after update');
       }
 
-      return updated as TagResponse;
+      return {
+        updated: updated as TagResponse,
+        tagUpdate: {
+          tagId: mapping.tag_id,
+          previousName: previousDefinition?.tag_text,
+          newName: updateData.tag_text ?? previousDefinition?.tag_text,
+        },
+      };
     });
+
+    // Publish after the transaction commits so subscribers can read the
+    // updated tag definition on their own connections.
+    await this.publishTagDefinitionUpdated(
+      tagUpdate.tagId,
+      tagUpdate.previousName,
+      tagUpdate.newName,
+      context,
+    );
+
+    return updated;
   }
 
   /**
@@ -677,7 +695,7 @@ export class TagService extends BaseService {
   ): Promise<{ updated: number }> {
     const { knex, tenant } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const result = await withTransaction(knex, async (trx) => {
       // Validate hex color codes if provided
       const hexColorRegex = /^#[0-9A-F]{6}$/i;
       if (backgroundColor && !hexColorRegex.test(backgroundColor)) {
@@ -691,7 +709,7 @@ export class TagService extends BaseService {
       const definition = await TagDefinition.findByTextAndType(trx, tenant, tagText, entityType);
 
       if (!definition) {
-        return { updated: 0 };
+        return { updated: 0, definitionToPublish: null };
       }
 
       await TagDefinition.update(trx, tenant, definition.tag_id, {
@@ -699,18 +717,27 @@ export class TagService extends BaseService {
         text_color: textColor
       });
 
-      await this.publishTagDefinitionUpdated(
-        definition.tag_id,
-        definition.tag_text,
-        definition.tag_text,
-        context,
-      );
-
       // Get count of affected mappings
       const updated = await TagMapping.getUsageCount(trx, tenant, definition.tag_id);
 
-      return { updated };
+      return {
+        updated,
+        definitionToPublish: { tagId: definition.tag_id, tagText: definition.tag_text },
+      };
     });
+
+    // Publish after the transaction commits so subscribers can read the
+    // updated tag definition on their own connections.
+    if (result.definitionToPublish) {
+      await this.publishTagDefinitionUpdated(
+        result.definitionToPublish.tagId,
+        result.definitionToPublish.tagText,
+        result.definitionToPublish.tagText,
+        context,
+      );
+    }
+
+    return { updated: result.updated };
   }
 
   /**
@@ -723,7 +750,7 @@ export class TagService extends BaseService {
   ): Promise<{ old_tag_text: string; new_tag_text: string; tagged_type: TaggedEntityType; updated_count: number; }> {
     const { knex, tenant } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const { result, publish } = await withTransaction(knex, async (trx) => {
       // Validate tag text
       if (!newTagText || !newTagText.trim()) {
         throw new Error('Tag text cannot be empty');
@@ -758,10 +785,13 @@ export class TagService extends BaseService {
       // Don't update if text is the same
       if (tag.tag_text === trimmedNewText) {
         return {
-          old_tag_text: tag.tag_text,
-          new_tag_text: trimmedNewText,
-          tagged_type: tag.tagged_type,
-          updated_count: 0,
+          result: {
+            old_tag_text: tag.tag_text,
+            new_tag_text: trimmedNewText,
+            tagged_type: tag.tagged_type,
+            updated_count: 0,
+          },
+          publish: null,
         };
       }
 
@@ -770,10 +800,13 @@ export class TagService extends BaseService {
 
       if (!oldDefinition) {
         return {
-          old_tag_text: tag.tag_text,
-          new_tag_text: trimmedNewText,
-          tagged_type: tag.tagged_type,
-          updated_count: 0,
+          result: {
+            old_tag_text: tag.tag_text,
+            new_tag_text: trimmedNewText,
+            tagged_type: tag.tagged_type,
+            updated_count: 0,
+          },
+          publish: null,
         };
       }
 
@@ -789,23 +822,36 @@ export class TagService extends BaseService {
         tag_text: trimmedNewText
       });
 
-      await this.publishTagDefinitionUpdated(
-        oldDefinition.tag_id,
-        tag.tag_text,
-        trimmedNewText,
-        context,
-      );
-
       // Return count of affected mappings
       const updatedCount = await TagMapping.getUsageCount(trx, tenant, oldDefinition.tag_id);
 
       return {
-        old_tag_text: tag.tag_text,
-        new_tag_text: trimmedNewText,
-        tagged_type: tag.tagged_type,
-        updated_count: updatedCount,
+        result: {
+          old_tag_text: tag.tag_text,
+          new_tag_text: trimmedNewText,
+          tagged_type: tag.tagged_type,
+          updated_count: updatedCount,
+        },
+        publish: {
+          tagId: oldDefinition.tag_id,
+          previousName: tag.tag_text,
+          newName: trimmedNewText,
+        },
       };
     });
+
+    // Publish after the transaction commits so subscribers can read the
+    // updated tag definition on their own connections.
+    if (publish) {
+      await this.publishTagDefinitionUpdated(
+        publish.tagId,
+        publish.previousName,
+        publish.newName,
+        context,
+      );
+    }
+
+    return result;
   }
 
   /**
@@ -818,7 +864,7 @@ export class TagService extends BaseService {
   ): Promise<{ deleted_count: number }> {
     const { knex, tenant } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const { deletedCount, deletedTagId } = await withTransaction(knex, async (trx) => {
       // Validate tag text
       if (!tagText || !tagText.trim()) {
         throw new Error('Tag text cannot be empty');
@@ -829,6 +875,7 @@ export class TagService extends BaseService {
       // Find the definition and delete it (mappings will cascade delete)
       const definition = await TagDefinition.findByTextAndType(trx, tenant, trimmedText, taggedType);
       let deletedCount = 0;
+      let deletedTagId: string | null = null;
 
       if (definition) {
         // Get count before deletion
@@ -836,13 +883,21 @@ export class TagService extends BaseService {
 
         // Delete the definition (mappings will cascade delete)
         await TagDefinition.delete(trx, tenant, definition.tag_id);
-        await this.publishTagDefinitionDeleted(definition.tag_id, context);
+        deletedTagId = definition.tag_id;
       }
-      
-      return {
-        deleted_count: deletedCount,
-      };
+
+      return { deletedCount, deletedTagId };
     });
+
+    // Publish after the transaction commits so subscribers can observe the
+    // deletion on their own connections.
+    if (deletedTagId) {
+      await this.publishTagDefinitionDeleted(deletedTagId, context);
+    }
+
+    return {
+      deleted_count: deletedCount,
+    };
   }
 
   // ========================================================================

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -11,12 +11,9 @@ import { ITicketMaterial } from 'server/src/interfaces/material.interfaces';
 import { TICKET_ORIGINS } from '@alga-psa/types';
 import { withTransaction } from '@alga-psa/db';
 import { maybeReopenBundleMasterFromChildReply } from '@alga-psa/tickets/actions/ticketBundleUtils';
-import { getEventBus } from 'server/src/lib/eventBus';
 import { publishWorkflowEvent } from 'server/src/lib/eventBus/publishers';
-import { getEmailEventChannel } from '@alga-psa/notifications';
 import { NotFoundError, ValidationError } from '../middleware/apiMiddleware';
 import { TicketModel, CreateTicketInput } from '@shared/models/ticketModel';
-import { ServerEventPublisher } from '@alga-psa/event-bus';
 import { ServerAnalyticsTracker } from '@alga-psa/analytics';
 // Event types no longer needed as we create objects directly
 import {
@@ -773,7 +770,7 @@ export class TicketService extends BaseService<ITicket> {
     private async createTicket(data: CreateTicketData, context: ServiceContext): Promise<ITicket> {
       const { knex } = await this.getKnex();
   
-      return withTransaction(knex, async (trx) => {
+      const fullTicket = await withTransaction(knex, async (trx) => {
         // Validate status belongs to the specified board before proceeding
         const statusBelongsToBoard = await TicketModel.validateStatusBelongsToBoard(
           data.status_id,
@@ -806,17 +803,17 @@ export class TicketService extends BaseService<ITicket> {
           ticket_origin: TICKET_ORIGINS.API,
         };
 
-        // Create adapters for API service context
-        const eventPublisher = new ServerEventPublisher();
+        // Publish after the transaction commits so notification subscribers can
+        // read the newly-created ticket on their own connections.
         const analyticsTracker = new ServerAnalyticsTracker();
 
-        // Use shared TicketModel with retry logic, events, and analytics
+        // Use shared TicketModel with retry logic and analytics
         const ticketResult = await TicketModel.createTicketWithRetry(
           createTicketInput,
           context.tenant,
           trx,
           {}, // validation options
-          eventPublisher,
+          undefined,
           analyticsTracker,
           context.userId,
           3 // max retries
@@ -843,6 +840,21 @@ export class TicketService extends BaseService<ITicket> {
 
         return fullTicket as ITicket;
       });
+
+      await this.safePublishEvent('TICKET_CREATED', context, {
+        ticketId: fullTicket.ticket_id,
+        userId: context.userId,
+        createdByUserId: context.userId,
+        createdAt: fullTicket.entered_at
+          ? new Date(fullTicket.entered_at as unknown as string).toISOString()
+          : new Date().toISOString(),
+        source: 'api',
+        board_id: fullTicket.board_id,
+        priority_id: fullTicket.priority_id,
+        client_id: fullTicket.client_id,
+      });
+
+      return fullTicket;
     }
 
 
@@ -999,7 +1011,7 @@ export class TicketService extends BaseService<ITicket> {
   async createFromAsset(data: CreateTicketFromAssetData, context: ServiceContext): Promise<ITicket> {
     const { knex } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const fullTicket = await withTransaction(knex, async (trx) => {
       // Verify asset exists
       const asset = await trx('assets')
         .where({ asset_id: data.asset_id, tenant: context.tenant })
@@ -1022,8 +1034,8 @@ export class TicketService extends BaseService<ITicket> {
         ]);
       }
 
-      // Create adapters for API service context
-      const eventPublisher = new ServerEventPublisher();
+      // Publish after the transaction commits so notification subscribers can
+      // read the newly-created ticket on their own connections.
       const analyticsTracker = new ServerAnalyticsTracker();
 
       // Use shared TicketModel for asset ticket creation
@@ -1040,7 +1052,7 @@ export class TicketService extends BaseService<ITicket> {
         context.userId,
         context.tenant,
         trx,
-        eventPublisher,
+        undefined,
         analyticsTracker
       );
 
@@ -1063,6 +1075,21 @@ export class TicketService extends BaseService<ITicket> {
 
       return fullTicket as ITicket;
     });
+
+    await this.safePublishEvent('TICKET_CREATED', context, {
+      ticketId: fullTicket.ticket_id,
+      userId: context.userId,
+      createdByUserId: context.userId,
+      createdAt: fullTicket.entered_at
+        ? new Date(fullTicket.entered_at as unknown as string).toISOString()
+        : new Date().toISOString(),
+      source: 'api',
+      board_id: fullTicket.board_id,
+      priority_id: fullTicket.priority_id,
+      client_id: fullTicket.client_id,
+    });
+
+    return fullTicket;
   }
 
   /**
@@ -1192,7 +1219,7 @@ export class TicketService extends BaseService<ITicket> {
   ): Promise<any> {
     const { knex } = await this.getKnex();
 
-    return withTransaction(knex, async (trx) => {
+    const result = await withTransaction(knex, async (trx) => {
       // Verify ticket exists
       const ticket = await trx('tickets')
         .where({ ticket_id: ticketId, tenant: context.tenant })
@@ -1264,20 +1291,8 @@ export class TicketService extends BaseService<ITicket> {
 
       const authorName = user ? `${user.first_name} ${user.last_name}` : 'Unknown User';
 
-      // Publish TICKET_COMMENT_ADDED event for mention notifications
-      await this.safePublishEvent('TICKET_COMMENT_ADDED', context, {
-        ticketId: ticketId,
-        userId: context.userId,
-        comment: {
-          id: comment.comment_id,
-          content: comment.note,
-          author: authorName,
-          isInternal: comment.is_internal
-        }
-      });
-
       // Map database fields to API response format
-      return {
+      const response = {
         ...comment,
         comment_text: comment.note,
         comment_html: renderTicketRichTextHtml(comment.note),
@@ -1286,7 +1301,27 @@ export class TicketService extends BaseService<ITicket> {
         author_contact_name: null,
         author_contact_email: null
       };
+
+      return {
+        response,
+        eventPayload: {
+          ticketId: ticketId,
+          userId: context.userId,
+          comment: {
+            id: comment.comment_id,
+            content: comment.note,
+            author: authorName,
+            isInternal: comment.is_internal
+          }
+        }
+      };
     });
+
+    // Publish after the transaction commits so email and in-app notification
+    // subscribers can load the ticket/comment rows reliably.
+    await this.safePublishEvent('TICKET_COMMENT_ADDED', context, result.eventPayload);
+
+    return result.response;
   }
 
   /**

--- a/server/src/lib/api/services/TimeSheetService.ts
+++ b/server/src/lib/api/services/TimeSheetService.ts
@@ -250,7 +250,7 @@ export class TimeSheetService extends BaseService<any> {
   async create(data: CreateTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      const created = await withTransaction(knex, async (trx) => {
         const timeSheetData = {
           ...data,
           user_id: data.user_id || context.userId,
@@ -259,33 +259,35 @@ export class TimeSheetService extends BaseService<any> {
           created_at: new Date(),
           updated_at: new Date()
         };
-  
+
         const [timeSheet] = await trx(this.tableName)
           .insert(timeSheetData)
           .returning('*');
-  
-        return this.getWithDetails(timeSheet.id, context);
+
+        return timeSheet;
       });
 
       await publishEvent({
         eventType: 'TIME_SHEET_CREATED',
         payload: {
           tenantId: context.tenant,
-          timeSheetId: timeSheet.id,
+          timeSheetId: created.id,
           userId: context.userId,
-          periodId: timeSheet.period_id,
+          periodId: created.period_id,
           timestamp: new Date().toISOString()
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getWithDetails runs on a pooled
+      // (non-transaction) connection and must read the row post-commit.
+      return this.getWithDetails(created.id, context);
     }
 
 
   async update(id: string, data: UpdateTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const existing = await this.getById(id, context);
         if (!existing) {
           throw new Error('Time sheet not found');
@@ -310,7 +312,6 @@ export class TimeSheetService extends BaseService<any> {
           .where({ [this.primaryKey]: id, tenant: context.tenant })
           .update(updateData);
   
-        return this.getById(id, context);
       });
 
       await publishEvent({
@@ -324,7 +325,9 @@ export class TimeSheetService extends BaseService<any> {
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getById runs on a pooled (non-transaction)
+      // connection and must read the row post-commit.
+      return this.getById(id, context);
     }
 
 
@@ -368,7 +371,7 @@ export class TimeSheetService extends BaseService<any> {
   async submitTimeSheet(id: string, data: SubmitTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -399,7 +402,6 @@ export class TimeSheetService extends BaseService<any> {
             updated_at: new Date()
           });
   
-        return this.getById(id, context);
       });
 
       await publishEvent({
@@ -412,14 +414,16 @@ export class TimeSheetService extends BaseService<any> {
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getById runs on a pooled (non-transaction)
+      // connection and must read the row post-commit.
+      return this.getById(id, context);
     }
 
 
   async approveTimeSheet(id: string, data: ApproveTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -455,7 +459,6 @@ export class TimeSheetService extends BaseService<any> {
             updated_at: new Date()
           });
   
-        return this.getById(id, context);
       });
 
       await publishEvent({
@@ -468,14 +471,16 @@ export class TimeSheetService extends BaseService<any> {
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getById runs on a pooled (non-transaction)
+      // connection and must read the row post-commit.
+      return this.getById(id, context);
     }
 
 
   async requestChanges(id: string, data: RequestChangesTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -505,7 +510,6 @@ export class TimeSheetService extends BaseService<any> {
           comment_text: `Changes requested: ${data.change_reason}${data.detailed_feedback ? `\n\nDetails: ${data.detailed_feedback}` : ''}`
         }, context);
   
-        return this.getById(id, context);
       });
 
       await publishEvent({
@@ -519,7 +523,9 @@ export class TimeSheetService extends BaseService<any> {
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getById runs on a pooled (non-transaction)
+      // connection and must read the row post-commit.
+      return this.getById(id, context);
     }
 
 
@@ -543,7 +549,7 @@ export class TimeSheetService extends BaseService<any> {
   async reverseApproval(id: string, data: ReverseApprovalData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      const timeSheet = await withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -592,7 +598,6 @@ export class TimeSheetService extends BaseService<any> {
           comment_text: `Approval reversed: ${data.reversal_reason}`
         }, context);
   
-        return this.getById(id, context);
       });
 
       await publishEvent({
@@ -606,7 +611,9 @@ export class TimeSheetService extends BaseService<any> {
         }
       });
 
-      return timeSheet;
+      // Re-fetch after commit: getById runs on a pooled (non-transaction)
+      // connection and must read the row post-commit.
+      return this.getById(id, context);
     }
 
 
@@ -944,7 +951,7 @@ export class TimeSheetService extends BaseService<any> {
           assignedByUserId: context.userId
         });
 
-        return this.getScheduleEntry(entry.entry_id, context);
+        return entry;
       });
 
       await publishEvent({
@@ -960,7 +967,9 @@ export class TimeSheetService extends BaseService<any> {
         },
       });
 
-      return entry;
+      // Re-fetch after commit: getScheduleEntry runs on a pooled
+      // (non-transaction) connection and must read the row post-commit.
+      return this.getScheduleEntry(entry.entry_id, context);
     }
 
 
@@ -1012,7 +1021,6 @@ export class TimeSheetService extends BaseService<any> {
           .first();
 
         return {
-          scheduleEntry: await this.getScheduleEntry(id, context),
           existing,
           updated,
         };
@@ -1032,7 +1040,9 @@ export class TimeSheetService extends BaseService<any> {
         },
       });
 
-      return result.scheduleEntry;
+      // Re-fetch after commit: getScheduleEntry runs on a pooled
+      // (non-transaction) connection and must read the row post-commit.
+      return this.getScheduleEntry(id, context);
     }
 
 

--- a/server/src/lib/api/services/TimeSheetService.ts
+++ b/server/src/lib/api/services/TimeSheetService.ts
@@ -250,7 +250,7 @@ export class TimeSheetService extends BaseService<any> {
   async create(data: CreateTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const timeSheetData = {
           ...data,
           user_id: data.user_id || context.userId,
@@ -264,27 +264,28 @@ export class TimeSheetService extends BaseService<any> {
           .insert(timeSheetData)
           .returning('*');
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_CREATED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: timeSheet.id,
-            userId: context.userId,
-            periodId: timeSheet.period_id,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getWithDetails(timeSheet.id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_CREATED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: timeSheet.id,
+          userId: context.userId,
+          periodId: timeSheet.period_id,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
   async update(id: string, data: UpdateTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const existing = await this.getById(id, context);
         if (!existing) {
           throw new Error('Time sheet not found');
@@ -309,27 +310,28 @@ export class TimeSheetService extends BaseService<any> {
           .where({ [this.primaryKey]: id, tenant: context.tenant })
           .update(updateData);
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_UPDATED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            userId: context.userId,
-            changes: data,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getById(id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_UPDATED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          userId: context.userId,
+          changes: data,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
   async delete(id: string, context: ServiceContext): Promise<void> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      await withTransaction(knex, async (trx) => {
         const existing = await this.getById(id, context);
         if (!existing) {
           throw new Error('Time sheet not found');
@@ -348,17 +350,16 @@ export class TimeSheetService extends BaseService<any> {
         await trx(this.tableName)
           .where({ [this.primaryKey]: id, tenant: context.tenant })
           .del();
-  
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_DELETED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            userId: context.userId,
-            timestamp: new Date().toISOString()
-          }
-        });
+      });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_DELETED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          userId: context.userId,
+          timestamp: new Date().toISOString()
+        }
       });
     }
 
@@ -367,7 +368,7 @@ export class TimeSheetService extends BaseService<any> {
   async submitTimeSheet(id: string, data: SubmitTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -398,26 +399,27 @@ export class TimeSheetService extends BaseService<any> {
             updated_at: new Date()
           });
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_SUBMITTED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            userId: context.userId,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getById(id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_SUBMITTED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          userId: context.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
   async approveTimeSheet(id: string, data: ApproveTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -453,26 +455,27 @@ export class TimeSheetService extends BaseService<any> {
             updated_at: new Date()
           });
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_APPROVED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            approvedBy: context.userId,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getById(id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_APPROVED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          approvedBy: context.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
   async requestChanges(id: string, data: RequestChangesTimeSheetData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -502,20 +505,21 @@ export class TimeSheetService extends BaseService<any> {
           comment_text: `Changes requested: ${data.change_reason}${data.detailed_feedback ? `\n\nDetails: ${data.detailed_feedback}` : ''}`
         }, context);
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_CHANGES_REQUESTED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            requestedBy: context.userId,
-            reason: data.change_reason,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getById(id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_CHANGES_REQUESTED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          requestedBy: context.userId,
+          reason: data.change_reason,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
@@ -539,7 +543,7 @@ export class TimeSheetService extends BaseService<any> {
   async reverseApproval(id: string, data: ReverseApprovalData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const timeSheet = await withTransaction(knex, async (trx) => {
         const timeSheet = await this.getById(id, context);
         if (!timeSheet) {
           throw new Error('Time sheet not found');
@@ -588,20 +592,21 @@ export class TimeSheetService extends BaseService<any> {
           comment_text: `Approval reversed: ${data.reversal_reason}`
         }, context);
   
-        // Publish event
-        await publishEvent({
-          eventType: 'TIME_SHEET_APPROVAL_REVERSED',
-          payload: {
-            tenantId: context.tenant,
-            timeSheetId: id,
-            reversedBy: context.userId,
-            reason: data.reversal_reason,
-            timestamp: new Date().toISOString()
-          }
-        });
-  
         return this.getById(id, context);
       });
+
+      await publishEvent({
+        eventType: 'TIME_SHEET_APPROVAL_REVERSED',
+        payload: {
+          tenantId: context.tenant,
+          timeSheetId: id,
+          reversedBy: context.userId,
+          reason: data.reversal_reason,
+          timestamp: new Date().toISOString()
+        }
+      });
+
+      return timeSheet;
     }
 
 
@@ -912,7 +917,7 @@ export class TimeSheetService extends BaseService<any> {
       const { knex } = await this.getKnex();
       const ScheduleEntry = (await import('@alga-psa/shared/models/scheduleEntry')).default;
 
-      return withTransaction(knex, async (trx) => {
+      const entry = await withTransaction(knex, async (trx) => {
         // Map work_item_type to valid WorkItemType or default
         let workItemType: 'ticket' | 'project_task' | 'non_billable_category' | 'ad_hoc' | 'interaction';
         if (data.work_item_type === 'ticket' || data.work_item_type === 'project_task') {
@@ -939,28 +944,30 @@ export class TimeSheetService extends BaseService<any> {
           assignedByUserId: context.userId
         });
 
-        await publishEvent({
-          eventType: 'SCHEDULE_ENTRY_CREATED',
-          payload: {
-            tenantId: context.tenant,
-            userId: context.userId,
-            entryId: entry.entry_id,
-            changes: {
-              after: entry,
-              assignedUserIds: data.assigned_user_ids || [],
-            },
-          },
-        });
-
         return this.getScheduleEntry(entry.entry_id, context);
       });
+
+      await publishEvent({
+        eventType: 'SCHEDULE_ENTRY_CREATED',
+        payload: {
+          tenantId: context.tenant,
+          userId: context.userId,
+          entryId: entry.entry_id,
+          changes: {
+            after: entry,
+            assignedUserIds: data.assigned_user_ids || [],
+          },
+        },
+      });
+
+      return entry;
     }
 
 
   async updateScheduleEntry(id: string, data: UpdateScheduleEntryData, context: ServiceContext): Promise<any> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const result = await withTransaction(knex, async (trx) => {
         const existing = await knex('schedule_entries')
           .where({ entry_id: id, tenant: context.tenant })
           .first();
@@ -1004,29 +1011,35 @@ export class TimeSheetService extends BaseService<any> {
           .where({ entry_id: id, tenant: context.tenant })
           .first();
 
-        await publishEvent({
-          eventType: 'SCHEDULE_ENTRY_UPDATED',
-          payload: {
-            tenantId: context.tenant,
-            userId: context.userId,
-            entryId: id,
-            changes: {
-              before: existing,
-              after: updated,
-              assignedUserIds: data.assigned_user_ids,
-            },
-          },
-        });
-
-        return this.getScheduleEntry(id, context);
+        return {
+          scheduleEntry: await this.getScheduleEntry(id, context),
+          existing,
+          updated,
+        };
       });
+
+      await publishEvent({
+        eventType: 'SCHEDULE_ENTRY_UPDATED',
+        payload: {
+          tenantId: context.tenant,
+          userId: context.userId,
+          entryId: id,
+          changes: {
+            before: result.existing,
+            after: result.updated,
+            assignedUserIds: data.assigned_user_ids,
+          },
+        },
+      });
+
+      return result.scheduleEntry;
     }
 
 
   async deleteScheduleEntry(id: string, context: ServiceContext): Promise<void> {
       const { knex } = await this.getKnex();
       
-      return withTransaction(knex, async (trx) => {
+      const existing = await withTransaction(knex, async (trx) => {
         const existing = await knex('schedule_entries')
           .where({ entry_id: id, tenant: context.tenant })
           .first();
@@ -1044,17 +1057,19 @@ export class TimeSheetService extends BaseService<any> {
           .where({ entry_id: id, tenant: context.tenant })
           .del();
 
-        await publishEvent({
-          eventType: 'SCHEDULE_ENTRY_DELETED',
-          payload: {
-            tenantId: context.tenant,
-            userId: context.userId,
-            entryId: id,
-            changes: {
-              before: existing,
-            },
+        return existing;
+      });
+
+      await publishEvent({
+        eventType: 'SCHEDULE_ENTRY_DELETED',
+        payload: {
+          tenantId: context.tenant,
+          userId: context.userId,
+          entryId: id,
+          changes: {
+            before: existing,
           },
-        });
+        },
       });
     }
 


### PR DESCRIPTION
  Move publishEvent/publishWorkflowEvent calls out of withTransaction
  callbacks across ContractLine, Invoice, Project, Tag, Ticket, and
  TimeSheet services. Payloads are now captured inside the transaction
  and emitted only once it commits (InvoiceService gains a deferred-
  event queue; TicketService stops passing an in-transaction publisher
  into TicketModel). This fixes a race where notification subscribers
  on separate DB connections couldn't see the not-yet-committed row.

  "No, no!" said the Queen. "Subscribers first — visibility afterwards!"
  "Stuff and nonsense!" said Alice loudly. "The idea of querying a row
  before the transaction's even committed!" And so every publishEvent
  was made to wait politely outside the withTransaction door until the
  COMMIT croquet-ball had finished rolling. 🐇🎴⏳