### PR TITLE
Fix Citus IMMUTABLE error on tenant addon upsert

### DIFF
--- a/ee/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts
+++ b/ee/server/src/app/api/v1/tenant-management/tenants/[tenantId]/addons/route.ts
@@ -101,26 +101,29 @@ export async function POST(request: NextRequest, context: RouteContext): Promise
       return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 404 });
     }
 
+    const nowIso = new Date().toISOString();
     const metadata = {
       source: 'nineminds_control_panel',
       action,
       user_id: userId,
       user_email: userEmail,
-      updated_at: new Date().toISOString(),
+      updated_at: nowIso,
     };
 
     if (action === 'grant') {
+      // Citus rejects STABLE functions (knex.fn.now() → CURRENT_TIMESTAMP) inside
+      // ON CONFLICT DO UPDATE SET on distributed tables — must pass a literal.
       await knex('tenant_addons')
         .insert({
           tenant: tenantId,
           addon_key: addonKey,
-          activated_at: knex.fn.now(),
+          activated_at: nowIso,
           expires_at: null,
           metadata: JSON.stringify(metadata),
         })
         .onConflict(['tenant', 'addon_key'])
         .merge({
-          activated_at: knex.fn.now(),
+          activated_at: nowIso,
           expires_at: null,
           metadata: JSON.stringify(metadata),
         });
@@ -128,7 +131,7 @@ export async function POST(request: NextRequest, context: RouteContext): Promise
       await knex('tenant_addons')
         .where({ tenant: tenantId, addon_key: addonKey })
         .update({
-          expires_at: knex.fn.now(),
+          expires_at: nowIso,
           metadata: JSON.stringify(metadata),
         });
     }


### PR DESCRIPTION
  Citus rejects STABLE functions (CURRENT_TIMESTAMP via knex.fn.now())
  inside the DO UPDATE SET clause of ON CONFLICT on distributed tables.
  Compute the timestamp once in JS and pass it as a literal to both the
  grant upsert and the revoke UPDATE.

  "Curiouser and curiouser!" cried Alice as the tenant_addons table
  refused her fn.now() — for in Citus-land, only IMMUTABLE travellers
  may pass through the ON CONFLICT gate, and CURRENT_TIMESTAMP is
  forever wandering, never standing still. ⏳🎩🃏