### PR TITLE
Allow timesheet self-approval by default

### DIFF
--- a/ee/docs/plans/2026-05-21-timesheet-self-approval-default/PRD.md
+++ b/ee/docs/plans/2026-05-21-timesheet-self-approval-default/PRD.md
@@ -1,0 +1,24 @@
+# PRD — Timesheet Self-Approval Defaults
+
+## Problem
+Alga PSA serves small MSP owners and operators who often enter and approve their own time. Current timesheet approval paths block self-approval unconditionally, even when no premium ABAC policy has been configured. This makes the default product behavior too restrictive.
+
+## Goal
+Allow any user with the standard `timesheet:approve` permission to approve their own submitted time by default. Preserve the existing premium ABAC `not_self_approver` constraint so tenants that explicitly configure separation-of-duties policies can still block self-approval.
+
+## Non-goals
+- Do not change billing/quote self-approval behavior.
+- Do not broaden approval of other users' time beyond existing RBAC/read_all/manager rules.
+- Do not add new UI or settings.
+
+## Requirements
+1. Server-action timesheet approval allows self-approval when the actor has `timesheet:approve` and no assigned active ABAC bundle rule blocks it.
+2. Workflow time approval allows self-approval under the same default rule while retaining an independent shared-code check for configured `not_self_approver` bundle rules.
+3. Active, published, assigned authorization bundles with `resourceType=time_entry`, `action=approve`, and `constraintKey=not_self_approver` still deny self-approval.
+4. The authorization bundle simulator reflects the same policy: no built-in timesheet self-approval denial, with denial coming from configured bundle constraints only.
+5. Approval of another user's time remains governed by the existing `timesheet:approve` plus `timesheet:read_all` or manager relationship rules.
+
+## Acceptance Criteria
+- A user with `timesheet:approve` can approve their own timesheet by default.
+- A configured `not_self_approver` ABAC bundle denies the same self-approval attempt.
+- Existing non-self approval authorization behavior is unchanged.

--- a/ee/docs/plans/2026-05-21-timesheet-self-approval-default/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-21-timesheet-self-approval-default/SCRATCHPAD.md
@@ -1,0 +1,22 @@
+# Scratchpad — Timesheet Self-Approval Defaults
+
+## 2026-05-21
+- User confirmed desired default: any user with `timesheet:approve` may approve their own time.
+- Investigation found unconditional denial in `packages/scheduling/src/actions/timeEntryDelegationAuth.ts` and `shared/workflow/runtime/actions/businessOperations/timeDomain.ts`.
+- Decision: default RBAC permits self-approval; premium ABAC `not_self_approver` remains tenant-configured opt-in separation of duties.
+- Constraint: workflow shared code should not depend on the full authorization kernel, so it needs a direct DB check for active assigned bundle rules.
+- Existing user changes before implementation: `.env.localtest`, `package-lock.json`; do not touch.
+
+## Implementation notes
+- Removed the built-in mutation guard from `assertCanApproveSubject`; bundle narrowing/mutation evaluation remains responsible for `not_self_approver`.
+- Added `hasAssignedNotSelfApproverBundleRuleForWorkflowTime` in `timeDomain.ts` to query active assigned bundles directly for workflow approval self-checks.
+- Updated the EE bundle simulator so its built-in self-approval guard remains billing-only; time approval simulation now relies on configured bundle rules.
+- Updated static/contract tests for server approval wiring, workflow ABAC self-approval behavior, and simulator guard scope.
+
+## Validation
+- PASS: `npx tsc --noEmit -p shared/tsconfig.json --pretty false`
+- PASS: `npm run typecheck --workspace packages/scheduling -- --pretty false`
+- PASS: `npm test --workspace server -- --run src/test/unit/scheduling/workflowTimeSelfApproval.contract.test.ts src/test/unit/scheduling/approvalBehavior.test.ts src/test/unit/authorization/bundleSimulatorSelfApproval.contract.test.ts`
+- PARTIAL: `npm test --workspace packages/scheduling -- timeEntryDelegationAuth.authorization.test.ts timeDelegationSweep.contract.test.ts` runs `timeDelegationSweep` successfully but `timeEntryDelegationAuth.authorization.test.ts` fails before executing tests because Vitest cannot resolve `@alga-psa/authorization/kernel` from the package test harness.
+- PRE-EXISTING HARNESS FAILURE OBSERVED: `npm test --workspace server -- --run src/test/unit/authorization/bundleSimulatorAction.test.ts` fails in existing tests with `knex(...).leftJoin is not a function` before simulator assertions run.
+- LIMITATION: `npm run typecheck --workspace server -- --pretty false` OOMs near the Node heap limit after ~8 GB; narrower shared/scheduling typechecks passed.

--- a/ee/docs/plans/2026-05-21-timesheet-self-approval-default/features.json
+++ b/ee/docs/plans/2026-05-21-timesheet-self-approval-default/features.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "F001",
+    "description": "Remove the unconditional built-in timesheet self-approval denial from the server-action authorization flow.",
+    "implemented": true
+  },
+  {
+    "id": "F002",
+    "description": "Retain ABAC bundle-provider enforcement of the `not_self_approver` constraint for configured authorization bundles.",
+    "implemented": true
+  },
+  {
+    "id": "F003",
+    "description": "Update workflow time approval to allow self-approval by default while directly checking assigned active bundle rules for `not_self_approver`.",
+    "implemented": true
+  },
+  {
+    "id": "F004",
+    "description": "Preserve existing approve-other-users authorization semantics based on approve permission plus read_all or manager relationship.",
+    "implemented": true
+  },
+  {
+    "id": "F005",
+    "description": "Remove the timesheet-specific built-in self-approval denial from the authorization bundle simulator while leaving billing behavior unchanged.",
+    "implemented": true
+  }
+]

--- a/ee/docs/plans/2026-05-21-timesheet-self-approval-default/tests.json
+++ b/ee/docs/plans/2026-05-21-timesheet-self-approval-default/tests.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "T001",
+    "featureIds": ["F001", "F002"],
+    "description": "Unit coverage proves `assertCanApproveSubject` allows self-approval by default and denies it when a matching `not_self_approver` bundle rule is resolved.",
+    "implemented": true
+  },
+  {
+    "id": "T002",
+    "featureIds": ["F003"],
+    "description": "Static/contract coverage proves workflow approval no longer has an unconditional actor==subject denial and includes a direct `not_self_approver` bundle-rule check.",
+    "implemented": true
+  },
+  {
+    "id": "T003",
+    "featureIds": ["F004"],
+    "description": "Existing delegation tests continue to prove approval of other users requires existing approve/read_all or manager authorization.",
+    "implemented": true
+  },
+  {
+    "id": "T004",
+    "featureIds": ["F005"],
+    "description": "Static simulator coverage proves the built-in simulator self-approval guard remains billing-only and no longer emits timesheet self-approval denial reason codes.",
+    "implemented": true
+  }
+]

--- a/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
+++ b/ee/server/src/lib/actions/auth/authorizationBundleActions.ts
@@ -1063,8 +1063,7 @@ export const runAuthorizationBundleSimulationAction = withAuth(
               ? [{ template: 'own' }, { template: 'same_client' }]
               : [],
           mutationGuards:
-            input.action === 'approve' &&
-            (input.resourceType === 'billing' || input.resourceType === 'time_entry')
+            input.action === 'approve' && input.resourceType === 'billing'
               ? [
                   (evaluationInput) => {
                     const ownerUserId = evaluationInput.record?.ownerUserId;
@@ -1075,14 +1074,8 @@ export const runAuthorizationBundleSimulationAction = withAuth(
                           {
                             stage: 'mutation' as const,
                             sourceType: 'builtin' as const,
-                            code:
-                              input.resourceType === 'billing'
-                                ? 'billing_not_self_approver_denied'
-                                : 'timesheet_not_self_approver_denied',
-                            message:
-                              input.resourceType === 'billing'
-                                ? 'Approvers cannot approve their own quotes.'
-                                : 'Approvers cannot approve their own time submissions.',
+                            code: 'billing_not_self_approver_denied',
+                            message: 'Approvers cannot approve their own quotes.',
                           },
                         ],
                       };
@@ -1094,14 +1087,8 @@ export const runAuthorizationBundleSimulationAction = withAuth(
                         {
                           stage: 'mutation' as const,
                           sourceType: 'builtin' as const,
-                          code:
-                            input.resourceType === 'billing'
-                              ? 'billing_not_self_approver_passed'
-                              : 'timesheet_not_self_approver_passed',
-                          message:
-                            input.resourceType === 'billing'
-                              ? 'Not-self-approver guard passed for billing approvals.'
-                              : 'Not-self-approver guard passed for time approvals.',
+                          code: 'billing_not_self_approver_passed',
+                          message: 'Not-self-approver guard passed for billing approvals.',
                         },
                       ],
                     };

--- a/packages/scheduling/src/actions/timeEntryDelegationAuth.ts
+++ b/packages/scheduling/src/actions/timeEntryDelegationAuth.ts
@@ -16,38 +16,6 @@ import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorizatio
 
 export type DelegationScope = 'self' | 'tenant-wide' | 'manager';
 
-function buildTimesheetNotSelfApproverGuard(input: AuthorizationEvaluationInput) {
-  if (
-    input.mutation?.kind === 'approve' &&
-    typeof input.record?.ownerUserId === 'string' &&
-    input.record.ownerUserId === input.subject.userId
-  ) {
-    return {
-      allowed: false,
-      reasons: [
-        {
-          stage: 'mutation' as const,
-          sourceType: 'builtin' as const,
-          code: 'timesheet_not_self_approver_denied',
-          message: 'Approvers cannot approve their own time submissions.',
-        },
-      ],
-    };
-  }
-
-  return {
-    allowed: true,
-    reasons: [
-      {
-        stage: 'mutation' as const,
-        sourceType: 'builtin' as const,
-        code: 'timesheet_not_self_approver_passed',
-        message: 'Not-self-approver guard passed.',
-      },
-    ],
-  };
-}
-
 async function resolveBundleRulesOrThrow(
   db: Knex | Knex.Transaction,
   input: AuthorizationEvaluationInput,
@@ -198,9 +166,7 @@ export async function assertCanApproveSubject(
   };
 
   const approvalKernel = createAuthorizationKernel({
-    builtinProvider: new BuiltinAuthorizationKernelProvider({
-      mutationGuards: [buildTimesheetNotSelfApproverGuard],
-    }),
+    builtinProvider: new BuiltinAuthorizationKernelProvider(),
     bundleProvider: new BundleAuthorizationKernelProvider({
       resolveRules: async (input) =>
         resolveBundleRulesOrThrow(db, input, 'Permission denied: Cannot approve time submissions'),

--- a/packages/scheduling/tests/timeDelegationSweep.contract.test.ts
+++ b/packages/scheduling/tests/timeDelegationSweep.contract.test.ts
@@ -13,9 +13,10 @@ describe('time/delegation narrowing sweep contracts', () => {
     expect(delegationSource).toContain("type: 'time_entry'");
     expect(delegationSource).toContain("action: 'read'");
     expect(delegationSource).toContain("action: 'approve'");
-    expect(delegationSource).toContain('function buildTimesheetNotSelfApproverGuard(');
     expect(delegationSource).toContain('async function resolveBundleRulesOrThrow(');
-    expect(delegationSource).toContain("code: 'timesheet_not_self_approver_denied'");
+    expect(delegationSource).toContain('new BuiltinAuthorizationKernelProvider()');
+    expect(delegationSource).not.toContain('function buildTimesheetNotSelfApproverGuard(');
+    expect(delegationSource).not.toContain("code: 'timesheet_not_self_approver_denied'");
     expect(delegationSource).toContain('const managedUserIds = canReadAll ? [] : await resolveManagedSubjectUserIds(db, tenant, actor);');
     expect(delegationSource).toContain("resolveBundleRulesOrThrow(db, input, 'Permission denied: Cannot access other users time sheets')");
     expect(delegationSource).toContain("resolveBundleRulesOrThrow(db, input, 'Permission denied: Cannot approve time submissions')");

--- a/packages/scheduling/tests/timeEntryDelegationAuth.authorization.test.ts
+++ b/packages/scheduling/tests/timeEntryDelegationAuth.authorization.test.ts
@@ -247,7 +247,7 @@ describe('time authorization delegation and approval contracts', () => {
     );
   });
 
-  it('T019: not-self-approver mutation guard remains enforced on kernelized approval flow', async () => {
+  it('T019: self-approval is allowed by default and denied only by configured not-self-approver bundle rules', async () => {
     const actor: TestUser = { user_id: 'u-1', user_type: 'internal' };
 
     hasPermissionMock.mockImplementation(async (_user: unknown, resource: string, action: string) => {
@@ -256,6 +256,16 @@ describe('time authorization delegation and approval contracts', () => {
       if (action === 'read_all') return true;
       return false;
     });
+
+    await expect(assertCanApproveSubject(actor as any, 'tenant-1', 'u-1', buildDb([]))).resolves.toBe('self');
+
+    resolveBundleRulesMock.mockResolvedValueOnce([
+      {
+        resource: 'time_entry',
+        action: 'approve',
+        constraintKey: 'not_self_approver',
+      },
+    ]);
 
     await expect(assertCanApproveSubject(actor as any, 'tenant-1', 'u-1', buildDb([]))).rejects.toThrow(
       'Permission denied: Cannot approve your own time submissions'

--- a/server/src/test/unit/authorization/bundleSimulatorSelfApproval.contract.test.ts
+++ b/server/src/test/unit/authorization/bundleSimulatorSelfApproval.contract.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePathFromRepoRoot: string): string {
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  return readFileSync(path.join(repoRoot, relativePathFromRepoRoot), 'utf8');
+}
+
+describe('authorization bundle simulator self-approval contracts', () => {
+  it('keeps time self-approval as bundle-provider policy instead of a built-in simulator guard', () => {
+    const src = readRepoFile('ee/server/src/lib/actions/auth/authorizationBundleActions.ts');
+
+    expect(src).toContain("input.action === 'approve' && input.resourceType === 'billing'");
+    expect(src).toContain("code: 'billing_not_self_approver_denied'");
+    expect(src).not.toContain("code: 'timesheet_not_self_approver_denied'");
+    expect(src).not.toContain("code: 'timesheet_not_self_approver_passed'");
+  });
+});

--- a/server/src/test/unit/scheduling/approvalBehavior.test.ts
+++ b/server/src/test/unit/scheduling/approvalBehavior.test.ts
@@ -8,15 +8,15 @@ function readRepoFile(relativePathFromRepoRoot: string): string {
 }
 
 describe('timesheet approval behavior (static)', () => {
-  it('approveTimeSheet enforces delegation and marks timesheet APPROVED', () => {
+  it('approveTimeSheet enforces approval authorization and marks timesheet APPROVED', () => {
     const src = readRepoFile('packages/scheduling/src/actions/timeSheetActions.ts');
-    expect(src).toMatch(/export const approveTimeSheet[\\s\\S]*assertCanActOnBehalf/);
-    expect(src).toMatch(/approveTimeSheet[\\s\\S]*approval_status:\\s*'APPROVED'/);
+    expect(src).toMatch(/export const approveTimeSheet[\s\S]*assertCanApproveSubject/);
+    expect(src).toMatch(/approveTimeSheet[\s\S]*approval_status:\s*'APPROVED'/);
   });
 
-  it('bulkApproveTimeSheets enforces manager scope via assertCanActOnBehalf', () => {
+  it('bulkApproveTimeSheets enforces approval authorization', () => {
     const src = readRepoFile('packages/scheduling/src/actions/timeSheetActions.ts');
-    expect(src).toMatch(/export const bulkApproveTimeSheets[\\s\\S]*assertCanActOnBehalf/);
-    expect(src).toMatch(/managerId\\s*!==\\s*user\\.user_id/);
+    expect(src).toMatch(/export const bulkApproveTimeSheets[\s\S]*assertCanApproveSubject/);
+    expect(src).toMatch(/managerId\s*!==\s*user\.user_id/);
   });
 });

--- a/server/src/test/unit/scheduling/workflowTimeSelfApproval.contract.test.ts
+++ b/server/src/test/unit/scheduling/workflowTimeSelfApproval.contract.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePathFromRepoRoot: string): string {
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  return readFileSync(path.join(repoRoot, relativePathFromRepoRoot), 'utf8');
+}
+
+describe('workflow time self-approval behavior (static)', () => {
+  it('allows self-approval by default and checks configured ABAC not-self-approver rules', () => {
+    const src = readRepoFile('shared/workflow/runtime/actions/businessOperations/timeDomain.ts');
+
+    expect(src).toContain('async function hasAssignedNotSelfApproverBundleRuleForWorkflowTime(');
+    expect(src).toContain(".andWhere('r.resource_type', 'time_entry')");
+    expect(src).toContain(".andWhere('r.action', 'approve')");
+    expect(src).toContain(".andWhere('r.constraint_key', 'not_self_approver')");
+    expect(src).toContain('await hasAssignedNotSelfApproverBundleRuleForWorkflowTime(trx, tenantId, actorUserId)');
+    expect(src).not.toContain('if (actorUserId === subjectUserId) {\n    throw new WorkflowTimeDomainError');
+  });
+});

--- a/shared/workflow/runtime/actions/businessOperations/timeDomain.ts
+++ b/shared/workflow/runtime/actions/businessOperations/timeDomain.ts
@@ -248,6 +248,61 @@ async function isManagerOfSubject(
   return Boolean(reportsToRow);
 }
 
+async function hasAssignedNotSelfApproverBundleRuleForWorkflowTime(
+  trx: Knex.Transaction,
+  tenantId: string,
+  actorUserId: string
+): Promise<boolean> {
+  const [roleRows, teamRows] = await Promise.all([
+    trx('user_roles')
+      .where({ tenant: tenantId, user_id: actorUserId })
+      .select<Array<{ role_id: string }>>('role_id'),
+    trx('team_members')
+      .where({ tenant: tenantId, user_id: actorUserId })
+      .select<Array<{ team_id: string }>>('team_id'),
+  ]);
+
+  const roleIds = roleRows.map((row) => row.role_id).filter(Boolean);
+  const teamIds = teamRows.map((row) => row.team_id).filter(Boolean);
+
+  const rule = await trx('authorization_bundle_assignments as a')
+    .join('authorization_bundles as b', function joinBundles() {
+      this.on('b.tenant', '=', 'a.tenant').andOn('b.bundle_id', '=', 'a.bundle_id');
+    })
+    .join('authorization_bundle_rules as r', function joinRules() {
+      this.on('r.tenant', '=', 'b.tenant')
+        .andOn('r.bundle_id', '=', 'b.bundle_id')
+        .andOn('r.revision_id', '=', 'b.published_revision_id');
+    })
+    .where('a.tenant', tenantId)
+    .andWhere('a.status', 'active')
+    .andWhere('b.status', 'active')
+    .whereNotNull('b.published_revision_id')
+    .andWhere('r.resource_type', 'time_entry')
+    .andWhere('r.action', 'approve')
+    .andWhere('r.constraint_key', 'not_self_approver')
+    .andWhere((builder) => {
+      builder.orWhere((subBuilder) => {
+        subBuilder.where('a.target_type', 'user').where('a.target_id', actorUserId);
+      });
+
+      if (roleIds.length > 0) {
+        builder.orWhere((subBuilder) => {
+          subBuilder.where('a.target_type', 'role').whereIn('a.target_id', roleIds);
+        });
+      }
+
+      if (teamIds.length > 0) {
+        builder.orWhere((subBuilder) => {
+          subBuilder.where('a.target_type', 'team').whereIn('a.target_id', teamIds);
+        });
+      }
+    })
+    .first('r.rule_id');
+
+  return Boolean(rule);
+}
+
 async function assertCanActOnBehalfForWorkflowTime(
   trx: Knex.Transaction,
   tenantId: string,
@@ -291,7 +346,10 @@ async function assertCanApproveSubjectForWorkflowTime(
   actorUserId: string,
   subjectUserId: string
 ): Promise<void> {
-  if (actorUserId === subjectUserId) {
+  if (
+    actorUserId === subjectUserId &&
+    (await hasAssignedNotSelfApproverBundleRuleForWorkflowTime(trx, tenantId, actorUserId))
+  ) {
     throw new WorkflowTimeDomainError({
       category: 'ActionError',
       code: 'PERMISSION_DENIED',


### PR DESCRIPTION
## Summary
- Allow users with timesheet approval permission to approve their own time by default
- Keep `not_self_approver` enforcement as an opt-in ABAC authorization bundle constraint
- Update workflow runtime and bundle simulator behavior to match the default policy

## Validation
- `npx tsc --noEmit -p shared/tsconfig.json --pretty false`
- `npm run typecheck --workspace packages/scheduling -- --pretty false`
- `npm test --workspace server -- --run src/test/unit/scheduling/workflowTimeSelfApproval.contract.test.ts src/test/unit/scheduling/approvalBehavior.test.ts src/test/unit/authorization/bundleSimulatorSelfApproval.contract.test.ts`

## Notes
- Package-level `timeEntryDelegationAuth.authorization.test.ts` remains blocked by existing Vitest package resolution for `@alga-psa/authorization/kernel`.
- Server full typecheck OOMs near the Node heap limit.
