### PR TITLE
Stop prefilling rates from currency-untagged default_rate

### DIFF
--- a/packages/billing/src/actions/contractWizardActions.ts
+++ b/packages/billing/src/actions/contractWizardActions.ts
@@ -1022,34 +1022,21 @@ export const createClientContractFromWizard = withAuth(async (
         });
       }
 
-      // Mode-specific defaults (and legacy catalog defaults used as fallback) also satisfy pricing.
+      // Mode-specific defaults (already filtered to the contract currency) satisfy pricing.
+      // The legacy service_catalog.default_rate column is untagged (effectively USD-only via the
+      // 20251205130000 migration) and is intentionally NOT treated as covering a non-USD contract.
       filteredFixedServices.forEach((service) => {
-        if (
-          firstPositiveRateInCents(
-            fixedModeDefaultsByServiceId.get(service.service_id),
-            serviceCatalogById.get(service.service_id)?.default_rate
-          ) !== undefined
-        ) {
+        if (firstPositiveRateInCents(fixedModeDefaultsByServiceId.get(service.service_id)) !== undefined) {
           servicesWithCustomRates.add(service.service_id);
         }
       });
       filteredHourlyServices.forEach((service) => {
-        if (
-          firstPositiveRateInCents(
-            hourlyModeDefaultsByServiceId.get(service.service_id),
-            serviceCatalogById.get(service.service_id)?.default_rate
-          ) !== undefined
-        ) {
+        if (firstPositiveRateInCents(hourlyModeDefaultsByServiceId.get(service.service_id)) !== undefined) {
           servicesWithCustomRates.add(service.service_id);
         }
       });
       filteredUsageServices.forEach((service) => {
-        if (
-          firstPositiveRateInCents(
-            usageModeDefaultsByServiceId.get(service.service_id),
-            serviceCatalogById.get(service.service_id)?.default_rate
-          ) !== undefined
-        ) {
+        if (firstPositiveRateInCents(usageModeDefaultsByServiceId.get(service.service_id)) !== undefined) {
           servicesWithCustomRates.add(service.service_id);
         }
       });

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
@@ -23,6 +23,10 @@ interface HourlyServicesStepProps {
 export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps) {
   const { t } = useTranslation('msp/contracts');
   const [rateInputs, setRateInputs] = useState<Record<number, string>>({});
+  // Legacy default_rate (untagged) from service_catalog, shown as a hint when no currency-specific price exists.
+  const [legacyDefaultRates, setLegacyDefaultRates] = useState<Record<number, number | null>>({});
+  // Marks rows where the picked service has no service_prices row in the contract currency.
+  const [missingCurrencyPrice, setMissingCurrencyPrice] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
     const inputs: Record<number, string> = {};
@@ -50,14 +54,24 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
 
   const handleServiceChange = (index: number, item: ServiceCatalogPickerItem) => {
     const next = [...data.hourly_services];
+    const currencyRate =
+      typeof item.currency_rate === 'number' && item.currency_rate > 0
+        ? item.currency_rate
+        : undefined;
     next[index] = {
       ...next[index],
       service_id: item.service_id,
       service_name: item.service_name,
-      // Use default_rate from catalog if available
-      hourly_rate: item.default_rate > 0 ? item.default_rate : undefined,
+      // Only prefill when a price exists for this contract's currency. Legacy default_rate is
+      // untagged and likely USD — don't paste it into a non-USD contract.
+      hourly_rate: currencyRate,
     };
     updateData({ hourly_services: next });
+    setLegacyDefaultRates((prev) => ({
+      ...prev,
+      [index]: item.default_rate > 0 ? item.default_rate : null,
+    }));
+    setMissingCurrencyPrice((prev) => ({ ...prev, [index]: currencyRate === undefined }));
   };
 
   const handleRateChange = (index: number, cents: number) => {
@@ -208,6 +222,7 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
                   selectedLabel={service.service_name}
                   onSelect={(item) => handleServiceChange(index, item)}
                   itemKinds={['service']}
+                  currencyCode={data.currency_code}
                   placeholder={t('wizardHourly.labels.selectServicePlaceholder', { defaultValue: 'Select a service' })}
                 />
               </div>
@@ -257,6 +272,22 @@ export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps
                     })
                     : t('wizardHourly.labels.enterHourlyRate', { defaultValue: 'Enter the hourly rate' })}
                 </p>
+                {service.service_id && missingCurrencyPrice[index] ? (
+                  <p className="text-xs text-amber-700">
+                    {legacyDefaultRates[index]
+                      ? t('wizardHourly.labels.noCurrencyPriceWithLegacyHint', {
+                          defaultValue:
+                            'No {{currency}} price in the catalog. Legacy default rate: {{rate}}. Enter an hourly rate in {{currency}}.',
+                          currency: data.currency_code,
+                          rate: ((legacyDefaultRates[index] ?? 0) / 100).toFixed(2),
+                        })
+                      : t('wizardHourly.labels.noCurrencyPriceEnterRate', {
+                          defaultValue:
+                            'No {{currency}} price in the catalog. Enter an hourly rate.',
+                          currency: data.currency_code,
+                        })}
+                  </p>
+                ) : null}
               </div>
 
               <div className="space-y-3 pt-2 border-t border-dashed border-blue-100">

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/ProductsStep.tsx
@@ -20,8 +20,10 @@ interface ProductsStepProps {
 export function ProductsStep({ data, updateData }: ProductsStepProps) {
   const { t } = useTranslation('msp/contracts');
   const [rateInputs, setRateInputs] = useState<Record<number, string>>({});
-  // Track default rates from catalog for display
-  const [catalogRates, setCatalogRates] = useState<Record<number, number>>({});
+  // Catalog price in the contract currency (from service_prices). null when no row exists for this currency.
+  const [currencyRates, setCurrencyRates] = useState<Record<number, number | null>>({});
+  // Legacy default_rate (untagged). Shown as a fallback hint only when no currency-specific price exists.
+  const [legacyDefaultRates, setLegacyDefaultRates] = useState<Record<number, number>>({});
 
   useEffect(() => {
     const next: Record<number, string> = {};
@@ -59,11 +61,9 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
     };
     updateData({ product_services: next });
 
-    // Store the catalog rate for display
-    setCatalogRates((prev) => ({
-      ...prev,
-      [index]: item.default_rate,
-    }));
+    const currencyRate = item.currency_rate ?? null;
+    setCurrencyRates((prev) => ({ ...prev, [index]: currencyRate }));
+    setLegacyDefaultRates((prev) => ({ ...prev, [index]: item.default_rate }));
 
     setRateInputs((prev) => {
       const { [index]: _, ...rest } = prev;
@@ -133,8 +133,11 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
           </Label>
 
           {data.product_services.map((line, index) => {
-            const catalogRate = catalogRates[index] ?? null;
-            const isMissingPrice = Boolean(line.service_id && catalogRate === null && line.custom_rate == null);
+            const currencyRate = currencyRates[index] ?? null;
+            const legacyDefaultRate = legacyDefaultRates[index] ?? null;
+            const isMissingPrice = Boolean(
+              line.service_id && currencyRate === null && line.custom_rate == null,
+            );
 
             return (
               <div
@@ -155,6 +158,7 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
                       selectedLabel={line.service_name}
                       onSelect={(item) => handleProductChange(index, item)}
                       itemKinds={['product']}
+                      currencyCode={data.currency_code}
                       placeholder={t('wizardProducts.labels.selectProductPlaceholder', {
                         defaultValue: 'Select a product',
                       })}
@@ -199,17 +203,29 @@ export function ProductsStep({ data, updateData }: ProductsStepProps) {
                           className="pl-10"
                         />
                       </div>
-                      {catalogRate !== null && catalogRate > 0 ? (
+                      {currencyRate !== null && currencyRate > 0 ? (
                         <div className="text-xs text-muted-foreground">
-                          {t('wizardProducts.labels.defaultCatalogPrice', { defaultValue: 'Default catalog price:' })}{' '}
+                          {t('wizardProducts.labels.catalogPriceInCurrency', {
+                            defaultValue: 'Catalog price in {{currency}}:',
+                            currency: data.currency_code,
+                          })}{' '}
                           {currencySymbol}
-                          {(catalogRate / 100).toFixed(2)}
+                          {(currencyRate / 100).toFixed(2)}
                         </div>
                       ) : line.service_id ? (
                         <div className="text-xs text-amber-700">
-                          {t('wizardProducts.validation.noDefaultPriceEnterUnitPrice', {
-                            defaultValue: 'No default price set. Enter a unit price.',
-                          })}
+                          {legacyDefaultRate !== null && legacyDefaultRate > 0
+                            ? t('wizardProducts.validation.noCurrencyPriceWithLegacyHint', {
+                                defaultValue:
+                                  'No {{currency}} price in the catalog. Legacy default rate: {{rate}}. Enter a unit price in {{currency}}.',
+                                currency: data.currency_code,
+                                rate: (legacyDefaultRate / 100).toFixed(2),
+                              })
+                            : t('wizardProducts.validation.noCurrencyPriceEnterUnitPrice', {
+                                defaultValue:
+                                  'No {{currency}} price in the catalog. Enter a unit price.',
+                                currency: data.currency_code,
+                              })}
                         </div>
                       ) : null}
                     </div>

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
@@ -22,6 +22,9 @@ interface UsageBasedServicesStepProps {
 export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesStepProps) {
   const { t } = useTranslation('msp/contracts');
   const [rateInputs, setRateInputs] = useState<Record<number, string>>({});
+  // Legacy default_rate (untagged), shown as a hint when no service_prices row exists for the contract currency.
+  const [legacyDefaultRates, setLegacyDefaultRates] = useState<Record<number, number | null>>({});
+  const [missingCurrencyPrice, setMissingCurrencyPrice] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
     const inputs: Record<number, string> = {};
@@ -55,15 +58,25 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
 
   const handleServiceChange = (index: number, item: ServiceCatalogPickerItem) => {
     const next = [...(data.usage_services ?? [])];
+    const currencyRate =
+      typeof item.currency_rate === 'number' && item.currency_rate > 0
+        ? item.currency_rate
+        : undefined;
     next[index] = {
       ...next[index],
       service_id: item.service_id,
       service_name: item.service_name,
-      // Use default_rate from catalog if available
-      unit_rate: item.default_rate > 0 ? item.default_rate : undefined,
+      // Only prefill when a price exists in the contract's currency. Legacy default_rate is
+      // untagged and likely USD — don't paste it into a non-USD contract.
+      unit_rate: currencyRate,
       unit_of_measure: item.unit_of_measure || next[index].unit_of_measure || 'unit',
     };
     updateData({ usage_services: next });
+    setLegacyDefaultRates((prev) => ({
+      ...prev,
+      [index]: item.default_rate > 0 ? item.default_rate : null,
+    }));
+    setMissingCurrencyPrice((prev) => ({ ...prev, [index]: currencyRate === undefined }));
   };
 
   const handleRateChange = (index: number, cents: number) => {
@@ -160,6 +173,7 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
                   selectedLabel={service.service_name}
                   onSelect={(item) => handleServiceChange(index, item)}
                   itemKinds={['service']}
+                  currencyCode={data.currency_code}
                   placeholder={t('wizardUsage.labels.selectServicePlaceholder', {
                     defaultValue: 'Select a service',
                   })}
@@ -213,6 +227,22 @@ export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesS
                       })
                       : t('wizardUsage.labels.enterUnitRate', { defaultValue: 'Enter the unit rate' })}
                   </p>
+                  {service.service_id && missingCurrencyPrice[index] ? (
+                    <p className="text-xs text-amber-700">
+                      {legacyDefaultRates[index]
+                        ? t('wizardUsage.labels.noCurrencyPriceWithLegacyHint', {
+                            defaultValue:
+                              'No {{currency}} price in the catalog. Legacy default rate: {{rate}}. Enter a unit rate in {{currency}}.',
+                            currency: data.currency_code,
+                            rate: ((legacyDefaultRates[index] ?? 0) / 100).toFixed(2),
+                          })
+                        : t('wizardUsage.labels.noCurrencyPriceEnterRate', {
+                            defaultValue:
+                              'No {{currency}} price in the catalog. Enter a unit rate.',
+                            currency: data.currency_code,
+                          })}
+                    </p>
+                  ) : null}
                 </div>
 
                 <div className="space-y-2">

--- a/packages/billing/src/lib/billing/billingEngine.ts
+++ b/packages/billing/src/lib/billing/billingEngine.ts
@@ -3018,6 +3018,8 @@ export class BillingEngine {
     }
 
     const tenant = this.tenant; // Capture tenant value for joins
+    const knexRef = this.knex; // Closure-friendly knex reference for join callbacks
+    const contractCurrency = clientContractLine.currency_code || "USD";
     const clientConfigService = new ClientContractServiceConfigurationService(
       this.knex,
       tenant,
@@ -3130,6 +3132,15 @@ export class BillingEngine {
           "time_entries.service_id",
         ).andOn("service_catalog.tenant", "=", "time_entries.tenant");
       })
+      .leftJoin("service_prices as sp", function () {
+        this.on("sp.service_id", "=", "service_catalog.service_id")
+          .andOn("sp.tenant", "=", "service_catalog.tenant")
+          .andOn(
+            "sp.currency_code",
+            "=",
+            knexRef.raw("?", [contractCurrency]),
+          );
+      })
       .leftJoin("project_ticket_links", function () {
         this.on(
           "time_entries.work_item_id",
@@ -3213,6 +3224,7 @@ export class BillingEngine {
         "service_catalog.service_name",
         "service_catalog.default_rate",
         "service_catalog.tax_rate_id",
+        "sp.rate as currency_rate",
         this.knex.raw(
           "COALESCE(project_tasks.task_name, tickets.title) as work_item_name",
         ),
@@ -3259,11 +3271,28 @@ export class BillingEngine {
         // Convert to hours
         const duration = Math.ceil(durationMinutes / 60);
 
-        // Determine rate based on user type if applicable
-        let rate = Math.ceil(entry.custom_rate ?? entry.default_rate);
-        if (!isSystemManagedDefault && serviceConfig && serviceConfig.userTypeRates.has(entry.user_type)) {
-          rate = serviceConfig.userTypeRates.get(entry.user_type) as number;
+        // Resolve rate, preferring overrides over the currency-specific catalog price.
+        // Order: per-entry custom rate → per-user-type rate (contract-line config) → service_prices
+        // row in the contract's currency. We deliberately do NOT fall back to the legacy
+        // service_catalog.default_rate column because it is currency-untagged and would
+        // silently bill a USD-intended amount in a non-USD contract.
+        const userTypeRate =
+          !isSystemManagedDefault &&
+          serviceConfig &&
+          serviceConfig.userTypeRates.has(entry.user_type)
+            ? (serviceConfig.userTypeRates.get(entry.user_type) as number)
+            : undefined;
+        const resolvedRate =
+          entry.custom_rate ??
+          userTypeRate ??
+          (entry.currency_rate != null ? Number(entry.currency_rate) : undefined);
+        if (resolvedRate === undefined) {
+          throw new Error(
+            `Missing pricing for time entry on service "${entry.service_name}" (${entry.service_id}) in ${contractCurrency}. ` +
+              `Add a ${contractCurrency} price in the service catalog or set a custom rate on the time entry / contract line.`,
+          );
         }
+        const rate = Math.ceil(Number(resolvedRate) || 0);
 
         // Check for overtime if applicable
         let total = Math.round(duration * rate);
@@ -3377,6 +3406,8 @@ export class BillingEngine {
     }
 
     const tenant = this.tenant; // Capture tenant value for joins
+    const knexRef = this.knex; // Closure-friendly knex reference for join callbacks
+    const contractCurrency = clientContractLine.currency_code || "USD";
     const clientConfigService = new ClientContractServiceConfigurationService(
       this.knex,
       tenant,
@@ -3480,6 +3511,15 @@ export class BillingEngine {
           "usage_tracking.service_id",
         ).andOn("service_catalog.tenant", "=", "usage_tracking.tenant");
       })
+      .leftJoin("service_prices as sp", function () {
+        this.on("sp.service_id", "=", "service_catalog.service_id")
+          .andOn("sp.tenant", "=", "service_catalog.tenant")
+          .andOn(
+            "sp.currency_code",
+            "=",
+            knexRef.raw("?", [contractCurrency]),
+          );
+      })
       .where({
         "usage_tracking.client_id": clientId,
         "usage_tracking.tenant": this.tenant,
@@ -3509,6 +3549,7 @@ export class BillingEngine {
         "service_catalog.service_name",
         "service_catalog.default_rate",
         "service_catalog.tax_rate_id",
+        "sp.rate as currency_rate",
       ); // Fetch tax_rate_id
 
     const usageRecords = await usageRecordQuery;
@@ -3530,15 +3571,30 @@ export class BillingEngine {
           quantity = serviceConfig.config.minimum_usage;
         }
 
-        // Determine rate and calculate total
-        let rate = Math.ceil(record.default_rate);
-        let total = Math.ceil(quantity * rate);
-
-        // If service has a custom rate in the configuration, use that
-        if (!isSystemManagedDefault && serviceConfig && serviceConfig.config.custom_rate) {
-          rate = Math.ceil(serviceConfig.config.custom_rate);
-          total = Math.ceil(quantity * rate);
+        // Determine rate and calculate total.
+        // Order: contract-line configured custom_rate → service_prices row in the contract
+        // currency. The legacy service_catalog.default_rate is intentionally not used here
+        // because it is currency-untagged and would silently mis-price non-USD contracts.
+        const configuredCustomRate =
+          !isSystemManagedDefault && serviceConfig && serviceConfig.config.custom_rate
+            ? Number(serviceConfig.config.custom_rate)
+            : undefined;
+        const resolvedRate =
+          configuredCustomRate ??
+          (record.currency_rate != null ? Number(record.currency_rate) : undefined);
+        const willUseTieredPricing =
+          !isSystemManagedDefault &&
+          serviceConfig &&
+          serviceConfig.config.enable_tiered_pricing &&
+          serviceConfig.rateTiers.length > 0;
+        if (resolvedRate === undefined && !willUseTieredPricing) {
+          throw new Error(
+            `Missing pricing for usage on service "${record.service_name}" (${record.service_id}) in ${contractCurrency}. ` +
+              `Add a ${contractCurrency} price in the service catalog, set a custom rate on the contract line, or enable tiered pricing.`,
+          );
         }
+        let rate = Math.ceil(resolvedRate ?? 0);
+        let total = Math.ceil(quantity * rate);
 
         // Apply tiered pricing if enabled
         if (

--- a/server/src/test/unit/billing/billingEngine.endExclusiveQueries.test.ts
+++ b/server/src/test/unit/billing/billingEngine.endExclusiveQueries.test.ts
@@ -322,6 +322,9 @@ describe('BillingEngine end-exclusive query boundaries', () => {
             service_id: 'service-1',
             service_name: 'Software Development',
             default_rate: 15000,
+            // Joined from service_prices for the contract's currency; required since the
+            // engine no longer falls back to the untagged service_catalog.default_rate.
+            currency_rate: 15000,
             tax_rate_id: null,
             start_time: new Date('2026-02-13T10:00:00.000Z'),
             end_time: new Date('2026-02-13T11:00:00.000Z'),

--- a/server/src/test/unit/billing/defaultContractClientSchedulePricing.wiring.test.ts
+++ b/server/src/test/unit/billing/defaultContractClientSchedulePricing.wiring.test.ts
@@ -17,9 +17,11 @@ describe('system-managed default runtime billing routing and pricing wiring', ()
 
   it('F076: ignores contract-authored service configuration pricing overrides for system-managed default lines', () => {
     expect(billingEngineSource).toContain('if (serviceConfig && !isSystemManagedDefault) {');
-    expect(billingEngineSource).toContain('if (!isSystemManagedDefault && serviceConfig && serviceConfig.userTypeRates.has(entry.user_type)) {');
-    expect(billingEngineSource).toContain('if (!isSystemManagedDefault && serviceConfig && serviceConfig.config.custom_rate) {');
+    // Per-user-type override is still gated on !isSystemManagedDefault, but now reads as a const
+    // assignment inside the time-rate resolution chain rather than a standalone if-statement.
     expect(billingEngineSource).toContain('!isSystemManagedDefault &&');
+    expect(billingEngineSource).toContain('serviceConfig.userTypeRates.has(entry.user_type)');
+    expect(billingEngineSource).toContain('serviceConfig.config.custom_rate');
     expect(billingEngineSource).toContain('serviceConfig.config.enable_tiered_pricing');
   });
 });

--- a/server/src/test/unit/billingEngine.test.ts
+++ b/server/src/test/unit/billingEngine.test.ts
@@ -153,6 +153,7 @@ describe('BillingEngine', () => {
               service_id: 'service1',
               service_name: 'Managed Support (Contract: Acme Corp)',
               default_rate: 12000,
+              currency_rate: 12000,
               tax_rate_id: null,
               service_quantity: 1,
               configuration_quantity: 1,
@@ -168,6 +169,7 @@ describe('BillingEngine', () => {
               service_id: 'service1',
               service_name: 'Managed Support (Contract: Acme Corp)',
               default_rate: 12000,
+              currency_rate: 12000,
               tax_rate_id: null,
               service_quantity: 1,
               configuration_quantity: 1,
@@ -1219,6 +1221,7 @@ describe('BillingEngine', () => {
             end_time: new Date('2023-01-01T12:00:00.000Z'),
             user_rate: 50,
             default_rate: 40,
+            currency_rate: 40,
             tax_rate_id: null,
             contract_line_id: 'contract_line_1'
           },
@@ -1232,6 +1235,7 @@ describe('BillingEngine', () => {
             end_time: new Date('2023-01-02T17:00:00.000Z'),
             user_rate: null,
             default_rate: 60,
+            currency_rate: 60,
             tax_rate_id: null,
             contract_line_id: 'contract_line_2'
           },
@@ -1245,6 +1249,7 @@ describe('BillingEngine', () => {
             end_time: new Date('2023-01-03T11:00:00.000Z'),
             user_rate: null,
             default_rate: 70,
+            currency_rate: 70,
             tax_rate_id: null,
             contract_line_id: null
           },
@@ -1305,6 +1310,7 @@ describe('BillingEngine', () => {
               start_time: new Date('2023-01-01T10:00:00.000Z'),
               end_time: new Date('2023-01-01T12:00:00.000Z'),
               default_rate: 40,
+              currency_rate: 40,
               tax_rate_id: null,
               contract_line_id: null,
             },
@@ -1319,6 +1325,7 @@ describe('BillingEngine', () => {
               start_time: new Date('2023-01-01T10:00:00.000Z'),
               end_time: new Date('2023-01-01T12:00:00.000Z'),
               default_rate: 40,
+              currency_rate: 40,
               tax_rate_id: null,
               contract_line_id: null,
             },
@@ -1385,6 +1392,7 @@ describe('BillingEngine', () => {
             service_name: 'Service 1',
             quantity: 10,
             default_rate: 5,
+            currency_rate: 5,
             contract_line_id: 'contract_line_1'
           },
           {
@@ -1392,6 +1400,7 @@ describe('BillingEngine', () => {
             service_name: 'Service 2',
             quantity: 20,
             default_rate: 3,
+            currency_rate: 3,
             contract_line_id: 'contract_line_2'
           },
           {
@@ -1399,6 +1408,7 @@ describe('BillingEngine', () => {
             service_name: 'Service 3',
             quantity: 15,
             default_rate: 4,
+            currency_rate: 4,
             contract_line_id: null
           },
         ];
@@ -1453,6 +1463,7 @@ describe('BillingEngine', () => {
               service_name: 'Service 1',
               quantity: 8,
               default_rate: 5,
+              currency_rate: 5,
               tax_rate_id: null,
               contract_line_id: null,
             },
@@ -1464,6 +1475,7 @@ describe('BillingEngine', () => {
               service_name: 'Service 1',
               quantity: 8,
               default_rate: 5,
+              currency_rate: 5,
               tax_rate_id: null,
               contract_line_id: null,
             },
@@ -1535,6 +1547,7 @@ describe('BillingEngine', () => {
             end_time: new Date('2023-01-01T12:00:00.000Z'),
             user_rate: 50,
             default_rate: 40,
+            currency_rate: 40,
             tax_rate_id: null
           },
           {
@@ -1547,6 +1560,7 @@ describe('BillingEngine', () => {
             end_time: new Date('2023-01-02T17:00:00.000Z'),
             user_rate: null,
             default_rate: 60,
+            currency_rate: 60,
             tax_rate_id: null
           },
         ];
@@ -1624,12 +1638,14 @@ describe('BillingEngine', () => {
             service_name: 'Service 1',
             quantity: 10,
             default_rate: 5,
+            currency_rate: 5,
           },
           {
             service_id: 'service2',
             service_name: 'Service 2',
             quantity: 20,
             default_rate: 3,
+            currency_rate: 3,
           },
         ];
 
@@ -1698,6 +1714,7 @@ describe('BillingEngine', () => {
             start_time: new Date('2025-02-14T10:00:00.000Z'),
             end_time: new Date('2025-02-14T12:00:00.000Z'),
             default_rate: 40,
+            currency_rate: 40,
             tax_rate_id: null,
           },
         ];
@@ -1708,6 +1725,7 @@ describe('BillingEngine', () => {
             service_name: 'Usage Service',
             quantity: 6,
             default_rate: 9,
+            currency_rate: 9,
             tax_rate_id: null,
           },
         ];


### PR DESCRIPTION
  Wizard rate inputs no longer paste service_catalog.default_rate into
  hourly, usage, or product lines for non-USD contracts. Pickers now ask
  for the contract currency, prefer the matching service_prices row, and
  fall back to an empty field with the legacy rate shown only as a hint.

  Wizard validation no longer treats default_rate as satisfying pricing —
  only currency-specific mode defaults, service_prices rows, or explicit
  custom rates count. The billing engine joins service_prices on the
  contract currency for both time- and usage-based charges and throws
  "Missing pricing in {currency}" when no currency-tagged rate or override
  exists, mirroring the product/license behavior.

  Down the rabbit hole of untagged rates we tumbled, where every coin
  looked like a dollar and every contract a dreaming hatter — now each
  service_price wears its proper currency-code coat, and the Cheshire
  default_rate, smiling no more, has been politely escorted out of the
  non-USD tea party. 🎩💱🐇