### PR TITLE
feat(licensing): make EE tier-gating self-host-aware (forward-port 2/7)

### DIFF
--- a/packages/auth/src/lib/nextAuthOptions.ts
+++ b/packages/auth/src/lib/nextAuthOptions.ts
@@ -19,6 +19,7 @@ import {
 import { issuePortalDomainOtt } from "./PortalDomainSessionToken";
 import { buildTenantPortalSlug, isValidTenantSlug } from "@alga-psa/validation";
 import { isEnterprise } from "@alga-psa/core/features";
+import { getLicenseStateRow, resolveSelfHostTier } from "@alga-psa/licensing";
 import { getSSORegistry, registerSSOProvider } from "./sso/registry";
 import { loadEnterpriseSsoProviderRegistryImpl } from "./sso/enterpriseRegistryEntry";
 import type { OAuthProfileMappingInput, OAuthProfileMappingResult, OAuthLinkProvider } from "./sso/types";
@@ -45,6 +46,22 @@ import { getLocationFromIp } from "./geolocation";
 import { getConnection } from "@alga-psa/db";
 import { getPortalDomain, getPortalDomainByHostname } from "./PortalDomainModel";
 import { resolveMicrosoftConsumerProfileConfig } from "./microsoftConsumerProfileResolution";
+
+/**
+ * Effective tier override for self-host installs. Returns the tier resolved from
+ * the offline `license_state` row (essentials/pro/premium/...) when present, or
+ * undefined in SaaS mode so the session falls back to the Stripe plan. Non-fatal
+ * on any error (e.g. an un-migrated `license_state`) — returns undefined.
+ */
+async function resolveSelfHostEffectiveTier(): Promise<string | undefined> {
+    try {
+        const selfHost = resolveSelfHostTier(await getLicenseStateRow());
+        if (selfHost !== null) return selfHost.tier;
+    } catch {
+        // Non-fatal — fall through to plan-based resolution.
+    }
+    return undefined;
+}
 
 function applyPortToVanityUrl(url: URL, portCandidate: string | undefined, protocol: string): void {
     if (!portCandidate || portCandidate.length === 0) {
@@ -1695,6 +1712,7 @@ export async function buildAuthOptions(context?: BuildAuthOptionsContext): Promi
                         token.premium_trial_end = subInfo.premium_trial_end;
                         token.premium_trial_confirmed = subInfo.premium_trial_confirmed;
                         token.premium_trial_effective_date = subInfo.premium_trial_effective_date;
+                        token.effectiveTier = await resolveSelfHostEffectiveTier();
                         token.last_plan_check = Date.now();
                     } catch (error) {
                         console.error('[auth] Failed to fetch tenant subscription info:', error);
@@ -1809,6 +1827,7 @@ export async function buildAuthOptions(context?: BuildAuthOptionsContext): Promi
                         token.premium_trial_end = subInfo.premium_trial_end;
                         token.premium_trial_confirmed = subInfo.premium_trial_confirmed;
                         token.premium_trial_effective_date = subInfo.premium_trial_effective_date;
+                        token.effectiveTier = await resolveSelfHostEffectiveTier();
                         token.last_plan_check = now;
                     } catch (error) {
                         console.error('[auth] Failed to refresh tenant subscription info:', error);
@@ -1878,6 +1897,7 @@ export async function buildAuthOptions(context?: BuildAuthOptionsContext): Promi
                 (user as any).premium_trial_end = token.premium_trial_end ?? null;
                 (user as any).premium_trial_confirmed = token.premium_trial_confirmed ?? false;
                 (user as any).premium_trial_effective_date = token.premium_trial_effective_date ?? null;
+                (user as any).effectiveTier = token.effectiveTier ?? undefined;
             }
             logger.trace("Session Object:", session);
             console.log('Session callback - final session.user:', {
@@ -2442,6 +2462,7 @@ export const options: NextAuthConfig = {
                         token.premium_trial_end = subInfo.premium_trial_end;
                         token.premium_trial_confirmed = subInfo.premium_trial_confirmed;
                         token.premium_trial_effective_date = subInfo.premium_trial_effective_date;
+                        token.effectiveTier = await resolveSelfHostEffectiveTier();
                         token.last_plan_check = Date.now();
                     } catch (error) {
                         console.error('[auth] Failed to fetch tenant subscription info:', error);
@@ -2556,6 +2577,7 @@ export const options: NextAuthConfig = {
                         token.premium_trial_end = subInfo.premium_trial_end;
                         token.premium_trial_confirmed = subInfo.premium_trial_confirmed;
                         token.premium_trial_effective_date = subInfo.premium_trial_effective_date;
+                        token.effectiveTier = await resolveSelfHostEffectiveTier();
                         token.last_plan_check = now;
                     } catch (error) {
                         console.error('[auth] Failed to refresh tenant subscription info:', error);
@@ -2624,6 +2646,7 @@ export const options: NextAuthConfig = {
                 (user as any).premium_trial_end = token.premium_trial_end ?? null;
                 (user as any).premium_trial_confirmed = token.premium_trial_confirmed ?? false;
                 (user as any).premium_trial_effective_date = token.premium_trial_effective_date ?? null;
+                (user as any).effectiveTier = token.effectiveTier ?? undefined;
             }
             logger.trace("Session Object:", session);
             console.log('Session callback - final session.user:', {

--- a/packages/auth/src/types/next-auth.ts
+++ b/packages/auth/src/types/next-auth.ts
@@ -49,6 +49,8 @@ declare module 'next-auth' {
       premium_trial_end?: string | null;
       premium_trial_confirmed?: boolean;
       premium_trial_effective_date?: string | null;
+      /** Effective tier resolved for the session; self-host installs override the Stripe plan. */
+      effectiveTier?: string;
     };
   }
 
@@ -73,6 +75,7 @@ declare module 'next-auth' {
     premium_trial_end?: string | null;
     premium_trial_confirmed?: boolean;
     premium_trial_effective_date?: string | null;
+    effectiveTier?: string;
     session_id?: string;
     login_method?: string;
     last_activity_check?: number;

--- a/server/src/app/msp/reports/page.tsx
+++ b/server/src/app/msp/reports/page.tsx
@@ -13,7 +13,7 @@ export default async function ReportsPage() {
     getSession(),
     getCurrentTenantProduct(),
   ]);
-  const { tier } = resolveTier(session?.user?.plan);
+  const { tier } = resolveTier(session?.user?.effectiveTier ?? session?.user?.plan);
 
   return <Reports productCode={productCode} tier={tier} />;
 }

--- a/server/src/context/TierContext.tsx
+++ b/server/src/context/TierContext.tsx
@@ -78,10 +78,13 @@ export function TierProvider({ children }: TierProviderProps) {
   const { data: session, status, update } = useSession();
   const isLoading = status === 'loading';
 
-  // Resolve tier from session plan
+  // Resolve tier from the server-resolved effectiveTier when present (this
+  // includes self-host licensing and the 'essentials' floor), falling back to
+  // the raw Stripe plan for SaaS sessions (and sessions issued before
+  // effectiveTier existed — NULL plan still resolves to 'pro').
   const { tier, isMisconfigured } = useMemo(() => {
-    return resolveTier(session?.user?.plan);
-  }, [session?.user?.plan]);
+    return resolveTier(session?.user?.effectiveTier ?? session?.user?.plan);
+  }, [session?.user?.effectiveTier, session?.user?.plan]);
 
   // Convenience tier checks
   const isSolo = tier === 'solo';

--- a/server/src/lib/tier-gating/assertTierAccess.ts
+++ b/server/src/lib/tier-gating/assertTierAccess.ts
@@ -10,6 +10,7 @@ import {
 } from '@alga-psa/types';
 import { getSession } from '@alga-psa/auth';
 import { getAdminConnection } from '@alga-psa/db/admin';
+import { getLicenseStateRow, resolveSelfHostTier } from '@alga-psa/licensing';
 import { isEnterprise } from '../features';
 
 export class TierAccessError extends Error {
@@ -50,7 +51,9 @@ export async function assertTierAccess(feature: TIER_FEATURES): Promise<void> {
   const effectiveTier = tenantId
     ? await getTenantTier(tenantId)
     : (() => {
-        const { tier } = resolveTier(session?.user?.plan);
+        // No tenant in session: resolve from the session's effectiveTier
+        // (self-host override) when present, else the Stripe plan.
+        const { tier } = resolveTier(session?.user?.effectiveTier ?? session?.user?.plan);
         return tier === 'solo' && hasActiveSoloProTrial(session?.user?.solo_pro_trial_end)
           ? 'pro'
           : tier;
@@ -68,6 +71,19 @@ function hasActiveSoloProTrial(value?: string | null): boolean {
 }
 
 async function getTenantTier(tenantId: string): Promise<TenantTier> {
+  // Self-host mode: a license_state row supersedes tenants.plan (offline
+  // license / trial / 'essentials' floor). Guard against the table not existing
+  // yet (rolling deploy hitting an un-migrated DB) — fall through to the SaaS
+  // plan/Stripe resolution rather than 500-ing every tier-gated action.
+  try {
+    const selfHost = resolveSelfHostTier(await getLicenseStateRow());
+    if (selfHost !== null) {
+      return selfHost.tier;
+    }
+  } catch {
+    // license_state unavailable; fall through to plan/Stripe resolution.
+  }
+
   const knex = await getAdminConnection();
   const tenantRecord = await knex('tenants')
     .where({ tenant: tenantId })


### PR DESCRIPTION
## Forward-port: PR 2 of ~7 (licensing → distribution)

Builds on #2592 (PR1, licensing foundation, merged). Makes EE tier-gating **self-host-aware**.

### The key finding that re-scoped this
The 1.0.0 branch predates main's mature tier system, so it carried a **parallel** gating mechanism (`session.user.eeEnabled` + a `useEeEnabled` hook + ~18 call-site edits). But main **already** gates EE features through `assertTierAccess` (29 files) and `TierContext` (34 files), all resolving tier centrally via `tenants.plan → resolveTier()`. Porting the branch's mechanism would have bolted a second, redundant system onto main.

So this PR does the **surgical** thing instead: teach main's existing central resolvers to consult `license_state`. Every one of the 29–34 existing gating sites becomes self-host-aware automatically.

### Changes (5 files, ~50 lines)
- **`assertTierAccess.getTenantTier()`** — a `license_state` row supersedes `tenants.plan`: offline license/trial → `premium`, none → the `essentials` floor (rank −1) which denies every tier-gated feature. `try/catch` falls through to the existing SaaS plan/Stripe resolution if `license_state` is unavailable (rolling deploy / un-migrated DB). Same for the no-tenant session fallback.
- **`nextAuthOptions`** — resolves a self-host `effectiveTier` into the session token/user; `undefined` in SaaS so it falls back to the Stripe `plan`. Done at the existing plan-refresh points (token approach, not a per-request DB read).
- **`TierContext` / `msp/reports`** — `resolveTier(effectiveTier ?? plan)`, so the client UI and other session-tier readers gate correctly on appliances.

### Why it matters
On an appliance, `tenants.plan` is NULL → `resolveTier(null)` → `'pro'`. Without this wiring an unlicensed appliance would resolve to **pro and bypass all gating**, both server- and client-side.

### Deliberately NOT ported
The branch's `session.eeEnabled` / `useEeEnabled` parallel mechanism and its ~18 integration/AI/dashboard call-site edits — redundant with main's tier system (per design review). One mechanism, not two.

### Validation
- `server/tsconfig.json` tsc: clean.
- `@alga-psa/auth` tsc: clean.
- Logic: `tierHasFeature → tierAtLeast(tier, FEATURE_MINIMUM_TIER[feature])`; `essentials` (rank −1) is below every feature minimum (solo/pro/premium), so it denies all EE features — CE-equivalent for an unlicensed appliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
