### PR TITLE
fix(licensing): move appliance seat enforcement out of the CE codebase

### DIFF
--- a/ee/server/src/lib/license/userSeatGuard.ts
+++ b/ee/server/src/lib/license/userSeatGuard.ts
@@ -1,0 +1,37 @@
+import { getAdminConnection } from '@alga-psa/db/admin';
+import { resolveSelfHostTier, verifyLicense } from '@alga-psa/licensing';
+
+/**
+ * Self-host appliance license seat enforcement (Enterprise Edition).
+ *
+ * Returns the licensed seat count when adding another internal user would exceed
+ * the appliance license's signed `seats` claim; returns null when allowed:
+ *   - SaaS / no `license_state` row,
+ *   - 'essentials' floor tier (unmetered),
+ *   - no/invalid license token,
+ *   - or any read error (never block user creation on a transient fault).
+ *
+ * @param usedSeats current count of active internal users for the tenant
+ */
+export async function checkApplianceLicenseSeatLimit(
+  usedSeats: number
+): Promise<{ seats: number } | null> {
+  try {
+    const adminKnex = await getAdminConnection();
+    const licenseRow = await adminKnex('license_state').orderBy('id').first();
+    if (!licenseRow) return null;
+
+    const resolved = resolveSelfHostTier(licenseRow);
+    if (!resolved || resolved.tier === 'essentials' || !licenseRow.license_token) {
+      return null;
+    }
+
+    const verified = verifyLicense(licenseRow.license_token);
+    if (verified.valid && typeof verified.claims.seats === 'number' && usedSeats >= verified.claims.seats) {
+      return { seats: verified.claims.seats };
+    }
+  } catch {
+    // Don't block user creation on a transient license_state read failure.
+  }
+  return null;
+}

--- a/packages/ee/src/lib/license/userSeatGuard.ts
+++ b/packages/ee/src/lib/license/userSeatGuard.ts
@@ -1,0 +1,12 @@
+/**
+ * Appliance license seat enforcement — Enterprise Edition only.
+ *
+ * Community Edition stub: CE has no appliance licensing, so it never limits
+ * seats. The real implementation (resolved via `@enterprise/lib/license/userSeatGuard`
+ * on EE builds) lives in `ee/server/src/lib/license/userSeatGuard.ts`.
+ */
+export async function checkApplianceLicenseSeatLimit(
+  _usedSeats: number
+): Promise<{ seats: number } | null> {
+  return null;
+}

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -235,28 +235,23 @@ export const addUser = withAuth(async (
           };
         }
 
-        // Self-host mode: enforce the appliance license `seats` claim.
-        // No-op on SaaS (no license_state row). 'essentials' is unmetered;
-        // EE tiers (pro/premium) enforce the signed `seats` count.
-        try {
-          const adminKnex = await getAdminConnection();
-          const licenseRow = await adminKnex('license_state').orderBy('id').first();
-          if (licenseRow) {
-            const { resolveSelfHostTier, verifyLicense } = await import('@alga-psa/licensing');
-            const resolved = resolveSelfHostTier(licenseRow);
-            if (resolved && resolved.tier !== 'essentials' && licenseRow.license_token) {
-              const v = verifyLicense(licenseRow.license_token);
-              if (v.valid && typeof v.claims.seats === 'number' && used >= v.claims.seats) {
-                return {
-                  success: false,
-                  code: 'LICENSE_LIMIT_REACHED',
-                  error: `You've reached the seat limit (${v.claims.seats}) of your Alga appliance license.`,
-                };
-              }
-            }
+        // Appliance license seat limit — Enterprise Edition only. Resolves to a
+        // no-op stub on CE (`@enterprise` → packages/ee/src), so no appliance
+        // licensing concept ships in or runs on Community Edition.
+        const seatLimit = await (async () => {
+          try {
+            const { checkApplianceLicenseSeatLimit } = await import('@enterprise/lib/license/userSeatGuard');
+            return await checkApplianceLicenseSeatLimit(used);
+          } catch {
+            return null;
           }
-        } catch {
-          // Don't block user creation on a transient license_state read failure.
+        })();
+        if (seatLimit) {
+          return {
+            success: false,
+            code: 'LICENSE_LIMIT_REACHED',
+            error: `You've reached the seat limit (${seatLimit.seats}) of your Alga appliance license.`,
+          };
         }
 
       }


### PR DESCRIPTION
## Correction follow-up to #2594 (PR3)

PR3 added appliance-license **seat enforcement directly in `@alga-psa/users`** — a shared package that ships in Community Edition — and reached the shared `@alga-psa/licensing`. Because the dynamic import targets a *shared* package, the EE-only logic actually **executed on CE** (running a `license_state` query on every internal-user creation), inert only because the table is empty there. That's an EE-only concept leaking into the CE codebase.

### Fix
Relocate it behind the codebase's established `@enterprise` stub seam (same pattern as `auth`/`billing`/`clients`/`integrations`, where `@enterprise` → `ee/server/src` on EE builds and `packages/ee/src` stubs on CE):

- **Real impl** — `ee/server/src/lib/license/userSeatGuard.ts` (`checkApplianceLicenseSeatLimit`): the `resolveSelfHostTier` / `verifyLicense` / `license_state` check.
- **CE stub** — `packages/ee/src/lib/license/userSeatGuard.ts`: a no-op returning `null`.
- **`addUser`** now calls `@enterprise/lib/license/userSeatGuard` → real on EE, no-op stub on CE.

Result: no appliance-licensing concept (or `license_state` query) ships in or runs on Community Edition. EE/appliance behavior is unchanged. `@alga-psa/users` no longer references `@alga-psa/licensing` at all.

### Validation
- `server/tsconfig.json` (CE side: `addUser` + stub): clean.
- `ee/server` (EE side: real impl): clean.
- `@alga-psa/users`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
