### PR TITLE
Fix 404 when opening documents from search results

### DIFF
--- a/packages/documents/src/components/Documents.tsx
+++ b/packages/documents/src/components/Documents.tsx
@@ -36,6 +36,7 @@ import { useUserPreference } from '@alga-psa/user-composition/hooks';
 import { getCurrentUser, searchUsersForMentions } from '@alga-psa/user-composition/actions';
 import { getExperimentalFeatures } from '@alga-psa/tenancy/actions';
 import {
+  getDocument,
   getDocumentsByEntity,
   getDocumentsByFolder,
   moveDocumentsToFolder,
@@ -1089,6 +1090,48 @@ const Documents = ({
     }
     return clickHandlersRef.current.get(key)!;
   };
+
+  // Auto-open a document when ?doc=<id> is present (e.g. from search results / notifications)
+  const autoOpenedDocRef = useRef<string | null>(null);
+  const handleDocumentClickRef = useRef(handleDocumentClick);
+  useEffect(() => {
+    handleDocumentClickRef.current = handleDocumentClick;
+  });
+  useEffect(() => {
+    if (!inFolderMode) return;
+    const docId = searchParams?.get('doc') ?? null;
+    if (!docId || autoOpenedDocRef.current === docId) return;
+    autoOpenedDocRef.current = docId;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await getDocument(docId);
+        if (cancelled) return;
+        if (!result) return;
+        if (isActionPermissionError(result)) {
+          handleError(result.permissionError);
+          return;
+        }
+        await handleDocumentClickRef.current(result as IDocument);
+      } catch (err) {
+        if (!cancelled) {
+          handleError(err, 'Failed to open document');
+        }
+      } finally {
+        if (!cancelled) {
+          const params = new URLSearchParams(searchParams?.toString() ?? '');
+          params.delete('doc');
+          const query = params.toString();
+          router.replace(query ? `?${query}` : window.location.pathname);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, inFolderMode, router]);
 
   // Similarly for delete and disassociate handlers
   const deleteHandlersRef = useRef<Map<string, () => void>>(new Map());

--- a/server/src/lib/search/indexers/document.ts
+++ b/server/src/lib/search/indexers/document.ts
@@ -43,7 +43,7 @@ function toSearchDoc(tenant: string, row: DocumentSearchRow): SearchDoc {
     objectId: row.document_id,
     title: row.document_name,
     body: resolveBody(row),
-    url: `/msp/documents/${row.document_id}`,
+    url: `/msp/documents?doc=${row.document_id}`,
     acl: {
       requiredPermission: 'document:read',
     },


### PR DESCRIPTION
  The search indexer emitted /msp/documents/<id>, but no [id] route
  exists. Switch to the ?doc=<id> convention already used by
  notifications, and have DocumentsPage auto-open the document via
  the existing handleDocumentClick (drawer / preview / download)
  when the param is present, then strip it from the URL.

  Off to see the Wizard of /msp/documents! The yellow-brick [id]
  route was a mirage all along — turns out clicking your ?doc=
  together three times sends you straight to the drawer.  🧙‍📄✨