### PR TITLE
feat(licensing): self-host MSP shell gating — License banner + on-prem→portal (forward-port 5/7)

### DIFF
--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -12,6 +12,7 @@ import { getTenantSettings } from "@alga-psa/tenancy/actions";
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { AIChatContextProvider } from '@product/chat/context';
 import { TierProvider } from "@/context/TierContext";
+import LicenseBanner from "@/components/licenses/LicenseBanner";
 import { ProductProvider } from "@/context/ProductContext";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -30,6 +31,8 @@ interface Props {
   needsOnboarding: boolean;
   initialSidebarCollapsed: boolean;
   initialLocale?: SupportedLocale | null;
+  /** Self-host install (license_state row present). Hosted/SaaS = false. */
+  selfHostLicensing?: boolean;
 }
 
 function OnboardingRedirectFallback() {
@@ -64,6 +67,7 @@ export function MspLayoutClient({
   needsOnboarding,
   initialSidebarCollapsed,
   initialLocale,
+  selfHostLicensing = false,
 }: Props) {
   const router = useRouter();
   const pathname = usePathname();
@@ -123,6 +127,7 @@ export function MspLayoutClient({
     <AppSessionProvider session={session}>
       <ProductProvider>
         <TierProvider>
+          {selfHostLicensing && <LicenseBanner />}
           <PostHogUserIdentifier />
           <TagProvider>
             <ClientUIStateProvider

--- a/server/src/app/msp/account/layout.tsx
+++ b/server/src/app/msp/account/layout.tsx
@@ -1,13 +1,24 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { isSelfHostLicensing } from '@alga-psa/licensing';
+import { NINEMINDS_PORTAL_URL } from '@/lib/ninemindsPortal';
 
 export const metadata: Metadata = {
   title: 'Account',
 };
 
-export default function Layout({
+// Account management is the hosted/SaaS Stripe subscription page (plan, add-ons,
+// payment, invoices, buy/upgrade licenses). Self-host/on-prem installs purchase
+// licensing through the Nine Minds client portal, not in-app Stripe — so send
+// any direct access here to the portal on-prem (the in-menu "Account" entry
+// opens it in a new tab).
+export default async function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  if (await isSelfHostLicensing()) {
+    redirect(NINEMINDS_PORTAL_URL);
+  }
   return children;
 }

--- a/server/src/app/msp/layout.tsx
+++ b/server/src/app/msp/layout.tsx
@@ -7,6 +7,7 @@ import { MspLayoutClient } from "./MspLayoutClient";
 import { registerSlaIntegration } from "@alga-psa/msp-composition/tickets/registerSlaIntegration";
 import { registerScheduleEntryIntegration } from "@alga-psa/msp-composition/workflows/registerScheduleEntryIntegration";
 import { getCurrentTenantProduct } from "@/lib/productAccess";
+import { isSelfHostLicensing } from "@alga-psa/licensing";
 import type { Metadata } from 'next';
 
 // This template overrides the root layout's template for all /msp/* pages.
@@ -57,6 +58,9 @@ export default async function MspLayout({
 
   const locale = await getHierarchicalLocaleAction();
   const productCode = await getCurrentTenantProduct();
+  // Only self-host installs carry a license_state row; gate the trial/expiry
+  // banner here so it never mounts (or calls getLicenseStatus) on hosted/SaaS.
+  const selfHostLicensing = await isSelfHostLicensing();
 
   if (productCode === 'psa') {
     // Keep PSA-only integrations out of AlgaDesk composition.
@@ -71,6 +75,7 @@ export default async function MspLayout({
       needsOnboarding={needsOnboarding}
       initialSidebarCollapsed={initialSidebarCollapsed}
       initialLocale={locale}
+      selfHostLicensing={selfHostLicensing}
     >
       {children}
     </MspLayoutClient>

--- a/server/src/app/msp/licenses/purchase/layout.tsx
+++ b/server/src/app/msp/licenses/purchase/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { isSelfHostLicensing } from '@alga-psa/licensing';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
+import { NINEMINDS_PORTAL_URL } from '@/lib/ninemindsPortal';
 
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await getServerTranslation(undefined, 'msp/licensing');
@@ -9,10 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function Layout({
+// In-app Stripe checkout is hosted/SaaS-only. Self-host/on-prem installs buy
+// licensing through the Nine Minds client portal, so the purchase flow (and its
+// /success child) sends them to the portal on-prem.
+export default async function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  if (await isSelfHostLicensing()) {
+    redirect(NINEMINDS_PORTAL_URL);
+  }
   return children;
 }

--- a/server/src/components/layout/Header.tsx
+++ b/server/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import {
   Activity,
   ChevronRight,
+  ExternalLink,
   Home,
   PlusCircle,
   Settings,
@@ -30,6 +31,8 @@ import { menuItems, bottomMenuItems, MenuItem } from '@/config/menuConfig';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { useUserAvatar, useContactAvatar } from '@alga-psa/user-composition/hooks';
 import { checkAccountManagementPermission } from '@alga-psa/auth/actions';
+import { isSelfHostLicensingAction } from '@alga-psa/licensing/actions';
+import { NINEMINDS_PORTAL_URL } from '@/lib/ninemindsPortal';
 import type { JobMetrics } from '@alga-psa/jobs/actions';
 import { getQueueMetricsAction } from '@alga-psa/jobs/actions';
 import { analytics } from '@alga-psa/analytics/client';
@@ -384,6 +387,9 @@ export default function Header({
   const { t } = useTranslation('msp/core');
   const [userData, setUserData] = useState<IUserWithRoles | null>(null);
   const [canManageAccount, setCanManageAccount] = useState<boolean>(false);
+  // Self-host/on-prem installs manage billing via the Nine Minds client portal,
+  // not the in-app Stripe account page.
+  const [isOnPrem, setIsOnPrem] = useState<boolean>(false);
   const router = useRouter();
   const { aiAssistantAvailable, openQuickAsk } = useQuickAsk();
 
@@ -406,8 +412,12 @@ export default function Header({
       if (user) {
         setUserData(user);
 
-        const hasAccountPermission = await checkAccountManagementPermission();
+        const [hasAccountPermission, onPrem] = await Promise.all([
+          checkAccountManagementPermission(),
+          isSelfHostLicensingAction(),
+        ]);
         setCanManageAccount(hasAccountPermission);
+        setIsOnPrem(onPrem);
       }
     };
 
@@ -571,10 +581,15 @@ export default function Header({
             {canManageAccount && (
               <DropdownMenuItem
                 id="user-account-menu-item"
-                onSelect={() => router.push('/msp/account')}
+                onSelect={() =>
+                  isOnPrem
+                    ? window.open(NINEMINDS_PORTAL_URL, '_blank', 'noopener,noreferrer')
+                    : router.push('/msp/account')
+                }
               >
                 <Settings className="mr-2 h-4 w-4" />
                 {t('header.account', { defaultValue: 'Account' })}
+                {isOnPrem && <ExternalLink className="ml-2 h-3 w-3 opacity-60" />}
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />

--- a/server/src/lib/ninemindsPortal.ts
+++ b/server/src/lib/ninemindsPortal.ts
@@ -1,0 +1,10 @@
+/**
+ * The Nine Minds client portal.
+ *
+ * Self-host / on-prem installs are Nine Minds customers and manage billing /
+ * purchase licensing through this portal (itself an Alga PSA instance), not the
+ * in-app Stripe pages. The UI routes the "Account" entry and the in-app
+ * purchase routes here on-prem. Overridable via NEXT_PUBLIC_NINEMINDS_PORTAL_URL.
+ */
+export const NINEMINDS_PORTAL_URL =
+  process.env.NEXT_PUBLIC_NINEMINDS_PORTAL_URL || 'https://portal.nineminds.com';


### PR DESCRIPTION
## Forward-port: PR 5 of ~7 (licensing → distribution)

Builds on #2592–#2595 (merged). Wires PR4's License page/banner into the **MSP shell** and routes on-prem billing to the Nine Minds client portal.

All changes are in `server/src` with direct `@alga-psa/licensing` imports — matching the established precedent (PR2's `assertTierAccess`, PR4's pages). **No CE-package changes**, so the recent "move appliance licensing out of CE" rule isn't touched here.

### Changes (6 files)
- **`msp/layout.tsx`** — computes `isSelfHostLicensing()` server-side, passes it to the client shell.
- **`MspLayoutClient.tsx`** — mounts `<LicenseBanner/>` **only** when self-host; otherwise not rendered.
- **`Header.tsx`** — the Account menu opens the Nine Minds portal in a new tab (with an `ExternalLink` affordance) on on-prem installs, else the in-app `/msp/account`; `isOnPrem` resolved via `isSelfHostLicensingAction()`.
- **`account/layout.tsx`** + **`licenses/purchase/layout.tsx`** — redirect on-prem access to the portal (in-app Stripe billing is SaaS-only). *(main never touched these → clean brings.)*
- **`ninemindsPortal.ts`** — `NINEMINDS_PORTAL_URL` constant (net-new).

### Rollout posture
**Inert on SaaS.** `isSelfHostLicensing()` is false with no `license_state` row → the banner isn't mounted, the Account menu stays in-app, and the layout redirects don't fire. No change to hosted-tenant behavior.

### Deferred to PR7
The client-portal distribution-surface gating (sidebar "Licenses" nav, `clientUserActions`) lives in the **CE `packages/client-portal` package**, so it must go through the `@enterprise` stub seam (consistent with #2596) — and it's part of the distribution surface anyway.

### Validation
- `server/tsconfig.json` tsc: clean (also confirms `LicenseBanner` default export + `isSelfHostLicensingAction` export wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
