### PR TITLE
Bulk-apply tags to selected project tasks

### DIFF
--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -21,9 +21,16 @@ import type {
   ITaskType,
   IUser,
   IUserWithRoles,
+  PendingTag,
   ProjectStatus,
 } from '@alga-psa/types';
-import { findTagsByEntityIds } from '@alga-psa/tags/actions';
+import { revalidatePath } from 'next/cache';
+import {
+  captureEntityTagTextSnapshot,
+  createTagsForEntityWithTransaction,
+  findTagsByEntityIds,
+  publishEntityTagBulkUpdate,
+} from '@alga-psa/tags/actions';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { validateArray, validateData } from '@alga-psa/validation';
@@ -2897,4 +2904,125 @@ export const getProjectTaskData = withAuth(async (
 
         return { tasks, taskResources, taskTags, checklistItems, taskDependencies };
     });
+});
+
+export const bulkAddTagsToTasks = withAuth(async (
+  user,
+  { tenant },
+  taskIds: string[],
+  tagTexts: string[],
+): Promise<{
+  updatedIds: string[];
+  failed: Array<{ taskId: string; message: string }>;
+}> => {
+  const uniqueIds = Array.from(new Set(taskIds.filter((id) => !!id)));
+  const normalizedTexts = Array.from(
+    new Set(tagTexts.map((t) => t.trim()).filter((t) => t.length > 0)),
+  );
+
+  const updatedIds: string[] = [];
+  const failed: Array<{ taskId: string; message: string }> = [];
+
+  if (uniqueIds.length === 0 || normalizedTexts.length === 0) {
+    return { updatedIds, failed };
+  }
+
+  const { knex } = await createTenantKnex();
+  if (!(await hasPermission(user, 'project', 'update', knex))) {
+    throw new Error('Permission denied: Cannot update project tasks');
+  }
+
+  // Filter to task IDs that actually exist in this tenant. tag_mappings.tagged_id
+  // has no FK to project_tasks, so without this we'd silently insert orphan
+  // mappings for any UUID a project:update holder submits.
+  const existingTaskRows = await knex('project_tasks')
+    .where('tenant', tenant)
+    .whereIn('task_id', uniqueIds)
+    .select<Array<{ task_id: string }>>('task_id');
+  const knownTaskIds = new Set<string>(existingTaskRows.map((row) => row.task_id));
+  const validIds: string[] = [];
+  for (const id of uniqueIds) {
+    if (knownTaskIds.has(id)) {
+      validIds.push(id);
+    } else {
+      failed.push({ taskId: id, message: 'Task not found' });
+    }
+  }
+
+  if (validIds.length === 0) {
+    return { updatedIds, failed };
+  }
+
+  const existingByTask = new Map<string, Set<string>>();
+  try {
+    const existing = await findTagsByEntityIds(validIds, 'project_task');
+    for (const tag of existing) {
+      const set = existingByTask.get(tag.tagged_id) ?? new Set<string>();
+      set.add(tag.tag_text.toLowerCase());
+      existingByTask.set(tag.tagged_id, set);
+    }
+  } catch (error) {
+    console.warn('[bulkAddTagsToTasks] Failed to load existing tags for dedupe:', error);
+  }
+
+  for (const taskId of validIds) {
+    try {
+      const alreadyOnTask = existingByTask.get(taskId) ?? new Set<string>();
+      const newTexts = normalizedTexts.filter((t) => !alreadyOnTask.has(t.toLowerCase()));
+      if (newTexts.length === 0) {
+        updatedIds.push(taskId);
+        continue;
+      }
+      const pendingTags: PendingTag[] = newTexts.map((text) => ({
+        tag_text: text,
+        background_color: null,
+        text_color: null,
+        isNew: true,
+      }));
+
+      let createdTexts: string[] = [];
+      await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const previousSnapshot = await captureEntityTagTextSnapshot(
+          trx, tenant, taskId, 'project_task',
+        );
+        const created = await createTagsForEntityWithTransaction(
+          trx, tenant, taskId, 'project_task', pendingTags,
+        );
+        createdTexts = created.map((tag) => tag.tag_text);
+        // createTagsForEntityWithTransaction intentionally suppresses the
+        // per-entity update event; emit it here so search/webhook consumers
+        // see one PROJECT_TASK_UPDATED per task that actually changed.
+        await publishEntityTagBulkUpdate({
+          trx,
+          tenant,
+          taggedId: taskId,
+          taggedType: 'project_task',
+          userId: user.user_id,
+          previousTags: previousSnapshot,
+        });
+      });
+
+      const createdLower = new Set(createdTexts.map((t) => t.toLowerCase()));
+      const dropped = newTexts.filter((t) => !createdLower.has(t.toLowerCase()));
+      if (dropped.length > 0) {
+        failed.push({
+          taskId,
+          message: `Could not add tag(s): ${dropped.join(', ')}`,
+        });
+      } else {
+        updatedIds.push(taskId);
+      }
+    } catch (error: unknown) {
+      failed.push({
+        taskId,
+        message: error instanceof Error ? error.message : 'Failed to add tags to task',
+      });
+    }
+  }
+
+  if (updatedIds.length > 0) {
+    revalidatePath('/msp/projects');
+  }
+
+  return { updatedIds, failed };
 });

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -21,15 +21,12 @@ import type {
   ITaskType,
   IUser,
   IUserWithRoles,
-  PendingTag,
   ProjectStatus,
 } from '@alga-psa/types';
 import { revalidatePath } from 'next/cache';
 import {
-  captureEntityTagTextSnapshot,
-  createTagsForEntityWithTransaction,
+  bulkApplyTagsToEntities,
   findTagsByEntityIds,
-  publishEntityTagBulkUpdate,
 } from '@alga-psa/tags/actions';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
@@ -2916,9 +2913,16 @@ export const bulkAddTagsToTasks = withAuth(async (
   failed: Array<{ taskId: string; message: string }>;
 }> => {
   const uniqueIds = Array.from(new Set(taskIds.filter((id) => !!id)));
-  const normalizedTexts = Array.from(
-    new Set(tagTexts.map((t) => t.trim()).filter((t) => t.length > 0)),
-  );
+  // Dedupe case-insensitively (keeping first-seen casing) so it matches the
+  // lower-cased existing-tag and applied-tag comparisons used downstream.
+  const normalizedTextByLower = new Map<string, string>();
+  for (const raw of tagTexts) {
+    const text = raw.trim();
+    if (!text) continue;
+    const lower = text.toLowerCase();
+    if (!normalizedTextByLower.has(lower)) normalizedTextByLower.set(lower, text);
+  }
+  const normalizedTexts = Array.from(normalizedTextByLower.values());
 
   const updatedIds: string[] = [];
   const failed: Array<{ taskId: string; message: string }> = [];
@@ -2953,70 +2957,100 @@ export const bulkAddTagsToTasks = withAuth(async (
     return { updatedIds, failed };
   }
 
-  const existingByTask = new Map<string, Set<string>>();
+  // Load each task's current tags once (batched) for before/after snapshots
+  // and dedupe — bulkApplyTagsToEntities resolves definitions and applies the
+  // mappings in one pass rather than per task.
+  const existingByTask = new Map<string, string[]>();
   try {
     const existing = await findTagsByEntityIds(validIds, 'project_task');
     for (const tag of existing) {
-      const set = existingByTask.get(tag.tagged_id) ?? new Set<string>();
-      set.add(tag.tag_text.toLowerCase());
-      existingByTask.set(tag.tagged_id, set);
+      const texts = existingByTask.get(tag.tagged_id) ?? [];
+      texts.push(tag.tag_text);
+      existingByTask.set(tag.tagged_id, texts);
     }
   } catch (error) {
     console.warn('[bulkAddTagsToTasks] Failed to load existing tags for dedupe:', error);
   }
 
-  for (const taskId of validIds) {
-    try {
-      const alreadyOnTask = existingByTask.get(taskId) ?? new Set<string>();
-      const newTexts = normalizedTexts.filter((t) => !alreadyOnTask.has(t.toLowerCase()));
-      if (newTexts.length === 0) {
-        updatedIds.push(taskId);
-        continue;
+  const unauthorizedIds = new Set<string>();
+  let appliedByEntity: Record<string, string[]> = {};
+  try {
+    const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      // The global project:update grant above isn't enough: a client can submit
+      // task IDs from projects the caller can't read. Authorize each task's
+      // project (resolved once per distinct project, not per task) the same way
+      // every other task mutation here does, and drop tasks that fail.
+      const taskProjectRows = await trx('project_tasks as pt')
+        .join('project_phases as pp', function joinPhases() {
+          this.on('pt.phase_id', '=', 'pp.phase_id')
+            .andOn('pt.tenant', '=', 'pp.tenant');
+        })
+        .where('pt.tenant', tenant)
+        .whereIn('pt.task_id', validIds)
+        .select<Array<{ task_id: string; project_id: string }>>('pt.task_id', 'pp.project_id');
+      const projectIdByTask = new Map(taskProjectRows.map((row) => [row.task_id, row.project_id]));
+
+      const authorizeProjectRead = await createProjectReadAuthorizer(trx, tenant, user as IUserWithRoles);
+      const projectAllowed = new Map<string, boolean>();
+      const isProjectAllowed = async (projectId: string): Promise<boolean> => {
+        const cached = projectAllowed.get(projectId);
+        if (cached !== undefined) return cached;
+        const project = await ProjectModel.getById(trx, tenant, projectId);
+        const allowed = !!project && (await authorizeProjectRead(project));
+        projectAllowed.set(projectId, allowed);
+        return allowed;
+      };
+
+      const authorizedIds: string[] = [];
+      for (const taskId of validIds) {
+        const projectId = projectIdByTask.get(taskId);
+        if (projectId && (await isProjectAllowed(projectId))) {
+          authorizedIds.push(taskId);
+        } else {
+          unauthorizedIds.add(taskId);
+        }
       }
-      const pendingTags: PendingTag[] = newTexts.map((text) => ({
-        tag_text: text,
-        background_color: null,
-        text_color: null,
-        isNew: true,
+
+      if (authorizedIds.length === 0) {
+        return { appliedByEntity: {} as Record<string, string[]> };
+      }
+
+      const applications = authorizedIds.map((taskId) => ({
+        entityId: taskId,
+        existingTexts: existingByTask.get(taskId) ?? [],
+        newTexts: normalizedTexts,
       }));
+      return bulkApplyTagsToEntities(trx, tenant, 'project_task', applications);
+    });
+    appliedByEntity = result.appliedByEntity;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to add tags to tasks';
+    // The whole batch shares one transaction, so a throw fails every valid task;
+    // keep the not-found entries already collected above.
+    return {
+      updatedIds: [],
+      failed: [...failed, ...validIds.map((taskId) => ({ taskId, message }))],
+    };
+  }
 
-      let createdTexts: string[] = [];
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
-        const previousSnapshot = await captureEntityTagTextSnapshot(
-          trx, tenant, taskId, 'project_task',
-        );
-        const created = await createTagsForEntityWithTransaction(
-          trx, tenant, taskId, 'project_task', pendingTags,
-        );
-        createdTexts = created.map((tag) => tag.tag_text);
-        // createTagsForEntityWithTransaction intentionally suppresses the
-        // per-entity update event; emit it here so search/webhook consumers
-        // see one PROJECT_TASK_UPDATED per task that actually changed.
-        await publishEntityTagBulkUpdate({
-          trx,
-          tenant,
-          taggedId: taskId,
-          taggedType: 'project_task',
-          userId: user.user_id,
-          previousTags: previousSnapshot,
-        });
-      });
-
-      const createdLower = new Set(createdTexts.map((t) => t.toLowerCase()));
-      const dropped = newTexts.filter((t) => !createdLower.has(t.toLowerCase()));
-      if (dropped.length > 0) {
-        failed.push({
-          taskId,
-          message: `Could not add tag(s): ${dropped.join(', ')}`,
-        });
-      } else {
-        updatedIds.push(taskId);
-      }
-    } catch (error: unknown) {
+  for (const taskId of validIds) {
+    if (unauthorizedIds.has(taskId)) {
+      failed.push({ taskId, message: 'Permission denied: Cannot read project' });
+      continue;
+    }
+    const existingLower = new Set((existingByTask.get(taskId) ?? []).map((t) => t.toLowerCase()));
+    const requestedNew = normalizedTexts.filter((t) => !existingLower.has(t.toLowerCase()));
+    const appliedLower = new Set((appliedByEntity[taskId] ?? []).map((t) => t.toLowerCase()));
+    // A tag is "dropped" only when it needed creating but the user lacks
+    // tag:create. Tasks already carrying every requested tag count as updated.
+    const dropped = requestedNew.filter((t) => !appliedLower.has(t.toLowerCase()));
+    if (dropped.length > 0) {
       failed.push({
         taskId,
-        message: error instanceof Error ? error.message : 'Failed to add tags to task',
+        message: `Could not add tag(s): ${dropped.join(', ')}`,
       });
+    } else {
+      updatedIds.push(taskId);
     }
   }
 

--- a/packages/projects/src/components/BulkAddTagsToTasksDialog.tsx
+++ b/packages/projects/src/components/BulkAddTagsToTasksDialog.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { QuickAddTagPicker } from '@alga-psa/tags/components';
+import type { PendingTag } from '@alga-psa/types';
+import { useTranslation } from 'react-i18next';
+
+interface BulkAddTagsToTasksDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  taskCount: number;
+  failed: Array<{ taskId: string; message: string; label?: string }>;
+  isSubmitting: boolean;
+  onConfirm: (tagTexts: string[]) => Promise<void>;
+  idPrefix?: string;
+}
+
+export default function BulkAddTagsToTasksDialog({
+  isOpen,
+  onClose,
+  taskCount,
+  failed,
+  isSubmitting,
+  onConfirm,
+  idPrefix = 'task-bulk-add-tags',
+}: BulkAddTagsToTasksDialogProps) {
+  const { t } = useTranslation(['features/projects', 'common']);
+  const [pendingTags, setPendingTags] = useState<PendingTag[]>([]);
+
+  useEffect(() => {
+    if (isOpen) setPendingTags([]);
+  }, [isOpen]);
+
+  const trimmedTexts = Array.from(
+    new Set(pendingTags.map((tag) => tag.tag_text.trim()).filter((text) => text.length > 0)),
+  );
+  const hasTags = trimmedTexts.length > 0;
+
+  const handleConfirm = async () => {
+    if (!hasTags) return;
+    await onConfirm(trimmedTexts);
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      id={`${idPrefix}-dialog`}
+      title={t('bulk.tags.dialogTitle', 'Add Tags to Selected Tasks')}
+      className="max-w-md"
+    >
+      <DialogContent>
+        {failed.length > 0 && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>
+              <p className="font-medium">
+                {t('bulk.tags.failedHeading', 'Tags could not be added to the following tasks:')}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {failed.map((error) => (
+                  <li key={error.taskId}>
+                    <span className="font-medium">{error.label ?? error.taskId}</span>: {error.message}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <div className="mb-3 text-sm text-gray-600">
+          {t(
+            'bulk.tags.message',
+            'Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.',
+            { count: taskCount },
+          )}
+        </div>
+        <div className="mb-4">
+          <QuickAddTagPicker
+            id={`${idPrefix}-picker`}
+            entityType="project_task"
+            pendingTags={pendingTags}
+            onPendingTagsChange={setPendingTags}
+            placeholder={t('bulk.tags.placeholder', 'Type a tag and press Enter')}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <Button id={`${idPrefix}-cancel`} variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            {t('common:actions.cancel', 'Cancel')}
+          </Button>
+          <Button id={`${idPrefix}-confirm`} onClick={handleConfirm} disabled={isSubmitting || !hasTags}>
+            {isSubmitting
+              ? t('bulk.tags.submitting', 'Adding tags...')
+              : t('bulk.tags.confirm', {
+                  count: taskCount,
+                  defaultValue: taskCount === 1 ? 'Add Tags to {{count}} Task' : 'Add Tags to {{count}} Tasks',
+                })}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/projects/src/components/BulkTaskActionBar.tsx
+++ b/packages/projects/src/components/BulkTaskActionBar.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { BulkActionBar } from '@alga-psa/ui/components/BulkActionBar';
-import { Move, UserPlus, Trash2 } from 'lucide-react';
+import { Move, Tag, UserPlus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTaskSelection } from './TaskSelectionContext';
 
 interface BulkTaskActionBarProps {
   onMove: () => void;
   onAssign: () => void;
+  onTags: () => void;
   onDelete: () => void;
 }
 
-export default function BulkTaskActionBar({ onMove, onAssign, onDelete }: BulkTaskActionBarProps) {
+export default function BulkTaskActionBar({ onMove, onAssign, onTags, onDelete }: BulkTaskActionBarProps) {
   const { t } = useTranslation(['features/projects', 'common']);
   const { selectedTaskIds, clearSelection } = useTaskSelection();
   const count = selectedTaskIds.size;
@@ -33,6 +34,12 @@ export default function BulkTaskActionBar({ onMove, onAssign, onDelete }: BulkTa
           label: t('bulkActions.assign', 'Assign'),
           icon: <UserPlus className="h-4 w-4" />,
           onClick: onAssign,
+        },
+        {
+          id: 'tags',
+          label: t('bulkActions.tags', 'Tags'),
+          icon: <Tag className="h-4 w-4" />,
+          onClick: onTags,
         },
         {
           id: 'delete',

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -10,7 +10,7 @@ import { useDrawer } from "@alga-psa/ui";
 import { extractTaskDescriptionText } from '../lib/taskRichText';
 import { getAllPriorities } from '@alga-psa/reference-data/actions';
 import { getTaskTypes } from '../actions/projectTaskActions';
-import { findTagsByEntityId } from '@alga-psa/tags/actions';
+import { findTagsByEntityId, findTagsByEntityIds } from '@alga-psa/tags/actions';
 import { useDocumentsCrossFeature } from '@alga-psa/core/context/DocumentsCrossFeatureContext';
 import { getTaskCommentCountsBatch } from '../actions/projectTaskCommentActions';
 import { TagFilter } from '@alga-psa/ui/components';
@@ -27,7 +27,7 @@ import PhaseQuickAdd from './PhaseQuickAdd';
 import TaskListView from './TaskListView';
 import ViewSwitcher from '@alga-psa/ui/components/ViewSwitcher';
 import { getProjectTaskStatuses, getProjectStatusesByPhase, updatePhase, deletePhase, getProjectTreeData, reorderPhase } from '../actions/projectActions';
-import { updateTaskStatus, reorderTask, reorderTasksInStatus, moveTaskToPhase, updateTaskWithChecklist, getTaskChecklistItems, getTaskResourcesAction, getTaskTicketLinksAction, duplicateTaskToPhase, deleteTask as deleteTaskAction, getTasksForPhase, getTaskById, getProjectTaskData, assignTeamToProjectTask, removeTeamFromProjectTask } from '../actions/projectTaskActions';
+import { updateTaskStatus, reorderTask, reorderTasksInStatus, moveTaskToPhase, updateTaskWithChecklist, getTaskChecklistItems, getTaskResourcesAction, getTaskTicketLinksAction, duplicateTaskToPhase, deleteTask as deleteTaskAction, getTasksForPhase, getTaskById, getProjectTaskData, assignTeamToProjectTask, removeTeamFromProjectTask, bulkAddTagsToTasks } from '../actions/projectTaskActions';
 import styles from './ProjectDetail.module.css';
 import { Toaster, toast } from 'react-hot-toast';
 import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
@@ -36,6 +36,7 @@ import DuplicateTaskDialog, { DuplicateOptions } from './DuplicateTaskDialog';
 import MoveTaskDialog from './MoveTaskDialog';
 import BulkMoveTaskDialog from './BulkMoveTaskDialog';
 import BulkAssignDialog from './BulkAssignDialog';
+import BulkAddTagsToTasksDialog from './BulkAddTagsToTasksDialog';
 import BulkTaskActionBar from './BulkTaskActionBar';
 import { useTaskSelection } from './TaskSelectionContext';
 import ProjectPhases from './ProjectPhases';
@@ -311,6 +312,9 @@ export default function ProjectDetail({
   const { selectedTaskIds, clearSelection, setTasksSelected } = useTaskSelection();
   const [isBulkMoveOpen, setIsBulkMoveOpen] = useState(false);
   const [isBulkAssignOpen, setIsBulkAssignOpen] = useState(false);
+  const [isBulkTagsOpen, setIsBulkTagsOpen] = useState(false);
+  const [bulkTagsErrors, setBulkTagsErrors] = useState<Array<{ taskId: string; message: string }>>([]);
+  const [isBulkAddingTags, setIsBulkAddingTags] = useState(false);
   const [isBulkDeleteOpen, setIsBulkDeleteOpen] = useState(false);
 
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
@@ -2913,6 +2917,66 @@ export default function ProjectDetail({
     setIsBulkAssignOpen(false);
   };
 
+  // Handler for bulk tag add confirmation
+  const handleBulkAddTagsConfirm = async (tagTexts: string[]) => {
+    const ids = Array.from(selectedTaskIds);
+    if (ids.length === 0 || tagTexts.length === 0) return;
+
+    setIsBulkAddingTags(true);
+    setBulkTagsErrors([]);
+
+    try {
+      const result = await bulkAddTagsToTasks(ids, tagTexts);
+
+      if (result.updatedIds.length > 0) {
+        // Refetch authoritative tags for the updated tasks and push them into
+        // the per-task tag state via the existing handler.
+        try {
+          const refreshed = await findTagsByEntityIds(result.updatedIds, 'project_task');
+          const byTask = new Map<string, ITag[]>();
+          for (const id of result.updatedIds) byTask.set(id, []);
+          for (const tag of refreshed) {
+            const list = byTask.get(tag.tagged_id) ?? [];
+            list.push(tag);
+            byTask.set(tag.tagged_id, list);
+          }
+          for (const [taskId, tags] of byTask) {
+            handleTaskTagsChange(taskId, tags);
+          }
+        } catch (error) {
+          console.error('Failed to refresh task tags after bulk add:', error);
+        }
+      }
+
+      if (result.failed.length > 0) {
+        setBulkTagsErrors(result.failed);
+        // Narrow selection to failed tasks so the user can retry on just those.
+        setTasksSelected(ids, false);
+        setTasksSelected(result.failed.map(f => f.taskId), true);
+        if (result.updatedIds.length > 0) {
+          toast.success(
+            t('projectDetail.bulkTagsSuccess', 'Tags added to {{count}} task(s)', { count: result.updatedIds.length }),
+          );
+        }
+        toast.error(
+          t('projectDetail.bulkTagsPartial', 'Tags could not be added to some tasks'),
+        );
+      } else {
+        if (result.updatedIds.length > 0) {
+          toast.success(
+            t('projectDetail.bulkTagsSuccess', 'Tags added to {{count}} task(s)', { count: result.updatedIds.length }),
+          );
+        }
+        // Keep selection so user can run more bulk actions on the same tasks.
+        setIsBulkTagsOpen(false);
+      }
+    } catch (error) {
+      handleError(error, t('projectDetail.bulkTagsFailure', 'Failed to add tags to selected tasks'));
+    } finally {
+      setIsBulkAddingTags(false);
+    }
+  };
+
   // Render the sticky header with title, view switcher, search, and filters
   const renderHeader = () => {
     const completionPercentage = (completedTasksCount / filteredTasks.length) * 100 || 0;
@@ -3842,6 +3906,10 @@ export default function ProjectDetail({
       <BulkTaskActionBar
         onMove={() => setIsBulkMoveOpen(true)}
         onAssign={() => setIsBulkAssignOpen(true)}
+        onTags={() => {
+          setBulkTagsErrors([]);
+          setIsBulkTagsOpen(true);
+        }}
         onDelete={() => setIsBulkDeleteOpen(true)}
       />
 
@@ -3867,6 +3935,20 @@ export default function ProjectDetail({
           onConfirm={handleBulkAssignConfirm}
         />
       )}
+
+      {/* Bulk Add Tags Dialog */}
+      <BulkAddTagsToTasksDialog
+        isOpen={isBulkTagsOpen && selectedTaskIds.size > 0}
+        onClose={() => setIsBulkTagsOpen(false)}
+        taskCount={selectedTaskIds.size}
+        failed={bulkTagsErrors.map(err => {
+          const task = projectTasks.find(t => t.task_id === err.taskId)
+            || allProjectTasks.find(t => t.task_id === err.taskId);
+          return { ...err, label: task?.task_name };
+        })}
+        isSubmitting={isBulkAddingTags}
+        onConfirm={handleBulkAddTagsConfirm}
+      />
 
       {/* Bulk Delete Confirmation Dialog */}
       {isBulkDeleteOpen && (

--- a/packages/tags/src/actions/tagActions.ts
+++ b/packages/tags/src/actions/tagActions.ts
@@ -127,6 +127,56 @@ async function publishEntityTagUpdateEvent(params: {
   }
 }
 
+/**
+ * Capture the current alphabetically-sorted tag-text snapshot for an entity.
+ * Use this before a bulk tag write (which goes through
+ * createTagsForEntityWithTransaction and deliberately suppresses the
+ * per-entity update event) to feed publishEntityTagBulkUpdate afterwards.
+ */
+export async function captureEntityTagTextSnapshot(
+  trx: Knex.Transaction,
+  tenant: string,
+  taggedId: string,
+  taggedType: TaggedEntityType,
+): Promise<string[]> {
+  return getTagTextSnapshot(trx, tenant, taggedId, taggedType);
+}
+
+/**
+ * Emit the per-entity update event (PROJECT_TASK_UPDATED / TICKET_UPDATED /…)
+ * that bulk callers must publish themselves — createTagsForEntityWithTransaction
+ * intentionally does not, so consumers like webhooks and search indexers
+ * still need a single update event per entity per bulk operation.
+ *
+ * No-ops if the tag-text set is unchanged.
+ */
+export async function publishEntityTagBulkUpdate(params: {
+  trx: Knex.Transaction;
+  tenant: string;
+  taggedId: string;
+  taggedType: TaggedEntityType;
+  userId: string;
+  previousTags: string[];
+  occurredAt?: string;
+}): Promise<void> {
+  const newTags = await getTagTextSnapshot(
+    params.trx,
+    params.tenant,
+    params.taggedId,
+    params.taggedType,
+  );
+  await publishEntityTagUpdateEvent({
+    trx: params.trx,
+    tenant: params.tenant,
+    taggedId: params.taggedId,
+    taggedType: params.taggedType,
+    userId: params.userId,
+    occurredAt: params.occurredAt ?? new Date().toISOString(),
+    previousTags: params.previousTags,
+    newTags,
+  });
+}
+
 export const findTagsByEntityId = withAuth(async (_user: IUserWithRoles, { tenant }: AuthContext, entityId: string, entityType: string): Promise<ITag[]> => {
   const { knex: db } = await createTenantKnex();
   try {
@@ -743,6 +793,10 @@ export const createTagsForEntityWithTransaction = withAuth(async (
 ): Promise<ITag[]> => {
   const userId = currentUser.user_id;
 
+  // Mirror createTag's gate: minting a brand-new tag definition requires
+  // tag:create permission. Resolved once per call since pendingTags is small.
+  const userHasTagCreate = await hasPermissionAsync(currentUser, 'tag', 'create', trx);
+
   const createdTags: ITag[] = [];
 
   for (const tag of pendingTags) {
@@ -754,6 +808,18 @@ export const createTagsForEntityWithTransaction = withAuth(async (
       if (tagText.length > 50) {
         console.warn(`Tag text "${tagText}" too long, skipping`);
         continue;
+      }
+
+      if (!userHasTagCreate) {
+        const existingDefinition = await TagDefinition.findByTextAndType(
+          trx,
+          tenant,
+          tagText,
+          entityType,
+        );
+        if (!existingDefinition) {
+          throw new Error(`Permission denied: cannot create new tag "${tagText}"`);
+        }
       }
 
       // Determine colors
@@ -830,7 +896,12 @@ export const createTagsForEntityWithTransaction = withAuth(async (
       });
     } catch (error) {
       console.error(`Failed to create tag "${tag.tag_text}" for ${entityType}:`, error);
-      // Continue with other tags - don't fail the entire operation
+      // Re-throw permission errors so the caller can attribute the failure
+      // to the right cause; other errors are swallowed so a single bad tag
+      // doesn't drop the rest.
+      if (error instanceof Error && error.message.includes('Permission denied')) {
+        throw error;
+      }
     }
   }
 

--- a/packages/tags/src/actions/tagActions.ts
+++ b/packages/tags/src/actions/tagActions.ts
@@ -9,6 +9,7 @@ import { withAuth, withOptionalAuth, type AuthContext } from '@alga-psa/auth';
 import { hasPermissionAsync, throwPermissionErrorAsync } from '../lib/authHelpers';
 import { generateEntityColorAsync } from '../lib/uiHelpers';
 import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
 import { publishEvent, publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import {
   buildTagAppliedPayload,
@@ -70,6 +71,39 @@ async function resolveProjectTaskTagContext(
   };
 }
 
+/**
+ * Batched form of resolveProjectTaskTagContext: resolve project/phase context
+ * for many tasks in one query so bulk callers don't pay a lookup per task.
+ */
+async function resolveProjectTaskTagContexts(
+  trx: Knex.Transaction,
+  tenant: string,
+  taskIds: string[]
+): Promise<Map<string, { projectId: string; phaseId: string }>> {
+  const contexts = new Map<string, { projectId: string; phaseId: string }>();
+  if (taskIds.length === 0) {
+    return contexts;
+  }
+
+  const rows = await trx('project_tasks as pt')
+    .join('project_phases as pp', function joinProjectPhases() {
+      this.on('pt.phase_id', '=', 'pp.phase_id')
+        .andOn('pt.tenant', '=', 'pp.tenant');
+    })
+    .where('pt.tenant', tenant)
+    .whereIn('pt.task_id', taskIds)
+    .select<Array<{ task_id: string; project_id: string; phase_id: string }>>(
+      'pt.task_id',
+      'pp.project_id',
+      'pt.phase_id',
+    );
+
+  for (const row of rows) {
+    contexts.set(row.task_id, { projectId: row.project_id, phaseId: row.phase_id });
+  }
+  return contexts;
+}
+
 async function publishEntityTagUpdateEvent(params: {
   trx: Knex.Transaction;
   tenant: string;
@@ -79,6 +113,9 @@ async function publishEntityTagUpdateEvent(params: {
   occurredAt: string;
   previousTags: TagTextSnapshot;
   newTags: TagTextSnapshot;
+  // Pre-resolved project_task context lets bulk callers batch the project/phase
+  // lookup; when omitted the single-entity path resolves it on demand.
+  projectTaskContext?: { projectId: string; phaseId: string } | null;
 }): Promise<void> {
   if (tagTextSnapshotsEqual(params.previousTags, params.newTags)) {
     return;
@@ -92,7 +129,9 @@ async function publishEntityTagUpdateEvent(params: {
   };
 
   if (params.taggedType === 'project_task') {
-    const context = await resolveProjectTaskTagContext(params.trx, params.tenant, params.taggedId);
+    const context = params.projectTaskContext !== undefined
+      ? params.projectTaskContext
+      : await resolveProjectTaskTagContext(params.trx, params.tenant, params.taggedId);
     if (!context) {
       return;
     }
@@ -125,56 +164,6 @@ async function publishEntityTagUpdateEvent(params: {
       },
     });
   }
-}
-
-/**
- * Capture the current alphabetically-sorted tag-text snapshot for an entity.
- * Use this before a bulk tag write (which goes through
- * createTagsForEntityWithTransaction and deliberately suppresses the
- * per-entity update event) to feed publishEntityTagBulkUpdate afterwards.
- */
-export async function captureEntityTagTextSnapshot(
-  trx: Knex.Transaction,
-  tenant: string,
-  taggedId: string,
-  taggedType: TaggedEntityType,
-): Promise<string[]> {
-  return getTagTextSnapshot(trx, tenant, taggedId, taggedType);
-}
-
-/**
- * Emit the per-entity update event (PROJECT_TASK_UPDATED / TICKET_UPDATED /…)
- * that bulk callers must publish themselves — createTagsForEntityWithTransaction
- * intentionally does not, so consumers like webhooks and search indexers
- * still need a single update event per entity per bulk operation.
- *
- * No-ops if the tag-text set is unchanged.
- */
-export async function publishEntityTagBulkUpdate(params: {
-  trx: Knex.Transaction;
-  tenant: string;
-  taggedId: string;
-  taggedType: TaggedEntityType;
-  userId: string;
-  previousTags: string[];
-  occurredAt?: string;
-}): Promise<void> {
-  const newTags = await getTagTextSnapshot(
-    params.trx,
-    params.tenant,
-    params.taggedId,
-    params.taggedType,
-  );
-  await publishEntityTagUpdateEvent({
-    trx: params.trx,
-    tenant: params.tenant,
-    taggedId: params.taggedId,
-    taggedType: params.taggedType,
-    userId: params.userId,
-    occurredAt: params.occurredAt ?? new Date().toISOString(),
-    previousTags: params.previousTags,
-    newTags,
-  });
 }
 
 export const findTagsByEntityId = withAuth(async (_user: IUserWithRoles, { tenant }: AuthContext, entityId: string, entityType: string): Promise<ITag[]> => {
@@ -906,6 +895,230 @@ export const createTagsForEntityWithTransaction = withAuth(async (
   }
 
   return createdTags;
+});
+
+/**
+ * Apply a set of tag texts to many entities of one type in a single pass.
+ *
+ * Calling createTagsForEntityWithTransaction in a loop re-resolves the same tag
+ * definitions, re-checks tag:create, and re-reads tag-set snapshots once per
+ * entity — an N×(entities) query storm for what is otherwise identical work.
+ * This resolves the tag:create permission and the (shared) tag definitions once,
+ * then performs a single multi-row tag_mappings insert.
+ *
+ * The mapping insert uses ON CONFLICT DO NOTHING so a stale dedupe read or a
+ * concurrent add can't roll back the whole batch on the unique mapping
+ * constraint. Events match the per-entity path but fire only for rows actually
+ * inserted: TAG_DEFINITION_CREATED once per newly minted definition, TAG_APPLIED
+ * once per inserted (entity, tag) mapping, and one entity-update event
+ * (PROJECT_TASK_UPDATED / TICKET_UPDATED) per entity that actually gained a tag
+ * (project-task context is batch-resolved).
+ *
+ * @param applications  Per-entity tags to add. `existingTexts` is the entity's
+ *   current tag set (drives the before/after update-event snapshot and skips
+ *   duplicates); `newTexts` are the texts to apply.
+ * @returns appliedByEntity — entityId -> tag texts that are present after the
+ *   call (newly inserted or already there via a conflict). Requested texts
+ *   absent from the result were dropped because they'd require minting a new
+ *   definition and the user lacks tag:create.
+ */
+export const bulkApplyTagsToEntities = withAuth(async (
+  currentUser: IUserWithRoles,
+  _ctx: AuthContext,
+  trx: Knex.Transaction,
+  tenant: string,
+  taggedType: TaggedEntityType,
+  applications: Array<{ entityId: string; newTexts: string[]; existingTexts: string[] }>
+): Promise<{ appliedByEntity: Record<string, string[]> }> => {
+  const userId = currentUser.user_id;
+  const appliedByEntity: Record<string, string[]> = {};
+
+  // Dedupe each entity's requested texts against what it already has (and
+  // against itself), and drop entities left with nothing to do.
+  const normalized = applications
+    .map((app) => {
+      const existingLower = new Set(app.existingTexts.map((t) => t.toLowerCase()));
+      const seen = new Set<string>();
+      const newTexts: string[] = [];
+      for (const raw of app.newTexts) {
+        const text = raw.trim();
+        if (!text) continue;
+        const lower = text.toLowerCase();
+        if (existingLower.has(lower) || seen.has(lower)) continue;
+        seen.add(lower);
+        newTexts.push(text);
+      }
+      return { entityId: app.entityId, existingTexts: app.existingTexts, newTexts };
+    })
+    .filter((app) => app.newTexts.length > 0);
+
+  if (normalized.length === 0) {
+    return { appliedByEntity };
+  }
+
+  // tag:create gate (mints brand-new definitions) resolved once for the batch.
+  const userHasTagCreate = await hasPermissionAsync(currentUser, 'tag', 'create', trx);
+
+  // Definitions are shared across entities — resolve each unique text once,
+  // keyed by lowercased text while preserving the first-seen casing.
+  const uniqueTexts = new Map<string, string>();
+  for (const app of normalized) {
+    for (const text of app.newTexts) {
+      const lower = text.toLowerCase();
+      if (!uniqueTexts.has(lower)) uniqueTexts.set(lower, text);
+    }
+  }
+
+  const definitionByLowerText = new Map<string, ITagDefinition>();
+  const createdDefinitions: ITagDefinition[] = [];
+  for (const [lower, text] of uniqueTexts) {
+    if (text.length > 50) {
+      console.warn(`Tag text "${text}" too long, skipping`);
+      continue;
+    }
+    if (!userHasTagCreate) {
+      // Can only apply texts whose definition already exists.
+      const existingDefinition = await TagDefinition.findByTextAndType(trx, tenant, text, taggedType);
+      if (existingDefinition) {
+        definitionByLowerText.set(lower, existingDefinition);
+      }
+      continue;
+    }
+    const colors = await generateEntityColorAsync(text);
+    const { definition, created } = await TagDefinition.getOrCreateWithStatus(
+      trx,
+      tenant,
+      text,
+      taggedType,
+      { background_color: colors.backgroundColor, text_color: colors.textColor },
+    );
+    definitionByLowerText.set(lower, definition);
+    if (created) createdDefinitions.push(definition);
+  }
+
+  // Build every mapping row, then insert them in one statement.
+  const rows: Array<{
+    mapping_id: string;
+    tenant: string;
+    tag_id: string;
+    tagged_id: string;
+    tagged_type: TaggedEntityType;
+    created_by: string;
+  }> = [];
+  for (const app of normalized) {
+    // "applied" = texts that resolved to a definition, so the mapping will be
+    // present after this call (whether we insert it or it already existed via a
+    // conflict). The caller treats these as success; texts dropped here (no
+    // permission to mint / too long) are surfaced as failures.
+    const applied: string[] = [];
+    for (const text of app.newTexts) {
+      const definition = definitionByLowerText.get(text.toLowerCase());
+      if (!definition) continue; // dropped: forbidden new tag or too long
+      rows.push({
+        mapping_id: uuidv4(),
+        tenant,
+        tag_id: definition.tag_id,
+        tagged_id: app.entityId,
+        tagged_type: taggedType,
+        created_by: userId,
+      });
+      applied.push(text);
+    }
+    if (applied.length > 0) {
+      appliedByEntity[app.entityId] = applied;
+    }
+  }
+
+  if (rows.length === 0) {
+    return { appliedByEntity };
+  }
+
+  // ON CONFLICT DO NOTHING: existing tags are read before the transaction, so a
+  // stale read or a concurrent add could otherwise hit
+  // unique(tenant, tag_id, tagged_id) and roll back the entire batch. RETURNING
+  // yields only the rows we actually inserted, so events fire for real changes
+  // only; a skipped row just means the tag is already present.
+  const insertedRows = await trx('tag_mappings')
+    .insert(rows)
+    .onConflict(['tenant', 'tag_id', 'tagged_id'])
+    .ignore()
+    .returning(['tag_id', 'tagged_id']) as Array<{ tag_id: string; tagged_id: string }>;
+
+  const occurredAt = new Date().toISOString();
+
+  for (const definition of createdDefinitions) {
+    await publishWorkflowEvent({
+      eventType: 'TAG_DEFINITION_CREATED',
+      payload: buildTagDefinitionCreatedPayload({
+        tagId: definition.tag_id,
+        tagName: definition.tag_text,
+        createdByUserId: userId,
+        createdAt: definition.created_at ?? occurredAt,
+      }),
+      ctx: {
+        tenantId: tenant,
+        occurredAt,
+        actor: { actorType: 'USER', actorUserId: userId },
+      },
+    });
+  }
+
+  // TAG_APPLIED per actually-inserted mapping; track which entities changed.
+  const changedEntities = new Set<string>();
+  for (const row of insertedRows) {
+    await publishWorkflowEvent({
+      eventType: 'TAG_APPLIED',
+      payload: buildTagAppliedPayload({
+        tagId: row.tag_id,
+        entityType: taggedType,
+        entityId: row.tagged_id,
+        appliedByUserId: userId,
+        appliedAt: occurredAt,
+      }),
+      ctx: {
+        tenantId: tenant,
+        occurredAt,
+        actor: { actorType: 'USER', actorUserId: userId },
+      },
+    });
+    changedEntities.add(row.tagged_id);
+  }
+
+  // One entity-update event per entity that actually gained a tag. Re-read the
+  // authoritative post-insert tag set in a single batched query rather than
+  // computing existing ∪ inserted: a concurrent add could leave the entity with
+  // tags beyond what we saw or inserted, and webhook consumers treat
+  // changes.tags.new as the source of truth.
+  const changedEntityIds = Array.from(changedEntities);
+  const finalTagsByEntity = new Map<string, string[]>();
+  for (const row of await TagMapping.getByEntities(trx, tenant, changedEntityIds, taggedType)) {
+    const list = finalTagsByEntity.get(row.tagged_id) ?? [];
+    list.push(row.tag_text);
+    finalTagsByEntity.set(row.tagged_id, list);
+  }
+  const projectTaskContexts = taggedType === 'project_task'
+    ? await resolveProjectTaskTagContexts(trx, tenant, changedEntityIds)
+    : null;
+  for (const app of normalized) {
+    if (!changedEntities.has(app.entityId)) continue;
+    const previousTags = Array.from(new Set(app.existingTexts)).sort((a, b) => a.localeCompare(b));
+    const newTags = Array.from(new Set(finalTagsByEntity.get(app.entityId) ?? [])).sort((a, b) => a.localeCompare(b));
+    await publishEntityTagUpdateEvent({
+      trx,
+      tenant,
+      taggedId: app.entityId,
+      taggedType,
+      userId,
+      occurredAt,
+      previousTags,
+      newTags,
+      projectTaskContext: projectTaskContexts
+        ? (projectTaskContexts.get(app.entityId) ?? null)
+        : undefined,
+    });
+  }
+
+  return { appliedByEntity };
 });
 
 export const updateTagColor = withAuth(async (currentUser: IUserWithRoles, { tenant }: AuthContext, tagId: string, backgroundColor: string | null, textColor: string | null): Promise<{ tag_text: string; background_color: string | null; text_color: string | null; }> => {

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} Aufgaben nach {{phaseName}} verschoben",
     "moveTasksTitle": "Aufgaben verschieben",
     "confirmMoveTasksMessage": "Möchten Sie {{count}} ausgewählte Aufgaben wirklich in die Phase „{{targetPhase}}“ verschieben?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Tags zu {{count}} Aufgabe hinzugefügt",
+    "bulkTagsSuccess_other": "Tags zu {{count}} Aufgaben hinzugefügt",
+    "bulkTagsPartial": "Tags konnten zu einigen Aufgaben nicht hinzugefügt werden",
+    "bulkTagsFailure": "Tags konnten nicht zu den ausgewählten Aufgaben hinzugefügt werden"
   },
   "taskForm": {
     "addTitle": "Aufgabe hinzufügen",
@@ -1461,13 +1461,13 @@
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Tags zu ausgewählten Aufgaben hinzufügen",
+      "message": "Fügen Sie {{count}} ausgewählten Aufgabe(n) ein oder mehrere Tags hinzu. Tags, die bereits an einer Aufgabe vorhanden sind, werden übersprungen.",
+      "placeholder": "Tag eingeben und Enter drücken",
+      "submitting": "Tags werden hinzugefügt...",
+      "confirm_one": "Tags zu {{count}} Aufgabe hinzufügen",
+      "confirm_other": "Tags zu {{count}} Aufgaben hinzufügen",
+      "failedHeading": "Tags konnten zu den folgenden Aufgaben nicht hinzugefügt werden:"
     }
   }
 }

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} Aufgaben verschoben",
     "bulkTasksMovedToPhase": "{{count}} Aufgaben nach {{phaseName}} verschoben",
     "moveTasksTitle": "Aufgaben verschieben",
-    "confirmMoveTasksMessage": "Möchten Sie {{count}} ausgewählte Aufgaben wirklich in die Phase „{{targetPhase}}“ verschieben?"
+    "confirmMoveTasksMessage": "Möchten Sie {{count}} ausgewählte Aufgaben wirklich in die Phase „{{targetPhase}}“ verschieben?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Aufgabe hinzufügen",
@@ -1452,6 +1456,18 @@
     "move": "Verschieben",
     "assign": "Zuweisen",
     "delete": "Löschen",
-    "clear": "Zurücksetzen"
+    "clear": "Zurücksetzen",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -252,6 +252,10 @@
     "bulkAssignPartial": "Assigned {{success}} task(s), {{failed}} failed.",
     "bulkAssignTeamSuccess": "{{count}} task(s) assigned to team successfully!",
     "bulkAssignTeamPartial": "Assigned {{success}} task(s) to team, {{failed}} failed.",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks",
     "bulkDeleteTitle": "Delete Tasks",
     "bulkDeleteMessage": "Are you sure you want to delete {{count}} selected task(s)? This action cannot be undone.",
     "bulkTasksMovedSuccess": "{{count}} tasks moved",
@@ -1451,7 +1455,19 @@
     "selectedCount": "{{count}} selected",
     "move": "Move",
     "assign": "Assign",
+    "tags": "Tags",
     "delete": "Delete",
     "clear": "Clear"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} tareas movidas",
     "bulkTasksMovedToPhase": "{{count}} tareas movidas a {{phaseName}}",
     "moveTasksTitle": "Mover tareas",
-    "confirmMoveTasksMessage": "¿Seguro que quieres mover {{count}} tareas seleccionadas a la fase \"{{targetPhase}}\"?"
+    "confirmMoveTasksMessage": "¿Seguro que quieres mover {{count}} tareas seleccionadas a la fase \"{{targetPhase}}\"?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Agregar tarea",
@@ -1452,6 +1456,18 @@
     "move": "Mover",
     "assign": "Asignar",
     "delete": "Eliminar",
-    "clear": "Borrar"
+    "clear": "Borrar",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} tareas movidas a {{phaseName}}",
     "moveTasksTitle": "Mover tareas",
     "confirmMoveTasksMessage": "¿Seguro que quieres mover {{count}} tareas seleccionadas a la fase \"{{targetPhase}}\"?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Etiquetas añadidas a {{count}} tarea",
+    "bulkTagsSuccess_other": "Etiquetas añadidas a {{count}} tareas",
+    "bulkTagsPartial": "No se pudieron añadir etiquetas a algunas tareas",
+    "bulkTagsFailure": "No se pudieron añadir etiquetas a las tareas seleccionadas"
   },
   "taskForm": {
     "addTitle": "Agregar tarea",
@@ -1457,17 +1457,17 @@
     "assign": "Asignar",
     "delete": "Eliminar",
     "clear": "Borrar",
-    "tags": "Tags"
+    "tags": "Etiquetas"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Añadir etiquetas a las tareas seleccionadas",
+      "message": "Añade una o más etiquetas a {{count}} tarea(s) seleccionada(s). Las etiquetas que ya están en una tarea se omiten.",
+      "placeholder": "Escribe una etiqueta y pulsa Enter",
+      "submitting": "Añadiendo etiquetas...",
+      "confirm_one": "Añadir etiquetas a {{count}} tarea",
+      "confirm_other": "Añadir etiquetas a {{count}} tareas",
+      "failedHeading": "No se pudieron añadir etiquetas a las siguientes tareas:"
     }
   }
 }

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} tâches déplacées",
     "bulkTasksMovedToPhase": "{{count}} tâches déplacées vers {{phaseName}}",
     "moveTasksTitle": "Déplacer les tâches",
-    "confirmMoveTasksMessage": "Voulez-vous vraiment déplacer {{count}} tâches sélectionnées vers la phase « {{targetPhase}} » ?"
+    "confirmMoveTasksMessage": "Voulez-vous vraiment déplacer {{count}} tâches sélectionnées vers la phase « {{targetPhase}} » ?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Ajouter une tâche",
@@ -1452,6 +1456,18 @@
     "move": "Déplacer",
     "assign": "Affecter",
     "delete": "Supprimer",
-    "clear": "Effacer"
+    "clear": "Effacer",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} tâches déplacées vers {{phaseName}}",
     "moveTasksTitle": "Déplacer les tâches",
     "confirmMoveTasksMessage": "Voulez-vous vraiment déplacer {{count}} tâches sélectionnées vers la phase « {{targetPhase}} » ?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Étiquettes ajoutées à {{count}} tâche",
+    "bulkTagsSuccess_other": "Étiquettes ajoutées à {{count}} tâches",
+    "bulkTagsPartial": "Impossible d'ajouter des étiquettes à certaines tâches",
+    "bulkTagsFailure": "Échec de l'ajout d'étiquettes aux tâches sélectionnées"
   },
   "taskForm": {
     "addTitle": "Ajouter une tâche",
@@ -1457,17 +1457,17 @@
     "assign": "Affecter",
     "delete": "Supprimer",
     "clear": "Effacer",
-    "tags": "Tags"
+    "tags": "Étiquettes"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Ajouter des étiquettes aux tâches sélectionnées",
+      "message": "Ajoutez une ou plusieurs étiquettes à {{count}} tâche(s) sélectionnée(s). Les étiquettes déjà présentes sur une tâche sont ignorées.",
+      "placeholder": "Saisissez une étiquette et appuyez sur Entrée",
+      "submitting": "Ajout des étiquettes...",
+      "confirm_one": "Ajouter des étiquettes à {{count}} tâche",
+      "confirm_other": "Ajouter des étiquettes à {{count}} tâches",
+      "failedHeading": "Impossible d'ajouter des étiquettes aux tâches suivantes :"
     }
   }
 }

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} attività spostate in {{phaseName}}",
     "moveTasksTitle": "Sposta attività",
     "confirmMoveTasksMessage": "Sei sicuro di voler spostare {{count}} attività selezionate nella fase \"{{targetPhase}}\"?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Tag aggiunti a {{count}} attività",
+    "bulkTagsSuccess_other": "Tag aggiunti a {{count}} attività",
+    "bulkTagsPartial": "Impossibile aggiungere i tag ad alcune attività",
+    "bulkTagsFailure": "Impossibile aggiungere i tag alle attività selezionate"
   },
   "taskForm": {
     "addTitle": "Aggiungi attività",
@@ -1457,17 +1457,17 @@
     "assign": "Assegna",
     "delete": "Elimina",
     "clear": "Cancella",
-    "tags": "Tags"
+    "tags": "Tag"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Aggiungi tag alle attività selezionate",
+      "message": "Aggiungi uno o più tag a {{count}} attività selezionata/e. I tag già presenti su un'attività vengono ignorati.",
+      "placeholder": "Digita un tag e premi Invio",
+      "submitting": "Aggiunta dei tag...",
+      "confirm_one": "Aggiungi tag a {{count}} attività",
+      "confirm_other": "Aggiungi tag a {{count}} attività",
+      "failedHeading": "Impossibile aggiungere i tag alle seguenti attività:"
     }
   }
 }

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} attività spostate",
     "bulkTasksMovedToPhase": "{{count}} attività spostate in {{phaseName}}",
     "moveTasksTitle": "Sposta attività",
-    "confirmMoveTasksMessage": "Sei sicuro di voler spostare {{count}} attività selezionate nella fase \"{{targetPhase}}\"?"
+    "confirmMoveTasksMessage": "Sei sicuro di voler spostare {{count}} attività selezionate nella fase \"{{targetPhase}}\"?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Aggiungi attività",
@@ -1452,6 +1456,18 @@
     "move": "Sposta",
     "assign": "Assegna",
     "delete": "Elimina",
-    "clear": "Cancella"
+    "clear": "Cancella",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} taken verplaatst",
     "bulkTasksMovedToPhase": "{{count}} taken verplaatst naar {{phaseName}}",
     "moveTasksTitle": "Taken verplaatsen",
-    "confirmMoveTasksMessage": "Weet je zeker dat je {{count}} geselecteerde taken naar fase \"{{targetPhase}}\" wilt verplaatsen?"
+    "confirmMoveTasksMessage": "Weet je zeker dat je {{count}} geselecteerde taken naar fase \"{{targetPhase}}\" wilt verplaatsen?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Nieuwe taak toevoegen",
@@ -1452,6 +1456,18 @@
     "move": "Verplaatsen",
     "assign": "Toewijzen",
     "delete": "Verwijderen",
-    "clear": "Wissen"
+    "clear": "Wissen",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} taken verplaatst naar {{phaseName}}",
     "moveTasksTitle": "Taken verplaatsen",
     "confirmMoveTasksMessage": "Weet je zeker dat je {{count}} geselecteerde taken naar fase \"{{targetPhase}}\" wilt verplaatsen?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Labels toegevoegd aan {{count}} taak",
+    "bulkTagsSuccess_other": "Labels toegevoegd aan {{count}} taken",
+    "bulkTagsPartial": "Labels konden niet aan sommige taken worden toegevoegd",
+    "bulkTagsFailure": "Labels konden niet aan de geselecteerde taken worden toegevoegd"
   },
   "taskForm": {
     "addTitle": "Nieuwe taak toevoegen",
@@ -1457,17 +1457,17 @@
     "assign": "Toewijzen",
     "delete": "Verwijderen",
     "clear": "Wissen",
-    "tags": "Tags"
+    "tags": "Labels"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Labels toevoegen aan geselecteerde taken",
+      "message": "Voeg een of meer labels toe aan {{count}} geselecteerde taak/taken. Labels die al op een taak staan, worden overgeslagen.",
+      "placeholder": "Typ een label en druk op Enter",
+      "submitting": "Labels toevoegen...",
+      "confirm_one": "Labels toevoegen aan {{count}} taak",
+      "confirm_other": "Labels toevoegen aan {{count}} taken",
+      "failedHeading": "Labels konden niet aan de volgende taken worden toegevoegd:"
     }
   }
 }

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "Przeniesiono {{count}} zadania do {{phaseName}}",
     "moveTasksTitle": "Przenieś zadania",
     "confirmMoveTasksMessage": "Czy na pewno chcesz przenieść {{count}} wybrane zadania do fazy „{{targetPhase}}”?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Dodano tagi do {{count}} zadania",
+    "bulkTagsSuccess_other": "Dodano tagi do {{count}} zadań",
+    "bulkTagsPartial": "Nie udało się dodać tagów do niektórych zadań",
+    "bulkTagsFailure": "Nie udało się dodać tagów do wybranych zadań"
   },
   "taskForm": {
     "addTitle": "Dodaj nowe zadanie",
@@ -1457,17 +1457,17 @@
     "assign": "Przypisz",
     "delete": "Usuń",
     "clear": "Wyczyść",
-    "tags": "Tags"
+    "tags": "Tagi"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Dodaj tagi do wybranych zadań",
+      "message": "Dodaj jeden lub więcej tagów do {{count}} wybranych zadań. Tagi już przypisane do zadania zostaną pominięte.",
+      "placeholder": "Wpisz tag i naciśnij Enter",
+      "submitting": "Dodawanie tagów...",
+      "confirm_one": "Dodaj tagi do {{count}} zadania",
+      "confirm_other": "Dodaj tagi do {{count}} zadań",
+      "failedHeading": "Nie udało się dodać tagów do następujących zadań:"
     }
   }
 }

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "Przeniesiono {{count}} zadania",
     "bulkTasksMovedToPhase": "Przeniesiono {{count}} zadania do {{phaseName}}",
     "moveTasksTitle": "Przenieś zadania",
-    "confirmMoveTasksMessage": "Czy na pewno chcesz przenieść {{count}} wybrane zadania do fazy „{{targetPhase}}”?"
+    "confirmMoveTasksMessage": "Czy na pewno chcesz przenieść {{count}} wybrane zadania do fazy „{{targetPhase}}”?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Dodaj nowe zadanie",
@@ -1452,6 +1456,18 @@
     "move": "Przenieś",
     "assign": "Przypisz",
     "delete": "Usuń",
-    "clear": "Wyczyść"
+    "clear": "Wyczyść",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "{{count}} tasks moved",
     "bulkTasksMovedToPhase": "{{count}} tasks moved to {{phaseName}}",
     "moveTasksTitle": "Move Tasks",
-    "confirmMoveTasksMessage": "Are you sure you want to move {{count}} selected tasks to phase \"{{targetPhase}}\"?"
+    "confirmMoveTasksMessage": "Are you sure you want to move {{count}} selected tasks to phase \"{{targetPhase}}\"?",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "Add New Task",
@@ -1452,6 +1456,18 @@
     "move": "Move",
     "assign": "Assign",
     "delete": "Delete",
-    "clear": "Clear"
+    "clear": "Clear",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -258,10 +258,10 @@
     "bulkTasksMovedToPhase": "{{count}} tasks moved to {{phaseName}}",
     "moveTasksTitle": "Move Tasks",
     "confirmMoveTasksMessage": "Are you sure you want to move {{count}} selected tasks to phase \"{{targetPhase}}\"?",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "bulkTagsSuccess_one": "Tags adicionadas a {{count}} tarefa",
+    "bulkTagsSuccess_other": "Tags adicionadas a {{count}} tarefas",
+    "bulkTagsPartial": "Não foi possível adicionar tags a algumas tarefas",
+    "bulkTagsFailure": "Não foi possível adicionar tags às tarefas selecionadas"
   },
   "taskForm": {
     "addTitle": "Add New Task",
@@ -1461,13 +1461,13 @@
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "Adicionar tags às tarefas selecionadas",
+      "message": "Adicione uma ou mais tags a {{count}} tarefa(s) selecionada(s). As tags que já estão numa tarefa são ignoradas.",
+      "placeholder": "Digite uma tag e pressione Enter",
+      "submitting": "Adicionando tags...",
+      "confirm_one": "Adicionar tags a {{count}} tarefa",
+      "confirm_other": "Adicionar tags a {{count}} tarefas",
+      "failedHeading": "Não foi possível adicionar tags às seguintes tarefas:"
     }
   }
 }

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "11111 {{count}} 11111",
     "bulkTasksMovedToPhase": "11111 {{count}} 11111 {{phaseName}} 11111",
     "moveTasksTitle": "11111",
-    "confirmMoveTasksMessage": "11111 {{count}} 11111 {{targetPhase}} 11111"
+    "confirmMoveTasksMessage": "11111 {{count}} 11111 {{targetPhase}} 11111",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "11111",
@@ -1452,6 +1456,18 @@
     "move": "11111",
     "assign": "11111",
     "delete": "11111",
-    "clear": "11111"
+    "clear": "11111",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -252,16 +252,16 @@
     "bulkAssignPartial": "11111 {{success}} 11111 {{failed}} 11111",
     "bulkAssignTeamSuccess": "11111 {{count}} 11111",
     "bulkAssignTeamPartial": "11111 {{success}} 11111 {{failed}} 11111",
+    "bulkTagsSuccess_one": "11111 {{count}} 11111",
+    "bulkTagsSuccess_other": "11111 {{count}} 11111",
+    "bulkTagsPartial": "11111",
+    "bulkTagsFailure": "11111",
     "bulkDeleteTitle": "11111",
     "bulkDeleteMessage": "11111 {{count}} 11111",
     "bulkTasksMovedSuccess": "11111 {{count}} 11111",
     "bulkTasksMovedToPhase": "11111 {{count}} 11111 {{phaseName}} 11111",
     "moveTasksTitle": "11111",
-    "confirmMoveTasksMessage": "11111 {{count}} 11111 {{targetPhase}} 11111",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "confirmMoveTasksMessage": "11111 {{count}} 11111 {{targetPhase}} 11111"
   },
   "taskForm": {
     "addTitle": "11111",
@@ -1455,19 +1455,19 @@
     "selectedCount": "11111 {{count}} 11111",
     "move": "11111",
     "assign": "11111",
+    "tags": "11111",
     "delete": "11111",
-    "clear": "11111",
-    "tags": "Tags"
+    "clear": "11111"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "11111",
+      "message": "11111 {{count}} 11111",
+      "placeholder": "11111",
+      "submitting": "11111",
+      "confirm_one": "11111 {{count}} 11111",
+      "confirm_other": "11111 {{count}} 11111",
+      "failedHeading": "11111"
     }
   }
 }

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -257,7 +257,11 @@
     "bulkTasksMovedSuccess": "55555 {{count}} 55555",
     "bulkTasksMovedToPhase": "55555 {{count}} 55555 {{phaseName}} 55555",
     "moveTasksTitle": "55555",
-    "confirmMoveTasksMessage": "55555 {{count}} 55555 {{targetPhase}} 55555"
+    "confirmMoveTasksMessage": "55555 {{count}} 55555 {{targetPhase}} 55555",
+    "bulkTagsSuccess_one": "Tags added to {{count}} task",
+    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
+    "bulkTagsPartial": "Tags could not be added to some tasks",
+    "bulkTagsFailure": "Failed to add tags to selected tasks"
   },
   "taskForm": {
     "addTitle": "55555",
@@ -1452,6 +1456,18 @@
     "move": "55555",
     "assign": "55555",
     "delete": "55555",
-    "clear": "55555"
+    "clear": "55555",
+    "tags": "Tags"
+  },
+  "bulk": {
+    "tags": {
+      "dialogTitle": "Add Tags to Selected Tasks",
+      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
+      "placeholder": "Type a tag and press Enter",
+      "submitting": "Adding tags...",
+      "confirm_one": "Add Tags to {{count}} Task",
+      "confirm_other": "Add Tags to {{count}} Tasks",
+      "failedHeading": "Tags could not be added to the following tasks:"
+    }
   }
 }

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -252,16 +252,16 @@
     "bulkAssignPartial": "55555 {{success}} 55555 {{failed}} 55555",
     "bulkAssignTeamSuccess": "55555 {{count}} 55555",
     "bulkAssignTeamPartial": "55555 {{success}} 55555 {{failed}} 55555",
+    "bulkTagsSuccess_one": "55555 {{count}} 55555",
+    "bulkTagsSuccess_other": "55555 {{count}} 55555",
+    "bulkTagsPartial": "55555",
+    "bulkTagsFailure": "55555",
     "bulkDeleteTitle": "55555",
     "bulkDeleteMessage": "55555 {{count}} 55555",
     "bulkTasksMovedSuccess": "55555 {{count}} 55555",
     "bulkTasksMovedToPhase": "55555 {{count}} 55555 {{phaseName}} 55555",
     "moveTasksTitle": "55555",
-    "confirmMoveTasksMessage": "55555 {{count}} 55555 {{targetPhase}} 55555",
-    "bulkTagsSuccess_one": "Tags added to {{count}} task",
-    "bulkTagsSuccess_other": "Tags added to {{count}} tasks",
-    "bulkTagsPartial": "Tags could not be added to some tasks",
-    "bulkTagsFailure": "Failed to add tags to selected tasks"
+    "confirmMoveTasksMessage": "55555 {{count}} 55555 {{targetPhase}} 55555"
   },
   "taskForm": {
     "addTitle": "55555",
@@ -1455,19 +1455,19 @@
     "selectedCount": "55555 {{count}} 55555",
     "move": "55555",
     "assign": "55555",
+    "tags": "55555",
     "delete": "55555",
-    "clear": "55555",
-    "tags": "Tags"
+    "clear": "55555"
   },
   "bulk": {
     "tags": {
-      "dialogTitle": "Add Tags to Selected Tasks",
-      "message": "Add one or more tags to {{count}} selected task(s). Tags already on a task are skipped.",
-      "placeholder": "Type a tag and press Enter",
-      "submitting": "Adding tags...",
-      "confirm_one": "Add Tags to {{count}} Task",
-      "confirm_other": "Add Tags to {{count}} Tasks",
-      "failedHeading": "Tags could not be added to the following tasks:"
+      "dialogTitle": "55555",
+      "message": "55555 {{count}} 55555",
+      "placeholder": "55555",
+      "submitting": "55555",
+      "confirm_one": "55555 {{count}} 55555",
+      "confirm_other": "55555 {{count}} 55555",
+      "failedHeading": "55555"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a **Tags** entry to the project-task multi-select toolbar, mirroring the ticket bulk-tag flow: pick tasks, open the dialog, type one or more tags, and they're applied to every selected task (tags already on a task are skipped).
- New `bulkAddTagsToTasks` server action: tenant-scoped `project_tasks` existence filter (so unknown UUIDs cannot mint orphan `tag_mappings`), dedupes IDs/tag texts, runs per-task in its own transaction, reports partial failures with task names so the UI narrows selection to just the failed rows.
- Hardens the shared tag helper used by both the new task bulk path and the existing ticket bulk path:
  - `createTagsForEntityWithTransaction` now mirrors `createTag`'s `tag:create` gate — minting a brand-new tag definition requires `tag:create`; permission errors re-throw out of the per-tag catch so the caller can attribute the failure.
  - New exported helpers `captureEntityTagTextSnapshot` + `publishEntityTagBulkUpdate` let bulk callers emit the per-entity update event (`PROJECT_TASK_UPDATED` / `TICKET_UPDATED`) that the helper itself deliberately suppresses. The webhook-emission contract test still passes — its assertion is scoped to the helper's own source.
- Bulk task action compares the helper's returned tag list against the requested texts and surfaces dropped tags in `failed` (length-overflow, unique-conflict, etc. no longer silently report success).
- i18n: adds `bulkActions.tags`, `bulk.tags.*`, and `projectDetail.bulkTags*` (success_one/_other, partial, failure) to `en` plus all 8 non-English projects locales (`fr/es/de/nl/it/pl/xx/yy`) so the projects i18n audit's per-locale key-count parity stays green.

## Test plan
- [ ] Open a project with several tasks across phases and statuses; multi-select 3+ rows and click the new **Tags** action.
- [ ] Submit a mix of new + already-present tags — confirm the new ones appear inline in each row without page reload and the already-present tag is not duplicated.
- [ ] Submit a tag that exceeds 50 chars in the mix — the task lands in the failed list with a message naming the dropped tag; valid tags on other tasks still apply.
- [ ] As a user with `project:update` but without `tag:create`, try to apply a brand-new tag in bulk — every task lands in failed with a permission message; applying an existing tag works.
- [ ] Run with one of the selected task IDs deliberately invalid (force a stale selection) — that task lands in failed with "Task not found", others succeed.
- [ ] Verify the existing single-task `TagManager` (inline in the list row and inside the Edit Task dialog) still works unchanged.
- [ ] Confirm `npm run typecheck` passes in `packages/projects`, `packages/tags`, and `packages/tickets`.
- [ ] Confirm the tag webhook-emission contract test passes (`packages/tags` → `tagActions.webhookEmission.contract.test.ts`).
- [ ] Confirm the projects i18n-audit key-parity tests pass for all 8 non-English locales.

## Docs
- Companion doc edit in nm-store: `67-using-the-project-list-view.md` gains a new **Selecting Tasks for Bulk Actions** section describing Move / Assign / Tags / Delete and the partial-failure narrowing behavior.