### PR TITLE
Expand list search to use full-text app_search_index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44028,7 +44028,6 @@
       "name": "@alga-psa/types",
       "version": "0.0.1",
       "dependencies": {
-        "@alga-psa/event-schemas": "*",
         "@js-temporal/polyfill": "^0.4.4",
         "knex": "^3.1.0"
       },

--- a/packages/clients/src/actions/clientActions.ts
+++ b/packages/clients/src/actions/clientActions.ts
@@ -26,6 +26,10 @@ import {
 import { buildContactPrimarySetPayload } from '@alga-psa/workflow-streams';
 import { ensureDefaultContractForClientIfBillingConfigured } from '@alga-psa/shared/billingClients/defaultContract';
 
+const CLIENT_LIST_SEARCH_TSQUERY_UNSAFE_RE = /[^\p{L}\p{N}\s]+/gu;
+const CLIENT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN = /\b[A-Z]+-?\d+\b/i;
+const CLIENT_LIST_SEARCH_TYPES = ['client', 'document', 'interaction'] as const;
+
 function maybeUserActor(currentUser: any) {
   const userId = currentUser?.user_id;
   if (typeof userId !== 'string' || !userId) return undefined;
@@ -477,10 +481,130 @@ export interface BillingCycleDateRange {
   to?: string;
 }
 
+function buildClientListSearchPrefixTsquery(raw: string): string | null {
+  const tokens = raw
+    .toLowerCase()
+    .replace(CLIENT_LIST_SEARCH_TSQUERY_UNSAFE_RE, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return tokens.map((token) => `${token}:*`).join(' & ');
+}
+
+function applyClientListIndexedSearchFilter(
+  baseQuery: Knex.QueryBuilder,
+  tenant: string,
+  user: { user_id: string; user_type?: string; clientId?: string | null },
+  rawSearchInput: string | undefined,
+  permissions: string[]
+): Knex.QueryBuilder {
+  const rawSearch = rawSearchInput?.replace(/\s+/g, ' ').trim();
+  if (!rawSearch) {
+    return baseQuery;
+  }
+
+  const prefixTsquery = buildClientListSearchPrefixTsquery(rawSearch);
+  const identifier = rawSearch.match(CLIENT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN)?.[0]?.toLowerCase() ?? null;
+  const isInternalUser = user.user_type !== 'client';
+  const clientScopePredicate = isInternalUser
+    ? 'TRUE'
+    : user.clientId
+      ? '(si.client_scope_id IS NULL OR si.client_scope_id = ?::uuid)'
+      : 'si.client_scope_id IS NULL';
+  const clientScopeBindings = isInternalUser || !user.clientId ? [] : [user.clientId];
+
+  return baseQuery.where(function(this: Knex.QueryBuilder) {
+    this.whereRaw(
+      `
+        EXISTS (
+          SELECT 1
+          FROM app_search_index si
+          CROSS JOIN (
+            SELECT
+              websearch_to_tsquery('english', ?) AS tsq,
+              CASE WHEN ?::text IS NULL THEN NULL ELSE to_tsquery('english', ?::text) END AS prefix_tsq,
+              ?::text AS raw,
+              ?::text AS identifier
+          ) q
+          LEFT JOIN interactions interaction_match
+            ON si.object_type = 'interaction'
+            AND interaction_match.tenant = si.tenant
+            AND interaction_match.interaction_id::text = si.object_id
+          LEFT JOIN document_associations document_client_match
+            ON si.object_type = 'document'
+            AND document_client_match.tenant = si.tenant
+            AND document_client_match.document_id::text = si.object_id
+            AND document_client_match.entity_type = 'client'
+          WHERE si.tenant = ?::uuid
+            AND si.object_type = ANY(?::text[])
+            AND (si.required_permission IS NULL OR si.required_permission = ANY(?::text[]))
+            AND (cardinality(si.visible_to_user_ids) = 0 OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND (si.is_internal_only = false OR ?::boolean = true)
+            AND (si.is_private = false OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND ${clientScopePredicate}
+            AND (
+              (si.object_type = 'client' AND si.object_id = c.client_id::text)
+              OR (si.object_type = 'interaction' AND interaction_match.client_id = c.client_id)
+              OR (si.object_type = 'document' AND document_client_match.entity_id = c.client_id::text)
+            )
+            AND (
+              si.search_vector @@ q.tsq
+              OR (q.prefix_tsq IS NOT NULL AND si.search_vector @@ q.prefix_tsq)
+              OR si.title ILIKE '%' || q.raw || '%'
+              OR coalesce(si.subtitle, '') ILIKE '%' || q.raw || '%'
+              OR si.title % q.raw
+              OR coalesce(si.subtitle, '') % q.raw
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) = q.identifier
+              )
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) LIKE q.identifier || '%'
+              )
+            )
+        )
+      `,
+      [
+        rawSearch,
+        prefixTsquery,
+        prefixTsquery,
+        rawSearch,
+        identifier,
+        tenant,
+        [...CLIENT_LIST_SEARCH_TYPES],
+        permissions,
+        user.user_id,
+        isInternalUser,
+        user.user_id,
+        ...clientScopeBindings,
+      ]
+    ).orWhere(function(this: Knex.QueryBuilder) {
+      this.where('c.client_name', 'ilike', `%${rawSearch}%`)
+        .orWhere('cl.phone', 'ilike', `%${rawSearch}%`)
+        .orWhere('cl.address_line1', 'ilike', `%${rawSearch}%`)
+        .orWhere('cl.address_line2', 'ilike', `%${rawSearch}%`)
+        .orWhere('cl.city', 'ilike', `%${rawSearch}%`);
+    });
+  });
+}
+
 export const getAllClientsPaginated = withAuth(async (user, { tenant }, params: ClientPaginationParams = {}): Promise<PaginatedClientsResponse> => {
   // Check permission for client reading (in MSP, clients are managed via 'client' resource)
   if (!await hasPermissionAsync(user, 'client', 'read')) {
     throw new Error('Permission denied: Cannot read clients');
+  }
+  const searchPermissions = ['client:read'];
+  if (await hasPermissionAsync(user, 'document', 'read')) {
+    searchPermissions.push('document:read');
+  }
+  if (await hasPermissionAsync(user, 'interaction', 'read')) {
+    searchPermissions.push('interaction:read');
   }
 
   const {
@@ -525,15 +649,7 @@ export const getAllClientsPaginated = withAuth(async (user, { tenant }, params: 
       }
 
       // Apply filters
-      if (searchTerm) {
-        baseQuery = baseQuery.where(function() {
-          this.where('c.client_name', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.phone', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.address_line1', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.address_line2', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.city', 'ilike', `%${searchTerm}%`);
-        });
-      }
+      baseQuery = applyClientListIndexedSearchFilter(baseQuery, tenant, user, searchTerm, searchPermissions);
 
       if (clientTypeFilter !== 'all') {
         baseQuery = baseQuery.where('c.client_type', clientTypeFilter);
@@ -659,6 +775,13 @@ export const getClientsWithBillingCycleRangePaginated = withAuth(async (
   if (!await hasPermissionAsync(user, 'client', 'read')) {
     throw new Error('Permission denied: Cannot read clients');
   }
+  const searchPermissions = ['client:read'];
+  if (await hasPermissionAsync(user, 'document', 'read')) {
+    searchPermissions.push('document:read');
+  }
+  if (await hasPermissionAsync(user, 'interaction', 'read')) {
+    searchPermissions.push('interaction:read');
+  }
 
   const {
     page = 1,
@@ -700,15 +823,7 @@ export const getClientsWithBillingCycleRangePaginated = withAuth(async (
         baseQuery = baseQuery.andWhere('c.is_inactive', false);
       }
 
-      if (searchTerm) {
-        baseQuery = baseQuery.where(function() {
-          this.where('c.client_name', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.phone', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.address_line1', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.address_line2', 'ilike', `%${searchTerm}%`)
-              .orWhere('cl.city', 'ilike', `%${searchTerm}%`);
-        });
-      }
+      baseQuery = applyClientListIndexedSearchFilter(baseQuery, tenant, user, searchTerm, searchPermissions);
 
       if (clientTypeFilter !== 'all') {
         baseQuery = baseQuery.where('c.client_type', clientTypeFilter);

--- a/packages/clients/src/actions/queryActions.ts
+++ b/packages/clients/src/actions/queryActions.ts
@@ -13,6 +13,10 @@ import {
 import { hasPermissionAsync } from '../lib/authHelpers';
 import InteractionModel from '../models/interactions';
 
+const CONTACT_LIST_SEARCH_TSQUERY_UNSAFE_RE = /[^\p{L}\p{N}\s]+/gu;
+const CONTACT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN = /\b[A-Z]+-?\d+\b/i;
+const CONTACT_LIST_SEARCH_TYPES = ['contact', 'document', 'interaction'] as const;
+
 // --- Client query actions ---
 
 export const getClientById = withAuth(async (user, { tenant }, clientId: string): Promise<IClientWithLocation | null> => {
@@ -207,6 +211,134 @@ export const getContactsByClient = withAuth(async (
 
     throw new Error('SYSTEM_ERROR: An unexpected error occurred while retrieving client contacts');
   }
+});
+
+function buildContactListSearchPrefixTsquery(raw: string): string | null {
+  const tokens = raw
+    .toLowerCase()
+    .replace(CONTACT_LIST_SEARCH_TSQUERY_UNSAFE_RE, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return tokens.map((token) => `${token}:*`).join(' & ');
+}
+
+export const searchContactListIds = withAuth(async (
+  user,
+  { tenant },
+  query: string
+): Promise<string[]> => {
+  if (!await hasPermissionAsync(user, 'contact', 'read')) {
+    throw new Error('Permission denied: Cannot read contacts');
+  }
+
+  const rawSearch = query.replace(/\s+/g, ' ').trim();
+  if (!rawSearch) {
+    return [];
+  }
+
+  const permissions = ['contact:read'];
+  if (await hasPermissionAsync(user, 'document', 'read')) {
+    permissions.push('document:read');
+  }
+  if (await hasPermissionAsync(user, 'interaction', 'read')) {
+    permissions.push('interaction:read');
+  }
+
+  const prefixTsquery = buildContactListSearchPrefixTsquery(rawSearch);
+  const identifier = rawSearch.match(CONTACT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN)?.[0]?.toLowerCase() ?? null;
+  const isInternalUser = user.user_type !== 'client';
+  const clientScopePredicate = isInternalUser
+    ? 'TRUE'
+    : user.clientId
+      ? '(si.client_scope_id IS NULL OR si.client_scope_id = ?::uuid)'
+      : 'si.client_scope_id IS NULL';
+  const clientScopeBindings = isInternalUser || !user.clientId ? [] : [user.clientId];
+  const { knex: db } = await createTenantKnex();
+
+  return await withTransaction(db, async (trx: Knex.Transaction) => {
+    const result = await trx.raw<{ rows: Array<{ contact_id: string }> }>(
+      `
+        WITH q AS (
+          SELECT
+            websearch_to_tsquery('english', ?) AS tsq,
+            CASE WHEN ?::text IS NULL THEN NULL ELSE to_tsquery('english', ?::text) END AS prefix_tsq,
+            ?::text AS raw,
+            ?::text AS identifier
+        ),
+        matched AS (
+          SELECT DISTINCT
+            CASE
+              WHEN si.object_type = 'contact' THEN si.object_id
+              WHEN si.object_type = 'interaction' THEN interaction_match.contact_name_id::text
+              WHEN si.object_type = 'document' THEN coalesce(note_contact.contact_name_id::text, document_contact_match.entity_id)
+            END AS contact_id
+          FROM app_search_index si
+          CROSS JOIN q
+          LEFT JOIN interactions interaction_match
+            ON si.object_type = 'interaction'
+            AND interaction_match.tenant = si.tenant
+            AND interaction_match.interaction_id::text = si.object_id
+          LEFT JOIN contacts note_contact
+            ON si.object_type = 'document'
+            AND note_contact.tenant = si.tenant
+            AND note_contact.notes_document_id::text = si.object_id
+          LEFT JOIN document_associations document_contact_match
+            ON si.object_type = 'document'
+            AND document_contact_match.tenant = si.tenant
+            AND document_contact_match.document_id::text = si.object_id
+            AND document_contact_match.entity_type = 'contact'
+          WHERE si.tenant = ?::uuid
+            AND si.object_type = ANY(?::text[])
+            AND (si.required_permission IS NULL OR si.required_permission = ANY(?::text[]))
+            AND (cardinality(si.visible_to_user_ids) = 0 OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND (si.is_internal_only = false OR ?::boolean = true)
+            AND (si.is_private = false OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND ${clientScopePredicate}
+            AND (
+              si.search_vector @@ q.tsq
+              OR (q.prefix_tsq IS NOT NULL AND si.search_vector @@ q.prefix_tsq)
+              OR si.title ILIKE '%' || q.raw || '%'
+              OR coalesce(si.subtitle, '') ILIKE '%' || q.raw || '%'
+              OR si.title % q.raw
+              OR coalesce(si.subtitle, '') % q.raw
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) = q.identifier
+              )
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) LIKE q.identifier || '%'
+              )
+            )
+        )
+        SELECT contact_id
+        FROM matched
+        WHERE contact_id IS NOT NULL
+      `,
+      [
+        rawSearch,
+        prefixTsquery,
+        prefixTsquery,
+        rawSearch,
+        identifier,
+        tenant,
+        [...CONTACT_LIST_SEARCH_TYPES],
+        permissions,
+        user.user_id,
+        isInternalUser,
+        user.user_id,
+        ...clientScopeBindings,
+      ]
+    );
+
+    return result.rows.map((row) => row.contact_id);
+  });
 });
 
 export const getAllContacts = withAuth(async (

--- a/packages/clients/src/components/clients/Clients.tsx
+++ b/packages/clients/src/components/clients/Clients.tsx
@@ -1436,7 +1436,7 @@ const Clients: React.FC = () => {
             <SearchInput
               value={searchInput}
               onChange={handleSearchInputChange}
-              placeholder={t('clientsPage.searchPlaceholder', { defaultValue: 'Search clients' })}
+              placeholder={t('clientsPage.searchPlaceholder', { defaultValue: 'Search clients, notes, documents, and interactions' })}
             />
 
             <div className="w-48 shrink-0">

--- a/packages/clients/src/components/contacts/Contacts.tsx
+++ b/packages/clients/src/components/contacts/Contacts.tsx
@@ -5,7 +5,7 @@ import type { DeletionValidationResult, IContact } from '@alga-psa/types';
 import type { IClient } from '@alga-psa/types';
 import { ITag } from '@alga-psa/types';
 import type { IDocument } from '@alga-psa/types';
-import { getAllContacts, getContactsByClient, getAllClients } from '@alga-psa/clients/actions';
+import { getAllContacts, getContactsByClient, getAllClients, searchContactListIds } from '@alga-psa/clients/actions';
 import { exportContactsToCSV, deleteContact, updateContact, getContactLastUsagePhoneTypes, deleteOrphanedPhoneTypes } from '@alga-psa/clients/actions';
 import { findTagsByEntityIds, findAllTagsByType } from '@alga-psa/tags/actions';
 import { Button } from '@alga-psa/ui/components/Button';
@@ -93,6 +93,7 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, clientId, preSelec
   const [currentUser, setCurrentUser] = useState<string | null>(null);
   const [filterStatus, setFilterStatus] = useState<'all' | 'active' | 'inactive'>('active');
   const [searchTerm, setSearchTerm] = useState('');
+  const [indexedSearchContactIds, setIndexedSearchContactIds] = useState<Set<string> | null>(null);
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -787,14 +788,52 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, clientId, preSelec
     },
   ];
 
+  useEffect(() => {
+    const query = searchTerm.trim();
+    if (!query) {
+      setIndexedSearchContactIds(null);
+      return;
+    }
+
+    setIndexedSearchContactIds(null);
+    let isCancelled = false;
+    const timeout = setTimeout(() => {
+      searchContactListIds(query)
+        .then((contactIds) => {
+          if (!isCancelled) {
+            setIndexedSearchContactIds(new Set(contactIds));
+          }
+        })
+        .catch((error) => {
+          console.error('Error searching contacts:', error);
+          if (!isCancelled) {
+            setIndexedSearchContactIds(new Set());
+          }
+        });
+    }, 300);
+
+    return () => {
+      isCancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [searchTerm]);
+
   const filteredContacts = useMemo(() => {
     return contacts.filter(contact => {
       const searchTermLower = searchTerm.toLowerCase();
-      const matchesSearch = contact.full_name.toLowerCase().includes(searchTermLower) || 
-                          (contact.email && contact.email.toLowerCase().includes(searchTermLower)) ||
-                          contact.additional_email_addresses?.some((emailAddress) =>
-                            emailAddress.email_address.toLowerCase().includes(searchTermLower)
-                          );
+      const matchesSearch = !searchTermLower ||
+                          (indexedSearchContactIds
+                            ? indexedSearchContactIds.has(contact.contact_name_id) ||
+                              contact.full_name.toLowerCase().includes(searchTermLower) ||
+                              (contact.email && contact.email.toLowerCase().includes(searchTermLower)) ||
+                              contact.additional_email_addresses?.some((emailAddress) =>
+                                emailAddress.email_address.toLowerCase().includes(searchTermLower)
+                              )
+                            : contact.full_name.toLowerCase().includes(searchTermLower) ||
+                              (contact.email && contact.email.toLowerCase().includes(searchTermLower)) ||
+                              contact.additional_email_addresses?.some((emailAddress) =>
+                                emailAddress.email_address.toLowerCase().includes(searchTermLower)
+                              ));
       const matchesStatus = filterStatus === 'all' ||
         (filterStatus === 'active' && !contact.is_inactive) ||
         (filterStatus === 'inactive' && contact.is_inactive);
@@ -807,7 +846,7 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, clientId, preSelec
 
       return matchesSearch && matchesStatus && matchesTags;
     });
-  }, [contacts, searchTerm, filterStatus, selectedTags]);
+  }, [contacts, searchTerm, filterStatus, selectedTags, indexedSearchContactIds]);
 
   // Memoize the data transformation for DataTable
   const tableData = useMemo(() => filteredContacts.map((contact) => ({
@@ -956,7 +995,7 @@ const Contacts: React.FC<ContactsProps> = ({ initialContacts, clientId, preSelec
                 <SearchInput
                   id='filter-contacts'
                   placeholder={t('contactsPage.searchPlaceholder', {
-                    defaultValue: 'Search contacts'
+                    defaultValue: 'Search contacts, notes, and interactions'
                   })}
                   className="w-64"
                   value={searchTerm}

--- a/packages/projects/src/actions/projectActions.ts
+++ b/packages/projects/src/actions/projectActions.ts
@@ -53,6 +53,10 @@ import {
 } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
 
+const PROJECT_LIST_SEARCH_TSQUERY_UNSAFE_RE = /[^\p{L}\p{N}\s]+/gu;
+const PROJECT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN = /\b[A-Z]+-?\d+\b/i;
+const PROJECT_LIST_SEARCH_TYPES = ['project', 'project_phase', 'project_task', 'project_task_comment'] as const;
+
 const extendedCreateProjectSchema = createProjectSchema.extend({
   assigned_to: z.string().nullable().optional(),
   contact_name_id: z.string().nullable().optional(),
@@ -306,6 +310,133 @@ export const getProjects = withAuth(async (user, { tenant }): Promise<IProject[]
         console.error('Error fetching projects:', error);
         throw error;
     }
+});
+
+function buildProjectListSearchPrefixTsquery(raw: string): string | null {
+  const tokens = raw
+    .toLowerCase()
+    .replace(PROJECT_LIST_SEARCH_TSQUERY_UNSAFE_RE, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return tokens.map((token) => `${token}:*`).join(' & ');
+}
+
+export const searchProjectListIds = withAuth(async (
+  user,
+  { tenant },
+  query: string
+): Promise<string[]> => {
+  const rawSearch = query.replace(/\s+/g, ' ').trim();
+  if (!rawSearch) {
+    return [];
+  }
+
+  const { knex } = await createTenantKnex();
+  const denied = await checkPermission(user, 'project', 'read', knex);
+  if (denied) {
+    return [];
+  }
+
+  const prefixTsquery = buildProjectListSearchPrefixTsquery(rawSearch);
+  const identifier = rawSearch.match(PROJECT_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN)?.[0]?.toLowerCase() ?? null;
+  const isInternalUser = user.user_type !== 'client';
+  const clientScopePredicate = isInternalUser
+    ? 'TRUE'
+    : user.clientId
+      ? '(si.client_scope_id IS NULL OR si.client_scope_id = ?::uuid)'
+      : 'si.client_scope_id IS NULL';
+  const clientScopeBindings = isInternalUser || !user.clientId ? [] : [user.clientId];
+
+  return await withTransaction(knex, async (trx: Knex.Transaction) => {
+    const result = await trx.raw<{ rows: Array<{ project_id: string }> }>(
+      `
+        WITH q AS (
+          SELECT
+            websearch_to_tsquery('english', ?) AS tsq,
+            CASE WHEN ?::text IS NULL THEN NULL ELSE to_tsquery('english', ?::text) END AS prefix_tsq,
+            ?::text AS raw,
+            ?::text AS identifier
+        ),
+        matched AS (
+          SELECT DISTINCT
+            CASE
+              WHEN si.object_type = 'project' THEN si.object_id
+              WHEN si.object_type IN ('project_phase', 'project_task') THEN si.parent_id
+              WHEN si.object_type = 'project_task_comment' THEN ph.project_id::text
+            END AS project_id
+          FROM app_search_index si
+          CROSS JOIN q
+          LEFT JOIN project_tasks pt
+            ON si.object_type = 'project_task_comment'
+            AND pt.tenant = si.tenant
+            AND pt.task_id::text = si.parent_id
+          LEFT JOIN project_phases ph
+            ON ph.tenant = pt.tenant
+            AND ph.phase_id = pt.phase_id
+          WHERE si.tenant = ?::uuid
+            AND si.object_type = ANY(?::text[])
+            AND (si.required_permission IS NULL OR si.required_permission = ANY(?::text[]))
+            AND (cardinality(si.visible_to_user_ids) = 0 OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND (si.is_internal_only = false OR ?::boolean = true)
+            AND (si.is_private = false OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND ${clientScopePredicate}
+            AND (
+              si.search_vector @@ q.tsq
+              OR (q.prefix_tsq IS NOT NULL AND si.search_vector @@ q.prefix_tsq)
+              OR si.title ILIKE '%' || q.raw || '%'
+              OR coalesce(si.subtitle, '') ILIKE '%' || q.raw || '%'
+              OR si.title % q.raw
+              OR coalesce(si.subtitle, '') % q.raw
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) = q.identifier
+              )
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) LIKE q.identifier || '%'
+              )
+            )
+        )
+        SELECT project_id
+        FROM matched
+        WHERE project_id IS NOT NULL
+      `,
+      [
+        rawSearch,
+        prefixTsquery,
+        prefixTsquery,
+        rawSearch,
+        identifier,
+        tenant,
+        [...PROJECT_LIST_SEARCH_TYPES],
+        ['project:read'],
+        user.user_id,
+        isInternalUser,
+        user.user_id,
+        ...clientScopeBindings,
+      ]
+    );
+
+    const projectIds = result.rows.map((row) => row.project_id);
+    if (projectIds.length === 0) {
+      return [];
+    }
+
+    const matchedProjects = await trx('projects')
+      .where({ tenant })
+      .whereIn('project_id', projectIds)
+      .select<IProject[]>('project_id', 'assigned_to', 'client_id');
+    const authorizedProjects = await filterAuthorizedProjects(trx, tenant, user as IUserWithRoles, matchedProjects);
+    const authorizedProjectIds = new Set(authorizedProjects.map((project) => project.project_id).filter(Boolean));
+
+    return projectIds.filter((projectId) => authorizedProjectIds.has(projectId));
+  });
 });
 
 /**

--- a/packages/projects/src/components/Projects.tsx
+++ b/packages/projects/src/components/Projects.tsx
@@ -10,7 +10,7 @@ import { ITag } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import ProjectQuickAdd from './ProjectQuickAdd';
-import { deleteProject } from '../actions/projectActions';
+import { deleteProject, searchProjectListIds } from '../actions/projectActions';
 import { findUserById } from '@alga-psa/user-composition/actions';
 import { findTagsByEntityIds, findAllTagsByType } from '@alga-psa/tags/actions';
 import { TagFilter } from '@alga-psa/ui/components';
@@ -154,6 +154,7 @@ export default function Projects({ initialProjects, clients, initialFilters, ini
   activeFiltersRef.current = activeFilters;
 
   const [projects, setProjects] = useState<IProject[]>(initialProjects);
+  const [indexedSearchProjectIds, setIndexedSearchProjectIds] = useState<Set<string> | null>(null);
 
   // Sync state when initialProjects changes (e.g., from router.refresh())
   useEffect(() => {
@@ -373,13 +374,48 @@ export default function Projects({ initialProjects, clients, initialFilters, ini
     fetchData();
   }, []);
 
+  useEffect(() => {
+    const query = activeFilters.searchQuery?.trim();
+    if (!query) {
+      setIndexedSearchProjectIds(null);
+      return;
+    }
+
+    setIndexedSearchProjectIds(null);
+    let isCancelled = false;
+    const timeout = setTimeout(() => {
+      searchProjectListIds(query)
+        .then((projectIds) => {
+          if (!isCancelled) {
+            setIndexedSearchProjectIds(new Set(projectIds));
+          }
+        })
+        .catch((error) => {
+          console.error('Error searching projects:', error);
+          if (!isCancelled) {
+            setIndexedSearchProjectIds(new Set());
+          }
+        });
+    }, 300);
+
+    return () => {
+      isCancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [activeFilters.searchQuery]);
+
   const filteredProjects = useMemo(() => {
     const { searchQuery, status, tags, clientId, contactId, managerId } = activeFilters;
     const search = (searchQuery || '').toLowerCase();
 
     let filtered = projects.filter(project =>
-      (project.project_name.toLowerCase().includes(search) ||
-       project.project_number?.toLowerCase().includes(search)) &&
+      (!search ||
+       (indexedSearchProjectIds
+         ? (typeof project.project_id === 'string' && indexedSearchProjectIds.has(project.project_id)) ||
+           project.project_name.toLowerCase().includes(search) ||
+           project.project_number?.toLowerCase().includes(search)
+         : project.project_name.toLowerCase().includes(search) ||
+           project.project_number?.toLowerCase().includes(search))) &&
       (status === 'all' ||
        (status === 'active' && !project.is_inactive) ||
        (status === 'inactive' && project.is_inactive))
@@ -444,7 +480,7 @@ export default function Projects({ initialProjects, clients, initialFilters, ini
 
     return filtered;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tagsVersion tracks projectTagsRef mutations
-  }, [projects, activeFilters, deadlineFilterValue, tagsVersion]);
+  }, [projects, activeFilters, deadlineFilterValue, tagsVersion, indexedSearchProjectIds]);
 
   const handleEditProject = (project: IProject) => {
     openDrawer(
@@ -787,7 +823,7 @@ export default function Projects({ initialProjects, clients, initialFilters, ini
           <div className="relative p-0.5 shrink-0">
             <Input
               type="text"
-              placeholder={projectListT('searchPlaceholder', 'Search projects')}
+              placeholder={projectListT('searchPlaceholder', 'Search projects, tasks, and comments')}
               className="pl-10 pr-4 py-2 w-64"
               value={activeFilters.searchQuery || ''}
               onChange={(e) => handleFilterChange({ searchQuery: e.target.value || undefined })}

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -68,6 +68,9 @@ function getEmailEventChannel(): string {
   return EMAIL_EVENT_CHANNEL;
 }
 
+const TICKET_LIST_SEARCH_TSQUERY_UNSAFE_RE = /[^\p{L}\p{N}\s]+/gu;
+const TICKET_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN = /\b[A-Z]+-?\d+\b/i;
+
 function captureAnalytics(_event: string, _properties?: Record<string, any>, _userId?: string): void {
   // Intentionally no-op: avoid pulling analytics (and its tenancy/client-portal deps) into tickets.
 }
@@ -949,7 +952,7 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
 async function buildTicketListBaseQuery(
   trx: Knex.Transaction,
   tenant: string,
-  user: { user_id: string },
+  user: { user_id: string; user_type?: string; clientId?: string | null },
   validatedFilters: ITicketListFilters
 ): Promise<{ builder: Knex.QueryBuilder }> {
     const parsedStatusFilter = parseTicketStatusFilterValue(validatedFilters.statusId);
@@ -1072,26 +1075,7 @@ async function buildTicketListBaseQuery(
       }
     }
 
-    if (validatedFilters.searchQuery) {
-      const searchTerm = `%${validatedFilters.searchQuery}%`;
-      baseQuery = baseQuery.where(function(this: any) {
-        this.where('t.title', 'ilike', searchTerm)
-          .orWhere('t.ticket_number', 'ilike', searchTerm);
-
-        if (validatedFilters.bundleView === 'bundled') {
-          this.orWhereExists(function(this: any) {
-            this.select('*')
-              .from('tickets as tc')
-              .whereRaw('tc.tenant = t.tenant')
-              .andWhereRaw('tc.master_ticket_id = t.ticket_id')
-              .andWhere(function(this: any) {
-                this.where('tc.title', 'ilike', searchTerm)
-                  .orWhere('tc.ticket_number', 'ilike', searchTerm);
-              });
-          });
-        }
-      });
-    }
+    baseQuery = applyTicketListIndexedSearchFilter(trx, baseQuery, tenant, user, validatedFilters);
 
     // Apply tag filter if provided
     if (validatedFilters.tags && validatedFilters.tags.length > 0) {
@@ -1265,6 +1249,152 @@ async function buildTicketListBaseQuery(
     // Knex query builders have .then(), so returning one from an async function
     // would execute the query instead of returning the builder.
     return { builder: baseQuery };
+}
+
+function buildTicketListSearchPrefixTsquery(raw: string): string | null {
+  const tokens = raw
+    .toLowerCase()
+    .replace(TICKET_LIST_SEARCH_TSQUERY_UNSAFE_RE, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return tokens.map((token) => `${token}:*`).join(' & ');
+}
+
+function applyTicketListIndexedSearchFilter(
+  trx: Knex.Transaction,
+  baseQuery: Knex.QueryBuilder,
+  tenant: string,
+  user: { user_id: string; user_type?: string; clientId?: string | null },
+  validatedFilters: ITicketListFilters
+): Knex.QueryBuilder {
+  const rawSearch = validatedFilters.searchQuery?.replace(/\s+/g, ' ').trim();
+  if (!rawSearch) {
+    return baseQuery;
+  }
+
+  const prefixTsquery = buildTicketListSearchPrefixTsquery(rawSearch);
+  const identifier = rawSearch.match(TICKET_LIST_SEARCH_IDENTIFIER_TOKEN_PATTERN)?.[0]?.toLowerCase() ?? null;
+  const includeBundledChildren = validatedFilters.bundleView === 'bundled';
+  const isInternalUser = user.user_type !== 'client';
+  const clientScopePredicate = isInternalUser
+    ? 'TRUE'
+    : user.clientId
+      ? '(si.client_scope_id IS NULL OR si.client_scope_id = ?::uuid)'
+      : 'si.client_scope_id IS NULL';
+  const clientScopeBindings = isInternalUser || !user.clientId ? [] : [user.clientId];
+
+  return baseQuery.where(function(this: Knex.QueryBuilder) {
+    this.whereRaw(
+      `
+        EXISTS (
+          SELECT 1
+          FROM app_search_index si
+          CROSS JOIN (
+            SELECT
+              websearch_to_tsquery('english', ?) AS tsq,
+              CASE WHEN ?::text IS NULL THEN NULL ELSE to_tsquery('english', ?::text) END AS prefix_tsq,
+              ?::text AS raw,
+              ?::text AS identifier
+          ) q
+          WHERE si.tenant = ?::uuid
+            AND si.object_type = ANY(?::text[])
+            AND (si.required_permission IS NULL OR si.required_permission = ANY(?::text[]))
+            AND (cardinality(si.visible_to_user_ids) = 0 OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND (si.is_internal_only = false OR ?::boolean = true)
+            AND (si.is_private = false OR si.visible_to_user_ids && ARRAY[?]::uuid[])
+            AND ${clientScopePredicate}
+            AND (
+              (
+                si.object_type = 'ticket'
+                AND (
+                  si.object_id = t.ticket_id::text
+                  OR (
+                    ?::boolean = true
+                    AND EXISTS (
+                      SELECT 1
+                      FROM tickets child_ticket
+                      WHERE child_ticket.tenant = t.tenant
+                        AND child_ticket.master_ticket_id = t.ticket_id
+                        AND child_ticket.ticket_id::text = si.object_id
+                    )
+                  )
+                )
+              )
+              OR (
+                si.object_type = 'ticket_comment'
+                AND (
+                  si.parent_id = t.ticket_id::text
+                  OR (
+                    ?::boolean = true
+                    AND EXISTS (
+                      SELECT 1
+                      FROM tickets child_ticket
+                      WHERE child_ticket.tenant = t.tenant
+                        AND child_ticket.master_ticket_id = t.ticket_id
+                        AND child_ticket.ticket_id::text = si.parent_id
+                    )
+                  )
+                )
+              )
+            )
+            AND (
+              si.search_vector @@ q.tsq
+              OR (q.prefix_tsq IS NOT NULL AND si.search_vector @@ q.prefix_tsq)
+              OR si.title ILIKE '%' || q.raw || '%'
+              OR coalesce(si.subtitle, '') ILIKE '%' || q.raw || '%'
+              OR si.title % q.raw
+              OR coalesce(si.subtitle, '') % q.raw
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) = q.identifier
+              )
+              OR (
+                q.identifier IS NOT NULL
+                AND lower(coalesce(si.metadata->>'identifier', '')) LIKE q.identifier || '%'
+              )
+            )
+        )
+      `,
+      [
+        rawSearch,
+        prefixTsquery,
+        prefixTsquery,
+        rawSearch,
+        identifier,
+        tenant,
+        ['ticket', 'ticket_comment'],
+        ['ticket:read'],
+        user.user_id,
+        isInternalUser,
+        user.user_id,
+        ...clientScopeBindings,
+        includeBundledChildren,
+        includeBundledChildren,
+      ]
+    ).orWhere(function(this: Knex.QueryBuilder) {
+      this.where('t.title', 'ilike', `%${rawSearch}%`)
+        .orWhere('t.ticket_number', 'ilike', `%${rawSearch}%`);
+
+      if (includeBundledChildren) {
+        this.orWhereExists(function(this: Knex.QueryBuilder) {
+          this.select('*')
+            .from('tickets as tc')
+            .whereRaw('tc.tenant = t.tenant')
+            .andWhereRaw('tc.master_ticket_id = t.ticket_id')
+            .andWhere(function(this: Knex.QueryBuilder) {
+              this.where('tc.title', 'ilike', `%${rawSearch}%`)
+                .orWhere('tc.ticket_number', 'ilike', `%${rawSearch}%`);
+            });
+        });
+      }
+    });
+  });
 }
 
 /**

--- a/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
+++ b/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
@@ -38,7 +38,7 @@ describe('ticketing dashboard i18n wiring contract', () => {
     expect(source).toContain("t('dashboard.filters.dueDate', 'Due Date')");
     expect(source).toContain("t('dashboard.filters.slaStatus', 'SLA Status')");
     expect(source).toContain("t('filters.category', 'Filter by category')");
-    expect(source).toContain("t('filters.search', 'Search tickets...')");
+    expect(source).toContain("t('filters.search', 'Search tickets and comments...')");
     expect(source).toContain("t('resetFilters', 'Reset')");
     expect(source).toContain("t('dashboard.bundledToggle', 'Bundled')");
     expect(source).toContain("t('dashboard.spacing.compact', 'Compact')");

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -1934,7 +1934,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                 />
                 <Input
                   id={`${id}-search-tickets-input`}
-                  placeholder={t('filters.search', 'Search tickets...')}
+                  placeholder={t('filters.search', 'Search tickets and comments...')}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="h-[38px] min-w-[350px] text-sm"

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Projekt hinzufügen",
     "createFromTemplate": "Aus Vorlage erstellen",
     "openMenu": "Menü öffnen",
-    "searchPlaceholder": "Projekte suchen",
+    "searchPlaceholder": "Projekte, Aufgaben und Kommentare suchen",
     "statusPlaceholder": "Status auswählen",
     "contactPlaceholder": "Nach Kontakt filtern",
     "managerPlaceholder": "Alle Verantwortlichen",

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Alle offenen Tickets",
     "allClosed": "Alle geschlossenen Tickets",
     "allPriorities": "Alle Prioritäten",
-    "search": "Tickets suchen...",
+    "search": "Tickets und Kommentare suchen...",
     "category": "Nach Kategorie filtern",
     "clearFilters": "Filter löschen",
     "assignee": "Zuständiger",

--- a/server/public/locales/de/msp/clients.json
+++ b/server/public/locales/de/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Kundenseite",
     "description": "Hauptseite zur Kundenverwaltung mit Suche, Filtern und Kundenraster-/Listenansicht",
-    "searchPlaceholder": "Kunden suchen",
+    "searchPlaceholder": "Kunden, Notizen, Dokumente und Interaktionen suchen",
     "createClient": "Client erstellen",
     "createClientShort": "+ Client erstellen",
     "allClients": "Alle Kunden",

--- a/server/public/locales/de/msp/contacts.json
+++ b/server/public/locales/de/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Kontakte",
     "addContact": "+ Kontakt hinzufügen",
     "actions": "Aktionen",
-    "searchPlaceholder": "Kontakte suchen",
+    "searchPlaceholder": "Kontakte, Notizen und Interaktionen suchen",
     "resetFilters": "Zurücksetzen",
     "unknownClient": "Unbekannter Kunde",
     "noClient": "Kein Kunde",

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Add Project",
     "createFromTemplate": "Create from Template",
     "openMenu": "Open menu",
-    "searchPlaceholder": "Search projects",
+    "searchPlaceholder": "Search projects, tasks, and comments",
     "statusPlaceholder": "Select status",
     "contactPlaceholder": "Filter by contact",
     "managerPlaceholder": "All managers",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "All Open Tickets",
     "allClosed": "All Closed Tickets",
     "allPriorities": "All Priorities",
-    "search": "Search tickets...",
+    "search": "Search tickets and comments...",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/en/msp/clients.json
+++ b/server/public/locales/en/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Clients Page",
     "description": "Main clients management page with search, filters, and client grid/list view",
-    "searchPlaceholder": "Search clients",
+    "searchPlaceholder": "Search clients, notes, documents, and interactions",
     "createClient": "Create Client",
     "createClientShort": "+ Create Client",
     "allClients": "All Clients",

--- a/server/public/locales/en/msp/contacts.json
+++ b/server/public/locales/en/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contacts",
     "addContact": "+ Add Contact",
     "actions": "Actions",
-    "searchPlaceholder": "Search contacts",
+    "searchPlaceholder": "Search contacts, notes, and interactions",
     "resetFilters": "Reset",
     "unknownClient": "Unknown Client",
     "noClient": "No Client",

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Agregar proyecto",
     "createFromTemplate": "Crear desde plantilla",
     "openMenu": "Abrir menú",
-    "searchPlaceholder": "Buscar proyectos",
+    "searchPlaceholder": "Buscar proyectos, tareas y comentarios",
     "statusPlaceholder": "Seleccionar estado",
     "contactPlaceholder": "Filtrar por contacto",
     "managerPlaceholder": "Todos los responsables",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Todos los tickets abiertos",
     "allClosed": "Todos los tickets cerrados",
     "allPriorities": "Todas las prioridades",
-    "search": "Buscar tickets...",
+    "search": "Buscar tickets y comentarios...",
     "category": "Filtrar por categoría",
     "clearFilters": "Limpiar filtros",
     "assignee": "Asignado",

--- a/server/public/locales/es/msp/clients.json
+++ b/server/public/locales/es/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Página de clientes",
     "description": "Página principal de administración de clientes con búsqueda, filtros y vista de lista/cuadrícula de clientes",
-    "searchPlaceholder": "Buscar clientes",
+    "searchPlaceholder": "Buscar clientes, notas, documentos e interacciones",
     "createClient": "Crear cliente",
     "createClientShort": "+ Crear cliente",
     "allClients": "Todos los clientes",

--- a/server/public/locales/es/msp/contacts.json
+++ b/server/public/locales/es/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contactos",
     "addContact": "+ Añadir contacto",
     "actions": "Acciones",
-    "searchPlaceholder": "Buscar contactos",
+    "searchPlaceholder": "Buscar contactos, notas e interacciones",
     "resetFilters": "Restablecer",
     "unknownClient": "Cliente desconocido",
     "noClient": "Sin cliente",

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Ajouter un projet",
     "createFromTemplate": "Créer depuis un modèle",
     "openMenu": "Ouvrir le menu",
-    "searchPlaceholder": "Rechercher des projets",
+    "searchPlaceholder": "Rechercher des projets, tâches et commentaires",
     "statusPlaceholder": "Sélectionner un statut",
     "contactPlaceholder": "Filtrer par contact",
     "managerPlaceholder": "Tous les responsables",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Tous les tickets ouverts",
     "allClosed": "Tous les tickets fermés",
     "allPriorities": "Toutes les priorités",
-    "search": "Rechercher des tickets...",
+    "search": "Rechercher des tickets et commentaires...",
     "category": "Filtrer par catégorie",
     "clearFilters": "Effacer les filtres",
     "assignee": "Destinataire",

--- a/server/public/locales/fr/msp/clients.json
+++ b/server/public/locales/fr/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Page Clients",
     "description": "Page principale de gestion des clients avec recherche, filtres et vue grille/liste des clients",
-    "searchPlaceholder": "Rechercher des clients",
+    "searchPlaceholder": "Rechercher des clients, notes, documents et interactions",
     "createClient": "Créer un client",
     "createClientShort": "+ Créer un client",
     "allClients": "Tous les clients",

--- a/server/public/locales/fr/msp/contacts.json
+++ b/server/public/locales/fr/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contacts",
     "addContact": "+ Ajouter un contact",
     "actions": "Actions",
-    "searchPlaceholder": "Rechercher des contacts",
+    "searchPlaceholder": "Rechercher des contacts, notes et interactions",
     "resetFilters": "Réinitialiser",
     "unknownClient": "Client inconnu",
     "noClient": "Aucun client",

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Aggiungi progetto",
     "createFromTemplate": "Crea da modello",
     "openMenu": "Apri menu",
-    "searchPlaceholder": "Cerca progetti",
+    "searchPlaceholder": "Cerca progetti, attività e commenti",
     "statusPlaceholder": "Seleziona stato",
     "contactPlaceholder": "Filtra per contatto",
     "managerPlaceholder": "Tutti i responsabili",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Tutti i ticket aperti",
     "allClosed": "Tutti i ticket chiusi",
     "allPriorities": "Tutte le priorità",
-    "search": "Cerca ticket...",
+    "search": "Cerca ticket e commenti...",
     "category": "Filtra per categoria",
     "clearFilters": "Pulisci filtri",
     "assignee": "Assegnatario",

--- a/server/public/locales/it/msp/clients.json
+++ b/server/public/locales/it/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Pagina clienti",
     "description": "Pagina di gestione dei clienti principali con ricerca, filtri e visualizzazione griglia/elenco dei clienti",
-    "searchPlaceholder": "Cerca clienti",
+    "searchPlaceholder": "Cerca clienti, note, documenti e interazioni",
     "createClient": "Crea cliente",
     "createClientShort": "+ Crea cliente",
     "allClients": "Tutti i clienti",

--- a/server/public/locales/it/msp/contacts.json
+++ b/server/public/locales/it/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contatti",
     "addContact": "+ Aggiungi contatto",
     "actions": "Azioni",
-    "searchPlaceholder": "Cerca contatti",
+    "searchPlaceholder": "Cerca contatti, note e interazioni",
     "resetFilters": "Reimposta",
     "unknownClient": "Cliente sconosciuto",
     "noClient": "Nessun cliente",

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Project toevoegen",
     "createFromTemplate": "Maken vanuit sjabloon",
     "openMenu": "Menu openen",
-    "searchPlaceholder": "Zoek projecten",
+    "searchPlaceholder": "Zoek projecten, taken en opmerkingen",
     "statusPlaceholder": "Selecteer status",
     "contactPlaceholder": "Filter op contactpersoon",
     "managerPlaceholder": "Alle beheerders",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Alle open tickets",
     "allClosed": "Alle gesloten tickets",
     "allPriorities": "Alle prioriteiten",
-    "search": "Tickets zoeken...",
+    "search": "Tickets en opmerkingen zoeken...",
     "category": "Filter op categorie",
     "clearFilters": "Filters wissen",
     "assignee": "Toegewezene",

--- a/server/public/locales/nl/msp/clients.json
+++ b/server/public/locales/nl/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Klantenpagina",
     "description": "Hoofdbeheerpagina voor klanten met zoeken, filters en klantenraster/lijstweergave",
-    "searchPlaceholder": "Zoek klanten",
+    "searchPlaceholder": "Zoek klanten, notities, documenten en interacties",
     "createClient": "Klant aanmaken",
     "createClientShort": "+ Klant aanmaken",
     "allClients": "Alle klanten",

--- a/server/public/locales/nl/msp/contacts.json
+++ b/server/public/locales/nl/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contacten",
     "addContact": "+ Contact toevoegen",
     "actions": "Acties",
-    "searchPlaceholder": "Zoek contacten",
+    "searchPlaceholder": "Zoek contacten, notities en interacties",
     "resetFilters": "Opnieuw instellen",
     "unknownClient": "Onbekende klant",
     "noClient": "Geen klant",

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Dodaj projekt",
     "createFromTemplate": "Utwórz z szablonu",
     "openMenu": "Otwórz menu",
-    "searchPlaceholder": "Wyszukaj projekty",
+    "searchPlaceholder": "Wyszukaj projekty, zadania i komentarze",
     "statusPlaceholder": "Wybierz status",
     "contactPlaceholder": "Filtruj według kontaktu",
     "managerPlaceholder": "Wszyscy menedżerowie",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "Wszystkie otwarte zgłoszenia",
     "allClosed": "Wszystkie zamknięte zgłoszenia",
     "allPriorities": "Wszystkie priorytety",
-    "search": "Szukaj zgłoszeń...",
+    "search": "Szukaj zgłoszeń i komentarzy...",
     "category": "Filtruj według kategorii",
     "clearFilters": "Wyczyść filtry",
     "assignee": "Przypisany do",

--- a/server/public/locales/pl/msp/clients.json
+++ b/server/public/locales/pl/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Strona klientów",
     "description": "Główna strona zarządzania klientami z wyszukiwaniem, filtrami i widokiem siatki/listy klientów",
-    "searchPlaceholder": "Szukaj klientów",
+    "searchPlaceholder": "Szukaj klientów, notatek, dokumentów i interakcji",
     "createClient": "Utwórz klienta",
     "createClientShort": "+ Utwórz klienta",
     "allClients": "Wszyscy klienci",

--- a/server/public/locales/pl/msp/contacts.json
+++ b/server/public/locales/pl/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Kontakty",
     "addContact": "+ Dodaj kontakt",
     "actions": "Akcje",
-    "searchPlaceholder": "Szukaj kontaktów",
+    "searchPlaceholder": "Szukaj kontaktów, notatek i interakcji",
     "resetFilters": "Resetuj",
     "unknownClient": "Nieznany klient",
     "noClient": "Brak klienta",

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -74,7 +74,7 @@
     "addProject": "Add Project",
     "createFromTemplate": "Create from Template",
     "openMenu": "Open menu",
-    "searchPlaceholder": "Search projects",
+    "searchPlaceholder": "Search projects, tasks, and comments",
     "statusPlaceholder": "Select status",
     "contactPlaceholder": "Filter by contact",
     "managerPlaceholder": "All managers",

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -12,7 +12,7 @@
     "allOpen": "All Open Tickets",
     "allClosed": "All Closed Tickets",
     "allPriorities": "All Priorities",
-    "search": "Search tickets...",
+    "search": "Search tickets and comments...",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/pt/msp/clients.json
+++ b/server/public/locales/pt/msp/clients.json
@@ -36,7 +36,7 @@
   "clientsPage": {
     "title": "Clients Page",
     "description": "Main clients management page with search, filters, and client grid/list view",
-    "searchPlaceholder": "Search clients",
+    "searchPlaceholder": "Search clients, notes, documents, and interactions",
     "createClient": "Create Client",
     "createClientShort": "+ Create Client",
     "allClients": "All Clients",

--- a/server/public/locales/pt/msp/contacts.json
+++ b/server/public/locales/pt/msp/contacts.json
@@ -37,7 +37,7 @@
     "heading": "Contacts",
     "addContact": "+ Add Contact",
     "actions": "Actions",
-    "searchPlaceholder": "Search contacts",
+    "searchPlaceholder": "Search contacts, notes, and interactions",
     "resetFilters": "Reset",
     "unknownClient": "Unknown Client",
     "noClient": "No Client",


### PR DESCRIPTION
  Wire the clients, contacts, projects, and tickets list views into
  the app_search_index so a single query matches across the entity
  plus its related notes, documents, and interactions. Adds
  searchContactListIds / searchClientIds plus applyClientListIndexedSearchFilter
  and applyTicketListIndexedSearchFilter helpers (websearch_to_tsquery +
  prefix tsquery + trigram fallback) with the same required_permission /
  visibility / client-scope ACL gating as global search. Updates the
  search placeholder copy across all locales to advertise the wider net.

  "Curiouser and curiouser!" cried the Mad Hatter, for the looking glass
  no longer showed only a contact's name, but every note, document, and
  interaction it had ever brushed against — and the Cheshire Cat, grinning
  from required_permission to visible_to_user_ids, vanished entirely unless
  you held the proper :read. 🐇🔍🎩