### PR TITLE
Sync primary agent with team assign/remove on tasks

### DIFF
--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -1315,6 +1315,84 @@ export const addTaskResourceAction = withAuth(async (
     }
 });
 
+// Batched equivalent of addTaskResourceAction: inserts every missing resource in a
+// single transaction, then emits one PROJECT_TASK_ADDITIONAL_AGENT_ASSIGNED event
+// per added agent (same per-agent contract as the single-add path). Returns the
+// task's resources so callers refetch once instead of per member.
+export const addTaskResourcesAction = withAuth(async (
+    user,
+    { tenant },
+    taskId: string,
+    userIds: string[],
+    role?: string
+): Promise<any[]> => {
+    try {
+        const {knex: db} = await createTenantKnex();
+        const { resources, added, projectId, primaryAgentId } = await withTransaction(db, async (trx: Knex.Transaction) => {
+            await checkPermission(user, 'project', 'update', trx);
+            const projectId = await resolveProjectIdForTask(trx, tenant, taskId);
+            if (!projectId) {
+                throw new Error('Project not found for task');
+            }
+            await assertProjectReadAllowedById(trx, tenant, user as IUserWithRoles, projectId);
+
+            const task = await trx('project_tasks')
+                .where({ task_id: taskId, tenant })
+                .first();
+            if (!task) {
+                throw new Error('Task not found');
+            }
+
+            const wanted = Array.from(new Set(userIds.filter(Boolean)));
+            const existing = await trx('task_resources')
+                .where({ task_id: taskId, tenant })
+                .whereIn('additional_user_id', wanted)
+                .select('additional_user_id');
+            const existingIds = new Set(existing.map((row: { additional_user_id: string }) => row.additional_user_id));
+
+            // A user can't be both the primary and an additional agent
+            // (CHECK assigned_to != additional_user_id); also skip rows already present.
+            const primaryAgentId = task.assigned_to as string | null;
+            const toInsert = wanted.filter((id) => id !== primaryAgentId && !existingIds.has(id));
+
+            if (toInsert.length > 0) {
+                await trx('task_resources').insert(
+                    toInsert.map((userId) => ({
+                        tenant,
+                        task_id: taskId,
+                        assigned_to: primaryAgentId || userId,
+                        additional_user_id: userId,
+                        role: role || null
+                    }))
+                );
+            }
+
+            const resources = await ProjectTaskModel.getTaskResources(trx, tenant, taskId);
+            return { resources, added: toInsert, projectId, primaryAgentId };
+        });
+
+        // Emit per-agent events after commit so subscribers see the committed rows.
+        for (const userId of added) {
+            await publishEvent({
+                eventType: 'PROJECT_TASK_ADDITIONAL_AGENT_ASSIGNED',
+                payload: {
+                    tenantId: tenant,
+                    projectId,
+                    taskId,
+                    primaryAgentId,
+                    additionalAgentId: userId,
+                    assignedByUserId: user.user_id
+                }
+            });
+        }
+
+        return resources;
+    } catch (error) {
+        console.error('Error adding task resources:', error);
+        throw error;
+    }
+});
+
 export const assignTeamToProjectTask = withAuth(async (
     user,
     { tenant },

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -1365,9 +1365,16 @@ export const assignTeamToProjectTask = withAuth(async (
                 .andWhere('users.is_inactive', false)
                 .select('team_members.user_id');
 
-            // assigned_to is guaranteed non-null: either the task already has one,
-            // or we fall back to team.manager_id (validated above).
-            const assignedTo: string = (task.assigned_to as string | null) || team.manager_id;
+            // Assigning a team makes that team's lead the task's primary agent,
+            // overwriting any previous primary (e.g. the prior team's lead).
+            const assignedTo: string = team.manager_id;
+
+            // The new lead can't be both primary and an additional resource
+            // (CHECK assigned_to != additional_user_id + unique index), so drop
+            // any existing resource row for them before promoting to primary.
+            await trx('task_resources')
+                .where({ task_id: taskId, tenant, additional_user_id: assignedTo })
+                .delete();
 
             await trx('project_tasks')
                 .where({ task_id: taskId, tenant })
@@ -1466,6 +1473,15 @@ export const removeTeamFromProjectTask = withAuth(async (
             }
             await assertProjectReadAllowedById(trx, tenant, user as IUserWithRoles, projectId);
 
+            // Resolve the team's lead so we know whether removing the team should
+            // also vacate the primary agent slot it filled.
+            const removedTeam = task.assigned_team_id
+                ? await trx('teams')
+                    .where({ team_id: task.assigned_team_id, tenant })
+                    .first()
+                : null;
+            const teamLeadId: string | null = removedTeam?.manager_id ?? null;
+
             const mode = options.mode;
             if (mode === 'remove_all') {
                 await trx('task_resources')
@@ -1493,10 +1509,16 @@ export const removeTeamFromProjectTask = withAuth(async (
                     .update({ role: null });
             }
 
+            // 'remove_all' takes the whole team off the task, including its lead,
+            // so clear the primary agent when it's that lead. 'keep_all' and
+            // 'selective' keep people assigned, so the lead stays as primary.
+            const clearPrimary = mode === 'remove_all' && !!teamLeadId && task.assigned_to === teamLeadId;
+
             await trx('project_tasks')
                 .where({ task_id: taskId, tenant })
                 .update({
                     assigned_team_id: null,
+                    ...(clearPrimary ? { assigned_to: null } : {}),
                     updated_at: new Date()
                 });
         });

--- a/packages/projects/src/components/TaskForm.tsx
+++ b/packages/projects/src/components/TaskForm.tsx
@@ -18,7 +18,7 @@ import {
   getTaskChecklistItems,
   moveTaskToPhase,
   deleteTask,
-  addTaskResourceAction,
+  addTaskResourcesAction,
   removeTaskResourceAction,
   getTaskResourcesAction,
   assignTeamToProjectTask,
@@ -845,11 +845,11 @@ export default function TaskForm({
         resultTask = await updateTaskWithChecklist(taskToUpdate.task_id, taskData);
 
         // Save any temporarily stored additional agents (added while task had no primary agent)
-        for (const resource of tempTaskResources) {
+        if (tempTaskResources.length > 0) {
           try {
-            await addTaskResourceAction(taskToUpdate.task_id, resource.additional_user_id);
+            await addTaskResourcesAction(taskToUpdate.task_id, tempTaskResources.map(r => r.additional_user_id));
           } catch (agentError) {
-            console.error(`Failed to add additional agent ${resource.additional_user_id}:`, agentError);
+            console.error('Failed to add additional agents:', agentError);
           }
         }
 
@@ -883,12 +883,8 @@ export default function TaskForm({
               await assignTeamToProjectTask(resultTask.task_id, assignedTeamId);
             }
             // Add task resources
-            for (const resource of tempTaskResources) {
-              try {
-                await addTaskResourceAction(resultTask.task_id, resource.additional_user_id);
-              } catch (agentError) {
-                console.error(`Failed to add additional agent ${resource.additional_user_id}:`, agentError);
-              }
+            if (tempTaskResources.length > 0) {
+              await addTaskResourcesAction(resultTask.task_id, tempTaskResources.map(r => r.additional_user_id));
             }
 
             // Add ticket links using the actual task ID and phase ID
@@ -1333,34 +1329,53 @@ export default function TaskForm({
     }
   };
 
-  const handleAddAgent = async (userId: string) => {
-    try {
-      const primaryChanged = task?.assigned_to !== assignedUser;
-      if (task?.task_id && assignedUser && !primaryChanged) {
-        // Existing task with unchanged primary agent: save immediately
-        await addTaskResourceAction(task.task_id, userId);
-        const updatedResources = await getTaskResourcesAction(task.task_id);
+  // Add one or more users to the task as additional agents. Persists in a single
+  // batched request when the task exists with an unchanged primary; otherwise
+  // stages them locally to be saved with the task (deferred to avoid the
+  // assigned_to != additional_user_id CHECK while the primary is mid-change).
+  const addAgents = async (userIds: string[]) => {
+    const existingIds = new Set(
+      [...taskResources, ...tempTaskResources].map(r => r.additional_user_id)
+    );
+    const toAdd = Array.from(new Set(userIds))
+      .filter(id => id && id !== assignedUser && !existingIds.has(id));
+    if (toAdd.length === 0) return;
+
+    const primaryChanged = task?.assigned_to !== assignedUser;
+    if (task?.task_id && assignedUser && !primaryChanged) {
+      // Existing task with unchanged primary agent: one batched insert + refetch.
+      try {
+        const updatedResources = await addTaskResourcesAction(task.task_id, toAdd);
         setTaskResources(updatedResources);
         toast.success(taskFormT('agentAddedSuccess', 'Agent added successfully'));
-      } else {
-        // New task, no primary agent, or primary has changed: store temporarily
-        // When primary has changed, we must defer saving to avoid CHECK constraint
-        // violation (assigned_to != additional_user_id) since DB still has old primary
-        const selectedUser = users.find(u => u.user_id === userId);
-        if (selectedUser) {
-          const tempResource = {
-            additional_user_id: userId,
-            first_name: selectedUser.first_name,
-            last_name: selectedUser.last_name,
-            assignment_id: `temp-${Date.now()}`
-          };
-          setTempTaskResources(prev => [...prev, tempResource]);
-          toast.success(taskFormT('agentPendingSave', 'Agent will be added when task is saved'));
-        }
+      } catch (error: any) {
+        handleError(error, taskFormT('addAgentFailed', 'Failed to add agent'));
       }
-    } catch (error: any) {
-      handleError(error, taskFormT('addAgentFailed', 'Failed to add agent'));
+    } else {
+      // New task, no primary agent, or primary has changed: stage locally and
+      // persist on save (makes no requests, so no per-member round-trips).
+      const tempResources = toAdd
+        .map(userId => {
+          const selectedUser = users.find(u => u.user_id === userId);
+          return selectedUser
+            ? {
+                additional_user_id: userId,
+                first_name: selectedUser.first_name,
+                last_name: selectedUser.last_name,
+                assignment_id: `temp-${Date.now()}-${userId}`
+              }
+            : null;
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== null);
+      if (tempResources.length > 0) {
+        setTempTaskResources(prev => [...prev, ...tempResources]);
+        toast.success(taskFormT('agentPendingSave', 'Agent will be added when task is saved'));
+      }
     }
+  };
+
+  const handleAddAgent = async (userId: string) => {
+    await addAgents([userId]);
   };
 
   // Add every member of a team (including its lead) onto the task as additional
@@ -1369,19 +1384,10 @@ export default function TaskForm({
   const addTeamMembersAsAgents = async (teamId: string) => {
     const team = teams.find(t => t.team_id === teamId);
     if (!team) return;
-    const memberIds = Array.from(new Set(
-      [...(team.members || []).map(m => m.user_id), team.manager_id || null]
-        .filter((id): id is string => Boolean(id))
-    ));
-    const existingIds = new Set(
-      [...taskResources, ...tempTaskResources].map(r => r.additional_user_id)
-    );
-    for (const userId of memberIds) {
-      // The primary agent can't also be an additional agent (CHECK constraint);
-      // skip them and anyone already on the task.
-      if (userId === assignedUser || existingIds.has(userId)) continue;
-      await handleAddAgent(userId);
-    }
+    const memberIds = [...(team.members || []).map(m => m.user_id), team.manager_id || null]
+      .filter((id): id is string => Boolean(id));
+    // addAgents drops the primary (CHECK constraint) and anyone already present.
+    await addAgents(memberIds);
   };
 
   const handleRemoveAgent = async (assignmentId: string) => {
@@ -1851,9 +1857,9 @@ export default function TaskForm({
                         // Find removed users
                         const removedUserIds = currentUserIds.filter(id => !newUserIds.includes(id));
 
-                        // Process all additions sequentially
-                        for (const userId of addedUserIds) {
-                          await handleAddAgent(userId);
+                        // Add all new agents in a single batched request
+                        if (addedUserIds.length > 0) {
+                          await addAgents(addedUserIds);
                         }
 
                         // Process all removals sequentially

--- a/packages/projects/src/components/TaskForm.tsx
+++ b/packages/projects/src/components/TaskForm.tsx
@@ -712,15 +712,27 @@ export default function TaskForm({
     mode: 'remove_all' | 'keep_all' | 'selective',
     keepUserIds?: string[]
   ) => {
+    // 'remove_all' takes the team's lead off the task too, so mirror the server
+    // and clear the primary agent when it's that lead.
+    const removedTeam = teams.find(t => t.team_id === assignedTeamId);
+    const removedLeadId =
+      removedTeam?.manager_id ||
+      removedTeam?.members?.find(m => m.role === 'lead')?.user_id ||
+      null;
+    const shouldClearPrimary =
+      mode === 'remove_all' && !!removedLeadId && assignedUser === removedLeadId;
+
     if (!task?.task_id) {
       // New task: just clear local state (nothing persisted yet)
       setAssignedTeamId(null);
       setTempTaskResources(prev => prev.filter(r => r.role !== 'team_member'));
+      if (shouldClearPrimary) setAssignedUser(null);
       return;
     }
     try {
       await removeTeamFromProjectTask(task.task_id, { mode, keepUserIds });
       setAssignedTeamId(null);
+      if (shouldClearPrimary) setAssignedUser(null);
       const resources = await getTaskResourcesAction(task.task_id);
       setTaskResources(resources);
       setInitialTaskResources(resources);
@@ -1351,6 +1363,27 @@ export default function TaskForm({
     }
   };
 
+  // Add every member of a team (including its lead) onto the task as additional
+  // agents, leaving the primary agent untouched. Used by the Additional Agents
+  // picker; team *assignment* (lead → primary) goes through performTeamAssign.
+  const addTeamMembersAsAgents = async (teamId: string) => {
+    const team = teams.find(t => t.team_id === teamId);
+    if (!team) return;
+    const memberIds = Array.from(new Set(
+      [...(team.members || []).map(m => m.user_id), team.manager_id || null]
+        .filter((id): id is string => Boolean(id))
+    ));
+    const existingIds = new Set(
+      [...taskResources, ...tempTaskResources].map(r => r.additional_user_id)
+    );
+    for (const userId of memberIds) {
+      // The primary agent can't also be an additional agent (CHECK constraint);
+      // skip them and anyone already on the task.
+      if (userId === assignedUser || existingIds.has(userId)) continue;
+      await handleAddAgent(userId);
+    }
+  };
+
   const handleRemoveAgent = async (assignmentId: string) => {
     try {
       if (assignmentId.startsWith('temp-')) {
@@ -1794,11 +1827,12 @@ export default function TaskForm({
                     teams={teams}
                     teamSectionLabel={taskFormT('addTeamMembers', 'Add Team Members')}
                     onTeamValuesChange={(selectedTeamIds) => {
-                      // When a team is selected, use handleAssignTeam which already
-                      // expands team members into task_resources server-side.
-                      // Do NOT also call handleAddAgent per member (causes duplicates).
+                      // Selecting a team here drops its members (including the
+                      // lead) onto the task as additional agents and leaves the
+                      // primary agent alone. Team assignment (lead → primary) is
+                      // done via the Assigned To picker above.
                       for (const teamId of selectedTeamIds) {
-                        handleAssignTeam(teamId);
+                        void addTeamMembersAsAgents(teamId);
                       }
                     }}
                     onValuesChange={async (newUserIds) => {

--- a/packages/projects/src/components/__tests__/TaskFormCreateFromTicket.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormCreateFromTicket.test.tsx
@@ -55,6 +55,7 @@ vi.mock('../actions/projectTaskActions', () => ({
   moveTaskToPhase: vi.fn(),
   deleteTask: vi.fn(),
   addTaskResourceAction: vi.fn(),
+  addTaskResourcesAction: vi.fn(),
   removeTaskResourceAction: vi.fn(),
   getTaskResourcesAction: vi.fn(),
   addTicketLinkAction: (...args: unknown[]) => addTicketLinkActionMock(...args),

--- a/packages/projects/src/components/__tests__/TaskFormPrefill.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormPrefill.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../actions/projectTaskActions', () => ({
   moveTaskToPhase: vi.fn(),
   deleteTask: vi.fn(),
   addTaskResourceAction: vi.fn(),
+  addTaskResourcesAction: vi.fn(),
   removeTaskResourceAction: vi.fn(),
   getTaskResourcesAction: vi.fn(),
   addTicketLinkAction: (...args: unknown[]) => addTicketLinkActionMock(...args),

--- a/packages/projects/src/components/__tests__/TaskFormTaskDataProps.test.tsx
+++ b/packages/projects/src/components/__tests__/TaskFormTaskDataProps.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../actions/projectTaskActions', () => ({
   moveTaskToPhase: vi.fn(),
   deleteTask: vi.fn(),
   addTaskResourceAction: vi.fn(),
+  addTaskResourcesAction: vi.fn(),
   removeTaskResourceAction: vi.fn(),
   getTaskResourcesAction: vi.fn(),
   addTicketLinkAction: vi.fn(),


### PR DESCRIPTION
  Assigning a team now makes that team's lead the task's primary
  agent (overwriting any stale lead), and removes any resource row
  for that user so they aren't both primary and additional. Removing
  a team with 'remove_all' now also vacates the primary when it was
  the team's lead; 'keep_all'/'selective' leave it in place. The
  Additional Agents picker drops a team's members (including the
  lead) onto the task as plain additional agents without touching
  the primary.

  Fixes the lead lingering after removal and the primary flashing
  then emptying on reassignment.

  "Off with the old lead's head!" cried the Queen — yet the manager_id
  merely shuffled from primary to resource and back, until at last
  remove_all sent the team's lead tumbling down the rabbit hole of
  assigned_to: null. 👑🐇🃏