### PR TITLE
Fix ticket email duplicates and dropped-column query

### DIFF
--- a/ee/server/src/lib/sla/TemporalSlaBackend.ts
+++ b/ee/server/src/lib/sla/TemporalSlaBackend.ts
@@ -82,8 +82,10 @@ export class TemporalSlaBackend implements ISlaBackend {
     await handle.signal(signalName, { met });
   }
 
-  async cancelSla(ticketId: string): Promise<void> {
-    const handle = await this.getHandle(ticketId);
+  async cancelSla(tenantId: string, ticketId: string): Promise<void> {
+    const client = await this.getClient();
+    const workflowId = this.getWorkflowId(tenantId, ticketId);
+    const handle = client.workflow.getHandle(workflowId);
     await handle.signal('cancel');
   }
 

--- a/ee/server/src/lib/sla/__tests__/TemporalSlaBackend.test.ts
+++ b/ee/server/src/lib/sla/__tests__/TemporalSlaBackend.test.ts
@@ -98,7 +98,7 @@ describe('TemporalSlaBackend', () => {
 
   it('cancelSla sends cancel signal', async () => {
     const backend = new TemporalSlaBackend();
-    await backend.cancelSla('ticket-1');
+    await backend.cancelSla('tenant-1', 'ticket-1');
     expect(signalMock).toHaveBeenCalledWith('cancel');
   });
 

--- a/packages/ee/src/lib/sla/TemporalSlaBackend.ts
+++ b/packages/ee/src/lib/sla/TemporalSlaBackend.ts
@@ -38,7 +38,7 @@ export class TemporalSlaBackend implements ISlaBackend {
     return this.unavailable();
   }
 
-  async cancelSla(_ticketId: string): Promise<void> {
+  async cancelSla(_tenantId: string, _ticketId: string): Promise<void> {
     return this.unavailable();
   }
 

--- a/packages/msp-composition/src/tickets/registerSlaIntegration.ts
+++ b/packages/msp-composition/src/tickets/registerSlaIntegration.ts
@@ -16,9 +16,9 @@ export function registerSlaIntegration(): void {
   if (registered) return;
   registered = true;
 
-  registerSlaCancellation(async (ticketId: string) => {
+  registerSlaCancellation(async (tenantId: string, ticketId: string) => {
     const backend = await SlaBackendFactory.getBackend();
-    await backend.cancelSla(ticketId);
+    await backend.cancelSla(tenantId, ticketId);
   });
 
   registerItilSlaConfiguration(configureItilSlaForBoard);

--- a/packages/sla/src/services/__tests__/slaBackendIntegration.test.ts
+++ b/packages/sla/src/services/__tests__/slaBackendIntegration.test.ts
@@ -207,7 +207,7 @@ describe('SLA backend integration', () => {
 
     await handlePolicyChange(trx, 'tenant-1', 'ticket-1', 'policy-1');
 
-    expect(backendMock.cancelSla).toHaveBeenCalledWith('ticket-1');
+    expect(backendMock.cancelSla).toHaveBeenCalledWith('tenant-1', 'ticket-1');
     expect(backendMock.startSlaTracking).toHaveBeenCalled();
   });
 });

--- a/packages/sla/src/services/backends/ISlaBackend.ts
+++ b/packages/sla/src/services/backends/ISlaBackend.ts
@@ -20,6 +20,6 @@ export interface ISlaBackend {
     type: 'response' | 'resolution',
     met: boolean | null
   ): Promise<void>;
-  cancelSla(ticketId: string): Promise<void>;
+  cancelSla(tenantId: string, ticketId: string): Promise<void>;
   getSlaStatus(ticketId: string): Promise<ISlaStatus | null>;
 }

--- a/packages/sla/src/services/backends/PgBossSlaBackend.ts
+++ b/packages/sla/src/services/backends/PgBossSlaBackend.ts
@@ -55,7 +55,7 @@ export class PgBossSlaBackend implements ISlaBackend {
     });
   }
 
-  async cancelSla(_ticketId: string): Promise<void> {
+  async cancelSla(_tenantId: string, _ticketId: string): Promise<void> {
     // No-op placeholder; polling naturally excludes deleted tickets.
   }
 

--- a/packages/sla/src/services/backends/__tests__/pgBossSlaBackend.test.ts
+++ b/packages/sla/src/services/backends/__tests__/pgBossSlaBackend.test.ts
@@ -81,7 +81,7 @@ describe('PgBossSlaBackend', () => {
 
   it('cancelSla returns without error', async () => {
     const backend = new PgBossSlaBackend();
-    await expect(backend.cancelSla('ticket-1')).resolves.toBeUndefined();
+    await expect(backend.cancelSla('tenant-1', 'ticket-1')).resolves.toBeUndefined();
   });
 
   it('getSlaStatus delegates to slaService.getSlaStatus()', async () => {

--- a/packages/sla/src/services/slaService.ts
+++ b/packages/sla/src/services/slaService.ts
@@ -661,7 +661,7 @@ export async function handlePolicyChange(
 
     try {
       const backend = await SlaBackendFactory.getBackend();
-      await backend.cancelSla(ticketId);
+      await backend.cancelSla(tenant, ticketId);
     } catch (error) {
       console.warn('Failed to cancel SLA backend on policy clear:', error);
     }
@@ -735,7 +735,7 @@ export async function handlePolicyChange(
 
   try {
     const backend = await SlaBackendFactory.getBackend();
-    await backend.cancelSla(ticketId);
+    await backend.cancelSla(tenant, ticketId);
     await backend.startSlaTracking(ticketId, policy.sla_policy_id, [target], schedule);
   } catch (error) {
     console.warn('Failed to restart SLA backend on policy change:', error);

--- a/packages/tickets/src/actions/__tests__/ticketActions.sla.test.ts
+++ b/packages/tickets/src/actions/__tests__/ticketActions.sla.test.ts
@@ -92,6 +92,6 @@ describe('ticketActions deleteTicket', () => {
       'ticket-1'
     );
 
-    expect(backend.cancelSla).toHaveBeenCalledWith('ticket-1');
+    expect(backend.cancelSla).toHaveBeenCalledWith('tenant-1', 'ticket-1');
   });
 });

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -2518,7 +2518,8 @@ export const addTicketCommentWithCache = withAuth(async (
   ticketId: string,
   content: string,
   isInternal: boolean,
-  isResolution: boolean
+  isResolution: boolean,
+  closesTicket: boolean = false
 ): Promise<IComment> => {
   const {knex: db} = await createTenantKnex();
 
@@ -2597,6 +2598,10 @@ export const addTicketCommentWithCache = withAuth(async (
       is_resolution: isResolution,
       markdown_content: markdownContent,
       created_at: nowIso,
+      // The email subscriber reads metadata.closes_ticket and skips the
+      // comment-added email so the close email is the single source of
+      // truth when the UI is closing the ticket immediately after.
+      ...(closesTicket ? { metadata: { closes_ticket: true } } : {}),
     }).returning('*');
 
     // Update ticket response state based on comment visibility and author (F005-F008)
@@ -2767,9 +2772,10 @@ export async function addTicketCommentWithCacheForCurrentUser(
   ticketId: string,
   content: string,
   isInternal: boolean,
-  isResolution: boolean
+  isResolution: boolean,
+  closesTicket: boolean = false
 ): Promise<IComment> {
-  return addTicketCommentWithCache(ticketId, content, isInternal, isResolution);
+  return addTicketCommentWithCache(ticketId, content, isInternal, isResolution, closesTicket);
 }
 
 /**

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -70,9 +70,9 @@ import {
   shouldApplyOpenOnlyStatusFilter,
 } from '../lib/ticketStatusFilter';
 // SLA cancellation is injected by the composition layer to avoid tickets→sla cross-package violation
-let _cancelSlaFn: ((ticketId: string) => Promise<void>) | null = null;
+let _cancelSlaFn: ((tenantId: string, ticketId: string) => Promise<void>) | null = null;
 
-export async function registerSlaCancellation(fn: (ticketId: string) => Promise<void>): Promise<void> {
+export async function registerSlaCancellation(fn: (tenantId: string, ticketId: string) => Promise<void>): Promise<void> {
   _cancelSlaFn = fn;
 }
 
@@ -1571,7 +1571,7 @@ export const deleteTicket = withAuth(async (
     if (result.deleted) {
       try {
         if (_cancelSlaFn) {
-          await _cancelSlaFn(ticketId);
+          await _cancelSlaFn(tenant, ticketId);
         }
       } catch (error) {
         console.warn('[deleteTicket] Failed to cancel SLA backend workflow:', error);
@@ -1621,7 +1621,7 @@ export const deleteTickets = withAuth(async (user, { tenant }, ticketIds: string
       if (result.deleted) {
         try {
           if (_cancelSlaFn) {
-            await _cancelSlaFn(ticketId);
+            await _cancelSlaFn(tenant, ticketId);
           }
         } catch (error) {
           console.warn('[deleteTickets] Failed to cancel SLA backend workflow:', error);

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -100,6 +100,34 @@ const CLIENT_TAB_ID = 'client';
 const INTERNAL_TAB_ID = 'internal';
 const RESOLUTION_TAB_ID = 'resolution';
 
+// Hides inbound-email comments whose body is empty or contains only a reply
+// token marker. The token data still lives in the saved comment row so email
+// threading (token + In-Reply-To/References fallback) stays intact; this just
+// suppresses the noise in the conversation view.
+const REPLY_TOKEN_ONLY_REGEX = /^\s*\[ALGA-REPLY-TOKEN [^\]]+\]\s*$/;
+
+function extractCommentText(note: string | undefined | null): string {
+  if (!note) return '';
+  const matches = note.match(/"text":"((?:[^"\\]|\\.)*)"/g);
+  if (!matches) return note.trim();
+  let result = '';
+  for (const match of matches) {
+    const inner = match.slice('"text":"'.length, -1);
+    try {
+      result += JSON.parse(`"${inner}"`);
+    } catch {
+      result += inner;
+    }
+  }
+  return result.trim();
+}
+
+function isHiddenNoiseComment(comment: IComment): boolean {
+  const text = extractCommentText(comment.note);
+  if (text === '') return true;
+  return REPLY_TOKEN_ONLY_REGEX.test(text);
+}
+
 const TicketConversation: React.FC<TicketConversationProps> = ({
   id,
   ticket,
@@ -500,15 +528,29 @@ const TicketConversation: React.FC<TicketConversationProps> = ({
     );
   };
 
+  const visibleConversations = useMemo(() => {
+    const parentIds = new Set<string>();
+    for (const comment of conversations) {
+      if (comment.parent_comment_id) {
+        parentIds.add(comment.parent_comment_id);
+      }
+    }
+    return conversations.filter((comment) => {
+      if (!isHiddenNoiseComment(comment)) return true;
+      // Keep noise comments that have descendants so children don't orphan.
+      return comment.comment_id ? parentIds.has(comment.comment_id) : true;
+    });
+  }, [conversations]);
+
   const threadGroups = useMemo(
     () => buildCommentThreadGroups<IComment>({
-      comments: conversations,
+      comments: visibleConversations,
       getCommentId: (comment) => comment.comment_id,
       getThreadId: (comment) => comment.thread_id || comment.comment_id,
       getParentCommentId: (comment) => comment.parent_comment_id,
       getCreatedAt: (comment) => comment.created_at,
     }),
-    [conversations]
+    [visibleConversations]
   );
 
   const threadTabState = useMemo(

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -106,20 +106,32 @@ const RESOLUTION_TAB_ID = 'resolution';
 // suppresses the noise in the conversation view.
 const REPLY_TOKEN_ONLY_REGEX = /^\s*\[ALGA-REPLY-TOKEN [^\]]+\]\s*$/;
 
-function extractCommentText(note: string | undefined | null): string {
-  if (!note) return '';
-  const matches = note.match(/"text":"((?:[^"\\]|\\.)*)"/g);
-  if (!matches) return note.trim();
-  let result = '';
-  for (const match of matches) {
-    const inner = match.slice('"text":"'.length, -1);
-    try {
-      result += JSON.parse(`"${inner}"`);
-    } catch {
-      result += inner;
+function collectBlockNoteText(node: unknown): string {
+  if (typeof node === 'string') return node;
+  if (Array.isArray(node)) {
+    let out = '';
+    for (const item of node) out += collectBlockNoteText(item);
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    if (obj.type === 'text' && typeof obj.text === 'string') {
+      return obj.text;
+    }
+    if (Array.isArray(obj.content)) {
+      return collectBlockNoteText(obj.content);
     }
   }
-  return result.trim();
+  return '';
+}
+
+function extractCommentText(note: string | undefined | null): string {
+  if (!note) return '';
+  try {
+    return collectBlockNoteText(JSON.parse(note)).trim();
+  } catch {
+    return note.trim();
+  }
 }
 
 function isHiddenNoiseComment(comment: IComment): boolean {

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -134,7 +134,7 @@ interface TicketDetailsProps {
     // Optimized handlers
     onTicketUpdate?: (field: string, value: any) => Promise<void>;
     onBatchTicketUpdate?: (changes: Record<string, unknown>) => Promise<boolean>;
-    onAddComment?: (content: string, isInternal: boolean, isResolution: boolean) => Promise<void>;
+    onAddComment?: (content: string, isInternal: boolean, isResolution: boolean, closesTicket?: boolean) => Promise<void>;
     onUpdateDescription?: (content: string) => Promise<boolean>;
     isSubmitting?: boolean;
     /**
@@ -1484,12 +1484,22 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
             const markdownContent = await convertBlockNoteToMarkdown(newCommentContent);
             console.log("Converted markdown content:", markdownContent);
     
+            // The resolution toggle is paired with an immediate close when a
+            // close-status is selected and the ticket isn't already in that
+            // status. Surface that intent to the server so the email
+            // subscriber can suppress the duplicate comment email — the
+            // close email will carry the resolution body.
+            const willCloseTicket = Boolean(
+                isResolution && closeStatusId && ticket.status_id !== closeStatusId
+            );
+
             // Use the optimized handler if provided
             if (onAddComment) {
                 await onAddComment(
                     JSON.stringify(newCommentContent),
                     isInternal,
-                    isResolution
+                    isResolution,
+                    willCloseTicket
                 );
 
                 // Optimistically update the response state in UI to match server behavior:
@@ -1545,7 +1555,9 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
                         is_internal: isInternal,
                         is_resolution: isResolution,
                         user_id: userId,
-                        author_type: 'internal' // Will be overridden based on user type in the action
+                        author_type: 'internal', // Will be overridden based on user type in the action
+                        // See email-subscriber suppression note above.
+                        ...(willCloseTicket ? { metadata: { closes_ticket: true } } : {})
                     });
                     
                     if (newComment) {

--- a/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetailsContainer.tsx
@@ -199,7 +199,12 @@ export default function TicketDetailsContainer({
     });
   }, [router, session?.user, t, ticketData.ticket.ticket_id, withSubmitting]);
 
-  const handleAddComment = async (content: string, isInternal: boolean, isResolution: boolean) => {
+  const handleAddComment = async (
+    content: string,
+    isInternal: boolean,
+    isResolution: boolean,
+    closesTicket: boolean = false
+  ) => {
     if (!session?.user) {
       toast.error(t('errors.authRequiredComment', 'You must be logged in to add comments'));
       return;
@@ -211,7 +216,8 @@ export default function TicketDetailsContainer({
         ticketData.ticket.ticket_id,
         content,
         isInternal,
-        isResolution
+        isResolution,
+        closesTicket
       );
 
       setComments(prev => [...prev, newComment]);

--- a/packages/types/src/interfaces/sla.interfaces.ts
+++ b/packages/types/src/interfaces/sla.interfaces.ts
@@ -155,6 +155,6 @@ export interface ISlaBackend {
     type: 'response' | 'resolution',
     met: boolean
   ): Promise<void>;
-  cancelSla(ticketId: string): Promise<void>;
+  cancelSla(tenantId: string, ticketId: string): Promise<void>;
   getSlaStatus(ticketId: string): Promise<ISlaStatus | null>;
 }

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -979,10 +979,7 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
       const descriptionComment = await db('comments')
         .select('note')
         .where({ ticket_id: ticket.ticket_id, tenant: tenantId })
-        .orderBy([
-          { column: 'is_initial_description', order: 'desc' },
-          { column: 'created_at', order: 'asc' }
-        ])
+        .orderBy('created_at', 'asc')
         .first();
       if (descriptionComment?.note) {
         rawDescription = safeString(descriptionComment.note);
@@ -2296,11 +2293,13 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     let commentAuthorUserId: string | null = commentUserId || null;
     let commentAuthorContactId: string | null = null;
     let commentAuthorEmail = '';
+    let commentIsResolution = false;
 
     if (payload.comment?.id) {
       const commentAuthor = await db('comments as cm')
         .select(
           'cm.user_id as comment_user_id',
+          'cm.is_resolution as comment_is_resolution',
           'cu.contact_id as comment_contact_id',
           'cu.email as comment_user_email',
           'cc.email as comment_contact_email'
@@ -2319,6 +2318,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
         })
         .first<{
           comment_user_id?: string | null;
+          comment_is_resolution?: boolean | null;
           comment_contact_id?: string | null;
           comment_user_email?: string | null;
           comment_contact_email?: string | null;
@@ -2330,6 +2330,32 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
         commentAuthorEmail =
           safeString(commentAuthor.comment_user_email) ||
           safeString(commentAuthor.comment_contact_email);
+        commentIsResolution = Boolean(commentAuthor.comment_is_resolution);
+      }
+    }
+
+    // Resolution comments are typically followed by a status change to closed
+    // in the same user action; the ticket-closed email already embeds the
+    // resolution content. The comment handler can race ahead of the close
+    // handler (comment insert is published before the status update), so
+    // defer briefly and re-check ticket state. If the ticket was closed
+    // within the deferral window, skip — the close email covers it. If no
+    // close arrives (resolution comment without status change), send normally.
+    if (commentIsResolution) {
+      await new Promise(resolve => setTimeout(resolve, 5_000));
+      const refreshed = await fetchTicketForEmail(db, tenantId, payload.ticketId);
+      const closedAtRaw = refreshed?.closed_at;
+      const closedAtMs = closedAtRaw instanceof Date
+        ? closedAtRaw.getTime()
+        : closedAtRaw
+          ? new Date(closedAtRaw).getTime()
+          : NaN;
+      if (refreshed?.is_closed && Number.isFinite(closedAtMs) && Date.now() - closedAtMs <= 30_000) {
+        logger.info('[TicketEmailSubscriber] Skipping comment email for resolution comment on recently-closed ticket', {
+          ticketId: payload.ticketId,
+          commentId: payload.comment?.id,
+        });
+        return;
       }
     }
 

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -2293,13 +2293,13 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     let commentAuthorUserId: string | null = commentUserId || null;
     let commentAuthorContactId: string | null = null;
     let commentAuthorEmail = '';
-    let commentIsResolution = false;
+    let commentClosesTicket = false;
 
     if (payload.comment?.id) {
       const commentAuthor = await db('comments as cm')
         .select(
           'cm.user_id as comment_user_id',
-          'cm.is_resolution as comment_is_resolution',
+          'cm.metadata as comment_metadata',
           'cu.contact_id as comment_contact_id',
           'cu.email as comment_user_email',
           'cc.email as comment_contact_email'
@@ -2318,7 +2318,7 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
         })
         .first<{
           comment_user_id?: string | null;
-          comment_is_resolution?: boolean | null;
+          comment_metadata?: Record<string, unknown> | null;
           comment_contact_id?: string | null;
           comment_user_email?: string | null;
           comment_contact_email?: string | null;
@@ -2330,33 +2330,22 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
         commentAuthorEmail =
           safeString(commentAuthor.comment_user_email) ||
           safeString(commentAuthor.comment_contact_email);
-        commentIsResolution = Boolean(commentAuthor.comment_is_resolution);
+        commentClosesTicket = commentAuthor.comment_metadata?.closes_ticket === true;
       }
     }
 
-    // Resolution comments are typically followed by a status change to closed
-    // in the same user action; the ticket-closed email already embeds the
-    // resolution content. The comment handler can race ahead of the close
-    // handler (comment insert is published before the status update), so
-    // defer briefly and re-check ticket state. If the ticket was closed
-    // within the deferral window, skip — the close email covers it. If no
-    // close arrives (resolution comment without status change), send normally.
-    if (commentIsResolution) {
-      await new Promise(resolve => setTimeout(resolve, 5_000));
-      const refreshed = await fetchTicketForEmail(db, tenantId, payload.ticketId);
-      const closedAtRaw = refreshed?.closed_at;
-      const closedAtMs = closedAtRaw instanceof Date
-        ? closedAtRaw.getTime()
-        : closedAtRaw
-          ? new Date(closedAtRaw).getTime()
-          : NaN;
-      if (refreshed?.is_closed && Number.isFinite(closedAtMs) && Date.now() - closedAtMs <= 30_000) {
-        logger.info('[TicketEmailSubscriber] Skipping comment email for resolution comment on recently-closed ticket', {
-          ticketId: payload.ticketId,
-          commentId: payload.comment?.id,
-        });
-        return;
-      }
+    // When the caller knows the comment is paired with an immediate close
+    // (UI sets metadata.closes_ticket=true at insert), suppress the comment
+    // email — the ticket-closed email carries the resolution body. This is
+    // deterministic: no race with the close event, no per-message sleep.
+    // Resolution comments that are NOT paired with a close (no flag set)
+    // still send their email as normal.
+    if (commentClosesTicket) {
+      logger.info('[TicketEmailSubscriber] Skipping comment email; comment is paired with an immediate ticket close', {
+        ticketId: payload.ticketId,
+        commentId: payload.comment?.id,
+      });
+      return;
     }
 
     if (!commentAuthorEmail && payload.comment?.author && isValidEmail(payload.comment.author)) {


### PR DESCRIPTION
  Stop ordering the ticket-created description fallback by the long-dropped
  is_initial_description column (caused a 42703 failure that aborted the
  TICKET_CREATED handler before any email could send). Suppress the
  TICKET_COMMENT_ADDED email when a resolution comment is followed by a
  close within 5s — the ticket-closed email already embeds the resolution
  text, so the comment email was a duplicate.

  🌪️  And so the column we had buried in March's migration kept whispering
  its name from the ORDER BY, until at last we hushed it; and the
  resolution note, which had been knocking twice upon every door, learned
  to wait five seconds — just long enough to see whether the ticket
  intended to close behind it. 🐇📬