### PR TITLE
fix: bake NEXT_PUBLIC_EDITION into client bundle for MS card

### DIFF
--- a/packages/integrations/src/lib/microsoftConsumerVisibility.test.ts
+++ b/packages/integrations/src/lib/microsoftConsumerVisibility.test.ts
@@ -7,18 +7,34 @@ import {
 
 describe('microsoftConsumerVisibility', () => {
   it('treats only enterprise editions as multi-consumer Microsoft environments', () => {
-    expect(isMicrosoftConsumerEnterpriseEdition({ EDITION: 'ee' } as unknown as NodeJS.ProcessEnv)).toBe(true);
-    expect(
-      isMicrosoftConsumerEnterpriseEdition({
-        NEXT_PUBLIC_EDITION: 'enterprise',
-      } as unknown as NodeJS.ProcessEnv)
-    ).toBe(true);
-    expect(
-      isMicrosoftConsumerEnterpriseEdition({
-        EDITION: 'ce',
-        NEXT_PUBLIC_EDITION: 'community',
-      } as unknown as NodeJS.ProcessEnv)
-    ).toBe(false);
+    const originalEdition = process.env.EDITION;
+    const originalPublicEdition = process.env.NEXT_PUBLIC_EDITION;
+
+    try {
+      process.env.EDITION = 'ee';
+      delete process.env.NEXT_PUBLIC_EDITION;
+      expect(isMicrosoftConsumerEnterpriseEdition()).toBe(true);
+
+      delete process.env.EDITION;
+      process.env.NEXT_PUBLIC_EDITION = 'enterprise';
+      expect(isMicrosoftConsumerEnterpriseEdition()).toBe(true);
+
+      process.env.EDITION = 'ce';
+      process.env.NEXT_PUBLIC_EDITION = 'community';
+      expect(isMicrosoftConsumerEnterpriseEdition()).toBe(false);
+    } finally {
+      if (originalEdition === undefined) {
+        delete process.env.EDITION;
+      } else {
+        process.env.EDITION = originalEdition;
+      }
+
+      if (originalPublicEdition === undefined) {
+        delete process.env.NEXT_PUBLIC_EDITION;
+      } else {
+        process.env.NEXT_PUBLIC_EDITION = originalPublicEdition;
+      }
+    }
   });
 
   it('returns only MSP SSO in community edition', () => {

--- a/packages/integrations/src/lib/microsoftConsumerVisibility.ts
+++ b/packages/integrations/src/lib/microsoftConsumerVisibility.ts
@@ -3,9 +3,9 @@ import type { MicrosoftProfileConsumer } from '../actions/integrations/microsoft
 const CE_VISIBLE_MICROSOFT_CONSUMERS: MicrosoftProfileConsumer[] = ['msp_sso'];
 const EE_VISIBLE_MICROSOFT_CONSUMERS: MicrosoftProfileConsumer[] = ['msp_sso', 'email', 'calendar', 'teams'];
 
-export function isMicrosoftConsumerEnterpriseEdition(env: NodeJS.ProcessEnv = process.env): boolean {
-  const edition = (env.EDITION ?? '').toLowerCase();
-  const publicEdition = (env.NEXT_PUBLIC_EDITION ?? '').toLowerCase();
+export function isMicrosoftConsumerEnterpriseEdition(): boolean {
+  const edition = (process.env.EDITION ?? '').toLowerCase();
+  const publicEdition = (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase();
 
   return edition === 'ee' || edition === 'enterprise' || publicEdition === 'enterprise';
 }


### PR DESCRIPTION
  Drop the env parameter from isMicrosoftConsumerEnterpriseEdition so it
  references process.env.NEXT_PUBLIC_EDITION as a literal — Next.js's
  DefinePlugin only inlines literal accesses into client bundles. The
  prior parameter pattern left the value undefined in the browser, so the
  Microsoft email provider card was hidden in production EE despite the
  runtime env being set correctly. Tests updated to mutate process.env
  directly with backup/restore.

  "Curiouser and curiouser!" cried the DefinePlugin, for the enterprise
  edition had slipped through the looking-glass of a default parameter
  and emerged on the client side as plain undefined — until at last we
  spoke its name aloud as process.env, and the Microsoft card appeared,
  grinning, like a Cheshire cat. 🎩🪞 🔍