### PR TITLE
Remove workflow step quota card from designer page header

### DIFF
--- a/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowDesigner.tsx
@@ -5251,9 +5251,7 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
           {isControlPanelMode ? (
             workflowStepQuotaCard
           ) : isEditorDesignerMode ? (
-            <div className="flex flex-col items-end gap-3">
-              {workflowStepQuotaCard}
-              <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2">
               {activeWorkflowRecord && (
                 <span
                   className={`inline-flex items-center gap-1 px-2 py-1 rounded-full border text-xs font-medium ${workflowValidationBadge.className}`}
@@ -5320,7 +5318,6 @@ const WorkflowDesigner: React.FC<WorkflowDesignerProps> = ({
                   {t('designer.toolbar.run', { defaultValue: 'Run' })}
                 </Button>
               )}
-              </div>
             </div>
           ) : isEditorListMode ? (
             workflowStepQuotaCard


### PR DESCRIPTION
## Summary
- Removes the \"Workflow actions\" quota/usage counter card from the workflow designer page header.
- Quota card still appears on the workflow editor list page and the workflow control panel.

## Test plan
- [ ] Open an existing workflow in the designer — confirm the quota counter card is no longer shown in the header.
- [ ] Confirm the toolbar buttons (Save Draft, Publish, Run, New Workflow, validation badge) still render and function.
- [ ] Visit the workflow editor list page and the workflow control panel — confirm the quota card still appears there.