### PR TITLE
Add client filter to user activities

### DIFF
--- a/ee/packages/workflows/src/actions/activity-actions/activityAggregationActions.ts
+++ b/ee/packages/workflows/src/actions/activity-actions/activityAggregationActions.ts
@@ -74,6 +74,71 @@ function toPlainDate(isoString: string): string {
   return date.toISOString().split('T')[0];
 }
 
+type ScheduleEntryWorkItemLink = {
+  work_item_type?: string | null;
+  work_item_id?: string | null;
+};
+
+async function filterScheduleEntriesByClient<T extends ScheduleEntryWorkItemLink>(
+  knex: Knex,
+  tenant: string,
+  entries: T[],
+  clientId: string
+): Promise<T[]> {
+  const ticketIds = [
+    ...new Set(
+      entries
+        .filter((entry) => entry.work_item_type === 'ticket' && entry.work_item_id)
+        .map((entry) => entry.work_item_id)
+    ),
+  ];
+  const projectTaskIds = [
+    ...new Set(
+      entries
+        .filter((entry) => entry.work_item_type === 'project_task' && entry.work_item_id)
+        .map((entry) => entry.work_item_id)
+    ),
+  ];
+
+  const [matchingTicketIds, matchingProjectTaskIds] = await Promise.all([
+    ticketIds.length > 0
+      ? knex('tickets')
+          .where({ tenant, client_id: clientId })
+          .whereIn('ticket_id', ticketIds)
+          .pluck('ticket_id')
+      : Promise.resolve([]),
+    projectTaskIds.length > 0
+      ? knex('project_tasks')
+          .join('project_phases', function() {
+            this.on('project_tasks.phase_id', 'project_phases.phase_id')
+              .andOn('project_tasks.tenant', 'project_phases.tenant');
+          })
+          .join('projects', function() {
+            this.on('project_phases.project_id', 'projects.project_id')
+              .andOn('project_phases.tenant', 'projects.tenant');
+          })
+          .where('project_tasks.tenant', tenant)
+          .where('projects.client_id', clientId)
+          .whereIn('project_tasks.task_id', projectTaskIds)
+          .pluck('project_tasks.task_id')
+      : Promise.resolve([]),
+  ]);
+
+  const matchingTicketIdSet = new Set(matchingTicketIds);
+  const matchingProjectTaskIdSet = new Set(matchingProjectTaskIds);
+
+  return entries.filter((entry) => {
+    if (!entry.work_item_id) return false;
+    if (entry.work_item_type === 'ticket') {
+      return matchingTicketIdSet.has(entry.work_item_id);
+    }
+    if (entry.work_item_type === 'project_task') {
+      return matchingProjectTaskIdSet.has(entry.work_item_id);
+    }
+    return false;
+  });
+}
+
 /**
  * Fetch all activities for a user with optional filters and pagination
  */
@@ -203,6 +268,10 @@ export async function fetchScheduleActivities(
     
     if (filters.workItemType) {
       userEntries = userEntries.filter(entry => entry.work_item_type === filters.workItemType);
+    }
+
+    if (filters.clientId) {
+      userEntries = await filterScheduleEntriesByClient(knex, tenant, userEntries, filters.clientId);
     }
     
     if (filters.search) {
@@ -362,6 +431,11 @@ export async function fetchProjectActivities(
           });
         }
         
+        // Client filter
+        if (filters.clientId) {
+          queryBuilder.where("projects.client_id", filters.clientId);
+        }
+
         // Apply project and phase filters with OR semantics:
         // A task matches if its project is selected OR its phase is selected.
         const hasProjectIds = filters.projectIds && filters.projectIds.length > 0;
@@ -740,6 +814,38 @@ export async function fetchTimeEntryActivities(
         if (filters.status && filters.status.length > 0) {
           queryBuilder.whereIn("time_entries.approval_status", filters.status);
         }
+
+        if (filters.clientId) {
+          queryBuilder.where(function() {
+            this.where(function() {
+              this.where("time_entries.work_item_type", "ticket")
+                .whereExists(function() {
+                  this.select(db.raw(1))
+                    .from("tickets")
+                    .whereRaw("tickets.ticket_id = time_entries.work_item_id")
+                    .andWhere("tickets.tenant", tenant)
+                    .andWhere("tickets.client_id", filters.clientId);
+                });
+            }).orWhere(function() {
+              this.where("time_entries.work_item_type", "project_task")
+                .whereExists(function() {
+                  this.select(db.raw(1))
+                    .from("project_tasks")
+                    .join("project_phases", function() {
+                      this.on("project_tasks.phase_id", "project_phases.phase_id")
+                        .andOn("project_tasks.tenant", "project_phases.tenant");
+                    })
+                    .join("projects", function() {
+                      this.on("project_phases.project_id", "projects.project_id")
+                        .andOn("project_phases.tenant", "projects.tenant");
+                    })
+                    .whereRaw("project_tasks.task_id = time_entries.work_item_id")
+                    .andWhere("project_tasks.tenant", tenant)
+                    .andWhere("projects.client_id", filters.clientId);
+                });
+            });
+          });
+        }
       });
     });
 
@@ -801,6 +907,10 @@ export async function fetchWorkflowTaskActivities(
   filters: ActivityFilters
 ): Promise<Activity[]> {
   try {
+    if (filters.clientId) {
+      return [];
+    }
+
     const { knex: db, tenant } = await createTenantKnex(tenantId);
     if (!tenant) {
       throw new Error("Tenant is required");
@@ -1084,6 +1194,10 @@ export async function fetchNotificationActivities(
   filters: ActivityFilters
 ): Promise<Activity[]> {
   try {
+    if (filters.clientId) {
+      return [];
+    }
+
     const { knex: db, tenant } = await createTenantKnex(tenantId);
     if (!tenant) {
       throw new Error("Tenant is required");

--- a/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
+++ b/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
@@ -7,6 +7,7 @@ import {
   ActivityFilters,
   ActivitySortBy,
   ActivityType,
+  IClient,
   IPriority,
   IStatus,
   ITag,
@@ -159,6 +160,9 @@ function formatActivityPrintDate(dateString?: string): string {
   // Priorities for the filter dropdown
   const [priorities, setPriorities] = useState<IPriority[]>([]);
 
+  // Clients for the shared client filter
+  const [clients, setClients] = useState<IClient[]>([]);
+
   // Projects (with phases + statuses) for the filter tree-select
   const [projects, setProjects] = useState<ProjectWithPhases[]>([]);
 
@@ -228,6 +232,17 @@ function formatActivityPrintDate(dateString?: string): string {
     }
     setPriorities([]);
   }, [filters.types]);
+
+  // Load clients for the shared client filter on mount
+  useEffect(() => {
+    ctx.getAllClients(false)
+      .then((data: unknown) => {
+        if (!isActionPermissionError(data)) {
+          setClients(data as IClient[]);
+        }
+      })
+      .catch((err: unknown) => console.error('Error loading clients:', err));
+  }, [ctx]);
 
   // Load projects with phases + statuses for the filter tree on mount
   useEffect(() => {
@@ -457,6 +472,7 @@ function formatActivityPrintDate(dateString?: string): string {
           filters={filters}
           onChange={handleFilterChange}
           priorities={priorities}
+          clients={clients}
           projects={projects}
           boards={boards}
           ticketStatuses={ticketStatuses}

--- a/ee/packages/workflows/src/components/user-activities/filters/ActivitiesTableFilters.tsx
+++ b/ee/packages/workflows/src/components/user-activities/filters/ActivitiesTableFilters.tsx
@@ -5,6 +5,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import {
   ActivityFilters as ActivityFiltersType,
   ActivityType,
+  IClient,
   IPriority,
   IStatus,
   ITag,
@@ -16,10 +17,11 @@ import { Label } from "@alga-psa/ui/components/Label";
 import { Checkbox } from "@alga-psa/ui/components/Checkbox";
 import { SearchInput } from "@alga-psa/ui/components/SearchInput";
 import { StringDateRangePicker } from "@alga-psa/ui/components/DateRangePicker";
+import { ClientPicker } from "@alga-psa/ui/components/ClientPicker";
 import CustomSelect from "@alga-psa/ui/components/CustomSelect";
 import TreeSelect, { TreeSelectOption } from "@alga-psa/ui/components/TreeSelect";
 import { TagFilter } from "@alga-psa/ui/components";
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, X } from 'lucide-react';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { DEFAULT_TABLE_TYPES } from '../constants';
 
@@ -31,6 +33,7 @@ interface ActivitiesTableFiltersProps {
   filters: ActivityFiltersType;
   onChange: (filters: ActivityFiltersType) => void;
   priorities?: IPriority[];
+  clients?: IClient[];
   projects?: ProjectWithPhases[];
   boards?: Array<{ board_id?: string; board_name?: string }>;
   ticketStatuses?: IStatus[];
@@ -69,6 +72,7 @@ export function ActivitiesTableFilters({
   filters,
   onChange,
   priorities = [],
+  clients = [],
   projects = [],
   boards = [],
   ticketStatuses = [],
@@ -85,6 +89,8 @@ export function ActivitiesTableFilters({
   const [selectedPriorityId, setSelectedPriorityId] = useState<string>(
     filters.priorityIds?.[0] || 'all'
   );
+  const [clientFilterState, setClientFilterState] = useState<'all' | 'active' | 'inactive'>('active');
+  const [clientClientTypeFilter, setClientClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
 
   const selectedTypes = filters.types || [];
   const hasTickets = selectedTypes.includes(ActivityType.TICKET);
@@ -92,6 +98,8 @@ export function ActivitiesTableFilters({
 
   const isPriorityFilterAvailable =
     selectedTypes.length === 1 && PRIORITY_FILTERABLE_TYPES.has(selectedTypes[0]);
+  const hasPriorityFilter = isPriorityFilterAvailable && priorities.length > 0;
+  const hasClientFilter = clients.length > 0;
 
   // -------- Handlers -------------------------------------------------------
 
@@ -194,6 +202,19 @@ export function ActivitiesTableFilters({
     delete next.search;
     onChange(next);
   }, [filters, onChange]);
+
+  const handleClientChange = useCallback(
+    (clientId: string | null) => {
+      const next: ActivityFiltersType = { ...filters };
+      if (clientId) {
+        next.clientId = clientId;
+      } else {
+        delete next.clientId;
+      }
+      onChange(next);
+    },
+    [filters, onChange]
+  );
 
   // -------- Ticket board (multi-select) ------------------------------------
 
@@ -426,107 +447,49 @@ export function ActivitiesTableFilters({
   // -------- Render ---------------------------------------------------------
 
   return (
-    <div className="border-b border-border pb-4 mb-4 space-y-3">
-      {/* Row 1: Activity types */}
+    <div className="border-b border-border pb-3 mb-4">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Label className="text-sm font-semibold whitespace-nowrap">{t('filters.labels.types', { defaultValue: 'Types:' })}</Label>
-        {ACTIVITY_TYPE_OPTIONS.map((option) => (
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+          <Label className="text-sm font-semibold whitespace-nowrap">{t('filters.labels.types', { defaultValue: 'Types:' })}</Label>
+          {ACTIVITY_TYPE_OPTIONS.map((option) => (
+            <Checkbox
+              key={option.value}
+              id={`activity-type-${option.value}`}
+              label={option.label}
+              checked={selectedTypes.includes(option.value)}
+              onChange={() => toggleType(option.value)}
+              containerClassName="mb-0"
+              size="sm"
+            />
+          ))}
+        </div>
+
+        <div className="ml-auto flex items-center gap-3">
           <Checkbox
-            key={option.value}
-            id={`activity-type-${option.value}`}
-            label={option.label}
-            checked={selectedTypes.includes(option.value)}
-            onChange={() => toggleType(option.value)}
-            containerClassName="mb-0"
+            id="show-closed"
+            label={t('filters.labels.showClosed', { defaultValue: 'Show closed' })}
+            checked={filters.isClosed}
+            onChange={handleClosedToggle}
+            containerClassName="mb-0 whitespace-nowrap"
             size="sm"
           />
-        ))}
+          <Button
+            id="reset-filters-button"
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            className="whitespace-nowrap"
+          >
+            <RotateCcw className="h-3.5 w-3.5 mr-1" />
+            {t('filters.actions.reset', { defaultValue: 'Reset' })}
+          </Button>
+        </div>
       </div>
 
-      {/* Ticket-specific filters */}
-      {hasTickets && (
-        <div className="flex flex-wrap items-end gap-x-3 gap-y-2 pl-4 border-l-2 border-primary-300">
-          <Label className="text-xs font-semibold text-primary-600 self-center whitespace-nowrap">
-            {t('filters.labels.tickets', { defaultValue: 'Tickets:' })}
-          </Label>
-
-          {boardTreeOptions.length > 0 && (
-            <div className="min-w-[150px] max-w-[240px]">
-              <TreeSelect<'board'>
-                options={boardTreeOptions}
-                value=""
-                onValueChange={handleBoardToggle}
-                placeholder={t('filters.placeholders.allBoards', { defaultValue: 'All Boards' })}
-                multiSelect
-                showReset
-                allowEmpty
-              />
-            </div>
-          )}
-
-          {ticketStatusTreeOptions.length > 0 && (
-            <div className="min-w-[150px] max-w-[240px]">
-              <TreeSelect<'ticketStatus'>
-                options={ticketStatusTreeOptions}
-                value=""
-                onValueChange={handleTicketStatusToggle}
-                placeholder={t('filters.placeholders.allStatuses', { defaultValue: 'All Statuses' })}
-                multiSelect
-                showReset
-                allowEmpty
-              />
-            </div>
-          )}
-
-          {uniqueTicketTags.length > 0 && (
-            <TagFilter
-              tags={uniqueTicketTags}
-              selectedTags={selectedTicketTagTexts}
-              onToggleTag={handleTicketTagToggle}
-              onClearTags={() => onChange({ ...filters, ticketTagIds: undefined })}
-            />
-          )}
-        </div>
-      )}
-
-      {/* Project task-specific filters */}
-      {hasProjectTasks && (
-        <div className="flex flex-wrap items-end gap-x-3 gap-y-2 pl-4 border-l-2" style={{ borderColor: 'rgb(var(--color-secondary-500))' }}>
-          <Label className="text-xs font-semibold self-center whitespace-nowrap" style={{ color: 'rgb(var(--color-secondary-500))' }}>
-            {t('filters.labels.tasks', { defaultValue: 'Tasks:' })}
-          </Label>
-
-          {projects.length > 0 && (
-            <div className="min-w-[220px] max-w-[320px]">
-              <TreeSelect<ProjectNodeType>
-                options={projectTreeOptions}
-                value=""
-                onValueChange={handleProjectTreeToggle}
-                placeholder={t('filters.placeholders.allProjects', { defaultValue: 'All Projects' })}
-                multiSelect
-                showReset
-                allowEmpty
-              />
-            </div>
-          )}
-
-          {uniqueProjectTaskTags.length > 0 && (
-            <TagFilter
-              tags={uniqueProjectTaskTags}
-              selectedTags={selectedProjectTaskTagTexts}
-              onToggleTag={handleProjectTaskTagToggle}
-              onClearTags={() =>
-                onChange({ ...filters, projectTaskTagIds: undefined })
-              }
-            />
-          )}
-        </div>
-      )}
-
-      {/* Shared filters row */}
-      <div className="flex flex-wrap items-end gap-x-4 gap-y-2">
-        <div className="min-w-[220px] max-w-[320px] flex-1">
-          <Label htmlFor="activities-search-input" className="text-sm font-semibold mb-1 block">
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <div className="min-w-[220px] flex-1 basis-[260px] lg:max-w-[320px]">
+          <Label htmlFor="activities-search-input" className="sr-only">
             {t('filters.labels.search', { defaultValue: 'Search' })}
           </Label>
           <SearchInput
@@ -535,13 +498,48 @@ export function ActivitiesTableFilters({
             onChange={handleSearchChange}
             onClear={handleSearchClear}
             placeholder={t('filters.placeholders.search', { defaultValue: 'Search activities...' })}
-            className="w-full h-10 py-2 text-sm"
+            className="w-full h-9 py-2 text-sm"
           />
         </div>
 
-        {isPriorityFilterAvailable && priorities.length > 0 && (
-          <div className="min-w-[180px]">
-            <Label htmlFor="priority-select" className="text-sm font-semibold mb-1 block">
+        {hasClientFilter && (
+          <div className={`flex items-center gap-1 ${filters.clientId ? 'w-[280px]' : 'w-[160px]'}`}>
+            <Label htmlFor="activities-client-picker" className="sr-only">
+              {t('filters.labels.client', { defaultValue: 'Client' })}
+            </Label>
+            <ClientPicker
+              id="activities-client-picker"
+              clients={clients}
+              selectedClientId={filters.clientId || null}
+              onSelect={handleClientChange}
+              filterState={clientFilterState}
+              onFilterStateChange={setClientFilterState}
+              clientTypeFilter={clientClientTypeFilter}
+              onClientTypeFilterChange={setClientClientTypeFilter}
+              placeholder={t('filters.placeholders.allClients', { defaultValue: 'All Clients' })}
+              fitContent={false}
+              className="min-w-0 flex-1"
+              triggerButtonClassName="h-9"
+            />
+            {filters.clientId && (
+              <Button
+                id="clear-client-filter-button"
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleClientChange(null)}
+                aria-label={t('filters.actions.clearClient', { defaultValue: 'Clear client filter' })}
+                className="shrink-0 px-1.5"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        )}
+
+        {hasPriorityFilter && (
+          <div className="w-[170px]">
+            <Label htmlFor="priority-select" className="sr-only">
               {t('filters.labels.priority', { defaultValue: 'Priority' })}
             </Label>
             <CustomSelect
@@ -570,8 +568,106 @@ export function ActivitiesTableFilters({
           </div>
         )}
 
-        <div className="min-w-[240px]">
-          <Label className="text-sm font-semibold mb-1 block">{t('filters.labels.dueDate', { defaultValue: 'Due Date' })}</Label>
+
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+          {hasTickets && (
+            <div
+              className="flex flex-wrap items-center gap-2 rounded-md border border-[rgb(var(--color-border-200))] border-l-2 bg-[rgb(var(--color-card))] px-2 py-1"
+              style={{ borderLeftColor: 'rgb(var(--color-primary-500))' }}
+            >
+              <span className="text-xs font-semibold whitespace-nowrap" style={{ color: 'rgb(var(--color-primary-500))' }}>
+                {t('filters.labels.ticketsCompact', { defaultValue: 'Tickets' })}
+              </span>
+
+              {boardTreeOptions.length > 0 && (
+                <div className="w-[135px]">
+                  <TreeSelect<'board'>
+                    options={boardTreeOptions}
+                    value=""
+                    onValueChange={handleBoardToggle}
+                    placeholder={t('filters.placeholders.allBoards', { defaultValue: 'All Boards' })}
+                    multiSelect
+                    showReset
+                    allowEmpty
+                  />
+                </div>
+              )}
+
+              {ticketStatusTreeOptions.length > 0 && (
+                <div className="w-[135px]">
+                  <TreeSelect<'ticketStatus'>
+                    options={ticketStatusTreeOptions}
+                    value=""
+                    onValueChange={handleTicketStatusToggle}
+                    placeholder={t('filters.placeholders.allStatuses', { defaultValue: 'All Statuses' })}
+                    multiSelect
+                    showReset
+                    allowEmpty
+                  />
+                </div>
+              )}
+
+              {uniqueTicketTags.length > 0 && (
+                <TagFilter
+                  id="ticket-tag-filter"
+                  tags={uniqueTicketTags}
+                  selectedTags={selectedTicketTagTexts}
+                  onToggleTag={handleTicketTagToggle}
+                  onClearTags={() => onChange({ ...filters, ticketTagIds: undefined })}
+                  triggerLabel={t('filters.labels.tags', { defaultValue: 'Tags' })}
+                  selectedLabel={t('filters.labels.tagsSelected', { count: selectedTicketTagTexts.length, defaultValue: '{{count}} tags' })}
+                  placeholder={t('filters.placeholders.ticketTags', { defaultValue: 'Filter ticket tags...' })}
+                />
+              )}
+            </div>
+          )}
+
+          {hasProjectTasks && (
+            <div
+              className="flex flex-wrap items-center gap-2 rounded-md border border-[rgb(var(--color-border-200))] border-l-2 bg-[rgb(var(--color-card))] px-2 py-1"
+              style={{ borderLeftColor: 'rgb(var(--color-secondary-500))' }}
+            >
+              <span className="text-xs font-semibold whitespace-nowrap" style={{ color: 'rgb(var(--color-secondary-500))' }}>
+                {t('filters.labels.tasksCompact', { defaultValue: 'Tasks' })}
+              </span>
+
+              {projects.length > 0 && (
+                <div className="w-[190px]">
+                  <TreeSelect<ProjectNodeType>
+                    options={projectTreeOptions}
+                    value=""
+                    onValueChange={handleProjectTreeToggle}
+                    placeholder={t('filters.placeholders.allProjects', { defaultValue: 'All Projects' })}
+                    multiSelect
+                    showReset
+                    allowEmpty
+                  />
+                </div>
+              )}
+
+              {uniqueProjectTaskTags.length > 0 && (
+                <TagFilter
+                  id="project-task-tag-filter"
+                  tags={uniqueProjectTaskTags}
+                  selectedTags={selectedProjectTaskTagTexts}
+                  onToggleTag={handleProjectTaskTagToggle}
+                  onClearTags={() =>
+                    onChange({ ...filters, projectTaskTagIds: undefined })
+                  }
+                  triggerLabel={t('filters.labels.tags', { defaultValue: 'Tags' })}
+                  selectedLabel={t('filters.labels.tagsSelected', { count: selectedProjectTaskTagTexts.length, defaultValue: '{{count}} tags' })}
+                  placeholder={t('filters.placeholders.projectTaskTags', { defaultValue: 'Filter task tags...' })}
+                />
+              )}
+            </div>
+          )}
+
+        <div className="flex items-center gap-2 rounded-md border border-[rgb(var(--color-border-200))] bg-[rgb(var(--color-card))] px-2 py-1">
+          <Label htmlFor="activities-due-date-range-from" className="text-xs font-semibold text-[rgb(var(--color-text-600))] whitespace-nowrap">
+            {t('filters.labels.dueDateShort', { defaultValue: 'Due' })}
+          </Label>
           <StringDateRangePicker
             id="activities-due-date-range"
             value={{
@@ -583,31 +679,12 @@ export function ActivitiesTableFilters({
                 : '',
             }}
             onChange={handleDateRangeChange}
+            containerClassName="space-y-0"
+            rangeClassName="flex gap-1"
+            datePickerClassName="w-[128px]"
+            fromPlaceholder={t('filters.placeholders.fromDateShort', { defaultValue: 'From' })}
+            toPlaceholder={t('filters.placeholders.toDateShort', { defaultValue: 'To' })}
           />
-        </div>
-
-        <div className="flex items-center pb-0.5">
-          <Checkbox
-            id="show-closed"
-            label={t('filters.labels.showClosed', { defaultValue: 'Show closed' })}
-            checked={filters.isClosed}
-            onChange={handleClosedToggle}
-            containerClassName="mb-0"
-            size="sm"
-          />
-        </div>
-
-        <div className="flex items-center pb-0.5 ml-auto">
-          <Button
-            id="reset-filters-button"
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleReset}
-          >
-            <RotateCcw className="h-3.5 w-3.5 mr-1" />
-            {t('filters.actions.reset', { defaultValue: 'Reset' })}
-          </Button>
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/DateRangePicker.tsx
+++ b/packages/ui/src/components/DateRangePicker.tsx
@@ -14,32 +14,42 @@ interface DateRangePickerProps {
   label?: string;
   value: DateRange;
   onChange: (range: DateRange) => void;
+  containerClassName?: string;
+  rangeClassName?: string;
+  datePickerClassName?: string;
+  fromPlaceholder?: string;
+  toPlaceholder?: string;
 }
 
 export const DateRangePicker = ({
   id,
   label,
   value,
-  onChange
+  onChange,
+  containerClassName = 'space-y-2',
+  rangeClassName = 'flex gap-2',
+  datePickerClassName = 'min-w-[160px]',
+  fromPlaceholder,
+  toPlaceholder,
 }: DateRangePickerProps & AutomationProps) => {
   const { t } = useTranslation();
   return (
-    <div id={id} className="space-y-2">
+    <div id={id} className={containerClassName}>
       {label && <Label>{label}</Label>}
-      <div className="flex gap-2">
+      <div className={rangeClassName}>
         <DatePicker
           id={id ? `${id}-from` : undefined}
           value={value.from}
           onChange={(date) => onChange({ ...value, from: date })}
-          placeholder={t('form.fromDate', { defaultValue: 'From date' })}
-          className="min-w-[160px]"
+          placeholder={fromPlaceholder ?? t('form.fromDate', { defaultValue: 'From date' })}
+          className={datePickerClassName}
         />
         <DatePicker
           id={id ? `${id}-to` : undefined}
           value={value.to}
           onChange={(date) => onChange({ ...value, to: date })}
-          placeholder={t('form.toDate', { defaultValue: 'To date' })}
-          className="min-w-[160px]"
+          placeholder={toPlaceholder ?? t('form.toDate', { defaultValue: 'To date' })}
+          className={datePickerClassName}
         />
       </div>
     </div>
@@ -57,19 +67,29 @@ interface StringDateRangePickerProps {
   label?: string;
   value: StringDateRange;
   onChange: (range: StringDateRange) => void;
+  containerClassName?: string;
+  rangeClassName?: string;
+  datePickerClassName?: string;
+  fromPlaceholder?: string;
+  toPlaceholder?: string;
 }
 
 export const StringDateRangePicker = ({
   id,
   label,
   value,
-  onChange
+  onChange,
+  containerClassName = 'space-y-2',
+  rangeClassName = 'flex gap-2',
+  datePickerClassName = 'min-w-[160px]',
+  fromPlaceholder,
+  toPlaceholder,
 }: StringDateRangePickerProps & AutomationProps) => {
   const { t } = useTranslation();
   return (
-    <div id={id} className="space-y-2">
+    <div id={id} className={containerClassName}>
       {label && <Label>{label}</Label>}
-      <div className="flex gap-2">
+      <div className={rangeClassName}>
         <DatePicker
           id={id ? `${id}-from` : undefined}
           value={value.from ? new Date(value.from) : undefined}
@@ -77,8 +97,8 @@ export const StringDateRangePicker = ({
             ...value,
             from: date ? date.toISOString().split('T')[0] : ''
           })}
-          placeholder={t('form.fromDate', { defaultValue: 'From date' })}
-          className="min-w-[160px]"
+          placeholder={fromPlaceholder ?? t('form.fromDate', { defaultValue: 'From date' })}
+          className={datePickerClassName}
         />
         <DatePicker
           id={id ? `${id}-to` : undefined}
@@ -87,8 +107,8 @@ export const StringDateRangePicker = ({
             ...value,
             to: date ? date.toISOString().split('T')[0] : ''
           })}
-          placeholder={t('form.toDate', { defaultValue: 'To date' })}
-          className="min-w-[160px]"
+          placeholder={toPlaceholder ?? t('form.toDate', { defaultValue: 'To date' })}
+          className={datePickerClassName}
         />
       </div>
     </div>

--- a/packages/ui/src/components/tags/TagFilter.tsx
+++ b/packages/ui/src/components/tags/TagFilter.tsx
@@ -7,24 +7,31 @@ import * as Popover from '@radix-ui/react-popover';
 import { TagGrid } from './TagGrid';
 import { filterTagsByText } from '../../lib/utils';
 import { ITag } from '@alga-psa/types';
-import Spinner from '@alga-psa/ui/components/Spinner';
 import { Button } from '../Button';
 import { useTranslation } from '../../lib/i18n/client';
 
 interface TagFilterProps {
+  id?: string;
   tags: ITag[];
   selectedTags: string[];
   onToggleTag: (tagText: string) => void;
   onClearTags: () => void;
   placeholder?: string;
+  triggerLabel?: string;
+  selectedLabel?: string;
+  triggerClassName?: string;
 }
 
 export function TagFilter({
+  id = 'tag-filter',
   tags,
   selectedTags,
   onToggleTag,
   onClearTags,
   placeholder,
+  triggerLabel,
+  selectedLabel,
+  triggerClassName = '',
 }: TagFilterProps) {
   const { t } = useTranslation();
   const resolvedPlaceholder = placeholder ?? t('tagFilter.placeholder', { defaultValue: 'Filter by tags...' });
@@ -36,12 +43,12 @@ export function TagFilter({
   return (
     <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
       <Popover.Trigger asChild>
-        <Button id="tag-filter-trigger" variant="outline" className="h-9 gap-2">
+        <Button id={`${id}-trigger`} variant="outline" className={`h-9 gap-2 whitespace-nowrap ${triggerClassName}`}>
           <TagIcon className="h-4 w-4" />
           <span>
             {selectedTags.length > 0
-              ? t('tagFilter.selectedCount', { count: selectedTags.length, defaultValue: '{{count}} selected' })
-              : t('tagFilter.filter', { defaultValue: 'Filter' })}
+              ? selectedLabel ?? t('tagFilter.selectedCount', { count: selectedTags.length, defaultValue: '{{count}} selected' })
+              : triggerLabel ?? t('tagFilter.filter', { defaultValue: 'Filter' })}
           </span>
         </Button>
       </Popover.Trigger>
@@ -64,7 +71,7 @@ export function TagFilter({
             />
             {selectedTags.length > 0 && (
               <div className="pt-2 border-t flex justify-end">
-                <Button id="tag-filter-clear" variant="ghost" size="sm" onClick={onClearTags}>
+                <Button id={`${id}-clear`} variant="ghost" size="sm" onClick={onClearTags}>
                   {t('tagFilter.clearAll', { defaultValue: 'Clear all' })}
                 </Button>
               </div>


### PR DESCRIPTION
## Summary
- add a client picker to the user activities table filters
- filter tickets, project tasks, linked schedule entries, and linked time entries by client
- compact and reorganize the activities filter bar, including inline Tickets/Tasks/Due Date clusters
- add compact customization hooks for shared tag and date range filter components

## Validation
- npm --workspace ee/packages/workflows run typecheck
- npm --workspace packages/ui run typecheck