### PR TITLE
Fix survey response page revealing raw template placeholders

### DIFF
--- a/packages/surveys/src/components/public/SurveyResponsePage.tsx
+++ b/packages/surveys/src/components/public/SurveyResponsePage.tsx
@@ -9,6 +9,7 @@ import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { submitSurveyResponse } from '@alga-psa/surveys/actions/surveyResponseActions';
 import type { SurveyInvitationView } from '@alga-psa/surveys/actions/surveyResponseActions';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { interpolateFallback } from '@alga-psa/ui/lib/i18n/interpolateFallback';
 import { RatingButton, RatingDisplay, type RatingType } from '../shared/RatingDisplay';
 
 interface SurveyResponsePageProps {
@@ -89,7 +90,12 @@ export function SurveyResponsePage({ token, invitation, initialRating }: SurveyR
           <CardDescription>{invitation.template.promptText}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p>{t('response.submittedMessage', { defaultValue: '{{thankYouText}}', thankYouText: thankYouMessage })}</p>
+          <p>
+            {interpolateFallback(
+              t('response.submittedMessage', { defaultValue: '{{thankYouText}}', thankYouText: thankYouMessage }),
+              { thankYouText: thankYouMessage }
+            )}
+          </p>
           <div className="flex items-center gap-3 rounded-lg bg-gray-50 p-4">
             <span className="text-sm font-medium text-gray-600">
               {t('response.ratingSubmitted', { defaultValue: 'Feedback submitted' })}:
@@ -135,10 +141,13 @@ export function SurveyResponsePage({ token, invitation, initialRating }: SurveyR
 
           <div className="space-y-3">
             <p className="text-sm text-gray-600">
-              {t('response.ratingAssistive', {
-                defaultValue: 'Select a score from 1 to {{scale}}',
-                scale: ratingScale,
-              })}
+              {interpolateFallback(
+                t('response.ratingAssistive', {
+                  defaultValue: 'Select a score from 1 to {{scale}}',
+                  scale: ratingScale,
+                }),
+                { scale: ratingScale }
+              )}
             </p>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
               {ratingOptions.map(({ rating, label }) => {

--- a/packages/surveys/src/components/shared/RatingDisplay.tsx
+++ b/packages/surveys/src/components/shared/RatingDisplay.tsx
@@ -3,6 +3,7 @@
 import { Star } from 'lucide-react';
 import { cn } from '@alga-psa/ui/lib/utils';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { interpolateFallback } from '@alga-psa/ui/lib/i18n/interpolateFallback';
 
 export type RatingType = 'stars' | 'numbers' | 'emojis';
 
@@ -129,16 +130,22 @@ export function RatingButton({
       aria-pressed={selected}
       aria-label={
         label
-          ? t('rating.buttonAriaWithLabel', {
-              defaultValue: '{{rating}} - {{label}}',
-              rating,
-              label,
-            })
-          : t('rating.buttonAria', {
-              defaultValue: 'Rating {{rating}} of {{scale}}',
-              rating,
-              scale,
-            })
+          ? interpolateFallback(
+              t('rating.buttonAriaWithLabel', {
+                defaultValue: '{{rating}} - {{label}}',
+                rating,
+                label,
+              }),
+              { rating, label }
+            )
+          : interpolateFallback(
+              t('rating.buttonAria', {
+                defaultValue: 'Rating {{rating}} of {{scale}}',
+                rating,
+                scale,
+              }),
+              { rating, scale }
+            )
       }
       className={cn(
         'flex flex-col items-center justify-center gap-2 rounded-lg border-2 px-4 py-3 transition-all',


### PR DESCRIPTION
## Summary

The public survey response page was rendering raw i18n template placeholders (e.g. `{{thankYouText}}`, `{{scale}}`, `{{rating}}`) instead of their interpolated values in some cases. This wraps the affected `t()` calls with `interpolateFallback` so the placeholder tokens are substituted with their actual values.

## Changes

- **`SurveyResponsePage.tsx`**: wrap the submitted thank-you message and the rating assistive text in `interpolateFallback`.
- **`RatingDisplay.tsx`**: wrap the `RatingButton` aria-label strings (both the with-label and scale variants) in `interpolateFallback`.

## Testing

- [ ] Verify the survey response page renders interpolated text rather than `{{...}}` placeholders.