### PR TITLE
Uncover unified full-text search API endpoint

### DIFF
--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -101,6 +101,9 @@
       "name": "Quotes & Contracts v1"
     },
     {
+      "name": "Search"
+    },
+    {
       "name": "Service Catalog"
     },
     {
@@ -1962,6 +1965,11 @@
             "format": "uuid",
             "description": "Client UUID from clients.client_id."
           },
+          "location_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Client location UUID from client_locations.location_id."
+          },
           "asset_type": {
             "type": "string",
             "enum": [
@@ -2192,9 +2200,17 @@
             "minLength": 1,
             "description": "Required asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional client_locations.location_id link. Validated to belong to client_id."
+          },
           "location": {
             "type": "string",
-            "description": "Optional asset location."
+            "description": "Optional free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2259,9 +2275,17 @@
             "minLength": 1,
             "description": "Asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link. Pass null to clear."
+          },
           "location": {
             "type": "string",
-            "description": "Asset location."
+            "description": "Free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2607,6 +2631,14 @@
           "status": {
             "type": "string",
             "description": "Asset status."
+          },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link, when set."
           },
           "location": {
             "type": [
@@ -13228,6 +13260,200 @@
           }
         },
         "description": "Payload for updating a status. All fields are optional."
+      },
+      "SearchQuery": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+          },
+          "types": {
+            "type": "string",
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "relevance",
+              "recent"
+            ],
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "SearchResultRow": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "client",
+              "contact",
+              "user",
+              "ticket",
+              "ticket_comment",
+              "project",
+              "project_phase",
+              "project_task",
+              "project_task_comment",
+              "asset",
+              "invoice",
+              "invoice_item",
+              "invoice_annotation",
+              "contract",
+              "client_contract",
+              "document",
+              "kb_article",
+              "service_catalog",
+              "service_request_submission",
+              "service_request_definition",
+              "workflow_task",
+              "interaction",
+              "schedule_entry",
+              "time_entry",
+              "board",
+              "category",
+              "tag",
+              "status"
+            ],
+            "description": "Indexed business object type."
+          },
+          "id": {
+            "type": "string",
+            "description": "Object identifier within its type."
+          },
+          "parentId": {
+            "type": "string",
+            "description": "Identifier of the parent record for nested results (e.g. the ticket of a ticket comment)."
+          },
+          "title": {
+            "type": "string",
+            "description": "Primary display label for the record."
+          },
+          "subtitle": {
+            "type": "string",
+            "description": "Secondary context line."
+          },
+          "snippet": {
+            "type": "string",
+            "description": "Matched-text excerpt with <mark> tags around the highlighted terms."
+          },
+          "url": {
+            "type": "string",
+            "description": "Relative in-app URL pointing at the record."
+          },
+          "score": {
+            "type": "number",
+            "description": "Relevance score; higher is more relevant."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Source record last-updated timestamp."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "title",
+          "url",
+          "score",
+          "updatedAt"
+        ]
+      },
+      "SearchResultData": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultRow"
+            },
+            "description": "Matching records for this page, ordered by the requested sort."
+          },
+          "groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Total match counts keyed by object type (across all pages), before the page limit is applied."
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "Total number of matches across all permitted types."
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Cursor for the next page; absent when the result set fits within the page."
+          }
+        },
+        "required": [
+          "results",
+          "groups",
+          "totalCount"
+        ]
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SearchResultData"
+              },
+              {
+                "description": "Search payload returned by createSuccessResponse."
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SearchApiErrorEnvelope": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED, or INTERNAL_ERROR."
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message."
+              },
+              "details": {
+                "description": "Optional structured details, including Zod validation errors."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
       },
       "ServiceCategory": {
         "type": "object",
@@ -26623,6 +26849,17 @@
             "required": false,
             "description": "Client UUID from clients.client_id.",
             "name": "client_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Client location UUID from client_locations.location_id."
+            },
+            "required": false,
+            "description": "Client location UUID from client_locations.location_id.",
+            "name": "location_id",
             "in": "query"
           },
           {
@@ -57594,6 +57831,140 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "summary": "Unified full-text search",
+        "description": "Full-text search across all indexed business records (tickets, clients, contacts, projects, assets, invoices, contracts, documents, knowledge-base articles, and more) backed by the shared app_search_index. Results are tenant-scoped and filtered by the API key user's permissions: a coarse per-type permission gate plus a per-row access-control check, so only records the user could see in-app are returned. No dedicated search permission is required — any valid API key may call this endpoint. Client-portal API keys are automatically scoped to their own client.",
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-acl-filtered": true,
+          "x-not-paginated": false
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+            },
+            "required": true,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\").",
+            "name": "query",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+            },
+            "required": false,
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
+            "name": "types",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+            },
+            "required": false,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+            },
+            "required": false,
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor.",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "recent"
+              ],
+              "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+            },
+            "required": false,
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update.",
+            "name": "sort",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching records returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Query parameter validation failed (missing/empty query, unknown type, or out-of-range limit).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "API rate limit exceeded for the key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while executing the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
                 }
               }
             }

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -37,6 +37,7 @@ tags:
   - name: Projects
   - name: QuickBooks v1
   - name: Quotes & Contracts v1
+  - name: Search
   - name: Service Catalog
   - name: Service Categories
   - name: Service Types
@@ -1318,6 +1319,10 @@ components:
           type: string
           format: uuid
           description: Client UUID from clients.client_id.
+        location_id:
+          type: string
+          format: uuid
+          description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
           enum: &a2
@@ -1491,9 +1496,16 @@ components:
           type: string
           minLength: 1
           description: Required asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Optional client_locations.location_id link. Validated to belong to
+            client_id.
         location:
           type: string
-          description: Optional asset location.
+          description: Optional free-text asset location.
         serial_number:
           type: string
           description: Optional serial number.
@@ -1538,9 +1550,15 @@ components:
           type: string
           minLength: 1
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link. Pass null to clear.
         location:
           type: string
-          description: Asset location.
+          description: Free-text asset location.
         serial_number:
           type: string
           description: Serial number.
@@ -1785,6 +1803,12 @@ components:
         status:
           type: string
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link, when set.
         location:
           type:
             - string
@@ -9351,6 +9375,166 @@ components:
           type: string
           maxLength: 50
       description: Payload for updating a status. All fields are optional.
+    SearchQuery:
+      type: object
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+        types:
+          type: string
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+        cursor:
+          type: string
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+        sort:
+          type: string
+          enum: &a95
+            - relevance
+            - recent
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+      required:
+        - query
+    SearchResultRow:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - client
+            - contact
+            - user
+            - ticket
+            - ticket_comment
+            - project
+            - project_phase
+            - project_task
+            - project_task_comment
+            - asset
+            - invoice
+            - invoice_item
+            - invoice_annotation
+            - contract
+            - client_contract
+            - document
+            - kb_article
+            - service_catalog
+            - service_request_submission
+            - service_request_definition
+            - workflow_task
+            - interaction
+            - schedule_entry
+            - time_entry
+            - board
+            - category
+            - tag
+            - status
+          description: Indexed business object type.
+        id:
+          type: string
+          description: Object identifier within its type.
+        parentId:
+          type: string
+          description: Identifier of the parent record for nested results (e.g. the ticket
+            of a ticket comment).
+        title:
+          type: string
+          description: Primary display label for the record.
+        subtitle:
+          type: string
+          description: Secondary context line.
+        snippet:
+          type: string
+          description: Matched-text excerpt with <mark> tags around the highlighted terms.
+        url:
+          type: string
+          description: Relative in-app URL pointing at the record.
+        score:
+          type: number
+          description: Relevance score; higher is more relevant.
+        updatedAt:
+          type: string
+          format: date-time
+          description: Source record last-updated timestamp.
+      required:
+        - type
+        - id
+        - title
+        - url
+        - score
+        - updatedAt
+    SearchResultData:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchResultRow"
+          description: Matching records for this page, ordered by the requested sort.
+        groups:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Total match counts keyed by object type (across all pages), before
+            the page limit is applied.
+        totalCount:
+          type: integer
+          description: Total number of matches across all permitted types.
+        nextCursor:
+          type: string
+          description: Cursor for the next page; absent when the result set fits within
+            the page.
+      required:
+        - results
+        - groups
+        - totalCount
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          allOf:
+            - $ref: "#/components/schemas/SearchResultData"
+            - description: Search payload returned by createSuccessResponse.
+      required:
+        - data
+    SearchApiErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED,
+                or INTERNAL_ERROR.
+            message:
+              type: string
+              description: Human-readable error message.
+            details:
+              description: Optional structured details, including Zod validation errors.
+          required:
+            - code
+            - message
+      required:
+        - error
     ServiceCategory:
       type: object
       properties:
@@ -9545,7 +9729,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a96
             - asc
             - desc
         search:
@@ -9572,19 +9756,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a98
+          enum: &a99
             - "true"
             - "false"
         offset:
@@ -9593,17 +9777,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a99
+          enum: &a100
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a101
+          enum: &a102
             - service
             - ticket
     CategoryMoveRequest:
@@ -9630,7 +9814,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a102
+          enum: &a103
             - service
             - ticket
         board_id:
@@ -9638,7 +9822,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a103
+          enum: &a104
             - "true"
             - "false"
         limit:
@@ -9652,7 +9836,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a104
+          enum: &a105
             - service
             - ticket
         board_id:
@@ -9666,7 +9850,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -10287,7 +10471,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a111
+          enum: &a112
             - asc
             - desc
         name:
@@ -10298,24 +10482,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a114
+          enum: &a115
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a115
+          enum: &a116
             - "true"
             - "false"
         last_delivery_from:
@@ -10349,7 +10533,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a116
+          enum: &a117
             - pending
             - delivered
             - failed
@@ -12111,7 +12295,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         fields:
@@ -12337,7 +12521,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a118
+          enum: &a119
             - asc
             - desc
         search:
@@ -12346,12 +12530,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -18502,6 +18686,14 @@ paths:
           required: false
           description: Client UUID from clients.client_id.
           name: client_id
+          in: query
+        - schema:
+            type: string
+            format: uuid
+            description: Client location UUID from client_locations.location_id.
+          required: false
+          description: Client location UUID from client_locations.location_id.
+          name: location_id
           in: query
         - schema:
             type: string
@@ -39151,6 +39343,123 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/search:
+    get:
+      summary: Unified full-text search
+      description: "Full-text search across all indexed business records (tickets,
+        clients, contacts, projects, assets, invoices, contracts, documents,
+        knowledge-base articles, and more) backed by the shared
+        app_search_index. Results are tenant-scoped and filtered by the API key
+        user's permissions: a coarse per-type permission gate plus a per-row
+        access-control check, so only records the user could see in-app are
+        returned. No dedicated search permission is required — any valid API key
+        may call this endpoint. Client-portal API keys are automatically scoped
+        to their own client."
+      tags:
+        - Search
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-acl-filtered: true
+        x-not-paginated: false
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+            description: Full-text query. A concise expression of likely record words,
+              identifiers, names, or quoted phrases — not a full sentence.
+              Supports OR for alternatives (e.g. "laptop OR workstation").
+          required: true
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+          name: query
+          in: query
+        - schema:
+            type: string
+            description: "Comma-separated list of object types to restrict the search (e.g.
+              \"ticket,project\"). Omit to search every type the API key's user
+              is permitted to read. Allowed values: client, contact, user,
+              ticket, ticket_comment, project, project_phase, project_task,
+              project_task_comment, asset, invoice, invoice_item,
+              invoice_annotation, contract, client_contract, document,
+              kb_article, service_catalog, service_request_submission,
+              service_request_definition, workflow_task, interaction,
+              schedule_entry, time_entry, board, category, tag, status."
+          required: false
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Maximum number of results to return. Defaults to 30; capped at 100.
+          required: false
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor copied from a prior response's nextCursor.
+          required: false
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum: *a95
+            description: Result ordering. "relevance" (default) ranks by full-text score;
+              "recent" orders by last update.
+          required: false
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: Matching records returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "400":
+          description: Query parameter validation failed (missing/empty query, unknown
+            type, or out-of-range limit).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "401":
+          description: API key is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "429":
+          description: API rate limit exceeded for the key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "500":
+          description: Unexpected error while executing the search.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
   /api/v1/categories/service:
     get:
       summary: List service categories
@@ -39486,7 +39795,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: order
           in: query
@@ -39538,13 +39847,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
           required: false
           name: is_child
           in: query
@@ -39555,7 +39864,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: active
           in: query
@@ -39571,19 +39880,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: category_type
           in: query
@@ -40039,7 +40348,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: category_type
           in: query
@@ -40051,7 +40360,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: include_inactive
           in: query
@@ -40126,7 +40435,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: category_type
           in: query
@@ -40150,7 +40459,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: include_usage
           in: query
@@ -40236,7 +40545,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a106
+      tags: &a107
         - Services
         - Service Catalog
       security:
@@ -40312,7 +40621,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a107
+            enum: &a108
               - fixed
               - hourly
               - usage
@@ -40360,7 +40669,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40389,7 +40698,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40451,7 +40760,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40500,7 +40809,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40538,7 +40847,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40599,7 +40908,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40648,7 +40957,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a108
+      tags: &a109
         - Products
         - Service Catalog
       security:
@@ -40759,7 +41068,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40788,7 +41097,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a109
+                  enum: &a110
                     - usage
                   default: usage
                 default_rate:
@@ -40927,7 +41236,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40976,7 +41285,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41014,7 +41323,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a109
+                  enum: *a110
                   default: usage
                 default_rate:
                   type: number
@@ -41153,7 +41462,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41201,7 +41510,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a110
+      tags: &a111
         - Service Types
         - Service Catalog
       security:
@@ -41262,7 +41571,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a110
+      tags: *a111
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41343,7 +41652,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: order
           in: query
@@ -41364,25 +41673,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: has_failures
           in: query
@@ -42413,7 +42722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
           required: false
           name: status
           in: query
@@ -44531,7 +44840,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44832,7 +45141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44916,7 +45225,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45000,7 +45309,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45093,7 +45402,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45191,7 +45500,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45494,7 +45803,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45591,7 +45900,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45849,7 +46158,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45939,7 +46248,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46083,7 +46392,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46378,7 +46687,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46469,7 +46778,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46613,7 +46922,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47048,7 +47357,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47359,7 +47668,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47785,7 +48094,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47869,7 +48178,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48056,7 +48365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48141,7 +48450,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48499,7 +48808,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48597,7 +48906,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48832,7 +49141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48974,7 +49283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49283,7 +49592,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49426,7 +49735,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49569,7 +49878,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49726,7 +50035,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50009,7 +50318,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50153,7 +50462,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50588,7 +50897,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50791,7 +51100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50877,7 +51186,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51320,7 +51629,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51791,7 +52100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51883,7 +52192,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51899,13 +52208,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -51974,7 +52283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51990,13 +52299,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53411,7 +53720,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53427,13 +53736,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53506,7 +53815,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53522,13 +53831,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -104,6 +104,9 @@
       "name": "Quotes & Contracts v1"
     },
     {
+      "name": "Search"
+    },
+    {
       "name": "Service Catalog"
     },
     {
@@ -1962,6 +1965,11 @@
             "format": "uuid",
             "description": "Client UUID from clients.client_id."
           },
+          "location_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Client location UUID from client_locations.location_id."
+          },
           "asset_type": {
             "type": "string",
             "enum": [
@@ -2192,9 +2200,17 @@
             "minLength": 1,
             "description": "Required asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional client_locations.location_id link. Validated to belong to client_id."
+          },
           "location": {
             "type": "string",
-            "description": "Optional asset location."
+            "description": "Optional free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2259,9 +2275,17 @@
             "minLength": 1,
             "description": "Asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link. Pass null to clear."
+          },
           "location": {
             "type": "string",
-            "description": "Asset location."
+            "description": "Free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2607,6 +2631,14 @@
           "status": {
             "type": "string",
             "description": "Asset status."
+          },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link, when set."
           },
           "location": {
             "type": [
@@ -13228,6 +13260,200 @@
           }
         },
         "description": "Payload for updating a status. All fields are optional."
+      },
+      "SearchQuery": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+          },
+          "types": {
+            "type": "string",
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "relevance",
+              "recent"
+            ],
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "SearchResultRow": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "client",
+              "contact",
+              "user",
+              "ticket",
+              "ticket_comment",
+              "project",
+              "project_phase",
+              "project_task",
+              "project_task_comment",
+              "asset",
+              "invoice",
+              "invoice_item",
+              "invoice_annotation",
+              "contract",
+              "client_contract",
+              "document",
+              "kb_article",
+              "service_catalog",
+              "service_request_submission",
+              "service_request_definition",
+              "workflow_task",
+              "interaction",
+              "schedule_entry",
+              "time_entry",
+              "board",
+              "category",
+              "tag",
+              "status"
+            ],
+            "description": "Indexed business object type."
+          },
+          "id": {
+            "type": "string",
+            "description": "Object identifier within its type."
+          },
+          "parentId": {
+            "type": "string",
+            "description": "Identifier of the parent record for nested results (e.g. the ticket of a ticket comment)."
+          },
+          "title": {
+            "type": "string",
+            "description": "Primary display label for the record."
+          },
+          "subtitle": {
+            "type": "string",
+            "description": "Secondary context line."
+          },
+          "snippet": {
+            "type": "string",
+            "description": "Matched-text excerpt with <mark> tags around the highlighted terms."
+          },
+          "url": {
+            "type": "string",
+            "description": "Relative in-app URL pointing at the record."
+          },
+          "score": {
+            "type": "number",
+            "description": "Relevance score; higher is more relevant."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Source record last-updated timestamp."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "title",
+          "url",
+          "score",
+          "updatedAt"
+        ]
+      },
+      "SearchResultData": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultRow"
+            },
+            "description": "Matching records for this page, ordered by the requested sort."
+          },
+          "groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Total match counts keyed by object type (across all pages), before the page limit is applied."
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "Total number of matches across all permitted types."
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Cursor for the next page; absent when the result set fits within the page."
+          }
+        },
+        "required": [
+          "results",
+          "groups",
+          "totalCount"
+        ]
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SearchResultData"
+              },
+              {
+                "description": "Search payload returned by createSuccessResponse."
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SearchApiErrorEnvelope": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED, or INTERNAL_ERROR."
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message."
+              },
+              "details": {
+                "description": "Optional structured details, including Zod validation errors."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
       },
       "ServiceCategory": {
         "type": "object",
@@ -26623,6 +26849,17 @@
             "required": false,
             "description": "Client UUID from clients.client_id.",
             "name": "client_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Client location UUID from client_locations.location_id."
+            },
+            "required": false,
+            "description": "Client location UUID from client_locations.location_id.",
+            "name": "location_id",
             "in": "query"
           },
           {
@@ -57594,6 +57831,140 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "summary": "Unified full-text search",
+        "description": "Full-text search across all indexed business records (tickets, clients, contacts, projects, assets, invoices, contracts, documents, knowledge-base articles, and more) backed by the shared app_search_index. Results are tenant-scoped and filtered by the API key user's permissions: a coarse per-type permission gate plus a per-row access-control check, so only records the user could see in-app are returned. No dedicated search permission is required — any valid API key may call this endpoint. Client-portal API keys are automatically scoped to their own client.",
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-acl-filtered": true,
+          "x-not-paginated": false
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+            },
+            "required": true,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\").",
+            "name": "query",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+            },
+            "required": false,
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
+            "name": "types",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+            },
+            "required": false,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+            },
+            "required": false,
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor.",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "recent"
+              ],
+              "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+            },
+            "required": false,
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update.",
+            "name": "sort",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching records returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Query parameter validation failed (missing/empty query, unknown type, or out-of-range limit).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "API rate limit exceeded for the key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while executing the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
                 }
               }
             }

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -38,6 +38,7 @@ tags:
   - name: Projects
   - name: QuickBooks v1
   - name: Quotes & Contracts v1
+  - name: Search
   - name: Service Catalog
   - name: Service Categories
   - name: Service Types
@@ -1318,6 +1319,10 @@ components:
           type: string
           format: uuid
           description: Client UUID from clients.client_id.
+        location_id:
+          type: string
+          format: uuid
+          description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
           enum: &a2
@@ -1491,9 +1496,16 @@ components:
           type: string
           minLength: 1
           description: Required asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Optional client_locations.location_id link. Validated to belong to
+            client_id.
         location:
           type: string
-          description: Optional asset location.
+          description: Optional free-text asset location.
         serial_number:
           type: string
           description: Optional serial number.
@@ -1538,9 +1550,15 @@ components:
           type: string
           minLength: 1
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link. Pass null to clear.
         location:
           type: string
-          description: Asset location.
+          description: Free-text asset location.
         serial_number:
           type: string
           description: Serial number.
@@ -1785,6 +1803,12 @@ components:
         status:
           type: string
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link, when set.
         location:
           type:
             - string
@@ -9351,6 +9375,166 @@ components:
           type: string
           maxLength: 50
       description: Payload for updating a status. All fields are optional.
+    SearchQuery:
+      type: object
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+        types:
+          type: string
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+        cursor:
+          type: string
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+        sort:
+          type: string
+          enum: &a95
+            - relevance
+            - recent
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+      required:
+        - query
+    SearchResultRow:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - client
+            - contact
+            - user
+            - ticket
+            - ticket_comment
+            - project
+            - project_phase
+            - project_task
+            - project_task_comment
+            - asset
+            - invoice
+            - invoice_item
+            - invoice_annotation
+            - contract
+            - client_contract
+            - document
+            - kb_article
+            - service_catalog
+            - service_request_submission
+            - service_request_definition
+            - workflow_task
+            - interaction
+            - schedule_entry
+            - time_entry
+            - board
+            - category
+            - tag
+            - status
+          description: Indexed business object type.
+        id:
+          type: string
+          description: Object identifier within its type.
+        parentId:
+          type: string
+          description: Identifier of the parent record for nested results (e.g. the ticket
+            of a ticket comment).
+        title:
+          type: string
+          description: Primary display label for the record.
+        subtitle:
+          type: string
+          description: Secondary context line.
+        snippet:
+          type: string
+          description: Matched-text excerpt with <mark> tags around the highlighted terms.
+        url:
+          type: string
+          description: Relative in-app URL pointing at the record.
+        score:
+          type: number
+          description: Relevance score; higher is more relevant.
+        updatedAt:
+          type: string
+          format: date-time
+          description: Source record last-updated timestamp.
+      required:
+        - type
+        - id
+        - title
+        - url
+        - score
+        - updatedAt
+    SearchResultData:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchResultRow"
+          description: Matching records for this page, ordered by the requested sort.
+        groups:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Total match counts keyed by object type (across all pages), before
+            the page limit is applied.
+        totalCount:
+          type: integer
+          description: Total number of matches across all permitted types.
+        nextCursor:
+          type: string
+          description: Cursor for the next page; absent when the result set fits within
+            the page.
+      required:
+        - results
+        - groups
+        - totalCount
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          allOf:
+            - $ref: "#/components/schemas/SearchResultData"
+            - description: Search payload returned by createSuccessResponse.
+      required:
+        - data
+    SearchApiErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED,
+                or INTERNAL_ERROR.
+            message:
+              type: string
+              description: Human-readable error message.
+            details:
+              description: Optional structured details, including Zod validation errors.
+          required:
+            - code
+            - message
+      required:
+        - error
     ServiceCategory:
       type: object
       properties:
@@ -9545,7 +9729,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a96
             - asc
             - desc
         search:
@@ -9572,19 +9756,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a98
+          enum: &a99
             - "true"
             - "false"
         offset:
@@ -9593,17 +9777,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a99
+          enum: &a100
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a101
+          enum: &a102
             - service
             - ticket
     CategoryMoveRequest:
@@ -9630,7 +9814,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a102
+          enum: &a103
             - service
             - ticket
         board_id:
@@ -9638,7 +9822,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a103
+          enum: &a104
             - "true"
             - "false"
         limit:
@@ -9652,7 +9836,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a104
+          enum: &a105
             - service
             - ticket
         board_id:
@@ -9666,7 +9850,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -10287,7 +10471,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a111
+          enum: &a112
             - asc
             - desc
         name:
@@ -10298,24 +10482,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a114
+          enum: &a115
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a115
+          enum: &a116
             - "true"
             - "false"
         last_delivery_from:
@@ -10349,7 +10533,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a116
+          enum: &a117
             - pending
             - delivered
             - failed
@@ -12111,7 +12295,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         fields:
@@ -12337,7 +12521,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a118
+          enum: &a119
             - asc
             - desc
         search:
@@ -12346,12 +12530,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -18502,6 +18686,14 @@ paths:
           required: false
           description: Client UUID from clients.client_id.
           name: client_id
+          in: query
+        - schema:
+            type: string
+            format: uuid
+            description: Client location UUID from client_locations.location_id.
+          required: false
+          description: Client location UUID from client_locations.location_id.
+          name: location_id
           in: query
         - schema:
             type: string
@@ -39151,6 +39343,123 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/search:
+    get:
+      summary: Unified full-text search
+      description: "Full-text search across all indexed business records (tickets,
+        clients, contacts, projects, assets, invoices, contracts, documents,
+        knowledge-base articles, and more) backed by the shared
+        app_search_index. Results are tenant-scoped and filtered by the API key
+        user's permissions: a coarse per-type permission gate plus a per-row
+        access-control check, so only records the user could see in-app are
+        returned. No dedicated search permission is required — any valid API key
+        may call this endpoint. Client-portal API keys are automatically scoped
+        to their own client."
+      tags:
+        - Search
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-acl-filtered: true
+        x-not-paginated: false
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+            description: Full-text query. A concise expression of likely record words,
+              identifiers, names, or quoted phrases — not a full sentence.
+              Supports OR for alternatives (e.g. "laptop OR workstation").
+          required: true
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+          name: query
+          in: query
+        - schema:
+            type: string
+            description: "Comma-separated list of object types to restrict the search (e.g.
+              \"ticket,project\"). Omit to search every type the API key's user
+              is permitted to read. Allowed values: client, contact, user,
+              ticket, ticket_comment, project, project_phase, project_task,
+              project_task_comment, asset, invoice, invoice_item,
+              invoice_annotation, contract, client_contract, document,
+              kb_article, service_catalog, service_request_submission,
+              service_request_definition, workflow_task, interaction,
+              schedule_entry, time_entry, board, category, tag, status."
+          required: false
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Maximum number of results to return. Defaults to 30; capped at 100.
+          required: false
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor copied from a prior response's nextCursor.
+          required: false
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum: *a95
+            description: Result ordering. "relevance" (default) ranks by full-text score;
+              "recent" orders by last update.
+          required: false
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: Matching records returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "400":
+          description: Query parameter validation failed (missing/empty query, unknown
+            type, or out-of-range limit).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "401":
+          description: API key is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "429":
+          description: API rate limit exceeded for the key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "500":
+          description: Unexpected error while executing the search.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
   /api/v1/categories/service:
     get:
       summary: List service categories
@@ -39486,7 +39795,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: order
           in: query
@@ -39538,13 +39847,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
           required: false
           name: is_child
           in: query
@@ -39555,7 +39864,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: active
           in: query
@@ -39571,19 +39880,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: category_type
           in: query
@@ -40039,7 +40348,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: category_type
           in: query
@@ -40051,7 +40360,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: include_inactive
           in: query
@@ -40126,7 +40435,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: category_type
           in: query
@@ -40150,7 +40459,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: include_usage
           in: query
@@ -40236,7 +40545,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a106
+      tags: &a107
         - Services
         - Service Catalog
       security:
@@ -40312,7 +40621,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a107
+            enum: &a108
               - fixed
               - hourly
               - usage
@@ -40360,7 +40669,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40389,7 +40698,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40451,7 +40760,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40500,7 +40809,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40538,7 +40847,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40599,7 +40908,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40648,7 +40957,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a108
+      tags: &a109
         - Products
         - Service Catalog
       security:
@@ -40759,7 +41068,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40788,7 +41097,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a109
+                  enum: &a110
                     - usage
                   default: usage
                 default_rate:
@@ -40927,7 +41236,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40976,7 +41285,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41014,7 +41323,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a109
+                  enum: *a110
                   default: usage
                 default_rate:
                   type: number
@@ -41153,7 +41462,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41201,7 +41510,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a110
+      tags: &a111
         - Service Types
         - Service Catalog
       security:
@@ -41262,7 +41571,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a110
+      tags: *a111
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41343,7 +41652,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: order
           in: query
@@ -41364,25 +41673,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: has_failures
           in: query
@@ -42413,7 +42722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
           required: false
           name: status
           in: query
@@ -44531,7 +44840,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44832,7 +45141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44916,7 +45225,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45000,7 +45309,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45093,7 +45402,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45191,7 +45500,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45494,7 +45803,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45591,7 +45900,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45849,7 +46158,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45939,7 +46248,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46083,7 +46392,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46378,7 +46687,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46469,7 +46778,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46613,7 +46922,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47048,7 +47357,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47359,7 +47668,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47785,7 +48094,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47869,7 +48178,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48056,7 +48365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48141,7 +48450,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48499,7 +48808,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48597,7 +48906,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48832,7 +49141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48974,7 +49283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49283,7 +49592,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49426,7 +49735,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49569,7 +49878,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49726,7 +50035,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50009,7 +50318,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50153,7 +50462,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50588,7 +50897,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50791,7 +51100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50877,7 +51186,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51320,7 +51629,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51791,7 +52100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51883,7 +52192,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51899,13 +52208,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -51974,7 +52283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51990,13 +52299,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53411,7 +53720,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53427,13 +53736,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53506,7 +53815,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53522,13 +53831,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -101,6 +101,9 @@
       "name": "Quotes & Contracts v1"
     },
     {
+      "name": "Search"
+    },
+    {
       "name": "Service Catalog"
     },
     {
@@ -1962,6 +1965,11 @@
             "format": "uuid",
             "description": "Client UUID from clients.client_id."
           },
+          "location_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Client location UUID from client_locations.location_id."
+          },
           "asset_type": {
             "type": "string",
             "enum": [
@@ -2192,9 +2200,17 @@
             "minLength": 1,
             "description": "Required asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional client_locations.location_id link. Validated to belong to client_id."
+          },
           "location": {
             "type": "string",
-            "description": "Optional asset location."
+            "description": "Optional free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2259,9 +2275,17 @@
             "minLength": 1,
             "description": "Asset status."
           },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link. Pass null to clear."
+          },
           "location": {
             "type": "string",
-            "description": "Asset location."
+            "description": "Free-text asset location."
           },
           "serial_number": {
             "type": "string",
@@ -2607,6 +2631,14 @@
           "status": {
             "type": "string",
             "description": "Asset status."
+          },
+          "location_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Client_locations.location_id link, when set."
           },
           "location": {
             "type": [
@@ -13228,6 +13260,200 @@
           }
         },
         "description": "Payload for updating a status. All fields are optional."
+      },
+      "SearchQuery": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+          },
+          "types": {
+            "type": "string",
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "relevance",
+              "recent"
+            ],
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "SearchResultRow": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "client",
+              "contact",
+              "user",
+              "ticket",
+              "ticket_comment",
+              "project",
+              "project_phase",
+              "project_task",
+              "project_task_comment",
+              "asset",
+              "invoice",
+              "invoice_item",
+              "invoice_annotation",
+              "contract",
+              "client_contract",
+              "document",
+              "kb_article",
+              "service_catalog",
+              "service_request_submission",
+              "service_request_definition",
+              "workflow_task",
+              "interaction",
+              "schedule_entry",
+              "time_entry",
+              "board",
+              "category",
+              "tag",
+              "status"
+            ],
+            "description": "Indexed business object type."
+          },
+          "id": {
+            "type": "string",
+            "description": "Object identifier within its type."
+          },
+          "parentId": {
+            "type": "string",
+            "description": "Identifier of the parent record for nested results (e.g. the ticket of a ticket comment)."
+          },
+          "title": {
+            "type": "string",
+            "description": "Primary display label for the record."
+          },
+          "subtitle": {
+            "type": "string",
+            "description": "Secondary context line."
+          },
+          "snippet": {
+            "type": "string",
+            "description": "Matched-text excerpt with <mark> tags around the highlighted terms."
+          },
+          "url": {
+            "type": "string",
+            "description": "Relative in-app URL pointing at the record."
+          },
+          "score": {
+            "type": "number",
+            "description": "Relevance score; higher is more relevant."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Source record last-updated timestamp."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "title",
+          "url",
+          "score",
+          "updatedAt"
+        ]
+      },
+      "SearchResultData": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultRow"
+            },
+            "description": "Matching records for this page, ordered by the requested sort."
+          },
+          "groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Total match counts keyed by object type (across all pages), before the page limit is applied."
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "Total number of matches across all permitted types."
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Cursor for the next page; absent when the result set fits within the page."
+          }
+        },
+        "required": [
+          "results",
+          "groups",
+          "totalCount"
+        ]
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SearchResultData"
+              },
+              {
+                "description": "Search payload returned by createSuccessResponse."
+              }
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SearchApiErrorEnvelope": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED, or INTERNAL_ERROR."
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message."
+              },
+              "details": {
+                "description": "Optional structured details, including Zod validation errors."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ]
       },
       "ServiceCategory": {
         "type": "object",
@@ -26623,6 +26849,17 @@
             "required": false,
             "description": "Client UUID from clients.client_id.",
             "name": "client_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Client location UUID from client_locations.location_id."
+            },
+            "required": false,
+            "description": "Client location UUID from client_locations.location_id.",
+            "name": "location_id",
             "in": "query"
           },
           {
@@ -57594,6 +57831,140 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "summary": "Unified full-text search",
+        "description": "Full-text search across all indexed business records (tickets, clients, contacts, projects, assets, invoices, contracts, documents, knowledge-base articles, and more) backed by the shared app_search_index. Results are tenant-scoped and filtered by the API key user's permissions: a coarse per-type permission gate plus a per-row access-control check, so only records the user could see in-app are returned. No dedicated search permission is required — any valid API key may call this endpoint. Client-portal API keys are automatically scoped to their own client.",
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-acl-filtered": true,
+          "x-not-paginated": false
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\")."
+            },
+            "required": true,
+            "description": "Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. \"laptop OR workstation\").",
+            "name": "query",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status."
+            },
+            "required": false,
+            "description": "Comma-separated list of object types to restrict the search (e.g. \"ticket,project\"). Omit to search every type the API key's user is permitted to read. Allowed values: client, contact, user, ticket, ticket_comment, project, project_phase, project_task, project_task_comment, asset, invoice, invoice_item, invoice_annotation, contract, client_contract, document, kb_article, service_catalog, service_request_submission, service_request_definition, workflow_task, interaction, schedule_entry, time_entry, board, category, tag, status.",
+            "name": "types",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Maximum number of results to return. Defaults to 30; capped at 100."
+            },
+            "required": false,
+            "description": "Maximum number of results to return. Defaults to 30; capped at 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Opaque pagination cursor copied from a prior response's nextCursor."
+            },
+            "required": false,
+            "description": "Opaque pagination cursor copied from a prior response's nextCursor.",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "recent"
+              ],
+              "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update."
+            },
+            "required": false,
+            "description": "Result ordering. \"relevance\" (default) ranks by full-text score; \"recent\" orders by last update.",
+            "name": "sort",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching records returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Query parameter validation failed (missing/empty query, unknown type, or out-of-range limit).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "API rate limit exceeded for the key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while executing the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchApiErrorEnvelope"
                 }
               }
             }

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -37,6 +37,7 @@ tags:
   - name: Projects
   - name: QuickBooks v1
   - name: Quotes & Contracts v1
+  - name: Search
   - name: Service Catalog
   - name: Service Categories
   - name: Service Types
@@ -1318,6 +1319,10 @@ components:
           type: string
           format: uuid
           description: Client UUID from clients.client_id.
+        location_id:
+          type: string
+          format: uuid
+          description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
           enum: &a2
@@ -1491,9 +1496,16 @@ components:
           type: string
           minLength: 1
           description: Required asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Optional client_locations.location_id link. Validated to belong to
+            client_id.
         location:
           type: string
-          description: Optional asset location.
+          description: Optional free-text asset location.
         serial_number:
           type: string
           description: Optional serial number.
@@ -1538,9 +1550,15 @@ components:
           type: string
           minLength: 1
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link. Pass null to clear.
         location:
           type: string
-          description: Asset location.
+          description: Free-text asset location.
         serial_number:
           type: string
           description: Serial number.
@@ -1785,6 +1803,12 @@ components:
         status:
           type: string
           description: Asset status.
+        location_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Client_locations.location_id link, when set.
         location:
           type:
             - string
@@ -9351,6 +9375,166 @@ components:
           type: string
           maxLength: 50
       description: Payload for updating a status. All fields are optional.
+    SearchQuery:
+      type: object
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+        types:
+          type: string
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+        cursor:
+          type: string
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+        sort:
+          type: string
+          enum: &a95
+            - relevance
+            - recent
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+      required:
+        - query
+    SearchResultRow:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - client
+            - contact
+            - user
+            - ticket
+            - ticket_comment
+            - project
+            - project_phase
+            - project_task
+            - project_task_comment
+            - asset
+            - invoice
+            - invoice_item
+            - invoice_annotation
+            - contract
+            - client_contract
+            - document
+            - kb_article
+            - service_catalog
+            - service_request_submission
+            - service_request_definition
+            - workflow_task
+            - interaction
+            - schedule_entry
+            - time_entry
+            - board
+            - category
+            - tag
+            - status
+          description: Indexed business object type.
+        id:
+          type: string
+          description: Object identifier within its type.
+        parentId:
+          type: string
+          description: Identifier of the parent record for nested results (e.g. the ticket
+            of a ticket comment).
+        title:
+          type: string
+          description: Primary display label for the record.
+        subtitle:
+          type: string
+          description: Secondary context line.
+        snippet:
+          type: string
+          description: Matched-text excerpt with <mark> tags around the highlighted terms.
+        url:
+          type: string
+          description: Relative in-app URL pointing at the record.
+        score:
+          type: number
+          description: Relevance score; higher is more relevant.
+        updatedAt:
+          type: string
+          format: date-time
+          description: Source record last-updated timestamp.
+      required:
+        - type
+        - id
+        - title
+        - url
+        - score
+        - updatedAt
+    SearchResultData:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchResultRow"
+          description: Matching records for this page, ordered by the requested sort.
+        groups:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Total match counts keyed by object type (across all pages), before
+            the page limit is applied.
+        totalCount:
+          type: integer
+          description: Total number of matches across all permitted types.
+        nextCursor:
+          type: string
+          description: Cursor for the next page; absent when the result set fits within
+            the page.
+      required:
+        - results
+        - groups
+        - totalCount
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          allOf:
+            - $ref: "#/components/schemas/SearchResultData"
+            - description: Search payload returned by createSuccessResponse.
+      required:
+        - data
+    SearchApiErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED,
+                or INTERNAL_ERROR.
+            message:
+              type: string
+              description: Human-readable error message.
+            details:
+              description: Optional structured details, including Zod validation errors.
+          required:
+            - code
+            - message
+      required:
+        - error
     ServiceCategory:
       type: object
       properties:
@@ -9545,7 +9729,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a96
             - asc
             - desc
         search:
@@ -9572,19 +9756,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a96
+          enum: &a97
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a97
+          enum: &a98
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a98
+          enum: &a99
             - "true"
             - "false"
         offset:
@@ -9593,17 +9777,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a99
+          enum: &a100
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a100
+          enum: &a101
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a101
+          enum: &a102
             - service
             - ticket
     CategoryMoveRequest:
@@ -9630,7 +9814,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a102
+          enum: &a103
             - service
             - ticket
         board_id:
@@ -9638,7 +9822,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a103
+          enum: &a104
             - "true"
             - "false"
         limit:
@@ -9652,7 +9836,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a104
+          enum: &a105
             - service
             - ticket
         board_id:
@@ -9666,7 +9850,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a105
+          enum: &a106
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -10287,7 +10471,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a111
+          enum: &a112
             - asc
             - desc
         name:
@@ -10298,24 +10482,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a112
+          enum: &a113
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a113
+          enum: &a114
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a114
+          enum: &a115
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a115
+          enum: &a116
             - "true"
             - "false"
         last_delivery_from:
@@ -10349,7 +10533,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a116
+          enum: &a117
             - pending
             - delivered
             - failed
@@ -12111,7 +12295,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a117
+          enum: &a118
             - asc
             - desc
         fields:
@@ -12337,7 +12521,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a118
+          enum: &a119
             - asc
             - desc
         search:
@@ -12346,12 +12530,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a119
+          enum: &a120
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a120
+          enum: &a121
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -18502,6 +18686,14 @@ paths:
           required: false
           description: Client UUID from clients.client_id.
           name: client_id
+          in: query
+        - schema:
+            type: string
+            format: uuid
+            description: Client location UUID from client_locations.location_id.
+          required: false
+          description: Client location UUID from client_locations.location_id.
+          name: location_id
           in: query
         - schema:
             type: string
@@ -39151,6 +39343,123 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/search:
+    get:
+      summary: Unified full-text search
+      description: "Full-text search across all indexed business records (tickets,
+        clients, contacts, projects, assets, invoices, contracts, documents,
+        knowledge-base articles, and more) backed by the shared
+        app_search_index. Results are tenant-scoped and filtered by the API key
+        user's permissions: a coarse per-type permission gate plus a per-row
+        access-control check, so only records the user could see in-app are
+        returned. No dedicated search permission is required — any valid API key
+        may call this endpoint. Client-portal API keys are automatically scoped
+        to their own client."
+      tags:
+        - Search
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-acl-filtered: true
+        x-not-paginated: false
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+            description: Full-text query. A concise expression of likely record words,
+              identifiers, names, or quoted phrases — not a full sentence.
+              Supports OR for alternatives (e.g. "laptop OR workstation").
+          required: true
+          description: Full-text query. A concise expression of likely record words,
+            identifiers, names, or quoted phrases — not a full sentence.
+            Supports OR for alternatives (e.g. "laptop OR workstation").
+          name: query
+          in: query
+        - schema:
+            type: string
+            description: "Comma-separated list of object types to restrict the search (e.g.
+              \"ticket,project\"). Omit to search every type the API key's user
+              is permitted to read. Allowed values: client, contact, user,
+              ticket, ticket_comment, project, project_phase, project_task,
+              project_task_comment, asset, invoice, invoice_item,
+              invoice_annotation, contract, client_contract, document,
+              kb_article, service_catalog, service_request_submission,
+              service_request_definition, workflow_task, interaction,
+              schedule_entry, time_entry, board, category, tag, status."
+          required: false
+          description: "Comma-separated list of object types to restrict the search (e.g.
+            \"ticket,project\"). Omit to search every type the API key's user is
+            permitted to read. Allowed values: client, contact, user, ticket,
+            ticket_comment, project, project_phase, project_task,
+            project_task_comment, asset, invoice, invoice_item,
+            invoice_annotation, contract, client_contract, document, kb_article,
+            service_catalog, service_request_submission,
+            service_request_definition, workflow_task, interaction,
+            schedule_entry, time_entry, board, category, tag, status."
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            description: Maximum number of results to return. Defaults to 30; capped at 100.
+          required: false
+          description: Maximum number of results to return. Defaults to 30; capped at 100.
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor copied from a prior response's nextCursor.
+          required: false
+          description: Opaque pagination cursor copied from a prior response's nextCursor.
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum: *a95
+            description: Result ordering. "relevance" (default) ranks by full-text score;
+              "recent" orders by last update.
+          required: false
+          description: Result ordering. "relevance" (default) ranks by full-text score;
+            "recent" orders by last update.
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: Matching records returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "400":
+          description: Query parameter validation failed (missing/empty query, unknown
+            type, or out-of-range limit).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "401":
+          description: API key is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "429":
+          description: API rate limit exceeded for the key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
+        "500":
+          description: Unexpected error while executing the search.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchApiErrorEnvelope"
   /api/v1/categories/service:
     get:
       summary: List service categories
@@ -39486,7 +39795,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a96
           required: false
           name: order
           in: query
@@ -39538,13 +39847,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a96
+            enum: *a97
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a98
           required: false
           name: is_child
           in: query
@@ -39555,7 +39864,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a99
           required: false
           name: active
           in: query
@@ -39571,19 +39880,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a99
+            enum: *a100
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a100
+            enum: *a101
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a102
           required: false
           name: category_type
           in: query
@@ -40039,7 +40348,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a103
           required: false
           name: category_type
           in: query
@@ -40051,7 +40360,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a104
           required: false
           name: include_inactive
           in: query
@@ -40126,7 +40435,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a104
+            enum: *a105
           required: false
           name: category_type
           in: query
@@ -40150,7 +40459,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a106
           required: false
           name: include_usage
           in: query
@@ -40236,7 +40545,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a106
+      tags: &a107
         - Services
         - Service Catalog
       security:
@@ -40312,7 +40621,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a107
+            enum: &a108
               - fixed
               - hourly
               - usage
@@ -40360,7 +40669,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40389,7 +40698,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40451,7 +40760,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40500,7 +40809,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40538,7 +40847,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a107
+                  enum: *a108
                 default_rate:
                   type: number
                   minimum: 0
@@ -40599,7 +40908,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a106
+      tags: *a107
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40648,7 +40957,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a108
+      tags: &a109
         - Products
         - Service Catalog
       security:
@@ -40759,7 +41068,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40788,7 +41097,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a109
+                  enum: &a110
                     - usage
                   default: usage
                 default_rate:
@@ -40927,7 +41236,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -40976,7 +41285,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41014,7 +41323,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a109
+                  enum: *a110
                   default: usage
                 default_rate:
                   type: number
@@ -41153,7 +41462,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a108
+      tags: *a109
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41201,7 +41510,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a110
+      tags: &a111
         - Service Types
         - Service Catalog
       security:
@@ -41262,7 +41571,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a110
+      tags: *a111
       security:
         - ApiKeyAuth: []
       extensions:
@@ -41343,7 +41652,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a112
           required: false
           name: order
           in: query
@@ -41364,25 +41673,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a113
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a114
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a115
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a115
+            enum: *a116
           required: false
           name: has_failures
           in: query
@@ -42413,7 +42722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a117
           required: false
           name: status
           in: query
@@ -44531,7 +44840,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44832,7 +45141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -44916,7 +45225,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45000,7 +45309,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45093,7 +45402,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45191,7 +45500,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45494,7 +45803,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45591,7 +45900,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45849,7 +46158,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -45939,7 +46248,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46083,7 +46392,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46378,7 +46687,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46469,7 +46778,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -46613,7 +46922,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47048,7 +47357,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47359,7 +47668,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47785,7 +48094,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -47869,7 +48178,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48056,7 +48365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48141,7 +48450,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48499,7 +48808,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48597,7 +48906,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48832,7 +49141,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -48974,7 +49283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49283,7 +49592,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49426,7 +49735,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49569,7 +49878,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -49726,7 +50035,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50009,7 +50318,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50153,7 +50462,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50588,7 +50897,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50791,7 +51100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -50877,7 +51186,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51320,7 +51629,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51791,7 +52100,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a117
+            enum: *a118
           required: false
           name: order
           in: query
@@ -51883,7 +52192,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51899,13 +52208,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -51974,7 +52283,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -51990,13 +52299,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53411,7 +53720,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53427,13 +53736,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query
@@ -53506,7 +53815,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a118
+            enum: *a119
           required: false
           name: order
           in: query
@@ -53522,13 +53831,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a119
+            enum: *a120
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a120
+            enum: *a121
           required: false
           name: include_client
           in: query

--- a/server/src/app/api/v1/search/route.ts
+++ b/server/src/app/api/v1/search/route.ts
@@ -1,0 +1,13 @@
+/**
+ * Unified Search API Route
+ * GET /api/v1/search - Full-text search across all indexed business records
+ */
+
+import { ApiSearchController } from 'server/src/lib/api/controllers/ApiSearchController';
+
+const controller = new ApiSearchController();
+
+export const GET = controller.search();
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/lib/actions/searchActions.ts
+++ b/server/src/lib/actions/searchActions.ts
@@ -3,31 +3,29 @@
 import { withAuth } from '@alga-psa/auth';
 import logger from '@alga-psa/core/logger';
 import { createTenantKnex } from '@alga-psa/db';
-import type { IUserWithRoles } from '@alga-psa/types';
 import { RateLimiterMemory } from 'rate-limiter-flexible';
 
-import { registeredObjectTypes } from '../search';
 import {
   resolveSearchAclPrincipal,
   verifyResultVisibility,
-  type ClientAccess,
 } from '../search/acl';
 import {
   countSearchMatches,
-  countSearchMatchesByType,
-  encodeSearchCursor,
-  runSearchQuery,
   runSearchTypeaheadQuery,
 } from '../search/query';
-import { SEARCH_OBJECT_TYPES, type SearchObjectType } from '@alga-psa/types';
+import {
+  filterTypesByPermission,
+  resolveAllowedTypes,
+  resolveClientAccess,
+  runAppSearch,
+  toSearchResultRow,
+} from '../search/runAppSearch';
 import {
   SearchRateLimitError,
   searchAppInputSchema,
-  searchAppResultSchema,
   searchTypeaheadResultSchema,
   type SearchAppInput,
   type SearchAppResult,
-  type SearchResultRow,
   type SearchTypeaheadResult,
 } from './searchActionShared';
 
@@ -38,44 +36,8 @@ export type {
   SearchTypeaheadResult,
 } from './searchActionShared';
 
-const SEARCH_OBJECT_TYPE_SET = new Set<string>(SEARCH_OBJECT_TYPES);
 const fullSearchLimiter = new RateLimiterMemory({ points: 10, duration: 1 });
 const typeaheadSearchLimiter = new RateLimiterMemory({ points: 30, duration: 1 });
-// Coarse query-time gate: a type is queried only if the user holds at least
-// one of these permissions. The precise per-row filter is the stored
-// `required_permission` enforced by aclPredicateSql. Types whose rows can
-// require different permissions (e.g. `status` spans ticket vs project
-// statuses) list all of them so no class of user is wrongly excluded.
-const TYPE_REQUIRED_PERMISSION: Record<SearchObjectType, string | readonly string[]> = {
-  client: 'client:read',
-  contact: 'contact:read',
-  user: 'user:read',
-  ticket: 'ticket:read',
-  ticket_comment: 'ticket:read',
-  project: 'project:read',
-  project_phase: 'project:read',
-  project_task: 'project:read',
-  project_task_comment: 'project:read',
-  asset: 'asset:read',
-  invoice: 'invoice:read',
-  invoice_item: 'invoice:read',
-  invoice_annotation: 'invoice:read',
-  contract: 'contract:read',
-  client_contract: 'contract:read',
-  document: 'document:read',
-  kb_article: 'kb:read',
-  service_catalog: 'service_catalog:read',
-  service_request_submission: 'service_request:read',
-  service_request_definition: 'admin',
-  workflow_task: 'workflow_task:read',
-  interaction: 'interaction:read',
-  schedule_entry: 'schedule:read',
-  time_entry: 'time:read',
-  board: 'ticket:read',
-  category: 'ticket:read',
-  tag: 'ticket:read',
-  status: ['ticket:read', 'project:read'],
-};
 
 function emitSearchTelemetry(
   metric: 'search.query.count' | 'search.query.empty' | 'search.query.latency_ms',
@@ -101,78 +63,6 @@ async function enforceSearchRateLimit(
   }
 }
 
-function normalizeLimit(limit: number | undefined): number {
-  const parsed = Number(limit ?? 30);
-  if (!Number.isFinite(parsed)) {
-    return 30;
-  }
-  return Math.max(1, Math.min(Math.floor(parsed), 100));
-}
-
-function resolveAllowedTypes(inputTypes: SearchObjectType[] | undefined): SearchObjectType[] {
-  const registered = registeredObjectTypes()
-    .filter((type): type is SearchObjectType => SEARCH_OBJECT_TYPE_SET.has(type));
-  if (!inputTypes || inputTypes.length === 0) {
-    return registered;
-  }
-
-  const requested = new Set(inputTypes);
-  return registered.filter((type) => requested.has(type));
-}
-
-function filterTypesByPermission(
-  types: SearchObjectType[],
-  permissions: readonly string[],
-): SearchObjectType[] {
-  const permissionSet = new Set(permissions);
-  return types.filter((type) => {
-    const required = TYPE_REQUIRED_PERMISSION[type];
-    const candidates = Array.isArray(required) ? required : [required];
-    return candidates.some((permission) => permissionSet.has(permission));
-  });
-}
-
-function emptyGroups(): Record<SearchObjectType, number> {
-  return Object.fromEntries(
-    SEARCH_OBJECT_TYPES.map((type) => [type, 0]),
-  ) as Record<SearchObjectType, number>;
-}
-
-/**
- * Single source of truth for which clients a search principal may see.
- *
- * Internal/MSP users are currently unrestricted, so they get `{ mode: 'all' }`
- * — no `clients` table scan and no giant UUID array bound into every search
- * query. Client-portal users are scoped to their own client.
- *
- * When ABAC per-internal-user client restrictions are introduced, the *only*
- * change is here: return `{ mode: 'scoped', clientIds }` for restricted
- * internal users. The SQL predicate and the per-row visibility verifier both
- * consume this mode, so the restriction is enforced in both layers without
- * an `isInternal` shortcut to audit.
- */
-function resolveClientAccess(user: IUserWithRoles): ClientAccess {
-  if (user.user_type === 'client') {
-    return { mode: 'scoped', clientIds: user.clientId ? [user.clientId] : [] };
-  }
-
-  return { mode: 'all' };
-}
-
-function toSearchResultRow(hit: Awaited<ReturnType<typeof runSearchQuery>>[number]): SearchResultRow {
-  return {
-    type: hit.type,
-    id: hit.id,
-    parentId: hit.parentId,
-    title: hit.title,
-    subtitle: hit.subtitle,
-    snippet: hit.snippet,
-    url: hit.url,
-    score: hit.score,
-    updatedAt: hit.updatedAt.toISOString(),
-  };
-}
-
 export const searchAppAction = withAuth(async (
   user,
   { tenant },
@@ -189,48 +79,7 @@ export const searchAppAction = withAuth(async (
 
   try {
     const { knex } = await createTenantKnex();
-    const limit = normalizeLimit(parsedInput.limit);
-    const requestedTypes = resolveAllowedTypes(parsedInput.types);
-    const clientAccess = resolveClientAccess(user);
-    const acl = await resolveSearchAclPrincipal(knex, user, clientAccess);
-    const allowedTypes = filterTypesByPermission(requestedTypes, acl.permissions);
-
-    const [hits, typeCounts] = await Promise.all([
-      runSearchQuery({
-        knex,
-        tenant,
-        query: parsedInput.query,
-        allowedTypes,
-        limit: limit + 1,
-        cursor: parsedInput.cursor,
-        sort: parsedInput.sort,
-        includeSnippets: true,
-        acl,
-      }),
-      countSearchMatchesByType({
-        knex,
-        tenant,
-        query: parsedInput.query,
-        allowedTypes,
-        acl,
-      }),
-    ]);
-
-    const visibleHits = await verifyResultVisibility(knex, acl, hits);
-    const pageHits = visibleHits.slice(0, limit);
-    const groups = emptyGroups();
-    for (const [type, count] of Object.entries(typeCounts) as Array<[SearchObjectType, number]>) {
-      groups[type] = count;
-    }
-    const totalCount = Object.values(typeCounts).reduce((sum, value) => sum + value, 0);
-
-    const lastHit = pageHits[pageHits.length - 1];
-    const result: SearchAppResult = {
-      results: pageHits.map(toSearchResultRow),
-      groups,
-      totalCount,
-      nextCursor: visibleHits.length > limit && lastHit ? encodeSearchCursor(lastHit) : undefined,
-    };
+    const result = await runAppSearch(knex, tenant, user, parsedInput);
 
     if (result.totalCount === 0) {
       emitSearchTelemetry('search.query.empty', {
@@ -240,7 +89,7 @@ export const searchAppAction = withAuth(async (
       });
     }
 
-    return searchAppResultSchema.parse(result) as SearchAppResult;
+    return result;
   } finally {
     emitSearchTelemetry('search.query.latency_ms', {
       variant: 'full',

--- a/server/src/lib/api/controllers/ApiSearchController.ts
+++ b/server/src/lib/api/controllers/ApiSearchController.ts
@@ -1,0 +1,76 @@
+/**
+ * API Search Controller
+ *
+ * Exposes the unified full-text search engine (`app_search_index`) over the
+ * public REST API at `GET /api/v1/search`. Reuses the same ACL/permission
+ * filtering as the in-app search via `runAppSearch`, so an API key only
+ * surfaces records the underlying user is allowed to see. Any valid API key
+ * may call this endpoint — there is no separate `search` permission gate; the
+ * per-type and per-row ACL inside `runAppSearch` does the filtering.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { SEARCH_OBJECT_TYPES, type IUserWithRoles } from '@alga-psa/types';
+
+import { ApiBaseController } from './ApiBaseController';
+import { ApiSearchService } from '../services/ApiSearchService';
+import { runWithTenant } from '../../db';
+import { getConnection } from '../../db/db';
+import { createSuccessResponse, handleApiError } from '../middleware/apiMiddleware';
+import { runAppSearch } from '../../search/runAppSearch';
+
+/**
+ * Query-string schema for the GET endpoint. Mirrors `searchAppInputSchema`
+ * but coerces the transport encoding of query params: `types` arrives as a
+ * comma-separated string (`types=ticket,project`) and `limit` as a string.
+ */
+export const searchApiQuerySchema = z.object({
+  query: z.string().trim().min(1).max(200),
+  types: z
+    .preprocess(
+      (value) =>
+        typeof value === 'string'
+          ? value.split(',').map((part) => part.trim()).filter(Boolean)
+          : value,
+      z.array(z.enum(SEARCH_OBJECT_TYPES)),
+    )
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  cursor: z.string().min(1).optional(),
+  sort: z.enum(['relevance', 'recent']).optional(),
+});
+
+export class ApiSearchController extends ApiBaseController {
+  constructor() {
+    super(new ApiSearchService(), {
+      resource: 'search',
+    });
+  }
+
+  /**
+   * GET /api/v1/search
+   * Unified full-text search across all indexed business records.
+   */
+  search() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+        return await runWithTenant(apiRequest.context.tenant, async () => {
+          const input = this.validateQuery(apiRequest, searchApiQuerySchema);
+          const knex = await getConnection(apiRequest.context.tenant);
+          const result = await runAppSearch(
+            knex,
+            apiRequest.context.tenant,
+            apiRequest.context.user as IUserWithRoles,
+            input,
+          );
+          return createSuccessResponse(result, 200, undefined, apiRequest);
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+}

--- a/server/src/lib/api/openapi/index.ts
+++ b/server/src/lib/api/openapi/index.ts
@@ -18,6 +18,7 @@ import { registerInstallRoutes } from './routes/installs';
 import { registerInboundWebhookRoutes } from './routes/inboundWebhooks';
 import { registerStatusRoutes } from './routes/statuses';
 import { registerProjectRoutes } from './routes/projects';
+import { registerSearchRoutes } from './routes/search';
 import { registerServiceCategoryRoutes } from './routes/serviceCategories';
 import { registerServiceRoutes } from './routes/services';
 import { registerProductRoutes } from './routes/products';
@@ -62,6 +63,7 @@ export function buildBaseRegistry(options: RegistryInitOptions = {}): ApiOpenApi
   registerQuickBooksV1Routes(registry);
   registerBoardRoutes(registry, components);
   registerStatusRoutes(registry, components);
+  registerSearchRoutes(registry);
   registerServiceCategoryRoutes(registry, components);
   registerServiceRoutes(registry, components);
   registerProductRoutes(registry, components);

--- a/server/src/lib/api/openapi/routes/search.ts
+++ b/server/src/lib/api/openapi/routes/search.ts
@@ -1,0 +1,142 @@
+import { SEARCH_OBJECT_TYPES } from '@alga-psa/types';
+
+import { ApiOpenApiRegistry, zOpenApi } from '../registry';
+
+export function registerSearchRoutes(registry: ApiOpenApiRegistry) {
+  const tag = 'Search';
+
+  const SearchObjectType = zOpenApi
+    .enum(SEARCH_OBJECT_TYPES)
+    .describe('Indexed business object type.');
+
+  const SearchQuery = registry.registerSchema(
+    'SearchQuery',
+    zOpenApi.object({
+      query: zOpenApi
+        .string()
+        .min(1)
+        .max(200)
+        .describe(
+          'Full-text query. A concise expression of likely record words, identifiers, names, or quoted phrases — not a full sentence. Supports OR for alternatives (e.g. "laptop OR workstation").',
+        ),
+      types: zOpenApi
+        .string()
+        .optional()
+        .describe(
+          `Comma-separated list of object types to restrict the search (e.g. "ticket,project"). Omit to search every type the API key's user is permitted to read. Allowed values: ${SEARCH_OBJECT_TYPES.join(', ')}.`,
+        ),
+      limit: zOpenApi
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Maximum number of results to return. Defaults to 30; capped at 100.'),
+      cursor: zOpenApi
+        .string()
+        .optional()
+        .describe('Opaque pagination cursor copied from a prior response\'s nextCursor.'),
+      sort: zOpenApi
+        .enum(['relevance', 'recent'])
+        .optional()
+        .describe('Result ordering. "relevance" (default) ranks by full-text score; "recent" orders by last update.'),
+    }),
+  );
+
+  const SearchResultRow = registry.registerSchema(
+    'SearchResultRow',
+    zOpenApi.object({
+      type: SearchObjectType,
+      id: zOpenApi.string().describe('Object identifier within its type.'),
+      parentId: zOpenApi
+        .string()
+        .optional()
+        .describe('Identifier of the parent record for nested results (e.g. the ticket of a ticket comment).'),
+      title: zOpenApi.string().describe('Primary display label for the record.'),
+      subtitle: zOpenApi.string().optional().describe('Secondary context line.'),
+      snippet: zOpenApi
+        .string()
+        .optional()
+        .describe('Matched-text excerpt with <mark> tags around the highlighted terms.'),
+      url: zOpenApi.string().describe('Relative in-app URL pointing at the record.'),
+      score: zOpenApi.number().describe('Relevance score; higher is more relevant.'),
+      updatedAt: zOpenApi.string().datetime().describe('Source record last-updated timestamp.'),
+    }),
+  );
+
+  const SearchResultData = registry.registerSchema(
+    'SearchResultData',
+    zOpenApi.object({
+      results: zOpenApi.array(SearchResultRow).describe('Matching records for this page, ordered by the requested sort.'),
+      groups: zOpenApi
+        .record(zOpenApi.number().int())
+        .describe('Total match counts keyed by object type (across all pages), before the page limit is applied.'),
+      totalCount: zOpenApi.number().int().describe('Total number of matches across all permitted types.'),
+      nextCursor: zOpenApi
+        .string()
+        .optional()
+        .describe('Cursor for the next page; absent when the result set fits within the page.'),
+    }),
+  );
+
+  const SearchResponse = registry.registerSchema(
+    'SearchResponse',
+    zOpenApi.object({
+      data: SearchResultData.describe('Search payload returned by createSuccessResponse.'),
+    }),
+  );
+
+  const ApiErrorEnvelope = registry.registerSchema(
+    'SearchApiErrorEnvelope',
+    zOpenApi.object({
+      error: zOpenApi.object({
+        code: zOpenApi
+          .string()
+          .describe('Machine-readable error code such as VALIDATION_ERROR, UNAUTHORIZED, or INTERNAL_ERROR.'),
+        message: zOpenApi.string().describe('Human-readable error message.'),
+        details: zOpenApi.unknown().optional().describe('Optional structured details, including Zod validation errors.'),
+      }),
+    }),
+  );
+
+  registry.registerRoute({
+    method: 'get',
+    path: '/api/v1/search',
+    summary: 'Unified full-text search',
+    description:
+      'Full-text search across all indexed business records (tickets, clients, contacts, projects, assets, invoices, contracts, documents, knowledge-base articles, and more) backed by the shared app_search_index. Results are tenant-scoped and filtered by the API key user\'s permissions: a coarse per-type permission gate plus a per-row access-control check, so only records the user could see in-app are returned. No dedicated search permission is required — any valid API key may call this endpoint. Client-portal API keys are automatically scoped to their own client.',
+    tags: [tag],
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      query: SearchQuery,
+    },
+    responses: {
+      200: {
+        description: 'Matching records returned successfully.',
+        schema: SearchResponse,
+      },
+      400: {
+        description: 'Query parameter validation failed (missing/empty query, unknown type, or out-of-range limit).',
+        schema: ApiErrorEnvelope,
+      },
+      401: {
+        description: 'API key is missing or invalid.',
+        schema: ApiErrorEnvelope,
+      },
+      429: {
+        description: 'API rate limit exceeded for the key.',
+        schema: ApiErrorEnvelope,
+      },
+      500: {
+        description: 'Unexpected error while executing the search.',
+        schema: ApiErrorEnvelope,
+      },
+    },
+    extensions: {
+      'x-tenant-scoped': true,
+      'x-acl-filtered': true,
+      'x-not-paginated': false,
+    },
+    edition: 'both',
+  });
+}

--- a/server/src/lib/api/services/ApiSearchService.ts
+++ b/server/src/lib/api/services/ApiSearchService.ts
@@ -1,0 +1,35 @@
+/**
+ * API Search Service
+ *
+ * Minimal BaseService implementation backing the unified full-text search
+ * endpoint. Search is read-only and served by `runAppSearch`, so the CRUD
+ * methods are intentionally unsupported — the controller never calls them.
+ */
+
+import type { BaseService, ListOptions } from '../controllers/types';
+
+export class ApiSearchService implements BaseService {
+  private unsupported(): never {
+    throw new Error('Search resource does not support this operation');
+  }
+
+  async list(_options: ListOptions, _context: any): Promise<{ data: any[]; total: number }> {
+    return this.unsupported();
+  }
+
+  async getById(_id: string, _context: any): Promise<any | null> {
+    return this.unsupported();
+  }
+
+  async create(_data: any, _context: any): Promise<any> {
+    return this.unsupported();
+  }
+
+  async update(_id: string, _data: any, _context: any): Promise<any> {
+    return this.unsupported();
+  }
+
+  async delete(_id: string, _context: any): Promise<void> {
+    return this.unsupported();
+  }
+}

--- a/server/src/lib/search/runAppSearch.ts
+++ b/server/src/lib/search/runAppSearch.ts
@@ -1,0 +1,196 @@
+import type { Knex } from 'knex';
+
+import type { IUserWithRoles } from '@alga-psa/types';
+import { SEARCH_OBJECT_TYPES, type SearchObjectType } from '@alga-psa/types';
+
+import { registeredObjectTypes } from './index';
+import {
+  resolveSearchAclPrincipal,
+  verifyResultVisibility,
+  type ClientAccess,
+} from './acl';
+import {
+  countSearchMatchesByType,
+  encodeSearchCursor,
+  runSearchQuery,
+} from './query';
+import {
+  searchAppResultSchema,
+  type SearchAppInput,
+  type SearchAppResult,
+  type SearchResultRow,
+} from '../actions/searchActionShared';
+
+const SEARCH_OBJECT_TYPE_SET = new Set<string>(SEARCH_OBJECT_TYPES);
+
+// Coarse query-time gate: a type is queried only if the user holds at least
+// one of these permissions. The precise per-row filter is the stored
+// `required_permission` enforced by aclPredicateSql. Types whose rows can
+// require different permissions (e.g. `status` spans ticket vs project
+// statuses) list all of them so no class of user is wrongly excluded.
+export const TYPE_REQUIRED_PERMISSION: Record<SearchObjectType, string | readonly string[]> = {
+  client: 'client:read',
+  contact: 'contact:read',
+  user: 'user:read',
+  ticket: 'ticket:read',
+  ticket_comment: 'ticket:read',
+  project: 'project:read',
+  project_phase: 'project:read',
+  project_task: 'project:read',
+  project_task_comment: 'project:read',
+  asset: 'asset:read',
+  invoice: 'invoice:read',
+  invoice_item: 'invoice:read',
+  invoice_annotation: 'invoice:read',
+  contract: 'contract:read',
+  client_contract: 'contract:read',
+  document: 'document:read',
+  kb_article: 'kb:read',
+  service_catalog: 'service_catalog:read',
+  service_request_submission: 'service_request:read',
+  service_request_definition: 'admin',
+  workflow_task: 'workflow_task:read',
+  interaction: 'interaction:read',
+  schedule_entry: 'schedule:read',
+  time_entry: 'time:read',
+  board: 'ticket:read',
+  category: 'ticket:read',
+  tag: 'ticket:read',
+  status: ['ticket:read', 'project:read'],
+};
+
+export function normalizeLimit(limit: number | undefined): number {
+  const parsed = Number(limit ?? 30);
+  if (!Number.isFinite(parsed)) {
+    return 30;
+  }
+  return Math.max(1, Math.min(Math.floor(parsed), 100));
+}
+
+export function resolveAllowedTypes(inputTypes: SearchObjectType[] | undefined): SearchObjectType[] {
+  const registered = registeredObjectTypes()
+    .filter((type): type is SearchObjectType => SEARCH_OBJECT_TYPE_SET.has(type));
+  if (!inputTypes || inputTypes.length === 0) {
+    return registered;
+  }
+
+  const requested = new Set(inputTypes);
+  return registered.filter((type) => requested.has(type));
+}
+
+export function filterTypesByPermission(
+  types: SearchObjectType[],
+  permissions: readonly string[],
+): SearchObjectType[] {
+  const permissionSet = new Set(permissions);
+  return types.filter((type) => {
+    const required = TYPE_REQUIRED_PERMISSION[type];
+    const candidates = Array.isArray(required) ? required : [required];
+    return candidates.some((permission) => permissionSet.has(permission));
+  });
+}
+
+export function emptyGroups(): Record<SearchObjectType, number> {
+  return Object.fromEntries(
+    SEARCH_OBJECT_TYPES.map((type) => [type, 0]),
+  ) as Record<SearchObjectType, number>;
+}
+
+/**
+ * Single source of truth for which clients a search principal may see.
+ *
+ * Internal/MSP users are currently unrestricted, so they get `{ mode: 'all' }`
+ * — no `clients` table scan and no giant UUID array bound into every search
+ * query. Client-portal users are scoped to their own client.
+ *
+ * When ABAC per-internal-user client restrictions are introduced, the *only*
+ * change is here: return `{ mode: 'scoped', clientIds }` for restricted
+ * internal users. The SQL predicate and the per-row visibility verifier both
+ * consume this mode, so the restriction is enforced in both layers without
+ * an `isInternal` shortcut to audit.
+ */
+export function resolveClientAccess(user: IUserWithRoles): ClientAccess {
+  if (user.user_type === 'client') {
+    return { mode: 'scoped', clientIds: user.clientId ? [user.clientId] : [] };
+  }
+
+  return { mode: 'all' };
+}
+
+export function toSearchResultRow(
+  hit: Awaited<ReturnType<typeof runSearchQuery>>[number],
+): SearchResultRow {
+  return {
+    type: hit.type,
+    id: hit.id,
+    parentId: hit.parentId,
+    title: hit.title,
+    subtitle: hit.subtitle,
+    snippet: hit.snippet,
+    url: hit.url,
+    score: hit.score,
+    updatedAt: hit.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Core full-text search over `app_search_index`, shared by the in-app server
+ * action (`searchAppAction`) and the public REST endpoint (`GET /api/v1/search`).
+ *
+ * It is intentionally free of transport concerns (no auth wrapper, no rate
+ * limiting, no telemetry) so both callers enforce ACL/permission filtering
+ * identically — keeping the security-critical logic single-sourced. Callers
+ * are responsible for authentication, tenant context, and providing a
+ * permissioned `user` (with roles) plus an explicit tenant `knex`.
+ */
+export async function runAppSearch(
+  knex: Knex,
+  tenant: string,
+  user: IUserWithRoles,
+  input: SearchAppInput,
+): Promise<SearchAppResult> {
+  const limit = normalizeLimit(input.limit);
+  const requestedTypes = resolveAllowedTypes(input.types);
+  const clientAccess = resolveClientAccess(user);
+  const acl = await resolveSearchAclPrincipal(knex, user, clientAccess);
+  const allowedTypes = filterTypesByPermission(requestedTypes, acl.permissions);
+
+  const [hits, typeCounts] = await Promise.all([
+    runSearchQuery({
+      knex,
+      tenant,
+      query: input.query,
+      allowedTypes,
+      limit: limit + 1,
+      cursor: input.cursor,
+      sort: input.sort,
+      includeSnippets: true,
+      acl,
+    }),
+    countSearchMatchesByType({
+      knex,
+      tenant,
+      query: input.query,
+      allowedTypes,
+      acl,
+    }),
+  ]);
+
+  const visibleHits = await verifyResultVisibility(knex, acl, hits);
+  const pageHits = visibleHits.slice(0, limit);
+  const groups = emptyGroups();
+  for (const [type, count] of Object.entries(typeCounts) as Array<[SearchObjectType, number]>) {
+    groups[type] = count;
+  }
+  const totalCount = Object.values(typeCounts).reduce((sum, value) => sum + value, 0);
+
+  const lastHit = pageHits[pageHits.length - 1];
+  const result: SearchAppResult = {
+    results: pageHits.map(toSearchResultRow),
+    groups,
+    totalCount,
+    nextCursor: visibleHits.length > limit && lastHit ? encodeSearchCursor(lastHit) : undefined,
+  };
+
+  return searchAppResultSchema.parse(result) as SearchAppResult;
+}

--- a/server/src/test/unit/api/apiSearchController.test.ts
+++ b/server/src/test/unit/api/apiSearchController.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  runAppSearch: vi.fn(),
+  getConnection: vi.fn(),
+}));
+
+vi.mock('../../../lib/search/runAppSearch', () => ({
+  runAppSearch: mocks.runAppSearch,
+}));
+
+vi.mock('../../../lib/db/db', () => ({
+  getConnection: mocks.getConnection,
+}));
+
+import {
+  ApiSearchController,
+  searchApiQuerySchema,
+} from '../../../lib/api/controllers/ApiSearchController';
+
+describe('searchApiQuerySchema (GET query coercion)', () => {
+  it('splits the comma-separated types param into an array', () => {
+    const parsed = searchApiQuerySchema.parse({ query: 'laptop', types: 'ticket,project' });
+    expect(parsed.types).toEqual(['ticket', 'project']);
+  });
+
+  it('coerces a string limit into a number', () => {
+    const parsed = searchApiQuerySchema.parse({ query: 'laptop', limit: '5' });
+    expect(parsed.limit).toBe(5);
+  });
+
+  it('leaves types undefined when the param is absent', () => {
+    const parsed = searchApiQuerySchema.parse({ query: 'laptop' });
+    expect(parsed.types).toBeUndefined();
+  });
+
+  it('rejects unknown object types', () => {
+    expect(() => searchApiQuerySchema.parse({ query: 'x', types: 'ticket,bogus' })).toThrow();
+  });
+
+  it('rejects an empty query', () => {
+    expect(() => searchApiQuerySchema.parse({ query: '' })).toThrow();
+  });
+});
+
+describe('ApiSearchController.search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConnection.mockResolvedValue({ fake: 'knex' });
+  });
+
+  it('returns 401 when no API key is supplied', async () => {
+    const controller = new ApiSearchController();
+    const req = new NextRequest('http://localhost:3000/api/v1/search?query=laptop');
+
+    const res = await controller.search()(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+    expect(mocks.runAppSearch).not.toHaveBeenCalled();
+  });
+
+  it('parses query params and delegates to runAppSearch with the authenticated user', async () => {
+    const controller = new ApiSearchController();
+    const user = { user_id: 'u1', tenant: 'tenant-1', user_type: 'internal' };
+    const req = new NextRequest(
+      'http://localhost:3000/api/v1/search?query=laptop&types=ticket,project&limit=5&sort=recent',
+      { headers: { 'x-api-key': 'k' } },
+    );
+
+    vi.spyOn(controller as any, 'authenticate').mockResolvedValue(
+      Object.assign(req, { context: { tenant: 'tenant-1', user } }),
+    );
+
+    const searchResult = {
+      results: [],
+      groups: {},
+      totalCount: 0,
+    };
+    mocks.runAppSearch.mockResolvedValue(searchResult);
+
+    const res = await controller.search()(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual(searchResult);
+    expect(mocks.runAppSearch).toHaveBeenCalledWith(
+      { fake: 'knex' },
+      'tenant-1',
+      user,
+      { query: 'laptop', types: ['ticket', 'project'], limit: 5, sort: 'recent' },
+    );
+  });
+});

--- a/server/src/test/unit/runAppSearch.test.ts
+++ b/server/src/test/unit/runAppSearch.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SEARCH_OBJECT_TYPES } from '@alga-psa/types';
+
+const mocks = vi.hoisted(() => ({
+  resolveSearchAclPrincipal: vi.fn(),
+  verifyResultVisibility: vi.fn(),
+  runSearchQuery: vi.fn(),
+  countSearchMatchesByType: vi.fn(),
+  encodeSearchCursor: vi.fn(),
+  registeredObjectTypes: vi.fn(),
+}));
+
+vi.mock('../../lib/search/acl', () => ({
+  resolveSearchAclPrincipal: mocks.resolveSearchAclPrincipal,
+  verifyResultVisibility: mocks.verifyResultVisibility,
+}));
+
+vi.mock('../../lib/search/query', () => ({
+  runSearchQuery: mocks.runSearchQuery,
+  countSearchMatchesByType: mocks.countSearchMatchesByType,
+  encodeSearchCursor: mocks.encodeSearchCursor,
+}));
+
+vi.mock('../../lib/search/index', () => ({
+  registeredObjectTypes: mocks.registeredObjectTypes,
+}));
+
+import { runAppSearch } from '../../lib/search/runAppSearch';
+
+const knex = { fake: 'knex' } as any;
+
+const internalUser = {
+  user_id: 'user-1',
+  tenant: 'tenant-1',
+  user_type: 'internal',
+} as any;
+
+const clientUser = {
+  user_id: 'user-2',
+  tenant: 'tenant-1',
+  user_type: 'client',
+  clientId: 'client-1',
+} as any;
+
+function hit(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'ticket',
+    id: 'ticket-1',
+    title: 'Laptop will not boot',
+    url: '/msp/tickets/ticket-1',
+    score: 1,
+    updatedAt: new Date('2026-05-13T12:00:00.000Z'),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('runAppSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.registeredObjectTypes.mockReturnValue([...SEARCH_OBJECT_TYPES]);
+    mocks.countSearchMatchesByType.mockResolvedValue({ ticket: 1 });
+    mocks.encodeSearchCursor.mockReturnValue('cursor-token');
+  });
+
+  it('scopes client-portal users to their own client', async () => {
+    const acl = { userId: 'user-2', tenant: 'tenant-1', permissions: ['ticket:read'] };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    mocks.runSearchQuery.mockResolvedValue([hit()]);
+    mocks.verifyResultVisibility.mockResolvedValue([hit()]);
+
+    await runAppSearch(knex, 'tenant-1', clientUser, { query: 'laptop' });
+
+    expect(mocks.resolveSearchAclPrincipal).toHaveBeenCalledWith(
+      knex,
+      clientUser,
+      { mode: 'scoped', clientIds: ['client-1'] },
+    );
+  });
+
+  it('leaves internal users unrestricted', async () => {
+    const acl = { userId: 'user-1', tenant: 'tenant-1', permissions: ['ticket:read'] };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    mocks.runSearchQuery.mockResolvedValue([]);
+    mocks.verifyResultVisibility.mockResolvedValue([]);
+
+    await runAppSearch(knex, 'tenant-1', internalUser, { query: 'laptop' });
+
+    expect(mocks.resolveSearchAclPrincipal).toHaveBeenCalledWith(
+      knex,
+      internalUser,
+      { mode: 'all' },
+    );
+  });
+
+  it('queries only the types the user has permission for', async () => {
+    const acl = { userId: 'user-1', tenant: 'tenant-1', permissions: ['ticket:read'] };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    mocks.runSearchQuery.mockResolvedValue([]);
+    mocks.verifyResultVisibility.mockResolvedValue([]);
+
+    await runAppSearch(knex, 'tenant-1', internalUser, { query: 'laptop' });
+
+    const { allowedTypes } = mocks.runSearchQuery.mock.calls[0][0];
+    // ticket:read maps to ticket-family types, never to client/invoice/etc.
+    expect(allowedTypes).toContain('ticket');
+    expect(allowedTypes).not.toContain('client');
+    expect(allowedTypes).not.toContain('invoice');
+  });
+
+  it('honours an explicit type filter intersected with permissions', async () => {
+    const acl = {
+      userId: 'user-1',
+      tenant: 'tenant-1',
+      permissions: ['ticket:read', 'invoice:read'],
+    };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    mocks.runSearchQuery.mockResolvedValue([]);
+    mocks.verifyResultVisibility.mockResolvedValue([]);
+
+    await runAppSearch(knex, 'tenant-1', internalUser, {
+      query: 'laptop',
+      types: ['ticket', 'invoice'],
+    });
+
+    const { allowedTypes } = mocks.runSearchQuery.mock.calls[0][0];
+    expect([...allowedTypes].sort()).toEqual(['invoice', 'ticket']);
+  });
+
+  it('returns a nextCursor only when there are more results than the page', async () => {
+    const acl = { userId: 'user-1', tenant: 'tenant-1', permissions: ['ticket:read'] };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    // limit 1 -> runSearchQuery is asked for limit + 1 = 2; returning 2 signals "more".
+    const hits = [hit({ id: 'ticket-1' }), hit({ id: 'ticket-2' })];
+    mocks.runSearchQuery.mockResolvedValue(hits);
+    mocks.verifyResultVisibility.mockResolvedValue(hits);
+
+    const result = await runAppSearch(knex, 'tenant-1', internalUser, {
+      query: 'laptop',
+      limit: 1,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].id).toBe('ticket-1');
+    expect(result.nextCursor).toBe('cursor-token');
+    expect(result.totalCount).toBe(1);
+    expect(result.groups.ticket).toBe(1);
+  });
+
+  it('omits nextCursor when the result set fits the page', async () => {
+    const acl = { userId: 'user-1', tenant: 'tenant-1', permissions: ['ticket:read'] };
+    mocks.resolveSearchAclPrincipal.mockResolvedValue(acl);
+    mocks.runSearchQuery.mockResolvedValue([hit()]);
+    mocks.verifyResultVisibility.mockResolvedValue([hit()]);
+
+    const result = await runAppSearch(knex, 'tenant-1', internalUser, {
+      query: 'laptop',
+      limit: 10,
+    });
+
+    expect(result.nextCursor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
  Expose GET /api/v1/search, a single REST entry point that searches
  across all indexed business records via the shared app_search_index,
  rather than fanning out across the per-resource /search routes.

  - Extract the search core into runAppSearch(), single-sourcing the ACL/permission filtering shared by the in-app server action and the new endpoint so the two can't drift on what a user may see
  - Add ApiSearchController + route reusing API-key auth, the standard rate limiter, and per-type/per-row ACL (no separate search gate)
  - Register the endpoint in the OpenAPI registry and regenerate the CE/EE specs

  🐇 Down the index it tumbled, one query knocking on thirty doors at
  once — yet only the rooms your key unlocks swing open, the rest left
  curtained behind the ACL, with a nextCursor breadcrumb dropped for
  whoever dares follow. "We're all permissioned here." 🔍🍄