### PR TITLE
 Persist collaborative docs via internal app API

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -32,6 +32,7 @@ services:
       DB_HOST: ${PGBOUNCER_HOST:-pgbouncer}
       DB_PORT: ${PGBOUNCER_PORT:-6432}
       REQUIRE_HOCUSPOCUS: ${REQUIRE_HOCUSPOCUS:-false}
+      COLLAB_PERSIST_API_KEY: ${COLLAB_PERSIST_API_KEY:-alga-collab-persist-dev}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_IS_FORMAT_JSON: ${LOG_IS_FORMAT_JSON:-false}
       LOG_IS_FULL_DETAILS: ${LOG_IS_FULL_DETAILS:-false}
@@ -317,6 +318,8 @@ services:
       DB_USER_HOCUSPOCUS: ${DB_USER_HOCUSPOCUS:-hocuspocus_user}
       AI_DOCUMENT_API_URL: ${AI_DOCUMENT_API_URL:-http://host.docker.internal:3000/api/v1/ai/document-assist}
       AI_DOCUMENT_API_KEY: ${AI_DOCUMENT_API_KEY:-}
+      COLLAB_PERSIST_API_URL: ${COLLAB_PERSIST_API_URL:-http://host.docker.internal:3000/api/internal/collab/persist}
+      COLLAB_PERSIST_API_KEY: ${COLLAB_PERSIST_API_KEY:-alga-collab-persist-dev}
     secrets:
       - postgres_password
       - db_password_hocuspocus

--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -46,6 +46,7 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       NEXTAUTH_SESSION_EXPIRES: ${NEXTAUTH_SESSION_EXPIRES:-86400}
+      COLLAB_PERSIST_API_KEY: ${COLLAB_PERSIST_API_KEY:-alga-collab-persist-dev}
       TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-temporal-dev:7233}
       TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-default}
       TEMPORAL_JOB_TASK_QUEUE: ${TEMPORAL_JOB_TASK_QUEUE:-alga-jobs}
@@ -365,6 +366,8 @@ services:
       DB_PORT: ${DB_PORT:-5432}
       AI_DOCUMENT_API_URL: ${AI_DOCUMENT_API_URL:-http://server:3000/api/v1/ai/document-assist}
       AI_DOCUMENT_API_KEY: ${AI_DOCUMENT_API_KEY:-}
+      COLLAB_PERSIST_API_URL: ${COLLAB_PERSIST_API_URL:-http://server:3000/api/internal/collab/persist}
+      COLLAB_PERSIST_API_KEY: ${COLLAB_PERSIST_API_KEY:-alga-collab-persist-dev}
     volumes:
       - type: bind
         source: ./secrets/db_password_server

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -234,6 +234,13 @@ spec:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: AI_DOCUMENT_API_KEY
 
+          # ----------- Collaborative Doc Persistence ----------------
+          - name: COLLAB_PERSIST_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: COLLAB_PERSIST_API_KEY
+
           # ----------- HOCUSPOCUS JWT ----------------
           - name: HOCUSPOCUS_JWT_SECRET
             valueFrom:

--- a/helm/templates/hocuspocus/deployment.yaml
+++ b/helm/templates/hocuspocus/deployment.yaml
@@ -155,6 +155,14 @@ spec:
               secretKeyRef:
                 name: "{{include "sebastian.fullname" .}}-secrets"
                 key: AI_DOCUMENT_API_KEY
+          # ----------- Collaborative Doc Persistence ----------------
+          - name: COLLAB_PERSIST_API_URL
+            value: "https://{{ .Values.host }}/api/internal/collab/persist"
+          - name: COLLAB_PERSIST_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: COLLAB_PERSIST_API_KEY
           # ----------- HOCUSPOCUS JWT ----------------
           - name: HOCUSPOCUS_JWT_SECRET
             valueFrom:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -19,7 +19,8 @@ data:
   CRYPTR_KEY: {{ if and .Values.secrets .Values.secrets.CRYPTR_KEY }}{{ .Values.secrets.CRYPTR_KEY | b64enc | quote }}{{ else }}{{ index $existing.data "CRYPTR_KEY" }}{{ end }}
   TOKEN_SECRET_KEY: {{ if and .Values.secrets .Values.secrets.TOKEN_SECRET_KEY }}{{ .Values.secrets.TOKEN_SECRET_KEY | b64enc | quote }}{{ else }}{{ index $existing.data "TOKEN_SECRET_KEY" }}{{ end }}
   IMAP_WEBHOOK_SECRET: {{ if and .Values.secrets .Values.secrets.IMAP_WEBHOOK_SECRET }}{{ .Values.secrets.IMAP_WEBHOOK_SECRET | b64enc | quote }}{{ else }}{{ index $existing.data "IMAP_WEBHOOK_SECRET" }}{{ end }}
-  AI_DOCUMENT_API_KEY: {{ if and .Values.secrets .Values.secrets.AI_DOCUMENT_API_KEY }}{{ .Values.secrets.AI_DOCUMENT_API_KEY | b64enc | quote }}{{ else }}{{ index $existing.data "AI_DOCUMENT_API_KEY" }}{{ end }}
+  AI_DOCUMENT_API_KEY: {{ if and .Values.secrets .Values.secrets.AI_DOCUMENT_API_KEY }}{{ .Values.secrets.AI_DOCUMENT_API_KEY | b64enc | quote }}{{ else if index $existing.data "AI_DOCUMENT_API_KEY" }}{{ index $existing.data "AI_DOCUMENT_API_KEY" }}{{ else }}{{ randAlphaNum 64 | b64enc | quote }}{{ end }}
+  COLLAB_PERSIST_API_KEY: {{ if and .Values.secrets .Values.secrets.COLLAB_PERSIST_API_KEY }}{{ .Values.secrets.COLLAB_PERSIST_API_KEY | b64enc | quote }}{{ else if index $existing.data "COLLAB_PERSIST_API_KEY" }}{{ index $existing.data "COLLAB_PERSIST_API_KEY" }}{{ else }}{{ randAlphaNum 64 | b64enc | quote }}{{ end }}
   HOCUSPOCUS_JWT_SECRET: {{ if and .Values.secrets .Values.secrets.HOCUSPOCUS_JWT_SECRET }}{{ .Values.secrets.HOCUSPOCUS_JWT_SECRET | b64enc | quote }}{{ else }}{{ index $existing.data "HOCUSPOCUS_JWT_SECRET" }}{{ end }}
   {{- if and .Values.secrets .Values.secrets.stripe_secret_key }}
   stripe_secret_key: {{ .Values.secrets.stripe_secret_key | b64enc | quote }}
@@ -114,6 +115,7 @@ data:
   TOKEN_SECRET_KEY: {{ (.Values.secrets.TOKEN_SECRET_KEY | default (randAlphaNum 32)) | b64enc | quote }}
   IMAP_WEBHOOK_SECRET: {{ (.Values.secrets.IMAP_WEBHOOK_SECRET | default (randAlphaNum 48)) | b64enc | quote }}
   AI_DOCUMENT_API_KEY: {{ (.Values.secrets.AI_DOCUMENT_API_KEY | default (randAlphaNum 64)) | b64enc | quote }}
+  COLLAB_PERSIST_API_KEY: {{ (.Values.secrets.COLLAB_PERSIST_API_KEY | default (randAlphaNum 64)) | b64enc | quote }}
   HOCUSPOCUS_JWT_SECRET: {{ (.Values.secrets.HOCUSPOCUS_JWT_SECRET | default (randAlphaNum 64)) | b64enc | quote }}
   {{- if .Values.secrets.stripe_secret_key }}
   stripe_secret_key: {{ .Values.secrets.stripe_secret_key | b64enc | quote }}
@@ -172,6 +174,7 @@ data:
   TOKEN_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   IMAP_WEBHOOK_SECRET: {{ randAlphaNum 48 | b64enc | quote }}
   AI_DOCUMENT_API_KEY: {{ randAlphaNum 64 | b64enc | quote }}
+  COLLAB_PERSIST_API_KEY: {{ randAlphaNum 64 | b64enc | quote }}
   HOCUSPOCUS_JWT_SECRET: {{ randAlphaNum 64 | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/hocuspocus/CollabPersistenceExtension.js
+++ b/hocuspocus/CollabPersistenceExtension.js
@@ -1,0 +1,70 @@
+import * as Y from 'yjs'
+
+/**
+ * Durable persistence for collaborative documents.
+ *
+ * Hocuspocus only syncs the Y.js document in memory (and across instances via
+ * Redis). On its own nothing is written to Postgres, so edits are lost on room
+ * eviction. This extension implements `onStoreDocument` — which Hocuspocus
+ * calls debounced while editing and again when the last client disconnects —
+ * and ships the Y.js state to an internal app endpoint that converts it to
+ * ProseMirror JSON and writes it to document_block_content.
+ *
+ * Only `document:<tenant>:<id>` rooms are persisted. Ticket / notification /
+ * AI rooms are ignored. Errors are logged, never thrown: a failed persist must
+ * not disrupt the live editing session — Hocuspocus retries on the next
+ * debounce / unload.
+ */
+export class CollabPersistenceExtension {
+  constructor(config = {}) {
+    this.apiUrl = config.apiUrl || 'http://localhost:3000/api/internal/collab/persist'
+    this.apiKey = config.apiKey || ''
+  }
+
+  async onStoreDocument({ document, documentName }) {
+    if (!documentName || !documentName.startsWith('document:')) {
+      return
+    }
+    const parts = documentName.split(':')
+    if (parts.length !== 3) {
+      return
+    }
+    const [, tenantId, documentId] = parts
+    if (!tenantId || !documentId) {
+      return
+    }
+
+    const fragment = document.getXmlFragment('prosemirror')
+    if (!fragment || fragment.length === 0) {
+      // Fresh/empty room — don't overwrite stored content before the client
+      // has seeded it from the database.
+      return
+    }
+
+    if (!this.apiKey) {
+      console.error('[CollabPersistenceExtension] COLLAB_PERSIST_API_KEY not set; skipping persistence')
+      return
+    }
+
+    try {
+      const update = Buffer.from(Y.encodeStateAsUpdate(document)).toString('base64')
+      const response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+        },
+        body: JSON.stringify({ tenantId, documentId, update }),
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '')
+        console.error(
+          `[CollabPersistenceExtension] persist failed ${response.status} for ${documentName}: ${errorBody}`
+        )
+      }
+    } catch (error) {
+      console.error(`[CollabPersistenceExtension] persist error for ${documentName}:`, error)
+    }
+  }
+}

--- a/hocuspocus/server.js
+++ b/hocuspocus/server.js
@@ -1,10 +1,10 @@
 import { Server } from '@hocuspocus/server'
 import { Redis } from '@hocuspocus/extension-redis'
-import { Database } from '@hocuspocus/extension-database'
 import { Logger } from '@hocuspocus/extension-logger'
 import { NotificationExtension } from './NotificationExtension.js'
 import { TicketUpdatesExtension } from './TicketUpdatesExtension.js'
 import { AiParticipantExtension } from './AiParticipantExtension.js'
+import { CollabPersistenceExtension } from './CollabPersistenceExtension.js'
 import { validateDocumentRoomAccess } from './tenantValidation.js'
 
 // Helper function to get required env var or fail in production
@@ -22,6 +22,11 @@ function getEnvOrFail(key, fallbackValue = null) {
 
 const server = Server.configure({
     port: process.env.PORT || 1234,
+    // Coalesce onStoreDocument: persist ~2s after the last edit, and force a
+    // flush at most every 15s during continuous editing. Hocuspocus also fires
+    // onStoreDocument when the last client disconnects.
+    debounce: Number(process.env.COLLAB_PERSIST_DEBOUNCE_MS || 2000),
+    maxDebounce: Number(process.env.COLLAB_PERSIST_MAX_DEBOUNCE_MS || 15000),
     extensions: [
         // redisExtension,
         new Redis({
@@ -32,13 +37,9 @@ const server = Server.configure({
                 password: getEnvOrFail('REDIS_PASSWORD', 'sebastian123')
             },
         }),
-        new Database({
-            type: 'DB',
-            host: process.env.DB_HOST ||  'localhost',
-            port: process.env.DB_PORT || 5432,
-            database: process.env.DB_NAME_HOCUSPOCUS || 'hocuspocus',
-            username: process.env.DB_USER_HOCUSPOCUS || 'hocuspocus_user',
-            password: getEnvOrFail('DB_PASSWORD_HOCUSPOCUS', 'sebastian123'),
+        new CollabPersistenceExtension({
+            apiUrl: process.env.COLLAB_PERSIST_API_URL || 'http://localhost:3000/api/internal/collab/persist',
+            apiKey: process.env.COLLAB_PERSIST_API_KEY || '',
         }),
         new NotificationExtension({
             redisHost: process.env.REDIS_HOST || 'localhost',

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -38,6 +38,10 @@
       "import": "./src/handlers/*.ts",
       "types": "./src/handlers/*.ts"
     },
+    "./lib/collabPersistence": {
+      "import": "./src/lib/collabPersistence.ts",
+      "types": "./src/lib/collabPersistence.ts"
+    },
     "./lib/documentUtils": {
       "import": "./src/lib/documentUtils.ts",
       "types": "./src/lib/documentUtils.ts"

--- a/packages/documents/src/actions/collaborativeEditingActions.ts
+++ b/packages/documents/src/actions/collaborativeEditingActions.ts
@@ -3,9 +3,8 @@
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { yXmlFragmentToProsemirrorJSON } from 'y-prosemirror';
 import { withAuth } from '@alga-psa/auth';
-import { createTenantKnex, withTransaction } from '@alga-psa/db';
 import { createYjsProvider } from '@alga-psa/ui/editor';
-import { CacheFactory } from '../cache/CacheFactory';
+import { persistCollabSnapshot } from '../lib/collabPersistence';
 
 const SYNC_TIMEOUT_MS = 5000;
 
@@ -46,37 +45,7 @@ export const syncCollabSnapshot = withAuth(async (user, { tenant }, documentId: 
     const fragment = ydoc.getXmlFragment('prosemirror');
     const json = yXmlFragmentToProsemirrorJSON(fragment);
 
-    const { knex } = await createTenantKnex();
-
-    const updated = await withTransaction(knex, async (trx) => {
-      const existing = await trx('document_block_content')
-        .where({ document_id: documentId, tenant })
-        .first();
-
-      if (!existing) {
-        return null;
-      }
-
-      const [result] = await trx('document_block_content')
-        .where({ document_id: documentId, tenant })
-        .update({
-          block_data: JSON.stringify(json),
-          updated_at: trx.fn.now(),
-        })
-        .returning(['content_id', 'block_data']);
-
-      return result;
-    });
-
-    if (!updated) {
-      return { success: false, message: 'Document not found.' };
-    }
-
-    // Invalidate preview cache so the grid thumbnail regenerates
-    const cache = CacheFactory.getPreviewCache(tenant);
-    await cache.delete(documentId);
-
-    return { success: true };
+    return await persistCollabSnapshot(tenant, documentId, json);
   } catch (error) {
     console.error('[syncCollabSnapshot] Failed to sync snapshot:', error);
     return { success: false, message: 'Snapshot sync failed.' };

--- a/packages/documents/src/components/kb/KBArticleEditor.tsx
+++ b/packages/documents/src/components/kb/KBArticleEditor.tsx
@@ -27,7 +27,10 @@ import {
   Trash2,
 } from 'lucide-react';
 import { CollaborativeEditor } from '../CollaborativeEditor';
+import type { CollaborativeEditorHandle } from '../CollaborativeEditor';
 import { DocumentEditor } from '../DocumentEditor';
+import { syncCollabSnapshot } from '../../actions/collaborativeEditingActions';
+import { updateBlockContent } from '../../actions/documentBlockContentActions';
 import { searchUsersForMentions } from '@alga-psa/user-composition/actions';
 import {
   getArticle,
@@ -98,6 +101,13 @@ export default function KBArticleEditor({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Explicit "save now" for collaborative content. Live edits autosave
+  // server-side (Hocuspocus persistence extension); this forces an immediate
+  // flush + preview refresh.
+  const collabEditorRef = useRef<CollaborativeEditorHandle | null>(null);
+  const isSavingContentRef = useRef(false);
+  const [isSavingContent, setIsSavingContent] = useState(false);
 
   // Auto-fallback if CollaborativeEditor can't connect within 5 seconds
   const collabConnectedRef = useRef(false);
@@ -228,6 +238,51 @@ export default function KBArticleEditor({
     setHasUnsavedMetadata(true);
   };
 
+  const documentId = article?.document_id;
+
+  // Force an immediate save of the collaborative content. Live edits are
+  // autosaved server-side by the Hocuspocus persistence extension (~2s
+  // debounce + on disconnect); this is an explicit "save now" that also
+  // refreshes the document preview immediately.
+  const saveContent = useCallback(async (): Promise<void> => {
+    if (!documentId || isFallbackMode || isSavingContentRef.current) return;
+    isSavingContentRef.current = true;
+    setIsSavingContent(true);
+    try {
+      const result = await syncCollabSnapshot(documentId);
+      if (!result || !('success' in result) || !result.success) {
+        // Fallback: write the client-side editor JSON directly.
+        const json = collabEditorRef.current?.getJSON();
+        if (!json) {
+          const message =
+            result && 'message' in result && result.message
+              ? result.message
+              : 'Snapshot sync failed';
+          throw new Error(message);
+        }
+        await updateBlockContent(documentId, {
+          block_data: JSON.stringify(json),
+          user_id: userId,
+        });
+      }
+      toast.success(
+        tRef.current('editor.feedback.contentSaveSuccess', {
+          defaultValue: 'Article content saved',
+        })
+      );
+    } catch (error) {
+      handleError(
+        error,
+        tRef.current('editor.feedback.contentSaveError', {
+          defaultValue: 'Failed to save article content',
+        })
+      );
+    } finally {
+      isSavingContentRef.current = false;
+      setIsSavingContent(false);
+    }
+  }, [documentId, isFallbackMode, userId]);
+
   const handleStatusChange = async (newStatus: 'review' | 'published' | 'archived') => {
     if (!article) return;
 
@@ -346,6 +401,20 @@ export default function KBArticleEditor({
           </div>
           {/* Status Actions */}
           <div className="flex items-center gap-2">
+            {!isFallbackMode && (
+              <Button
+                id="kb-editor-save-content"
+                variant="outline"
+                size="sm"
+                onClick={() => void saveContent()}
+                disabled={isSavingContent}
+              >
+                <Save className="w-4 h-4 mr-2" />
+                {isSavingContent
+                  ? t('editor.actions.saving', { defaultValue: 'Saving...' })
+                  : t('editor.actions.saveContent', { defaultValue: 'Save' })}
+              </Button>
+            )}
             {article.status === 'draft' && (
               <>
                 <Button
@@ -420,6 +489,7 @@ export default function KBArticleEditor({
             tenantId={tenantId || article.tenant || ''}
             userId={userId}
             userName={userName || userId}
+            editorRef={collabEditorRef}
             searchMentions={searchUsersForMentions}
             aiAssistantEnabled={aiAssistantEnabled}
             initialContent={article.block_data ?? undefined}

--- a/packages/documents/src/lib/collabPersistence.ts
+++ b/packages/documents/src/lib/collabPersistence.ts
@@ -1,0 +1,53 @@
+import { createTenantKnex, runWithTenant, withTransaction } from '@alga-psa/db';
+import { CacheFactory } from '../cache/CacheFactory';
+
+export interface PersistCollabResult {
+  success: boolean;
+  message?: string;
+}
+
+/**
+ * Session-less core of the collaborative snapshot save: writes the ProseMirror
+ * JSON for an already-authorized document room to document_block_content and
+ * invalidates the preview cache. Shared by the browser server action
+ * (syncCollabSnapshot) and the internal Hocuspocus persistence route.
+ */
+export async function persistCollabSnapshot(
+  tenant: string,
+  documentId: string,
+  json: unknown
+): Promise<PersistCollabResult> {
+  return runWithTenant(tenant, async () => {
+    const { knex } = await createTenantKnex();
+
+    const updated = await withTransaction(knex, async (trx) => {
+      const existing = await trx('document_block_content')
+        .where({ document_id: documentId, tenant })
+        .first();
+
+      if (!existing) {
+        return null;
+      }
+
+      const [result] = await trx('document_block_content')
+        .where({ document_id: documentId, tenant })
+        .update({
+          block_data: JSON.stringify(json),
+          updated_at: trx.fn.now(),
+        })
+        .returning(['content_id']);
+
+      return result;
+    });
+
+    if (!updated) {
+      return { success: false, message: 'Document not found.' };
+    }
+
+    // Invalidate preview cache so the grid thumbnail regenerates
+    const cache = CacheFactory.getPreviewCache(tenant);
+    await cache.delete(documentId);
+
+    return { success: true };
+  });
+}

--- a/server/src/app/api/internal/collab/persist/route.ts
+++ b/server/src/app/api/internal/collab/persist/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server';
+import * as Y from 'yjs';
+import { yXmlFragmentToProsemirrorJSON } from 'y-prosemirror';
+import { persistCollabSnapshot } from '@alga-psa/documents/lib/collabPersistence';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const json = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+/**
+ * Internal service-to-service endpoint. The Hocuspocus collaboration server
+ * calls this (debounced + on room unload) to durably persist live Y.js edits.
+ * Authenticated by a shared key, mirroring the AI document-assist route.
+ */
+export async function POST(req: NextRequest) {
+  const apiKey = req.headers.get('x-api-key');
+  const expectedKey = process.env.COLLAB_PERSIST_API_KEY;
+  if (!expectedKey || apiKey !== expectedKey) {
+    return json({ error: 'Invalid API key' }, 401);
+  }
+
+  let body: { tenantId?: string; documentId?: string; update?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const { tenantId, documentId, update } = body;
+  if (!tenantId || !documentId || !update) {
+    return json({ error: 'Missing required fields: tenantId, documentId, update' }, 400);
+  }
+
+  const ydoc = new Y.Doc();
+  try {
+    Y.applyUpdate(ydoc, new Uint8Array(Buffer.from(update, 'base64')));
+    const fragment = ydoc.getXmlFragment('prosemirror');
+
+    // Never overwrite stored content with an empty room (e.g. a freshly
+    // opened room before the client has seeded it from the database).
+    if (fragment.length === 0) {
+      return json({ success: true, skipped: 'empty' }, 200);
+    }
+
+    const prosemirrorJson = yXmlFragmentToProsemirrorJSON(fragment);
+    const result = await persistCollabSnapshot(tenantId, documentId, prosemirrorJson);
+
+    if (!result.success) {
+      // Document not found is expected/benign (e.g. deleted while editing).
+      return json(result, result.message === 'Document not found.' ? 404 : 500);
+    }
+    return json({ success: true }, 200);
+  } catch (error) {
+    console.error('[collab/persist] Failed to persist snapshot:', error);
+    return json({ error: 'Failed to persist snapshot' }, 500);
+  } finally {
+    ydoc.destroy();
+  }
+}


### PR DESCRIPTION
  Replace @hocuspocus/extension-database with a CollabPersistenceExtension
  that ships Y.js state to a new internal app endpoint
  (/api/internal/collab/persist) on debounce and room unload. The route
  converts the update to ProseMirror JSON and writes it through a shared
  persistCollabSnapshot helper, also reused by the syncCollabSnapshot
  server action. Adds a "Save" button to KBArticleEditor for an explicit
  flush + preview refresh, plus COLLAB_PERSIST_API_KEY/URL wiring across
  docker-compose and Helm (with the 3-way provided→existing→generate
  secret pattern).

  "Why, sometimes the document believed as many as six edited paragraphs
  before disconnect," the Y.js Doc said, dabbing its XmlFragment with a
  base64 handkerchief — and lo, the Database extension that never wrote a
  word was politely shown the rabbit-hole door. 🐇📝🔐