### PR TITLE
feat(licensing): self-host License management page + actions (forward-port 4/7)

### DIFF
--- a/server/src/app/msp/licenses/page.tsx
+++ b/server/src/app/msp/licenses/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { isSelfHostLicensing } from '@alga-psa/licensing';
+import LicenseManagementPage from '@/components/licenses/LicenseManagementPage';
+
+export const metadata: Metadata = {
+  title: 'License',
+};
+
+// Self-host licensing UI only. On hosted/SaaS there is no license_state row, so
+// redirect away rather than render the "self-hosted only" stub.
+export default async function Page() {
+  if (!(await isSelfHostLicensing())) {
+    redirect('/msp/dashboard');
+  }
+  return <LicenseManagementPage />;
+}

--- a/server/src/components/licenses/LicenseBanner.tsx
+++ b/server/src/components/licenses/LicenseBanner.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getLicenseStatus } from '@/lib/actions/licenseManagementActions';
+import type { LicenseStatus } from '@/lib/actions/licenseManagementActions';
+
+/**
+ * Trial / license expiry banner for self-hosted installs.
+ *
+ * Shown only in self-host mode (license_state row present).
+ * Displays trial countdown, upcoming license expiry, or expired state.
+ * Links to the in-app License page for renewal.
+ *
+ * Intentionally uses the server action for licensing status rather than
+ * TierContext so it remains accurate regardless of session freshness.
+ */
+export default function LicenseBanner() {
+  const router = useRouter();
+  const [status, setStatus] = useState<LicenseStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    getLicenseStatus().then(setStatus).catch(() => {});
+  }, []);
+
+  if (!status?.selfHostMode || dismissed) return null;
+
+  const { state, daysRemaining, tier } = status;
+
+  // Determine whether to show the banner and with what urgency.
+  let message: string | null = null;
+  let urgency: 'info' | 'warning' | 'error' = 'info';
+
+  switch (state) {
+    case 'trial':
+      if (daysRemaining !== null && daysRemaining <= 7) {
+        message = `Enterprise trial expires in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}. Enter a license key to keep Enterprise features.`;
+        urgency = 'warning';
+      } else if (daysRemaining !== null) {
+        message = `Enterprise trial active — ${daysRemaining} days remaining.`;
+        urgency = 'info';
+      }
+      break;
+    case 'trial_expired':
+      message = 'Enterprise trial has expired. The install is now running Essentials features.';
+      urgency = 'warning';
+      break;
+    case 'licensed':
+      if (daysRemaining !== null && daysRemaining <= 14) {
+        message = `License expires in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}. Renew to avoid service interruption.`;
+        urgency = daysRemaining <= 3 ? 'error' : 'warning';
+      }
+      break;
+    case 'license_expired':
+      message = 'License has expired. The install is now running Essentials features.';
+      urgency = 'error';
+      break;
+    case 'ce':
+      // CE installs: only show if they haven't used their trial yet.
+      if (!status.trialUsed) {
+        message = 'Running Essentials features. Start a free 30-day Enterprise trial to unlock all features.';
+        urgency = 'info';
+      }
+      break;
+  }
+
+  if (!message) return null;
+
+  const bgColor = urgency === 'error' ? '#fef2f2' : urgency === 'warning' ? '#fffbeb' : '#eff6ff';
+  const borderColor = urgency === 'error' ? '#fecaca' : urgency === 'warning' ? '#fde68a' : '#bfdbfe';
+  const textColor = urgency === 'error' ? '#991b1b' : urgency === 'warning' ? '#92400e' : '#1e40af';
+
+  return (
+    <div
+      style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0.5rem 1rem', background: bgColor,
+        borderBottom: `1px solid ${borderColor}`, color: textColor,
+        fontSize: '0.875rem',
+      }}
+      role="banner"
+      aria-label="License status"
+    >
+      <span>{message}</span>
+      <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexShrink: 0, marginLeft: '1rem' }}>
+        <button
+          onClick={() => router.push('/msp/licenses')}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', color: 'inherit', fontSize: 'inherit' }}
+        >
+          Manage License
+        </button>
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', fontSize: '1rem', lineHeight: 1 }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useState, useEffect, useTransition } from 'react';
+import { getLicenseStatus, submitLicense, startTrial, connectAppliance } from '@/lib/actions/licenseManagementActions';
+import type { LicenseStatus } from '@/lib/actions/licenseManagementActions';
+
+/**
+ * In-app License management page.
+ *
+ * Gated by admin RBAC only — NOT by eeRuntimeEnabled — so an expired install
+ * can always navigate here to renew or start a trial.
+ *
+ * Includes C5 "Connect this appliance" claim-code flow for connected transport.
+ */
+export default function LicenseManagementPage() {
+  const [status, setStatus] = useState<LicenseStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [licenseKey, setLicenseKey] = useState('');
+  const [claimCode, setClaimCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    getLicenseStatus().then((s) => { setStatus(s); setLoading(false); });
+  }, []);
+
+  function refresh(newStatus: LicenseStatus) {
+    setStatus(newStatus);
+    setError(null);
+  }
+
+  function handleSubmitLicense() {
+    setError(null);
+    setSuccessMsg(null);
+    startTransition(async () => {
+      const result = await submitLicense(licenseKey.trim());
+      if (result.success && result.status) {
+        refresh(result.status);
+        setLicenseKey('');
+        setSuccessMsg('License activated successfully.');
+      } else {
+        setError(result.error ?? 'Failed to activate license');
+      }
+    });
+  }
+
+  function handleConnectAppliance() {
+    setError(null);
+    setSuccessMsg(null);
+    startTransition(async () => {
+      const result = await connectAppliance(claimCode.trim());
+      if (result.success && result.status) {
+        refresh(result.status);
+        setClaimCode('');
+        setSuccessMsg('Appliance connected and license activated. Daily refresh is now active.');
+      } else {
+        setError(result.error ?? 'Failed to connect appliance');
+      }
+    });
+  }
+
+  function handleStartTrial() {
+    setError(null);
+    setSuccessMsg(null);
+    startTransition(async () => {
+      const result = await startTrial();
+      if (result.success && result.status) {
+        refresh(result.status);
+        setSuccessMsg('30-day Enterprise trial started.');
+      } else {
+        setError(result.error ?? 'Failed to start trial');
+      }
+    });
+  }
+
+  if (loading) {
+    return <div style={{ padding: '2rem' }}>Loading license status…</div>;
+  }
+
+  if (!status?.selfHostMode) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 600 }}>License</h1>
+        <p style={{ marginTop: '1rem', color: '#6b7280' }}>
+          License management is only available for self-hosted installations.
+        </p>
+      </div>
+    );
+  }
+
+  const stateLabelMap: Record<string, string> = {
+    ce: 'Community Edition (Essentials)',
+    trial: 'Enterprise Trial',
+    trial_expired: 'Trial Expired — Essentials',
+    licensed: 'Licensed',
+    license_expired: 'License Expired — Essentials',
+  };
+
+  const stateLabel = status.state ? (stateLabelMap[status.state] ?? status.state) : 'Unknown';
+  const canStartTrial = !status.trialUsed && status.state !== 'licensed';
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '640px' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 600 }}>License</h1>
+
+      {/* Current status */}
+      <section style={{ marginTop: '1.5rem', padding: '1.25rem', border: '1px solid #e5e7eb', borderRadius: '0.5rem' }}>
+        <h2 style={{ fontWeight: 600, marginBottom: '0.75rem' }}>Current Status</h2>
+        <dl style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', rowGap: '0.4rem' }}>
+          <dt style={{ color: '#6b7280' }}>Status</dt>
+          <dd><strong>{stateLabel}</strong></dd>
+          {status.tier && (
+            <>
+              <dt style={{ color: '#6b7280' }}>Tier</dt>
+              <dd style={{ textTransform: 'capitalize' }}>{status.tier}</dd>
+            </>
+          )}
+          {status.customer && (
+            <>
+              <dt style={{ color: '#6b7280' }}>Licensed to</dt>
+              <dd>{status.customer}</dd>
+            </>
+          )}
+          {status.expiresAt && (
+            <>
+              <dt style={{ color: '#6b7280' }}>Expires</dt>
+              <dd>
+                {new Date(status.expiresAt).toLocaleDateString()}
+                {status.daysRemaining !== null && (
+                  <span style={{ marginLeft: '0.5rem', color: status.daysRemaining < 7 ? '#dc2626' : '#6b7280' }}>
+                    ({status.daysRemaining} days remaining)
+                  </span>
+                )}
+              </dd>
+            </>
+          )}
+          <dt style={{ color: '#6b7280' }}>Connection</dt>
+          <dd>
+            {status.connected ? (
+              <span style={{ color: '#16a34a' }}>
+                ✓ Connected
+                {status.lastCheckinAt && (
+                  <span style={{ color: '#6b7280', marginLeft: '0.5rem', fontSize: '0.85em' }}>
+                    (last check-in: {new Date(status.lastCheckinAt).toLocaleString()})
+                  </span>
+                )}
+              </span>
+            ) : (
+              <span style={{ color: '#6b7280' }}>Air-gapped / not connected</span>
+            )}
+          </dd>
+        </dl>
+      </section>
+
+      {/* Connect this appliance (C5) */}
+      <section style={{ marginTop: '1.5rem', padding: '1.25rem', border: '1px solid #e5e7eb', borderRadius: '0.5rem' }}>
+        <h2 style={{ fontWeight: 600, marginBottom: '0.25rem' }}>Connect this Appliance</h2>
+        <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+          After purchasing a connected license, paste the claim code from your delivery email.
+          The appliance will auto-refresh its license daily.
+          {status.connected && ' To rebind, paste a new claim code.'}
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <input
+            type="text"
+            value={claimCode}
+            onChange={(e) => setClaimCode(e.target.value.toUpperCase())}
+            placeholder="XXXX-XXXX (8 characters)"
+            maxLength={9}
+            style={{
+              flex: 1, fontFamily: 'monospace', fontSize: '1rem', letterSpacing: '0.1em',
+              padding: '0.5rem 0.75rem', border: '1px solid #d1d5db', borderRadius: '0.375rem',
+            }}
+          />
+          <button
+            onClick={handleConnectAppliance}
+            disabled={isPending || claimCode.replace(/-/g, '').length < 8}
+            style={{
+              padding: '0.5rem 1rem', background: '#16a34a', color: '#fff',
+              border: 'none', borderRadius: '0.375rem', cursor: 'pointer',
+              opacity: isPending || claimCode.replace(/-/g, '').length < 8 ? 0.5 : 1,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {isPending ? 'Connecting…' : 'Connect'}
+          </button>
+        </div>
+      </section>
+
+      {/* Enter / renew license (air-gap) */}
+      <section style={{ marginTop: '1.5rem' }}>
+        <h2 style={{ fontWeight: 600, marginBottom: '0.5rem' }}>Enter License Key (Air-Gapped)</h2>
+        <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+          Paste the signed license JWT provided in your delivery email. The key takes effect immediately.
+        </p>
+        <textarea
+          value={licenseKey}
+          onChange={(e) => setLicenseKey(e.target.value)}
+          rows={4}
+          placeholder="eyJhbGci…"
+          style={{
+            width: '100%', fontFamily: 'monospace', fontSize: '0.8rem',
+            padding: '0.5rem', border: '1px solid #d1d5db', borderRadius: '0.375rem',
+            resize: 'vertical',
+          }}
+        />
+        <button
+          onClick={handleSubmitLicense}
+          disabled={isPending || !licenseKey.trim()}
+          style={{
+            marginTop: '0.5rem', padding: '0.5rem 1rem', background: '#2563eb',
+            color: '#fff', border: 'none', borderRadius: '0.375rem', cursor: 'pointer',
+            opacity: isPending || !licenseKey.trim() ? 0.5 : 1,
+          }}
+        >
+          {isPending ? 'Activating…' : 'Activate License'}
+        </button>
+      </section>
+
+      {/* Start trial */}
+      {canStartTrial && (
+        <section style={{ marginTop: '1.5rem', padding: '1rem', background: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: '0.5rem' }}>
+          <h2 style={{ fontWeight: 600, marginBottom: '0.25rem' }}>30-Day Enterprise Trial</h2>
+          <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+            Try all Enterprise features free for 30 days. No credit card required.
+            This trial is available once per installation.
+          </p>
+          <button
+            onClick={handleStartTrial}
+            disabled={isPending}
+            style={{
+              padding: '0.5rem 1rem', background: '#0ea5e9', color: '#fff',
+              border: 'none', borderRadius: '0.375rem', cursor: 'pointer',
+              opacity: isPending ? 0.5 : 1,
+            }}
+          >
+            {isPending ? 'Starting…' : 'Start 30-Day Trial'}
+          </button>
+        </section>
+      )}
+
+      {error && (
+        <div style={{ marginTop: '1rem', padding: '0.75rem', background: '#fef2f2', border: '1px solid #fecaca', borderRadius: '0.375rem', color: '#dc2626' }}>
+          {error}
+        </div>
+      )}
+      {successMsg && (
+        <div style={{ marginTop: '1rem', padding: '0.75rem', background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: '0.375rem', color: '#16a34a' }}>
+          {successMsg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server/src/lib/actions/licenseManagementActions.ts
+++ b/server/src/lib/actions/licenseManagementActions.ts
@@ -1,0 +1,178 @@
+'use server';
+
+import { getCurrentUser } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
+import {
+  getLicenseStateRow,
+  upsertLicenseState,
+  resolveSelfHostTier,
+  type ResolvedLicenseState,
+  type LicenseStateKind,
+} from '@alga-psa/licensing';
+import { verifyLicense } from '@alga-psa/licensing';
+import crypto from 'node:crypto';
+
+export interface LicenseStatus {
+  /** Whether a license_state row exists (self-host mode). */
+  selfHostMode: boolean;
+  state: LicenseStateKind | null;
+  tier: string | null;
+  expiresAt: string | null;
+  daysRemaining: number | null;
+  /** Customer name from the current license, if any. */
+  customer: string | null;
+  /** True if the install has already used its one-time trial. */
+  trialUsed: boolean;
+  /** Connected-appliance status */
+  connected: boolean;
+  lastCheckinAt: string | null;
+}
+
+async function assertAdminPermission(): Promise<void> {
+  // Must use getCurrentUser (returns a full IUserWithRoles with user_id) — the
+  // raw NextAuth session.user exposes `id`, not `user_id`, and hasPermission
+  // binds user_roles.user_id, so passing session.user yields an undefined-binding
+  // SQL error rather than a permission check.
+  const user = await getCurrentUser();
+  if (!user) throw new Error('Unauthorized');
+  const allowed = await hasPermission(user, 'account_management', 'read');
+  if (!allowed) throw new Error('Forbidden: account_management permission required');
+}
+
+/**
+ * Returns the current license status for self-hosted installs.
+ * In SaaS mode (no license_state row) returns { selfHostMode: false }.
+ */
+export async function getLicenseStatus(): Promise<LicenseStatus> {
+  await assertAdminPermission();
+
+  const row = await getLicenseStateRow();
+  if (!row) {
+    return { selfHostMode: false, state: null, tier: null, expiresAt: null, daysRemaining: null, customer: null, trialUsed: false, connected: false, lastCheckinAt: null };
+  }
+
+  const resolved: ResolvedLicenseState = resolveSelfHostTier(row)!;
+  let customer: string | null = null;
+  if (row.license_token) {
+    const v = verifyLicense(row.license_token);
+    if (v.valid) customer = v.claims.cust;
+  }
+
+  return {
+    selfHostMode: true,
+    state: resolved.state,
+    tier: resolved.tier,
+    expiresAt: resolved.expiresAt?.toISOString() ?? null,
+    daysRemaining: resolved.daysRemaining,
+    customer,
+    trialUsed: row.trial_started_at !== null,
+    connected: !!(row.appliance_credential && row.check_in_url),
+    lastCheckinAt: row.last_checkin_at?.toISOString() ?? null,
+  };
+}
+
+/**
+ * Verifies and stores a signed license token.
+ * Rejects invalid/expired/wrong-kid tokens.
+ */
+export async function submitLicense(token: string): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
+  await assertAdminPermission();
+
+  const result = verifyLicense(token.trim());
+  if (!result.valid) {
+    return { success: false, error: `License is invalid: ${result.reason}` };
+  }
+  if (result.claims.exp * 1000 <= Date.now()) {
+    return { success: false, error: 'License has already expired' };
+  }
+
+  await upsertLicenseState({ license_token: token.trim() });
+
+  const status = await getLicenseStatus();
+  return { success: true, status };
+}
+
+/**
+ * Starts the one-time 30-day Enterprise trial.
+ * Blocked if: trial already used, or a valid license is already active.
+ */
+export async function startTrial(): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
+  await assertAdminPermission();
+
+  const row = await getLicenseStateRow();
+  if (!row) return { success: false, error: 'Not a self-hosted install' };
+
+  if (row.trial_started_at !== null) {
+    return { success: false, error: 'Trial has already been used for this install' };
+  }
+
+  const resolved = resolveSelfHostTier(row);
+  if (resolved?.state === 'licensed') {
+    return { success: false, error: 'A valid license is already active' };
+  }
+
+  await upsertLicenseState({ trial_started_at: new Date(), edition_choice: 'ee' });
+
+  const status = await getLicenseStatus();
+  return { success: true, status };
+}
+
+/**
+ * Redeems a one-time claim code against the alga-license service.
+ * Stores the per-appliance credential and the first JWT in license_state.
+ * Called by the in-app License page "Connect this appliance" flow (C5).
+ */
+export async function connectAppliance(
+  claimCode: string
+): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
+  await assertAdminPermission();
+
+  const row = await getLicenseStateRow();
+  if (!row) return { success: false, error: 'Not a self-hosted install' };
+
+  const serviceUrl = process.env.ALGA_LICENSE_SERVICE_URL;
+  if (!serviceUrl) return { success: false, error: 'License service URL not configured' };
+
+  // Derive a stable install id from the existing license state id
+  const applianceId = `appliance-${row.id}-${crypto.createHash('sha256').update(String(row.id)).digest('hex').slice(0, 8)}`;
+
+  try {
+    const res = await fetch(`${serviceUrl.replace(/\/$/, '')}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ claim_code: claimCode.trim().toUpperCase(), appliance_id: applianceId }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: 'unknown' })) as { error?: string; code?: string };
+      const codeMap: Record<string, string> = {
+        invalid_claim_code: 'Invalid claim code. Check the code and try again.',
+        expired_claim_code: 'Claim code has expired. Request a new one from the portal.',
+        consumed_claim_code: 'Claim code has already been used.',
+      };
+      return { success: false, error: codeMap[body.code ?? ''] ?? body.error ?? 'Registration failed' };
+    }
+
+    const { appliance_credential, first_jwt, check_in_url } = await res.json() as {
+      appliance_credential: string;
+      first_jwt: string;
+      check_in_url: string;
+    };
+
+    // Store the plaintext credential in the DB (high-entropy 64-hex random bytes;
+    // DB access-controlled; needed in plaintext by the daily refresh route to
+    // authenticate check-in calls to the alga-license service).
+    await upsertLicenseState({
+      license_token: first_jwt,
+      appliance_id: applianceId,
+      check_in_url: check_in_url,
+      appliance_credential: appliance_credential,
+      last_checkin_at: new Date(),
+    } as any);
+
+    const status = await getLicenseStatus();
+    return { success: true, status };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'Connection failed' };
+  }
+}


### PR DESCRIPTION
## Forward-port: PR 4 of ~7 (licensing → distribution)

Builds on #2592–#2594 (merged). Adds the **self-host License management page + its server actions** — all net-new, self-host-only.

### Changes (4 net-new files)
- **`licenseManagementActions.ts`** — `getLicenseStatus`, `submitLicense` (paste + cryptographically verify a signed token, store it), `startTrial`, `connectAppliance` (claim-code register against the license service). Admin-gated. Imports only `@alga-psa/auth`, `@alga-psa/licensing` (PR1), `node:crypto` — no distribution/C4/Stripe deps.
- **`LicenseManagementPage.tsx` / `LicenseBanner.tsx`** — the page component + trial/expiry banner.
- **`/msp/licenses/page.tsx`** — the route, gated by `isSelfHostLicensing()` → redirects SaaS to the dashboard.

### Rollout posture
- **Inert on SaaS:** no `license_state` row → the page redirects away; `LicenseBanner` isn't mounted anywhere yet (its mount + the nav link land in PR5), so nothing new renders for hosted tenants.
- On a self-host install the page is reachable by direct URL and functional; the nav entry arrives in PR5.

### Validation
- `server/tsconfig.json` tsc: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
