### PR TITLE
Fix delete perm check for phantom RBAC resources

### DIFF
--- a/packages/auth/src/lib/preCheckDeletion.ts
+++ b/packages/auth/src/lib/preCheckDeletion.ts
@@ -23,6 +23,10 @@ function permissionEntityFor(entityType: string): string {
   if (entityType === 'role') return 'security_settings';
   if (entityType === 'invoice_template') return 'invoice';
   if (entityType === 'tax_rate') return 'billing';
+  if (entityType === 'priority') return 'ticket_settings';
+  if (entityType === 'category') return 'ticket_settings';
+  if (entityType === 'board') return 'ticket_settings';
+  if (entityType === 'contract_line') return 'billing';
   return entityType;
 }
 


### PR DESCRIPTION
  Map priority, category, board, and contract_line entity types to
  their real governing resources (ticket_settings/billing) in
  permissionEntityFor(). These types fell through to resource names
  that have no permission row, so hasPermission() denied deletion for
  everyone including Admin, surfacing a detail-free error.

  "But I don't *want* to go among mad permissions," said Alice. "Oh,
  you can't help that," said the Cat. "We're all phantom resources
  here — priority, category, board, every last contract_line — none of
  them ever existed in the table, yet still they guard the door."
  🐱🗝️ 🃏