### PR TITLE
Fix appliance status port conflict on release 1.0

### DIFF
--- a/ee/appliance/flux/base/platform/appliance-status.yaml
+++ b/ee/appliance/flux/base/platform/appliance-status.yaml
@@ -67,8 +67,7 @@ spec:
       labels:
         app.kubernetes.io/name: appliance-status
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       serviceAccountName: appliance-status
       automountServiceAccountToken: true
       containers:


### PR DESCRIPTION
## Summary
- remove hostNetwork from appliance-status on release/1.0.0
- use ClusterFirst DNS policy so the in-cluster status pod does not bind the host's port 8080

## Why
The Ubuntu host setup/status service already listens on port 8080. With hostNetwork=true, the in-cluster appliance-status pod crashes with EADDRINUSE when it also tries to bind 0.0.0.0:8080.

## Validation
- kubectl apply --dry-run=client -f ee/appliance/flux/base/platform/appliance-status.yaml
- confirmed manifest now only has dnsPolicy: ClusterFirst and no hostNetwork entry for appliance-status