### PR TITLE
docs: asset management documentation update (2026-05-27)

### DIFF
--- a/docs/features/asset_management.md
+++ b/docs/features/asset_management.md
@@ -76,7 +76,7 @@ CREATE TABLE assets (
     tenant UUID NOT NULL REFERENCES tenants,
     asset_id UUID DEFAULT gen_random_uuid() NOT NULL,
     type_id UUID NOT NULL,
-    company_id UUID NOT NULL, -- Client association
+    client_id UUID NOT NULL, -- Client association
     asset_tag TEXT NOT NULL,
     serial_number TEXT,
     name TEXT NOT NULL,
@@ -89,7 +89,7 @@ CREATE TABLE assets (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (tenant, asset_id),
     FOREIGN KEY (tenant, type_id) REFERENCES asset_types(tenant, type_id),
-    FOREIGN KEY (tenant, company_id) REFERENCES companies(tenant, company_id),
+    FOREIGN KEY (tenant, client_id) REFERENCES clients(tenant, client_id),
     FOREIGN KEY (tenant, location_id) REFERENCES client_locations(tenant, location_id)
 );
 ```

--- a/docs/features/asset_management.md
+++ b/docs/features/asset_management.md
@@ -13,10 +13,26 @@ The Asset Management System is a comprehensive solution for managing IT assets w
 ### Asset Tracking
 - Unique asset identification
 - Serial number tracking
-- Location management
+- Location management (free-text `location` field and structured `location_id` FK to `client_locations`)
 - Warranty tracking
 - Client association
 - Status management
+
+### Location Linking
+
+Assets can be linked to a saved client location record (`client_locations`) via the `location_id` UUID field, in addition to the free-text `location` string. When a saved location is selected in the UI, the formatted address is auto-populated into the free-text field but can be overridden with a more specific descriptor (e.g. "Server room — Rack 3").
+
+The REST API (`GET /api/v1/assets`, `POST /api/v1/assets`, `PUT /api/v1/assets/:id`) includes `location_id` as an optional nullable UUID on create, update, and read payloads. The list endpoint accepts `location_id` as a query filter to retrieve all assets at a specific site. The server validates that the supplied `location_id` belongs to the asset's client (active locations only); changing the client without supplying a new `location_id` automatically clears any stale location association.
+
+### Bulk Asset Actions
+
+The asset dashboard supports three bulk operations accessible from the action bar at the bottom of the asset list:
+
+- **Set Status** — update the status of up to 100 selected assets at once.
+- **Set Location** — assign a saved client location, enter a custom free-text location, or clear the location for up to 100 selected assets at once.
+- **Delete** — permanently delete up to 100 selected assets, with a confirmation dialog before proceeding.
+
+Bulk operations run with controlled concurrency (5 at a time) and produce a per-asset success/failure report via toast notifications.
 
 ### Asset Relationships
 - Parent/child relationship tracking
@@ -66,13 +82,15 @@ CREATE TABLE assets (
     name TEXT NOT NULL,
     status TEXT NOT NULL,
     location TEXT,
+    location_id UUID,            -- Optional FK to client_locations; validated against the asset's client
     purchase_date DATE,
     warranty_end_date DATE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (tenant, asset_id),
     FOREIGN KEY (tenant, type_id) REFERENCES asset_types(tenant, type_id),
-    FOREIGN KEY (tenant, company_id) REFERENCES companies(tenant, company_id)
+    FOREIGN KEY (tenant, company_id) REFERENCES companies(tenant, company_id),
+    FOREIGN KEY (tenant, location_id) REFERENCES client_locations(tenant, location_id)
 );
 ```
 
@@ -209,6 +227,14 @@ CREATE TABLE asset_history (
   - Extension tables ✓
   - Specialized fields ✓
   - Efficient querying ✓
+- Location linking ✓
+  - Structured FK to client_locations ✓
+  - REST API location_id field and filter ✓
+  - Client validation on create/update ✓
+- Bulk asset actions ✓
+  - Set status ✓
+  - Set location ✓
+  - Delete ✓
 - Advanced reporting
   - Custom report builder
   - Dashboard integration
@@ -305,7 +331,6 @@ CREATE TABLE asset_history (
 - Extension table partitioning
 
 ### Integration Expansion
-- API development
 - Third-party integrations
 - Mobile access
 - Client portal features


### PR DESCRIPTION
## Source PR

- [#2568 Assets location](https://github.com/Nine-Minds/alga-psa/pull/2568) — adds structured `location_id` FK to `client_locations` on the `assets` table, new REST API field + list filter, and three working bulk actions (Set Status, Set Location, Delete) replacing the previous "coming soon" stub.

## Files edited

### `docs/features/asset_management.md`

**Why:** The doc showed only the free-text `location TEXT` column in the assets table schema and made no mention of structured location linking, the `location_id` FK, REST API field changes, or bulk asset actions. All four omissions are now substantive user- and developer-visible behaviors introduced by #2568.

**What changed:**
- Updated "Asset Tracking" bullet to note both free-text and structured `location_id` linking.
- Added new **Location Linking** section explaining the `location_id` FK to `client_locations`, the UI auto-populate behavior, the REST API fields (`location_id` on create/update/read payloads and as a `GET /api/v1/assets` filter), and the server-side client-ownership validation.
- Added new **Bulk Asset Actions** section describing the three actions (Set Status, Set Location, Delete), the 100-asset limit, controlled concurrency, and toast reporting.
- Updated the `assets` SQL table schema to include `location_id UUID` with its FK constraint to `client_locations`.
- Marked Location linking and Bulk asset actions as complete (✓) in the Implementation Phases section.

## Needs human review

- **OpenAPI regeneration:** PR #2568 added `location_id` to the REST assets routes (`server/src/lib/api/openapi/routes/assets.ts`). The OpenAPI spec at `sdk/docs/openapi/` and `packages/nm-store/public/openapi/alga.json` may be stale — please regenerate via `cd sdk && npm run openapi:generate` and re-sync the result to nm-store.
- **PR #2566 "silence per-request Vault secret read logs"** — pure internal logging change (drops two `logger.debug` calls in VaultSecretProvider). No doc impact assessed.
- **PR #2564 "Fix ticket email duplicates and dropped-column query"** — fixes a crash in the TICKET_CREATED email handler (dropped column in ORDER BY) and suppresses the duplicate TICKET_COMMENT_ADDED email when a resolution comment is paired with an immediate close. This is user-visible (one fewer email in the resolve-and-close flow) but no in-scope doc currently covers ticket email notification behavior. Consider whether this warrants a new doc page or a note in an existing notifications guide.
- **PR #2562 "Teams observability"** — internal EE Microsoft Teams addon observability (new `teams_notification_deliveries` and `teams_audit_events` tables, new `teams_integration:read` permission seeded for admin roles). All changed files are in `ee/packages/microsoft-teams/` and test directories. No in-scope doc impact assessed; if there is a user-visible admin UI for reviewing Teams delivery history, that surface may need its own doc page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2AZXsAV2jwEEaEAHtnXX)_