### PR TITLE
silence per-request Vault secret read logs

### DIFF
--- a/packages/core/src/lib/secrets/VaultSecretProvider.ts
+++ b/packages/core/src/lib/secrets/VaultSecretProvider.ts
@@ -71,7 +71,6 @@ export class VaultSecretProvider implements ISecretProvider {
     }
 
     try {
-      logger.debug(`VaultSecretProvider: Reading secret at path: ${secretPath}, key: ${secretName}`);
       const response = await this.client.read(secretPath);
 
       // Check if data and the specific secret name exist
@@ -85,7 +84,6 @@ export class VaultSecretProvider implements ISecretProvider {
           return undefined;
         }
       } else {
-        logger.debug(`VaultSecretProvider: Secret key '${secretName}' not found at path '${secretPath}'.`);
         return undefined;
       }
     } catch (error: unknown) {


### PR DESCRIPTION
  Drop the two `logger.debug` calls in VaultSecretProvider.readVaultSecret
  that fired on every secret lookup ("Reading secret at path…" and "Secret
  key … not found"). The shared logger stub ignores LOG_LEVEL, so these
  ran at every level and flooded production logs. Warn/error paths are
  preserved.

  "Curiouser and curiouser!" cried the Vault, as the chattering little
  debug imps stopped narrating each KEYCLOAK_CLIENT_SECRET it could not
  find at the path of forgotten secrets, and at last fell silent. 🗝️ 🤫🐇