### PR TITLE
Remove knowledge base settings tab

### DIFF
--- a/server/src/components/settings/SettingsPage.tsx
+++ b/server/src/components/settings/SettingsPage.tsx
@@ -5,7 +5,7 @@
 
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { Settings, Globe, UserCog, Users, MessageSquare, Layers, Handshake, Bell, Clock, CreditCard, Download, Mail, Plug, Puzzle, KeyRound, FlaskConical, BookOpen } from 'lucide-react';
+import { Settings, Globe, UserCog, Users, MessageSquare, Layers, Handshake, Bell, Clock, CreditCard, Download, Mail, Plug, Puzzle, KeyRound, FlaskConical } from 'lucide-react';
 import type { TabContent } from "@alga-psa/ui/components/CustomTabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@alga-psa/ui/components/Card";
 import { FeatureUpgradeNotice } from '@alga-psa/ui/components/tier-gating/FeatureUpgradeNotice';
@@ -17,7 +17,6 @@ import SettingsTabSkeleton from '@alga-psa/ui/components/skeletons/SettingsTabSk
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { UnsavedChangesProvider } from "@alga-psa/ui";
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import Link from 'next/link';
 
 function TicketingSettingsLoading() {
   const { t } = useTranslation('msp/settings');
@@ -188,28 +187,6 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
         <Suspense fallback={<SettingsTabSkeleton title={t('tabs.ticketingSettings')} description={t('tabs.loadingTicketing')} />}>
           <TicketingSettings />
         </Suspense>
-      ),
-    },
-    {
-      id: 'knowledge-base',
-      label: t('tabs.knowledgeBase', { defaultValue: 'Knowledge Base' }),
-      icon: BookOpen,
-      content: (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('tabs.knowledgeBase', { defaultValue: 'Knowledge Base' })}</CardTitle>
-            <CardDescription>
-              {t('knowledgeBase.description', {
-                defaultValue: 'Manage knowledge base content and publishing workflow from the MSP knowledge base area.',
-              })}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link href="/msp/knowledge-base" className="text-sm text-[rgb(var(--color-primary-600))] hover:underline">
-              {t('knowledgeBase.open', { defaultValue: 'Open Knowledge Base' })}
-            </Link>
-          </CardContent>
-        </Card>
       ),
     },
     {

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -243,7 +243,6 @@ export const settingsNavigationSections: NavigationSection[] = [
     translationKey: 'settings.sections.workManagement',
     items: [
       { name: 'Ticketing', translationKey: 'settings.tabs.ticketing', icon: Ticket, href: '/msp/settings?tab=ticketing' },
-      { name: 'Knowledge Base', translationKey: 'settings.tabs.knowledgeBase', icon: BookOpen, href: '/msp/settings?tab=knowledge-base' },
       { name: 'SLA', translationKey: 'settings.tabs.sla', icon: Timer, href: '/msp/settings/sla' },
       { name: 'Projects', translationKey: 'settings.tabs.projects', icon: ListTodo, href: '/msp/settings?tab=projects' },
       { name: 'Interactions', translationKey: 'settings.tabs.interactions', icon: Handshake, href: '/msp/settings?tab=interactions' },

--- a/server/src/lib/productSurfaceRegistry.ts
+++ b/server/src/lib/productSurfaceRegistry.ts
@@ -246,7 +246,7 @@ function includeByHref(productCode: ProductCode, href?: string): boolean {
   if (!href || href.startsWith('http')) return true;
   if (productCode === 'algadesk' && href.startsWith('/msp/settings?tab=')) {
     const tab = new URLSearchParams(href.split('?')[1]).get('tab');
-    const allowedTabs = new Set(['general', 'users', 'teams', 'ticketing', 'knowledge-base', 'email', 'client-portal']);
+    const allowedTabs = new Set(['general', 'users', 'teams', 'ticketing', 'email', 'client-portal']);
     return tab ? allowedTabs.has(tab) : false;
   }
   if (href.startsWith('/msp/')) return resolveProductRouteBehavior(productCode, href) === 'allowed';

--- a/server/src/lib/settingsProductTabs.ts
+++ b/server/src/lib/settingsProductTabs.ts
@@ -5,7 +5,6 @@ const ALGA_DESK_ALLOWED_SETTINGS_TABS = [
   'users',
   'teams',
   'ticketing',
-  'knowledge-base',
   'email',
   'client-portal',
   'profile',

--- a/server/src/test/unit/productSurfaceRegistry.test.ts
+++ b/server/src/test/unit/productSurfaceRegistry.test.ts
@@ -101,7 +101,6 @@ describe('product surface registry', () => {
       {
         items: [
           { href: '/msp/settings?tab=email' },
-          { href: '/msp/settings?tab=knowledge-base' },
           { href: '/msp/settings?tab=integrations' },
           { href: '/msp/settings/extensions' },
           { href: '/msp/settings/notifications' },
@@ -113,7 +112,6 @@ describe('product surface registry', () => {
       {
         items: [
           { href: '/msp/settings?tab=email' },
-          { href: '/msp/settings?tab=knowledge-base' },
         ],
       },
     ]);

--- a/server/src/test/unit/settings/settingsProductTabs.test.ts
+++ b/server/src/test/unit/settings/settingsProductTabs.test.ts
@@ -8,7 +8,6 @@ describe('settings product tab allowlist', () => {
     expect(tabs.has('users')).toBe(true);
     expect(tabs.has('teams')).toBe(true);
     expect(tabs.has('ticketing')).toBe(true);
-    expect(tabs.has('knowledge-base')).toBe(true);
     expect(tabs.has('email')).toBe(true);
     expect(tabs.has('client-portal')).toBe(true);
 


### PR DESCRIPTION
  Drop the Knowledge Base entry from the settings page, navigation menu,
  AlgaDesk product surface allowlist, and accompanying unit tests. The
  tab only linked out to /msp/knowledge-base, so it added a redundant
  detour rather than any real configuration surface.

  "And so the Knowledge Base shelf vanished from the Settings cabinet,"
  murmured the BookOpen icon as it tiptoed out of the allowlist, "leaving
  only a hyperlink-shaped footprint where a tab once stood." 📚🚪✨