### PR TITLE
feat(licensing): enforce appliance license seat limit on user creation (forward-port 3/7)

### DIFF
--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -235,6 +235,30 @@ export const addUser = withAuth(async (
           };
         }
 
+        // Self-host mode: enforce the appliance license `seats` claim.
+        // No-op on SaaS (no license_state row). 'essentials' is unmetered;
+        // EE tiers (pro/premium) enforce the signed `seats` count.
+        try {
+          const adminKnex = await getAdminConnection();
+          const licenseRow = await adminKnex('license_state').orderBy('id').first();
+          if (licenseRow) {
+            const { resolveSelfHostTier, verifyLicense } = await import('@alga-psa/licensing');
+            const resolved = resolveSelfHostTier(licenseRow);
+            if (resolved && resolved.tier !== 'essentials' && licenseRow.license_token) {
+              const v = verifyLicense(licenseRow.license_token);
+              if (v.valid && typeof v.claims.seats === 'number' && used >= v.claims.seats) {
+                return {
+                  success: false,
+                  code: 'LICENSE_LIMIT_REACHED',
+                  error: `You've reached the seat limit (${v.claims.seats}) of your Alga appliance license.`,
+                };
+              }
+            }
+          }
+        } catch {
+          // Don't block user creation on a transient license_state read failure.
+        }
+
       }
 
       const [newUser] = await trx('users')


### PR DESCRIPTION
## Forward-port: PR 3 of ~7 (licensing → distribution)

Builds on #2592 + #2593 (merged). Adds **appliance license seat enforcement** to user creation.

### Change (1 file)
`addUser` now enforces the signed `seats` claim from the appliance license, inserted right after main's existing SaaS seat checks (`licensed_user_count`, solo-plan) and reusing the same `used` internal-user count:

- **No-op on SaaS** — gated on a `license_state` row existing; SaaS has none.
- `essentials` tier is unmetered; **pro/premium enforce the `seats` count** from the cryptographically-verified license token.
- Counts internal (`user_type='internal'`, active) users only — client-portal users are exempt.
- Wrapped in `try/catch` so a transient `license_state` read failure never blocks user creation.

On an appliance, `tenants.licensed_user_count` and `plan` are both NULL, so main's existing checks don't fire — this seats-claim path is what enforces the limit there. The two are complementary.

### Validation
- `@alga-psa/users` tsc: clean.
- `server/tsconfig.json` tsc: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
