### PR TITLE
Tickets: zoom/density controls, bulk actions, and DataTable fit/tooltip fixes

### DIFF
--- a/packages/msp-composition/src/clients/MspClientTickets.tsx
+++ b/packages/msp-composition/src/clients/MspClientTickets.tsx
@@ -11,9 +11,7 @@ import { BoardPicker } from '@alga-psa/ui/components/settings/general/BoardPicke
 import CategoryPicker from '@alga-psa/tickets/components/CategoryPicker';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { getTicketsForListWithCursor } from '@alga-psa/tickets/actions/optimizedTicketActions';
-import { deleteTicket } from '@alga-psa/tickets/actions/ticketActions';
 import { XCircle } from 'lucide-react';
-import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { useDrawer } from "@alga-psa/ui";
 import TicketDetails from '@alga-psa/tickets/components/ticket/TicketDetails';
 import { getConsolidatedTicketData } from '@alga-psa/tickets/actions/optimizedTicketActions';
@@ -72,9 +70,6 @@ const MspClientTickets: React.FC<ClientTicketsProps> = ({
   const [currentUser, setCurrentUser] = useState<IUser | null>(null);
   const [displaySettings, setDisplaySettings] = useState<TicketingDisplaySettings | null>(null);
   const ticketTagsRef = useRef<Record<string, ITag[]>>({});
-  const [ticketToDelete, setTicketToDelete] = useState<string | null>(null);
-  const [ticketToDeleteName, setTicketToDeleteName] = useState<string | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isQuickAddTicketOpen, setIsQuickAddTicketOpen] = useState(false);
 
   const { openDrawer } = useDrawer();
@@ -171,31 +166,6 @@ const MspClientTickets: React.FC<ClientTicketsProps> = ({
     loadTickets(undefined, true);
   }, [loadTickets]);
 
-  const handleDeleteTicket = (ticketId: string, ticketNameOrNumber: string) => {
-    setTicketToDelete(ticketId);
-    setTicketToDeleteName(ticketNameOrNumber);
-    setDeleteError(null);
-  };
-
-  const confirmDeleteTicket = async () => {
-    if (!ticketToDelete || !currentUser) return;
-
-    try {
-      await deleteTicket(ticketToDelete);
-      setTickets(prev => prev.filter(t => t.ticket_id !== ticketToDelete));
-      setTicketToDelete(null);
-      setTicketToDeleteName(null);
-      setDeleteError(null);
-    } catch (error: any) {
-      console.error('Failed to delete ticket:', error);
-      if (error.message && error.message.startsWith('VALIDATION_ERROR:')) {
-        setDeleteError(error.message.replace('VALIDATION_ERROR: ', ''));
-      } else {
-        setDeleteError('An unexpected error occurred while deleting the ticket.');
-      }
-    }
-  };
-
   const handleTicketClick = useCallback(async (ticketId: string) => {
     if (!currentUser) {
       toast.error('User not authenticated');
@@ -283,11 +253,10 @@ const MspClientTickets: React.FC<ClientTicketsProps> = ({
       boards: initialBoards,
       displaySettings: displaySettings || undefined,
       onTicketClick: handleTicketClick,
-      onDeleteClick: handleDeleteTicket,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
       showClient: false, // Don't show client column since we're already on client page
-    }), [initialCategories, initialBoards, displaySettings, handleTicketClick, handleDeleteTicket, handleTagsChange]);
+    }), [initialCategories, initialBoards, displaySettings, handleTicketClick, handleTagsChange]);
 
   // Filter tickets by selected tags
   const filteredTickets = useMemo(() => {
@@ -507,25 +476,6 @@ const MspClientTickets: React.FC<ClientTicketsProps> = ({
           </div>
         )}
       </div>
-
-      {/* Delete Confirmation Dialog */}
-      <ConfirmationDialog
-        isOpen={!!ticketToDelete}
-        onClose={() => {
-          setTicketToDelete(null);
-          setTicketToDeleteName(null);
-          setDeleteError(null);
-        }}
-        onConfirm={confirmDeleteTicket}
-        title="Delete Ticket"
-        message={
-          deleteError
-            ? deleteError
-            : `Are you sure you want to delete ticket "${ticketToDeleteName || ticketToDelete}"? This action cannot be undone.`
-        }
-        confirmLabel={deleteError ? undefined : "Delete"}
-        cancelLabel={deleteError ? "Close" : "Cancel"}
-      />
 
       {/* Quick Add Ticket Dialog */}
       <QuickAddTicket

--- a/packages/msp-composition/src/clients/MspContactTickets.tsx
+++ b/packages/msp-composition/src/clients/MspContactTickets.tsx
@@ -11,9 +11,7 @@ import { BoardPicker } from '@alga-psa/ui/components/settings/general/BoardPicke
 import CategoryPicker from '@alga-psa/tickets/components/CategoryPicker';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { getTicketsForListWithCursor } from '@alga-psa/tickets/actions/optimizedTicketActions';
-import { deleteTicket } from '@alga-psa/tickets/actions/ticketActions';
 import { XCircle } from 'lucide-react';
-import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { useDrawer } from "@alga-psa/ui";
 import TicketDetails from '@alga-psa/tickets/components/ticket/TicketDetails';
 import { getConsolidatedTicketData } from '@alga-psa/tickets/actions/optimizedTicketActions';
@@ -80,9 +78,6 @@ const MspContactTickets: React.FC<ContactTicketsProps> = ({
   const [currentUser, setCurrentUser] = useState<IUser | null>(null);
   const [displaySettings, setDisplaySettings] = useState<TicketingDisplaySettings | null>(null);
   const ticketTagsRef = useRef<Record<string, ITag[]>>({});
-  const [ticketToDelete, setTicketToDelete] = useState<string | null>(null);
-  const [ticketToDeleteName, setTicketToDeleteName] = useState<string | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isQuickAddTicketOpen, setIsQuickAddTicketOpen] = useState(false);
   const { openDrawer } = useDrawer();
 
@@ -177,31 +172,6 @@ const MspContactTickets: React.FC<ContactTicketsProps> = ({
   useEffect(() => {
     loadTickets(undefined, true);
   }, [loadTickets]);
-
-  const handleDeleteTicket = (ticketId: string, ticketNameOrNumber: string) => {
-    setTicketToDelete(ticketId);
-    setTicketToDeleteName(ticketNameOrNumber);
-    setDeleteError(null);
-  };
-
-  const confirmDeleteTicket = async () => {
-    if (!ticketToDelete || !currentUser) return;
-
-    try {
-      await deleteTicket(ticketToDelete);
-      setTickets(prev => prev.filter(t => t.ticket_id !== ticketToDelete));
-      setTicketToDelete(null);
-      setTicketToDeleteName(null);
-      setDeleteError(null);
-    } catch (error: any) {
-      console.error('Failed to delete ticket:', error);
-      if (error.message && error.message.startsWith('VALIDATION_ERROR:')) {
-        setDeleteError(error.message.replace('VALIDATION_ERROR: ', ''));
-      } else {
-        setDeleteError('An unexpected error occurred while deleting the ticket.');
-      }
-    }
-  };
 
   const handleTicketClick = useCallback(async (ticketId: string) => {
     if (!currentUser) {
@@ -312,12 +282,11 @@ const MspContactTickets: React.FC<ContactTicketsProps> = ({
       boards: initialBoards,
       displaySettings: displaySettings || undefined,
       onTicketClick: handleTicketClick,
-      onDeleteClick: handleDeleteTicket,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
       showClient: true, // Show client column in contact view
       onClientClick: handleClientClick,
-    }), [initialCategories, initialBoards, displaySettings, handleTicketClick, handleDeleteTicket, handleTagsChange, handleClientClick]);
+    }), [initialCategories, initialBoards, displaySettings, handleTicketClick, handleTagsChange, handleClientClick]);
 
   const handleCategorySelect = (
     selectedCategories: string[],
@@ -541,26 +510,6 @@ const MspContactTickets: React.FC<ContactTicketsProps> = ({
             </>
           )}
         </div>
-
-        {/* Delete Confirmation Dialog */}
-        <ConfirmationDialog
-          id="delete-ticket-dialog"
-          isOpen={!!ticketToDelete}
-          onClose={() => {
-            setTicketToDelete(null);
-            setTicketToDeleteName(null);
-            setDeleteError(null);
-          }}
-          onConfirm={confirmDeleteTicket}
-          title="Delete Ticket"
-          message={
-            deleteError
-              ? deleteError
-              : `Are you sure you want to delete ticket "${ticketToDeleteName}"? This action cannot be undone.`
-          }
-          confirmLabel={deleteError ? undefined : "Delete"}
-          cancelLabel={deleteError ? "Close" : "Cancel"}
-        />
 
         {/* Quick Add Ticket Dialog */}
         <QuickAddTicket

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -1756,6 +1756,54 @@ export const getAllMatchingTicketIds = withAuth(async (
 });
 
 /**
+ * Resolve the board for a specific set of ticket ids, scoped to what the caller is
+ * authorized to see. Used by the list's bulk action bar to determine whether a
+ * selection that spans off-page rows (paginate-then-select or select-all-matching)
+ * shares a single board, so the Status action can stay enabled. Tickets the caller
+ * can't access are simply omitted from the result.
+ */
+export const getTicketBoardIds = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[]
+): Promise<Array<{ ticket_id: string; board_id: string | null }>> => {
+  const uniqueIds = Array.from(
+    new Set(ticketIds.filter((id): id is string => typeof id === 'string' && id.length > 0))
+  );
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const { knex: db } = await createTenantKnex();
+
+  return withTransaction(db, async (trx) => {
+    if (!await hasPermission(user, 'ticket', 'read', trx)) {
+      throw new Error('Permission denied: Cannot view tickets');
+    }
+
+    const authorizationContext = await createTicketAuthorizationContext(
+      trx,
+      tenant,
+      user as IUserWithRoles
+    );
+
+    const rows = await trx('tickets as t')
+      .where('t.tenant', tenant)
+      .whereIn('t.ticket_id', uniqueIds)
+      .select('t.ticket_id', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id');
+
+    const authorizedRows = await filterAuthorizedTickets(trx, authorizationContext, rows);
+    return authorizedRows
+      .filter((row: { ticket_id?: string | null }): row is { ticket_id: string; board_id?: string | null } =>
+        typeof row.ticket_id === 'string' && row.ticket_id.length > 0)
+      .map((row) => ({
+        ticket_id: row.ticket_id,
+        board_id: row.board_id ?? null,
+      }));
+  });
+});
+
+/**
  * Get all options needed for ticket forms and filters
  * This consolidates multiple API calls into a single request
  */
@@ -1905,14 +1953,20 @@ export const getTicketFormOptions = withAuth(async (user, { tenant }) => {
 /**
  * Update ticket with proper caching
  */
-export const updateTicketWithCache = withAuth(async (user, { tenant }, id: string, data: Partial<ITicket>) => {
-  const {knex: db} = await createTenantKnex();
-
-  return withTransaction(db, async (trx) => {
-    if (!await hasPermission(user, 'ticket', 'update', trx)) {
-      throw new Error('Permission denied: Cannot update ticket');
-    }
-
+/**
+ * Core ticket-update logic, executed inside a caller-provided transaction.
+ *
+ * Intentionally does NOT check permissions — callers must authorize first. The public
+ * `updateTicketWithCache` wrapper performs the `ticket:update` check; bulk callers hoist
+ * a single check and reuse this core per ticket, avoiding one permission lookup per row.
+ */
+export async function updateTicketInTransaction(
+  trx: Knex.Transaction,
+  user: IUserWithRoles,
+  tenant: string,
+  id: string,
+  data: Partial<ITicket>,
+): Promise<'success'> {
     try {
       // Validate update data
       const validatedData = validateData(ticketUpdateSchema, data);
@@ -2396,6 +2450,17 @@ export const updateTicketWithCache = withAuth(async (user, { tenant }, id: strin
       }
       throw new Error('Failed to update ticket');
     }
+}
+
+export const updateTicketWithCache = withAuth(async (user, { tenant }, id: string, data: Partial<ITicket>) => {
+  const { knex: db } = await createTenantKnex();
+
+  return withTransaction(db, async (trx) => {
+    if (!await hasPermission(user, 'ticket', 'update', trx)) {
+      throw new Error('Permission denied: Cannot update ticket');
+    }
+
+    return updateTicketInTransaction(trx, user as IUserWithRoles, tenant, id, data);
   });
 });
 

--- a/packages/tickets/src/actions/ticketActions.moveToBoard.test.ts
+++ b/packages/tickets/src/actions/ticketActions.moveToBoard.test.ts
@@ -56,12 +56,9 @@ vi.mock('@alga-psa/tags/actions', () => ({
   findTagsByEntityIds: vi.fn(),
 }));
 
-vi.mock('@alga-psa/teams/actions', () => ({
-  getTeamById: vi.fn(),
-}));
-
-vi.mock('./ticketResourceActions', () => ({
-  addTicketResource: vi.fn(),
+vi.mock('./teamAssignmentActions', () => ({
+  assignTeamToTicket: vi.fn(),
+  removeTeamFromTicket: vi.fn(),
 }));
 
 vi.mock('@alga-psa/validation', () => ({

--- a/packages/tickets/src/actions/ticketActions.moveToBoard.test.ts
+++ b/packages/tickets/src/actions/ticketActions.moveToBoard.test.ts
@@ -51,6 +51,19 @@ vi.mock('@alga-psa/tags/lib/tagCleanup', () => ({
   deleteEntityTags: vi.fn(),
 }));
 
+vi.mock('@alga-psa/tags/actions', () => ({
+  createTagsForEntityWithTransaction: vi.fn(),
+  findTagsByEntityIds: vi.fn(),
+}));
+
+vi.mock('@alga-psa/teams/actions', () => ({
+  getTeamById: vi.fn(),
+}));
+
+vi.mock('./ticketResourceActions', () => ({
+  addTicketResource: vi.fn(),
+}));
+
 vi.mock('@alga-psa/validation', () => ({
   validateData: vi.fn((_schema: unknown, data: unknown) => data),
 }));

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -60,7 +60,7 @@ import { buildTicketTransitionWorkflowEvents } from '../lib/workflowTicketTransi
 import { buildTicketCommunicationWorkflowEvents } from '../lib/workflowTicketCommunicationEvents';
 import { getTicketOrigin, type ResolvedTicketOrigin } from '../lib/ticketOrigin';
 import { getClientContactVisibilityContext } from '../lib/clientPortalVisibility';
-import { updateTicketWithCache } from './optimizedTicketActions';
+import { updateTicketWithCache, updateTicketInTransaction } from './optimizedTicketActions';
 import {
   buildTicketResolutionSlaStageCompletionEvent,
   buildTicketResolutionSlaStageEnteredEvent,
@@ -1759,6 +1759,13 @@ export const bulkAssignTickets = withAuth(async (
     return { updatedIds: [], failed: [] };
   }
 
+  // Authorize once up front. The team helpers and the per-ticket update each still
+  // verify permission internally, but this entry check fails fast before any mutation.
+  const { knex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'ticket', 'update', knex))) {
+    throw new Error('Permission denied: Cannot update tickets');
+  }
+
   const updatedIds: string[] = [];
   const failed: Array<{ ticketId: string; message: string }> = [];
 
@@ -1772,7 +1779,9 @@ export const bulkAssignTickets = withAuth(async (
         // Assigning to a single user clears any team assignment (and its team_member resources)
         // first so a stale assigned_team_id / team badge isn't left behind.
         await removeTeamFromTicket(ticketId, { mode: 'remove_all' });
-        await updateTicketWithCache(ticketId, { assigned_to: selection.userId });
+        await withTransaction(knex, (trx: Knex.Transaction) =>
+          updateTicketInTransaction(trx, user as IUserWithRoles, tenant, ticketId, { assigned_to: selection.userId }),
+        );
       }
       updatedIds.push(ticketId);
     } catch (error: unknown) {
@@ -1878,12 +1887,21 @@ export const bulkUpdateTicketDueDate = withAuth(async (
     return { updatedIds: [], failed: [] };
   }
 
+  // Authorize once up front instead of paying a permission lookup per ticket.
+  const { knex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'ticket', 'update', knex))) {
+    throw new Error('Permission denied: Cannot update tickets');
+  }
+
   const updatedIds: string[] = [];
   const failed: Array<{ ticketId: string; message: string }> = [];
 
+  // Per-ticket transactions preserve partial success: one bad ticket fails alone.
   for (const ticketId of uniqueIds) {
     try {
-      await updateTicketWithCache(ticketId, { due_date: dueDate } as Partial<ITicket>);
+      await withTransaction(knex, (trx: Knex.Transaction) =>
+        updateTicketInTransaction(trx, user as IUserWithRoles, tenant, ticketId, { due_date: dueDate } as Partial<ITicket>),
+      );
       updatedIds.push(ticketId);
     } catch (error: unknown) {
       failed.push({
@@ -1915,12 +1933,21 @@ export const bulkUpdateTicketStatus = withAuth(async (
     return { updatedIds: [], failed: [] };
   }
 
+  // Authorize once up front instead of paying a permission lookup per ticket.
+  const { knex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'ticket', 'update', knex))) {
+    throw new Error('Permission denied: Cannot update tickets');
+  }
+
   const updatedIds: string[] = [];
   const failed: Array<{ ticketId: string; message: string }> = [];
 
+  // Per-ticket transactions preserve partial success: one bad ticket fails alone.
   for (const ticketId of uniqueIds) {
     try {
-      await updateTicketWithCache(ticketId, { status_id: statusId });
+      await withTransaction(knex, (trx: Knex.Transaction) =>
+        updateTicketInTransaction(trx, user as IUserWithRoles, tenant, ticketId, { status_id: statusId }),
+      );
       updatedIds.push(ticketId);
     } catch (error: unknown) {
       failed.push({
@@ -1952,12 +1979,21 @@ export const bulkUpdateTicketPriority = withAuth(async (
     return { updatedIds: [], failed: [] };
   }
 
+  // Authorize once up front instead of paying a permission lookup per ticket.
+  const { knex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'ticket', 'update', knex))) {
+    throw new Error('Permission denied: Cannot update tickets');
+  }
+
   const updatedIds: string[] = [];
   const failed: Array<{ ticketId: string; message: string }> = [];
 
+  // Per-ticket transactions preserve partial success: one bad ticket fails alone.
   for (const ticketId of uniqueIds) {
     try {
-      await updateTicketWithCache(ticketId, { priority_id: priorityId });
+      await withTransaction(knex, (trx: Knex.Transaction) =>
+        updateTicketInTransaction(trx, user as IUserWithRoles, tenant, ticketId, { priority_id: priorityId }),
+      );
       updatedIds.push(ticketId);
     } catch (error: unknown) {
       failed.push({

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -22,8 +22,7 @@ import { Knex } from 'knex';
 import { deleteEntityWithValidation } from '@alga-psa/core';
 import { deleteEntityTags } from '@alga-psa/tags/lib/tagCleanup';
 import { createTagsForEntityWithTransaction, findTagsByEntityIds } from '@alga-psa/tags/actions';
-import { getTeamById } from '@alga-psa/teams/actions';
-import { addTicketResource } from './ticketResourceActions';
+import { assignTeamToTicket, removeTeamFromTicket } from './teamAssignmentActions';
 import type { DeletionValidationResult } from '@alga-psa/types';
 import {
   ticketSchema,
@@ -1760,48 +1759,20 @@ export const bulkAssignTickets = withAuth(async (
     return { updatedIds: [], failed: [] };
   }
 
-  let primaryAssigneeId: string | null = null;
-  let additionalAgentIds: string[] = [];
-
-  if (selection.kind === 'user') {
-    primaryAssigneeId = selection.userId;
-  } else {
-    try {
-      const team = await getTeamById(selection.teamId);
-      primaryAssigneeId = team.manager_id ?? null;
-      if (!primaryAssigneeId) {
-        return {
-          updatedIds: [],
-          failed: uniqueIds.map((ticketId) => ({
-            ticketId,
-            message: 'Selected team has no lead to set as primary assignee',
-          })),
-        };
-      }
-      additionalAgentIds = (team.members ?? [])
-        .map((m) => m.user_id)
-        .filter((uid): uid is string => !!uid && uid !== primaryAssigneeId);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : 'Failed to load team';
-      return {
-        updatedIds: [],
-        failed: uniqueIds.map((ticketId) => ({ ticketId, message })),
-      };
-    }
-  }
-
   const updatedIds: string[] = [];
   const failed: Array<{ ticketId: string; message: string }> = [];
 
   for (const ticketId of uniqueIds) {
     try {
-      await updateTicketWithCache(ticketId, { assigned_to: primaryAssigneeId });
-      for (const additionalUserId of additionalAgentIds) {
-        try {
-          await addTicketResource(ticketId, additionalUserId, 'agent');
-        } catch {
-          // Resource may already exist; skip per-member errors so the assignment as a whole still succeeds.
-        }
+      if (selection.kind === 'team') {
+        // Canonical team flow: sets assigned_team_id + the team lead as primary assignee and
+        // records team members as `team_member` resources, so the team badge/filter persists.
+        await assignTeamToTicket(ticketId, selection.teamId);
+      } else {
+        // Assigning to a single user clears any team assignment (and its team_member resources)
+        // first so a stale assigned_team_id / team badge isn't left behind.
+        await removeTeamFromTicket(ticketId, { mode: 'remove_all' });
+        await updateTicketWithCache(ticketId, { assigned_to: selection.userId });
       }
       updatedIds.push(ticketId);
     } catch (error: unknown) {
@@ -1835,6 +1806,12 @@ export const bulkAddTagsToTickets = withAuth(async (
 
   if (uniqueIds.length === 0 || normalizedTexts.length === 0) {
     return { updatedIds: [], failed: [] };
+  }
+
+  // Tag writes don't go through updateTicketWithCache, so authorize explicitly here.
+  const { knex: authKnex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'ticket', 'update', authKnex))) {
+    throw new Error('Permission denied: Cannot update tickets');
   }
 
   const existingByTicket = new Map<string, Set<string>>();

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -8,6 +8,7 @@ import type {
   ITicketResource,
   IUser,
   IUserWithRoles,
+  PendingTag,
   TicketResponseState,
 } from '@alga-psa/types';
 import { TICKET_ORIGINS } from '@alga-psa/types';
@@ -20,6 +21,9 @@ import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { deleteEntityWithValidation } from '@alga-psa/core';
 import { deleteEntityTags } from '@alga-psa/tags/lib/tagCleanup';
+import { createTagsForEntityWithTransaction, findTagsByEntityIds } from '@alga-psa/tags/actions';
+import { getTeamById } from '@alga-psa/teams/actions';
+import { addTicketResource } from './ticketResourceActions';
 import type { DeletionValidationResult } from '@alga-psa/types';
 import {
   ticketSchema,
@@ -1735,6 +1739,262 @@ export const moveTicketsToBoard = withAuth(async (
   }
 
   return { movedIds, failed };
+});
+
+export type BulkTicketAssignSelection =
+  | { kind: 'user'; userId: string | null }
+  | { kind: 'team'; teamId: string };
+
+export const bulkAssignTickets = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[],
+  selection: BulkTicketAssignSelection,
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ ticketId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id) => !!id)));
+
+  if (uniqueIds.length === 0) {
+    return { updatedIds: [], failed: [] };
+  }
+
+  let primaryAssigneeId: string | null = null;
+  let additionalAgentIds: string[] = [];
+
+  if (selection.kind === 'user') {
+    primaryAssigneeId = selection.userId;
+  } else {
+    try {
+      const team = await getTeamById(selection.teamId);
+      primaryAssigneeId = team.manager_id ?? null;
+      if (!primaryAssigneeId) {
+        return {
+          updatedIds: [],
+          failed: uniqueIds.map((ticketId) => ({
+            ticketId,
+            message: 'Selected team has no lead to set as primary assignee',
+          })),
+        };
+      }
+      additionalAgentIds = (team.members ?? [])
+        .map((m) => m.user_id)
+        .filter((uid): uid is string => !!uid && uid !== primaryAssigneeId);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to load team';
+      return {
+        updatedIds: [],
+        failed: uniqueIds.map((ticketId) => ({ ticketId, message })),
+      };
+    }
+  }
+
+  const updatedIds: string[] = [];
+  const failed: Array<{ ticketId: string; message: string }> = [];
+
+  for (const ticketId of uniqueIds) {
+    try {
+      await updateTicketWithCache(ticketId, { assigned_to: primaryAssigneeId });
+      for (const additionalUserId of additionalAgentIds) {
+        try {
+          await addTicketResource(ticketId, additionalUserId, 'agent');
+        } catch {
+          // Resource may already exist; skip per-member errors so the assignment as a whole still succeeds.
+        }
+      }
+      updatedIds.push(ticketId);
+    } catch (error: unknown) {
+      failed.push({
+        ticketId,
+        message: error instanceof Error ? error.message : 'Failed to assign ticket',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
+  return { updatedIds, failed };
+});
+
+export const bulkAddTagsToTickets = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[],
+  tagTexts: string[],
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ ticketId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id) => !!id)));
+  const normalizedTexts = Array.from(
+    new Set(tagTexts.map((t) => t.trim()).filter((t) => t.length > 0)),
+  );
+
+  if (uniqueIds.length === 0 || normalizedTexts.length === 0) {
+    return { updatedIds: [], failed: [] };
+  }
+
+  const existingByTicket = new Map<string, Set<string>>();
+  try {
+    const existing = await findTagsByEntityIds(uniqueIds, 'ticket');
+    for (const tag of existing) {
+      const set = existingByTicket.get(tag.tagged_id) ?? new Set<string>();
+      set.add(tag.tag_text.toLowerCase());
+      existingByTicket.set(tag.tagged_id, set);
+    }
+  } catch (error) {
+    console.warn('[bulkAddTagsToTickets] Failed to load existing tags for dedupe:', error);
+  }
+
+  const { knex: ticketKnex } = await createTenantKnex();
+  const updatedIds: string[] = [];
+  const failed: Array<{ ticketId: string; message: string }> = [];
+
+  for (const ticketId of uniqueIds) {
+    try {
+      const alreadyOnTicket = existingByTicket.get(ticketId) ?? new Set<string>();
+      const newTexts = normalizedTexts.filter((t) => !alreadyOnTicket.has(t.toLowerCase()));
+      if (newTexts.length === 0) {
+        updatedIds.push(ticketId);
+        continue;
+      }
+      const pendingTags: PendingTag[] = newTexts.map((text) => ({
+        tag_text: text,
+        background_color: null,
+        text_color: null,
+        isNew: true,
+      }));
+      await withTransaction(ticketKnex, async (trx: Knex.Transaction) => {
+        await createTagsForEntityWithTransaction(trx, tenant, ticketId, 'ticket', pendingTags);
+      });
+      updatedIds.push(ticketId);
+    } catch (error: unknown) {
+      failed.push({
+        ticketId,
+        message: error instanceof Error ? error.message : 'Failed to add tags to ticket',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
+  return { updatedIds, failed };
+});
+
+export const bulkUpdateTicketDueDate = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[],
+  dueDate: string | null,
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ ticketId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id) => !!id)));
+
+  if (uniqueIds.length === 0) {
+    return { updatedIds: [], failed: [] };
+  }
+
+  const updatedIds: string[] = [];
+  const failed: Array<{ ticketId: string; message: string }> = [];
+
+  for (const ticketId of uniqueIds) {
+    try {
+      await updateTicketWithCache(ticketId, { due_date: dueDate } as Partial<ITicket>);
+      updatedIds.push(ticketId);
+    } catch (error: unknown) {
+      failed.push({
+        ticketId,
+        message: error instanceof Error ? error.message : 'Failed to update due date',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
+  return { updatedIds, failed };
+});
+
+export const bulkUpdateTicketStatus = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[],
+  statusId: string,
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ ticketId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id) => !!id)));
+
+  if (uniqueIds.length === 0) {
+    return { updatedIds: [], failed: [] };
+  }
+
+  const updatedIds: string[] = [];
+  const failed: Array<{ ticketId: string; message: string }> = [];
+
+  for (const ticketId of uniqueIds) {
+    try {
+      await updateTicketWithCache(ticketId, { status_id: statusId });
+      updatedIds.push(ticketId);
+    } catch (error: unknown) {
+      failed.push({
+        ticketId,
+        message: error instanceof Error ? error.message : 'Failed to update status',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
+  return { updatedIds, failed };
+});
+
+export const bulkUpdateTicketPriority = withAuth(async (
+  user,
+  { tenant },
+  ticketIds: string[],
+  priorityId: string,
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ ticketId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id) => !!id)));
+
+  if (uniqueIds.length === 0) {
+    return { updatedIds: [], failed: [] };
+  }
+
+  const updatedIds: string[] = [];
+  const failed: Array<{ ticketId: string; message: string }> = [];
+
+  for (const ticketId of uniqueIds) {
+    try {
+      await updateTicketWithCache(ticketId, { priority_id: priorityId });
+      updatedIds.push(ticketId);
+    } catch (error: unknown) {
+      failed.push({
+        ticketId,
+        message: error instanceof Error ? error.message : 'Failed to update priority',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
+  return { updatedIds, failed };
 });
 
 export const getScheduledHoursForTicket = withAuth(async (user, { tenant }, ticketId: string): Promise<IAgentSchedule[]> => {

--- a/packages/tickets/src/actions/ticketDisplaySettings.ts
+++ b/packages/tickets/src/actions/ticketDisplaySettings.ts
@@ -17,8 +17,7 @@ export type TicketListColumnKey =
   | 'due_date'
   | 'created'
   | 'created_by'
-  | 'tags'
-  | 'actions';
+  | 'tags';
 
 export type TicketListSettings = {
   columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
@@ -60,7 +59,6 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
           created: display?.list?.columnVisibility?.created ?? true,
           created_by: display?.list?.columnVisibility?.created_by ?? true,
           tags: display?.list?.columnVisibility?.tags ?? true,
-          actions: display?.list?.columnVisibility?.actions ?? true,
         },
         tagsInlineUnderTitle: display?.list?.tagsInlineUnderTitle ?? false,
       },
@@ -85,7 +83,6 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
           created: true,
           created_by: true,
           tags: true,
-          actions: true,
         },
         tagsInlineUnderTitle: false,
       },

--- a/packages/tickets/src/components/BulkAddTagsDialog.tsx
+++ b/packages/tickets/src/components/BulkAddTagsDialog.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { QuickAddTagPicker } from '@alga-psa/tags/components';
+import type { PendingTag } from '@alga-psa/types';
+import { useTranslation } from 'react-i18next';
+
+interface BulkAddTagsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ticketCount: number;
+  failed: Array<{ ticketId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (tagTexts: string[]) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkAddTagsDialog({
+  isOpen,
+  onClose,
+  ticketCount,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'ticket-bulk-add-tags',
+}: BulkAddTagsDialogProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+  const [pendingTags, setPendingTags] = useState<PendingTag[]>([]);
+
+  useEffect(() => {
+    if (isOpen) setPendingTags([]);
+  }, [isOpen]);
+
+  const trimmedTexts = Array.from(
+    new Set(pendingTags.map((tag) => tag.tag_text.trim()).filter((text) => text.length > 0)),
+  );
+  const hasTags = trimmedTexts.length > 0;
+
+  const handleConfirm = async () => {
+    if (!hasTags) return;
+    await onConfirm(trimmedTexts);
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.tags.dialogTitle', 'Add Tags to Selected Tickets')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.tags.failedHeading', 'Tags could not be added to the following tickets:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.ticketId}>
+                    <span className="font-medium">{error.label ?? error.ticketId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t(
+            'bulk.tags.message',
+            'Add one or more tags to {{count}} selected ticket(s). Tags already on a ticket are skipped.',
+            { count: ticketCount },
+          )}
+        </div>
+        <div className="mb-4">
+          <QuickAddTagPicker
+            id={`${idPrefix}-picker`}
+            entityType="ticket"
+            pendingTags={pendingTags}
+            onPendingTagsChange={setPendingTags}
+            placeholder={t('bulk.tags.placeholder', 'Type a tag and press Enter')}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || !hasTags}>
+            {isSubmitting
+              ? t('bulk.tags.submitting', 'Adding tags...')
+              : t('bulk.tags.confirm', {
+                  count: ticketCount,
+                  defaultValue: ticketCount === 1 ? 'Add Tags to {{count}} Ticket' : 'Add Tags to {{count}} Tickets',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/tickets/src/components/BulkAssignTicketsDialog.tsx
+++ b/packages/tickets/src/components/BulkAssignTicketsDialog.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import UserAndTeamPicker from '@alga-psa/ui/components/UserAndTeamPicker';
+import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
+import { getTeams, getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
+import type { IUser, ITeam } from '@alga-psa/types';
+import { useTranslation } from 'react-i18next';
+import type { BulkTicketAssignSelection } from '../actions/ticketActions';
+
+interface BulkAssignTicketsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ticketCount: number;
+  users: IUser[];
+  failed: Array<{ ticketId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (selection: BulkTicketAssignSelection) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkAssignTicketsDialog({
+  isOpen,
+  onClose,
+  ticketCount,
+  users,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'ticket-bulk-assign',
+}: BulkAssignTicketsDialogProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+  const [pickerValue, setPickerValue] = useState<string>('');
+  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
+  const [teams, setTeams] = useState<ITeam[]>([]);
+  const [isLoadingTeams, setIsLoadingTeams] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setPickerValue('');
+    setPendingTeamId(null);
+    let cancelled = false;
+    setIsLoadingTeams(true);
+    getTeams()
+      .then((fetched) => {
+        if (!cancelled) setTeams(fetched);
+      })
+      .catch((error) => {
+        console.error('[BulkAssignTicketsDialog] Failed to load teams:', error);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingTeams(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const assignableTeams = teams.filter((team) => !!team.manager_id);
+
+  const handleUserChange = (value: string) => {
+    setPickerValue(value);
+    setPendingTeamId(null);
+  };
+
+  const handleTeamSelect = (teamId: string) => {
+    setPendingTeamId(teamId);
+    setPickerValue(teamId);
+  };
+
+  const handleConfirm = async () => {
+    if (pendingTeamId) {
+      await onConfirm({ kind: 'team', teamId: pendingTeamId });
+    } else {
+      await onConfirm({ kind: 'user', userId: pickerValue || null });
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.assign.dialogTitle', 'Assign Selected Tickets')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.assign.failedHeading', 'The following tickets could not be reassigned:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.ticketId}>
+                    <span className="font-medium">{error.label ?? error.ticketId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t('bulk.assign.message', 'Reassign {{count}} selected ticket(s) to:', { count: ticketCount })}
+        </div>
+        <div className="mb-3">
+          <UserAndTeamPicker
+            id={`${idPrefix}-picker`}
+            value={pickerValue}
+            onValueChange={handleUserChange}
+            onTeamSelect={handleTeamSelect}
+            users={users}
+            teams={assignableTeams}
+            getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
+            getTeamAvatarUrlsBatch={getTeamAvatarUrlsBatchAction}
+            buttonWidth="full"
+            labelStyle="none"
+            placeholder={t('bulk.assign.unassigned', 'Not assigned')}
+            disabled={isLoadingTeams || isSubmitting}
+          />
+        </div>
+        {pendingTeamId && (
+          <p className="mb-6 text-xs text-gray-500">
+            {t(
+              'bulk.assign.teamHint',
+              'The team lead becomes the primary assignee; other team members are added as additional agents.',
+            )}
+          </p>
+        )}
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || isLoadingTeams}>
+            {isSubmitting
+              ? t('bulk.assign.submitting', 'Reassigning...')
+              : t('bulk.assign.confirm', {
+                  count: ticketCount,
+                  defaultValue: ticketCount === 1 ? 'Reassign {{count}} Ticket' : 'Reassign {{count}} Tickets',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/tickets/src/components/BulkChangePriorityDialog.tsx
+++ b/packages/tickets/src/components/BulkChangePriorityDialog.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { PrioritySelect } from '@alga-psa/ui/components';
+import type { SelectOption } from '@alga-psa/ui/components/CustomSelect';
+import { useTranslation } from 'react-i18next';
+
+interface BulkChangePriorityDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ticketCount: number;
+  options: SelectOption[];
+  failed: Array<{ ticketId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (priorityId: string) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkChangePriorityDialog({
+  isOpen,
+  onClose,
+  ticketCount,
+  options,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'ticket-bulk-priority',
+}: BulkChangePriorityDialogProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+  const [priorityId, setPriorityId] = useState<string>('');
+
+  useEffect(() => {
+    if (isOpen) setPriorityId('');
+  }, [isOpen]);
+
+  const canConfirm = !!priorityId;
+
+  const handleConfirm = async () => {
+    if (!priorityId) return;
+    await onConfirm(priorityId);
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.priority.dialogTitle', 'Change Priority for Selected Tickets')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.priority.failedHeading', 'Priority could not be updated on the following tickets:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.ticketId}>
+                    <span className="font-medium">{error.label ?? error.ticketId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t('bulk.priority.message', 'Set the priority for {{count}} selected ticket(s):', { count: ticketCount })}
+        </div>
+        <div className="mb-4">
+          <PrioritySelect
+            id={`${idPrefix}-picker`}
+            options={options}
+            value={priorityId}
+            onValueChange={setPriorityId}
+            placeholder={t('bulk.priority.placeholder', 'Select a priority')}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || !canConfirm}>
+            {isSubmitting
+              ? t('bulk.priority.submitting', 'Updating...')
+              : t('bulk.priority.confirm', {
+                  count: ticketCount,
+                  defaultValue: ticketCount === 1 ? 'Update {{count}} Ticket' : 'Update {{count}} Tickets',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/tickets/src/components/BulkChangeStatusDialog.tsx
+++ b/packages/tickets/src/components/BulkChangeStatusDialog.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import CustomSelect, { type SelectOption } from '@alga-psa/ui/components/CustomSelect';
+import { useTranslation } from 'react-i18next';
+
+interface BulkChangeStatusDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ticketCount: number;
+  statuses: SelectOption[];
+  isLoadingStatuses: boolean;
+  failed: Array<{ ticketId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (statusId: string) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkChangeStatusDialog({
+  isOpen,
+  onClose,
+  ticketCount,
+  statuses,
+  isLoadingStatuses,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'ticket-bulk-status',
+}: BulkChangeStatusDialogProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+  const [selectedStatusId, setSelectedStatusId] = useState<string>('');
+
+  useEffect(() => {
+    if (isOpen) setSelectedStatusId('');
+  }, [isOpen]);
+
+  const canConfirm = !!selectedStatusId && !isLoadingStatuses;
+
+  const handleConfirm = async () => {
+    if (!selectedStatusId) return;
+    await onConfirm(selectedStatusId);
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.status.dialogTitle', 'Change Status for Selected Tickets')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.status.failedHeading', 'Status could not be updated on the following tickets:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.ticketId}>
+                    <span className="font-medium">{error.label ?? error.ticketId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t('bulk.status.message', 'Set the status for {{count}} selected ticket(s):', { count: ticketCount })}
+        </div>
+        <div className="mb-4">
+          <CustomSelect
+            id={`${idPrefix}-picker`}
+            options={statuses}
+            value={selectedStatusId}
+            onValueChange={setSelectedStatusId}
+            placeholder={
+              isLoadingStatuses
+                ? t('bulk.status.loading', 'Loading statuses...')
+                : t('bulk.status.placeholder', 'Select a status')
+            }
+            disabled={isLoadingStatuses || isSubmitting}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || !canConfirm}>
+            {isSubmitting
+              ? t('bulk.status.submitting', 'Updating...')
+              : t('bulk.status.confirm', {
+                  count: ticketCount,
+                  defaultValue: ticketCount === 1 ? 'Update {{count}} Ticket' : 'Update {{count}} Tickets',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/tickets/src/components/BulkSetDueDateDialog.tsx
+++ b/packages/tickets/src/components/BulkSetDueDateDialog.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Calendar } from '@alga-psa/ui/components/Calendar';
+import { useTranslation } from 'react-i18next';
+
+interface BulkSetDueDateDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ticketCount: number;
+  failed: Array<{ ticketId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (dueDateIso: string | null) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkSetDueDateDialog({
+  isOpen,
+  onClose,
+  ticketCount,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'ticket-bulk-due-date',
+}: BulkSetDueDateDialogProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+  const [date, setDate] = useState<Date | undefined>(undefined);
+  const [mode, setMode] = useState<'set' | 'clear'>('set');
+
+  useEffect(() => {
+    if (isOpen) {
+      setDate(undefined);
+      setMode('set');
+    }
+  }, [isOpen]);
+
+  const canConfirm = mode === 'clear' || (mode === 'set' && !!date);
+
+  const handleConfirm = async () => {
+    if (mode === 'clear') {
+      await onConfirm(null);
+      return;
+    }
+    if (!date) return;
+    await onConfirm(date.toISOString());
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.dueDate.dialogTitle', 'Set Due Date for Selected Tickets')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.dueDate.failedHeading', 'Due date could not be updated on the following tickets:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.ticketId}>
+                    <span className="font-medium">{error.label ?? error.ticketId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t('bulk.dueDate.message', 'Set or clear the due date on {{count}} selected ticket(s).', { count: ticketCount })}
+        </div>
+        <div className="mb-4 flex items-center gap-3">
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name={`${idPrefix}-mode`}
+              checked={mode === 'set'}
+              onChange={() => setMode('set')}
+              disabled={isSubmitting}
+            />
+            {t('bulk.dueDate.modeSet', 'Set to')}
+          </label>
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name={`${idPrefix}-mode`}
+              checked={mode === 'clear'}
+              onChange={() => setMode('clear')}
+              disabled={isSubmitting}
+            />
+            {t('bulk.dueDate.modeClear', 'Clear due date')}
+          </label>
+        </div>
+        {mode === 'set' && (
+          <div className="mb-4 flex justify-center">
+            <Calendar
+              mode="single"
+              selected={date}
+              onSelect={(next) => setDate(next)}
+              onClear={() => setDate(undefined)}
+            />
+          </div>
+        )}
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || !canConfirm}>
+            {isSubmitting
+              ? t('bulk.dueDate.submitting', 'Updating...')
+              : t('bulk.dueDate.confirm', {
+                  count: ticketCount,
+                  defaultValue: ticketCount === 1 ? 'Update {{count}} Ticket' : 'Update {{count}} Tickets',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/tickets/src/components/BulkTicketActionBar.tsx
+++ b/packages/tickets/src/components/BulkTicketActionBar.tsx
@@ -1,15 +1,44 @@
 'use client';
 
 import { Button } from '@alga-psa/ui/components/Button';
-import { Move, Layers, Trash2, X } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@alga-psa/ui/components/DropdownMenu';
+import {
+  Move,
+  Layers,
+  Trash2,
+  X,
+  UserPlus,
+  CircleDot,
+  Flag,
+  Tag,
+  CalendarClock,
+  MoreHorizontal,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface BulkTicketActionBarProps {
   count: number;
   showMove: boolean;
   showBundle: boolean;
+  showAssign: boolean;
+  showStatus: boolean;
+  showPriority: boolean;
+  showTags: boolean;
+  showDueDate: boolean;
+  statusDisabled?: boolean;
+  statusDisabledTitle?: string;
   onMove: () => void;
   onBundle: () => void;
+  onAssign: () => void;
+  onStatus: () => void;
+  onPriority: () => void;
+  onTags: () => void;
+  onDueDate: () => void;
   onDelete: () => void;
   onClear: () => void;
   idPrefix?: string;
@@ -19,8 +48,20 @@ export default function BulkTicketActionBar({
   count,
   showMove,
   showBundle,
+  showAssign,
+  showStatus,
+  showPriority,
+  showTags,
+  showDueDate,
+  statusDisabled = false,
+  statusDisabledTitle,
   onMove,
   onBundle,
+  onAssign,
+  onStatus,
+  onPriority,
+  onTags,
+  onDueDate,
   onDelete,
   onClear,
   idPrefix = 'ticket-bulk-action-bar',
@@ -30,6 +71,7 @@ export default function BulkTicketActionBar({
   if (count === 0) return null;
 
   const bundleEnabled = count >= 2;
+  const hasMoreActions = showStatus || showPriority || showTags || showDueDate;
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-white dark:bg-[rgb(var(--color-card))] border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg px-4 py-2.5">
@@ -37,15 +79,16 @@ export default function BulkTicketActionBar({
         {t('bulk.actionBar.selectedCount', '{{count}} selected', { count })}
       </span>
       <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
-      {showMove && (
+      {showAssign && (
         <Button
-          id={`${idPrefix}-move-button`}
+          id={`${idPrefix}-assign-button`}
           variant="outline"
           size="sm"
-          onClick={onMove}
+          onClick={onAssign}
+          className="whitespace-nowrap"
         >
-          <Move className="h-4 w-4 mr-1.5" />
-          {t('bulk.actionBar.move', 'Move to Board')}
+          <UserPlus className="h-4 w-4 mr-1.5" />
+          {t('bulk.actionBar.assign', 'Assign')}
         </Button>
       )}
       {showBundle && (
@@ -56,9 +99,22 @@ export default function BulkTicketActionBar({
           onClick={onBundle}
           disabled={!bundleEnabled}
           title={!bundleEnabled ? t('bulk.actionBar.bundleNeedsTwo', 'Select at least 2 tickets to bundle') : undefined}
+          className="whitespace-nowrap"
         >
           <Layers className="h-4 w-4 mr-1.5" />
           {t('bulk.actionBar.bundle', 'Bundle')}
+        </Button>
+      )}
+      {showMove && (
+        <Button
+          id={`${idPrefix}-move-button`}
+          variant="outline"
+          size="sm"
+          onClick={onMove}
+          className="whitespace-nowrap"
+        >
+          <Move className="h-4 w-4 mr-1.5" />
+          {t('bulk.actionBar.move', 'Move to Board')}
         </Button>
       )}
       <Button
@@ -66,17 +122,76 @@ export default function BulkTicketActionBar({
         variant="outline"
         size="sm"
         onClick={onDelete}
-        className="text-destructive hover:text-destructive"
+        className="whitespace-nowrap text-destructive hover:text-destructive"
       >
         <Trash2 className="h-4 w-4 mr-1.5" />
         {t('bulk.actionBar.delete', 'Delete')}
       </Button>
+      {hasMoreActions && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              id={`${idPrefix}-more-button`}
+              variant="outline"
+              size="sm"
+              className="whitespace-nowrap"
+            >
+              <MoreHorizontal className="h-4 w-4 mr-1.5" />
+              {t('bulk.actionBar.more', 'More')}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[10rem]">
+            {showStatus && (
+              <DropdownMenuItem
+                id={`${idPrefix}-status-menu-item`}
+                disabled={statusDisabled}
+                onSelect={() => {
+                  if (statusDisabled) return;
+                  onStatus();
+                }}
+                title={statusDisabled ? statusDisabledTitle : undefined}
+              >
+                <CircleDot className="h-4 w-4 mr-2" />
+                {t('bulk.actionBar.status', 'Status')}
+              </DropdownMenuItem>
+            )}
+            {showPriority && (
+              <DropdownMenuItem
+                id={`${idPrefix}-priority-menu-item`}
+                onSelect={onPriority}
+              >
+                <Flag className="h-4 w-4 mr-2" />
+                {t('bulk.actionBar.priority', 'Priority')}
+              </DropdownMenuItem>
+            )}
+            {showTags && (
+              <DropdownMenuItem
+                id={`${idPrefix}-tags-menu-item`}
+                onSelect={onTags}
+              >
+                <Tag className="h-4 w-4 mr-2" />
+                {t('bulk.actionBar.tags', 'Tags')}
+              </DropdownMenuItem>
+            )}
+            {showDueDate && (
+              <DropdownMenuItem
+                id={`${idPrefix}-due-date-menu-item`}
+                onSelect={onDueDate}
+              >
+                <CalendarClock className="h-4 w-4 mr-2" />
+                {t('bulk.actionBar.dueDate', 'Due Date')}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
       <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
       <Button
         id={`${idPrefix}-clear-button`}
         variant="ghost"
         size="sm"
         onClick={onClear}
+        className="whitespace-nowrap"
       >
         <X className="h-4 w-4 mr-1.5" />
         {t('bulk.actionBar.clear', 'Clear')}

--- a/packages/tickets/src/components/BulkTicketActionBar.tsx
+++ b/packages/tickets/src/components/BulkTicketActionBar.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Button } from '@alga-psa/ui/components/Button';
+import { Move, Layers, Trash2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface BulkTicketActionBarProps {
+  count: number;
+  showMove: boolean;
+  showBundle: boolean;
+  onMove: () => void;
+  onBundle: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+  idPrefix?: string;
+}
+
+export default function BulkTicketActionBar({
+  count,
+  showMove,
+  showBundle,
+  onMove,
+  onBundle,
+  onDelete,
+  onClear,
+  idPrefix = 'ticket-bulk-action-bar',
+}: BulkTicketActionBarProps) {
+  const { t } = useTranslation(['features/tickets', 'common']);
+
+  if (count === 0) return null;
+
+  const bundleEnabled = count >= 2;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-white dark:bg-[rgb(var(--color-card))] border border-gray-200 dark:border-[rgb(var(--color-border-200))] rounded-lg shadow-lg px-4 py-2.5">
+      <span className="text-sm font-medium text-gray-700 dark:text-[rgb(var(--color-text-200))] whitespace-nowrap">
+        {t('bulk.actionBar.selectedCount', '{{count}} selected', { count })}
+      </span>
+      <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
+      {showMove && (
+        <Button
+          id={`${idPrefix}-move-button`}
+          variant="outline"
+          size="sm"
+          onClick={onMove}
+        >
+          <Move className="h-4 w-4 mr-1.5" />
+          {t('bulk.actionBar.move', 'Move to Board')}
+        </Button>
+      )}
+      {showBundle && (
+        <Button
+          id={`${idPrefix}-bundle-button`}
+          variant="outline"
+          size="sm"
+          onClick={onBundle}
+          disabled={!bundleEnabled}
+          title={!bundleEnabled ? t('bulk.actionBar.bundleNeedsTwo', 'Select at least 2 tickets to bundle') : undefined}
+        >
+          <Layers className="h-4 w-4 mr-1.5" />
+          {t('bulk.actionBar.bundle', 'Bundle')}
+        </Button>
+      )}
+      <Button
+        id={`${idPrefix}-delete-button`}
+        variant="outline"
+        size="sm"
+        onClick={onDelete}
+        className="text-destructive hover:text-destructive"
+      >
+        <Trash2 className="h-4 w-4 mr-1.5" />
+        {t('bulk.actionBar.delete', 'Delete')}
+      </Button>
+      <div className="h-5 w-px bg-gray-200 dark:bg-[rgb(var(--color-border-200))]" />
+      <Button
+        id={`${idPrefix}-clear-button`}
+        variant="ghost"
+        size="sm"
+        onClick={onClear}
+      >
+        <X className="h-4 w-4 mr-1.5" />
+        {t('bulk.actionBar.clear', 'Clear')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
+++ b/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
@@ -92,8 +92,6 @@ describe('ticketing dashboard i18n wiring contract', () => {
     expect(source).toContain("t('dashboard.drawer.loading', 'Loading...')");
     expect(source).toContain("t('dashboard.drawer.clientNotFound', 'Client not found.')");
     expect(source).toContain("t('dashboard.drawer.clientLoadFailed', 'Failed to load client.')");
-    expect(source).toContain("t('errors.validateDeletionFailed', 'Failed to validate deletion. Please try again.')");
-    expect(source).toContain("t('errors.deleteTicketUnexpected', 'An unexpected error occurred while deleting the ticket.')");
     expect(source).toContain("t('errors.loadBundledTickets', 'Failed to load bundled tickets')");
     expect(source).toContain("t('bulk.move.noTicketsSelected', 'No tickets selected.')");
     expect(source).toContain("t('bulk.delete.noTicketsSelected', 'No tickets selected.')");

--- a/packages/tickets/src/components/TicketingDashboard.moveBulk.contract.test.ts
+++ b/packages/tickets/src/components/TicketingDashboard.moveBulk.contract.test.ts
@@ -10,17 +10,21 @@ function read(relativePath: string): string {
 
 describe('ticketing dashboard bulk move wiring contract', () => {
   it('T001: shows Move to Board action when tickets are selected', () => {
-    const source = read('./TicketingDashboard.tsx');
+    const dashboard = read('./TicketingDashboard.tsx');
+    const bar = read('./BulkTicketActionBar.tsx');
 
-    expect(source).toContain('{hasSelection && canUpdateTickets && (');
-    expect(source).toContain('id={`${id}-bulk-move-button`}');
-    expect(source).toContain('Move to Board');
+    expect(dashboard).toContain('<BulkTicketActionBar');
+    expect(dashboard).toContain('showMove={canUpdateTickets}');
+    expect(bar).toContain('id={`${idPrefix}-move-button`}');
+    expect(bar).toContain("'bulk.actionBar.move'");
   });
 
   it('T002: hides Move to Board action when user cannot update tickets', () => {
-    const source = read('./TicketingDashboard.tsx');
+    const dashboard = read('./TicketingDashboard.tsx');
+    const bar = read('./BulkTicketActionBar.tsx');
 
-    expect(source).toContain('hasSelection && canUpdateTickets && (');
+    expect(dashboard).toContain('showMove={canUpdateTickets}');
+    expect(bar).toContain('{showMove && (');
   });
 
   it('T003: opens a bulk move dialog with destination board and status controls', () => {
@@ -84,10 +88,13 @@ describe('ticketing dashboard bulk move wiring contract', () => {
   });
 
   it('T018: bulk delete behavior remains in place', () => {
-    const source = read('./TicketingDashboard.tsx');
+    const dashboard = read('./TicketingDashboard.tsx');
+    const bar = read('./BulkTicketActionBar.tsx');
 
-    expect(source).toContain('id={`${id}-bulk-delete-button`}');
-    expect(source).toContain('id={`${id}-bulk-delete-dialog`}');
-    expect(source).toContain('setBulkDeleteErrors([]);');
+    // Trigger button now lives on the floating action bar.
+    expect(bar).toContain('id={`${idPrefix}-delete-button`}');
+    // Dialog and reset wiring remain on the dashboard.
+    expect(dashboard).toContain('id={`${id}-bulk-delete-dialog`}');
+    expect(dashboard).toContain('setBulkDeleteErrors([]);');
   });
 });

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -51,7 +51,7 @@ import {
 } from '../actions/ticketActions';
 import { getBoardTicketStatuses } from '../actions/board-actions/boardTicketStatusActions';
 import { bundleTicketsAction, getBundleMasterStatusAction } from '../actions/ticketBundleActions';
-import { fetchBundleChildrenForMaster, fetchTicketsWithPagination, getAllMatchingTicketIds } from '../actions/optimizedTicketActions';
+import { fetchBundleChildrenForMaster, fetchTicketsWithPagination, getAllMatchingTicketIds, getTicketBoardIds } from '../actions/optimizedTicketActions';
 import TicketExportDialog from './TicketExportDialog';
 import TicketImportDialog from './TicketImportDialog';
 import { XCircle, Clock, Download, Upload, ChevronDown, Printer, Settings2 } from 'lucide-react';
@@ -250,6 +250,9 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [tickets, setTickets] = useState<ITicketListItem[]>(initialTickets);
   const [selectedTicketIds, setSelectedTicketIds] = useState<Set<string>>(new Set());
   const [allMatchingMode, setAllMatchingMode] = useState(false);
+  // Boards resolved on demand for selected tickets that aren't on the current page
+  // (paginate-then-select / select-all-matching). Maps ticket_id -> board_id (or null).
+  const [offPageBoardById, setOffPageBoardById] = useState<Record<string, string | null>>({});
   const [visibleTicketIds, setVisibleTicketIds] = useState<string[]>([]);
   const currentUser = user || null;
   const { openDrawer, replaceDrawer } = useDrawer();
@@ -877,6 +880,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const clearSelection = useCallback(() => {
     setSelectedTicketIds(prev => (prev.size === 0 ? prev : new Set<string>()));
     setAllMatchingMode(false);
+    setOffPageBoardById(prev => (Object.keys(prev).length === 0 ? prev : {}));
   }, []);
 
   const visibleTicketIdSet = useMemo(() => new Set(visibleTicketIds.filter((id): id is string => !!id)), [visibleTicketIds]);
@@ -924,22 +928,74 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     return uniqueClientIds.size > 1;
   }, [selectedTicketDetails]);
 
-  const selectedTicketsSharedBoardId = useMemo<string | null>(() => {
-    if (selectedTicketDetails.length === 0) return null;
-    // We can only determine the board from rows loaded on the current page. If the selection
-    // includes off-page tickets (select-all-matching, or selected rows not in the current page),
-    // their boards are unknown — treat as "no shared board" so bulk status stays disabled rather
-    // than attempting a status change that would fail for tickets on other boards.
-    if (allMatchingMode || selectedTicketDetails.length !== selectedTicketIds.size) {
-      return null;
+  // Board id for every ticket currently rendered on the page.
+  const onPageBoardById = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const ticket of tickets) {
+      if (ticket.ticket_id) {
+        map.set(ticket.ticket_id, ticket.board_id ?? null);
+      }
     }
-    const uniqueBoardIds = new Set(
-      selectedTicketDetails
-        .map(detail => detail.board_id)
-        .filter((id): id is string => typeof id === 'string' && id.length > 0)
-    );
+    return map;
+  }, [tickets]);
+
+  // Selected tickets whose board we don't yet know (not on this page, not yet fetched).
+  const unresolvedBoardTicketIds = useMemo(
+    () => selectedTicketIdsArray.filter(
+      id => !onPageBoardById.has(id) && !(id in offPageBoardById)
+    ),
+    [selectedTicketIdsArray, onPageBoardById, offPageBoardById]
+  );
+
+  // While any selected board is still unknown the shared board can't be determined.
+  const isResolvingSelectedBoards = unresolvedBoardTicketIds.length > 0;
+
+  // Fetch boards for off-page selected rows so paginate-then-select and select-all-matching
+  // can still determine a shared board. Both success and failure populate every requested id
+  // (failures resolve to null) so the effect terminates and never refetches in a loop.
+  useEffect(() => {
+    if (unresolvedBoardTicketIds.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      let resolved: Array<{ ticket_id: string; board_id: string | null }> = [];
+      try {
+        resolved = await getTicketBoardIds(unresolvedBoardTicketIds);
+      } catch (error) {
+        console.error('[TicketingDashboard] Failed to resolve selected ticket boards:', error);
+      }
+      if (cancelled) return;
+      setOffPageBoardById(prev => {
+        const next = { ...prev };
+        for (const row of resolved) {
+          next[row.ticket_id] = row.board_id ?? null;
+        }
+        // Any id not returned (unauthorized or fetch failed) resolves to null so it is
+        // treated as "no shared board" rather than being requested again indefinitely.
+        for (const id of unresolvedBoardTicketIds) {
+          if (!(id in next)) next[id] = null;
+        }
+        return next;
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [unresolvedBoardTicketIds]);
+
+  const selectedTicketsSharedBoardId = useMemo<string | null>(() => {
+    if (selectedTicketIds.size === 0) return null;
+    // Wait until every selected ticket's board is known.
+    if (isResolvingSelectedBoards) return null;
+    const uniqueBoardIds = new Set<string>();
+    for (const id of selectedTicketIdsArray) {
+      const boardId = onPageBoardById.has(id) ? onPageBoardById.get(id) : offPageBoardById[id];
+      // A selected ticket with no board (or one we couldn't resolve) means there's no
+      // single board to scope the status change to.
+      if (typeof boardId !== 'string' || boardId.length === 0) return null;
+      uniqueBoardIds.add(boardId);
+    }
     return uniqueBoardIds.size === 1 ? Array.from(uniqueBoardIds)[0] : null;
-  }, [selectedTicketDetails, allMatchingMode, selectedTicketIds.size]);
+  }, [selectedTicketIds.size, selectedTicketIdsArray, isResolvingSelectedBoards, onPageBoardById, offPageBoardById]);
 
   const hasSelection = selectedTicketIds.size > 0;
   const showSelectAllBanner = allVisibleTicketsSelected && !hasHiddenSelections && !allMatchingMode && totalCount > visibleTicketIds.length && visibleTicketIds.length > 0;
@@ -2667,7 +2723,9 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         showTags={canUpdateTickets}
         showDueDate={canUpdateTickets}
         statusDisabled={!selectedTicketsSharedBoardId}
-        statusDisabledTitle={t('bulk.actionBar.statusDisabledMultiBoard', 'Selected tickets are on different boards')}
+        statusDisabledTitle={isResolvingSelectedBoards
+          ? t('bulk.actionBar.statusResolvingBoards', 'Checking the boards of selected tickets…')
+          : t('bulk.actionBar.statusDisabledMultiBoard', 'Selected tickets are on different boards')}
         onMove={() => {
           setBulkMoveErrors([]);
           setSelectedDestinationBoardId('');

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -24,6 +24,7 @@ import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
 import { BoardPicker } from '@alga-psa/ui/components/settings/general/BoardPicker';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
 import { TagFilter } from '@alga-psa/ui/components';
+import type { TagSize } from '@alga-psa/ui/components/tags';
 import { usePrintAction } from '@alga-psa/ui/components/PrintButton';
 import {
   PrintOptionsDialog,
@@ -137,24 +138,41 @@ const normalizeTicketListDensityLevel = (value: number): number => {
 };
 
 // Indexed by zoom/10; `[&>td_*]:!text-[Xpx]` forces descendant elements to follow the row font-size.
+// `tagSize` scales tag padding/gap/icons (font already tracks the row override); sm for the compact
+// half, md for the spacious half — md matches the look tags have at the spacious end today.
+// `filterControlClass` scales the filter controls' height + font via a cascade on the filter rows.
+// These MUST be literal strings so Tailwind's scanner generates the arbitrary utilities — do not
+// build them via interpolation. Applied to Row 1 directly and to a `display:contents` wrapper around
+// Row 2's filter controls so the Bundled toggle / density control stay untouched.
+// 5 bands change every ~2 zoom steps; spacious anchors at ~38px/14px (today's size).
+const FILTER_CONTROL_SHARED =
+  '[&_button]:!min-h-0 [&_button]:!py-0 [&_button]:!items-center';
+const FILTER_CONTROL_30_12 = `[&_button]:!h-[30px] [&_input]:!h-[30px] [&_button]:!text-[12px] [&_input]:!text-[12px] ${FILTER_CONTROL_SHARED}`;
+const FILTER_CONTROL_32_12 = `[&_button]:!h-[32px] [&_input]:!h-[32px] [&_button]:!text-[12px] [&_input]:!text-[12px] ${FILTER_CONTROL_SHARED}`;
+const FILTER_CONTROL_34_13 = `[&_button]:!h-[34px] [&_input]:!h-[34px] [&_button]:!text-[13px] [&_input]:!text-[13px] ${FILTER_CONTROL_SHARED}`;
+const FILTER_CONTROL_36_13 = `[&_button]:!h-[36px] [&_input]:!h-[36px] [&_button]:!text-[13px] [&_input]:!text-[13px] ${FILTER_CONTROL_SHARED}`;
+const FILTER_CONTROL_38_14 = `[&_button]:!h-[38px] [&_input]:!h-[38px] [&_button]:!text-[14px] [&_input]:!text-[14px] ${FILTER_CONTROL_SHARED}`;
+
 const TICKET_LIST_DENSITY_PRESETS: ReadonlyArray<{
   filterPadding: string;
   filterGap: string;
   bodyPadding: string;
   tableRowDensity: string;
   minColumnWidth: number;
+  tagSize: TagSize;
+  filterControlClass: string;
 }> = [
-  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-2.5', tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[11px] [&>td_*]:!text-[11px]', minColumnWidth: 80 },
-  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px] [&>td_*]:!text-[12px]',   minColumnWidth: 90 },
-  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[12px] [&>td_*]:!text-[12px]', minColumnWidth: 100 },
-  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3.5', tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[13px] [&>td_*]:!text-[13px]',   minColumnWidth: 105 },
-  { filterPadding: 'p-4',   filterGap: 'gap-3',   bodyPadding: 'p-4',   tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[13px] [&>td_*]:!text-[13px]', minColumnWidth: 115 },
-  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3 [&>td]:!text-[14px] [&>td_*]:!text-[14px]',   minColumnWidth: 130 },
-  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[14px] [&>td_*]:!text-[14px]', minColumnWidth: 145 },
-  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-6',   tableRowDensity: '[&>td]:!py-4 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 165 },
-  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 185 },
-  { filterPadding: 'p-7',   filterGap: 'gap-6',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-6 [&>td]:!text-[16px] [&>td_*]:!text-[16px]',   minColumnWidth: 210 },
-  { filterPadding: 'p-8',   filterGap: 'gap-6',   bodyPadding: 'p-8',   tableRowDensity: '[&>td]:!py-7 [&>td]:!text-[17px] [&>td_*]:!text-[17px]',   minColumnWidth: 240 },
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-2.5', tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[11px] [&>td_*]:!text-[11px]', minColumnWidth: 80,  tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px] [&>td_*]:!text-[12px]',   minColumnWidth: 90,  tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[12px] [&>td_*]:!text-[12px]', minColumnWidth: 100, tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3.5', tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[13px] [&>td_*]:!text-[13px]',   minColumnWidth: 105, tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
+  { filterPadding: 'p-4',   filterGap: 'gap-3',   bodyPadding: 'p-4',   tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[13px] [&>td_*]:!text-[13px]', minColumnWidth: 115, tagSize: 'sm', filterControlClass: FILTER_CONTROL_34_13 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3 [&>td]:!text-[14px] [&>td_*]:!text-[14px]',   minColumnWidth: 130, tagSize: 'md', filterControlClass: FILTER_CONTROL_34_13 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[14px] [&>td_*]:!text-[14px]', minColumnWidth: 145, tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-6',   tableRowDensity: '[&>td]:!py-4 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 165, tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 185, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
+  { filterPadding: 'p-7',   filterGap: 'gap-6',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-6 [&>td]:!text-[16px] [&>td_*]:!text-[16px]',   minColumnWidth: 210, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
+  { filterPadding: 'p-8',   filterGap: 'gap-6',   bodyPadding: 'p-8',   tableRowDensity: '[&>td]:!py-7 [&>td]:!text-[17px] [&>td_*]:!text-[17px]',   minColumnWidth: 240, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
 ];
 
 function formatPrintDate(value?: string | null): string {
@@ -941,6 +959,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       onTicketClick: handleTicketClick,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
+      tagSize: densityClasses.tagSize,
       showClient: true,
       onClientClick: onQuickViewClient,
       additionalAgentAvatarUrls,
@@ -1051,6 +1070,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     isBundleExpanded,
     toggleBundleExpanded,
     bundleView,
+    densityClasses.tagSize,
     t,
   ]);
 
@@ -1916,7 +1936,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           <ReflectionContainer id={`${id}-filters`} label="Ticket DashboardFilters">
             <div className={`space-y-3`}>
               {/* Row 1: Primary filters */}
-              <div className={`flex items-center ${densityClasses.filterGap}`}>
+              <div className={`flex items-center ${densityClasses.filterGap} ${densityClasses.filterControlClass}`}>
                 <BoardPicker
                   id={`${id}-board-picker`}
                   boards={boards}
@@ -2046,6 +2066,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
 
               {/* Row 2: Category, search, tags, reset, bundled, density */}
               <div className={`flex items-center ${densityClasses.filterGap}`}>
+                <div className={`contents ${densityClasses.filterControlClass}`}>
                 <CategoryPicker
                   id={`${id}-category-picker`}
                   categories={categories}
@@ -2100,6 +2121,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                   }}
                   onClearTags={() => onFilterChange({ tags: undefined })}
                 />
+                </div>
                 <Button
                   variant="ghost"
                   size="sm"
@@ -2113,13 +2135,14 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                 </Button>
                 <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />
                 <div className="flex items-center gap-2 shrink-0">
-                  <Label htmlFor={`${id}-bundle-view-toggle`} className="text-sm text-gray-600">
+                  <Label htmlFor={`${id}-bundle-view-toggle`} className={`${densityClasses.tagSize === 'sm' ? 'text-xs' : 'text-sm'} text-gray-600`}>
                     {t('dashboard.bundledToggle', 'Bundled')}
                   </Label>
                   <Switch
                     id={`${id}-bundle-view-toggle`}
                     checked={bundleView === 'bundled'}
                     onCheckedChange={(checked) => onFilterChange({ bundleView: checked ? 'bundled' : 'individual' })}
+                    size={densityClasses.tagSize}
                   />
                 </div>
                 <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -158,21 +158,20 @@ const TICKET_LIST_DENSITY_PRESETS: ReadonlyArray<{
   filterGap: string;
   bodyPadding: string;
   tableRowDensity: string;
-  minColumnWidth: number;
   tagSize: TagSize;
   filterControlClass: string;
 }> = [
-  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-2.5', tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[11px] [&>td_*]:!text-[11px]', minColumnWidth: 80,  tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
-  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px] [&>td_*]:!text-[12px]',   minColumnWidth: 90,  tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
-  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[12px] [&>td_*]:!text-[12px]', minColumnWidth: 100, tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
-  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3.5', tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[13px] [&>td_*]:!text-[13px]',   minColumnWidth: 105, tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
-  { filterPadding: 'p-4',   filterGap: 'gap-3',   bodyPadding: 'p-4',   tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[13px] [&>td_*]:!text-[13px]', minColumnWidth: 115, tagSize: 'sm', filterControlClass: FILTER_CONTROL_34_13 },
-  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3 [&>td]:!text-[14px] [&>td_*]:!text-[14px]',   minColumnWidth: 130, tagSize: 'md', filterControlClass: FILTER_CONTROL_34_13 },
-  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[14px] [&>td_*]:!text-[14px]', minColumnWidth: 145, tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
-  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-6',   tableRowDensity: '[&>td]:!py-4 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 165, tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
-  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 185, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
-  { filterPadding: 'p-7',   filterGap: 'gap-6',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-6 [&>td]:!text-[16px] [&>td_*]:!text-[16px]',   minColumnWidth: 210, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
-  { filterPadding: 'p-8',   filterGap: 'gap-6',   bodyPadding: 'p-8',   tableRowDensity: '[&>td]:!py-7 [&>td]:!text-[17px] [&>td_*]:!text-[17px]',   minColumnWidth: 240, tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-2.5', tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[11px] [&>td_*]:!text-[11px]', tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px] [&>td_*]:!text-[12px]',   tagSize: 'sm', filterControlClass: FILTER_CONTROL_30_12 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[12px] [&>td_*]:!text-[12px]', tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3.5', tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[13px] [&>td_*]:!text-[13px]',   tagSize: 'sm', filterControlClass: FILTER_CONTROL_32_12 },
+  { filterPadding: 'p-4',   filterGap: 'gap-3',   bodyPadding: 'p-4',   tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[13px] [&>td_*]:!text-[13px]', tagSize: 'sm', filterControlClass: FILTER_CONTROL_34_13 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3 [&>td]:!text-[14px] [&>td_*]:!text-[14px]',   tagSize: 'md', filterControlClass: FILTER_CONTROL_34_13 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[14px] [&>td_*]:!text-[14px]', tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-6',   tableRowDensity: '[&>td]:!py-4 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   tagSize: 'md', filterControlClass: FILTER_CONTROL_36_13 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
+  { filterPadding: 'p-7',   filterGap: 'gap-6',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-6 [&>td]:!text-[16px] [&>td_*]:!text-[16px]',   tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
+  { filterPadding: 'p-8',   filterGap: 'gap-6',   bodyPadding: 'p-8',   tableRowDensity: '[&>td]:!py-7 [&>td]:!text-[17px] [&>td_*]:!text-[17px]',   tagSize: 'md', filterControlClass: FILTER_CONTROL_38_14 },
 ];
 
 function formatPrintDate(value?: string | null): string {
@@ -927,13 +926,20 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
 
   const selectedTicketsSharedBoardId = useMemo<string | null>(() => {
     if (selectedTicketDetails.length === 0) return null;
+    // We can only determine the board from rows loaded on the current page. If the selection
+    // includes off-page tickets (select-all-matching, or selected rows not in the current page),
+    // their boards are unknown — treat as "no shared board" so bulk status stays disabled rather
+    // than attempting a status change that would fail for tickets on other boards.
+    if (allMatchingMode || selectedTicketDetails.length !== selectedTicketIds.size) {
+      return null;
+    }
     const uniqueBoardIds = new Set(
       selectedTicketDetails
         .map(detail => detail.board_id)
         .filter((id): id is string => typeof id === 'string' && id.length > 0)
     );
     return uniqueBoardIds.size === 1 ? Array.from(uniqueBoardIds)[0] : null;
-  }, [selectedTicketDetails]);
+  }, [selectedTicketDetails, allMatchingMode, selectedTicketIds.size]);
 
   const hasSelection = selectedTicketIds.size > 0;
   const showSelectAllBanner = allVisibleTicketsSelected && !hasHiddenSelections && !allMatchingMode && totalCount > visibleTicketIds.length && visibleTicketIds.length > 0;
@@ -2228,7 +2234,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
               pageSize={pageSize}
               totalItems={totalCount}
               onItemsPerPageChange={onPageSizeChange}
-              minColumnWidth={densityClasses.minColumnWidth}
               rowClassName={(record: ITicketListItem) =>
                 `${densityClasses.tableRowDensity} cursor-pointer ${record.ticket_id && selectedTicketIds.has(record.ticket_id)
                   ? '!bg-table-selected'

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -3,11 +3,16 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
-import { ITicket, ITicketListItem, ITicketCategory, ITicketListFilters, DeletionValidationResult } from '@alga-psa/types';
+import { ITicket, ITicketListItem, ITicketCategory, ITicketListFilters } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
 import { QuickAddTicket } from './QuickAddTicket';
 import { CategoryPicker } from './CategoryPicker';
 import BulkTicketActionBar from './BulkTicketActionBar';
+import BulkAssignTicketsDialog from './BulkAssignTicketsDialog';
+import BulkAddTagsDialog from './BulkAddTagsDialog';
+import BulkSetDueDateDialog from './BulkSetDueDateDialog';
+import BulkChangeStatusDialog from './BulkChangeStatusDialog';
+import BulkChangePriorityDialog from './BulkChangePriorityDialog';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { PrioritySelect } from '@alga-psa/ui/components';
 import { Button } from '@alga-psa/ui/components/Button';
@@ -31,10 +36,18 @@ import { useTagPermissions } from '@alga-psa/tags/hooks';
 import { IBoard, IClient, IUser, ITeam } from '@alga-psa/types';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
-import { DeleteEntityDialog } from '@alga-psa/ui';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { ColumnDefinition } from '@alga-psa/types';
-import { deleteTicket, deleteTickets, moveTicketsToBoard } from '../actions/ticketActions';
+import {
+  deleteTickets,
+  moveTicketsToBoard,
+  bulkAssignTickets,
+  bulkAddTagsToTickets,
+  bulkUpdateTicketDueDate,
+  bulkUpdateTicketStatus,
+  bulkUpdateTicketPriority,
+  type BulkTicketAssignSelection,
+} from '../actions/ticketActions';
 import { getBoardTicketStatuses } from '../actions/board-actions/boardTicketStatusActions';
 import { bundleTicketsAction, getBundleMasterStatusAction } from '../actions/ticketBundleActions';
 import { fetchBundleChildrenForMaster, fetchTicketsWithPagination, getAllMatchingTicketIds } from '../actions/optimizedTicketActions';
@@ -55,7 +68,6 @@ import QuickAddCategory from './QuickAddCategory';
 import MultiUserAndTeamPicker from '@alga-psa/ui/components/MultiUserAndTeamPicker';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
-import { preCheckDeletion } from '@alga-psa/auth/lib/preCheckDeletion';
 import ViewDensityControl from '@alga-psa/ui/components/ViewDensityControl';
 import { useDrawer } from '@alga-psa/ui';
 import { getClientById } from '../actions/clientLookupActions';
@@ -222,11 +234,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [selectedTicketIds, setSelectedTicketIds] = useState<Set<string>>(new Set());
   const [allMatchingMode, setAllMatchingMode] = useState(false);
   const [visibleTicketIds, setVisibleTicketIds] = useState<string[]>([]);
-  const [ticketToDelete, setTicketToDelete] = useState<string | null>(null);
-  const [ticketToDeleteName, setTicketToDeleteName] = useState<string | null>(null);
-  const [deleteValidation, setDeleteValidation] = useState<DeletionValidationResult | null>(null);
-  const [isDeleteValidating, setIsDeleteValidating] = useState(false);
-  const [isDeleteProcessing, setIsDeleteProcessing] = useState(false);
   const currentUser = user || null;
   const { openDrawer, replaceDrawer } = useDrawer();
   const [isBulkDeleteDialogOpen, setIsBulkDeleteDialogOpen] = useState(false);
@@ -253,6 +260,24 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [printTickets, setPrintTickets] = useState<ITicketListItem[] | null>(null);
   const [isPrintOptionsOpen, setIsPrintOptionsOpen] = useState(false);
+
+  const [isBulkAssignDialogOpen, setIsBulkAssignDialogOpen] = useState(false);
+  const [isBulkAssigning, setIsBulkAssigning] = useState(false);
+  const [bulkAssignErrors, setBulkAssignErrors] = useState<Array<{ ticketId: string; message: string }>>([]);
+  const [isBulkTagsDialogOpen, setIsBulkTagsDialogOpen] = useState(false);
+  const [isBulkAddingTags, setIsBulkAddingTags] = useState(false);
+  const [bulkTagsErrors, setBulkTagsErrors] = useState<Array<{ ticketId: string; message: string }>>([]);
+  const [isBulkDueDateDialogOpen, setIsBulkDueDateDialogOpen] = useState(false);
+  const [isBulkUpdatingDueDate, setIsBulkUpdatingDueDate] = useState(false);
+  const [bulkDueDateErrors, setBulkDueDateErrors] = useState<Array<{ ticketId: string; message: string }>>([]);
+  const [isBulkStatusDialogOpen, setIsBulkStatusDialogOpen] = useState(false);
+  const [isBulkUpdatingStatus, setIsBulkUpdatingStatus] = useState(false);
+  const [bulkStatusErrors, setBulkStatusErrors] = useState<Array<{ ticketId: string; message: string }>>([]);
+  const [bulkStatusOptions, setBulkStatusOptions] = useState<SelectOption[]>([]);
+  const [isLoadingBulkStatusOptions, setIsLoadingBulkStatusOptions] = useState(false);
+  const [isBulkPriorityDialogOpen, setIsBulkPriorityDialogOpen] = useState(false);
+  const [isBulkUpdatingPriority, setIsBulkUpdatingPriority] = useState(false);
+  const [bulkPriorityErrors, setBulkPriorityErrors] = useState<Array<{ ticketId: string; message: string }>>([]);
 
   const [boards] = useState<IBoard[]>(initialBoards);
   const [clients] = useState<IClient[]>(initialClients);
@@ -483,39 +508,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     return params.toString();
   }, [allowSlaStatusFilter, filterValues, sortBy, sortDirection, currentPage, pageSize]);
 
-  const resetDeleteState = () => {
-    setTicketToDelete(null);
-    setTicketToDeleteName(null);
-    setDeleteValidation(null);
-    setIsDeleteValidating(false);
-    setIsDeleteProcessing(false);
-  };
-
-  const runDeleteValidation = useCallback(async (ticketId: string) => {
-    setIsDeleteValidating(true);
-    try {
-      const result = await preCheckDeletion('ticket', ticketId);
-      setDeleteValidation(result);
-    } catch (error) {
-      console.error('Failed to validate ticket deletion:', error);
-      setDeleteValidation({
-        canDelete: false,
-        code: 'VALIDATION_FAILED',
-        message: t('errors.validateDeletionFailed', 'Failed to validate deletion. Please try again.'),
-        dependencies: [],
-        alternatives: []
-      });
-    } finally {
-      setIsDeleteValidating(false);
-    }
-  }, [t]);
-
-  const handleDeleteTicket = (ticketId: string, ticketNameOrNumber: string) => {
-    setTicketToDelete(ticketId);
-    setTicketToDeleteName(ticketNameOrNumber);
-    void runDeleteValidation(ticketId);
-  };
-  
   const onQuickViewClient = useCallback(async (clientId: string) => {
     if (!clientId) return;
 
@@ -559,42 +551,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   
   // Use interval tracking hook to get interval count
   const { intervalCount, isLoading: isLoadingIntervals } = useIntervalTracking(currentUser?.user_id);
-
-  const confirmDeleteTicket = async () => {
-    if (!ticketToDelete) return;
-
-    try {
-      setIsDeleteProcessing(true);
-      const result = await deleteTicket(ticketToDelete);
-
-      if (!result.success) {
-        setDeleteValidation(result);
-        return;
-      }
-
-      setTickets(prev => prev.filter(t => t.ticket_id !== ticketToDelete));
-      setSelectedTicketIds(prev => {
-        if (!ticketToDelete || !prev.has(ticketToDelete)) {
-          return prev;
-        }
-        const next = new Set(prev);
-        next.delete(ticketToDelete);
-        return next;
-      });
-      resetDeleteState();
-    } catch (error: any) {
-      console.error('Failed to delete ticket:', error);
-      setDeleteValidation({
-        canDelete: false,
-        code: 'VALIDATION_FAILED',
-        message: error?.message || t('errors.deleteTicketUnexpected', 'An unexpected error occurred while deleting the ticket.'),
-        dependencies: [],
-        alternatives: []
-      });
-    } finally {
-      setIsDeleteProcessing(false);
-    }
-  };
 
   // Custom function for clicking on tickets with filter preservation
   const handleTicketClick = useCallback((ticketId: string) => {
@@ -916,7 +872,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const isSelectionIndeterminate = selectedTicketIds.size > 0 && !allVisibleTicketsSelected;
   const selectedTicketDetails = useMemo(() => {
     if (selectedTicketIds.size === 0) {
-      return [] as Array<{ ticket_id: string; ticket_number?: string; title?: string; client_id?: string | null; client_name?: string }>;
+      return [] as Array<{ ticket_id: string; ticket_number?: string; title?: string; client_id?: string | null; client_name?: string; board_id?: string | null }>;
     }
 
     const selectedSet = new Set(selectedTicketIds);
@@ -929,6 +885,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         title: ticket.title,
         client_id: ticket.client_id ?? null,
         client_name: ticket.client_name,
+        board_id: ticket.board_id ?? null,
       }))
       .sort((a, b) => {
         if (a.ticket_number && b.ticket_number) {
@@ -948,6 +905,16 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         .filter((id): id is string => typeof id === 'string' && id.length > 0)
     );
     return uniqueClientIds.size > 1;
+  }, [selectedTicketDetails]);
+
+  const selectedTicketsSharedBoardId = useMemo<string | null>(() => {
+    if (selectedTicketDetails.length === 0) return null;
+    const uniqueBoardIds = new Set(
+      selectedTicketDetails
+        .map(detail => detail.board_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    );
+    return uniqueBoardIds.size === 1 ? Array.from(uniqueBoardIds)[0] : null;
   }, [selectedTicketDetails]);
 
   const hasSelection = selectedTicketIds.size > 0;
@@ -972,7 +939,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       boards,
       displaySettings: displaySettings || undefined,
       onTicketClick: handleTicketClick,
-      onDeleteClick: handleDeleteTicket,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
       showClient: true,
@@ -1068,7 +1034,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     boards,
     displaySettings,
     handleTicketClick,
-    handleDeleteTicket,
     handleTagsChange,
     ticketTagsRef,
     onQuickViewClient,
@@ -1226,6 +1191,256 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     }
   }, [selectedTicketIdsArray, clearSelection, currentUser, t]);
 
+  const handleConfirmBulkAssign = useCallback(async (selection: BulkTicketAssignSelection) => {
+    if (selectedTicketIdsArray.length === 0) return;
+    if (!currentUser) {
+      toast.error(t('bulk.auth.assignRequired', 'You must be logged in to reassign tickets'));
+      return;
+    }
+
+    setIsBulkAssigning(true);
+    setBulkAssignErrors([]);
+
+    try {
+      const result = await bulkAssignTickets(selectedTicketIdsArray, selection);
+
+      if (result.updatedIds.length > 0) {
+        onFilterChange({});
+      }
+
+      if (result.failed.length > 0) {
+        setBulkAssignErrors(result.failed);
+        setSelectedTicketIds(() => new Set(result.failed.map(item => item.ticketId)));
+        toast.error(t('bulk.assign.partialFailure', 'Some tickets could not be reassigned'));
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.assign.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? '{{count}} ticket reassigned' : '{{count}} tickets reassigned',
+          }));
+        }
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.assign.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? '{{count}} ticket reassigned' : '{{count}} tickets reassigned',
+          }));
+        }
+        clearSelection();
+        setIsBulkAssignDialogOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('bulk.assign.failure', 'Failed to reassign selected tickets'));
+    } finally {
+      setIsBulkAssigning(false);
+    }
+  }, [selectedTicketIdsArray, currentUser, onFilterChange, clearSelection, t]);
+
+  const handleConfirmBulkAddTags = useCallback(async (tagTexts: string[]) => {
+    if (selectedTicketIdsArray.length === 0 || tagTexts.length === 0) return;
+    if (!currentUser) {
+      toast.error(t('bulk.auth.tagsRequired', 'You must be logged in to add tags'));
+      return;
+    }
+
+    setIsBulkAddingTags(true);
+    setBulkTagsErrors([]);
+
+    try {
+      const result = await bulkAddTagsToTickets(selectedTicketIdsArray, tagTexts);
+
+      if (result.updatedIds.length > 0) {
+        onFilterChange({});
+      }
+
+      if (result.failed.length > 0) {
+        setBulkTagsErrors(result.failed);
+        setSelectedTicketIds(() => new Set(result.failed.map(item => item.ticketId)));
+        toast.error(t('bulk.tags.partialFailure', 'Tags could not be added to some tickets'));
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.tags.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Tags added to {{count}} ticket' : 'Tags added to {{count}} tickets',
+          }));
+        }
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.tags.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Tags added to {{count}} ticket' : 'Tags added to {{count}} tickets',
+          }));
+        }
+        clearSelection();
+        setIsBulkTagsDialogOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('bulk.tags.failure', 'Failed to add tags to selected tickets'));
+    } finally {
+      setIsBulkAddingTags(false);
+    }
+  }, [selectedTicketIdsArray, currentUser, onFilterChange, clearSelection, t]);
+
+  const handleConfirmBulkDueDate = useCallback(async (dueDateIso: string | null) => {
+    if (selectedTicketIdsArray.length === 0) return;
+    if (!currentUser) {
+      toast.error(t('bulk.auth.dueDateRequired', 'You must be logged in to update tickets'));
+      return;
+    }
+
+    setIsBulkUpdatingDueDate(true);
+    setBulkDueDateErrors([]);
+
+    try {
+      const result = await bulkUpdateTicketDueDate(selectedTicketIdsArray, dueDateIso);
+
+      if (result.updatedIds.length > 0) {
+        onFilterChange({});
+      }
+
+      if (result.failed.length > 0) {
+        setBulkDueDateErrors(result.failed);
+        setSelectedTicketIds(() => new Set(result.failed.map(item => item.ticketId)));
+        toast.error(t('bulk.dueDate.partialFailure', 'Due date could not be updated on some tickets'));
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.dueDate.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Due date updated on {{count}} ticket' : 'Due date updated on {{count}} tickets',
+          }));
+        }
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.dueDate.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Due date updated on {{count}} ticket' : 'Due date updated on {{count}} tickets',
+          }));
+        }
+        clearSelection();
+        setIsBulkDueDateDialogOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('bulk.dueDate.failure', 'Failed to update due date on selected tickets'));
+    } finally {
+      setIsBulkUpdatingDueDate(false);
+    }
+  }, [selectedTicketIdsArray, currentUser, onFilterChange, clearSelection, t]);
+
+  // Load statuses for the selected tickets' shared board when the Status dialog opens.
+  useEffect(() => {
+    if (!isBulkStatusDialogOpen) return;
+    if (!selectedTicketsSharedBoardId) {
+      setBulkStatusOptions([]);
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingBulkStatusOptions(true);
+    getBoardTicketStatuses(selectedTicketsSharedBoardId)
+      .then(statuses => {
+        if (cancelled) return;
+        setBulkStatusOptions(statuses.map((s: { status_id: string; name: string }) => ({
+          value: s.status_id,
+          label: s.name,
+        })));
+      })
+      .catch(error => {
+        if (cancelled) return;
+        console.error('[TicketingDashboard] Failed to load bulk status options:', error);
+        setBulkStatusOptions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingBulkStatusOptions(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isBulkStatusDialogOpen, selectedTicketsSharedBoardId]);
+
+  const handleConfirmBulkStatus = useCallback(async (statusId: string) => {
+    if (selectedTicketIdsArray.length === 0) return;
+    if (!currentUser) {
+      toast.error(t('bulk.auth.statusRequired', 'You must be logged in to update tickets'));
+      return;
+    }
+
+    setIsBulkUpdatingStatus(true);
+    setBulkStatusErrors([]);
+
+    try {
+      const result = await bulkUpdateTicketStatus(selectedTicketIdsArray, statusId);
+
+      if (result.updatedIds.length > 0) {
+        onFilterChange({});
+      }
+
+      if (result.failed.length > 0) {
+        setBulkStatusErrors(result.failed);
+        setSelectedTicketIds(() => new Set(result.failed.map(item => item.ticketId)));
+        toast.error(t('bulk.status.partialFailure', 'Status could not be updated on some tickets'));
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.status.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Status updated on {{count}} ticket' : 'Status updated on {{count}} tickets',
+          }));
+        }
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.status.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Status updated on {{count}} ticket' : 'Status updated on {{count}} tickets',
+          }));
+        }
+        clearSelection();
+        setIsBulkStatusDialogOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('bulk.status.failure', 'Failed to update status on selected tickets'));
+    } finally {
+      setIsBulkUpdatingStatus(false);
+    }
+  }, [selectedTicketIdsArray, currentUser, onFilterChange, clearSelection, t]);
+
+  const handleConfirmBulkPriority = useCallback(async (priorityId: string) => {
+    if (selectedTicketIdsArray.length === 0) return;
+    if (!currentUser) {
+      toast.error(t('bulk.auth.priorityRequired', 'You must be logged in to update tickets'));
+      return;
+    }
+
+    setIsBulkUpdatingPriority(true);
+    setBulkPriorityErrors([]);
+
+    try {
+      const result = await bulkUpdateTicketPriority(selectedTicketIdsArray, priorityId);
+
+      if (result.updatedIds.length > 0) {
+        onFilterChange({});
+      }
+
+      if (result.failed.length > 0) {
+        setBulkPriorityErrors(result.failed);
+        setSelectedTicketIds(() => new Set(result.failed.map(item => item.ticketId)));
+        toast.error(t('bulk.priority.partialFailure', 'Priority could not be updated on some tickets'));
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.priority.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Priority updated on {{count}} ticket' : 'Priority updated on {{count}} tickets',
+          }));
+        }
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(t('bulk.priority.success', {
+            count: result.updatedIds.length,
+            defaultValue: result.updatedIds.length === 1 ? 'Priority updated on {{count}} ticket' : 'Priority updated on {{count}} tickets',
+          }));
+        }
+        clearSelection();
+        setIsBulkPriorityDialogOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('bulk.priority.failure', 'Failed to update priority on selected tickets'));
+    } finally {
+      setIsBulkUpdatingPriority(false);
+    }
+  }, [selectedTicketIdsArray, currentUser, onFilterChange, clearSelection, t]);
+
   // When the bundle dialog opens, check which of the selected tickets are already
   // bundle masters of other bundles. Masters can't be added as children, so we must
   // either force them to BE the master or block the operation entirely.
@@ -1373,10 +1588,8 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         },
       },
       onTicketClick: handleTicketClick,
-      onDeleteClick: handleDeleteTicket,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
-      showActions: false,
       showTags: true,
       showClient: true,
       onClientClick: onQuickViewClient,
@@ -1450,7 +1663,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     bundleView,
     categories,
     displaySettings,
-    handleDeleteTicket,
     handleTagsChange,
     handleTicketClick,
     isBundleExpanded,
@@ -2067,16 +2279,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         onTicketAdded={handleTicketAdded}
         isAlgaDeskMode={useAlgaDeskQuickAddForm}
       />
-      <DeleteEntityDialog
-        id={`${id}-delete-ticket-dialog`}
-        isOpen={!!ticketToDelete}
-        onClose={resetDeleteState}
-        onConfirmDelete={confirmDeleteTicket}
-        entityName={ticketToDeleteName || ticketToDelete || t('bulk.delete.entityFallback', 'this ticket')}
-        validationResult={deleteValidation}
-        isValidating={isDeleteValidating}
-        isDeleting={isDeleteProcessing}
-      />
       <ConfirmationDialog
         id={`${id}-bundle-multi-client-confirm`}
         isOpen={isMultiClientBundleConfirmOpen}
@@ -2426,6 +2628,13 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         count={selectedTicketIds.size}
         showMove={canUpdateTickets}
         showBundle={canUpdateTickets}
+        showAssign={canUpdateTickets}
+        showStatus={canUpdateTickets}
+        showPriority={canUpdateTickets}
+        showTags={canUpdateTickets}
+        showDueDate={canUpdateTickets}
+        statusDisabled={!selectedTicketsSharedBoardId}
+        statusDisabledTitle={t('bulk.actionBar.statusDisabledMultiBoard', 'Selected tickets are on different boards')}
         onMove={() => {
           setBulkMoveErrors([]);
           setSelectedDestinationBoardId('');
@@ -2441,11 +2650,96 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           setBundleSyncUpdates(true);
           setIsBundleDialogOpen(true);
         }}
+        onAssign={() => {
+          setBulkAssignErrors([]);
+          setIsBulkAssignDialogOpen(true);
+        }}
+        onStatus={() => {
+          setBulkStatusErrors([]);
+          setBulkStatusOptions([]);
+          setIsBulkStatusDialogOpen(true);
+        }}
+        onPriority={() => {
+          setBulkPriorityErrors([]);
+          setIsBulkPriorityDialogOpen(true);
+        }}
+        onTags={() => {
+          setBulkTagsErrors([]);
+          setIsBulkTagsDialogOpen(true);
+        }}
+        onDueDate={() => {
+          setBulkDueDateErrors([]);
+          setIsBulkDueDateDialogOpen(true);
+        }}
         onDelete={() => {
           setBulkDeleteErrors([]);
           setIsBulkDeleteDialogOpen(true);
         }}
         onClear={clearSelection}
+      />
+      <BulkAssignTicketsDialog
+        idPrefix={`${id}-bulk-assign`}
+        isOpen={isBulkAssignDialogOpen && hasSelection}
+        onClose={() => setIsBulkAssignDialogOpen(false)}
+        ticketCount={selectedTicketIds.size}
+        users={initialUsers}
+        failed={bulkAssignErrors.map(err => ({
+          ...err,
+          label: selectedTicketDetails.find(d => d.ticket_id === err.ticketId)?.ticket_number,
+        }))}
+        isSubmitting={isBulkAssigning}
+        onConfirm={handleConfirmBulkAssign}
+      />
+      <BulkAddTagsDialog
+        idPrefix={`${id}-bulk-tags`}
+        isOpen={isBulkTagsDialogOpen && hasSelection}
+        onClose={() => setIsBulkTagsDialogOpen(false)}
+        ticketCount={selectedTicketIds.size}
+        failed={bulkTagsErrors.map(err => ({
+          ...err,
+          label: selectedTicketDetails.find(d => d.ticket_id === err.ticketId)?.ticket_number,
+        }))}
+        isSubmitting={isBulkAddingTags}
+        onConfirm={handleConfirmBulkAddTags}
+      />
+      <BulkSetDueDateDialog
+        idPrefix={`${id}-bulk-due-date`}
+        isOpen={isBulkDueDateDialogOpen && hasSelection}
+        onClose={() => setIsBulkDueDateDialogOpen(false)}
+        ticketCount={selectedTicketIds.size}
+        failed={bulkDueDateErrors.map(err => ({
+          ...err,
+          label: selectedTicketDetails.find(d => d.ticket_id === err.ticketId)?.ticket_number,
+        }))}
+        isSubmitting={isBulkUpdatingDueDate}
+        onConfirm={handleConfirmBulkDueDate}
+      />
+      <BulkChangeStatusDialog
+        idPrefix={`${id}-bulk-status`}
+        isOpen={isBulkStatusDialogOpen && hasSelection && !!selectedTicketsSharedBoardId}
+        onClose={() => setIsBulkStatusDialogOpen(false)}
+        ticketCount={selectedTicketIds.size}
+        statuses={bulkStatusOptions}
+        isLoadingStatuses={isLoadingBulkStatusOptions}
+        failed={bulkStatusErrors.map(err => ({
+          ...err,
+          label: selectedTicketDetails.find(d => d.ticket_id === err.ticketId)?.ticket_number,
+        }))}
+        isSubmitting={isBulkUpdatingStatus}
+        onConfirm={handleConfirmBulkStatus}
+      />
+      <BulkChangePriorityDialog
+        idPrefix={`${id}-bulk-priority`}
+        isOpen={isBulkPriorityDialogOpen && hasSelection}
+        onClose={() => setIsBulkPriorityDialogOpen(false)}
+        ticketCount={selectedTicketIds.size}
+        options={priorityOptions}
+        failed={bulkPriorityErrors.map(err => ({
+          ...err,
+          label: selectedTicketDetails.find(d => d.ticket_id === err.ticketId)?.ticket_number,
+        }))}
+        isSubmitting={isBulkUpdatingPriority}
+        onConfirm={handleConfirmBulkPriority}
       />
     </ReflectionContainer>
     {isImportDialogOpen && (

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -1250,7 +1250,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             defaultValue: result.updatedIds.length === 1 ? '{{count}} ticket reassigned' : '{{count}} tickets reassigned',
           }));
         }
-        clearSelection();
+        // Keep the selection so the user can run more bulk actions on the same tickets.
         setIsBulkAssignDialogOpen(false);
       }
     } catch (error) {
@@ -1294,7 +1294,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             defaultValue: result.updatedIds.length === 1 ? 'Tags added to {{count}} ticket' : 'Tags added to {{count}} tickets',
           }));
         }
-        clearSelection();
+        // Keep the selection so the user can run more bulk actions on the same tickets.
         setIsBulkTagsDialogOpen(false);
       }
     } catch (error) {
@@ -1338,7 +1338,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             defaultValue: result.updatedIds.length === 1 ? 'Due date updated on {{count}} ticket' : 'Due date updated on {{count}} tickets',
           }));
         }
-        clearSelection();
+        // Keep the selection so the user can run more bulk actions on the same tickets.
         setIsBulkDueDateDialogOpen(false);
       }
     } catch (error) {
@@ -1412,7 +1412,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             defaultValue: result.updatedIds.length === 1 ? 'Status updated on {{count}} ticket' : 'Status updated on {{count}} tickets',
           }));
         }
-        clearSelection();
+        // Keep the selection so the user can run more bulk actions on the same tickets.
         setIsBulkStatusDialogOpen(false);
       }
     } catch (error) {
@@ -1456,7 +1456,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
             defaultValue: result.updatedIds.length === 1 ? 'Priority updated on {{count}} ticket' : 'Priority updated on {{count}} tickets',
           }));
         }
-        clearSelection();
+        // Keep the selection so the user can run more bulk actions on the same tickets.
         setIsBulkPriorityDialogOpen(false);
       }
     } catch (error) {

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -114,18 +114,35 @@ const useDebounce = <T,>(value: T, delay: number): T => {
 
 const TICKET_LIST_DENSITY_STORAGE_KEY = 'ticket_list_density_level';
 const EMPTY_STRING_ARRAY: string[] = [];
-const TICKET_LIST_DENSITY_PRESETS = [0, 25, 50, 75, 100] as const;
+const TICKET_LIST_DENSITY_STEP = 10;
+const TICKET_LIST_DENSITY_DEFAULT = 50;
 const TICKET_PRINT_FALLBACK_PAGE_SIZE = 500;
 
-type TicketListDensityPreset = (typeof TICKET_LIST_DENSITY_PRESETS)[number];
-
-const normalizeTicketListDensityLevel = (value: number): TicketListDensityPreset => {
+const normalizeTicketListDensityLevel = (value: number): number => {
   const clamped = Math.min(100, Math.max(0, value));
-
-  return TICKET_LIST_DENSITY_PRESETS.reduce((closest, preset) => {
-    return Math.abs(preset - clamped) < Math.abs(closest - clamped) ? preset : closest;
-  }, TICKET_LIST_DENSITY_PRESETS[0]);
+  return Math.round(clamped / TICKET_LIST_DENSITY_STEP) * TICKET_LIST_DENSITY_STEP;
 };
+
+// Indexed by zoom/10; `[&>td_*]:!text-[Xpx]` forces descendant elements to follow the row font-size.
+const TICKET_LIST_DENSITY_PRESETS: ReadonlyArray<{
+  filterPadding: string;
+  filterGap: string;
+  bodyPadding: string;
+  tableRowDensity: string;
+  minColumnWidth: number;
+}> = [
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-2.5', tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[11px] [&>td_*]:!text-[11px]', minColumnWidth: 80 },
+  { filterPadding: 'p-3',   filterGap: 'gap-2',   bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px] [&>td_*]:!text-[12px]',   minColumnWidth: 90 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3',   tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[12px] [&>td_*]:!text-[12px]', minColumnWidth: 100 },
+  { filterPadding: 'p-3.5', filterGap: 'gap-2.5', bodyPadding: 'p-3.5', tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[13px] [&>td_*]:!text-[13px]',   minColumnWidth: 105 },
+  { filterPadding: 'p-4',   filterGap: 'gap-3',   bodyPadding: 'p-4',   tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[13px] [&>td_*]:!text-[13px]', minColumnWidth: 115 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3 [&>td]:!text-[14px] [&>td_*]:!text-[14px]',   minColumnWidth: 130 },
+  { filterPadding: 'p-5',   filterGap: 'gap-4',   bodyPadding: 'p-5',   tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[14px] [&>td_*]:!text-[14px]', minColumnWidth: 145 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-6',   tableRowDensity: '[&>td]:!py-4 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 165 },
+  { filterPadding: 'p-6',   filterGap: 'gap-5',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[15px] [&>td_*]:!text-[15px]',   minColumnWidth: 185 },
+  { filterPadding: 'p-7',   filterGap: 'gap-6',   bodyPadding: 'p-7',   tableRowDensity: '[&>td]:!py-6 [&>td]:!text-[16px] [&>td_*]:!text-[16px]',   minColumnWidth: 210 },
+  { filterPadding: 'p-8',   filterGap: 'gap-6',   bodyPadding: 'p-8',   tableRowDensity: '[&>td]:!py-7 [&>td]:!text-[17px] [&>td_*]:!text-[17px]',   minColumnWidth: 240 },
+];
 
 function formatPrintDate(value?: string | null): string {
   if (!value) return '';
@@ -273,7 +290,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const selectedResponseState = (filterValues.responseState ?? 'all') as 'awaiting_client' | 'awaiting_internal' | 'none' | 'all';
   const selectedSlaStatus = allowSlaStatusFilter ? (filterValues.slaStatusFilter ?? 'all') : 'all';
   const bundleView = (filterValues.bundleView ?? 'bundled') as 'bundled' | 'individual';
-  const [ticketListDensityLevel, setTicketListDensityLevel] = useState<TicketListDensityPreset>(50);
+  const [ticketListDensityLevel, setTicketListDensityLevel] = useState<number>(TICKET_LIST_DENSITY_DEFAULT);
 
   const [clientFilterState, setClientFilterState] = useState<'active' | 'inactive' | 'all'>('active');
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
@@ -399,46 +416,13 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   }, []);
 
   const densityClasses = useMemo(() => {
-    const densityPresetClasses: Record<TicketListDensityPreset, {
-      filterPadding: string;
-      filterGap: string;
-      bodyPadding: string;
-      tableRowDensity: string;
-    }> = {
-      0: {
-        filterPadding: 'p-3',
-        filterGap: 'gap-2',
-        bodyPadding: 'p-3',
-        tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px]',
-      },
-      25: {
-        filterPadding: 'p-4',
-        filterGap: 'gap-3',
-        bodyPadding: 'p-4',
-        tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[13px]',
-      },
-      50: {
-        filterPadding: 'p-5',
-        filterGap: 'gap-4',
-        bodyPadding: 'p-5',
-        tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[14px]',
-      },
-      75: {
-        filterPadding: 'p-6',
-        filterGap: 'gap-5',
-        bodyPadding: 'p-7',
-        tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[15px]',
-      },
-      100: {
-        filterPadding: 'p-8',
-        filterGap: 'gap-6',
-        bodyPadding: 'p-9',
-        tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[16px]',
-      },
-    };
-
-    return densityPresetClasses[ticketListDensityLevel];
+    const index = Math.min(
+      TICKET_LIST_DENSITY_PRESETS.length - 1,
+      Math.max(0, Math.round(ticketListDensityLevel / TICKET_LIST_DENSITY_STEP))
+    );
+    return TICKET_LIST_DENSITY_PRESETS[index];
   }, [ticketListDensityLevel]);
+
 
   const statusOptions = useMemo(
     () => buildTicketStatusFilterOptions(rawStatusOptions, selectedBoard, selectedStatus),
@@ -1979,7 +1963,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                     idPrefix={`${id}-list-density`}
                     value={ticketListDensityLevel}
                     onChange={handleTicketListDensityChange}
-                    step={25}
+                    step={TICKET_LIST_DENSITY_STEP}
                     compactLabel={t('dashboard.spacing.compact', 'Compact')}
                     spaciousLabel={t('dashboard.spacing.spacious', 'Spacious')}
                     decreaseTitle={t('dashboard.spacing.decrease', 'Decrease ticket list spacing')}
@@ -2051,6 +2035,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
               pageSize={pageSize}
               totalItems={totalCount}
               onItemsPerPageChange={onPageSizeChange}
+              minColumnWidth={densityClasses.minColumnWidth}
               rowClassName={(record: ITicketListItem) =>
                 `${densityClasses.tableRowDensity} cursor-pointer ${record.ticket_id && selectedTicketIds.has(record.ticket_id)
                   ? '!bg-table-selected'

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -1015,7 +1015,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       dataIndex: 'selection',
       width: '4%',
       headerClassName: 'text-center px-4',
-      cellClassName: 'text-center px-4',
+      cellClassName: 'relative text-center px-4',
       sortable: false,
       render: (_value: string, record: ITicketListItem) => {
         const ticketId = record.ticket_id;
@@ -1026,9 +1026,14 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         const isChecked = selectedTicketIds.has(ticketId);
 
         return (
+          // Overlay fills the whole cell (incl. padding) so clicking anywhere in the
+          // column toggles selection instead of navigating into the ticket.
           <div
-            className="flex justify-center"
-            onClick={(event) => event.stopPropagation()}
+            className="absolute inset-0 flex items-center justify-center cursor-pointer"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleTicketSelectionChange(ticketId, !isChecked);
+            }}
             onMouseDown={(event) => event.stopPropagation()}
           >
             <Checkbox
@@ -1039,7 +1044,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                 handleTicketSelectionChange(ticketId, event.target.checked);
               }}
               containerClassName="mb-0"
-              className="m-0"
+              className="m-0 pointer-events-none"
               skipRegistration
             />
           </div>

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -7,6 +7,7 @@ import { ITicket, ITicketListItem, ITicketCategory, ITicketListFilters, Deletion
 import { ITag } from '@alga-psa/types';
 import { QuickAddTicket } from './QuickAddTicket';
 import { CategoryPicker } from './CategoryPicker';
+import BulkTicketActionBar from './BulkTicketActionBar';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { PrioritySelect } from '@alga-psa/ui/components';
 import { Button } from '@alga-psa/ui/components/Button';
@@ -1649,54 +1650,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           {t('dashboard.title', 'Ticketing Dashboard')}
         </h1>
         <div className="flex items-center gap-3">
-          {hasSelection && canUpdateTickets && (
-            <Button
-              id={`${id}-bulk-move-button`}
-              onClick={() => {
-                setBulkMoveErrors([]);
-                setSelectedDestinationBoardId('');
-                setDestinationBoardStatuses([]);
-                setSelectedDestinationStatusId('');
-                setDestinationStatusError('');
-                setIsBulkMoveDialogOpen(true);
-              }}
-              className="flex items-center gap-2"
-            >
-              {t('bulk.moveToBoard', 'Move to Board')}
-            </Button>
-          )}
-          {hasSelection && (
-            <Button
-              id={`${id}-bulk-delete-button`}
-              variant="destructive"
-              onClick={() => {
-                setBulkDeleteErrors([]);
-                setIsBulkDeleteDialogOpen(true);
-              }}
-              className="flex items-center gap-2"
-            >
-              {t('bulk.deleteSelected', {
-                count: selectedTicketIds.size,
-                defaultValue: 'Delete Selected ({{count}})',
-              })}
-            </Button>
-          )}
-          {selectedTicketIds.size >= 2 && (
-            <Button
-              id={`${id}-bundle-tickets-button`}
-              onClick={() => {
-                setBundleError(null);
-                const first = Array.from(selectedTicketIds)[0] || null;
-                setBundleMasterTicketId(first);
-                setBundleSyncUpdates(true);
-                setIsBundleDialogOpen(true);
-              }}
-              className="flex items-center gap-2"
-              disabled={!canUpdateTickets}
-            >
-              {t('bulk.bundleTickets', 'Bundle Tickets')}
-            </Button>
-          )}
           <ShareActionsMenu
             id={`${id}-share-actions`}
             disabled={isLoadingMore && !hasSelection}
@@ -2467,6 +2420,32 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         filters={exportFilters}
         totalCount={totalCount}
         selectedTicketIds={selectedTicketIdsArray}
+      />
+      <BulkTicketActionBar
+        idPrefix={`${id}-bulk`}
+        count={selectedTicketIds.size}
+        showMove={canUpdateTickets}
+        showBundle={canUpdateTickets}
+        onMove={() => {
+          setBulkMoveErrors([]);
+          setSelectedDestinationBoardId('');
+          setDestinationBoardStatuses([]);
+          setSelectedDestinationStatusId('');
+          setDestinationStatusError('');
+          setIsBulkMoveDialogOpen(true);
+        }}
+        onBundle={() => {
+          setBundleError(null);
+          const first = Array.from(selectedTicketIds)[0] || null;
+          setBundleMasterTicketId(first);
+          setBundleSyncUpdates(true);
+          setIsBundleDialogOpen(true);
+        }}
+        onDelete={() => {
+          setBulkDeleteErrors([]);
+          setIsBulkDeleteDialogOpen(true);
+        }}
+        onClear={clearSelection}
       />
     </ReflectionContainer>
     {isImportDialogOpen && (

--- a/packages/tickets/src/components/settings/DisplaySettings.tsx
+++ b/packages/tickets/src/components/settings/DisplaySettings.tsx
@@ -32,7 +32,6 @@ const DisplaySettings = (): React.JSX.Element => {
     created_by: true,
     due_date: true,
     tags: true,
-    actions: true,
   });
   const [tagsInlineUnderTitle, setTagsInlineUnderTitle] = useState<boolean>(false);
   const [responseStateTrackingEnabled, setResponseStateTrackingEnabled] = useState<boolean>(true);
@@ -60,7 +59,6 @@ const DisplaySettings = (): React.JSX.Element => {
     { key: 'created', label: t('fields.created', 'Created'), required: false },
     { key: 'created_by', label: t('settings.display.columns.createdBy', 'Created By'), required: false },
     { key: 'due_date', label: t('fields.dueDate', 'Due Date'), required: false },
-    { key: 'actions', label: t('settings.display.columns.actions', 'Actions'), required: true },
   ] as const;
 
   // Track original values to detect changes
@@ -84,7 +82,6 @@ const DisplaySettings = (): React.JSX.Element => {
       created_by: true,
       due_date: true,
       tags: true,
-      actions: true,
     },
     tagsInlineUnderTitle: false,
     responseStateTrackingEnabled: true,
@@ -120,7 +117,6 @@ const DisplaySettings = (): React.JSX.Element => {
           created_by: true,
           due_date: true,
           tags: true,
-          actions: true,
         };
         const loadedTagsInline = s?.list?.tagsInlineUnderTitle || false;
         const loadedResponseStateTracking = s?.responseStateTrackingEnabled ?? true;

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import type { ColumnDefinition, ITicketListItem, ITicketCategory, TicketResponseState, ITag, IBoard } from '@alga-psa/types';
 import { TagManager } from '@alga-psa/tags/components';
+import type { TagSize } from '@alga-psa/ui/components/tags';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import UserAvatar from '@alga-psa/ui/components/UserAvatar';
 import TeamAvatar from '@alga-psa/ui/components/TeamAvatar';
@@ -112,6 +113,7 @@ interface CreateTicketColumnsOptions {
   onTicketClick: (ticketId: string) => void;
   ticketTagsRef?: React.MutableRefObject<Record<string, ITag[]>>;
   onTagsChange?: (ticketId: string, tags: ITag[]) => void;
+  tagSize?: TagSize;
   showTags?: boolean;
   showClient?: boolean;
   onClientClick?: (clientId: string) => void;
@@ -149,6 +151,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     onTicketClick,
     ticketTagsRef,
     onTagsChange,
+    tagSize = 'md',
     showTags = true,
     showClient = true,
     onClientClick,
@@ -286,6 +289,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
                 entityType="ticket"
                 initialTags={ticketTagsRef.current[record.ticket_id] || []}
                 onTagsChange={(tags) => onTagsChange(record.ticket_id!, tags)}
+                size={tagSize}
               />
             </div>
           )}
@@ -611,6 +615,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
                 entityType="ticket"
                 initialTags={ticketTagsRef.current[record.ticket_id] || []}
                 onTagsChange={(tags) => onTagsChange(record.ticket_id!, tags)}
+                size={tagSize}
               />
             </div>
           );

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -229,8 +229,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
                   e.stopPropagation();
                   onTicketClick(record.ticket_id as string);
                 }}
-                className="text-blue-600 hover:text-blue-800 break-all whitespace-normal text-left"
-                style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
+                className="text-blue-600 hover:text-blue-800 whitespace-normal text-left"
               >
                 {value}
               </Link>

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import Link from 'next/link';
 import type { ColumnDefinition, ITicketListItem, ITicketCategory, TicketResponseState, ITag, IBoard } from '@alga-psa/types';
 import { TagManager } from '@alga-psa/tags/components';
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@alga-psa/ui/components/DropdownMenu';
-import { Button } from '@alga-psa/ui/components/Button';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
 import UserAvatar from '@alga-psa/ui/components/UserAvatar';
 import TeamAvatar from '@alga-psa/ui/components/TeamAvatar';
-import { MoreVertical, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { format } from 'date-fns';
 import { ResponseStateBadge } from '@alga-psa/ui/components';
 import { SlaIndicator } from '@alga-psa/ui/components/sla';
@@ -94,8 +92,7 @@ type TicketListColumnKey =
   | 'due_date'
   | 'created'
   | 'created_by'
-  | 'tags'
-  | 'actions';
+  | 'tags';
 
 type TicketListSettings = {
   columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
@@ -113,10 +110,8 @@ interface CreateTicketColumnsOptions {
   boards: IBoard[];
   displaySettings?: TicketingDisplaySettings;
   onTicketClick: (ticketId: string) => void;
-  onDeleteClick?: (ticketId: string, ticketName: string) => void;
   ticketTagsRef?: React.MutableRefObject<Record<string, ITag[]>>;
   onTagsChange?: (ticketId: string, tags: ITag[]) => void;
-  showActions?: boolean;
   showTags?: boolean;
   showClient?: boolean;
   onClientClick?: (clientId: string) => void;
@@ -144,7 +139,6 @@ const ALL_TICKET_LIST_COLUMN_VISIBILITY: Record<TicketListColumnKey, boolean> = 
   created: true,
   created_by: true,
   tags: true,
-  actions: true,
 };
 
 export function createTicketColumns(options: CreateTicketColumnsOptions): ColumnDefinition<ITicketListItem>[] {
@@ -153,10 +147,8 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     boards: _boards,
     displaySettings,
     onTicketClick,
-    onDeleteClick,
     ticketTagsRef,
     onTagsChange,
-    showActions = true,
     showTags = true,
     showClient = true,
     onClientClick,
@@ -184,7 +176,6 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     created: true,
     created_by: true,
     tags: true,
-    actions: true,
   });
 
   const tagsInlineUnderTitle = displaySettings?.list?.tagsInlineUnderTitle ?? true;
@@ -624,38 +615,6 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
             </div>
           );
         },
-      }
-    });
-  }
-
-  // Actions
-  if (columnVisibility.actions && showActions && onDeleteClick) {
-    columns.push({
-      key: 'actions',
-      col: {
-        title: t('fields.actions', 'Actions'),
-        dataIndex: 'actions',
-        width: '3%',
-        sortable: false,
-        render: (_value: string, record: ITicketListItem) => (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button id={`ticket-actions-${record.ticket_id}`} variant="ghost" size="sm" className="h-8 w-8 p-0">
-                <span className="sr-only">Open menu</span>
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="bg-white z-50">
-              <DropdownMenuItem
-                className="px-2 py-1 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 text-red-600 dark:text-red-400 flex items-center"
-                onSelect={() => onDeleteClick(record.ticket_id as string, record.title || record.ticket_number)}
-              >
-                <Trash2 className="mr-2 h-4 w-4" />
-                {t('actions.delete', 'Delete')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ),
       }
     });
   }

--- a/packages/types/src/interfaces/dataTable.interfaces.ts
+++ b/packages/types/src/interfaces/dataTable.interfaces.ts
@@ -59,4 +59,6 @@ export interface DataTableProps<T> {
    * Use custom options for grid views (e.g., [9, 18, 27, 36]) or special cases.
    */
   itemsPerPageOptions?: Array<{ value: string; label: string }>;
+  /** Minimum width per column (px) for the responsive auto-hide calculation. Defaults to 120. */
+  minColumnWidth?: number;
 }

--- a/packages/types/src/interfaces/dataTable.interfaces.ts
+++ b/packages/types/src/interfaces/dataTable.interfaces.ts
@@ -59,6 +59,4 @@ export interface DataTableProps<T> {
    * Use custom options for grid views (e.g., [9, 18, 27, 36]) or special cases.
    */
   itemsPerPageOptions?: Array<{ value: string; label: string }>;
-  /** Minimum width per column (px) for the responsive auto-hide calculation. Defaults to 120. */
-  minColumnWidth?: number;
 }

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -748,13 +748,13 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
-              Showing all columns; scroll horizontally to see them.{' '}
+              {t('dataTable.showingAllColumns', 'Showing all columns; scroll horizontally to see them.')}{' '}
               <button
                 type="button"
                 onClick={() => setShowAllColumns(false)}
                 className="ml-1 font-medium text-[rgb(var(--color-primary-600))] underline underline-offset-2 hover:opacity-80 focus:outline-none"
               >
-                Show less
+                {t('dataTable.showLess', 'Show less')}
               </button>
             </AlertDescription>
           </Alert>
@@ -764,13 +764,16 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
-              {columns.length - visibleColumnIds.length} columns hidden due to limited space.{' '}
+              {t('dataTable.columnsHidden', {
+                count: columns.length - visibleColumnIds.length,
+                defaultValue: '{{count}} columns hidden due to limited space.',
+              })}{' '}
               <button
                 type="button"
                 onClick={() => setShowAllColumns(true)}
                 className="ml-1 font-medium text-[rgb(var(--color-primary-600))] underline underline-offset-2 hover:opacity-80 focus:outline-none"
               >
-                Show all
+                {t('dataTable.showAll', 'Show all')}
               </button>
             </AlertDescription>
           </Alert>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -22,6 +22,7 @@ import { ReflectionContainer } from '../ui-reflection/ReflectionContainer';
 import { cn } from '../lib/utils';
 import Pagination from './Pagination';
 import { Alert, AlertDescription } from './Alert';
+import { Tooltip } from './Tooltip';
 import { useTranslation } from '../lib/i18n/client';
 
 // Helper function to get nested property value
@@ -190,55 +191,70 @@ const hasOverflow = (element: HTMLElement): boolean => {
   return Array.from(element.querySelectorAll<HTMLElement>('*')).some(isElementOverflowing);
 };
 
+// Shows the custom Tooltip only when the content is actually truncated. The open state is
+// controlled and vetoed in onOpenChange so overflow is measured lazily (on hover) — no tooltip
+// is shown for content that fits.
 const OverflowTooltip = ({ text, children, className }: OverflowTooltipProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
-  const [activeTitle, setActiveTitle] = useState<string | undefined>(undefined);
+  const [open, setOpen] = useState(false);
 
-  const updateTitle = () => {
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setOpen(false);
+      return;
+    }
     const element = contentRef.current;
-    setActiveTitle(element && text && hasOverflow(element) ? text : undefined);
+    if (text && element && hasOverflow(element)) {
+      setOpen(true);
+    }
   };
 
-  const clearTitle = () => setActiveTitle(undefined);
-
-  return (
-    <div
-      ref={contentRef}
-      className={className}
-      title={activeTitle}
-      onMouseEnter={updateTitle}
-      onFocus={updateTitle}
-      onMouseLeave={clearTitle}
-      onBlur={clearTitle}
-    >
+  const content = (
+    <div ref={contentRef} className={className}>
       {children}
     </div>
+  );
+
+  if (!text) {
+    return content;
+  }
+
+  return (
+    <Tooltip content={text} open={open} onOpenChange={handleOpenChange}>
+      {content}
+    </Tooltip>
   );
 };
 
 const OverflowTooltipSpan = ({ text, children, className }: OverflowTooltipProps) => {
   const contentRef = useRef<HTMLSpanElement>(null);
-  const [activeTitle, setActiveTitle] = useState<string | undefined>(undefined);
+  const [open, setOpen] = useState(false);
 
-  const updateTitle = () => {
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setOpen(false);
+      return;
+    }
     const element = contentRef.current;
-    setActiveTitle(element && text && hasOverflow(element) ? text : undefined);
+    if (text && element && hasOverflow(element)) {
+      setOpen(true);
+    }
   };
 
-  const clearTitle = () => setActiveTitle(undefined);
-
-  return (
-    <span
-      ref={contentRef}
-      className={className}
-      title={activeTitle}
-      onMouseEnter={updateTitle}
-      onFocus={updateTitle}
-      onMouseLeave={clearTitle}
-      onBlur={clearTitle}
-    >
+  const content = (
+    <span ref={contentRef} className={className}>
       {children}
     </span>
+  );
+
+  if (!text) {
+    return content;
+  }
+
+  return (
+    <Tooltip content={text} open={open} onOpenChange={handleOpenChange}>
+      {content}
+    </Tooltip>
   );
 };
 
@@ -353,6 +369,9 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(
     columns.map(col => getColumnId(col.dataIndex))
   );
+  // When true, every column renders and the table scrolls horizontally; otherwise only the
+  // columns that fully fit the container are shown (no horizontal overflow).
+  const [showAllColumns, setShowAllColumns] = useState(false);
 
   const columnIds = useMemo(() => columns.map(col => getColumnId(col.dataIndex)), [columns]);
   const columnSizingStorageKey = id ? `datatable-column-sizing:${id}` : null;
@@ -387,109 +406,77 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     window.localStorage.setItem(columnSizingStorageKey, JSON.stringify(columnSizing));
   }, [columnSizing, columnSizingStorageKey, hasLoadedColumnSizing]);
 
-  // Function to calculate which columns should be visible based on available width
-  const updateVisibleColumns = () => {
-    if (!tableContainerRef.current) return;
-    
-    const containerWidth = tableContainerRef.current.clientWidth;
-
-    // Check if the last column is 'Actions' or 'Action' with interactive elements
-    const lastColumnIndex = columns.length - 1;
-    const lastColumn = columns[lastColumnIndex];
-    const isActionsColumn = lastColumn &&
-      (lastColumn.title === 'Actions' || lastColumn.title === 'Action') &&
-      lastColumn.render !== undefined;
-
-    const prioritizedColumns = [...columns].sort((a, b) => {
-      // Always prioritize Actions column if it's the last column
-      if (isActionsColumn) {
-        if (a === lastColumn) return -1;
-        if (b === lastColumn) return 1;
-      }
-
-      // Keep ID column and any columns with explicit width as highest priority
-      const aIsId = Array.isArray(a.dataIndex) ? a.dataIndex.includes('id') : a.dataIndex === 'id';
-      const bIsId = Array.isArray(b.dataIndex) ? b.dataIndex.includes('id') : b.dataIndex === 'id';
-
-      if (aIsId && !bIsId) return -1;
-      if (!aIsId && bIsId) return 1;
-
-      // Then prioritize columns with explicit width
-      if (a.width && !b.width) return -1;
-      if (!a.width && b.width) return 1;
-
-      return 0;
-    });
-
-    // Calculate how many columns we can fit
-    const maxColumns = Math.max(1, Math.floor(containerWidth / minColumnWidth));
-
-    // Get the IDs of columns that should be visible
-    const newVisibleColumnIds = prioritizedColumns
-      .slice(0, maxColumns)
-      .map(col => Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex);
-
-    setVisibleColumnIds(newVisibleColumnIds);
-  };
-
-  // Add resize event listener
+  // Recalculate which columns fit the container. Columns are accumulated in priority order using
+  // their real sizes (not a uniform estimate) so the visible set never exceeds the container width
+  // and the table doesn't scroll horizontally. `showAllColumns` bypasses this and renders everything.
   useEffect(() => {
-    // Define updateVisibleColumns inside the effect to properly capture the columns dependency
+    const allColumnIds = columns.map(col => getColumnId(col.dataIndex));
+
     const updateVisibleColumnsEffect = () => {
+      if (showAllColumns) {
+        setVisibleColumnIds(allColumnIds);
+        return;
+      }
       if (!tableContainerRef.current) return;
 
       const containerWidth = tableContainerRef.current.clientWidth;
-      
+
       // Check if the last column is 'Actions' or 'Action' with interactive elements
-      const lastColumnIndex = columns.length - 1;
-      const lastColumn = columns[lastColumnIndex];
-      const isActionsColumn = lastColumn && 
-        (lastColumn.title === 'Actions' || lastColumn.title === 'Action') && 
+      const lastColumn = columns[columns.length - 1];
+      const isActionsColumn = !!lastColumn &&
+        (lastColumn.title === 'Actions' || lastColumn.title === 'Action') &&
         lastColumn.render !== undefined;
-      
+
       const prioritizedColumns = [...columns].sort((a, b) => {
         // Always prioritize Actions column if it's the last column
         if (isActionsColumn) {
           if (a === lastColumn) return -1;
           if (b === lastColumn) return 1;
         }
-        
+
         // Keep ID column and any columns with explicit width as highest priority
         const aIsId = Array.isArray(a.dataIndex) ? a.dataIndex.includes('id') : a.dataIndex === 'id';
         const bIsId = Array.isArray(b.dataIndex) ? b.dataIndex.includes('id') : b.dataIndex === 'id';
-        
+
         if (aIsId && !bIsId) return -1;
         if (!aIsId && bIsId) return 1;
-        
+
         // Then prioritize columns with explicit width
         if (a.width && !b.width) return -1;
         if (!a.width && b.width) return 1;
-        
+
         return 0;
       });
-      
-      // Calculate how many columns we can fit
-      const maxColumns = Math.max(1, Math.floor(containerWidth / minColumnWidth));
-      
-      // Get the IDs of columns that should be visible
-      const newVisibleColumnIds = prioritizedColumns
-        .slice(0, maxColumns)
-        .map(col => Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex);
-      
-      setVisibleColumnIds(newVisibleColumnIds);
+
+      // Greedily include columns (highest priority first) until the next one would overflow.
+      // Using each column's real rendered size keeps the visible set within the container.
+      const visible = new Set<string>();
+      let usedWidth = 0;
+      for (const col of prioritizedColumns) {
+        const colId = getColumnId(col.dataIndex);
+        const { size } = getColumnSizeConfig(col);
+        if (visible.size > 0 && usedWidth + size > containerWidth) {
+          break;
+        }
+        usedWidth += size;
+        visible.add(colId);
+      }
+
+      // Preserve original column order in the visible list.
+      setVisibleColumnIds(allColumnIds.filter(colId => visible.has(colId)));
     };
-    
+
     updateVisibleColumnsEffect();
-    
+
     const handleResize = () => {
       updateVisibleColumnsEffect();
     };
-    
+
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [columns, minColumnWidth]); // Re-run when columns or min column width change
+  }, [columns, minColumnWidth, showAllColumns]); // Re-run when columns, min width, or show-all change
 
   // Memoize the initial column configuration to prevent loops
   const columnConfig = useMemo(() => {
@@ -756,13 +743,36 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
       data-automation-id={id}
       ref={tableContainerRef}
     >
-        {visibleColumnIds.length < columns.length && (
+        {showAllColumns ? (
           <Alert variant="info" className="rounded-none border-x-0 border-t-0">
             <AlertDescription className="flex items-center text-sm">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
-              {columns.length - visibleColumnIds.length} columns hidden due to limited space. Resize browser to see more.
+              Showing all columns; scroll horizontally to see them.{' '}
+              <button
+                type="button"
+                onClick={() => setShowAllColumns(false)}
+                className="ml-1 font-medium underline underline-offset-2 hover:opacity-80 focus:outline-none"
+              >
+                Show less
+              </button>
+            </AlertDescription>
+          </Alert>
+        ) : visibleColumnIds.length < columns.length && (
+          <Alert variant="info" className="rounded-none border-x-0 border-t-0">
+            <AlertDescription className="flex items-center text-sm">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              {columns.length - visibleColumnIds.length} columns hidden due to limited space.{' '}
+              <button
+                type="button"
+                onClick={() => setShowAllColumns(true)}
+                className="ml-1 font-medium underline underline-offset-2 hover:opacity-80 focus:outline-none"
+              >
+                Show all
+              </button>
             </AlertDescription>
           </Alert>
         )}

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -143,7 +143,7 @@ const ReflectedTableCell = ({
       style={style}
       data-automation-id={id}
     >
-      <div className="break-words min-w-0 [&_button:not(.whitespace-normal)]:whitespace-nowrap [&_a:not(.whitespace-normal)]:whitespace-nowrap">
+      <div className="break-normal min-w-0 [&_button:not(.whitespace-normal)]:whitespace-nowrap [&_a:not(.whitespace-normal)]:whitespace-nowrap">
         {children}
       </div>
     </td>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -332,7 +332,6 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     onVisibleRowsChange,
     onItemsPerPageChange,
     itemsPerPageOptions,
-    minColumnWidth = 120,
   } = props;
   const { t } = useTranslation('common');
   const defaultItemsPerPageOptions = useMemo(() => [
@@ -476,7 +475,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [columns, minColumnWidth, showAllColumns]); // Re-run when columns, min width, or show-all change
+  }, [columns, showAllColumns]); // Re-run when columns or show-all change
 
   // Memoize the initial column configuration to prevent loops
   const columnConfig = useMemo(() => {
@@ -753,7 +752,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               <button
                 type="button"
                 onClick={() => setShowAllColumns(false)}
-                className="ml-1 font-medium underline underline-offset-2 hover:opacity-80 focus:outline-none"
+                className="ml-1 font-medium text-[rgb(var(--color-primary-600))] underline underline-offset-2 hover:opacity-80 focus:outline-none"
               >
                 Show less
               </button>
@@ -769,7 +768,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
               <button
                 type="button"
                 onClick={() => setShowAllColumns(true)}
-                className="ml-1 font-medium underline underline-offset-2 hover:opacity-80 focus:outline-none"
+                className="ml-1 font-medium text-[rgb(var(--color-primary-600))] underline underline-offset-2 hover:opacity-80 focus:outline-none"
               >
                 Show all
               </button>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -176,6 +176,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     onVisibleRowsChange,
     onItemsPerPageChange,
     itemsPerPageOptions,
+    minColumnWidth = 120,
   } = props;
   const { t } = useTranslation('common');
   const defaultItemsPerPageOptions = useMemo(() => [
@@ -199,55 +200,53 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     if (!tableContainerRef.current) return;
     
     const containerWidth = tableContainerRef.current.clientWidth;
-    const minColumnWidth = 120; // Reduced minimum width to show more columns with multiline content
-    
+
     // Check if the last column is 'Actions' or 'Action' with interactive elements
     const lastColumnIndex = columns.length - 1;
     const lastColumn = columns[lastColumnIndex];
-    const isActionsColumn = lastColumn && 
-      (lastColumn.title === 'Actions' || lastColumn.title === 'Action') && 
+    const isActionsColumn = lastColumn &&
+      (lastColumn.title === 'Actions' || lastColumn.title === 'Action') &&
       lastColumn.render !== undefined;
-    
+
     const prioritizedColumns = [...columns].sort((a, b) => {
       // Always prioritize Actions column if it's the last column
       if (isActionsColumn) {
         if (a === lastColumn) return -1;
         if (b === lastColumn) return 1;
       }
-      
+
       // Keep ID column and any columns with explicit width as highest priority
       const aIsId = Array.isArray(a.dataIndex) ? a.dataIndex.includes('id') : a.dataIndex === 'id';
       const bIsId = Array.isArray(b.dataIndex) ? b.dataIndex.includes('id') : b.dataIndex === 'id';
-      
+
       if (aIsId && !bIsId) return -1;
       if (!aIsId && bIsId) return 1;
-      
+
       // Then prioritize columns with explicit width
       if (a.width && !b.width) return -1;
       if (!a.width && b.width) return 1;
-      
+
       return 0;
     });
-    
+
     // Calculate how many columns we can fit
     const maxColumns = Math.max(1, Math.floor(containerWidth / minColumnWidth));
-    
+
     // Get the IDs of columns that should be visible
     const newVisibleColumnIds = prioritizedColumns
       .slice(0, maxColumns)
       .map(col => Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex);
-    
+
     setVisibleColumnIds(newVisibleColumnIds);
   };
-  
+
   // Add resize event listener
   useEffect(() => {
     // Define updateVisibleColumns inside the effect to properly capture the columns dependency
     const updateVisibleColumnsEffect = () => {
       if (!tableContainerRef.current) return;
-      
+
       const containerWidth = tableContainerRef.current.clientWidth;
-      const minColumnWidth = 120; // Reduced minimum width to show more columns with multiline content
       
       // Check if the last column is 'Actions' or 'Action' with interactive elements
       const lastColumnIndex = columns.length - 1;
@@ -298,7 +297,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [columns]); // Re-run when columns change
+  }, [columns, minColumnWidth]); // Re-run when columns or min column width change
 
   // Memoize the initial column configuration to prevent loops
   const columnConfig = useMemo(() => {

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -12,6 +12,11 @@ interface TooltipProps extends AutomationProps { // Include AutomationProps here
   side?: TooltipPrimitive.TooltipContentProps['side'];
   align?: TooltipPrimitive.TooltipContentProps['align'];
   sideOffset?: TooltipPrimitive.TooltipContentProps['sideOffset'];
+  /** Controlled open state (e.g. to gate the tooltip on truncation). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Hover delay before the tooltip opens (ms). */
+  delayDuration?: number;
 }
 
 export const Tooltip = ({ // Removed AutomationProps from here as it's in the interface
@@ -21,13 +26,16 @@ export const Tooltip = ({ // Removed AutomationProps from here as it's in the in
   side,
   align,
   sideOffset = 6, // Default offset like Radix
+  open,
+  onOpenChange,
+  delayDuration,
   ...props // Pass down automation props if needed, though Radix might handle accessibility
 }: TooltipProps) => {
   // Removed useState, useCallback, useRef, handleMouseMove
 
   return (
-    <TooltipPrimitive.Provider>
-      <TooltipPrimitive.Root>
+    <TooltipPrimitive.Provider delayDuration={delayDuration}>
+      <TooltipPrimitive.Root open={open} onOpenChange={onOpenChange} delayDuration={delayDuration}>
         <TooltipPrimitive.Trigger asChild>
           {children}
         </TooltipPrimitive.Trigger>

--- a/server/public/locales/de/common.json
+++ b/server/public/locales/de/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Archivierte Datensätze werden in Standardansichten ausgeblendet."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} Spalte aus Platzgründen ausgeblendet.",
+    "columnsHidden_other": "{{count}} Spalten aus Platzgründen ausgeblendet.",
+    "showAll": "Alle anzeigen",
+    "showingAllColumns": "Alle Spalten werden angezeigt; horizontal scrollen, um sie zu sehen.",
+    "showLess": "Weniger anzeigen"
   }
 }

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Du musst angemeldet sein, um Tickets zu verschieben",
-      "deleteRequired": "Du musst angemeldet sein, um Tickets zu löschen"
+      "deleteRequired": "Du musst angemeldet sein, um Tickets zu löschen",
+      "assignRequired": "Sie müssen angemeldet sein, um Tickets zuzuweisen",
+      "tagsRequired": "Sie müssen angemeldet sein, um Tags hinzuzufügen",
+      "dueDateRequired": "Sie müssen angemeldet sein, um Tickets zu aktualisieren",
+      "statusRequired": "Sie müssen angemeldet sein, um Tickets zu aktualisieren",
+      "priorityRequired": "Sie müssen angemeldet sein, um Tickets zu aktualisieren"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} ausgewählt",
@@ -539,7 +544,83 @@
       "bundle": "Bündeln",
       "delete": "Löschen",
       "clear": "Auswahl aufheben",
-      "bundleNeedsTwo": "Wählen Sie mindestens 2 Tickets zum Bündeln aus"
+      "bundleNeedsTwo": "Wählen Sie mindestens 2 Tickets zum Bündeln aus",
+      "assign": "Zuweisen",
+      "status": "Status",
+      "priority": "Priorität",
+      "tags": "Tags",
+      "dueDate": "Fälligkeitsdatum",
+      "statusDisabledMultiBoard": "Ausgewählte Tickets liegen auf verschiedenen Boards",
+      "more": "Mehr"
+    },
+    "assign": {
+      "dialogTitle": "Ausgewählte Tickets zuweisen",
+      "message": "{{count}} ausgewählte(s) Ticket zuweisen an:",
+      "unassigned": "Nicht zugewiesen",
+      "teamHint": "Der Teamleiter wird zum Hauptverantwortlichen; weitere Teammitglieder werden als zusätzliche Bearbeiter hinzugefügt.",
+      "confirm_one": "{{count}} Ticket zuweisen",
+      "confirm_other": "{{count}} Tickets zuweisen",
+      "submitting": "Wird zugewiesen...",
+      "success_one": "{{count}} Ticket zugewiesen",
+      "success_other": "{{count}} Tickets zugewiesen",
+      "partialFailure": "Einige Tickets konnten nicht zugewiesen werden",
+      "failure": "Fehler beim Zuweisen ausgewählter Tickets",
+      "failedHeading": "Folgende Tickets konnten nicht zugewiesen werden:"
+    },
+    "tags": {
+      "dialogTitle": "Tags zu ausgewählten Tickets hinzufügen",
+      "message": "Fügen Sie einem oder mehreren Tags zu {{count}} ausgewählten Ticket(s) hinzu. Bereits vorhandene Tags werden übersprungen.",
+      "placeholder": "Tag eingeben und Enter drücken",
+      "confirm_one": "Tags zu {{count}} Ticket hinzufügen",
+      "confirm_other": "Tags zu {{count}} Tickets hinzufügen",
+      "submitting": "Tags werden hinzugefügt...",
+      "success_one": "Tags zu {{count}} Ticket hinzugefügt",
+      "success_other": "Tags zu {{count}} Tickets hinzugefügt",
+      "partialFailure": "Bei einigen Tickets konnten Tags nicht hinzugefügt werden",
+      "failure": "Fehler beim Hinzufügen von Tags",
+      "failedHeading": "Bei folgenden Tickets konnten Tags nicht hinzugefügt werden:"
+    },
+    "dueDate": {
+      "dialogTitle": "Fälligkeitsdatum für ausgewählte Tickets festlegen",
+      "message": "Fälligkeitsdatum für {{count}} ausgewählte(s) Ticket setzen oder entfernen.",
+      "modeSet": "Setzen auf",
+      "modeClear": "Fälligkeitsdatum entfernen",
+      "placeholder": "Datum auswählen",
+      "confirm_one": "{{count}} Ticket aktualisieren",
+      "confirm_other": "{{count}} Tickets aktualisieren",
+      "submitting": "Wird aktualisiert...",
+      "success_one": "Fälligkeitsdatum bei {{count}} Ticket aktualisiert",
+      "success_other": "Fälligkeitsdatum bei {{count}} Tickets aktualisiert",
+      "partialFailure": "Fälligkeitsdatum konnte bei einigen Tickets nicht aktualisiert werden",
+      "failure": "Fehler beim Aktualisieren des Fälligkeitsdatums",
+      "failedHeading": "Folgende Tickets konnten nicht aktualisiert werden:"
+    },
+    "status": {
+      "dialogTitle": "Status für ausgewählte Tickets ändern",
+      "message": "Status für {{count}} ausgewählte(s) Ticket festlegen:",
+      "placeholder": "Status auswählen",
+      "loading": "Status werden geladen...",
+      "confirm_one": "{{count}} Ticket aktualisieren",
+      "confirm_other": "{{count}} Tickets aktualisieren",
+      "submitting": "Wird aktualisiert...",
+      "success_one": "Status bei {{count}} Ticket aktualisiert",
+      "success_other": "Status bei {{count}} Tickets aktualisiert",
+      "partialFailure": "Status konnte bei einigen Tickets nicht aktualisiert werden",
+      "failure": "Fehler beim Aktualisieren des Status",
+      "failedHeading": "Folgende Tickets konnten nicht aktualisiert werden:"
+    },
+    "priority": {
+      "dialogTitle": "Priorität für ausgewählte Tickets ändern",
+      "message": "Priorität für {{count}} ausgewählte(s) Ticket festlegen:",
+      "placeholder": "Priorität auswählen",
+      "confirm_one": "{{count}} Ticket aktualisieren",
+      "confirm_other": "{{count}} Tickets aktualisieren",
+      "submitting": "Wird aktualisiert...",
+      "success_one": "Priorität bei {{count}} Ticket aktualisiert",
+      "success_other": "Priorität bei {{count}} Tickets aktualisiert",
+      "partialFailure": "Priorität konnte bei einigen Tickets nicht aktualisiert werden",
+      "failure": "Fehler beim Aktualisieren der Priorität",
+      "failedHeading": "Folgende Tickets konnten nicht aktualisiert werden:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Tags",
       "dueDate": "Fälligkeitsdatum",
       "statusDisabledMultiBoard": "Ausgewählte Tickets liegen auf verschiedenen Boards",
+      "statusResolvingBoards": "Boards der ausgewählten Tickets werden geprüft…",
       "more": "Mehr"
     },
     "assign": {

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "CSV importieren"
   },
   "bulk": {
-    "moveToBoard": "In Board verschieben",
-    "deleteSelected_one": "Ausgewählte Tickets löschen ({{count}})",
-    "deleteSelected_other": "Ausgewählte Tickets löschen ({{count}})",
     "bundleTickets": "Tickets bündeln",
     "moveDialogTitle": "Ausgewählte Tickets verschieben",
     "moveDialogDescription": "Wähle ein Ziel-Board und einen Status aus und bestätige dann das Verschieben der ausgewählten Tickets.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Du musst angemeldet sein, um Tickets zu verschieben",
       "deleteRequired": "Du musst angemeldet sein, um Tickets zu löschen"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} ausgewählt",
+      "selectedCount_other": "{{count}} ausgewählt",
+      "move": "In Board verschieben",
+      "bundle": "Bündeln",
+      "delete": "Löschen",
+      "clear": "Auswahl aufheben",
+      "bundleNeedsTwo": "Wählen Sie mindestens 2 Tickets zum Bündeln aus"
     }
   },
   "quickAdd": {

--- a/server/public/locales/en/common.json
+++ b/server/public/locales/en/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Archived records are hidden from default views."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} column hidden due to limited space.",
+    "columnsHidden_other": "{{count}} columns hidden due to limited space.",
+    "showAll": "Show all",
+    "showingAllColumns": "Showing all columns; scroll horizontally to see them.",
+    "showLess": "Show less"
   }
 }

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -438,7 +438,14 @@
       "bundle": "Bundle",
       "delete": "Delete",
       "clear": "Clear",
-      "bundleNeedsTwo": "Select at least 2 tickets to bundle"
+      "bundleNeedsTwo": "Select at least 2 tickets to bundle",
+      "assign": "Assign",
+      "status": "Status",
+      "priority": "Priority",
+      "tags": "Tags",
+      "dueDate": "Due Date",
+      "statusDisabledMultiBoard": "Selected tickets are on different boards",
+      "more": "More"
     },
     "moveDialogTitle": "Move Selected Tickets",
     "moveDialogDescription": "Select a destination board and status, then confirm moving the selected tickets.",
@@ -539,7 +546,81 @@
     },
     "auth": {
       "moveRequired": "You must be logged in to move tickets",
-      "deleteRequired": "You must be logged in to delete tickets"
+      "deleteRequired": "You must be logged in to delete tickets",
+      "assignRequired": "You must be logged in to reassign tickets",
+      "tagsRequired": "You must be logged in to add tags",
+      "dueDateRequired": "You must be logged in to update tickets",
+      "statusRequired": "You must be logged in to update tickets",
+      "priorityRequired": "You must be logged in to update tickets"
+    },
+    "assign": {
+      "dialogTitle": "Assign Selected Tickets",
+      "message": "Reassign {{count}} selected ticket(s) to:",
+      "unassigned": "Not assigned",
+      "teamHint": "The team lead becomes the primary assignee; other team members are added as additional agents.",
+      "confirm_one": "Reassign {{count}} Ticket",
+      "confirm_other": "Reassign {{count}} Tickets",
+      "submitting": "Reassigning...",
+      "success_one": "{{count}} ticket reassigned",
+      "success_other": "{{count}} tickets reassigned",
+      "partialFailure": "Some tickets could not be reassigned",
+      "failure": "Failed to reassign selected tickets",
+      "failedHeading": "The following tickets could not be reassigned:"
+    },
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tickets",
+      "message": "Add one or more tags to {{count}} selected ticket(s). Tags already on a ticket are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "confirm_one": "Add Tags to {{count}} Ticket",
+      "confirm_other": "Add Tags to {{count}} Tickets",
+      "submitting": "Adding tags...",
+      "success_one": "Tags added to {{count}} ticket",
+      "success_other": "Tags added to {{count}} tickets",
+      "partialFailure": "Tags could not be added to some tickets",
+      "failure": "Failed to add tags to selected tickets",
+      "failedHeading": "Tags could not be added to the following tickets:"
+    },
+    "dueDate": {
+      "dialogTitle": "Set Due Date for Selected Tickets",
+      "message": "Set or clear the due date on {{count}} selected ticket(s).",
+      "modeSet": "Set to",
+      "modeClear": "Clear due date",
+      "placeholder": "Pick a date",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Due date updated on {{count}} ticket",
+      "success_other": "Due date updated on {{count}} tickets",
+      "partialFailure": "Due date could not be updated on some tickets",
+      "failure": "Failed to update due date on selected tickets",
+      "failedHeading": "Due date could not be updated on the following tickets:"
+    },
+    "status": {
+      "dialogTitle": "Change Status for Selected Tickets",
+      "message": "Set the status for {{count}} selected ticket(s):",
+      "placeholder": "Select a status",
+      "loading": "Loading statuses...",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Status updated on {{count}} ticket",
+      "success_other": "Status updated on {{count}} tickets",
+      "partialFailure": "Status could not be updated on some tickets",
+      "failure": "Failed to update status on selected tickets",
+      "failedHeading": "Status could not be updated on the following tickets:"
+    },
+    "priority": {
+      "dialogTitle": "Change Priority for Selected Tickets",
+      "message": "Set the priority for {{count}} selected ticket(s):",
+      "placeholder": "Select a priority",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Priority updated on {{count}} ticket",
+      "success_other": "Priority updated on {{count}} tickets",
+      "partialFailure": "Priority could not be updated on some tickets",
+      "failure": "Failed to update priority on selected tickets",
+      "failedHeading": "Priority could not be updated on the following tickets:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -445,6 +445,7 @@
       "tags": "Tags",
       "dueDate": "Due Date",
       "statusDisabledMultiBoard": "Selected tickets are on different boards",
+      "statusResolvingBoards": "Checking the boards of selected tickets…",
       "more": "More"
     },
     "moveDialogTitle": "Move Selected Tickets",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -430,10 +430,16 @@
     "importAction": "Import CSV"
   },
   "bulk": {
-    "moveToBoard": "Move to Board",
-    "deleteSelected_one": "Delete Selected ({{count}})",
-    "deleteSelected_other": "Delete Selected ({{count}})",
     "bundleTickets": "Bundle Tickets",
+    "actionBar": {
+      "selectedCount_one": "{{count}} selected",
+      "selectedCount_other": "{{count}} selected",
+      "move": "Move to Board",
+      "bundle": "Bundle",
+      "delete": "Delete",
+      "clear": "Clear",
+      "bundleNeedsTwo": "Select at least 2 tickets to bundle"
+    },
     "moveDialogTitle": "Move Selected Tickets",
     "moveDialogDescription": "Select a destination board and status, then confirm moving the selected tickets.",
     "destinationBoard": "Destination Board",

--- a/server/public/locales/es/common.json
+++ b/server/public/locales/es/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Los registros archivados se ocultan en las vistas predeterminadas."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} columna oculta por falta de espacio.",
+    "columnsHidden_other": "{{count}} columnas ocultas por falta de espacio.",
+    "showAll": "Mostrar todo",
+    "showingAllColumns": "Mostrando todas las columnas; desplázate horizontalmente para verlas.",
+    "showLess": "Mostrar menos"
   }
 }

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "Importar CSV"
   },
   "bulk": {
-    "moveToBoard": "Mover al tablero",
-    "deleteSelected_one": "Eliminar seleccionados ({{count}})",
-    "deleteSelected_other": "Eliminar seleccionados ({{count}})",
     "bundleTickets": "Agrupar tickets",
     "moveDialogTitle": "Mover tickets seleccionados",
     "moveDialogDescription": "Selecciona un tablero y un estado de destino, y luego confirma el traslado de los tickets seleccionados.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Debes iniciar sesión para mover tickets",
       "deleteRequired": "Debes iniciar sesión para eliminar tickets"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} seleccionado",
+      "selectedCount_other": "{{count}} seleccionados",
+      "move": "Mover al tablero",
+      "bundle": "Agrupar",
+      "delete": "Eliminar",
+      "clear": "Limpiar selección",
+      "bundleNeedsTwo": "Selecciona al menos 2 tickets para agrupar"
     }
   },
   "quickAdd": {

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Debes iniciar sesión para mover tickets",
-      "deleteRequired": "Debes iniciar sesión para eliminar tickets"
+      "deleteRequired": "Debes iniciar sesión para eliminar tickets",
+      "assignRequired": "Debes iniciar sesión para reasignar tickets",
+      "tagsRequired": "Debes iniciar sesión para añadir etiquetas",
+      "dueDateRequired": "Debes iniciar sesión para actualizar tickets",
+      "statusRequired": "Debes iniciar sesión para actualizar tickets",
+      "priorityRequired": "Debes iniciar sesión para actualizar tickets"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} seleccionado",
@@ -539,7 +544,83 @@
       "bundle": "Agrupar",
       "delete": "Eliminar",
       "clear": "Limpiar selección",
-      "bundleNeedsTwo": "Selecciona al menos 2 tickets para agrupar"
+      "bundleNeedsTwo": "Selecciona al menos 2 tickets para agrupar",
+      "assign": "Asignar",
+      "status": "Estado",
+      "priority": "Prioridad",
+      "tags": "Etiquetas",
+      "dueDate": "Fecha de vencimiento",
+      "statusDisabledMultiBoard": "Los tickets seleccionados están en tableros distintos",
+      "more": "Más"
+    },
+    "assign": {
+      "dialogTitle": "Asignar tickets seleccionados",
+      "message": "Reasignar {{count}} ticket(s) seleccionado(s) a:",
+      "unassigned": "Sin asignar",
+      "teamHint": "El líder del equipo será el asignado principal; los demás miembros se añaden como agentes adicionales.",
+      "confirm_one": "Reasignar {{count}} ticket",
+      "confirm_other": "Reasignar {{count}} tickets",
+      "submitting": "Reasignando...",
+      "success_one": "{{count}} ticket reasignado",
+      "success_other": "{{count}} tickets reasignados",
+      "partialFailure": "Algunos tickets no pudieron reasignarse",
+      "failure": "No se pudieron reasignar los tickets seleccionados",
+      "failedHeading": "Los siguientes tickets no pudieron reasignarse:"
+    },
+    "tags": {
+      "dialogTitle": "Añadir etiquetas a los tickets seleccionados",
+      "message": "Añade una o varias etiquetas a {{count}} ticket(s). Las etiquetas ya presentes se omiten.",
+      "placeholder": "Escribe una etiqueta y pulsa Enter",
+      "confirm_one": "Añadir etiquetas a {{count}} ticket",
+      "confirm_other": "Añadir etiquetas a {{count}} tickets",
+      "submitting": "Añadiendo etiquetas...",
+      "success_one": "Etiquetas añadidas a {{count}} ticket",
+      "success_other": "Etiquetas añadidas a {{count}} tickets",
+      "partialFailure": "No se pudieron añadir etiquetas a algunos tickets",
+      "failure": "Error al añadir etiquetas",
+      "failedHeading": "No se pudieron añadir etiquetas a los siguientes tickets:"
+    },
+    "dueDate": {
+      "dialogTitle": "Establecer fecha de vencimiento",
+      "message": "Establece o borra la fecha de vencimiento en {{count}} ticket(s).",
+      "modeSet": "Establecer en",
+      "modeClear": "Borrar fecha de vencimiento",
+      "placeholder": "Elige una fecha",
+      "confirm_one": "Actualizar {{count}} ticket",
+      "confirm_other": "Actualizar {{count}} tickets",
+      "submitting": "Actualizando...",
+      "success_one": "Fecha de vencimiento actualizada en {{count}} ticket",
+      "success_other": "Fecha de vencimiento actualizada en {{count}} tickets",
+      "partialFailure": "La fecha de vencimiento no se pudo actualizar en algunos tickets",
+      "failure": "Error al actualizar la fecha de vencimiento",
+      "failedHeading": "No se pudo actualizar la fecha de vencimiento en los siguientes tickets:"
+    },
+    "status": {
+      "dialogTitle": "Cambiar estado de los tickets seleccionados",
+      "message": "Establece el estado para {{count}} ticket(s):",
+      "placeholder": "Selecciona un estado",
+      "loading": "Cargando estados...",
+      "confirm_one": "Actualizar {{count}} ticket",
+      "confirm_other": "Actualizar {{count}} tickets",
+      "submitting": "Actualizando...",
+      "success_one": "Estado actualizado en {{count}} ticket",
+      "success_other": "Estado actualizado en {{count}} tickets",
+      "partialFailure": "El estado no se pudo actualizar en algunos tickets",
+      "failure": "Error al actualizar el estado",
+      "failedHeading": "No se pudo actualizar el estado en los siguientes tickets:"
+    },
+    "priority": {
+      "dialogTitle": "Cambiar prioridad de los tickets seleccionados",
+      "message": "Establece la prioridad para {{count}} ticket(s):",
+      "placeholder": "Selecciona una prioridad",
+      "confirm_one": "Actualizar {{count}} ticket",
+      "confirm_other": "Actualizar {{count}} tickets",
+      "submitting": "Actualizando...",
+      "success_one": "Prioridad actualizada en {{count}} ticket",
+      "success_other": "Prioridad actualizada en {{count}} tickets",
+      "partialFailure": "La prioridad no se pudo actualizar en algunos tickets",
+      "failure": "Error al actualizar la prioridad",
+      "failedHeading": "No se pudo actualizar la prioridad en los siguientes tickets:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Etiquetas",
       "dueDate": "Fecha de vencimiento",
       "statusDisabledMultiBoard": "Los tickets seleccionados están en tableros distintos",
+      "statusResolvingBoards": "Comprobando los tableros de los tickets seleccionados…",
       "more": "Más"
     },
     "assign": {

--- a/server/public/locales/fr/common.json
+++ b/server/public/locales/fr/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Les enregistrements archivés sont masqués dans les vues par défaut."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} colonne masquée faute de place.",
+    "columnsHidden_other": "{{count}} colonnes masquées faute de place.",
+    "showAll": "Tout afficher",
+    "showingAllColumns": "Toutes les colonnes sont affichées ; faites défiler horizontalement pour les voir.",
+    "showLess": "Afficher moins"
   }
 }

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Vous devez être connecté pour déplacer des tickets",
-      "deleteRequired": "Vous devez être connecté pour supprimer des tickets"
+      "deleteRequired": "Vous devez être connecté pour supprimer des tickets",
+      "assignRequired": "Vous devez être connecté pour réassigner des tickets",
+      "tagsRequired": "Vous devez être connecté pour ajouter des étiquettes",
+      "dueDateRequired": "Vous devez être connecté pour mettre à jour des tickets",
+      "statusRequired": "Vous devez être connecté pour mettre à jour des tickets",
+      "priorityRequired": "Vous devez être connecté pour mettre à jour des tickets"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} sélectionné",
@@ -539,7 +544,83 @@
       "bundle": "Regrouper",
       "delete": "Supprimer",
       "clear": "Effacer la sélection",
-      "bundleNeedsTwo": "Sélectionnez au moins 2 tickets pour les regrouper"
+      "bundleNeedsTwo": "Sélectionnez au moins 2 tickets pour les regrouper",
+      "assign": "Assigner",
+      "status": "Statut",
+      "priority": "Priorité",
+      "tags": "Étiquettes",
+      "dueDate": "Échéance",
+      "statusDisabledMultiBoard": "Les tickets sélectionnés sont sur des tableaux différents",
+      "more": "Plus"
+    },
+    "assign": {
+      "dialogTitle": "Assigner les tickets sélectionnés",
+      "message": "Réassigner {{count}} ticket(s) sélectionné(s) à :",
+      "unassigned": "Non assigné",
+      "teamHint": "Le chef d'équipe devient l'assigné principal ; les autres membres sont ajoutés comme agents supplémentaires.",
+      "confirm_one": "Réassigner {{count}} ticket",
+      "confirm_other": "Réassigner {{count}} tickets",
+      "submitting": "Réassignation...",
+      "success_one": "{{count}} ticket réassigné",
+      "success_other": "{{count}} tickets réassignés",
+      "partialFailure": "Certains tickets n’ont pas pu être réassignés",
+      "failure": "Échec de la réassignation des tickets sélectionnés",
+      "failedHeading": "Les tickets suivants n’ont pas pu être réassignés :"
+    },
+    "tags": {
+      "dialogTitle": "Ajouter des étiquettes aux tickets sélectionnés",
+      "message": "Ajoutez une ou plusieurs étiquettes à {{count}} ticket(s). Les étiquettes déjà présentes sont ignorées.",
+      "placeholder": "Saisissez une étiquette et appuyez sur Entrée",
+      "confirm_one": "Ajouter aux {{count}} ticket",
+      "confirm_other": "Ajouter aux {{count}} tickets",
+      "submitting": "Ajout des étiquettes...",
+      "success_one": "Étiquettes ajoutées à {{count}} ticket",
+      "success_other": "Étiquettes ajoutées à {{count}} tickets",
+      "partialFailure": "Les étiquettes n’ont pas pu être ajoutées à certains tickets",
+      "failure": "Échec de l’ajout d’étiquettes",
+      "failedHeading": "Les étiquettes n’ont pas pu être ajoutées aux tickets suivants :"
+    },
+    "dueDate": {
+      "dialogTitle": "Définir l’échéance des tickets sélectionnés",
+      "message": "Définissez ou effacez l’échéance sur {{count}} ticket(s).",
+      "modeSet": "Définir à",
+      "modeClear": "Effacer l’échéance",
+      "placeholder": "Choisissez une date",
+      "confirm_one": "Mettre à jour {{count}} ticket",
+      "confirm_other": "Mettre à jour {{count}} tickets",
+      "submitting": "Mise à jour...",
+      "success_one": "Échéance mise à jour sur {{count}} ticket",
+      "success_other": "Échéance mise à jour sur {{count}} tickets",
+      "partialFailure": "L’échéance n’a pas pu être mise à jour sur certains tickets",
+      "failure": "Échec de la mise à jour de l’échéance",
+      "failedHeading": "L’échéance n’a pas pu être mise à jour sur les tickets suivants :"
+    },
+    "status": {
+      "dialogTitle": "Changer le statut des tickets sélectionnés",
+      "message": "Définissez le statut pour {{count}} ticket(s) :",
+      "placeholder": "Sélectionnez un statut",
+      "loading": "Chargement des statuts...",
+      "confirm_one": "Mettre à jour {{count}} ticket",
+      "confirm_other": "Mettre à jour {{count}} tickets",
+      "submitting": "Mise à jour...",
+      "success_one": "Statut mis à jour sur {{count}} ticket",
+      "success_other": "Statut mis à jour sur {{count}} tickets",
+      "partialFailure": "Le statut n’a pas pu être mis à jour sur certains tickets",
+      "failure": "Échec de la mise à jour du statut",
+      "failedHeading": "Le statut n’a pas pu être mis à jour sur les tickets suivants :"
+    },
+    "priority": {
+      "dialogTitle": "Changer la priorité des tickets sélectionnés",
+      "message": "Définissez la priorité pour {{count}} ticket(s) :",
+      "placeholder": "Sélectionnez une priorité",
+      "confirm_one": "Mettre à jour {{count}} ticket",
+      "confirm_other": "Mettre à jour {{count}} tickets",
+      "submitting": "Mise à jour...",
+      "success_one": "Priorité mise à jour sur {{count}} ticket",
+      "success_other": "Priorité mise à jour sur {{count}} tickets",
+      "partialFailure": "La priorité n’a pas pu être mise à jour sur certains tickets",
+      "failure": "Échec de la mise à jour de la priorité",
+      "failedHeading": "La priorité n’a pas pu être mise à jour sur les tickets suivants :"
     }
   },
   "quickAdd": {

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "Importer CSV"
   },
   "bulk": {
-    "moveToBoard": "Déplacer à bord",
-    "deleteSelected_one": "Supprimer la sélection ({{count}})",
-    "deleteSelected_other": "Supprimer la sélection ({{count}})",
     "bundleTickets": "Regrouper les tickets",
     "moveDialogTitle": "Déplacer les tickets sélectionnés",
     "moveDialogDescription": "Sélectionnez un tableau de destination et un statut, puis confirmez le déplacement des tickets sélectionnés.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Vous devez être connecté pour déplacer des tickets",
       "deleteRequired": "Vous devez être connecté pour supprimer des tickets"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} sélectionné",
+      "selectedCount_other": "{{count}} sélectionnés",
+      "move": "Déplacer au tableau",
+      "bundle": "Regrouper",
+      "delete": "Supprimer",
+      "clear": "Effacer la sélection",
+      "bundleNeedsTwo": "Sélectionnez au moins 2 tickets pour les regrouper"
     }
   },
   "quickAdd": {

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Étiquettes",
       "dueDate": "Échéance",
       "statusDisabledMultiBoard": "Les tickets sélectionnés sont sur des tableaux différents",
+      "statusResolvingBoards": "Vérification des tableaux des tickets sélectionnés…",
       "more": "Plus"
     },
     "assign": {

--- a/server/public/locales/it/common.json
+++ b/server/public/locales/it/common.json
@@ -1169,5 +1169,12 @@
         "warning": "I record archiviati sono nascosti nelle viste predefinite."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} colonna nascosta per spazio limitato.",
+    "columnsHidden_other": "{{count}} colonne nascoste per spazio limitato.",
+    "showAll": "Mostra tutto",
+    "showingAllColumns": "Vengono mostrate tutte le colonne; scorri orizzontalmente per vederle.",
+    "showLess": "Mostra meno"
   }
 }

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "Importa CSV"
   },
   "bulk": {
-    "moveToBoard": "Sposta su canale",
-    "deleteSelected_one": "Elimina selezionati ({{count}})",
-    "deleteSelected_other": "Elimina selezionati ({{count}})",
     "bundleTickets": "Raggruppa ticket",
     "moveDialogTitle": "Sposta i ticket selezionati",
     "moveDialogDescription": "Seleziona un canale e uno stato di destinazione, quindi conferma lo spostamento dei ticket selezionati.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Devi aver effettuato l'accesso per spostare i ticket",
       "deleteRequired": "Devi aver effettuato l'accesso per eliminare i ticket"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} selezionato",
+      "selectedCount_other": "{{count}} selezionati",
+      "move": "Sposta su canale",
+      "bundle": "Raggruppa",
+      "delete": "Elimina",
+      "clear": "Annulla selezione",
+      "bundleNeedsTwo": "Seleziona almeno 2 ticket per raggruppare"
     }
   },
   "quickAdd": {

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Tag",
       "dueDate": "Scadenza",
       "statusDisabledMultiBoard": "I ticket selezionati sono su canali diversi",
+      "statusResolvingBoards": "Verifica dei canali dei ticket selezionati…",
       "more": "Altro"
     },
     "assign": {

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Devi aver effettuato l'accesso per spostare i ticket",
-      "deleteRequired": "Devi aver effettuato l'accesso per eliminare i ticket"
+      "deleteRequired": "Devi aver effettuato l'accesso per eliminare i ticket",
+      "assignRequired": "Devi accedere per riassegnare i ticket",
+      "tagsRequired": "Devi accedere per aggiungere tag",
+      "dueDateRequired": "Devi accedere per aggiornare i ticket",
+      "statusRequired": "Devi accedere per aggiornare i ticket",
+      "priorityRequired": "Devi accedere per aggiornare i ticket"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} selezionato",
@@ -539,7 +544,83 @@
       "bundle": "Raggruppa",
       "delete": "Elimina",
       "clear": "Annulla selezione",
-      "bundleNeedsTwo": "Seleziona almeno 2 ticket per raggruppare"
+      "bundleNeedsTwo": "Seleziona almeno 2 ticket per raggruppare",
+      "assign": "Assegna",
+      "status": "Stato",
+      "priority": "Priorità",
+      "tags": "Tag",
+      "dueDate": "Scadenza",
+      "statusDisabledMultiBoard": "I ticket selezionati sono su canali diversi",
+      "more": "Altro"
+    },
+    "assign": {
+      "dialogTitle": "Assegna ticket selezionati",
+      "message": "Riassegna {{count}} ticket selezionato/i a:",
+      "unassigned": "Non assegnato",
+      "teamHint": "Il responsabile del team diventa l’assegnatario principale; gli altri membri sono aggiunti come agenti aggiuntivi.",
+      "confirm_one": "Riassegna {{count}} ticket",
+      "confirm_other": "Riassegna {{count}} ticket",
+      "submitting": "Riassegnazione...",
+      "success_one": "{{count}} ticket riassegnato",
+      "success_other": "{{count}} ticket riassegnati",
+      "partialFailure": "Alcuni ticket non sono stati riassegnati",
+      "failure": "Impossibile riassegnare i ticket selezionati",
+      "failedHeading": "I seguenti ticket non sono stati riassegnati:"
+    },
+    "tags": {
+      "dialogTitle": "Aggiungi tag ai ticket selezionati",
+      "message": "Aggiungi uno o più tag a {{count}} ticket. I tag già presenti vengono ignorati.",
+      "placeholder": "Digita un tag e premi Invio",
+      "confirm_one": "Aggiungi tag a {{count}} ticket",
+      "confirm_other": "Aggiungi tag a {{count}} ticket",
+      "submitting": "Aggiunta tag...",
+      "success_one": "Tag aggiunti a {{count}} ticket",
+      "success_other": "Tag aggiunti a {{count}} ticket",
+      "partialFailure": "Tag non aggiunti su alcuni ticket",
+      "failure": "Impossibile aggiungere i tag",
+      "failedHeading": "Tag non aggiunti ai seguenti ticket:"
+    },
+    "dueDate": {
+      "dialogTitle": "Imposta scadenza per i ticket selezionati",
+      "message": "Imposta o rimuovi la scadenza su {{count}} ticket.",
+      "modeSet": "Imposta a",
+      "modeClear": "Rimuovi scadenza",
+      "placeholder": "Scegli una data",
+      "confirm_one": "Aggiorna {{count}} ticket",
+      "confirm_other": "Aggiorna {{count}} ticket",
+      "submitting": "Aggiornamento...",
+      "success_one": "Scadenza aggiornata su {{count}} ticket",
+      "success_other": "Scadenza aggiornata su {{count}} ticket",
+      "partialFailure": "Scadenza non aggiornata su alcuni ticket",
+      "failure": "Impossibile aggiornare la scadenza",
+      "failedHeading": "Scadenza non aggiornata sui seguenti ticket:"
+    },
+    "status": {
+      "dialogTitle": "Cambia stato dei ticket selezionati",
+      "message": "Imposta lo stato per {{count}} ticket:",
+      "placeholder": "Seleziona uno stato",
+      "loading": "Caricamento stati...",
+      "confirm_one": "Aggiorna {{count}} ticket",
+      "confirm_other": "Aggiorna {{count}} ticket",
+      "submitting": "Aggiornamento...",
+      "success_one": "Stato aggiornato su {{count}} ticket",
+      "success_other": "Stato aggiornato su {{count}} ticket",
+      "partialFailure": "Stato non aggiornato su alcuni ticket",
+      "failure": "Impossibile aggiornare lo stato",
+      "failedHeading": "Stato non aggiornato sui seguenti ticket:"
+    },
+    "priority": {
+      "dialogTitle": "Cambia priorità dei ticket selezionati",
+      "message": "Imposta la priorità per {{count}} ticket:",
+      "placeholder": "Seleziona una priorità",
+      "confirm_one": "Aggiorna {{count}} ticket",
+      "confirm_other": "Aggiorna {{count}} ticket",
+      "submitting": "Aggiornamento...",
+      "success_one": "Priorità aggiornata su {{count}} ticket",
+      "success_other": "Priorità aggiornata su {{count}} ticket",
+      "partialFailure": "Priorità non aggiornata su alcuni ticket",
+      "failure": "Impossibile aggiornare la priorità",
+      "failedHeading": "Priorità non aggiornata sui seguenti ticket:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/nl/common.json
+++ b/server/public/locales/nl/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Gearchiveerde records worden verborgen in standaardweergaven."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} kolom verborgen wegens beperkte ruimte.",
+    "columnsHidden_other": "{{count}} kolommen verborgen wegens beperkte ruimte.",
+    "showAll": "Alles tonen",
+    "showingAllColumns": "Alle kolommen worden getoond; scroll horizontaal om ze te zien.",
+    "showLess": "Minder tonen"
   }
 }

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "CSV importeren"
   },
   "bulk": {
-    "moveToBoard": "Verplaatsen naar bord",
-    "deleteSelected_one": "Geselecteerde verwijderen ({{count}})",
-    "deleteSelected_other": "Geselecteerde verwijderen ({{count}})",
     "bundleTickets": "Tickets bundelen",
     "moveDialogTitle": "Geselecteerde tickets verplaatsen",
     "moveDialogDescription": "Selecteer een bestemmingsbord en status en bevestig het verplaatsen van de geselecteerde tickets.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Je moet zijn ingelogd om tickets te verplaatsen",
       "deleteRequired": "Je moet zijn ingelogd om tickets te verwijderen"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} geselecteerd",
+      "selectedCount_other": "{{count}} geselecteerd",
+      "move": "Verplaatsen naar bord",
+      "bundle": "Bundelen",
+      "delete": "Verwijderen",
+      "clear": "Selectie wissen",
+      "bundleNeedsTwo": "Selecteer minstens 2 tickets om te bundelen"
     }
   },
   "quickAdd": {

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Je moet zijn ingelogd om tickets te verplaatsen",
-      "deleteRequired": "Je moet zijn ingelogd om tickets te verwijderen"
+      "deleteRequired": "Je moet zijn ingelogd om tickets te verwijderen",
+      "assignRequired": "Je moet ingelogd zijn om tickets toe te wijzen",
+      "tagsRequired": "Je moet ingelogd zijn om tags toe te voegen",
+      "dueDateRequired": "Je moet ingelogd zijn om tickets bij te werken",
+      "statusRequired": "Je moet ingelogd zijn om tickets bij te werken",
+      "priorityRequired": "Je moet ingelogd zijn om tickets bij te werken"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} geselecteerd",
@@ -539,7 +544,83 @@
       "bundle": "Bundelen",
       "delete": "Verwijderen",
       "clear": "Selectie wissen",
-      "bundleNeedsTwo": "Selecteer minstens 2 tickets om te bundelen"
+      "bundleNeedsTwo": "Selecteer minstens 2 tickets om te bundelen",
+      "assign": "Toewijzen",
+      "status": "Status",
+      "priority": "Prioriteit",
+      "tags": "Tags",
+      "dueDate": "Vervaldatum",
+      "statusDisabledMultiBoard": "Geselecteerde tickets staan op verschillende borden",
+      "more": "Meer"
+    },
+    "assign": {
+      "dialogTitle": "Geselecteerde tickets toewijzen",
+      "message": "{{count}} geselecteerde ticket(s) toewijzen aan:",
+      "unassigned": "Niet toegewezen",
+      "teamHint": "De teamleider wordt de primaire toegewezene; overige teamleden worden als extra agenten toegevoegd.",
+      "confirm_one": "{{count}} ticket toewijzen",
+      "confirm_other": "{{count}} tickets toewijzen",
+      "submitting": "Toewijzen...",
+      "success_one": "{{count}} ticket toegewezen",
+      "success_other": "{{count}} tickets toegewezen",
+      "partialFailure": "Sommige tickets konden niet worden toegewezen",
+      "failure": "Toewijzen van geselecteerde tickets is mislukt",
+      "failedHeading": "De volgende tickets konden niet worden toegewezen:"
+    },
+    "tags": {
+      "dialogTitle": "Tags toevoegen aan geselecteerde tickets",
+      "message": "Voeg een of meer tags toe aan {{count}} ticket(s). Bestaande tags worden overgeslagen.",
+      "placeholder": "Typ een tag en druk op Enter",
+      "confirm_one": "Tags toevoegen aan {{count}} ticket",
+      "confirm_other": "Tags toevoegen aan {{count}} tickets",
+      "submitting": "Tags toevoegen...",
+      "success_one": "Tags toegevoegd aan {{count}} ticket",
+      "success_other": "Tags toegevoegd aan {{count}} tickets",
+      "partialFailure": "Tags konden niet bij alle tickets worden toegevoegd",
+      "failure": "Toevoegen van tags is mislukt",
+      "failedHeading": "Tags konden niet worden toegevoegd aan de volgende tickets:"
+    },
+    "dueDate": {
+      "dialogTitle": "Vervaldatum instellen voor geselecteerde tickets",
+      "message": "Stel de vervaldatum in of verwijder deze op {{count}} ticket(s).",
+      "modeSet": "Instellen op",
+      "modeClear": "Vervaldatum verwijderen",
+      "placeholder": "Kies een datum",
+      "confirm_one": "{{count}} ticket bijwerken",
+      "confirm_other": "{{count}} tickets bijwerken",
+      "submitting": "Bezig met bijwerken...",
+      "success_one": "Vervaldatum bijgewerkt op {{count}} ticket",
+      "success_other": "Vervaldatum bijgewerkt op {{count}} tickets",
+      "partialFailure": "Vervaldatum kon niet bij alle tickets worden bijgewerkt",
+      "failure": "Bijwerken van vervaldatum is mislukt",
+      "failedHeading": "Vervaldatum kon niet worden bijgewerkt bij de volgende tickets:"
+    },
+    "status": {
+      "dialogTitle": "Status wijzigen voor geselecteerde tickets",
+      "message": "Stel de status in voor {{count}} ticket(s):",
+      "placeholder": "Selecteer een status",
+      "loading": "Statussen laden...",
+      "confirm_one": "{{count}} ticket bijwerken",
+      "confirm_other": "{{count}} tickets bijwerken",
+      "submitting": "Bezig met bijwerken...",
+      "success_one": "Status bijgewerkt op {{count}} ticket",
+      "success_other": "Status bijgewerkt op {{count}} tickets",
+      "partialFailure": "Status kon niet bij alle tickets worden bijgewerkt",
+      "failure": "Bijwerken van status is mislukt",
+      "failedHeading": "Status kon niet worden bijgewerkt bij de volgende tickets:"
+    },
+    "priority": {
+      "dialogTitle": "Prioriteit wijzigen voor geselecteerde tickets",
+      "message": "Stel de prioriteit in voor {{count}} ticket(s):",
+      "placeholder": "Selecteer een prioriteit",
+      "confirm_one": "{{count}} ticket bijwerken",
+      "confirm_other": "{{count}} tickets bijwerken",
+      "submitting": "Bezig met bijwerken...",
+      "success_one": "Prioriteit bijgewerkt op {{count}} ticket",
+      "success_other": "Prioriteit bijgewerkt op {{count}} tickets",
+      "partialFailure": "Prioriteit kon niet bij alle tickets worden bijgewerkt",
+      "failure": "Bijwerken van prioriteit is mislukt",
+      "failedHeading": "Prioriteit kon niet worden bijgewerkt bij de volgende tickets:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Tags",
       "dueDate": "Vervaldatum",
       "statusDisabledMultiBoard": "Geselecteerde tickets staan op verschillende borden",
+      "statusResolvingBoards": "Borden van geselecteerde tickets controleren…",
       "more": "Meer"
     },
     "assign": {

--- a/server/public/locales/pl/common.json
+++ b/server/public/locales/pl/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Zarchiwizowane rekordy są ukryte w widokach domyślnych."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "Ukryto {{count}} kolumnę z powodu ograniczonego miejsca.",
+    "columnsHidden_other": "Ukryto {{count}} kolumn z powodu ograniczonego miejsca.",
+    "showAll": "Pokaż wszystko",
+    "showingAllColumns": "Wyświetlane są wszystkie kolumny; przewiń w poziomie, aby je zobaczyć.",
+    "showLess": "Pokaż mniej"
   }
 }

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "Importuj CSV"
   },
   "bulk": {
-    "moveToBoard": "Przenieś do tablicy",
-    "deleteSelected_one": "Usuń zaznaczone ({{count}})",
-    "deleteSelected_other": "Usuń zaznaczone ({{count}})",
     "bundleTickets": "Połącz zgłoszenia",
     "moveDialogTitle": "Przenieś zaznaczone zgłoszenia",
     "moveDialogDescription": "Wybierz tablicę docelową i status, a następnie potwierdź przeniesienie zaznaczonych zgłoszeń.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "Musisz być zalogowany, aby przenosić zgłoszenia",
       "deleteRequired": "Musisz być zalogowany, aby usuwać zgłoszenia"
+    },
+    "actionBar": {
+      "selectedCount_one": "Zaznaczono {{count}}",
+      "selectedCount_other": "Zaznaczono {{count}}",
+      "move": "Przenieś do tablicy",
+      "bundle": "Połącz",
+      "delete": "Usuń",
+      "clear": "Wyczyść zaznaczenie",
+      "bundleNeedsTwo": "Zaznacz co najmniej 2 zgłoszenia, aby je połączyć"
     }
   },
   "quickAdd": {

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "Musisz być zalogowany, aby przenosić zgłoszenia",
-      "deleteRequired": "Musisz być zalogowany, aby usuwać zgłoszenia"
+      "deleteRequired": "Musisz być zalogowany, aby usuwać zgłoszenia",
+      "assignRequired": "Musisz być zalogowany, aby ponownie przypisać zgłoszenia",
+      "tagsRequired": "Musisz być zalogowany, aby dodać tagi",
+      "dueDateRequired": "Musisz być zalogowany, aby aktualizować zgłoszenia",
+      "statusRequired": "Musisz być zalogowany, aby aktualizować zgłoszenia",
+      "priorityRequired": "Musisz być zalogowany, aby aktualizować zgłoszenia"
     },
     "actionBar": {
       "selectedCount_one": "Zaznaczono {{count}}",
@@ -539,7 +544,83 @@
       "bundle": "Połącz",
       "delete": "Usuń",
       "clear": "Wyczyść zaznaczenie",
-      "bundleNeedsTwo": "Zaznacz co najmniej 2 zgłoszenia, aby je połączyć"
+      "bundleNeedsTwo": "Zaznacz co najmniej 2 zgłoszenia, aby je połączyć",
+      "assign": "Przypisz",
+      "status": "Status",
+      "priority": "Priorytet",
+      "tags": "Tagi",
+      "dueDate": "Termin",
+      "statusDisabledMultiBoard": "Wybrane zgłoszenia są na różnych tablicach",
+      "more": "Więcej"
+    },
+    "assign": {
+      "dialogTitle": "Przypisz wybrane zgłoszenia",
+      "message": "Ponownie przypisz {{count}} wybranych zgłoszeń do:",
+      "unassigned": "Nieprzypisane",
+      "teamHint": "Lider zespołu staje się głównym przypisanym; pozostali członkowie zespołu są dodawani jako dodatkowi agenci.",
+      "confirm_one": "Ponownie przypisz {{count}} zgłoszenie",
+      "confirm_other": "Ponownie przypisz {{count}} zgłoszenia",
+      "submitting": "Przypisywanie...",
+      "success_one": "{{count}} zgłoszenie ponownie przypisane",
+      "success_other": "{{count}} zgłoszeń ponownie przypisanych",
+      "partialFailure": "Niektórych zgłoszeń nie udało się ponownie przypisać",
+      "failure": "Nie udało się ponownie przypisać wybranych zgłoszeń",
+      "failedHeading": "Następujących zgłoszeń nie udało się ponownie przypisać:"
+    },
+    "tags": {
+      "dialogTitle": "Dodaj tagi do wybranych zgłoszeń",
+      "message": "Dodaj jeden lub więcej tagów do {{count}} wybranych zgłoszeń. Tagi już obecne są pomijane.",
+      "placeholder": "Wpisz tag i naciśnij Enter",
+      "confirm_one": "Dodaj tagi do {{count}} zgłoszenia",
+      "confirm_other": "Dodaj tagi do {{count}} zgłoszeń",
+      "submitting": "Dodawanie tagów...",
+      "success_one": "Tagi dodane do {{count}} zgłoszenia",
+      "success_other": "Tagi dodane do {{count}} zgłoszeń",
+      "partialFailure": "Tagi nie zostały dodane do wszystkich zgłoszeń",
+      "failure": "Nie udało się dodać tagów",
+      "failedHeading": "Tagi nie zostały dodane do następujących zgłoszeń:"
+    },
+    "dueDate": {
+      "dialogTitle": "Ustaw termin dla wybranych zgłoszeń",
+      "message": "Ustaw lub wyczyść termin dla {{count}} wybranych zgłoszeń.",
+      "modeSet": "Ustaw na",
+      "modeClear": "Wyczyść termin",
+      "placeholder": "Wybierz datę",
+      "confirm_one": "Zaktualizuj {{count}} zgłoszenie",
+      "confirm_other": "Zaktualizuj {{count}} zgłoszeń",
+      "submitting": "Aktualizowanie...",
+      "success_one": "Termin zaktualizowany w {{count}} zgłoszeniu",
+      "success_other": "Termin zaktualizowany w {{count}} zgłoszeniach",
+      "partialFailure": "Termin nie został zaktualizowany w niektórych zgłoszeniach",
+      "failure": "Nie udało się zaktualizować terminu",
+      "failedHeading": "Termin nie został zaktualizowany w następujących zgłoszeniach:"
+    },
+    "status": {
+      "dialogTitle": "Zmień status wybranych zgłoszeń",
+      "message": "Ustaw status dla {{count}} wybranych zgłoszeń:",
+      "placeholder": "Wybierz status",
+      "loading": "Ładowanie statusów...",
+      "confirm_one": "Zaktualizuj {{count}} zgłoszenie",
+      "confirm_other": "Zaktualizuj {{count}} zgłoszeń",
+      "submitting": "Aktualizowanie...",
+      "success_one": "Status zaktualizowany w {{count}} zgłoszeniu",
+      "success_other": "Status zaktualizowany w {{count}} zgłoszeniach",
+      "partialFailure": "Status nie został zaktualizowany w niektórych zgłoszeniach",
+      "failure": "Nie udało się zaktualizować statusu",
+      "failedHeading": "Status nie został zaktualizowany w następujących zgłoszeniach:"
+    },
+    "priority": {
+      "dialogTitle": "Zmień priorytet wybranych zgłoszeń",
+      "message": "Ustaw priorytet dla {{count}} wybranych zgłoszeń:",
+      "placeholder": "Wybierz priorytet",
+      "confirm_one": "Zaktualizuj {{count}} zgłoszenie",
+      "confirm_other": "Zaktualizuj {{count}} zgłoszeń",
+      "submitting": "Aktualizowanie...",
+      "success_one": "Priorytet zaktualizowany w {{count}} zgłoszeniu",
+      "success_other": "Priorytet zaktualizowany w {{count}} zgłoszeniach",
+      "partialFailure": "Priorytet nie został zaktualizowany w niektórych zgłoszeniach",
+      "failure": "Nie udało się zaktualizować priorytetu",
+      "failedHeading": "Priorytet nie został zaktualizowany w następujących zgłoszeniach:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Tagi",
       "dueDate": "Termin",
       "statusDisabledMultiBoard": "Wybrane zgłoszenia są na różnych tablicach",
+      "statusResolvingBoards": "Sprawdzanie tablic wybranych zgłoszeń…",
       "more": "Więcej"
     },
     "assign": {

--- a/server/public/locales/pt/common.json
+++ b/server/public/locales/pt/common.json
@@ -1169,5 +1169,12 @@
         "warning": "Registros arquivados ficam ocultos nas visualizações padrão."
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "{{count}} column hidden due to limited space.",
+    "columnsHidden_other": "{{count}} columns hidden due to limited space.",
+    "showAll": "Show all",
+    "showingAllColumns": "Showing all columns; scroll horizontally to see them.",
+    "showLess": "Show less"
   }
 }

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "Importar CSV"
   },
   "bulk": {
-    "moveToBoard": "Move to Board",
-    "deleteSelected_one": "Delete Selected ({{count}})",
-    "deleteSelected_other": "Delete Selected ({{count}})",
     "bundleTickets": "Bundle Tickets",
     "moveDialogTitle": "Move Selected Tickets",
     "moveDialogDescription": "Select a destination board and status, then confirm moving the selected tickets.",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "You must be logged in to move tickets",
       "deleteRequired": "You must be logged in to delete tickets"
+    },
+    "actionBar": {
+      "selectedCount_one": "{{count}} selected",
+      "selectedCount_other": "{{count}} selected",
+      "move": "Move to Board",
+      "bundle": "Bundle",
+      "delete": "Delete",
+      "clear": "Clear",
+      "bundleNeedsTwo": "Select at least 2 tickets to bundle"
     }
   },
   "quickAdd": {

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "You must be logged in to move tickets",
-      "deleteRequired": "You must be logged in to delete tickets"
+      "deleteRequired": "You must be logged in to delete tickets",
+      "assignRequired": "You must be logged in to reassign tickets",
+      "tagsRequired": "You must be logged in to add tags",
+      "dueDateRequired": "You must be logged in to update tickets",
+      "statusRequired": "You must be logged in to update tickets",
+      "priorityRequired": "You must be logged in to update tickets"
     },
     "actionBar": {
       "selectedCount_one": "{{count}} selected",
@@ -539,7 +544,83 @@
       "bundle": "Bundle",
       "delete": "Delete",
       "clear": "Clear",
-      "bundleNeedsTwo": "Select at least 2 tickets to bundle"
+      "bundleNeedsTwo": "Select at least 2 tickets to bundle",
+      "assign": "Assign",
+      "status": "Status",
+      "priority": "Priority",
+      "tags": "Tags",
+      "dueDate": "Due Date",
+      "statusDisabledMultiBoard": "Selected tickets are on different boards",
+      "more": "More"
+    },
+    "assign": {
+      "dialogTitle": "Assign Selected Tickets",
+      "message": "Reassign {{count}} selected ticket(s) to:",
+      "unassigned": "Not assigned",
+      "teamHint": "The team lead becomes the primary assignee; other team members are added as additional agents.",
+      "confirm_one": "Reassign {{count}} Ticket",
+      "confirm_other": "Reassign {{count}} Tickets",
+      "submitting": "Reassigning...",
+      "success_one": "{{count}} ticket reassigned",
+      "success_other": "{{count}} tickets reassigned",
+      "partialFailure": "Some tickets could not be reassigned",
+      "failure": "Failed to reassign selected tickets",
+      "failedHeading": "The following tickets could not be reassigned:"
+    },
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tickets",
+      "message": "Add one or more tags to {{count}} selected ticket(s). Tags already on a ticket are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "confirm_one": "Add Tags to {{count}} Ticket",
+      "confirm_other": "Add Tags to {{count}} Tickets",
+      "submitting": "Adding tags...",
+      "success_one": "Tags added to {{count}} ticket",
+      "success_other": "Tags added to {{count}} tickets",
+      "partialFailure": "Tags could not be added to some tickets",
+      "failure": "Failed to add tags to selected tickets",
+      "failedHeading": "Tags could not be added to the following tickets:"
+    },
+    "dueDate": {
+      "dialogTitle": "Set Due Date for Selected Tickets",
+      "message": "Set or clear the due date on {{count}} selected ticket(s).",
+      "modeSet": "Set to",
+      "modeClear": "Clear due date",
+      "placeholder": "Pick a date",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Due date updated on {{count}} ticket",
+      "success_other": "Due date updated on {{count}} tickets",
+      "partialFailure": "Due date could not be updated on some tickets",
+      "failure": "Failed to update due date on selected tickets",
+      "failedHeading": "Due date could not be updated on the following tickets:"
+    },
+    "status": {
+      "dialogTitle": "Change Status for Selected Tickets",
+      "message": "Set the status for {{count}} selected ticket(s):",
+      "placeholder": "Select a status",
+      "loading": "Loading statuses...",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Status updated on {{count}} ticket",
+      "success_other": "Status updated on {{count}} tickets",
+      "partialFailure": "Status could not be updated on some tickets",
+      "failure": "Failed to update status on selected tickets",
+      "failedHeading": "Status could not be updated on the following tickets:"
+    },
+    "priority": {
+      "dialogTitle": "Change Priority for Selected Tickets",
+      "message": "Set the priority for {{count}} selected ticket(s):",
+      "placeholder": "Select a priority",
+      "confirm_one": "Update {{count}} Ticket",
+      "confirm_other": "Update {{count}} Tickets",
+      "submitting": "Updating...",
+      "success_one": "Priority updated on {{count}} ticket",
+      "success_other": "Priority updated on {{count}} tickets",
+      "partialFailure": "Priority could not be updated on some tickets",
+      "failure": "Failed to update priority on selected tickets",
+      "failedHeading": "Priority could not be updated on the following tickets:"
     }
   },
   "quickAdd": {

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "Tags",
       "dueDate": "Due Date",
       "statusDisabledMultiBoard": "Selected tickets are on different boards",
+      "statusResolvingBoards": "Checking the boards of selected tickets…",
       "more": "More"
     },
     "assign": {

--- a/server/public/locales/xx/common.json
+++ b/server/public/locales/xx/common.json
@@ -1169,5 +1169,12 @@
         "warning": "11111"
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "11111 {{count}} 11111",
+    "columnsHidden_other": "11111 {{count}} 11111",
+    "showAll": "11111",
+    "showingAllColumns": "11111",
+    "showLess": "11111"
   }
 }

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "11111"
   },
   "bulk": {
-    "moveToBoard": "11111",
-    "deleteSelected_one": "11111 {{count}} 11111",
-    "deleteSelected_other": "11111 {{count}} 11111",
     "bundleTickets": "11111",
     "moveDialogTitle": "11111",
     "moveDialogDescription": "11111",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "11111",
       "deleteRequired": "11111"
+    },
+    "actionBar": {
+      "selectedCount_one": "11111 {{count}} 11111",
+      "selectedCount_other": "11111 {{count}} 11111",
+      "move": "11111",
+      "bundle": "11111",
+      "delete": "11111",
+      "clear": "11111",
+      "bundleNeedsTwo": "11111"
     }
   },
   "quickAdd": {

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "11111",
-      "deleteRequired": "11111"
+      "deleteRequired": "11111",
+      "assignRequired": "11111",
+      "tagsRequired": "11111",
+      "dueDateRequired": "11111",
+      "statusRequired": "11111",
+      "priorityRequired": "11111"
     },
     "actionBar": {
       "selectedCount_one": "11111 {{count}} 11111",
@@ -539,7 +544,83 @@
       "bundle": "11111",
       "delete": "11111",
       "clear": "11111",
-      "bundleNeedsTwo": "11111"
+      "bundleNeedsTwo": "11111",
+      "assign": "11111",
+      "status": "11111",
+      "priority": "11111",
+      "tags": "11111",
+      "dueDate": "11111",
+      "statusDisabledMultiBoard": "11111",
+      "more": "11111"
+    },
+    "assign": {
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "unassigned": "11111",
+      "teamHint": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "submitting": "11111",
+      "success_one": "11111 {{count}} 11111",
+      "success_other": "11111 {{count}} 11111",
+      "partialFailure": "11111",
+      "failure": "11111",
+      "failedHeading": "11111"
+    },
+    "tags": {
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "placeholder": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "submitting": "11111",
+      "success_one": "11111 {{count}} 11111",
+      "success_other": "11111 {{count}} 11111",
+      "partialFailure": "11111",
+      "failure": "11111",
+      "failedHeading": "11111"
+    },
+    "dueDate": {
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "modeSet": "11111",
+      "modeClear": "11111",
+      "placeholder": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "submitting": "11111",
+      "success_one": "11111 {{count}} 11111",
+      "success_other": "11111 {{count}} 11111",
+      "partialFailure": "11111",
+      "failure": "11111",
+      "failedHeading": "11111"
+    },
+    "status": {
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "placeholder": "11111",
+      "loading": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "submitting": "11111",
+      "success_one": "11111 {{count}} 11111",
+      "success_other": "11111 {{count}} 11111",
+      "partialFailure": "11111",
+      "failure": "11111",
+      "failedHeading": "11111"
+    },
+    "priority": {
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "placeholder": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "submitting": "11111",
+      "success_one": "11111 {{count}} 11111",
+      "success_other": "11111 {{count}} 11111",
+      "partialFailure": "11111",
+      "failure": "11111",
+      "failedHeading": "11111"
     }
   },
   "quickAdd": {

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "11111",
       "dueDate": "11111",
       "statusDisabledMultiBoard": "11111",
+      "statusResolvingBoards": "11111",
       "more": "11111"
     },
     "assign": {

--- a/server/public/locales/yy/common.json
+++ b/server/public/locales/yy/common.json
@@ -1169,5 +1169,12 @@
         "warning": "55555"
       }
     }
+  },
+  "dataTable": {
+    "columnsHidden_one": "55555 {{count}} 55555",
+    "columnsHidden_other": "55555 {{count}} 55555",
+    "showAll": "55555",
+    "showingAllColumns": "55555",
+    "showLess": "55555"
   }
 }

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -530,7 +530,12 @@
     },
     "auth": {
       "moveRequired": "55555",
-      "deleteRequired": "55555"
+      "deleteRequired": "55555",
+      "assignRequired": "55555",
+      "tagsRequired": "55555",
+      "dueDateRequired": "55555",
+      "statusRequired": "55555",
+      "priorityRequired": "55555"
     },
     "actionBar": {
       "selectedCount_one": "55555 {{count}} 55555",
@@ -539,7 +544,83 @@
       "bundle": "55555",
       "delete": "55555",
       "clear": "55555",
-      "bundleNeedsTwo": "55555"
+      "bundleNeedsTwo": "55555",
+      "assign": "55555",
+      "status": "55555",
+      "priority": "55555",
+      "tags": "55555",
+      "dueDate": "55555",
+      "statusDisabledMultiBoard": "55555",
+      "more": "55555"
+    },
+    "assign": {
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "unassigned": "55555",
+      "teamHint": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "submitting": "55555",
+      "success_one": "55555 {{count}} 55555",
+      "success_other": "55555 {{count}} 55555",
+      "partialFailure": "55555",
+      "failure": "55555",
+      "failedHeading": "55555"
+    },
+    "tags": {
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "placeholder": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "submitting": "55555",
+      "success_one": "55555 {{count}} 55555",
+      "success_other": "55555 {{count}} 55555",
+      "partialFailure": "55555",
+      "failure": "55555",
+      "failedHeading": "55555"
+    },
+    "dueDate": {
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "modeSet": "55555",
+      "modeClear": "55555",
+      "placeholder": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "submitting": "55555",
+      "success_one": "55555 {{count}} 55555",
+      "success_other": "55555 {{count}} 55555",
+      "partialFailure": "55555",
+      "failure": "55555",
+      "failedHeading": "55555"
+    },
+    "status": {
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "placeholder": "55555",
+      "loading": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "submitting": "55555",
+      "success_one": "55555 {{count}} 55555",
+      "success_other": "55555 {{count}} 55555",
+      "partialFailure": "55555",
+      "failure": "55555",
+      "failedHeading": "55555"
+    },
+    "priority": {
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "placeholder": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "submitting": "55555",
+      "success_one": "55555 {{count}} 55555",
+      "success_other": "55555 {{count}} 55555",
+      "partialFailure": "55555",
+      "failure": "55555",
+      "failedHeading": "55555"
     }
   },
   "quickAdd": {

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -430,9 +430,6 @@
     "importAction": "55555"
   },
   "bulk": {
-    "moveToBoard": "55555",
-    "deleteSelected_one": "55555 {{count}} 55555",
-    "deleteSelected_other": "55555 {{count}} 55555",
     "bundleTickets": "55555",
     "moveDialogTitle": "55555",
     "moveDialogDescription": "55555",
@@ -534,6 +531,15 @@
     "auth": {
       "moveRequired": "55555",
       "deleteRequired": "55555"
+    },
+    "actionBar": {
+      "selectedCount_one": "55555 {{count}} 55555",
+      "selectedCount_other": "55555 {{count}} 55555",
+      "move": "55555",
+      "bundle": "55555",
+      "delete": "55555",
+      "clear": "55555",
+      "bundleNeedsTwo": "55555"
     }
   },
   "quickAdd": {

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -551,6 +551,7 @@
       "tags": "55555",
       "dueDate": "55555",
       "statusDisabledMultiBoard": "55555",
+      "statusResolvingBoards": "55555",
       "more": "55555"
     },
     "assign": {


### PR DESCRIPTION
## Summary

Builds out the ticketing dashboard's list experience and hardens the shared `DataTable`:

- **Zoom/density**: granular, responsive zoom for the tickets table with readable cell wrapping; tag sizes, filter-control sizes, and the Bundled toggle now scale with the zoom level (not just spacing).
- **Bulk actions**: a floating bulk-action bar with Assign, Bundle, Move to Board, Delete, and a "More" menu (Status, Priority, Tags, Due Date). The legacy per-row three-dot actions column is removed in favor of the bar.
- **DataTable**: columns now fit the container instead of overflowing, with a "Show all" toggle; the truncation tooltip uses our custom Tooltip component instead of the native `title`.

## Details

### Zoom / density
- Granular zoom slider (10 steps) driving padding, row density, font sizes, and per-step `minColumnWidth` originally — now superseded by size-based column fit.
- Cells wrap on word boundaries instead of mid-character.
- Tag size (`sm`/`md`), filter control height/font (5 bands, every ~2 steps), and the Bundled `Switch` + label scale with the zoom level. Spacious anchors at today's sizing and scales down toward compact.

### Bulk actions
- New floating `BulkTicketActionBar` (replaces the in-header buttons); appears when tickets are selected.
- Primary buttons: **Assign**, **Bundle**, **Move to Board**, **Delete**. Secondary in a **More** dropdown: **Status**, **Priority**, **Tags**, **Due Date**.
- New dialogs: `BulkAssignTicketsDialog`, `BulkAddTagsDialog`, `BulkSetDueDateDialog`, `BulkChangeStatusDialog`, `BulkChangePriorityDialog`.
- New server actions (`bulkAssignTickets`, `bulkAddTagsToTickets`, `bulkUpdateTicketDueDate`, `bulkUpdateTicketStatus`, `bulkUpdateTicketPriority`) returning per-ticket `{ updatedIds, failed }`.
- Team assign uses the canonical flow (`assignTeamToTicket` / `removeTeamFromTicket`) so `assigned_team_id` + `team_member` resources persist; user assign clears any stale team.
- Permission-gated: action buttons hidden without `ticket:update`; bulk tag writes check `ticket:update` server-side.
- Status is disabled when the selection spans multiple boards or includes off-page tickets (select-all-matching), avoiding partial-failure paths.
- Field-edit actions (Assign/Tags/Due Date/Status/Priority) keep the selection so users can chain bulk actions; Delete/Move clear it.
- Removed the per-row "Actions" three-dot column and the now-orphaned single-ticket delete dialog chain.
- Due-date picker mounts the `Calendar` inline so it's fully visible in the dialog.
- i18n: new `bulk.*` keys added across all 10 locales.

### Selection UX
- The entire checkbox column is a click target (overlay), so clicking cell padding no longer opens the ticket.

### Shared DataTable
- Column fit: visible columns are chosen by accumulating each column's real size until the container is full, so visible columns never overflow. Adds a **Show all** / **Show less** toggle in the hidden-columns banner for horizontal scrolling.
- Truncation tooltip now uses the custom `Tooltip` (controlled open, shown only when content actually overflows) instead of the native `title` attribute; `Tooltip` gains optional `open`/`onOpenChange`/`delayDuration`.
- Removed the dead `minColumnWidth` prop now that fit is size-based.

## Test plan
- [ ] Sweep the zoom slider: padding, row density, fonts, tags, filter controls, and Bundled toggle all scale; spacious matches prior look.
- [ ] Tickets table never shows a horizontal scrollbar in the default (fitted) view; "Show all" reveals all columns with scroll, "Show less" collapses.
- [ ] Truncated cells/headers show the custom dark tooltip; non-truncated content shows none.
- [ ] Clicking anywhere in the checkbox column toggles selection (doesn't open the ticket).
- [ ] Bulk bar: Assign (user + team), Bundle, Move to Board, Delete, and More → Status/Priority/Tags/Due Date all work, with partial-failure handling.
- [ ] Team assign persists the team badge/filter; reassigning to a user clears the team.
- [ ] Status disabled for multi-board / select-all-matching selections.
- [ ] Field-edit bulk actions keep the selection; Delete/Move clear it.
- [ ] Bulk tag add denied without `ticket:update`.