### PR TITLE
fix(shortcuts): stop "f" key from re-firing over link hints

### DIFF
--- a/server/src/components/layout/VimNavigationLayer.tsx
+++ b/server/src/components/layout/VimNavigationLayer.tsx
@@ -298,6 +298,7 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
   const safeActionsRef = useRef<Record<string, () => void>>({});
   const hintInputRef = useRef("");
   const hintTargetsRef = useRef<Record<string, HTMLElement>>({});
+  const hintsActiveRef = useRef(false);
   const linkHintNewTabRef = useRef(false);
   const hintActivationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [visualMode, setVisualMode] = useState(false);
@@ -391,6 +392,7 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
     }
     hintInputRef.current = "";
     hintTargetsRef.current = {};
+    hintsActiveRef.current = false;
     setHints([]);
   }, []);
 
@@ -409,6 +411,7 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
     linkHintNewTabRef.current = newTab;
     hintInputRef.current = "";
     hintTargetsRef.current = nextTargets;
+    hintsActiveRef.current = nextHints.length > 0;
     setHints(nextHints);
   }, []);
 
@@ -509,9 +512,10 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
         return;
       }
 
-      if (hints.length > 0) {
+      if (hintsActiveRef.current) {
         if (event.key === "Escape") {
           event.preventDefault();
+          event.stopImmediatePropagation();
           closeHints();
           return;
         }
@@ -521,7 +525,7 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
         }
 
         event.preventDefault();
-        event.stopPropagation();
+        event.stopImmediatePropagation();
         const nextInput = `${hintInputRef.current}${event.key.toLowerCase()}`;
         const labels = Object.keys(hintTargetsRef.current);
 
@@ -591,7 +595,7 @@ export default function VimNavigationLayer({ onOpenHelp }: VimNavigationLayerPro
 
     window.addEventListener("keydown", handleKeyDown, true);
     return () => window.removeEventListener("keydown", handleKeyDown, true);
-  }, [activateHint, closeHints, hints.length, replayMacro]);
+  }, [activateHint, closeHints, replayMacro]);
 
   const repeatLastAction = useCallback(() => {
     const lastAction = lastActionRef.current;


### PR DESCRIPTION
  Gate the VimNavigationLayer hint keydown handler on a synchronously
  updated ref instead of a stale closure of hints.length, and upgrade
  stopPropagation to stopImmediatePropagation so the global Provider
  can no longer re-trigger linkhints.show when the user types the
  label of an open hint (e.g. pressing "f" to follow the "f" hint).

  🔑🐇 And the Cheshire keystroke smiled twice, said "curiouser, curiouser
  — for the same letter that opened the door must also walk through it,"
  and at last the rabbit-hole of stale closures was paved over with a ref. 🎩