### PR TITLE
Stop comment edits from reordering threads

### DIFF
--- a/ee/mobile/src/features/ticketDetail/commentThreads.test.ts
+++ b/ee/mobile/src/features/ticketDetail/commentThreads.test.ts
@@ -28,7 +28,6 @@ function accessors(
     getThreadId: (c) => c.thread_id,
     getParentCommentId: (c) => c.parent_comment_id,
     getCreatedAt: (c) => c.created_at,
-    getUpdatedAt: (c) => c.updated_at,
     newestFirst,
   };
 }
@@ -100,7 +99,7 @@ describe("buildCommentThreadGroups", () => {
     expect(group.childrenByParentId.get("r1")!.map((c) => c.comment_id)).toEqual(["a", "b"]);
   });
 
-  it("T013: lastActivityAt = max(created/updated), replyCount = n - 1", () => {
+  it("T013: lastActivityAt = max(created_at), edits do not reorder", () => {
     const comments: TestComment[] = [
       {
         comment_id: "r1",
@@ -113,7 +112,8 @@ describe("buildCommentThreadGroups", () => {
         thread_id: "t1",
         parent_comment_id: "r1",
         created_at: "2026-05-18T10:05:00Z",
-        // updated later than any created_at -> drives lastActivityAt
+        // updated_at is intentionally later than any created_at, but edits
+        // must not bump the thread's lastActivityAt.
         updated_at: "2026-05-18T12:00:00Z",
       },
       {
@@ -127,7 +127,7 @@ describe("buildCommentThreadGroups", () => {
     const [group] = buildCommentThreadGroups(accessors(comments));
 
     expect(group.replyCount).toBe(2);
-    expect(group.lastActivityAt).toBe(new Date("2026-05-18T12:00:00Z").getTime());
+    expect(group.lastActivityAt).toBe(new Date("2026-05-18T11:00:00Z").getTime());
   });
 
   it("T014: newestFirst orders an older root w/ newer reply ahead of a more-recent standalone; oldest is inverse; in-thread order unchanged", () => {

--- a/ee/mobile/src/features/ticketDetail/commentThreads.ts
+++ b/ee/mobile/src/features/ticketDetail/commentThreads.ts
@@ -18,7 +18,6 @@ export interface BuildCommentThreadGroupsOptions<TComment> {
   getThreadId: (comment: TComment) => string | null | undefined;
   getParentCommentId: (comment: TComment) => string | null | undefined;
   getCreatedAt: (comment: TComment) => string | Date | null | undefined;
-  getUpdatedAt?: (comment: TComment) => string | Date | null | undefined;
   getThreadLastActivityAt?: (comments: TComment[]) => string | Date | null | undefined;
   newestFirst?: boolean;
 }
@@ -90,7 +89,6 @@ export function buildCommentThreadGroups<TComment>(
 
       activityTimestamp = Math.max(
         activityTimestamp,
-        toTimestamp(props.getUpdatedAt?.(comment)),
         toTimestamp(props.getCreatedAt(comment))
       );
 

--- a/packages/projects/src/components/TaskCommentThread.tsx
+++ b/packages/projects/src/components/TaskCommentThread.tsx
@@ -145,7 +145,6 @@ export const TaskCommentThread: React.FC<TaskCommentThreadProps> = ({
       getThreadId: (comment) => comment.threadId || comment.taskCommentId,
       getParentCommentId: (comment) => comment.parentCommentId,
       getCreatedAt: (comment) => comment.createdAt,
-      getUpdatedAt: (comment) => comment.updatedAt,
     }),
     [comments]
   );
@@ -307,7 +306,6 @@ export const TaskCommentThread: React.FC<TaskCommentThreadProps> = ({
             getThreadId={(comment) => comment.threadId || comment.taskCommentId}
             getParentCommentId={(comment) => comment.parentCommentId}
             getCreatedAt={(comment) => comment.createdAt}
-            getUpdatedAt={(comment) => comment.updatedAt}
             renderThreadGroup={(group) => (
               <HybridThreadNode<IProjectTaskCommentWithUser>
                 group={group}

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -479,7 +479,6 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
         getThreadId={(comment) => comment.thread_id || comment.comment_id}
         getParentCommentId={(comment) => comment.parent_comment_id}
         getCreatedAt={(comment) => comment.created_at}
-        getUpdatedAt={(comment) => comment.updated_at}
         renderThreadGroup={(group) => (
           <HybridThreadNode<IComment>
             key={`${group.threadId}-${group.replyCount}`}
@@ -501,7 +500,6 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
       getThreadId: (comment) => comment.thread_id || comment.comment_id,
       getParentCommentId: (comment) => comment.parent_comment_id,
       getCreatedAt: (comment) => comment.created_at,
-      getUpdatedAt: (comment) => comment.updated_at,
     }),
     [conversations]
   );

--- a/packages/tickets/src/components/ticket/ticketConversationThreadTabs.test.ts
+++ b/packages/tickets/src/components/ticket/ticketConversationThreadTabs.test.ts
@@ -21,7 +21,6 @@ function buildGroups(comments: IComment[]) {
     getThreadId: (item) => item.thread_id || item.comment_id,
     getParentCommentId: (item) => item.parent_comment_id,
     getCreatedAt: (item) => item.created_at,
-    getUpdatedAt: (item) => item.updated_at,
   });
 }
 

--- a/packages/ui/src/components/CommentThreadList.test.ts
+++ b/packages/ui/src/components/CommentThreadList.test.ts
@@ -8,7 +8,6 @@ interface TestComment {
   threadId: string;
   parentId: string | null;
   createdAt: string;
-  updatedAt?: string;
   threadLastActivityAt?: string;
 }
 
@@ -20,7 +19,6 @@ function group(comments: TestComment[], newestFirst = false) {
     getThreadId: (comment) => comment.threadId,
     getParentCommentId: (comment) => comment.parentId,
     getCreatedAt: (comment) => comment.createdAt,
-    getUpdatedAt: (comment) => comment.updatedAt,
     getThreadLastActivityAt: (threadComments) => threadComments[0]?.threadLastActivityAt,
   });
 }

--- a/packages/ui/src/components/CommentThreadList.tsx
+++ b/packages/ui/src/components/CommentThreadList.tsx
@@ -17,7 +17,6 @@ export interface CommentThreadListProps<TComment> {
   getThreadId: (comment: TComment) => string | null | undefined;
   getParentCommentId: (comment: TComment) => string | null | undefined;
   getCreatedAt: (comment: TComment) => string | Date | null | undefined;
-  getUpdatedAt?: (comment: TComment) => string | Date | null | undefined;
   getThreadLastActivityAt?: (comments: TComment[]) => string | Date | null | undefined;
   newestFirst?: boolean;
   emptyState?: React.ReactNode;
@@ -41,7 +40,6 @@ export function buildCommentThreadGroups<TComment>(
     | 'getThreadId'
     | 'getParentCommentId'
     | 'getCreatedAt'
-    | 'getUpdatedAt'
     | 'getThreadLastActivityAt'
     | 'newestFirst'
   >
@@ -89,7 +87,6 @@ export function buildCommentThreadGroups<TComment>(
 
       activityTimestamp = Math.max(
         activityTimestamp,
-        toTimestamp(props.getUpdatedAt?.(comment)),
         toTimestamp(props.getCreatedAt(comment))
       );
 


### PR DESCRIPTION
  Thread groups were sorted by lastActivityAt = max(created_at,
  updated_at) of all comments in the group. Editing any comment bumped
  its updated_at, which shuffled the thread to the top even though no
  new activity had happened. Drop updated_at from the activity timestamp
  in both the web (CommentThreadList) and mobile (commentThreads) thread
  builders; replies still reorder threads via their own created_at.

  "Curiouser and curiouser!" cried the comment, who had merely been
  edited, yet found itself flung to the very front of the conversation
  as though it had been born again. 🐛✏️ 🎩