### PR TITLE
feat(licensing): SR redirectUrl channel + appliance-license template tenant-gate (forward-port 6/7)

### DIFF
--- a/server/src/app/msp/service-requests/actions.ts
+++ b/server/src/app/msp/service-requests/actions.ts
@@ -74,13 +74,14 @@ export const listServiceRequestDefinitionsAction = withAuth(async (
 });
 
 export const listServiceRequestTemplatesAction = withAuth(async (
-  user
+  user,
+  { tenant }
 ): Promise<
   ServiceRequestTemplateOption[]
 > => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'read', knex);
-  return listServiceRequestTemplateOptions();
+  return listServiceRequestTemplateOptions(tenant);
 });
 
 export const getServiceRequestDefinitionEditorDataAction = withAuth(async (

--- a/server/src/lib/service-requests/definitionManagement.ts
+++ b/server/src/lib/service-requests/definitionManagement.ts
@@ -6,6 +6,16 @@ import {
 } from './definitionLifecycle';
 import { listServiceRequestTemplateProviders } from './providers/registry';
 import type { ServiceRequestTemplateDefinition } from './providers/contracts';
+import { isLicenseDistributionTenant } from '@alga-psa/licensing';
+
+/**
+ * Template provider whose templates author the in-app appliance-license purchase
+ * flow. Only the Nine Minds distribution tenant may create from it — otherwise a
+ * non-distribution tenant could stand up a purchase definition that runs real
+ * Stripe Checkout sessions against Nine Minds' account (price ids are
+ * instance-level env). Matches `licenseOrderTemplateProvider.key`.
+ */
+const DISTRIBUTION_ONLY_TEMPLATE_PROVIDER_KEY = 'appliance-license';
 import { publishServiceRequestDefinitionSearchEvent } from './searchEvents';
 
 export interface ServiceRequestDefinitionManagementRow {
@@ -171,16 +181,22 @@ export async function listServiceRequestDefinitionsForManagement(
     )) as ServiceRequestDefinitionManagementRow[];
 }
 
-export function listServiceRequestTemplateOptions(): ServiceRequestTemplateOption[] {
-  return listServiceRequestTemplateProviders().flatMap((provider) =>
-    provider.listTemplates().map((template) => ({
-      providerKey: provider.key,
-      providerDisplayName: provider.displayName,
-      templateId: template.id,
-      templateName: template.name,
-      templateDescription: template.description,
-    }))
-  );
+export function listServiceRequestTemplateOptions(tenant: string): ServiceRequestTemplateOption[] {
+  const allowDistributionOnly = isLicenseDistributionTenant(tenant);
+  return listServiceRequestTemplateProviders()
+    .filter(
+      (provider) =>
+        allowDistributionOnly || provider.key !== DISTRIBUTION_ONLY_TEMPLATE_PROVIDER_KEY
+    )
+    .flatMap((provider) =>
+      provider.listTemplates().map((template) => ({
+        providerKey: provider.key,
+        providerDisplayName: provider.displayName,
+        templateId: template.id,
+        templateName: template.name,
+        templateDescription: template.description,
+      }))
+    );
 }
 
 function findTemplateDefinition(
@@ -253,6 +269,13 @@ export async function createServiceRequestDefinitionFromTemplate({
   templateId,
   createdBy = null,
 }: CreateDefinitionFromTemplateInput): Promise<ServiceRequestDefinitionManagementRow> {
+  if (
+    templateProviderKey === DISTRIBUTION_ONLY_TEMPLATE_PROVIDER_KEY &&
+    !isLicenseDistributionTenant(tenant)
+  ) {
+    throw new Error('This template is not available for this tenant');
+  }
+
   const template = findTemplateDefinition(templateProviderKey, templateId);
   const draft = template.buildDraft();
 

--- a/server/src/lib/service-requests/providers/contracts.ts
+++ b/server/src/lib/service-requests/providers/contracts.ts
@@ -28,6 +28,8 @@ export interface ServiceRequestExecutionResult {
   status: 'succeeded' | 'failed';
   createdTicketId?: string;
   workflowExecutionId?: string;
+  /** Where the portal should send the user next (e.g. a Stripe Checkout URL). Transient. */
+  redirectUrl?: string;
   errorSummary?: string;
 }
 

--- a/server/src/lib/service-requests/submissionService.ts
+++ b/server/src/lib/service-requests/submissionService.ts
@@ -30,6 +30,11 @@ export interface SubmitPortalServiceRequestResult {
   executionStatus: 'pending' | 'succeeded' | 'failed';
   createdTicketId?: string;
   workflowExecutionId?: string;
+  /**
+   * Transient post-submit redirect target surfaced by the execution provider
+   * (e.g. a Stripe Checkout URL). Not persisted on the submission.
+   */
+  redirectUrl?: string;
 }
 
 function isMissingRequiredValue(value: unknown): boolean {
@@ -281,6 +286,7 @@ export async function submitPortalServiceRequest(
         executionStatus: 'succeeded',
         createdTicketId: executionResult.createdTicketId,
         workflowExecutionId: executionResult.workflowExecutionId,
+        redirectUrl: executionResult.redirectUrl,
       };
     }
 

--- a/server/src/test/integration/serviceRequestDefinitionManagement.integration.test.ts
+++ b/server/src/test/integration/serviceRequestDefinitionManagement.integration.test.ts
@@ -35,7 +35,7 @@ describe('service request definition management', () => {
       email: `tenant-${tenant.slice(0, 8)}@example.com`,
     });
 
-    const templates = listServiceRequestTemplateOptions();
+    const templates = listServiceRequestTemplateOptions(tenant);
     expect(templates).toHaveLength(6);
     const starterTemplate = templates.find(
       (template) => template.providerKey === 'ce-starter-pack' && template.templateId === 'new-hire'

--- a/server/src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts
+++ b/server/src/test/integration/serviceRequestTemplateInstantiation.integration.test.ts
@@ -32,7 +32,7 @@ describe('service request template instantiation', () => {
       email: `tenant-${tenant.slice(0, 8)}@example.com`,
     });
 
-    const templates = listServiceRequestTemplateOptions();
+    const templates = listServiceRequestTemplateOptions(tenant);
     expect(templates).toHaveLength(6);
     expect(templates.map((template) => template.templateName)).toEqual([
       'New Hire Onboarding',


### PR DESCRIPTION
## Forward-port: PR 6 of ~7 (licensing → distribution)

Builds on #2592–#2598 (merged). Generic, **inert** SR-framework extensions that the distribution handoff needs — the EE backend that consumes them lands in PR7.

### Changes (6 files, server/src only)
- **`contracts.ts` + `submissionService.ts`** — `ServiceRequestExecutionResult` and `SubmitPortalServiceRequestResult` gain a transient `redirectUrl`: a generic "send the user here on submit" channel any execution provider can use (e.g. a Stripe Checkout URL). Not persisted. **No provider returns it yet.**
- **`definitionManagement.ts`** — `listServiceRequestTemplateOptions(tenant)` + `createServiceRequestDefinitionFromTemplate` gate the `appliance-license` template to the Nine Minds distribution tenant (`isLicenseDistributionTenant`). Prevents any other tenant from authoring a purchase definition that would run real Checkout against Nine Minds' Stripe account. **Inert until PR7 registers that template provider.**
- **`msp/service-requests/actions.ts`** — thread `tenant` into `listServiceRequestTemplatesAction`.
- **Two SR integration tests** — updated for the new `tenant` signature (still assert the 6 starter templates; the gate is a no-op with no `appliance-license` provider registered).

Direct `@alga-psa/licensing` import in `server/src` (per the PR2/PR4 precedent the EE/CE move left in place). The CE `packages/client-portal` distribution surface stays in PR7 behind the `@enterprise` seam.

### Rollout posture
**Fully inert.** The `redirectUrl` channel is unused until PR7's provider returns one; the template gate is a no-op until PR7 registers the `appliance-license` template. No behavior change on SaaS or self-host.

### Validation
- `server/tsconfig.json` tsc: clean. All `listServiceRequestTemplateOptions` callers updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
