### PR TITLE
Restyle shared data tables

### DIFF
--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -409,31 +409,31 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         filterPadding: 'p-3',
         filterGap: 'gap-2',
         bodyPadding: 'p-3',
-        tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px]',
+        tableRowDensity: '[&>td]:!py-0.5 [&>td]:!text-[12px]',
       },
       25: {
         filterPadding: 'p-4',
         filterGap: 'gap-3',
         bodyPadding: 'p-4',
-        tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[13px]',
+        tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[12px]',
       },
       50: {
         filterPadding: 'p-5',
         filterGap: 'gap-4',
         bodyPadding: 'p-5',
-        tableRowDensity: '[&>td]:!py-2.5 [&>td]:!text-[14px]',
+        tableRowDensity: '[&>td]:!py-1 [&>td]:!text-[13px]',
       },
       75: {
         filterPadding: 'p-6',
         filterGap: 'gap-5',
         bodyPadding: 'p-7',
-        tableRowDensity: '[&>td]:!py-3.5 [&>td]:!text-[15px]',
+        tableRowDensity: '[&>td]:!py-1.5 [&>td]:!text-[13px]',
       },
       100: {
         filterPadding: 'p-8',
         filterGap: 'gap-6',
         bodyPadding: 'p-9',
-        tableRowDensity: '[&>td]:!py-5 [&>td]:!text-[16px]',
+        tableRowDensity: '[&>td]:!py-2 [&>td]:!text-[14px]',
       },
     };
 

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -187,7 +187,8 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     actions: true,
   });
 
-  const tagsInlineUnderTitle = displaySettings?.list?.tagsInlineUnderTitle || false;
+  const tagsInlineUnderTitle = displaySettings?.list?.tagsInlineUnderTitle ?? true;
+  const showInlineTagsInTitle = columnVisibility.tags && showTags && !showAllAvailableColumns;
   const dateTimeFormat = displaySettings?.dateTimeFormat || 'MMM d, yyyy h:mm a';
 
   const columns: Array<{ key: string; col: ColumnDefinition<ITicketListItem> }> = [];
@@ -273,7 +274,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     col: {
       title: t('fields.title', 'Title'),
       dataIndex: 'title',
-      width: tagsInlineUnderTitle ? '20%' : '16%',
+      width: showInlineTagsInTitle ? '20%' : '16%',
       render: (value: string, record: ITicketListItem) => (
         <div className="flex flex-col gap-1 overflow-hidden">
           <Link
@@ -288,7 +289,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
           >
             {value}
           </Link>
-          {tagsInlineUnderTitle && columnVisibility.tags && showTags && ticketTagsRef && onTagsChange && record.ticket_id && (
+          {showInlineTagsInTitle && ticketTagsRef && onTagsChange && record.ticket_id && (ticketTagsRef.current[record.ticket_id]?.length ?? 0) > 0 && (
             <div onClick={(e) => e.stopPropagation()}>
               <TagManager
                 entityId={record.ticket_id}
@@ -316,13 +317,14 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
           const responseState = (record as any).response_state as TicketResponseState | undefined;
           const showResponseState = displaySettings?.responseStateTrackingEnabled !== false;
           return (
-            <div className="flex items-center gap-1.5 flex-wrap">
-              <span>{value || 'No Status'}</span>
+            <div className="flex items-center gap-1.5 overflow-hidden whitespace-nowrap">
+              <span className="overflow-hidden text-ellipsis">{value || 'No Status'}</span>
               {showResponseState && responseState && (
                 <ResponseStateBadge
                   responseState={responseState}
-                  variant="badge"
+                  variant="icon"
                   size="sm"
+                  className="h-5 w-5 shrink-0 justify-center border-transparent !bg-transparent px-0 py-0 opacity-75"
                 />
               )}
             </div>
@@ -601,8 +603,8 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     });
   }
 
-  // Tags (as separate column)
-  if (columnVisibility.tags && !tagsInlineUnderTitle && showTags && ticketTagsRef && onTagsChange) {
+  // Tags (as separate column; retained for print/export column selection, not the default ticket list)
+  if (showAllAvailableColumns && columnVisibility.tags && !tagsInlineUnderTitle && showTags && ticketTagsRef && onTagsChange) {
     columns.push({
       key: 'tags',
       col: {

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -322,9 +322,9 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
               {showResponseState && responseState && (
                 <ResponseStateBadge
                   responseState={responseState}
-                  variant="icon"
+                  variant="text"
                   size="sm"
-                  className="h-5 w-5 shrink-0 justify-center border-transparent !bg-transparent px-0 py-0 opacity-75"
+                  className="h-5 w-5 shrink-0 justify-center overflow-hidden border-transparent !bg-transparent px-0 py-0 text-transparent opacity-75 [&_span]:hidden"
                 />
               )}
             </div>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -143,7 +143,7 @@ const ReflectedTableCell = ({
       style={style}
       data-automation-id={id}
     >
-      <div className="break-words min-w-0 [&_button:not(.whitespace-normal)]:whitespace-nowrap [&_a:not(.whitespace-normal)]:whitespace-nowrap">
+      <div className="min-w-0 overflow-hidden whitespace-nowrap [&_.break-all]:![overflow-wrap:normal] [&_.break-all]:![word-break:normal] [&_.break-words]:![overflow-wrap:normal] [&_.flex-wrap]:!flex-nowrap [&_a]:block [&_a]:max-w-full [&_a]:overflow-hidden [&_a]:text-ellipsis [&_a]:!text-[rgb(var(--color-text-800))] [&_a]:!whitespace-nowrap [&_a]:![overflow-wrap:normal] [&_a]:![word-break:normal] [&_a:hover]:!text-[rgb(var(--color-primary-700))] [&_button]:max-w-full [&_button]:overflow-hidden [&_button]:text-ellipsis [&_button]:!whitespace-nowrap">
         {children}
       </div>
     </td>
@@ -550,7 +550,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
 
   return (
     <div
-      className="datatable-container overflow-hidden bg-background rounded-lg border border-border"
+      className="datatable-container overflow-hidden rounded-xl border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] shadow-sm"
       data-automation-id={id}
       ref={tableContainerRef}
     >
@@ -564,11 +564,11 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
             </AlertDescription>
           </Alert>
         )}
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto [scrollbar-color:rgb(var(--color-border-300))_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[rgb(var(--color-border-300)/0.65)] [&::-webkit-scrollbar-thumb:hover]:bg-[rgb(var(--color-border-400)/0.8)]">
           <table
-            className="w-full divide-y divide-[rgb(var(--color-border-200))]"
+            className="w-full border-collapse text-[13px]"
           >
-            <thead className="bg-background">
+            <thead className="bg-[rgb(var(--color-border-50)/0.55)]">
               {table.getHeaderGroups().map((headerGroup): React.JSX.Element => (
                 <tr key={`headergroup_${headerGroup.id}`}>
                   {headerGroup.headers.map((header, headerIndex): React.JSX.Element => {
@@ -584,20 +584,20 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                       id={id ? `${id}-header-${columnId}` : `header-${columnId}`}
                       onClick={isSortable ? header.column.getToggleSortingHandler() : undefined}
                       className={cn(
-                        'px-6 py-3 text-xs font-medium text-[rgb(var(--color-text-700))] tracking-wider transition-colors',
-                        isSortable && 'cursor-pointer hover:bg-muted',
+                        'h-8 min-w-[10rem] whitespace-nowrap border-b border-r border-[rgb(var(--color-border-100)/0.82)] px-3 py-1.5 text-[12px] font-medium text-[rgb(var(--color-text-500))] transition-colors first:w-12 first:min-w-12 first:pl-4 last:border-r-0 last:pr-4',
+                        isSortable && 'cursor-pointer hover:bg-[rgb(var(--color-border-100)/0.62)] hover:text-[rgb(var(--color-text-700))]',
                         colDef?.headerClassName?.includes('text-center') ? 'text-center' : 'text-left',
                         colDef?.headerClassName ?? ''
                       )}
                       style={{ width: colDef?.width }}
                     >
-                        <div className={`flex space-x-1 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''} items-center`}>
+                        <div className={`flex items-center gap-1.5 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''}`}>
                           <span>{flexRender(header.column.columnDef.header, header.getContext())}</span>
                           {isSortable && (
-                            <span className="text-muted-foreground">
+                            <span className="text-[rgb(var(--color-text-400))]">
                               {{
-                                asc: ' ↑',
-                                desc: ' ↓',
+                                asc: '↑',
+                                desc: '↓',
                               }[header.column.getIsSorted() as string] ?? null}
                             </span>
                           )}
@@ -608,8 +608,8 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                 </tr>
               ))}
             </thead>
-            <tbody className="divide-y divide-[rgb(var(--color-border-100))]">
-              {table.getPaginationRowModel().rows.map((row, rowIndex): React.JSX.Element => {
+            <tbody className="divide-y divide-[rgb(var(--color-border-100)/0.72)] bg-[rgb(var(--color-card))]">
+              {table.getPaginationRowModel().rows.map((row): React.JSX.Element => {
                 // Use the id property if it exists in the data, otherwise use row.id
                 const rowId = ('id' in row.original) ? (row.original as { id: string }).id : row.id;
                 const extraRowClass = typeof rowClassName === 'function' ? rowClassName(row.original as any) : '';
@@ -618,9 +618,9 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                     key={`row_${rowId}`}
                     onClick={(e) => handleRowClick(e, row)}
                     className={`
-                    ${rowIndex % 2 === 0 ? 'bg-table-row-alt' : 'bg-background'}
-                    ${onRowClick ? 'hover:bg-table-hover cursor-pointer' : 'cursor-default'}
-                    transition-colors
+                    bg-[rgb(var(--color-card))]
+                    ${onRowClick ? 'hover:bg-[rgb(var(--color-border-50)/0.82)] cursor-pointer' : 'cursor-default'}
+                    transition-colors duration-150
                     ${extraRowClass}
                   `}
                   >
@@ -644,7 +644,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                           key={`cell_${rowId}_${columnId}_${cellIndex}`}
                           id={cellId}
                           content={cellContent}
-                          className={`px-6 py-3 text-[14px] leading-relaxed text-[rgb(var(--color-text-700))] max-w-0 align-top ${columnDef?.cellClassName ?? ''}`}
+                          className={`h-8 min-w-[10rem] max-w-0 overflow-hidden border-r border-[rgb(var(--color-border-100)/0.72)] px-3 py-1.5 text-[13px] leading-4 text-[rgb(var(--color-text-700))] align-middle first:w-12 first:min-w-12 first:pl-4 last:border-r-0 last:pr-4 ${columnDef?.cellClassName ?? ''}`}
                           style={{ width: columnDef?.width }}
                         >
                           <div className="min-w-0">
@@ -660,7 +660,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
           </table>
         </div>
         {pagination && safeData.length > 0 && (totalPages > 1 || onItemsPerPageChange) && (
-          <div className="border-t border-[rgb(var(--color-border-100))]">
+          <div className="border-t border-[rgb(var(--color-border-100)/0.72)]">
             <Pagination
               id={id ? `${id}-pagination` : 'datatable-pagination'}
               currentPage={pageIndex + 1}

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -45,6 +45,27 @@ const getNestedValue = (obj: unknown, path: string | string[]): unknown => {
   }, obj);
 };
 
+const extractTextFromReactNode = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(extractTextFromReactNode).filter(Boolean).join(' ');
+  }
+
+  if (React.isValidElement(node)) {
+    const resultProps = node.props as { children?: React.ReactNode };
+    return extractTextFromReactNode(resultProps.children);
+  }
+
+  return '';
+};
+
 // Helper function to extract display text from column render function
 const getDisplayText = (columnDef: ColumnDefinition<any> | undefined, cellValue: unknown, rowData: any): string => {
   if (!columnDef || !columnDef.render) {
@@ -60,20 +81,9 @@ const getDisplayText = (columnDef: ColumnDefinition<any> | undefined, cellValue:
     return renderResult;
   }
   
-  // For JSX elements, try to extract text content based on common patterns
-  if (React.isValidElement(renderResult)) {
-    // Handle common patterns in the codebase
-    const resultProps = renderResult.props as { children?: React.ReactNode };
-    if (resultProps && resultProps.children) {
-      const children = resultProps.children;
-      if (typeof children === 'string') {
-        return children;
-      }
-      // Handle nested text content
-      if (Array.isArray(children)) {
-        return children.filter(child => typeof child === 'string').join(' ');
-      }
-    }
+  const renderedText = extractTextFromReactNode(renderResult);
+  if (renderedText) {
+    return renderedText;
   }
   
   // Fallback: use the original value with N/A handling
@@ -192,13 +202,19 @@ const ReflectedTableCell = ({
     }
   }, [content, updateCellMetadata]);
   
+  const tooltipText = content && content !== 'N/A' ? content : undefined;
+
   return (
     <td
       className={className}
       style={style}
       data-automation-id={id}
+      title={tooltipText}
     >
-      <div className="min-w-0 overflow-hidden whitespace-nowrap [&_.break-all]:![overflow-wrap:normal] [&_.break-all]:![word-break:normal] [&_.break-words]:![overflow-wrap:normal] [&_.flex-wrap]:!flex-nowrap [&_a]:block [&_a]:max-w-full [&_a]:overflow-hidden [&_a]:text-ellipsis [&_a]:!text-[rgb(var(--color-text-800))] [&_a]:!whitespace-nowrap [&_a]:![overflow-wrap:normal] [&_a]:![word-break:normal] [&_a:hover]:!text-[rgb(var(--color-primary-700))] [&_button]:max-w-full [&_button]:overflow-hidden [&_button]:text-ellipsis [&_button]:!whitespace-nowrap">
+      <div
+        className="min-w-0 overflow-hidden whitespace-nowrap [&_.break-all]:![overflow-wrap:normal] [&_.break-all]:![word-break:normal] [&_.break-words]:![overflow-wrap:normal] [&_.flex-wrap]:!flex-nowrap [&_a]:block [&_a]:max-w-full [&_a]:overflow-hidden [&_a]:text-ellipsis [&_a]:!text-[rgb(var(--color-text-800))] [&_a]:!whitespace-nowrap [&_a]:![overflow-wrap:normal] [&_a]:![word-break:normal] [&_a:hover]:!text-[rgb(var(--color-primary-700))] [&_button]:max-w-full [&_button]:overflow-hidden [&_button]:text-ellipsis [&_button]:!whitespace-nowrap"
+        title={tooltipText}
+      >
         {children}
       </div>
     </td>
@@ -697,10 +713,12 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                     return colId === header.column.id;
                   });
                   const isSortable = header.column.getCanSort();
+                  const headerTitle = typeof colDef?.title === 'string' ? colDef.title : undefined;
                   return (
                     <th
                       key={`header_${columnId}_${headerIndex}`}
                       id={id ? `${id}-header-${columnId}` : `header-${columnId}`}
+                      title={headerTitle}
                       onClick={isSortable ? (event) => {
                         if (suppressNextHeaderSortClickRef.current) {
                           event.preventDefault();
@@ -723,7 +741,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                       style={{ width: header.getSize() }}
                     >
                         <div className={`flex min-w-0 items-center gap-1.5 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''}`}>
-                          <span className="min-w-0 overflow-hidden text-ellipsis">{flexRender(header.column.columnDef.header, header.getContext())}</span>
+                          <span className="min-w-0 overflow-hidden text-ellipsis" title={headerTitle}>{flexRender(header.column.columnDef.header, header.getContext())}</span>
                           {isSortable && (
                             <span className="shrink-0 text-[rgb(var(--color-text-400))]">
                               {{

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -172,6 +172,76 @@ const caseInsensitiveSort: SortingFn<any> = (rowA, rowB, columnId) => {
   return String(a ?? '').toLowerCase().localeCompare(String(b ?? '').toLowerCase());
 };
 
+interface OverflowTooltipProps {
+  text?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const isElementOverflowing = (element: HTMLElement): boolean => (
+  element.scrollWidth > element.clientWidth + 1 || element.scrollHeight > element.clientHeight + 1
+);
+
+const hasOverflow = (element: HTMLElement): boolean => {
+  if (isElementOverflowing(element)) {
+    return true;
+  }
+
+  return Array.from(element.querySelectorAll<HTMLElement>('*')).some(isElementOverflowing);
+};
+
+const OverflowTooltip = ({ text, children, className }: OverflowTooltipProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [activeTitle, setActiveTitle] = useState<string | undefined>(undefined);
+
+  const updateTitle = () => {
+    const element = contentRef.current;
+    setActiveTitle(element && text && hasOverflow(element) ? text : undefined);
+  };
+
+  const clearTitle = () => setActiveTitle(undefined);
+
+  return (
+    <div
+      ref={contentRef}
+      className={className}
+      title={activeTitle}
+      onMouseEnter={updateTitle}
+      onFocus={updateTitle}
+      onMouseLeave={clearTitle}
+      onBlur={clearTitle}
+    >
+      {children}
+    </div>
+  );
+};
+
+const OverflowTooltipSpan = ({ text, children, className }: OverflowTooltipProps) => {
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const [activeTitle, setActiveTitle] = useState<string | undefined>(undefined);
+
+  const updateTitle = () => {
+    const element = contentRef.current;
+    setActiveTitle(element && text && hasOverflow(element) ? text : undefined);
+  };
+
+  const clearTitle = () => setActiveTitle(undefined);
+
+  return (
+    <span
+      ref={contentRef}
+      className={className}
+      title={activeTitle}
+      onMouseEnter={updateTitle}
+      onFocus={updateTitle}
+      onMouseLeave={clearTitle}
+      onBlur={clearTitle}
+    >
+      {children}
+    </span>
+  );
+};
+
 // Component to register table cell content with UI reflection system
 interface ReflectedTableCellProps {
   id: string;
@@ -209,14 +279,13 @@ const ReflectedTableCell = ({
       className={className}
       style={style}
       data-automation-id={id}
-      title={tooltipText}
     >
-      <div
+      <OverflowTooltip
+        text={tooltipText}
         className="min-w-0 overflow-hidden whitespace-nowrap [&_.break-all]:![overflow-wrap:normal] [&_.break-all]:![word-break:normal] [&_.break-words]:![overflow-wrap:normal] [&_.flex-wrap]:!flex-nowrap [&_a]:block [&_a]:max-w-full [&_a]:overflow-hidden [&_a]:text-ellipsis [&_a]:!text-[rgb(var(--color-text-800))] [&_a]:!whitespace-nowrap [&_a]:![overflow-wrap:normal] [&_a]:![word-break:normal] [&_a:hover]:!text-[rgb(var(--color-primary-700))] [&_button]:max-w-full [&_button]:overflow-hidden [&_button]:text-ellipsis [&_button]:!whitespace-nowrap"
-        title={tooltipText}
       >
         {children}
-      </div>
+      </OverflowTooltip>
     </td>
   );
 };
@@ -718,7 +787,6 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                     <th
                       key={`header_${columnId}_${headerIndex}`}
                       id={id ? `${id}-header-${columnId}` : `header-${columnId}`}
-                      title={headerTitle}
                       onClick={isSortable ? (event) => {
                         if (suppressNextHeaderSortClickRef.current) {
                           event.preventDefault();
@@ -741,7 +809,7 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                       style={{ width: header.getSize() }}
                     >
                         <div className={`flex min-w-0 items-center gap-1.5 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''}`}>
-                          <span className="min-w-0 overflow-hidden text-ellipsis" title={headerTitle}>{flexRender(header.column.columnDef.header, header.getContext())}</span>
+                          <OverflowTooltipSpan className="min-w-0 overflow-hidden text-ellipsis" text={headerTitle}>{flexRender(header.column.columnDef.header, header.getContext())}</OverflowTooltipSpan>
                           {isSortable && (
                             <span className="shrink-0 text-[rgb(var(--color-text-400))]">
                               {{

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -12,6 +12,7 @@ import {
   getPaginationRowModel,
   flexRender,
   ColumnDef,
+  ColumnSizingState,
   Row,
   SortingFn,
   SortingState,
@@ -81,6 +82,60 @@ const getDisplayText = (columnDef: ColumnDefinition<any> | undefined, cellValue:
   }
   
   return String(cellValue);
+};
+
+const COLUMN_SIZE_BASE_WIDTH = 1800;
+const DEFAULT_COLUMN_SIZE = 160;
+const COMPACT_COLUMN_IDS = new Set(['selection', 'actions', 'tags']);
+
+const getColumnId = (dataIndex: string | string[]): string => (
+  Array.isArray(dataIndex) ? dataIndex.join('_') : dataIndex
+);
+
+const parseColumnWidth = (width: string | undefined): number | undefined => {
+  if (!width) return undefined;
+
+  const trimmed = width.trim();
+  if (trimmed.endsWith('px')) {
+    const px = Number.parseFloat(trimmed);
+    return Number.isFinite(px) ? Math.round(px) : undefined;
+  }
+
+  if (trimmed.endsWith('%')) {
+    const percent = Number.parseFloat(trimmed);
+    return Number.isFinite(percent) ? Math.round((percent / 100) * COLUMN_SIZE_BASE_WIDTH) : undefined;
+  }
+
+  const numeric = Number.parseFloat(trimmed);
+  return Number.isFinite(numeric) ? Math.round(numeric) : undefined;
+};
+
+const getColumnSizeConfig = (column: ColumnDefinition<any>): { size: number; minSize: number; maxSize: number } => {
+  const columnId = getColumnId(column.dataIndex);
+  const parsedWidth = parseColumnWidth(column.width);
+  const titleLength = typeof column.title === 'string' ? column.title.length : 12;
+
+  if (COMPACT_COLUMN_IDS.has(columnId)) {
+    return {
+      size: parsedWidth ?? 64,
+      minSize: columnId === 'selection' ? 44 : 56,
+      maxSize: 180,
+    };
+  }
+
+  if (columnId === 'title') {
+    return {
+      size: parsedWidth ?? 320,
+      minSize: 180,
+      maxSize: 720,
+    };
+  }
+
+  return {
+    size: parsedWidth ?? Math.max(DEFAULT_COLUMN_SIZE, Math.min(280, titleLength * 12 + 72)),
+    minSize: 96,
+    maxSize: 520,
+  };
 };
 
 // Custom case-insensitive sorting function for all columns
@@ -191,8 +246,41 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
   
   // State to track which columns should be visible
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(
-    columns.map(col => Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex)
+    columns.map(col => getColumnId(col.dataIndex))
   );
+
+  const columnIds = useMemo(() => columns.map(col => getColumnId(col.dataIndex)), [columns]);
+  const columnSizingStorageKey = id ? `datatable-column-sizing:${id}` : null;
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
+  const [hasLoadedColumnSizing, setHasLoadedColumnSizing] = useState(false);
+
+  useEffect(() => {
+    if (!columnSizingStorageKey || typeof window === 'undefined') {
+      setColumnSizing({});
+      setHasLoadedColumnSizing(true);
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(columnSizingStorageKey);
+      const parsed = stored ? JSON.parse(stored) as Record<string, unknown> : {};
+      const validColumnIds = new Set(columnIds);
+      const nextSizing = Object.fromEntries(
+        Object.entries(parsed).filter(([key, value]) => validColumnIds.has(key) && typeof value === 'number' && Number.isFinite(value))
+      ) as ColumnSizingState;
+      setColumnSizing(nextSizing);
+    } catch {
+      setColumnSizing({});
+    } finally {
+      setHasLoadedColumnSizing(true);
+    }
+  }, [columnIds, columnSizingStorageKey]);
+
+  useEffect(() => {
+    if (!hasLoadedColumnSizing || !columnSizingStorageKey || typeof window === 'undefined') return;
+
+    window.localStorage.setItem(columnSizingStorageKey, JSON.stringify(columnSizing));
+  }, [columnSizing, columnSizingStorageKey, hasLoadedColumnSizing]);
 
   // Function to calculate which columns should be visible based on available width
   const updateVisibleColumns = () => {
@@ -339,17 +427,24 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     () =>
       columns
         .filter(col => {
-          const colId = Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex;
+          const colId = getColumnId(col.dataIndex);
           return visibleColumnIds.includes(colId);
         })
-        .map((col): ColumnDef<T> => ({
-          id: Array.isArray(col.dataIndex) ? col.dataIndex.join('_') : col.dataIndex,
-          accessorFn: (row) => getNestedValue(row, col.dataIndex),
-          header: () => col.title,
-          cell: (info) => col.render ? col.render(info.getValue(), info.row.original, info.row.index) : info.getValue(),
-          sortingFn: caseInsensitiveSort,
-          enableSorting: col.sortable !== false,
-        })),
+        .map((col): ColumnDef<T> => {
+          const sizing = getColumnSizeConfig(col);
+          return {
+            id: getColumnId(col.dataIndex),
+            accessorFn: (row) => getNestedValue(row, col.dataIndex),
+            header: () => col.title,
+            cell: (info) => col.render ? col.render(info.getValue(), info.row.original, info.row.index) : info.getValue(),
+            sortingFn: caseInsensitiveSort,
+            enableSorting: col.sortable !== false,
+            enableResizing: true,
+            size: sizing.size,
+            minSize: sizing.minSize,
+            maxSize: sizing.maxSize,
+          };
+        }),
     [columns, visibleColumnIds]
   );
 
@@ -437,7 +532,11 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
         pageSize: currentPageSize,
       },
       sorting: validSorting,
+      columnSizing,
     },
+    enableColumnResizing: true,
+    columnResizeMode: 'onChange',
+    onColumnSizingChange: setColumnSizing,
     onPaginationChange: setPagination,
     onSortingChange: (updater) => {
       if (manualSorting && onSortChange) {
@@ -566,7 +665,8 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
         )}
         <div className="overflow-x-auto [scrollbar-color:rgb(var(--color-border-300))_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[rgb(var(--color-border-300)/0.65)] [&::-webkit-scrollbar-thumb:hover]:bg-[rgb(var(--color-border-400)/0.8)]">
           <table
-            className="w-full border-collapse text-[13px]"
+            className="border-collapse text-[13px]"
+            style={{ minWidth: '100%', width: table.getTotalSize() }}
           >
             <thead className="bg-[rgb(var(--color-border-50)/0.55)]">
               {table.getHeaderGroups().map((headerGroup): React.JSX.Element => (
@@ -584,17 +684,17 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                       id={id ? `${id}-header-${columnId}` : `header-${columnId}`}
                       onClick={isSortable ? header.column.getToggleSortingHandler() : undefined}
                       className={cn(
-                        'h-8 min-w-[10rem] whitespace-nowrap border-b border-r border-[rgb(var(--color-border-100)/0.82)] px-3 py-1.5 text-[12px] font-medium text-[rgb(var(--color-text-500))] transition-colors first:w-12 first:min-w-12 first:pl-4 last:border-r-0 last:pr-4',
+                        'group relative h-8 whitespace-nowrap border-b border-r border-[rgb(var(--color-border-100)/0.82)] px-3 py-1.5 text-[12px] font-medium text-[rgb(var(--color-text-500))] transition-colors first:pl-4 last:border-r-0 last:pr-4',
                         isSortable && 'cursor-pointer hover:bg-[rgb(var(--color-border-100)/0.62)] hover:text-[rgb(var(--color-text-700))]',
                         colDef?.headerClassName?.includes('text-center') ? 'text-center' : 'text-left',
                         colDef?.headerClassName ?? ''
                       )}
-                      style={{ width: colDef?.width }}
+                      style={{ width: header.getSize() }}
                     >
-                        <div className={`flex items-center gap-1.5 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''}`}>
-                          <span>{flexRender(header.column.columnDef.header, header.getContext())}</span>
+                        <div className={`flex min-w-0 items-center gap-1.5 ${colDef?.headerClassName?.includes('text-center') ? 'justify-center' : ''}`}>
+                          <span className="min-w-0 overflow-hidden text-ellipsis">{flexRender(header.column.columnDef.header, header.getContext())}</span>
                           {isSortable && (
-                            <span className="text-[rgb(var(--color-text-400))]">
+                            <span className="shrink-0 text-[rgb(var(--color-text-400))]">
                               {{
                                 asc: '↑',
                                 desc: '↓',
@@ -602,6 +702,36 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                             </span>
                           )}
                         </div>
+                        {header.column.getCanResize() && headerIndex < headerGroup.headers.length - 1 && (
+                          <div
+                            role="separator"
+                            aria-orientation="vertical"
+                            aria-label={`Resize ${typeof colDef?.title === 'string' ? colDef.title : columnId} column`}
+                            onMouseDown={(event) => {
+                              event.stopPropagation();
+                              header.getResizeHandler(document)(event);
+                            }}
+                            onTouchStart={(event) => {
+                              event.stopPropagation();
+                              header.getResizeHandler(document)(event);
+                            }}
+                            onDoubleClick={(event) => {
+                              event.stopPropagation();
+                              header.column.resetSize();
+                              setColumnSizing(prev => {
+                                const next = { ...prev };
+                                delete next[header.column.id];
+                                return next;
+                              });
+                            }}
+                            className={cn(
+                              'absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize touch-none select-none',
+                              'after:absolute after:right-1 after:top-1 after:h-[calc(100%-0.5rem)] after:w-px after:rounded-full after:bg-transparent after:transition-colors',
+                              'hover:after:bg-[rgb(var(--color-primary-400))] group-hover:after:bg-[rgb(var(--color-border-300)/0.9)]',
+                              header.column.getIsResizing() && 'after:bg-[rgb(var(--color-primary-500))]'
+                            )}
+                          />
+                        )}
                       </th>
                     );
                   })}
@@ -644,8 +774,8 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                           key={`cell_${rowId}_${columnId}_${cellIndex}`}
                           id={cellId}
                           content={cellContent}
-                          className={`h-8 min-w-[10rem] max-w-0 overflow-hidden border-r border-[rgb(var(--color-border-100)/0.72)] px-3 py-1.5 text-[13px] leading-4 text-[rgb(var(--color-text-700))] align-middle first:w-12 first:min-w-12 first:pl-4 last:border-r-0 last:pr-4 ${columnDef?.cellClassName ?? ''}`}
-                          style={{ width: columnDef?.width }}
+                          className={`h-8 max-w-0 overflow-hidden border-r border-[rgb(var(--color-border-100)/0.72)] px-3 py-1.5 text-[13px] leading-4 text-[rgb(var(--color-text-700))] align-middle first:pl-4 last:border-r-0 last:pr-4 ${columnDef?.cellClassName ?? ''}`}
+                          style={{ width: cell.column.getSize() }}
                         >
                           <div className="min-w-0">
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -243,6 +243,25 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
 
   // Reference to the table container for measuring available width
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const suppressNextHeaderSortClickRef = useRef(false);
+  const suppressHeaderSortClickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const suppressNextHeaderSortClick = () => {
+    suppressNextHeaderSortClickRef.current = true;
+    if (suppressHeaderSortClickTimeoutRef.current) {
+      clearTimeout(suppressHeaderSortClickTimeoutRef.current);
+    }
+    suppressHeaderSortClickTimeoutRef.current = setTimeout(() => {
+      suppressNextHeaderSortClickRef.current = false;
+      suppressHeaderSortClickTimeoutRef.current = null;
+    }, 500);
+  };
+
+  useEffect(() => () => {
+    if (suppressHeaderSortClickTimeoutRef.current) {
+      clearTimeout(suppressHeaderSortClickTimeoutRef.current);
+    }
+  }, []);
   
   // State to track which columns should be visible
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(
@@ -682,7 +701,19 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                     <th
                       key={`header_${columnId}_${headerIndex}`}
                       id={id ? `${id}-header-${columnId}` : `header-${columnId}`}
-                      onClick={isSortable ? header.column.getToggleSortingHandler() : undefined}
+                      onClick={isSortable ? (event) => {
+                        if (suppressNextHeaderSortClickRef.current) {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          suppressNextHeaderSortClickRef.current = false;
+                          if (suppressHeaderSortClickTimeoutRef.current) {
+                            clearTimeout(suppressHeaderSortClickTimeoutRef.current);
+                            suppressHeaderSortClickTimeoutRef.current = null;
+                          }
+                          return;
+                        }
+                        header.column.getToggleSortingHandler()?.(event);
+                      } : undefined}
                       className={cn(
                         'group relative h-8 whitespace-nowrap border-b border-r border-[rgb(var(--color-border-100)/0.82)] px-3 py-1.5 text-[12px] font-medium text-[rgb(var(--color-text-500))] transition-colors first:pl-4 last:border-r-0 last:pr-4',
                         isSortable && 'cursor-pointer hover:bg-[rgb(var(--color-border-100)/0.62)] hover:text-[rgb(var(--color-text-700))]',
@@ -707,15 +738,22 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
                             role="separator"
                             aria-orientation="vertical"
                             aria-label={`Resize ${typeof colDef?.title === 'string' ? colDef.title : columnId} column`}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                            }}
                             onMouseDown={(event) => {
                               event.stopPropagation();
+                              suppressNextHeaderSortClick();
                               header.getResizeHandler(document)(event);
                             }}
                             onTouchStart={(event) => {
                               event.stopPropagation();
+                              suppressNextHeaderSortClick();
                               header.getResizeHandler(document)(event);
                             }}
                             onDoubleClick={(event) => {
+                              event.preventDefault();
                               event.stopPropagation();
                               header.column.resetSize();
                               setColumnSizing(prev => {

--- a/packages/ui/src/components/Pagination.tsx
+++ b/packages/ui/src/components/Pagination.tsx
@@ -86,6 +86,11 @@ const Pagination = ({
         onPageChange(page);
     };
 
+    const pageButtonBaseClassName = 'inline-flex h-8 min-w-8 items-center justify-center rounded-lg border px-2 text-[13px] font-medium transition-colors';
+    const pageButtonIdleClassName = 'border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] hover:text-[rgb(var(--color-text-800))]';
+    const pageButtonActiveClassName = 'border-[rgb(var(--color-primary-400))] bg-[rgb(var(--color-primary-50))] text-[rgb(var(--color-primary-700))]';
+    const pageEllipsisClassName = 'inline-flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-[13px] font-medium text-[rgb(var(--color-text-400))]';
+
     // Generate page number buttons with ellipsis for many pages
     const renderPageButtons = () => {
         const buttons: ReactNode[] = [];
@@ -109,17 +114,14 @@ const Pagination = ({
                 <button
                     key={1}
                     onClick={() => handleChange(1)}
-                    className="border-[rgb(var(--color-border-300))] text-muted-foreground hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))] px-2 py-1 border text-sm font-medium rounded"
+                    className={`${pageButtonBaseClassName} ${pageButtonIdleClassName}`}
                 >
                     1
                 </button>
             );
             if (startPage > 2) {
                 buttons.push(
-                    <span
-                        key="ellipsis-start"
-                        className="border border-[rgb(var(--color-border-300))] px-2 py-1 text-sm font-medium text-[rgb(var(--color-text-700))] rounded"
-                    >
+                    <span key="ellipsis-start" className={pageEllipsisClassName}>
                         ...
                     </span>
                 );
@@ -132,11 +134,7 @@ const Pagination = ({
                 <button
                     key={i}
                     onClick={() => handleChange(i)}
-                    className={`${
-                        currentPage === i
-                            ? "border-[rgb(var(--color-primary-500))] text-[rgb(var(--color-primary-500))] bg-[rgb(var(--color-primary-50))]"
-                            : "border-[rgb(var(--color-border-300))] text-muted-foreground hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))]"
-                    } px-2 py-1 border text-sm font-medium rounded`}
+                    className={`${pageButtonBaseClassName} ${currentPage === i ? pageButtonActiveClassName : pageButtonIdleClassName}`}
                 >
                     {i}
                 </button>
@@ -147,10 +145,7 @@ const Pagination = ({
         if (endPage < totalPages) {
             if (endPage < totalPages - 1) {
                 buttons.push(
-                    <span
-                        key="ellipsis-end"
-                        className="border border-[rgb(var(--color-border-300))] px-2 py-1 text-sm font-medium text-[rgb(var(--color-text-700))] rounded"
-                    >
+                    <span key="ellipsis-end" className={pageEllipsisClassName}>
                         ...
                     </span>
                 );
@@ -159,7 +154,7 @@ const Pagination = ({
                 <button
                     key={totalPages}
                     onClick={() => handleChange(totalPages)}
-                    className="border-[rgb(var(--color-border-300))] text-muted-foreground hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))] px-2 py-1 border text-sm font-medium rounded"
+                    className={`${pageButtonBaseClassName} ${pageButtonIdleClassName}`}
                 >
                     {totalPages}
                 </button>
@@ -185,8 +180,8 @@ const Pagination = ({
                 id={id}
                 label={t('pagination.reflectionLabel', 'Pagination')}
             >
-                <div className={`flex py-3 items-center justify-end pr-6 ${className}`}>
-                    <p className="text-sm text-[rgb(var(--color-text-700))] mr-6">
+                <div className={`flex items-center justify-end gap-3 bg-[rgb(var(--color-card))] px-4 py-3 ${className}`}>
+                    <p className="text-[13px] text-[rgb(var(--color-text-500))]">
                         {t('pagination.totalItems', {
                             count: totalItems,
                             itemLabel: resolvedItemLabel,
@@ -211,8 +206,8 @@ const Pagination = ({
                 id={id}
                 label={t('pagination.reflectionLabel', 'Pagination')}
             >
-                <div className={`flex py-3 items-center justify-end pr-6 ${className}`}>
-                    <p className="text-sm text-[rgb(var(--color-text-700))] mr-6">
+                <div className={`flex items-center justify-end gap-3 bg-[rgb(var(--color-card))] px-4 py-3 ${className}`}>
+                    <p className="text-[13px] text-[rgb(var(--color-text-500))]">
                         {t('pagination.range', {
                             from: firstItemIndex,
                             to: lastItemIndex,
@@ -223,25 +218,25 @@ const Pagination = ({
                     </p>
 
                     <div
-                        className="inline-flex rounded-md gap-2 mr-8"
+                        className="mr-3 inline-flex items-center gap-1.5 rounded-lg"
                         aria-label={t('pagination.ariaLabel', 'Pagination')}
                     >
                         <button 
                             id={`${id}-prev-btn`}
                             onClick={() => handleChange(currentPage - 1)} 
                             disabled={currentPage === 1}
-                            className="px-1 py-1 border border-[rgb(var(--color-border-300))] text-sm font-medium text-muted-foreground hover:bg-muted rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                            <ChevronLeft className="text-[rgb(var(--color-text-900))]" />
+                            <ChevronLeft size={16} />
                         </button>
                         {renderPageButtons()}
                         <button 
                             id={`${id}-next-btn`}
                             onClick={() => handleChange(currentPage + 1)} 
                             disabled={currentPage === totalPages}
-                            className="px-1 py-1 border border-[rgb(var(--color-border-300))] text-sm font-medium text-muted-foreground hover:bg-muted rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                            <ChevronRight className="text-[rgb(var(--color-text-900))]" />
+                            <ChevronRight size={16} />
                         </button>
                     </div>
 
@@ -264,27 +259,27 @@ const Pagination = ({
                 id={id}
                 label={t('pagination.reflectionLabel', 'Pagination')}
             >
-                <div className={`flex justify-center items-center py-4 ${className}`}>
+                <div className={`flex items-center justify-center bg-[rgb(var(--color-card))] px-4 py-3 ${className}`}>
                     <div
-                        className="inline-flex rounded-md gap-1"
+                        className="inline-flex items-center gap-1.5 rounded-lg"
                         aria-label={t('pagination.ariaLabel', 'Pagination')}
                     >
                         <button 
                             id={`${id}-prev-btn`}
                             onClick={() => handleChange(currentPage - 1)} 
                             disabled={currentPage === 1}
-                            className="px-1 py-1 border border-[rgb(var(--color-border-300))] text-sm font-medium text-muted-foreground hover:bg-muted rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                            <ChevronLeft className="text-[rgb(var(--color-text-900))]" />
+                            <ChevronLeft size={16} />
                         </button>
                         {renderPageButtons()}
                         <button 
                             id={`${id}-next-btn`}
                             onClick={() => handleChange(currentPage + 1)} 
                             disabled={currentPage === totalPages}
-                            className="px-1 py-1 border border-[rgb(var(--color-border-300))] text-sm font-medium text-muted-foreground hover:bg-muted rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                            <ChevronRight className="text-[rgb(var(--color-text-900))]" />
+                            <ChevronRight size={16} />
                         </button>
                     </div>
                 </div>
@@ -297,8 +292,8 @@ const Pagination = ({
             id={id}
             label={t('pagination.reflectionLabel', 'Pagination')}
         >
-            <div className={`px-6 py-4 bg-background ${className}`}>
-                <div className="flex items-center justify-between space-x-4">
+            <div className={`bg-[rgb(var(--color-card))] px-4 py-3 ${className}`}>
+                <div className="flex items-center justify-between gap-3">
                     {variant === 'compact' ? (
                         // Compact variant with icon buttons
                         <>
@@ -306,11 +301,11 @@ const Pagination = ({
                                 id={`${id}-prev-btn`}
                                 onClick={() => handleChange(currentPage - 1)}
                                 disabled={currentPage === 1}
-                                className="w-8 h-8 flex items-center justify-center border border-[rgb(var(--color-border-300))] rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-muted"
+                                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 <ChevronLeft size={16} />
                             </button>
-                            <span className="text-sm text-[rgb(var(--color-text-700))]">
+                            <span className="text-[13px] text-[rgb(var(--color-text-500))]">
                                 {t('pagination.pageOf', {
                                     current: currentPage,
                                     total: totalPages,
@@ -327,7 +322,7 @@ const Pagination = ({
                                 id={`${id}-next-btn`}
                                 onClick={() => handleChange(currentPage + 1)}
                                 disabled={currentPage === totalPages}
-                                className="w-8 h-8 flex items-center justify-center border border-[rgb(var(--color-border-300))] rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-muted"
+                                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[rgb(var(--color-border-200))] text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 <ChevronRight size={16} />
                             </button>
@@ -339,11 +334,11 @@ const Pagination = ({
                                 id={`${id}-prev-btn`}
                                 onClick={() => handleChange(currentPage - 1)}
                                 disabled={currentPage === 1}
-                                className="px-4 py-2 border border-[rgb(var(--color-border-300))] rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-background hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                className="rounded-lg border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] px-3 py-1.5 text-[13px] font-medium text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] hover:text-[rgb(var(--color-text-800))] disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 {t('pagination.previous', 'Previous')}
                             </button>
-                            <span className="text-sm text-[rgb(var(--color-text-700))]">
+                            <span className="text-[13px] text-[rgb(var(--color-text-500))]">
                                 {t('pagination.pageOf', {
                                     current: currentPage,
                                     total: totalPages,
@@ -360,7 +355,7 @@ const Pagination = ({
                                 id={`${id}-next-btn`}
                                 onClick={() => handleChange(currentPage + 1)}
                                 disabled={currentPage === totalPages}
-                                className="px-4 py-2 border border-[rgb(var(--color-border-300))] rounded-md text-sm font-medium text-[rgb(var(--color-text-700))] bg-background hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                className="rounded-lg border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] px-3 py-1.5 text-[13px] font-medium text-[rgb(var(--color-text-600))] transition-colors hover:border-[rgb(var(--color-border-300))] hover:bg-[rgb(var(--color-border-50))] hover:text-[rgb(var(--color-text-800))] disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 {t('pagination.next', 'Next')}
                             </button>


### PR DESCRIPTION
## Summary
- Restyle the shared DataTable toward a compact Notion/Twenty-style grid with subtle dividers, horizontal scrolling, and cleaner pagination
- Add column resizing with per-table localStorage persistence and guard resizing from triggering header sorting
- Remove the default standalone Tickets tags column, render response state as a subtle icon, and show tooltips only when cell/header content is truncated

## Validation
- Refreshed `/msp/tickets` in Alga Dev and visually checked the ticket table
- Verified resize handles render and resize interactions do not trigger sorting
- Verified truncated cell tooltips appear lazily and non-truncated cells do not get titles
- Ran `npx eslint packages/ui/src/components/DataTable.tsx packages/ui/src/components/Pagination.tsx packages/tickets/src/lib/ticket-columns.tsx` (warnings only, no errors; warnings are pre-existing style/type warnings in touched files)
