### PR TITLE
Pin production Node runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # Designed for Argo workflows and CI systems that build separately
 # Expects .next, dist, and shared/dist to exist locally
 
-FROM node:alpine
+# Pin to the production-known-good Node runtime. node:alpine floated to Node 26.2.0
+# and broke bundled Vault provider initialization in the blue deployment.
+FROM node:26.1.0-alpine
 RUN apk add --no-cache \
     bash \
     postgresql-client \

--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -2,7 +2,9 @@
 # Designed for Argo workflows and CI systems that build separately
 # Expects .next, dist, shared/dist to exist locally with EE features included
 
-FROM node:alpine
+# Pin to the production-known-good Node runtime. node:alpine floated to Node 26.2.0
+# and broke bundled Vault provider initialization in the blue deployment.
+FROM node:26.1.0-alpine
 RUN apk add --no-cache \
     bash \
     postgresql-client \

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -1,5 +1,7 @@
-# Start with a base image and install system dependencies
-FROM node:alpine AS base
+# Start with a base image and install system dependencies.
+# Pin to the production-known-good Node runtime. node:alpine floated to Node 26.2.0
+# and broke bundled Vault provider initialization in the blue deployment.
+FROM node:26.1.0-alpine AS base
 RUN apk add --no-cache \
     bash \
     postgresql-client \
@@ -76,7 +78,7 @@ WORKDIR /app
 RUN npm run build:ee
 
 # Final production image with minimal runtime artifacts
-FROM node:alpine
+FROM node:26.1.0-alpine
 RUN apk add --no-cache bash \
     postgresql-client \
     redis \


### PR DESCRIPTION
## Summary
- Pin production/server Docker image runtime from floating `node:alpine` to `node:26.1.0-alpine`
- Apply the pin to generic and EE production Dockerfiles, including the EE build/final stages
- Document why the pin exists: Node 26.2.0 from floating `node:alpine` broke bundled Vault provider initialization in the blue deployment

## Validation
- `docker manifest inspect node:26.1.0-alpine`
- `git diff --check -- Dockerfile ee/server/Dockerfile ee/server/Dockerfile.build`