### PR TITLE
Add invoice label style support

### DIFF
--- a/ee/docs/plans/2026-05-25-invoice-label-styles/PRD.md
+++ b/ee/docs/plans/2026-05-25-invoice-label-styles/PRD.md
@@ -1,0 +1,33 @@
+# Invoice Label Styles
+
+## Problem
+Users need invoice labels such as “Invoice #”, “Issue Date”, “Due Date”, and totals-row labels to be stylable independently from their values. Today the invoice designer has limited preview-only label weight behavior, while production PDF rendering outputs field labels as plain spans.
+
+## Goals
+- Let users style field labels independently from field values and containers.
+- Support common typography controls: font weight, size, color, family, line height, italic/style, and text alignment where applicable.
+- Keep designer preview, saved template AST, imported templates, and production PDF rendering consistent.
+- Apply the same label-style data model to standalone totals rows and AST totals rows for consistency.
+
+## Non-goals
+- Rich text editing inside labels.
+- Per-character styling.
+- Changing invoice value styling in this work.
+
+## UX Notes
+- Add a Label Style panel to Data Field and Totals Row inspectors.
+- Controls write to a label-specific style object, not the container style.
+- Existing templates render unchanged unless label styles are explicitly set.
+
+## Data Model / Rendering
+- Add `labelStyle?: TemplateNodeStyleRef` to `TemplateFieldNode`.
+- Add `labelStyle?: TemplateNodeStyleRef` to `TemplateTotalsRow`.
+- Render field label spans and totals label spans with the resolved label style.
+- Import/export label styles via designer metadata at `metadata.labelStyle`.
+
+## Acceptance Criteria
+- A user can set field label style in the designer and see it in preview.
+- Exported AST includes `labelStyle` for styled labels.
+- Imported AST label styles round-trip without loss.
+- Production HTML/PDF renderer applies `labelStyle` to labels only.
+- Totals row labels support the same style object.

--- a/ee/docs/plans/2026-05-25-invoice-label-styles/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-05-25-invoice-label-styles/SCRATCHPAD.md
@@ -1,0 +1,11 @@
+# Scratchpad
+
+- Existing investigation found production field labels render as plain spans in `packages/billing/src/lib/invoice-template-ast/react-renderer.tsx`.
+- Designer canvas had preview-only `metadata.labelFontWeight`/`metadata.fontWeight` behavior for field labels.
+- Scope confirmed: full label style controls, consistently for field labels and totals labels.
+- Implemented `labelStyle?: TemplateNodeStyleRef` on `TemplateFieldNode` and `TemplateTotalsRow`.
+- Designer field/subtotal/tax/discount/custom-total inspectors now expose label style controls under `metadata.labelStyle.inline.*`.
+- Renderer applies label style only to label spans, leaving values/container styling independent.
+- While validating round-trip tests, fixed export logic to avoid re-emitting imported default field `borderStyle: 'none'` when the original AST did not have a `borderStyle` property.
+- Targeted package typecheck passed via `npm -w packages/billing run typecheck`.
+- Targeted vitest run passed for schema, renderer, and workspace AST roundtrip. Full component schema suite still has an existing unrelated reciprocal hierarchy failure (`page` vs `field` allowedParents) when run without a test-name filter.

--- a/ee/docs/plans/2026-05-25-invoice-label-styles/features.json
+++ b/ee/docs/plans/2026-05-25-invoice-label-styles/features.json
@@ -1,0 +1,9 @@
+[
+  { "id": "F001", "description": "Add labelStyle to invoice field AST nodes.", "implemented": true },
+  { "id": "F002", "description": "Add labelStyle to invoice totals rows.", "implemented": true },
+  { "id": "F003", "description": "Validate labelStyle in the invoice template AST schema.", "implemented": true },
+  { "id": "F004", "description": "Apply labelStyle in the production React/PDF renderer.", "implemented": true },
+  { "id": "F005", "description": "Expose label typography controls in field and totals-row designer inspectors.", "implemented": true },
+  { "id": "F006", "description": "Apply labelStyle in designer canvas previews.", "implemented": true },
+  { "id": "F007", "description": "Round-trip labelStyle through designer AST import/export.", "implemented": true }
+]

--- a/ee/docs/plans/2026-05-25-invoice-label-styles/tests.json
+++ b/ee/docs/plans/2026-05-25-invoice-label-styles/tests.json
@@ -1,0 +1,6 @@
+[
+  { "id": "T001", "description": "Schema validation accepts field and totals row labelStyle declarations.", "implemented": true, "featureIds": ["F001", "F002", "F003"] },
+  { "id": "T002", "description": "Renderer output applies labelStyle to field and totals labels only.", "implemented": true, "featureIds": ["F004"] },
+  { "id": "T003", "description": "Workspace AST round-trip preserves field and totals labelStyle.", "implemented": true, "featureIds": ["F007"] },
+  { "id": "T004", "description": "Component schema exposes label style controls for fields and totals rows.", "implemented": true, "featureIds": ["F005"] }
+]

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.roundtrip.nodes.test.ts
@@ -180,6 +180,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
               type: 'field',
               binding: { bindingId: 'tenantAddress' },
               label: 'From Address',
+              labelStyle: { inline: { fontWeight: '700', color: '#123456', fontSize: '13px' } },
               format: 'text',
               emptyValue: '-',
               placeholder: 'Company Address',
@@ -215,6 +216,7 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     if (!explicitField || explicitField.type !== 'field') return;
     expect(explicitField.binding).toEqual({ bindingId: 'tenantAddress' });
     expect(explicitField.label).toBe('From Address');
+    expect(explicitField.labelStyle).toEqual({ inline: { fontWeight: '700', color: '#123456', fontSize: '13px' } });
     expect(explicitField.format).toBe('text');
     expect(explicitField.emptyValue).toBe('-');
     expect(explicitField.placeholder).toBe('Company Address');
@@ -397,7 +399,14 @@ describe('workspaceAst roundtrip node/property matrix', () => {
           rows: [
             { id: 'subtotal', label: 'Subtotal', value: { type: 'binding', bindingId: 'subtotal' }, format: 'currency' },
             { id: 'tax', label: 'Tax', value: { type: 'path', path: 'tax' }, format: 'currency' },
-            { id: 'total', label: 'Total', value: { type: 'literal', value: 123.45 }, format: 'number', emphasize: true },
+            {
+              id: 'total',
+              label: 'Total',
+              labelStyle: { inline: { fontWeight: 700, color: '#111827' } },
+              value: { type: 'literal', value: 123.45 },
+              format: 'number',
+              emphasize: true,
+            },
           ],
         },
       ],
@@ -423,7 +432,14 @@ describe('workspaceAst roundtrip node/property matrix', () => {
     expect(totals.rows).toEqual([
       { id: 'subtotal', label: 'Subtotal', value: { type: 'binding', bindingId: 'subtotal' }, format: 'currency' },
       { id: 'tax', label: 'Tax', value: { type: 'path', path: 'tax' }, format: 'currency' },
-      { id: 'total', label: 'Total', value: { type: 'literal', value: 123.45 }, format: 'number', emphasize: true },
+      {
+        id: 'total',
+        label: 'Total',
+        labelStyle: { inline: { fontWeight: 700, color: '#111827' } },
+        value: { type: 'literal', value: 123.45 },
+        format: 'number',
+        emphasize: true,
+      },
     ]);
   });
 

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -446,6 +446,7 @@ const createNodeStyle = (node: WorkspaceNode): TemplateNode['style'] | undefined
   if (style.fontSize) inline.fontSize = style.fontSize;
   if (style.fontWeight !== undefined) inline.fontWeight = style.fontWeight;
   if (style.fontFamily) inline.fontFamily = style.fontFamily;
+  if (style.fontStyle) inline.fontStyle = style.fontStyle;
   if (style.lineHeight !== undefined) inline.lineHeight = style.lineHeight;
   if (style.textAlign) inline.textAlign = style.textAlign;
   if (style.display) inline.display = style.display;
@@ -485,6 +486,57 @@ const createNodeStyle = (node: WorkspaceNode): TemplateNode['style'] | undefined
   }
 
   return Object.keys(styleRef).length > 0 ? styleRef : undefined;
+};
+
+const mapTemplateNodeStyleRef = (value: unknown): TemplateNodeStyleRef | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const mapped: TemplateNodeStyleRef = {};
+
+  if (Array.isArray(value.tokenIds)) {
+    const tokenIds = value.tokenIds.filter(
+      (tokenId: unknown): tokenId is string => typeof tokenId === 'string' && tokenId.trim().length > 0
+    );
+    if (tokenIds.length > 0) {
+      mapped.tokenIds = tokenIds;
+    }
+  }
+
+  if (isRecord(value.inline)) {
+    const inline = Object.fromEntries(
+      Object.entries(value.inline as Record<string, unknown>).filter(([, entryValue]) => {
+        if (entryValue === null || entryValue === undefined) {
+          return false;
+        }
+        return typeof entryValue !== 'string' || entryValue.trim().length > 0;
+      })
+    );
+    if (Object.keys(inline).length > 0) {
+      mapped.inline = inline;
+    }
+  }
+
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+};
+
+const resolveLabelStyleRef = (metadata: UnknownRecord): TemplateNodeStyleRef | undefined => {
+  const explicitLabelStyle = mapTemplateNodeStyleRef(metadata.labelStyle);
+  if (explicitLabelStyle) {
+    return explicitLabelStyle;
+  }
+
+  const legacyFontWeight = metadata.labelFontWeight ?? metadata.fontWeight;
+  if (typeof legacyFontWeight === 'string' || typeof legacyFontWeight === 'number') {
+    return {
+      inline: {
+        fontWeight: legacyFontWeight,
+      },
+    };
+  }
+
+  return undefined;
 };
 
 const coerceCssLength = (value: unknown): string | undefined => {
@@ -711,6 +763,9 @@ const coerceNodeStyleFromInlineStyle = (inline: Record<string, unknown> | undefi
   const fontFamily = coerceString(inline.fontFamily);
   if (fontFamily) style.fontFamily = fontFamily;
 
+  const fontStyle = coerceString(inline.fontStyle);
+  if (fontStyle) style.fontStyle = fontStyle;
+
   const lineHeight = coerceNumberish(inline.lineHeight);
   if (lineHeight !== undefined) style.lineHeight = lineHeight;
 
@@ -752,29 +807,6 @@ const mapTableColumns = (node: WorkspaceNode): TemplateTableColumn[] => {
   const metadata = getWorkspaceNodeMetadata(node);
   const columns = Array.isArray(metadata.columns) ? metadata.columns : [];
 
-  const mapColumnStyle = (value: unknown): TemplateNodeStyleRef | undefined => {
-    if (!isRecord(value)) {
-      return undefined;
-    }
-
-    const mapped: TemplateNodeStyleRef = {};
-
-    if (Array.isArray(value.tokenIds)) {
-      const tokenIds = value.tokenIds.filter(
-        (tokenId: unknown): tokenId is string => typeof tokenId === 'string' && tokenId.trim().length > 0
-      );
-      if (tokenIds.length > 0) {
-        mapped.tokenIds = tokenIds;
-      }
-    }
-
-    if (isRecord(value.inline)) {
-      mapped.inline = { ...(value.inline as Record<string, unknown>) };
-    }
-
-    return Object.keys(mapped).length > 0 ? mapped : undefined;
-  };
-
   const mappedColumns = columns
     .map((column, index): TemplateTableColumn | null => {
       if (!isRecord(column)) {
@@ -802,7 +834,7 @@ const mapTableColumns = (node: WorkspaceNode): TemplateTableColumn[] => {
         header: header.length > 0 ? header : undefined,
         value: resolvedValue,
       };
-      const style = mapColumnStyle(column.style);
+      const style = mapTemplateNodeStyleRef(column.style);
       if (style) {
         mapped.style = style;
       }
@@ -1017,6 +1049,7 @@ const mapDesignerNodeToAstNode = (
       const hadImportedFormat = metadata.__astFieldHadFormat === true;
       const hadImportedEmptyValue = metadata.__astFieldHadEmptyValue === true;
       const hadImportedPlaceholder = metadata.__astFieldHadPlaceholder === true;
+      const hadImportedBorderStyle = metadata.__astFieldHadBorderStyle === true;
       const hasExplicitEmptyValue = typeof metadata.emptyValue === 'string';
       const emptyValue = hasExplicitEmptyValue ? asTrimmedString(metadata.emptyValue) : '';
       const hasExplicitPlaceholder = typeof metadata.placeholder === 'string';
@@ -1050,7 +1083,11 @@ const mapDesignerNodeToAstNode = (
       if (displayFormat && supportsFieldDisplayFormat(bindingPath)) {
         mapped.displayFormat = displayFormat;
       }
-      if (hasExplicitBorderStyle && borderStyle) {
+      const labelStyle = resolveLabelStyleRef(metadata);
+      if (labelStyle) {
+        mapped.labelStyle = labelStyle;
+      }
+      if (hasExplicitBorderStyle && borderStyle && (!astImported || hadImportedBorderStyle)) {
         mapped.borderStyle = borderStyle;
       }
       return mapped;
@@ -1125,14 +1162,13 @@ const mapDesignerNodeToAstNode = (
               if (row.emphasize === true) {
                 mappedRow.emphasize = true;
               }
-              if (isRecord(row.style) && Object.keys(row.style).length > 0) {
-                const rowStyleRef: TemplateNodeStyleRef = {};
-                if (isRecord(row.style.inline)) {
-                  rowStyleRef.inline = { ...(row.style.inline as Record<string, unknown>) };
-                }
-                if (Object.keys(rowStyleRef).length > 0) {
-                  mappedRow.style = rowStyleRef;
-                }
+              const labelStyle = mapTemplateNodeStyleRef(row.labelStyle);
+              if (labelStyle) {
+                mappedRow.labelStyle = labelStyle;
+              }
+              const rowStyle = mapTemplateNodeStyleRef(row.style);
+              if (rowStyle) {
+                mappedRow.style = rowStyle;
               }
               return mappedRow;
             })
@@ -1815,6 +1851,9 @@ export const importTemplateAstToWorkspace = (
           if (inputNode.label) {
             metadata.label = inputNode.label;
           }
+          if (inputNode.labelStyle) {
+            metadata.labelStyle = cloneJson(inputNode.labelStyle);
+          }
           if (typeof inputNode.emptyValue === 'string') {
             metadata.emptyValue = inputNode.emptyValue;
           }
@@ -1879,7 +1918,8 @@ export const importTemplateAstToWorkspace = (
             type: row.format,
             format: row.format,
             emphasize: row.emphasize === true,
-            ...(row.style ? { style: row.style } : {}),
+            ...(row.style ? { style: cloneJson(row.style) } : {}),
+            ...(row.labelStyle ? { labelStyle: cloneJson(row.labelStyle) } : {}),
           }));
         } else if (inputNode.type === 'image') {
           metadata.astSrcExpression = inputNode.src;

--- a/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
+++ b/packages/billing/src/components/invoice-designer/canvas/DesignCanvas.tsx
@@ -191,6 +191,76 @@ const resolveFontWeightStyle = (
   return fallback;
 };
 
+const normalizeFontWeightCssValue = (value: unknown): string | number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed === 'normal') return 400;
+  if (trimmed === 'medium') return 500;
+  if (trimmed === 'semibold') return 600;
+  if (trimmed === 'bold') return 700;
+  return trimmed;
+};
+
+const normalizeCssStringOrNumber = (value: unknown): string | number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const resolveLabelInlineStyle = (metadata: Record<string, unknown>): React.CSSProperties | undefined => {
+  const labelStyle = metadata.labelStyle;
+  const inline =
+    typeof labelStyle === 'object' && labelStyle !== null && !Array.isArray(labelStyle) &&
+    typeof (labelStyle as { inline?: unknown }).inline === 'object' &&
+    (labelStyle as { inline?: unknown }).inline !== null &&
+    !Array.isArray((labelStyle as { inline?: unknown }).inline)
+      ? ((labelStyle as { inline: Record<string, unknown> }).inline)
+      : null;
+
+  const resolved: React.CSSProperties = {};
+  if (inline) {
+    const color = typeof inline.color === 'string' && inline.color.trim().length > 0 ? inline.color.trim() : undefined;
+    const fontSize = typeof inline.fontSize === 'string' && inline.fontSize.trim().length > 0 ? inline.fontSize.trim() : undefined;
+    const fontFamily = typeof inline.fontFamily === 'string' && inline.fontFamily.trim().length > 0 ? inline.fontFamily.trim() : undefined;
+    const fontStyle = typeof inline.fontStyle === 'string' && inline.fontStyle.trim().length > 0 ? inline.fontStyle.trim() : undefined;
+    const lineHeight = normalizeCssStringOrNumber(inline.lineHeight);
+    const textAlign = typeof inline.textAlign === 'string' && inline.textAlign.trim().length > 0 ? inline.textAlign.trim() : undefined;
+    const fontWeight = normalizeFontWeightCssValue(inline.fontWeight);
+
+    if (color) resolved.color = color;
+    if (fontSize) resolved.fontSize = fontSize;
+    if (fontFamily) resolved.fontFamily = fontFamily;
+    if (fontStyle) resolved.fontStyle = fontStyle;
+    if (lineHeight !== undefined) resolved.lineHeight = lineHeight;
+    if (textAlign === 'left' || textAlign === 'center' || textAlign === 'right' || textAlign === 'justify') {
+      resolved.textAlign = textAlign;
+    }
+    if (fontWeight !== undefined) resolved.fontWeight = fontWeight;
+  }
+
+  if (resolved.fontWeight === undefined) {
+    const legacyFontWeight = normalizeFontWeightCssValue(metadata.labelFontWeight ?? metadata.fontWeight);
+    if (legacyFontWeight !== undefined) {
+      resolved.fontWeight = legacyFontWeight;
+    }
+  }
+
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+};
+
 const resolveTableBorderPreset = (metadata: Record<string, unknown>): TableBorderPreset => {
   const candidate = metadata.tableBorderPreset;
   if (candidate === 'list' || candidate === 'boxed' || candidate === 'grid' || candidate === 'none') {
@@ -707,6 +777,7 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
     case 'discount':
     case 'custom-total': {
       const totalsRow = resolveTotalsRowPreviewModel(node, previewData);
+      const labelInlineStyle = resolveLabelInlineStyle(metadata);
       return {
         content: (
           <div className="flex h-full flex-col justify-between gap-1">
@@ -721,6 +792,7 @@ const getPreviewContent = (node: DesignerNode, previewData: WasmInvoiceViewModel
                   'min-w-0 truncate',
                   totalsRow.isGrandTotal ? 'text-[11px] font-semibold text-slate-800' : 'text-[11px] font-medium text-slate-600'
                 )}
+                style={labelInlineStyle}
                 title={totalsRow.label}
               >
                 {totalsRow.label}
@@ -925,6 +997,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
   const isTextNode = node.type === 'text';
   const isFieldNode = node.type === 'field';
   const fieldDisplayLabel = isFieldNode ? asTrimmedString(metadata.label) : '';
+  const labelInlineStyle = isFieldNode ? resolveLabelInlineStyle(metadata) : undefined;
   const labelWeightClass = FONT_WEIGHT_CLASS[
     resolveFontWeightStyle(metadata.fontWeight ?? metadata.labelFontWeight, 'semibold')
   ];
@@ -1171,6 +1244,7 @@ const CanvasNodeInner: React.FC<CanvasNodeProps & { dnd: CanvasNodeDnd }> = ({
               {fieldDisplayLabel && (
                 <span
                   className="shrink-0 truncate text-[10px] font-medium text-slate-500"
+                  style={labelInlineStyle}
                   title={fieldDisplayLabel}
                 >
                   {fieldDisplayLabel}:

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.test.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.test.ts
@@ -70,6 +70,20 @@ describe('componentSchema', () => {
     expect(paths).toContain('metadata.bindingKey');
     expect(paths).toContain('metadata.format');
     expect(paths).toContain('metadata.emptyValue');
+    expect(paths).toContain('metadata.labelStyle.inline.fontWeight');
+    expect(paths).toContain('metadata.labelStyle.inline.fontSize');
+    expect(paths).toContain('metadata.labelStyle.inline.color');
     expect(paths).toContain('style.justifyContent');
+  });
+
+  it('exposes label style controls for totals row labels', () => {
+    const subtotalSchema = getComponentSchema('subtotal');
+    const paths = (subtotalSchema.inspector?.panels ?? [])
+      .flatMap((panel) => panel.fields)
+      .flatMap((field) => ('path' in field ? [field.path] : []));
+
+    expect(paths).toContain('metadata.labelStyle.inline.fontWeight');
+    expect(paths).toContain('metadata.labelStyle.inline.fontSize');
+    expect(paths).toContain('metadata.labelStyle.inline.color');
   });
 });

--- a/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
+++ b/packages/billing/src/components/invoice-designer/schema/componentSchema.ts
@@ -285,6 +285,85 @@ const SECTION_INSPECTOR: DesignerInspectorSchema = {
   ],
 };
 
+const createLabelStylePanel = (): DesignerInspectorSchema['panels'][number] => ({
+  id: 'label-style',
+  title: 'Label Style',
+  fields: [
+    {
+      kind: 'enum',
+      id: 'labelFontWeight',
+      domId: 'designer-label-font-weight',
+      label: 'Weight',
+      path: 'metadata.labelStyle.inline.fontWeight',
+      options: [
+        { value: '', label: 'Default' },
+        { value: '400', label: 'Normal' },
+        { value: '500', label: 'Medium' },
+        { value: '600', label: 'Semibold' },
+        { value: '700', label: 'Bold' },
+      ],
+    },
+    {
+      kind: 'css-length-stepper',
+      id: 'labelFontSize',
+      domId: 'designer-label-font-size',
+      label: 'Size',
+      path: 'metadata.labelStyle.inline.fontSize',
+      allowedUnits: ['px', 'rem'],
+      defaultUnit: 'px',
+    },
+    {
+      kind: 'css-color',
+      id: 'labelColor',
+      domId: 'designer-label-color',
+      label: 'Color',
+      path: 'metadata.labelStyle.inline.color',
+      placeholder: '#111827',
+    },
+    {
+      kind: 'string',
+      id: 'labelFontFamily',
+      domId: 'designer-label-font-family',
+      label: 'Font family',
+      path: 'metadata.labelStyle.inline.fontFamily',
+      placeholder: 'Inter, sans-serif',
+    },
+    {
+      kind: 'string',
+      id: 'labelLineHeight',
+      domId: 'designer-label-line-height',
+      label: 'Line height',
+      path: 'metadata.labelStyle.inline.lineHeight',
+      placeholder: '1.35 | 18px',
+    },
+    {
+      kind: 'enum',
+      id: 'labelFontStyle',
+      domId: 'designer-label-font-style',
+      label: 'Style',
+      path: 'metadata.labelStyle.inline.fontStyle',
+      options: [
+        { value: '', label: 'Default' },
+        { value: 'normal', label: 'Normal' },
+        { value: 'italic', label: 'Italic' },
+      ],
+    },
+    {
+      kind: 'enum',
+      id: 'labelTextAlign',
+      domId: 'designer-label-text-align',
+      label: 'Text align',
+      path: 'metadata.labelStyle.inline.textAlign',
+      options: [
+        { value: '', label: 'Default' },
+        { value: 'left', label: 'Left' },
+        { value: 'center', label: 'Center' },
+        { value: 'right', label: 'Right' },
+      ],
+    },
+  ],
+});
+
 const FIELD_INSPECTOR: DesignerInspectorSchema = {
   panels: [
     {
@@ -348,6 +427,7 @@ const FIELD_INSPECTOR: DesignerInspectorSchema = {
         },
       ],
     },
+    createLabelStylePanel(),
     {
       id: 'field-layout',
       title: 'Field Layout',
@@ -478,6 +558,7 @@ const TOTALS_ROW_INSPECTOR: DesignerInspectorSchema = {
         },
       ],
     },
+    createLabelStylePanel(),
   ],
 };
 
@@ -510,6 +591,7 @@ const CUSTOM_TOTAL_INSPECTOR: DesignerInspectorSchema = {
         },
       ],
     },
+    createLabelStylePanel(),
   ],
 };
 

--- a/packages/billing/src/components/invoice-designer/state/designerStore.ts
+++ b/packages/billing/src/components/invoice-designer/state/designerStore.ts
@@ -119,6 +119,7 @@ export interface DesignerNodeStyle {
   fontSize?: CssLength;
   fontWeight?: string | number;
   fontFamily?: string;
+  fontStyle?: string;
   lineHeight?: string | number;
   textAlign?: CssTextAlign;
 

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -112,6 +112,58 @@ describe('renderEvaluatedTemplateAst', () => {
     expect(rendered.html).toContain('300');
   });
 
+  it('applies labelStyle to field and totals labels', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+        },
+        collections: {
+          lineItems: { id: 'lineItems', kind: 'collection', path: 'items' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'invoice-number',
+            type: 'field',
+            label: 'Invoice #',
+            labelStyle: { inline: { fontWeight: 700, color: '#123456' } },
+            binding: { bindingId: 'invoiceNumber' },
+          },
+          {
+            id: 'totals',
+            type: 'totals',
+            sourceBinding: { bindingId: 'lineItems' },
+            rows: [
+              {
+                id: 'grandTotal',
+                label: 'Grand Total',
+                labelStyle: { inline: { fontSize: '16px', fontStyle: 'italic' } },
+                value: { type: 'literal', value: 330 },
+                format: 'currency',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, invoiceFixture);
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('Invoice #:');
+    expect(rendered.html).toContain('font-weight:700');
+    expect(rendered.html).toContain('color:#123456');
+    expect(rendered.html).toContain('Grand Total');
+    expect(rendered.html).toContain('font-size:16px');
+    expect(rendered.html).toContain('font-style:italic');
+  });
+
   it('renders multiline address fields with preserved line breaks', async () => {
     const ast: TemplateAst = {
       kind: 'invoice-template-ast',

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -494,9 +494,14 @@ const renderNode = (
         ...(multilineFieldAdjustments ?? null),
         ...(style ?? {}),
       };
+      const { className: labelClassName, style: labelStyle } = resolveStyleRef(node.labelStyle);
       return (
         <div key={node.id} id={node.id} className={elementClassName || undefined} style={fieldStyle}>
-          {node.label ? <span>{node.label}: </span> : null}
+          {node.label ? (
+            <span className={labelClassName || undefined} style={labelStyle}>
+              {node.label}:{' '}
+            </span>
+          ) : null}
           <span style={formattedValue.multiline ? { whiteSpace: 'pre-line' } : undefined}>
             {formattedValue.text ?? ''}
           </span>
@@ -632,13 +637,16 @@ const renderNode = (
           {node.rows.map((row) => {
             const raw = totals[row.id] ?? resolveExpressionValue(row.value, evaluation, scope, ctx) ?? '';
             const { style: rowStyle } = resolveStyleRef(row.style);
+            const { className: labelClassName, style: labelStyle } = resolveStyleRef(row.labelStyle);
             const emphasizeStyle = row.emphasize ? { fontWeight: 700 } : undefined;
             const mergedRowStyle = rowStyle || emphasizeStyle
               ? { ...(emphasizeStyle ?? {}), ...(rowStyle ?? {}) }
               : undefined;
             return (
               <div key={row.id} className="ast-totals-row" style={mergedRowStyle}>
-                <span className="ast-totals-label">{row.label}</span>
+                <span className={joinClassNames('ast-totals-label', labelClassName) || undefined} style={labelStyle}>
+                  {row.label}
+                </span>
                 <span className="ast-totals-value">{formatValue(raw, row.format, ctx)}</span>
               </div>
             );

--- a/packages/billing/src/lib/invoice-template-ast/schema.test.ts
+++ b/packages/billing/src/lib/invoice-template-ast/schema.test.ts
@@ -48,6 +48,49 @@ describe('templateAstSchema', () => {
     );
   });
 
+  it('accepts field and totals labelStyle declarations', () => {
+    const validResult = validateTemplateAst({
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      bindings: {
+        values: {
+          invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
+        },
+        collections: {
+          lineItems: { id: 'lineItems', kind: 'collection', path: 'items' },
+        },
+      },
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'invoice-number',
+            type: 'field',
+            binding: { bindingId: 'invoiceNumber' },
+            label: 'Invoice #',
+            labelStyle: { inline: { fontWeight: '700', color: '#111827', fontStyle: 'italic' } },
+          },
+          {
+            id: 'totals',
+            type: 'totals',
+            sourceBinding: { bindingId: 'lineItems' },
+            rows: [
+              {
+                id: 'total',
+                label: 'Total',
+                labelStyle: { inline: { fontSize: '14px', color: '#111827' } },
+                value: { type: 'literal', value: 0 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(validResult.success).toBe(true);
+  });
+
   it('accepts a stack node with an optional repeat region binding', () => {
     const validResult = validateTemplateAst({
       kind: 'invoice-template-ast',

--- a/packages/billing/src/lib/invoice-template-ast/schema.ts
+++ b/packages/billing/src/lib/invoice-template-ast/schema.ts
@@ -279,6 +279,7 @@ type NodeInput =
       style?: z.infer<typeof nodeStyleRefSchema>;
       binding: z.infer<typeof bindingRefSchema>;
       label?: string;
+      labelStyle?: z.infer<typeof nodeStyleRefSchema>;
       emptyValue?: string;
       placeholder?: string;
       format?: z.infer<typeof valueFormatSchema>;
@@ -341,6 +342,7 @@ type NodeInput =
         value: ValueExpressionInput;
         format?: z.infer<typeof valueFormatSchema>;
         emphasize?: boolean;
+        labelStyle?: z.infer<typeof nodeStyleRefSchema>;
       }>;
     };
 
@@ -383,6 +385,7 @@ const nodeSchema: z.ZodTypeAny = z.lazy(() =>
       style: nodeStyleRefSchema.optional(),
       binding: bindingRefSchema,
       label: z.string().optional(),
+      labelStyle: nodeStyleRefSchema.optional(),
       emptyValue: z.string().optional(),
       placeholder: z.string().optional(),
       format: valueFormatSchema.optional(),
@@ -448,6 +451,7 @@ const nodeSchema: z.ZodTypeAny = z.lazy(() =>
         format: valueFormatSchema.optional(),
         emphasize: z.boolean().optional(),
         style: nodeStyleRefSchema.optional(),
+        labelStyle: nodeStyleRefSchema.optional(),
       }).strict()).min(1),
     }).strict(),
   ])

--- a/packages/types/src/lib/invoice-template-ast.ts
+++ b/packages/types/src/lib/invoice-template-ast.ts
@@ -82,6 +82,7 @@ export interface TemplateFieldNode extends TemplateNodeBase {
   type: 'field';
   binding: TemplateBindingRef;
   label?: string;
+  labelStyle?: TemplateNodeStyleRef;
   emptyValue?: string;
   placeholder?: string;
   format?: TemplateValueFormat;
@@ -145,6 +146,7 @@ export interface TemplateTotalsNode extends TemplateNodeBase {
 export interface TemplateTotalsRow {
   id: string;
   label: string;
+  labelStyle?: TemplateNodeStyleRef;
   value: TemplateValueExpression;
   format?: TemplateValueFormat;
   emphasize?: boolean;


### PR DESCRIPTION
## Summary
- Add `labelStyle` support to invoice AST fields and totals rows
- Scope production and designer preview rendering so label styles apply only to labels, not values/containers
- Add designer inspector controls and AST round-trip/schema/renderer coverage

## Validation
- `npm -w packages/billing run typecheck`
- Targeted invoice AST schema/renderer/workspace AST tests passed
- Component schema label-style tests passed by filter
- Manual algadev smoke: created/saved/reopened `Label Style Smoke 2026-05-25`; confirmed field and totals labels keep independent color/size/weight in canvas, code AST, preview, and after reload

## Notes
- Full `componentSchema.test.ts` suite still has an unrelated existing reciprocal hierarchy assertion failure: expected `[ 'column', 'container', 'section' ]` to include `page`.
