### PR TITLE
Add group selection to activity print options

### DIFF
--- a/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
+++ b/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
@@ -16,6 +16,7 @@ import {
   TaggedEntityType,
 } from '@alga-psa/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@alga-psa/ui/components/Card';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Button } from '@alga-psa/ui/components/Button';
 import { usePrintAction } from '@alga-psa/ui/components/PrintButton';
 import {
@@ -182,6 +183,40 @@ function formatActivityPrintDate(dateString?: string): string {
 
   // User-defined activity groups (shared between GroupedActivitiesView + PrintableActivitiesView)
   const [activityGroups, setActivityGroups] = useState<ActivityGroup[]>([]);
+
+  // Print section selection: which groups and whether to include ungrouped
+  const {
+    value: savedPrintGroupIds,
+    setValue: setSavedPrintGroupIds,
+  } = useUserPreference<string[] | null>(
+    'activitiesPrintGroupIds',
+    {
+      defaultValue: null,
+      localStorageKey: 'activitiesPrintGroupIds',
+      debounceMs: 500,
+    }
+  );
+  const {
+    value: savedPrintUngrouped,
+    setValue: setSavedPrintUngrouped,
+  } = useUserPreference<boolean | null>(
+    'activitiesPrintUngrouped',
+    {
+      defaultValue: null,
+      localStorageKey: 'activitiesPrintUngrouped',
+      debounceMs: 500,
+    }
+  );
+  const effectivePrintUngrouped = savedPrintUngrouped ?? !ungroupedCollapsed;
+  // Derive the effective selected group IDs, sanitized against current activityGroups
+  const selectedPrintGroupIds = useMemo(() => {
+    if (listViewMode !== 'grouped' || activityGroups.length === 0) return undefined;
+    const validIds = new Set(activityGroups.map((g) => g.groupId));
+    // Default: all non-collapsed groups. Once saved, preserve even an intentionally empty selection.
+    const defaults = activityGroups.filter((g) => !g.isCollapsed).map((g) => g.groupId);
+    const saved = savedPrintGroupIds?.filter((id) => validIds.has(id));
+    return new Set(savedPrintGroupIds === null ? defaults : saved);
+  }, [listViewMode, activityGroups, savedPrintGroupIds]);
   const [printActivities, setPrintActivities] = useState<Activity[] | null>(null);
 
   const loadActivityGroups = useCallback(async (): Promise<ActivityGroup[]> => {
@@ -417,6 +452,12 @@ function formatActivityPrintDate(dateString?: string): string {
 
   const [isPrintOptionsOpen, setIsPrintOptionsOpen] = useState(false);
 
+  const handleResetPrintOptions = useCallback(() => {
+    resetSelectedActivityPrintColumnKeys();
+    setSavedPrintGroupIds(null);
+    setSavedPrintUngrouped(null);
+  }, [resetSelectedActivityPrintColumnKeys, setSavedPrintGroupIds, setSavedPrintUngrouped]);
+
   const { triggerPrint: triggerPrintActivities, isPreparing: isPreparingActivityPrint } = usePrintAction({
     onBeforePrint: preparePrintActivities,
     onAfterPrint: cleanupPrintActivities,
@@ -527,6 +568,8 @@ function formatActivityPrintDate(dateString?: string): string {
       ungroupedCollapsed={ungroupedCollapsed}
       title={effectiveTitle}
       columns={selectedActivityPrintColumns}
+      selectedGroupIds={selectedPrintGroupIds}
+      printUngrouped={effectivePrintUngrouped}
     />
     <PrintOptionsDialog
       id={`${id}-print-options-dialog`}
@@ -539,10 +582,51 @@ function formatActivityPrintDate(dateString?: string): string {
       columns={activityPrintColumns}
       selectedColumnKeys={selectedActivityPrintColumnKeys}
       onSelectedColumnKeysChange={setSelectedActivityPrintColumnKeys}
-      onReset={resetSelectedActivityPrintColumnKeys}
+      onReset={handleResetPrintOptions}
       onPrint={() => triggerPrintActivities()}
       isPrinting={isPreparingActivityPrint}
-    />
+      childrenSectionLabel={listViewMode === 'grouped' && activityGroups.length > 0
+        ? t('table.print.optionsDialog.groupsLabel', { defaultValue: 'Sections to print' })
+        : undefined}
+    >
+      {listViewMode === 'grouped' && activityGroups.length > 0 && (
+        <div className="space-y-2 px-1">
+          <div className="space-y-1.5">
+            {activityGroups.map((group) => {
+              const checked = selectedPrintGroupIds?.has(group.groupId) ?? false;
+              return (
+                <Checkbox
+                  key={group.groupId}
+                  id={`${id}-print-group-${group.groupId}`}
+                  label={group.groupName}
+                  checked={checked}
+                  onChange={() => {
+                    const next = new Set(selectedPrintGroupIds);
+                    if (checked) {
+                      next.delete(group.groupId);
+                    } else {
+                      next.add(group.groupId);
+                    }
+                    setSavedPrintGroupIds(Array.from(next));
+                  }}
+                  containerClassName="mb-0"
+                  skipRegistration
+                />
+              );
+            })}
+          </div>
+          <hr className="border-[rgb(var(--color-border-200))]" />
+          <Checkbox
+            id={`${id}-print-ungrouped`}
+            label={t('table.print.optionsDialog.printUngrouped', { defaultValue: 'Ungrouped items' })}
+            checked={effectivePrintUngrouped}
+            onChange={() => setSavedPrintUngrouped(!effectivePrintUngrouped)}
+            containerClassName="mb-0"
+            skipRegistration
+          />
+        </div>
+      )}
+    </PrintOptionsDialog>
     </>
   );
 }

--- a/ee/packages/workflows/src/components/user-activities/PrintableActivitiesView.tsx
+++ b/ee/packages/workflows/src/components/user-activities/PrintableActivitiesView.tsx
@@ -17,6 +17,10 @@ interface PrintableActivitiesViewProps {
   /** Fallback title */
   title?: string;
   columns?: PrintableTableColumn<Activity>[];
+  /** When set, only render groups whose groupId is in this set. */
+  selectedGroupIds?: Set<string>;
+  /** When false, skip the ungrouped section (default true). */
+  printUngrouped?: boolean;
 }
 
 function formatDate(dateString?: string): string {
@@ -62,6 +66,8 @@ export function PrintableActivitiesView({
   ungroupedCollapsed = false,
   title,
   columns: providedColumns,
+  selectedGroupIds,
+  printUngrouped = true,
 }: PrintableActivitiesViewProps) {
   const { t } = useTranslation('msp/user-activities');
   const effectiveTitle = title ?? t('printable.defaultTitle', { defaultValue: 'Activities' });
@@ -124,22 +130,26 @@ export function PrintableActivitiesView({
       activityByKey.set(`${a.type}:${a.id}`, a);
     }
     const assignedKeys = new Set<string>();
-    groupedSections = serverGroups
-      .filter((sg) => !sg.isCollapsed)
-      .map((sg) => {
-        const sgActs: Activity[] = [];
-        for (const item of sg.items) {
-          const key = `${item.activityType}:${item.activityId}`;
-          const act = activityByKey.get(key);
-          if (act) {
-            sgActs.push(act);
-            assignedKeys.add(key);
-          }
+
+    // Filter serverGroups by selectedGroupIds (if provided) and isCollapsed
+    const effectiveGroups = selectedGroupIds
+      ? serverGroups.filter((sg) => selectedGroupIds.has(sg.groupId))
+      : serverGroups.filter((sg) => !sg.isCollapsed);
+
+    groupedSections = effectiveGroups.map((sg) => {
+      const sgActs: Activity[] = [];
+      for (const item of sg.items) {
+        const key = `${item.activityType}:${item.activityId}`;
+        const act = activityByKey.get(key);
+        if (act) {
+          sgActs.push(act);
+          assignedKeys.add(key);
         }
-        return { name: sg.groupName, activities: sgActs };
-      });
-    // Items in collapsed groups should also be excluded from ungrouped
-    for (const sg of serverGroups.filter((sg) => sg.isCollapsed)) {
+      }
+      return { name: sg.groupName, activities: sgActs };
+    });
+    // Items in non-selected or collapsed groups should be excluded from ungrouped
+    for (const sg of serverGroups.filter((sg) => !effectiveGroups.includes(sg))) {
       for (const item of sg.items) {
         assignedKeys.add(`${item.activityType}:${item.activityId}`);
       }
@@ -149,14 +159,14 @@ export function PrintableActivitiesView({
 
   return (
     <div className="app-print-root app-print-only ua-print-root ua-print-only">
-      {groupedSections.length > 0 ? (
+      {grouped && serverGroups.length > 0 ? (
         <>
           {groupedSections.map((g) => (
             <div key={g.name} className="ua-print-group">
               {renderTable(g.name, g.activities)}
             </div>
           ))}
-          {ungroupedActivities.length > 0 && !ungroupedCollapsed && (
+          {ungroupedActivities.length > 0 && (printUngrouped ?? !ungroupedCollapsed) && (
             <div className="ua-print-group">
               {renderTable(t('printable.ungroupedHeading', { defaultValue: 'Ungrouped' }), ungroupedActivities)}
             </div>

--- a/packages/ui/src/components/PrintOptionsDialog.tsx
+++ b/packages/ui/src/components/PrintOptionsDialog.tsx
@@ -41,6 +41,10 @@ type PrintOptionsDialogProps<T> = {
   isPrinting?: boolean;
   title?: string;
   description?: React.ReactNode;
+  /** Optional extra content rendered between column checkboxes and footer. */
+  children?: React.ReactNode;
+  /** Label for the extra section (rendered as a heading above children). */
+  childrenSectionLabel?: React.ReactNode;
 };
 
 export function getDefaultPrintColumnKeys<T>(columns: PrintColumnOption<T>[]): string[] {
@@ -196,6 +200,8 @@ export function PrintOptionsDialog<T>({
   isPrinting,
   title,
   description,
+  children,
+  childrenSectionLabel,
 }: PrintOptionsDialogProps<T>) {
   const { t } = useTranslation('common');
   const selectedKeySet = React.useMemo(() => new Set(selectedColumnKeys), [selectedColumnKeys]);
@@ -244,6 +250,15 @@ export function PrintOptionsDialog<T>({
               />
             </div>
           ))}
+          {children && (
+            <>
+              <hr className="my-3 border-[rgb(var(--color-border-200))]" />
+              {childrenSectionLabel && (
+                <p className="text-sm font-semibold text-[rgb(var(--color-text-700))] mb-2 px-1">{childrenSectionLabel}</p>
+              )}
+              {children}
+            </>
+          )}
         </div>
         <DialogFooter className="justify-between">
           <Button


### PR DESCRIPTION
## Summary
- add a sections area to the activity print options dialog for grouped views
- allow selecting individual activity groups for printing
- add a persisted Ungrouped items toggle so ungrouped items can be excluded from print output
- extend the shared print options dialog with a generic children slot for feature-specific print controls

## Validation
- npm --workspace packages/ui run typecheck
- npm --workspace ee/packages/workflows run typecheck
- npx eslint packages/ui/src/components/PrintOptionsDialog.tsx ee/packages/workflows/src/components/user-activities/PrintableActivitiesView.tsx ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx

Note: This is stacked on #2548 / feature/filter-company-user-activities to avoid duplicating the client-filter changes.