### PR TITLE
Render onboarding redirect fallback

### DIFF
--- a/server/public/locales/de/msp/core.json
+++ b/server/public/locales/de/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Weiter zur Einrichtung",
+    "description": "Ihr Arbeitsbereich muss kurz eingerichtet werden, bevor Sie das Dashboard verwenden können.",
+    "action": "Mit der Einrichtung fortfahren"
   }
 }

--- a/server/public/locales/en/msp/core.json
+++ b/server/public/locales/en/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Taking you to setup",
+    "description": "Your workspace needs a quick setup before you can use the dashboard.",
+    "action": "Continue to setup"
   }
 }

--- a/server/public/locales/es/msp/core.json
+++ b/server/public/locales/es/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Te llevamos a la configuración",
+    "description": "Tu espacio de trabajo necesita una configuración rápida antes de que puedas usar el panel.",
+    "action": "Continuar a la configuración"
   }
 }

--- a/server/public/locales/fr/msp/core.json
+++ b/server/public/locales/fr/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Redirection vers la configuration",
+    "description": "Votre espace de travail nécessite une configuration rapide avant d’utiliser le tableau de bord.",
+    "action": "Continuer vers la configuration"
   }
 }

--- a/server/public/locales/it/msp/core.json
+++ b/server/public/locales/it/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Ti portiamo alla configurazione",
+    "description": "Il tuo workspace richiede una rapida configurazione prima di poter usare la dashboard.",
+    "action": "Continua alla configurazione"
   }
 }

--- a/server/public/locales/nl/msp/core.json
+++ b/server/public/locales/nl/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "We brengen je naar de configuratie",
+    "description": "Je werkruimte heeft een korte configuratie nodig voordat je het dashboard kunt gebruiken.",
+    "action": "Doorgaan naar configuratie"
   }
 }

--- a/server/public/locales/pl/msp/core.json
+++ b/server/public/locales/pl/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Przenosimy do konfiguracji",
+    "description": "Twój obszar roboczy wymaga krótkiej konfiguracji, zanim będzie można używać pulpitu.",
+    "action": "Przejdź do konfiguracji"
   }
 }

--- a/server/public/locales/pt/msp/core.json
+++ b/server/public/locales/pt/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "Previous",
       "next": "Next"
     }
+  },
+  "onboardingRedirect": {
+    "title": "Levando você para a configuração",
+    "description": "Seu espaço de trabalho precisa de uma configuração rápida antes que você possa usar o painel.",
+    "action": "Continuar para a configuração"
   }
 }

--- a/server/public/locales/xx/msp/core.json
+++ b/server/public/locales/xx/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "11111",
       "next": "11111"
     }
+  },
+  "onboardingRedirect": {
+    "title": "11111",
+    "description": "11111",
+    "action": "11111"
   }
 }

--- a/server/public/locales/yy/msp/core.json
+++ b/server/public/locales/yy/msp/core.json
@@ -322,5 +322,10 @@
       "previous": "55555",
       "next": "55555"
     }
+  },
+  "onboardingRedirect": {
+    "title": "55555",
+    "description": "55555",
+    "action": "55555"
   }
 }

--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -9,6 +9,7 @@ import { PostHogUserIdentifier } from "@alga-psa/ui/components/analytics/PostHog
 import { ClientUIStateProvider } from "@alga-psa/ui/ui-reflection/ClientUIStateProvider";
 import { I18nWrapper } from "@alga-psa/tenancy/components";
 import { getTenantSettings } from "@alga-psa/tenancy/actions";
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { AIChatContextProvider } from '@product/chat/context';
 import { TierProvider } from "@/context/TierContext";
 import { ProductProvider } from "@/context/ProductContext";
@@ -29,6 +30,31 @@ interface Props {
   needsOnboarding: boolean;
   initialSidebarCollapsed: boolean;
   initialLocale?: SupportedLocale | null;
+}
+
+function OnboardingRedirectFallback() {
+  const { t } = useTranslation('msp/core');
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[rgb(var(--color-background))] px-6">
+      <div className="max-w-md text-center" role="status" aria-live="polite">
+        <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-2 border-[rgb(var(--color-border-300))] border-t-[rgb(var(--color-primary-500))]" />
+        <h1 className="text-lg font-semibold text-[rgb(var(--color-text-900))]">
+          {t('onboardingRedirect.title')}
+        </h1>
+        <p className="mt-2 text-sm text-[rgb(var(--color-text-600))]">
+          {t('onboardingRedirect.description')}
+        </p>
+        <a
+          id="msp-onboarding-redirect-fallback-link"
+          href="/msp/onboarding"
+          className="mt-4 inline-flex text-sm font-medium text-[rgb(var(--color-primary-600))] underline-offset-4 hover:underline"
+        >
+          {t('onboardingRedirect.action')}
+        </a>
+      </div>
+    </div>
+  );
 }
 
 export function MspLayoutClient({
@@ -89,13 +115,11 @@ export function MspLayoutClient({
     };
   }, [needsOnboarding, isOnboardingPage, sessionTenant, router]);
 
-  if (shouldForceOnboarding && !isOnboardingPage) {
-    return null;
-  }
-
   const isAlgaDesk = productCode === 'algadesk';
 
-  const content = (
+  const content = shouldForceOnboarding && !isOnboardingPage ? (
+    <OnboardingRedirectFallback />
+  ) : (
     <AppSessionProvider session={session}>
       <ProductProvider>
         <TierProvider>

--- a/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
+++ b/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
@@ -37,12 +37,30 @@ vi.mock('@alga-psa/tenancy/actions', () => ({
   getTenantSettings: vi.fn(),
 }));
 
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({
+      'onboardingRedirect.title': 'Taking you to setup',
+      'onboardingRedirect.description': 'Your workspace needs a quick setup before you can use the dashboard.',
+      'onboardingRedirect.action': 'Continue to setup',
+    }[key] ?? key),
+  }),
+}));
+
 vi.mock('@/context/TierContext', () => ({
   TierProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('@/context/ProductContext', () => ({
   ProductProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@alga-psa/ui/keyboard-shortcuts', () => ({
+  KeyboardShortcutsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/useKeyboardShortcutPreferenceStorage', () => ({
+  useKeyboardShortcutPreferenceStorage: () => ({ storage: undefined }),
 }));
 
 vi.mock('@/components/layout/DefaultLayout', () => ({
@@ -96,6 +114,23 @@ describe('MspLayoutClient product shell behavior', () => {
 
     expect(screen.getByTestId('psa-default-layout')).toBeInTheDocument();
     expect(screen.queryByTestId('algadesk-shell')).not.toBeInTheDocument();
+  });
+
+  it('RT006: renders an onboarding redirect fallback instead of a blank screen', () => {
+    render(
+      <MspLayoutClient
+        session={{ user: { tenant: 'tenant-1' } } as any}
+        productCode="psa"
+        needsOnboarding={true}
+        initialSidebarCollapsed={false}
+      >
+        <div>psa content</div>
+      </MspLayoutClient>,
+    );
+
+    expect(screen.getByText('Taking you to setup')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Continue to setup' })).toHaveAttribute('href', '/msp/onboarding');
+    expect(screen.queryByText('psa content')).not.toBeInTheDocument();
   });
 
   it('RT006: client fallback redirects AlgaDesk tenants when onboarding is incomplete', async () => {


### PR DESCRIPTION
## Summary
- Replace the blank onboarding redirect state with a visible setup redirect fallback.
- Add a manual fallback link to `/msp/onboarding` in case client-side navigation is delayed or stale.
- Localize the redirect fallback labels through the existing `msp/core` namespace.
- Cover the redirect fallback in the MSP layout unit test.

## Testing
- `cd server && npx vitest src/test/unit/layout/MspLayoutClient.productShell.test.tsx --coverage.enabled=false`
- `node scripts/validate-translations.cjs`

No customer-specific details are included.