### PR TITLE
Fix hanging loading spinner after bulk ticket actions

### DIFF
--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -1776,6 +1776,10 @@ export const moveTicketsToBoard = withAuth(async (
     }
   }
 
+  if (movedIds.length > 0) {
+    revalidatePath('/msp/tickets');
+  }
+
   return { movedIds, failed };
 });
 

--- a/packages/tickets/src/actions/ticketBundleActions.ts
+++ b/packages/tickets/src/actions/ticketBundleActions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import { withTransaction } from '@alga-psa/db';
 import { createTenantKnex } from '@alga-psa/db';
 import { hasPermission } from '@alga-psa/auth/rbac';
@@ -194,6 +195,13 @@ export const bundleTicketsAction = withAuth(async (
       },
     });
   }
+
+  // Trigger an RSC refresh of the tickets list. The client also refetches via
+  // onFilterChange({}), but that fire-and-forget server action can be starved
+  // by background polling and never settle, leaving the loading spinner stuck.
+  // The revalidation here is a reliable backstop (the container clears its
+  // loading state when the refreshed data arrives).
+  revalidatePath('/msp/tickets');
 
   return result;
 });

--- a/packages/tickets/src/components/TicketingDashboardContainer.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.tsx
@@ -157,7 +157,6 @@ export default function TicketingDashboardContainer({
   const { t } = useTranslation('features/tickets');
   const initialStatusId = initialFilters?.statusId ?? TICKET_STATUS_FILTER_OPEN;
   const latestFetchRequestIdRef = useRef(0);
-  const pendingFetchCountRef = useRef(0);
   const filterFetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastAppliedSearchRef = useRef<string>('');
   const isSyncingFromHistoryRef = useRef(false);
@@ -213,6 +212,11 @@ export default function TicketingDashboardContainer({
     if (consolidatedData.metadata) {
       setTicketMetadata(consolidatedData.metadata);
     }
+    // A revalidatePath() inside a bulk action triggers an RSC refresh that can
+    // abort the concurrent client-side fetchTickets request, leaving its promise
+    // unsettled (so its finally never runs). The refresh itself delivers fresh
+    // data here, so clear the loading spinner — otherwise it hangs forever.
+    setIsLoading(false);
   }, [consolidatedData.tickets, consolidatedData.totalCount, consolidatedData.metadata]);
 
   const {
@@ -304,7 +308,6 @@ export default function TicketingDashboardContainer({
       return;
     }
     const requestId = ++latestFetchRequestIdRef.current;
-    pendingFetchCountRef.current++;
     setIsLoading(true);
     try {
       const effectiveSortBy = overrides?.sortBy ?? filters.sortBy ?? sortBy ?? 'entered_at';
@@ -363,9 +366,10 @@ export default function TicketingDashboardContainer({
       setTickets([]);
       setTotalCount(0);
     } finally {
-      pendingFetchCountRef.current--;
-      if (pendingFetchCountRef.current === 0) {
-        console.log('[Container] Setting isLoading to false (no pending fetches)');
+      // Clear loading only if this is still the latest request. A superseded
+      // (older) fetch must not flip the spinner off while a newer one is in
+      // flight, and an orphaned fetch must not be able to keep it stuck.
+      if (requestId === latestFetchRequestIdRef.current) {
         setIsLoading(false);
       }
     }


### PR DESCRIPTION
## Summary

After running a bulk ticket action (bundle, change status, change priority, assign, tag, set due date, move, delete), the tickets list would replace its table with a loading spinner that **hung forever**, even though the action itself succeeded. This was intermittent in production (status/priority) and reproducible locally with bundling.

## Root cause

The list's loading spinner is driven by `isLoading` in `TicketingDashboardContainer`. After a bulk action, the handler calls `onFilterChange({})`, which sets `isLoading = true` and fires `fetchTicketsWithPagination` as a **fire-and-forget server action**. `isLoading` was only cleared once that refetch settled.

Two problems made that fragile:

1. **The refetch is unreliable.** It's a separate server action dispatched right after the mutation, and it races with the background notification/queue-metrics polls. Dev-server logs proved that on the runs that hang, `fetchTicketsWithPagination` is **never dispatched/never returns** — so its `finally` never runs and the spinner never clears. (Confirmed across two back-to-back local bundles: the first logged a completed `fetchTicketsWithPagination`, the hanging second one did not.) In production this is load-dependent, which is why status/priority hang there but rarely locally. Kubernetes logs during a reproduced hang showed **no server-side error** — the action succeeds; only the client spinner is stuck.

2. **`pendingFetchCountRef` made one stuck fetch poison the state.** A prior refactor changed the spinner-clearing condition from "this is the latest request" to "all in-flight fetches have settled" (`pendingFetchCountRef === 0`). A single orphaned/never-settling fetch therefore pinned the counter above zero permanently, so subsequent actions could never clear the spinner either.

3. **Two bulk actions had no server-side backstop.** `bundleTicketsAction` and `moveTicketsToBoard` were the only bulk actions that didn't call `revalidatePath('/msp/tickets')`, so they had no reliable refresh to fall back on when the client refetch was dropped.

## Fix

`packages/tickets/src/components/TicketingDashboardContainer.tsx`
- Reverted to **request-id-based** loading clearing: the spinner clears when the latest request settles; a superseded fetch can't clear it early, and an orphaned fetch can't keep it stuck. Removed `pendingFetchCountRef`.
- Clear `isLoading` in the `consolidatedData` sync effect, so when an RSC refresh (from `revalidatePath`) delivers fresh data, the spinner clears even if the client refetch was dropped.

`packages/tickets/src/actions/ticketBundleActions.ts`, `packages/tickets/src/actions/ticketActions.ts`
- Added `revalidatePath('/msp/tickets')` to `bundleTicketsAction` and `moveTicketsToBoard`, giving every bulk action the same reliable RSC-refresh backstop the others already had.

Net effect: the spinner is no longer gated solely on a racy fire-and-forget refetch. Whichever path returns first (the client refetch or the server-driven refresh) clears it, so it can't hang.

## How it was verified

- Reproduced the bundling hang locally and used dev-server request logs to confirm the missing `fetchTicketsWithPagination` on the hanging run.
- Inspected production (`sebastian-green`, `msp` namespace) logs during a reproduced status/priority hang: action succeeded, no server-side error — consistent with the client-side race.
- Re-tested locally after the fix: repeated bundle/status/priority actions now refresh reliably with no stuck spinner.

## Test plan

- [ ] Bulk **bundle** 2+ tickets repeatedly — list refreshes, spinner always clears.
- [ ] Bulk **status** and **priority** changes repeatedly — no stuck spinner.
- [ ] Bulk **move to board**, **assign**, **add tags**, **due date**, **delete** — list refreshes, spinner clears.
- [ ] Confirm updated values are reflected in the list after each action.
- [ ] Verify in production once deployed (status/priority were prod-only).