### PR TITLE
Fix Citus upsert: bind indexed_at instead of now()

### DIFF
--- a/server/src/lib/search/upsert.ts
+++ b/server/src/lib/search/upsert.ts
@@ -7,6 +7,9 @@ import type { SearchDoc, SearchObjectType } from '@alga-psa/types';
 export async function upsertSearchDoc(knex: Knex, doc: SearchDoc): Promise<void> {
   const vector = buildTsvectorSql(doc.title, doc.subtitle, doc.body);
   const acl = composeAclHints(doc.acl);
+  // Citus rejects non-IMMUTABLE functions (e.g. now()) in the DO UPDATE SET
+  // target list of upserts on distributed tables, so bind the timestamp here.
+  const indexedAt = new Date();
 
   await knex.raw(
     `
@@ -52,7 +55,7 @@ export async function upsertSearchDoc(knex: Knex, doc: SearchDoc): Promise<void>
         ${vector.sql},
         'english',
         ?,
-        now()
+        ?
       )
       ON CONFLICT (tenant, object_type, object_id)
       DO UPDATE SET
@@ -72,7 +75,7 @@ export async function upsertSearchDoc(knex: Knex, doc: SearchDoc): Promise<void>
         search_vector = EXCLUDED.search_vector,
         search_lang = EXCLUDED.search_lang,
         source_updated_at = EXCLUDED.source_updated_at,
-        indexed_at = now()
+        indexed_at = ?
     `,
     [
       doc.tenant,
@@ -93,6 +96,8 @@ export async function upsertSearchDoc(knex: Knex, doc: SearchDoc): Promise<void>
       acl.requiredPermission ?? null,
       ...vector.bindings,
       doc.sourceUpdatedAt,
+      indexedAt,
+      indexedAt,
     ],
   );
 }

--- a/server/src/test/unit/searchUpsert.test.ts
+++ b/server/src/test/unit/searchUpsert.test.ts
@@ -79,11 +79,18 @@ describe('search index upsert helpers', () => {
     expect(sql).toContain('body = EXCLUDED.body');
     expect(sql).toContain('search_vector = EXCLUDED.search_vector');
     expect(sql).toContain('source_updated_at = EXCLUDED.source_updated_at');
-    expect(sql).toContain('indexed_at = now()');
+    // indexed_at must be a bound param, not now(): Citus forbids non-IMMUTABLE
+    // functions in the DO UPDATE SET clause of distributed-table upserts.
+    expect(sql).toContain('indexed_at = ?');
+    expect(sql).not.toContain('indexed_at = now()');
     expect(sql).toContain("setweight(public.process_large_lexemes(?), 'A')");
     expect(bindings).toContain('ACME Corp Updated');
     expect(bindings).toContain('Updated searchable body');
-    expect(bindings.at(-1)).toEqual(doc.sourceUpdatedAt);
+    // ...source_updated_at, then the same indexedAt bound twice (VALUES + DO UPDATE)
+    const indexedAt = bindings.at(-1);
+    expect(indexedAt).toBeInstanceOf(Date);
+    expect(bindings.at(-2)).toBe(indexedAt);
+    expect(bindings.at(-3)).toEqual(doc.sourceUpdatedAt);
   });
 
   it('T025 deletes a search row by tenant/type/id and tolerates no matching row', async () => {


### PR DESCRIPTION
  And the now() said, "I'm late, I'm late, for a very distributed
  date!" — but the White Rabbit of the conflict clause would have
  none of its un-IMMUTABLE tardiness, so we bound the poor timestamp
  in a Date and sent it down the rabbit hole twice. ⏰🐇🗂️