### PR TITLE
feat(licensing): appliance-license distribution backend (forward-port 7a/7)

### DIFF
--- a/ee/server/src/lib/actions/applianceLicenseActions.ts
+++ b/ee/server/src/lib/actions/applianceLicenseActions.ts
@@ -1,0 +1,170 @@
+'use server';
+
+import { getSession } from '@alga-psa/auth';
+import { createTenantKnex } from '@alga-psa/db';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import { isLicenseDistributionTenant } from '@alga-psa/licensing';
+import Stripe from 'stripe';
+import type { Knex } from 'knex';
+import logger from '@alga-psa/core/logger';
+
+export type ApplianceLicenseTier = 'pro' | 'premium';
+export type ApplianceLicenseTransport = 'connected-monthly' | 'connected-annual' | 'airgap-annual';
+
+export interface PurchaseApplianceLicenseInput {
+  submissionId: string;
+  clientId: string;
+  tier: ApplianceLicenseTier;
+  seats: number;
+  transport: ApplianceLicenseTransport;
+}
+
+export interface PurchaseApplianceLicenseResult {
+  checkoutUrl: string;
+}
+
+/** Context-driven inputs for {@link createApplianceLicenseCheckout}. */
+export interface CreateApplianceLicenseCheckoutInput {
+  knex: Knex;
+  tenant: string;
+  submissionId: string;
+  clientId: string;
+  tier: ApplianceLicenseTier;
+  seats: number;
+  transport: ApplianceLicenseTransport;
+}
+
+export interface ApplianceLicenseCheckout {
+  checkoutUrl: string;
+  checkoutSessionId: string;
+}
+
+/** Map tier × transport to the env key that holds the Stripe price id. */
+function getPriceEnvKey(tier: ApplianceLicenseTier, transport: ApplianceLicenseTransport): string {
+  const map: Record<string, string> = {
+    'pro:connected-monthly':  'STRIPE_APPLIANCE_PRO_CONNECTED_MONTHLY_PRICE_ID',
+    'pro:connected-annual':   'STRIPE_APPLIANCE_PRO_CONNECTED_ANNUAL_PRICE_ID',
+    'pro:airgap-annual':      'STRIPE_APPLIANCE_PRO_AIRGAP_ANNUAL_PRICE_ID',
+    'premium:connected-monthly': 'STRIPE_APPLIANCE_PREMIUM_CONNECTED_MONTHLY_PRICE_ID',
+    'premium:connected-annual':  'STRIPE_APPLIANCE_PREMIUM_CONNECTED_ANNUAL_PRICE_ID',
+    'premium:airgap-annual':     'STRIPE_APPLIANCE_PREMIUM_AIRGAP_ANNUAL_PRICE_ID',
+  };
+  return map[`${tier}:${transport}`] ?? '';
+}
+
+async function getStripeSecretKey(): Promise<string> {
+  const sp = await getSecretProviderInstance();
+  const key = await sp.getAppSecret('stripe_secret_key') || process.env.STRIPE_SECRET_KEY;
+  if (!key) throw new Error('Stripe secret key not configured');
+  return key;
+}
+
+function getAppBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://localhost:3000';
+}
+
+/**
+ * Creates a Stripe Checkout Session for an appliance license purchase.
+ *
+ * Context-driven: the caller supplies `knex`/`tenant` and the already-validated
+ * order params (the SR submission has already authenticated the requester), so
+ * this does NOT re-auth. Stamps the submission_id + order params into session
+ * metadata so the `checkout.session.completed` webhook can correlate back and
+ * fire issuance. Persistence of the session id onto the submission is the
+ * caller's responsibility (the SR submit service overwrites
+ * `workflow_execution_id` from the execution result, so the provider returns the
+ * stamp rather than writing it here).
+ */
+export async function createApplianceLicenseCheckout(
+  input: CreateApplianceLicenseCheckoutInput
+): Promise<ApplianceLicenseCheckout> {
+  const { submissionId, clientId, tier, seats, transport } = input;
+
+  // Hard gate: only the Nine Minds distribution tenant may create a license
+  // checkout. This is the execution-layer chokepoint — it holds no matter how a
+  // definition was authored (template, manual execution-provider selection, or a
+  // direct action call), so another tenant can never run Checkout sessions
+  // against Nine Minds' Stripe account.
+  if (!isLicenseDistributionTenant(input.tenant)) {
+    throw new Error('Appliance license checkout is not available for this tenant');
+  }
+
+  // Validate
+  if (tier !== 'pro' && tier !== 'premium') throw new Error('Invalid tier');
+  if (!Number.isInteger(seats) || seats < 1) throw new Error('seats must be a positive integer');
+  if (!['connected-monthly', 'connected-annual', 'airgap-annual'].includes(transport)) {
+    throw new Error('Invalid transport');
+  }
+
+  const priceEnvKey = getPriceEnvKey(tier, transport);
+  const priceId = process.env[priceEnvKey];
+  if (!priceId) {
+    throw new Error(`Stripe price not configured for ${tier}:${transport} (env: ${priceEnvKey})`);
+  }
+
+  const secretKey = await getStripeSecretKey();
+  const stripe = new Stripe(secretKey, { apiVersion: '2024-12-18.acacia' as any });
+
+  const isSubscription = transport !== 'airgap-annual';
+  const baseUrl = getAppBaseUrl();
+
+  const checkoutSession = await stripe.checkout.sessions.create({
+    mode: isSubscription ? 'subscription' : 'payment',
+    line_items: [{ price: priceId, quantity: seats }],
+    success_url: `${baseUrl}/client-portal/licenses?checkout=success&submission_id=${submissionId}`,
+    cancel_url:  `${baseUrl}/client-portal/licenses?checkout=cancelled`,
+    metadata: {
+      is_license_order: 'true',
+      service_request_submission_id: submissionId,
+      client_id: clientId,
+      tier,
+      seats: String(seats),
+      transport,
+    },
+  });
+
+  if (!checkoutSession.url) {
+    throw new Error('Stripe did not return a checkout URL');
+  }
+
+  logger.info('[applianceLicense] checkout session created', {
+    submissionId,
+    checkoutSessionId: checkoutSession.id,
+    tier,
+    seats,
+    transport,
+  });
+
+  return { checkoutUrl: checkoutSession.url, checkoutSessionId: checkoutSession.id };
+}
+
+/**
+ * Authenticated direct-call entry: creates the checkout for the current session's
+ * user and records the `stripe_session_<id>` stamp on the submission. The wired
+ * path is the `license-order-stripe` SR execution provider (which calls
+ * {@link createApplianceLicenseCheckout} and returns the stamp through the submit
+ * service); this wrapper remains for any UI that creates the checkout directly.
+ */
+export async function purchaseApplianceLicense(
+  input: PurchaseApplianceLicenseInput
+): Promise<PurchaseApplianceLicenseResult> {
+  const session = await getSession();
+  if (!session?.user) throw new Error('Unauthorized');
+
+  const { knex, tenant } = await createTenantKnex();
+  const { checkoutUrl, checkoutSessionId } = await createApplianceLicenseCheckout({
+    knex,
+    tenant,
+    submissionId: input.submissionId,
+    clientId: input.clientId,
+    tier: input.tier,
+    seats: input.seats,
+    transport: input.transport,
+  });
+
+  await knex('service_request_submissions')
+    .where({ submission_id: input.submissionId, tenant })
+    .update({ workflow_execution_id: `stripe_session_${checkoutSessionId}`, updated_at: knex.fn.now() });
+
+  return { checkoutUrl };
+}

--- a/ee/server/src/lib/service-requests/providers.ts
+++ b/ee/server/src/lib/service-requests/providers.ts
@@ -8,6 +8,11 @@ import type {
   ServiceRequestVisibilityProvider,
 } from 'server/src/lib/service-requests/providers/contracts';
 import { ticketOnlyExecutionProvider } from 'server/src/lib/service-requests/providers/builtins/ticketOnlyExecutionProvider';
+import {
+  createApplianceLicenseCheckout,
+  type ApplianceLicenseTier,
+  type ApplianceLicenseTransport,
+} from '../actions/applianceLicenseActions';
 
 interface WorkflowExecutionConfig {
   workflowId?: string;
@@ -484,12 +489,116 @@ const enterpriseTemplateProvider: ServiceRequestTemplateProvider = {
   listTemplates: () => [],
 };
 
+const licenseOrderTemplateProvider: ServiceRequestTemplateProvider = {
+  key: 'appliance-license',
+  displayName: 'Appliance License',
+  listTemplates: () => [
+    {
+      id: 'appliance-license-order',
+      name: 'Appliance License Purchase',
+      description: 'Purchase or renew an Alga appliance Enterprise license.',
+      buildDraft: () => ({
+        metadata: {
+          name: 'Appliance License Purchase',
+          description: 'Purchase or renew an Alga appliance Enterprise license.',
+          icon: 'key-round',
+        },
+        formSchema: {
+          fields: [
+            {
+              key: 'tier',
+              type: 'select',
+              label: 'Tier',
+              required: true,
+              options: [
+                { label: 'Pro', value: 'pro' },
+                { label: 'Premium', value: 'premium' },
+              ],
+            },
+            {
+              key: 'seats',
+              type: 'short-text',
+              label: 'Number of seats',
+              required: true,
+              defaultValue: '10',
+            },
+            {
+              key: 'transport',
+              type: 'select',
+              label: 'License delivery',
+              required: true,
+              options: [
+                { label: 'Connected (monthly auto-refresh)', value: 'connected-monthly' },
+                { label: 'Connected (annual, auto-refresh)', value: 'connected-annual' },
+                { label: 'Air-gapped (annual, paste license key)', value: 'airgap-annual' },
+              ],
+            },
+          ],
+        },
+        providers: {
+          executionProvider: 'license-order-stripe',
+          executionConfig: {},
+          formBehaviorProvider: 'basic',
+          formBehaviorConfig: {},
+          visibilityProvider: 'all-authenticated-client-users',
+          visibilityConfig: {},
+        },
+      }),
+    },
+  ],
+};
+
+/**
+ * Execution provider for license-order service requests.
+ *
+ * On submit it creates the Stripe Checkout Session directly from the submission
+ * context (tier/seats/transport in the payload) and returns the checkout URL as
+ * `redirectUrl`, so the portal submit action redirects the customer to payment.
+ * The `stripe_session_<id>` value is returned as `workflowExecutionId` so the
+ * submit service persists it on the submission; the `checkout.session.completed`
+ * webhook then correlates (by metadata) and fires issuance.
+ */
+const licenseOrderExecutionProvider: ServiceRequestExecutionProvider = {
+  key: 'license-order-stripe',
+  displayName: 'License Order (Stripe)',
+  executionMode: SERVICE_REQUEST_EXECUTION_MODES.WORKFLOW_ONLY,
+  validateConfig: () => ({ isValid: true }),
+  async execute(context): Promise<ServiceRequestExecutionResult> {
+    try {
+      const tier = String(context.payload.tier ?? '') as ApplianceLicenseTier;
+      const seats = Number.parseInt(String(context.payload.seats ?? ''), 10);
+      const transport = String(context.payload.transport ?? '') as ApplianceLicenseTransport;
+
+      const { checkoutUrl, checkoutSessionId } = await createApplianceLicenseCheckout({
+        knex: context.knex,
+        tenant: context.tenant,
+        submissionId: context.submissionId,
+        clientId: context.clientId,
+        tier,
+        seats,
+        transport,
+      });
+
+      return {
+        status: 'succeeded',
+        workflowExecutionId: `stripe_session_${checkoutSessionId}`,
+        redirectUrl: checkoutUrl,
+      };
+    } catch (error) {
+      return {
+        status: 'failed',
+        errorSummary: error instanceof Error ? error.message : 'Checkout creation failed.',
+      };
+    }
+  },
+};
+
 export async function getServiceRequestEnterpriseProviderRegistrations(): Promise<ServiceRequestProviderRegistrations> {
   return {
-    executionProviders: [workflowOnlyExecutionProvider, ticketPlusWorkflowExecutionProvider],
+    executionProviders: [workflowOnlyExecutionProvider, ticketPlusWorkflowExecutionProvider, licenseOrderExecutionProvider],
     formBehaviorProviders: [advancedFormBehaviorProvider],
     visibilityProviders: [advancedVisibilityProvider],
-    templateProviders: [enterpriseTemplateProvider],
+    templateProviders: [enterpriseTemplateProvider, licenseOrderTemplateProvider],
     adminExtensionProviders: [],
   };
 }

--- a/ee/server/src/lib/workflows/applianceLicenseIssuanceTemporal.ts
+++ b/ee/server/src/lib/workflows/applianceLicenseIssuanceTemporal.ts
@@ -1,0 +1,61 @@
+const DEFAULT_TEMPORAL_ADDRESS = 'temporal-frontend.temporal.svc.cluster.local:7233';
+const DEFAULT_TEMPORAL_NAMESPACE = 'default';
+// Non-authored workflows (registered in ee/temporal-workflows non-authored-index)
+// are served by the temporal-worker on these queues; tenant-workflows is the
+// general-purpose one used by tenant-creation etc.
+const TASK_QUEUE = process.env.APPLIANCE_LICENSE_TASK_QUEUE || 'tenant-workflows';
+
+/**
+ * Input for the appliance license issuance workflow.
+ * Kept in sync with ApplianceLicenseIssuanceInput in
+ * ee/temporal-workflows/src/workflows/appliance-license-issuance-workflow.ts
+ * (duplicated here to avoid a cross-package type import that doesn't resolve
+ * through the @alga-psa/workflows exports map).
+ */
+export interface ApplianceLicenseIssuanceInput {
+  tenant: string;
+  submissionId: string;
+  clientId: string;
+  customer: string;
+  tier: 'pro' | 'premium';
+  seats?: number;
+  transport: string;
+  stripeSubId: string;
+}
+
+/**
+ * Start the appliance license issuance Temporal workflow.
+ * Workflow id = license-issue:{paymentIntentId} → exactly-once.
+ */
+export async function startApplianceLicenseIssuance(
+  paymentIntentId: string,
+  input: ApplianceLicenseIssuanceInput
+): Promise<{ workflowId: string }> {
+  const temporal = await import('@temporalio/client');
+  const connection = await temporal.Connection.connect({
+    address: process.env.TEMPORAL_ADDRESS || DEFAULT_TEMPORAL_ADDRESS,
+  });
+  const client = new temporal.Client({
+    connection,
+    namespace: process.env.TEMPORAL_NAMESPACE || DEFAULT_TEMPORAL_NAMESPACE,
+  });
+
+  const workflowId = `license-issue:${paymentIntentId}`;
+  try {
+    const handle = await client.workflow.start('applianceLicenseIssuanceWorkflow', {
+      taskQueue: TASK_QUEUE,
+      workflowId,
+      args: [input],
+      workflowExecutionTimeout: '1h',
+    });
+    return { workflowId: handle.workflowId };
+  } catch (error: unknown) {
+    // WorkflowExecutionAlreadyStartedError → idempotent, already running/completed
+    if ((error as any)?.name === 'WorkflowExecutionAlreadyStartedError') {
+      return { workflowId };
+    }
+    throw error;
+  } finally {
+    await connection.close().catch(() => undefined);
+  }
+}

--- a/ee/temporal-workflows/src/activities/appliance-license-activities.ts
+++ b/ee/temporal-workflows/src/activities/appliance-license-activities.ts
@@ -1,0 +1,372 @@
+/**
+ * Temporal activities for the appliance license issuance pipeline (C3).
+ *
+ * These activities form the exactly-once issuance pipeline triggered by a
+ * Stripe checkout.session.completed webhook for a license order.
+ * The C4 (alga-license) service holds the private key; we call it here.
+ */
+
+import { Context } from '@temporalio/activity';
+import { getAdminConnection } from '@alga-psa/db/admin.js';
+import { v4 as uuidv4 } from 'uuid';
+import type { Knex } from 'knex';
+
+const logger = () => Context.current().log;
+
+// ── C4 client helpers ─────────────────────────────────────────────────────────
+
+function c4BaseUrl(): string {
+  const url = process.env.ALGA_LICENSE_SERVICE_URL;
+  if (!url) throw new Error('ALGA_LICENSE_SERVICE_URL is not configured');
+  return url.replace(/\/$/, '');
+}
+
+function c4ServiceSecret(): string {
+  const secret = process.env.ALGA_LICENSE_SERVICE_SECRET;
+  if (!secret) throw new Error('ALGA_LICENSE_SERVICE_SECRET is not configured');
+  return secret;
+}
+
+async function c4Post(path: string, body: unknown): Promise<unknown> {
+  const res = await fetch(`${c4BaseUrl()}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${c4ServiceSecret()}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`C4 ${path} failed (${res.status}): ${text}`);
+  }
+  return res.json();
+}
+
+// ── Activity inputs/outputs ───────────────────────────────────────────────────
+
+export interface SignApplianceLicenseInput {
+  stripeSubId: string;
+  customer: string;
+  tier: 'pro' | 'premium';
+  seats?: number;
+  transport: 'connected' | 'airgap';
+}
+
+export interface SignApplianceLicenseResult {
+  jwt: string;
+  exp: number;
+  sub: string;
+}
+
+export interface UpsertLicenseContractInput {
+  tenant: string;
+  clientId: string;
+  tier: 'pro' | 'premium';
+  seats?: number;
+  transport: string;
+  stripeSubId: string;
+  exp: number; // unix seconds
+}
+
+export interface UpsertLicenseContractResult {
+  contractId: string;
+  clientContractId: string;
+}
+
+export interface StoreLicenseDocumentInput {
+  tenant: string;
+  clientId: string;
+  contractId: string;
+  jwt: string;
+  tier: string;
+  exp: number;
+}
+
+export interface StoreLicenseDocumentResult {
+  documentId: string;
+}
+
+export interface MintClaimCodeInput {
+  stripeSubId: string;
+}
+
+export interface MintClaimCodeResult {
+  code: string;
+  expiresAt: number;
+}
+
+export interface DeliverLicenseEmailInput {
+  tenant: string;
+  submissionId: string;
+  transport: string;
+  jwt: string;
+  claimCode?: string;
+  exp: number; // unix seconds — formatted to a date inside the activity
+  tier: string;
+}
+
+export interface RevokeLicenseEntitlementInput {
+  stripeSubId: string;
+  tenant: string;
+  clientId: string;
+}
+
+// ── Activities ────────────────────────────────────────────────────────────────
+
+/** Call C4 /sign to get a signed license JWT. */
+export async function signApplianceLicense(
+  input: SignApplianceLicenseInput
+): Promise<SignApplianceLicenseResult> {
+  const log = logger();
+  log.info('signApplianceLicense', { stripeSubId: input.stripeSubId, tier: input.tier });
+
+  const result = await c4Post('/sign', {
+    stripe_sub_id: input.stripeSubId,
+    customer: input.customer,
+    tier: input.tier,
+    seats: input.seats,
+    transport: input.transport,
+  }) as SignApplianceLicenseResult;
+
+  return result;
+}
+
+/** Upsert a client_contracts assignment + license contract_line. */
+export async function upsertLicenseContract(
+  input: UpsertLicenseContractInput
+): Promise<UpsertLicenseContractResult> {
+  const log = logger();
+  log.info('upsertLicenseContract', { clientId: input.clientId, tier: input.tier });
+
+  const knex = await getAdminConnection();
+
+  // Check for existing contract for this subscription
+  const existing = await knex('client_contracts')
+    .join('contracts', function () {
+      this.on('client_contracts.contract_id', 'contracts.contract_id')
+        .andOn('client_contracts.tenant', 'contracts.tenant');
+    })
+    .where({
+      'client_contracts.client_id': input.clientId,
+      'client_contracts.tenant': input.tenant,
+    })
+    .whereRaw("contracts.contract_description LIKE ?", [`%stripe_sub:${input.stripeSubId}%`])
+    .first('client_contracts.client_contract_id as client_contract_id', 'contracts.contract_id as contract_id');
+
+  const startDate = new Date();
+  const endDate = new Date(input.exp * 1000);
+  const isAirgap = input.transport === 'airgap-annual' || input.transport === 'airgap';
+  const renewalMode = isAirgap ? 'manual' : 'auto';
+
+  if (existing) {
+    // Update end date + status on renewal
+    await knex('client_contracts')
+      .where({ client_contract_id: existing.client_contract_id, tenant: input.tenant })
+      .update({
+        end_date: endDate,
+        renewal_mode: renewalMode,
+        is_active: true,
+        updated_at: knex.fn.now(),
+      });
+    return {
+      contractId: existing.contract_id,
+      clientContractId: existing.client_contract_id,
+    };
+  }
+
+  // Create new contract + assignment
+  const contractId = uuidv4();
+  await knex('contracts').insert({
+    contract_id: contractId,
+    tenant: input.tenant,
+    contract_name: `Alga Appliance License — ${input.tier}`,
+    contract_description: `Appliance Enterprise license. tier:${input.tier} transport:${input.transport} stripe_sub:${input.stripeSubId}`,
+    billing_frequency: isAirgap ? 'annually' : 'monthly',
+    is_active: true,
+    status: 'active',
+    owner_client_id: input.clientId,
+    is_template: false,
+    created_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
+  const clientContractId = uuidv4();
+  await knex('client_contracts').insert({
+    client_contract_id: clientContractId,
+    tenant: input.tenant,
+    client_id: input.clientId,
+    contract_id: contractId,
+    start_date: startDate,
+    end_date: endDate,
+    is_active: true,
+    renewal_mode: renewalMode,
+    renewal_term_months: isAirgap ? 12 : 1,
+    created_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
+  // Insert a license contract_line (informational — tier + seats)
+  const lineId = uuidv4();
+  await knex('contract_lines').insert({
+    contract_line_id: lineId,
+    tenant: input.tenant,
+    contract_id: contractId,
+    contract_line_name: `Enterprise ${input.tier} — ${input.seats ?? 'unlimited'} seats`,
+    contract_line_type: 'Fixed',
+    billing_frequency: isAirgap ? 'annually' : 'monthly',
+    created_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
+  return { contractId, clientContractId };
+}
+
+/**
+ * Resolve a real user id to attribute system-created rows to.
+ * The `documents` table requires non-null `user_id` and `created_by`, and there
+ * is no dedicated service user — mirror the email-attachment background pattern:
+ * prefer inbound_ticket_defaults.entered_by, else the tenant's first user.
+ */
+async function resolveSystemUserId(knex: Knex, tenant: string): Promise<string | null> {
+  const inbound = await knex('inbound_ticket_defaults')
+    .where({ tenant, is_active: true })
+    .whereNotNull('entered_by')
+    .orderBy('updated_at', 'desc')
+    .first('entered_by')
+    .catch(() => undefined);
+  if (inbound?.entered_by) return inbound.entered_by as string;
+
+  const user = await knex('users')
+    .where({ tenant })
+    .orderBy('created_at', 'asc')
+    .first('user_id');
+  return (user?.user_id as string) ?? null;
+}
+
+/** Store the signed JWT as a document attached to the client. */
+export async function storeLicenseDocument(
+  input: StoreLicenseDocumentInput
+): Promise<StoreLicenseDocumentResult> {
+  const log = logger();
+  log.info('storeLicenseDocument', { clientId: input.clientId });
+
+  const knex = await getAdminConnection();
+  const documentId = uuidv4();
+  const expDate = new Date(input.exp * 1000).toISOString().split('T')[0];
+
+  const systemUserId = await resolveSystemUserId(knex, input.tenant);
+  if (!systemUserId) {
+    throw new Error(`No user available to attribute the license document (tenant ${input.tenant})`);
+  }
+
+  // documents requires user_id + created_by (real users); content is inline text;
+  // the timestamp column is entered_at (there is no created_at on documents).
+  await knex('documents').insert({
+    document_id: documentId,
+    tenant: input.tenant,
+    document_name: `Alga Appliance License — ${input.tier} (expires ${expDate})`,
+    type_id: null,
+    user_id: systemUserId,
+    created_by: systemUserId,
+    content: input.jwt,
+    entered_at: knex.fn.now(),
+    updated_at: knex.fn.now(),
+  });
+
+  // Associate to client (so it shows in portal Documents). No created_by column.
+  await knex('document_associations').insert({
+    association_id: uuidv4(),
+    tenant: input.tenant,
+    document_id: documentId,
+    entity_id: input.clientId,
+    entity_type: 'client',
+    created_at: knex.fn.now(),
+  });
+
+  // Also associate to contract (for bookkeeping)
+  if (input.contractId) {
+    await knex('document_associations').insert({
+      association_id: uuidv4(),
+      tenant: input.tenant,
+      document_id: documentId,
+      entity_id: input.contractId,
+      entity_type: 'contract',
+      created_at: knex.fn.now(),
+    });
+  }
+
+  return { documentId };
+}
+
+/** Call C4 /claim-codes to mint a one-time claim code for connected transport. */
+export async function mintClaimCode(
+  input: MintClaimCodeInput
+): Promise<MintClaimCodeResult> {
+  const log = logger();
+  log.info('mintClaimCode', { stripeSubId: input.stripeSubId });
+
+  const result = await c4Post('/claim-codes', {
+    stripe_sub_id: input.stripeSubId,
+  }) as { code: string; expires_at: number };
+
+  return { code: result.code, expiresAt: result.expires_at };
+}
+
+/** Send the license delivery email via the existing email activity pattern. */
+export async function deliverLicenseEmail(
+  input: DeliverLicenseEmailInput
+): Promise<void> {
+  const log = logger();
+  log.info('deliverLicenseEmail', { submissionId: input.submissionId, transport: input.transport });
+
+  // Record delivery on the submission
+  const knex = await getAdminConnection();
+  const licenseExpiry = new Date(input.exp * 1000).toISOString().split('T')[0];
+  const notes = input.transport.startsWith('connected')
+    ? `License claim code: ${input.claimCode} (paste into /msp/licenses → Connect this appliance)`
+    : `License JWT delivered. Paste into /msp/licenses → Enter license key. Expires: ${licenseExpiry}`;
+
+  await knex('service_request_submissions')
+    .where({ submission_id: input.submissionId, tenant: input.tenant })
+    .update({
+      workflow_execution_id: input.claimCode
+        ? `license-issued-connected:${input.claimCode}`
+        : `license-issued-airgap:${licenseExpiry}`,
+      updated_at: knex.fn.now(),
+    });
+
+  log.info('License delivery notes recorded', { submissionId: input.submissionId, notes });
+  // TODO: wire to the actual email-activities once email template is designed.
+}
+
+/** Call C4 /revoke to soft-revoke an entitlement and mark the contract terminated. */
+export async function revokeLicenseEntitlement(
+  input: RevokeLicenseEntitlementInput
+): Promise<void> {
+  const log = logger();
+  log.info('revokeLicenseEntitlement', { stripeSubId: input.stripeSubId });
+
+  // Revoke in C4
+  await c4Post('/revoke', { stripe_sub_id: input.stripeSubId });
+
+  // Mark the contract terminated. PG can't UPDATE two tables at once, so resolve
+  // the matching contract(s) first, then update each table separately.
+  const knex = await getAdminConnection();
+  const matches = await knex('contracts')
+    .where({ tenant: input.tenant, owner_client_id: input.clientId })
+    .whereRaw('contract_description LIKE ?', [`%stripe_sub:${input.stripeSubId}%`])
+    .select('contract_id');
+  const contractIds = matches.map((m: { contract_id: string }) => m.contract_id);
+  if (contractIds.length === 0) return;
+
+  await knex('contracts')
+    .where({ tenant: input.tenant })
+    .whereIn('contract_id', contractIds)
+    .update({ status: 'terminated', updated_at: knex.fn.now() });
+
+  await knex('client_contracts')
+    .where({ tenant: input.tenant })
+    .whereIn('contract_id', contractIds)
+    .update({ is_active: false, updated_at: knex.fn.now() });
+}

--- a/ee/temporal-workflows/src/activities/non-authored-index.ts
+++ b/ee/temporal-workflows/src/activities/non-authored-index.ts
@@ -7,6 +7,7 @@ export * from './onboarding-seeds-activities';
 export * from './customer-tracking-activities';
 export * from './extension-domain-activities';
 export * from './license-management-activities';
+export * from './appliance-license-activities';
 export * from './portal-domain-activities';
 export * from './email-domain-activities';
 export * from './job-activities';

--- a/ee/temporal-workflows/src/workflows/appliance-license-issuance-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/appliance-license-issuance-workflow.ts
@@ -1,0 +1,110 @@
+/**
+ * Temporal workflow for appliance license issuance (C3).
+ *
+ * Workflow id: license-issue:{paymentIntentId}
+ * This provides exactly-once issuance — a duplicate webhook will find the
+ * workflow already running/completed and will be a no-op.
+ *
+ * Steps:
+ *   1. Sign the license via C4 /sign
+ *   2. Upsert the customer-facing contract + line
+ *   3. Store JWT as a client document
+ *   4. For connected transport: mint a claim code via C4 /claim-codes
+ *   5. Deliver: record delivery notes + (future) send email
+ */
+
+import { proxyActivities } from '@temporalio/workflow';
+import type {
+  SignApplianceLicenseInput,
+  UpsertLicenseContractInput,
+  StoreLicenseDocumentInput,
+  MintClaimCodeInput,
+  DeliverLicenseEmailInput,
+  RevokeLicenseEntitlementInput,
+} from '../activities/appliance-license-activities.js';
+
+const {
+  signApplianceLicense,
+  upsertLicenseContract,
+  storeLicenseDocument,
+  mintClaimCode,
+  deliverLicenseEmail,
+} = proxyActivities<{
+  signApplianceLicense: (input: SignApplianceLicenseInput) => Promise<{ jwt: string; exp: number; sub: string }>;
+  upsertLicenseContract: (input: UpsertLicenseContractInput) => Promise<{ contractId: string; clientContractId: string }>;
+  storeLicenseDocument: (input: StoreLicenseDocumentInput) => Promise<{ documentId: string }>;
+  mintClaimCode: (input: MintClaimCodeInput) => Promise<{ code: string; expiresAt: number }>;
+  deliverLicenseEmail: (input: DeliverLicenseEmailInput) => Promise<void>;
+}>({
+  startToCloseTimeout: '5 minutes',
+  retry: { maximumAttempts: 5 },
+});
+
+export interface ApplianceLicenseIssuanceInput {
+  tenant: string;
+  submissionId: string;
+  clientId: string;
+  customer: string;
+  tier: 'pro' | 'premium';
+  seats?: number;
+  /** 'connected-monthly' | 'connected-annual' | 'airgap-annual' */
+  transport: string;
+  stripeSubId: string;
+}
+
+export async function applianceLicenseIssuanceWorkflow(
+  input: ApplianceLicenseIssuanceInput
+): Promise<void> {
+  const { tenant, submissionId, clientId, customer, tier, seats, transport, stripeSubId } = input;
+
+  const isConnected = transport.startsWith('connected');
+  const c4Transport: 'connected' | 'airgap' = isConnected ? 'connected' : 'airgap';
+
+  // 1. Sign the license
+  const { jwt, exp } = await signApplianceLicense({
+    stripeSubId,
+    customer,
+    tier,
+    seats,
+    transport: c4Transport,
+  });
+
+  // 2. Upsert the customer-facing contract
+  const { contractId } = await upsertLicenseContract({
+    tenant,
+    clientId,
+    tier,
+    seats,
+    transport,
+    stripeSubId,
+    exp,
+  });
+
+  // 3. Store JWT as a client document
+  await storeLicenseDocument({
+    tenant,
+    clientId,
+    contractId,
+    jwt,
+    tier,
+    exp,
+  });
+
+  // 4. Mint claim code for connected transport
+  let claimCode: string | undefined;
+  if (isConnected) {
+    const result = await mintClaimCode({ stripeSubId });
+    claimCode = result.code;
+  }
+
+  // 5. Deliver (date formatting happens inside the activity for determinism)
+  await deliverLicenseEmail({
+    tenant,
+    submissionId,
+    transport,
+    jwt,
+    claimCode,
+    exp,
+    tier,
+  });
+}

--- a/ee/temporal-workflows/src/workflows/non-authored-index.ts
+++ b/ee/temporal-workflows/src/workflows/non-authored-index.ts
@@ -19,3 +19,4 @@ export * from './tenant-deletion-workflow.js';
 export * from './tenant-export-workflow.js';
 export * from './sla-ticket-workflow.js';
 export * from './premium-trial-expiry-workflow.js';
+export * from './appliance-license-issuance-workflow.js';

--- a/packages/ee/src/lib/workflows/applianceLicenseIssuanceTemporal.ts
+++ b/packages/ee/src/lib/workflows/applianceLicenseIssuanceTemporal.ts
@@ -1,0 +1,30 @@
+/**
+ * Community Edition stub for the appliance license issuance workflow starter.
+ *
+ * `@enterprise/*` resolves to `packages/ee/src/*` (these CE stubs) at type-check
+ * time and is overridden to the real `ee/server/src/*` implementation by the EE
+ * webpack alias at runtime. Appliance license issuance is an Enterprise-only
+ * feature, so the CE stub keeps the type surface (matching
+ * ee/server/src/lib/workflows/applianceLicenseIssuanceTemporal.ts) and throws if
+ * ever invoked outside EE.
+ */
+
+export interface ApplianceLicenseIssuanceInput {
+  tenant: string;
+  submissionId: string;
+  clientId: string;
+  customer: string;
+  tier: 'pro' | 'premium';
+  seats?: number;
+  transport: string;
+  stripeSubId: string;
+}
+
+export async function startApplianceLicenseIssuance(
+  _paymentIntentId: string,
+  _input: ApplianceLicenseIssuanceInput
+): Promise<{ workflowId: string }> {
+  throw new Error(
+    'Appliance license issuance is only available in the Enterprise Edition.'
+  );
+}

--- a/packages/integrations/src/webhooks/stripe/payments.ts
+++ b/packages/integrations/src/webhooks/stripe/payments.ts
@@ -120,6 +120,26 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Check for license-order events FIRST (before tenant_id routing).
+    // License orders carry is_license_order: 'true' in session metadata.
+    if (isLicenseOrderEvent(event)) {
+      const licenseResult = await handleLicenseOrderWebhook(event);
+      const processingTime = Date.now() - startTime;
+      logger.info('[Stripe Payment Webhook] License order event processed', {
+        eventId: event.id,
+        eventType: event.type,
+        success: licenseResult.success,
+        processingTimeMs: processingTime,
+      });
+      return NextResponse.json({
+        received: true,
+        processed: licenseResult.success,
+        purpose: 'license_order',
+        processingTimeMs: processingTime,
+        ...(licenseResult.error ? { error: licenseResult.error } : {}),
+      });
+    }
+
     // Extract tenant ID from event metadata
     const tenantId = extractTenantId(event);
     if (!tenantId) {
@@ -240,6 +260,102 @@ function extractTenantId(event: Stripe.Event): string | null {
   }
 
   return null;
+}
+
+// ── License-order webhook handling ───────────────────────────────────────────
+
+function isLicenseOrderEvent(event: Stripe.Event): boolean {
+  if (event.type !== 'checkout.session.completed') return false;
+  const session = event.data.object as Stripe.Checkout.Session;
+  return session.metadata?.is_license_order === 'true';
+}
+
+async function handleLicenseOrderWebhook(
+  event: Stripe.Event
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const metadata = session.metadata ?? {};
+
+    const submissionId = metadata.service_request_submission_id;
+    const tier = metadata.tier as 'pro' | 'premium';
+    const seats = metadata.seats ? parseInt(metadata.seats, 10) : undefined;
+    const transport = metadata.transport;
+    const stripeSubId = (session.subscription as string) || session.id;
+    const paymentIntentId = (session.payment_intent as string) || session.id;
+
+    if (!submissionId || !tier || !transport) {
+      logger.error('[License Order Webhook] Missing required metadata', { eventId: event.id, metadata });
+      return { success: false, error: 'missing_metadata' };
+    }
+
+    const { getAdminConnection } = await import('@alga-psa/db/admin');
+    const knex = await getAdminConnection();
+
+    // Resolve the submission first — it carries the authoritative tenant + client_id.
+    const submission = await knex('service_request_submissions')
+      .where({ submission_id: submissionId })
+      .first('submitted_payload', 'tenant', 'client_id');
+
+    const tenant = submission?.tenant as string | undefined;
+    const clientId = (submission?.client_id as string | undefined) ?? metadata.client_id;
+    if (!tenant || !clientId) {
+      logger.error('[License Order Webhook] Submission not found', { submissionId });
+      return { success: false, error: 'submission_not_found' };
+    }
+
+    // Idempotency via payment_webhook_events (unique on tenant+provider+external id).
+    // Temporal's workflow id (license-issue:{paymentIntentId}) is the exactly-once
+    // backstop; this insert prevents redundant pre-workflow work.
+    const inserted = await knex('payment_webhook_events')
+      .insert({
+        tenant,
+        provider_type: 'stripe',
+        external_event_id: event.id,
+        event_type: event.type,
+        event_data: JSON.stringify(event),
+        processed: true,
+        processing_status: 'completed',
+        processed_at: knex.fn.now(),
+      })
+      .onConflict(['tenant', 'provider_type', 'external_event_id'])
+      .ignore()
+      .returning('event_id');
+
+    if (!inserted || inserted.length === 0) {
+      logger.info('[License Order Webhook] Already processed (idempotent)', { eventId: event.id });
+      return { success: true };
+    }
+
+    // Client name → license customer (table is `clients`, PK client_id).
+    const client = await knex('clients').where({ client_id: clientId, tenant }).first('client_name');
+    const customer = (client?.client_name as string | undefined) ?? 'Unknown';
+
+    // Start the issuance Temporal workflow (idempotent via workflow id)
+    const { startApplianceLicenseIssuance } = await import('@enterprise/lib/workflows/applianceLicenseIssuanceTemporal');
+    await startApplianceLicenseIssuance(paymentIntentId, {
+      tenant,
+      submissionId,
+      clientId,
+      customer,
+      tier,
+      seats,
+      transport,
+      stripeSubId,
+    });
+
+    logger.info('[License Order Webhook] Issuance workflow started', {
+      eventId: event.id,
+      workflowId: `license-issue:${paymentIntentId}`,
+      submissionId,
+    });
+
+    return { success: true };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.error('[License Order Webhook] Failed', { error: msg });
+    return { success: false, error: msg };
+  }
 }
 
 /**

--- a/server/src/test/unit/service-requests/enterpriseProviderRegistrations.unit.test.ts
+++ b/server/src/test/unit/service-requests/enterpriseProviderRegistrations.unit.test.ts
@@ -7,12 +7,16 @@ describe('enterprise service request provider registrations', () => {
     const registrations = await getServiceRequestEnterpriseProviderRegistrations();
 
     expect(registrations.executionProviders.map((provider) => provider.key).sort()).toEqual([
+      'license-order-stripe',
       'ticket-plus-workflow',
       'workflow-only',
     ]);
 
     expect(registrations.formBehaviorProviders.map((provider) => provider.key)).toEqual(['advanced']);
     expect(registrations.visibilityProviders.map((provider) => provider.key)).toEqual(['advanced-visibility']);
-    expect(registrations.templateProviders.map((provider) => provider.key)).toEqual(['ee-starter-pack']);
+    expect(registrations.templateProviders.map((provider) => provider.key)).toEqual([
+      'ee-starter-pack',
+      'appliance-license',
+    ]);
   });
 });


### PR DESCRIPTION
## Forward-port: PR 7a of ~7 (licensing → distribution)

Builds on #2592–#2599 (merged). The **distribution/issuance backend** — net-new EE code, **wired but inert**. The client-portal purchase surface that drives it comes in **PR7b**.

### Why it's inert despite being "wired"
- The Stripe webhook license-order branch only fires on `checkout.session.completed` events carrying `is_license_order` — and nothing produces such a checkout until PR7b's purchase UI exists.
- The `appliance-license` template provider registers, but PR6 already gates it to the Nine Minds distribution tenant, and it still requires an MSP admin to author a definition from it.
- All issuance terminates at C4 (`ALGA_LICENSE_SERVICE_*`), which isn't configured here.

### Changes (10 files)
- **`applianceLicenseActions.ts`** (new) — `createApplianceLicenseCheckout` + thin authed `purchaseApplianceLicense` wrapper, with the execution-layer hard gate to the distribution tenant.
- **`ee/.../service-requests/providers.ts`** — `license-order-stripe` `execute()` creates the Stripe Checkout and returns `redirectUrl` (PR6's channel); `appliance-license` template provider.
- **`packages/integrations/.../stripe/payments.ts`** — the `is_license_order` webhook branch → `startApplianceLicenseIssuance` via the **`@enterprise` seam**.
- **`applianceLicenseIssuanceTemporal.ts`** (real, `ee/server`) + **`packages/ee` stub** — the `@enterprise` issuance-starter seam (no-op on CE), consistent with #2596.
- **`ee/temporal-workflows`** — `applianceLicenseIssuanceWorkflow` + activities (C4 sign / contract / claim-code) + worker registration.
- **registrations unit test** updated.

### Rollout posture
**Inert.** No user-visible surface; the webhook branch and template are unreachable until PR7b + external config (C4, Stripe appliance prices) land. CE builds get the no-op stub — no appliance-licensing logic ships in CE.

### Validation
- `ee/server`, `ee/temporal-workflows`, `packages/integrations`, `server` tsc: all clean.
- provider-registrations unit test: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
