### PR TITLE
feat(licensing): client-portal appliance-license surface + dark-launch gate (forward-port 7b/7)

### DIFF
--- a/ee/server/src/lib/license/distributionTenant.ts
+++ b/ee/server/src/lib/license/distributionTenant.ts
@@ -1,0 +1,12 @@
+/**
+ * Appliance-license distribution-tenant gate — Enterprise Edition only.
+ *
+ * Resolved via `@enterprise/lib/license/distributionTenant` on EE builds (this
+ * file); Community Edition gets the no-op stub at
+ * `packages/ee/src/lib/license/distributionTenant.ts`. Keeping the real check
+ * behind the `@enterprise` seam means no appliance-licensing logic ships in CE.
+ *
+ * Returns true only for the Nine Minds distribution tenant with distribution
+ * switched on (see `isLicenseDistributionTenant` in `@alga-psa/licensing`).
+ */
+export { isLicenseDistributionTenant } from '@alga-psa/licensing';

--- a/packages/client-portal/src/actions/client-portal-actions/client-licenses.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-licenses.ts
@@ -1,0 +1,81 @@
+'use server';
+
+import { withAuth } from '@alga-psa/auth';
+import { createTenantKnex } from '@alga-psa/db';
+import type { IUserWithRoles } from '@alga-psa/types';
+
+export interface ClientLicenseContractSummary {
+  clientContractId: string;
+  contractId: string;
+  contractName: string;
+  tier: string;
+  transport: string;
+  startDate: string;
+  endDate: string | null;
+  status: string;
+  renewalMode: string;
+  /** Document ID of the license JWT, if available */
+  licenseDocumentId: string | null;
+}
+
+/**
+ * Returns the license contracts for the authenticated portal user's client.
+ * Only returns contracts whose description contains the appliance license
+ * marker (stripe_sub:), so MSP-internal contracts aren't exposed.
+ */
+export const getClientLicenses = withAuth(
+  async (user: IUserWithRoles): Promise<ClientLicenseContractSummary[]> => {
+    const { knex, tenant } = await createTenantKnex();
+
+    // Resolve the portal user's client_id from their contact (the user object
+    // does not carry client_id directly).
+    if (!user.contact_id) return [];
+    const contact = await knex('contacts')
+      .where({ tenant, contact_name_id: user.contact_id })
+      .first('client_id');
+    const clientId = contact?.client_id as string | undefined;
+    if (!clientId) return [];
+
+    const rows = await knex('client_contracts as cc')
+      .join('contracts as c', function () {
+        this.on('cc.contract_id', 'c.contract_id').andOn('cc.tenant', 'c.tenant');
+      })
+      .leftJoin('document_associations as da', function () {
+        this.on('da.entity_id', 'c.contract_id')
+          .andOnVal('da.entity_type', 'contract')
+          .andOn('da.tenant', 'c.tenant');
+      })
+      .where({ 'cc.client_id': clientId, 'cc.tenant': tenant })
+      .whereRaw("c.contract_description LIKE '%stripe_sub:%'")
+      .select(
+        'cc.client_contract_id as clientContractId',
+        'cc.contract_id as contractId',
+        'c.contract_name as contractName',
+        'c.contract_description as contractDescription',
+        'cc.start_date as startDate',
+        'cc.end_date as endDate',
+        'cc.is_active as isActive',
+        'cc.renewal_mode as renewalMode',
+        'da.document_id as licenseDocumentId'
+      )
+      .orderBy('cc.start_date', 'desc');
+
+    return rows.map((row: any) => {
+      const desc: string = row.contractDescription ?? '';
+      const tierMatch = desc.match(/tier:(\w+)/);
+      const transportMatch = desc.match(/transport:(\S+)/);
+      return {
+        clientContractId: row.clientContractId,
+        contractId: row.contractId,
+        contractName: row.contractName,
+        tier: tierMatch?.[1] ?? 'pro',
+        transport: transportMatch?.[1] ?? 'unknown',
+        startDate: row.startDate instanceof Date ? row.startDate.toISOString() : String(row.startDate),
+        endDate: row.endDate ? (row.endDate instanceof Date ? row.endDate.toISOString() : String(row.endDate)) : null,
+        status: row.isActive ? 'active' : 'inactive',
+        renewalMode: row.renewalMode ?? 'none',
+        licenseDocumentId: row.licenseDocumentId ?? null,
+      };
+    });
+  }
+);

--- a/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
@@ -482,6 +482,7 @@ export const checkClientPortalPermissions = withAuth(async (
   hasClientSettingsAccess: boolean;
   hasAccountAccess: boolean;
   hasVisibilityGroupAccess: boolean;
+  isLicenseDistributor: boolean;
 }> => {
   try {
     const { knex } = await createTenantKnex();
@@ -513,13 +514,20 @@ export const checkClientPortalPermissions = withAuth(async (
       hasVisibilityGroupAccess = !!actorContact?.is_client_admin;
     }
 
+    // Appliance-license distribution is Enterprise-only; resolved via the
+    // @enterprise seam (no-op stub on CE), so no licensing logic ships in CE.
+    const { isLicenseDistributionTenant } = await import('@enterprise/lib/license/distributionTenant');
+
     return {
       hasBillingAccess: hasBilling,
       hasUserManagementAccess: hasUser,
       hasClientSettingsAccess: hasClient,
       // Account access requires both hosted tenant and settings permission
       hasAccountAccess: isHosted && hasSettings,
-      hasVisibilityGroupAccess
+      hasVisibilityGroupAccess,
+      // Only the Nine Minds distribution tenant (with distribution enabled) sees
+      // the appliance-license surface.
+      isLicenseDistributor: isLicenseDistributionTenant(tenant)
     };
   } catch (error) {
     console.error('Error checking client portal permissions:', error);
@@ -528,7 +536,8 @@ export const checkClientPortalPermissions = withAuth(async (
       hasUserManagementAccess: false,
       hasClientSettingsAccess: false,
       hasAccountAccess: false,
-      hasVisibilityGroupAccess: false
+      hasVisibilityGroupAccess: false,
+      isLicenseDistributor: false
     };
   }
 });

--- a/packages/client-portal/src/components/index.ts
+++ b/packages/client-portal/src/components/index.ts
@@ -46,3 +46,6 @@ export { default as ClientPortalTenantDiscovery } from './auth/ClientPortalTenan
 
 // Knowledge Base
 export { ClientKBPage, ClientKBArticleView } from './kb';
+
+// Appliance Licenses (C6)
+export { default as ClientLicensesPage } from './licenses/ClientLicensesPage';

--- a/packages/client-portal/src/components/layout/ClientPortalLayout.tsx
+++ b/packages/client-portal/src/components/layout/ClientPortalLayout.tsx
@@ -44,6 +44,7 @@ function LayoutShell({
     hasBillingAccess: false,
     hasUserManagementAccess: false,
     hasAccountAccess: false,
+    isLicenseDistributor: false,
   });
   const [permissionsLoaded, setPermissionsLoaded] = useState(false);
   const { branding } = useBranding();
@@ -80,6 +81,7 @@ function LayoutShell({
             hasBillingAccess: perms.hasBillingAccess,
             hasUserManagementAccess: perms.hasUserManagementAccess,
             hasAccountAccess: perms.hasAccountAccess,
+            isLicenseDistributor: perms.isLicenseDistributor,
           });
         }
       } finally {
@@ -107,6 +109,7 @@ function LayoutShell({
         permissions={{
           hasClientSettingsAccess: permissions.hasClientSettingsAccess,
           hasBillingAccess: permissions.hasBillingAccess,
+          isLicenseDistributor: permissions.isLicenseDistributor,
         }}
         permissionsLoaded={permissionsLoaded}
         initialCollapsed={initialSidebarCollapsed}

--- a/packages/client-portal/src/components/layout/ClientPortalSidebar.tsx
+++ b/packages/client-portal/src/components/layout/ClientPortalSidebar.tsx
@@ -17,6 +17,7 @@ import {
   CreditCard,
   Settings,
   User,
+  KeyRound,
 } from 'lucide-react';
 import type { ProductCode } from '@alga-psa/types';
 import { useBranding } from '@alga-psa/tenancy/components';
@@ -34,6 +35,7 @@ const SIDEBAR_COOKIE_KEY = 'client_portal_sidebar_collapsed';
 interface SidebarPermissions {
   hasClientSettingsAccess: boolean;
   hasBillingAccess: boolean;
+  isLicenseDistributor: boolean;
 }
 
 interface SidebarProps {
@@ -146,6 +148,16 @@ export function ClientPortalSidebar({
                     href: '/client-portal/billing',
                     label: t('nav.billing'),
                     icon: CreditCard,
+                  }]
+                : []),
+              // Appliance-license purchase/management is only for the Nine Minds
+              // distribution tenant; hidden in every other tenant's portal.
+              ...(permissions.isLicenseDistributor
+                ? [{
+                    key: 'licenses',
+                    href: '/client-portal/licenses',
+                    label: t('nav.licenses', 'Licenses'),
+                    icon: KeyRound,
                   }]
                 : []),
             ]),

--- a/packages/client-portal/src/components/licenses/ClientLicensesPage.tsx
+++ b/packages/client-portal/src/components/licenses/ClientLicensesPage.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getClientLicenses } from '../../actions/client-portal-actions/client-licenses';
+import type { ClientLicenseContractSummary } from '../../actions/client-portal-actions/client-licenses';
+
+const transportLabels: Record<string, string> = {
+  'connected-monthly': 'Connected (monthly)',
+  'connected-annual':  'Connected (annual)',
+  'airgap-annual':     'Air-gapped (annual)',
+};
+
+const tierLabels: Record<string, string> = {
+  pro:     'Pro',
+  premium: 'Premium',
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function statusBadge(status: string) {
+  const colors: Record<string, { bg: string; text: string }> = {
+    active:      { bg: '#dcfce7', text: '#15803d' },
+    inactive:    { bg: '#f3f4f6', text: '#6b7280' },
+    expired:     { bg: '#fef3c7', text: '#92400e' },
+    terminated:  { bg: '#fef2f2', text: '#b91c1c' },
+  };
+  const c = colors[status] ?? colors.inactive;
+  return (
+    <span style={{
+      display: 'inline-block', padding: '0.15rem 0.5rem', borderRadius: '9999px',
+      background: c.bg, color: c.text, fontSize: '0.78rem', fontWeight: 600,
+      textTransform: 'capitalize',
+    }}>
+      {status}
+    </span>
+  );
+}
+
+/**
+ * Portal Licenses view (C6).
+ *
+ * Lists the customer's appliance license contracts with tier / term / expiry /
+ * renewal status, and offers a "Download key" action per contract.
+ *
+ * Route: /client-portal/licenses
+ */
+export default function ClientLicensesPage() {
+  const [licenses, setLicenses] = useState<ClientLicenseContractSummary[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getClientLicenses().then((data) => {
+      setLicenses(data);
+      setLoading(false);
+    }).catch(() => {
+      setLicenses([]);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) {
+    return <div style={{ padding: '2rem' }}>Loading licenses…</div>;
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 600, marginBottom: '0.5rem' }}>Appliance Licenses</h1>
+      <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
+        Your Alga appliance Enterprise license entitlements. Key documents are also available in the
+        Documents section.
+      </p>
+
+      {licenses && licenses.length === 0 ? (
+        <div style={{
+          padding: '2rem', border: '1px dashed #e5e7eb', borderRadius: '0.5rem',
+          textAlign: 'center', color: '#9ca3af',
+        }}>
+          No appliance licenses found.{' '}
+          <a href="/client-portal/request-services" style={{ color: '#2563eb', textDecoration: 'underline' }}>
+            Purchase a license
+          </a>{' '}
+          to get started.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {(licenses ?? []).map((lic) => {
+            const expiringSoon = lic.endDate
+              ? (new Date(lic.endDate).getTime() - Date.now()) < 30 * 24 * 60 * 60 * 1000
+              : false;
+
+            return (
+              <div
+                key={lic.clientContractId}
+                style={{
+                  border: `1px solid ${expiringSoon && lic.status === 'active' ? '#fde68a' : '#e5e7eb'}`,
+                  borderRadius: '0.5rem',
+                  padding: '1.25rem',
+                  background: expiringSoon && lic.status === 'active' ? '#fffbeb' : '#fff',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <span style={{ fontWeight: 600 }}>
+                      {tierLabels[lic.tier] ?? lic.tier} — {transportLabels[lic.transport] ?? lic.transport}
+                    </span>
+                    <div style={{ color: '#6b7280', fontSize: '0.85rem', marginTop: '0.15rem' }}>
+                      {lic.contractName}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                    {statusBadge(lic.status)}
+                    {lic.licenseDocumentId && (
+                      <a
+                        href={`/client-portal/documents?highlight=${lic.licenseDocumentId}`}
+                        style={{
+                          padding: '0.3rem 0.75rem', background: '#2563eb', color: '#fff',
+                          borderRadius: '0.375rem', fontSize: '0.8rem', textDecoration: 'none',
+                        }}
+                      >
+                        Download key
+                      </a>
+                    )}
+                  </div>
+                </div>
+
+                <dl style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '0.25rem 1rem', marginTop: '0.75rem', fontSize: '0.875rem' }}>
+                  <dt style={{ color: '#6b7280' }}>Valid from</dt>
+                  <dd>{formatDate(lic.startDate)}</dd>
+                  <dt style={{ color: '#6b7280' }}>Expires</dt>
+                  <dd>
+                    {formatDate(lic.endDate)}
+                    {expiringSoon && lic.status === 'active' && (
+                      <span style={{ marginLeft: '0.5rem', color: '#92400e', fontWeight: 600, fontSize: '0.8rem' }}>
+                        ⚠ Expiring soon
+                      </span>
+                    )}
+                  </dd>
+                  <dt style={{ color: '#6b7280' }}>Renewal</dt>
+                  <dd style={{ textTransform: 'capitalize' }}>{lic.renewalMode === 'auto' ? 'Auto-renews' : lic.renewalMode === 'manual' ? 'Manual renewal' : '—'}</dd>
+                </dl>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ee/src/lib/license/distributionTenant.ts
+++ b/packages/ee/src/lib/license/distributionTenant.ts
@@ -1,0 +1,10 @@
+/**
+ * Appliance-license distribution-tenant gate — Community Edition stub.
+ *
+ * CE has no appliance-license distribution, so no tenant is ever a distributor.
+ * The real implementation (resolved via `@enterprise/lib/license/distributionTenant`
+ * on EE builds) lives in `ee/server/src/lib/license/distributionTenant.ts`.
+ */
+export function isLicenseDistributionTenant(_tenant: string | null | undefined): boolean {
+  return false;
+}

--- a/packages/licensing/src/lib/license-state.ts
+++ b/packages/licensing/src/lib/license-state.ts
@@ -188,20 +188,21 @@ export async function isSelfHostLicensing(): Promise<boolean> {
 }
 
 /**
- * True only for the Nine Minds license-distribution tenant — the single tenant
- * permitted to author and sell appliance licenses in-app. Identified by the
- * established `MASTER_BILLING_TENANT_ID` env var (the same master-tenant gate used
- * by platform reports).
+ * True only for the Nine Minds appliance-license distribution tenant WHEN in-app
+ * distribution is switched on. Gated by two env vars:
+ *   - `MASTER_BILLING_TENANT_ID` — identifies the Nine Minds tenant (the same
+ *     master-tenant gate platform reports use);
+ *   - `ALGA_LICENSE_DISTRIBUTION_ENABLED` — the dark-launch switch. The whole
+ *     distribution stack (purchase template authoring, checkout creation, and the
+ *     client-portal license surface) stays off until this is set to 'true', so
+ *     the surface can ship dark and be activated once C4 + Stripe prices are live.
  *
- * Synchronous env compare — no DB. Use to gate the in-app appliance-license
- * purchase surface (client-portal nav, the licenses page, and template authoring)
- * so it appears in no other tenant's client portal.
- *
- * Fails closed: when `MASTER_BILLING_TENANT_ID` is unset (appliance / self-host,
- * or a misconfigured SaaS box) no tenant matches, so the distribution surface
- * stays hidden everywhere.
+ * Synchronous env compare — no DB. Fails closed: with either var unset (every
+ * appliance / self-host, and any SaaS box before distribution is switched on) no
+ * tenant matches, so the distribution surface stays hidden everywhere.
  */
 export function isLicenseDistributionTenant(tenant: string | null | undefined): boolean {
   const master = process.env.MASTER_BILLING_TENANT_ID;
-  return !!master && !!tenant && tenant === master;
+  const enabled = process.env.ALGA_LICENSE_DISTRIBUTION_ENABLED === 'true';
+  return enabled && !!master && !!tenant && tenant === master;
 }

--- a/server/src/app/client-portal/licenses/page.tsx
+++ b/server/src/app/client-portal/licenses/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@alga-psa/user-composition/actions';
+import { isLicenseDistributionTenant } from '@alga-psa/licensing';
+import ClientLicensesPage from '@alga-psa/client-portal/components/licenses/ClientLicensesPage';
+
+export const metadata: Metadata = {
+  title: 'Licenses',
+};
+
+// Appliance-license purchase/management is exclusive to the Nine Minds
+// distribution tenant. Any other tenant's client-portal user who reaches this
+// route directly is sent back to their dashboard.
+export default async function LicensesPage() {
+  const user = await getCurrentUser();
+  if (!user || !isLicenseDistributionTenant(user.tenant)) {
+    redirect('/client-portal/dashboard');
+  }
+  return <ClientLicensesPage />;
+}

--- a/server/src/app/client-portal/request-services/[definitionId]/actions.ts
+++ b/server/src/app/client-portal/request-services/[definitionId]/actions.ts
@@ -203,6 +203,7 @@ export const submitRequestServiceDefinitionAction = withAuth(async (
         status: 'success' as const,
         submissionId: result.submissionId,
         createdTicketId: result.createdTicketId ?? null,
+        redirectUrl: result.redirectUrl ?? null,
       };
     } catch (error) {
       await Promise.allSettled(
@@ -224,6 +225,13 @@ export const submitRequestServiceDefinitionAction = withAuth(async (
         error: outcome.message,
       })
     );
+  }
+
+  // Execution providers that need a post-submit redirect (e.g. license-order
+  // → Stripe Checkout) surface an absolute URL; send the customer straight
+  // there. Next's redirect() supports absolute/external URLs.
+  if (outcome.redirectUrl) {
+    redirect(outcome.redirectUrl);
   }
 
   redirect(


### PR DESCRIPTION
## Forward-port: PR 7b of ~7 — the finale (licensing → distribution)

Builds on #2592–#2600 (merged). The client-portal appliance-license **surface**, shipped **dark**.

### Dark-launch gate (master switch)
`isLicenseDistributionTenant` (in `@alga-psa/licensing`) now requires **both** `MASTER_BILLING_TENANT_ID` (the Nine Minds tenant) **and** `ALGA_LICENSE_DISTRIBUTION_ENABLED=true`. Because the merged PR6 (template authoring) and PR7a (checkout/webhook) gates already call this function, folding the flag in here makes it a **single master switch over the whole stack** — with zero changes to those merged files. Fails closed: until the flag is set, the appliance-license template can't be authored, no checkout is created, and the surface stays hidden — even on the Nine Minds tenant. Flip it on once C4 + Stripe appliance prices are live.

### `@enterprise` seam (per #2596)
The CE `packages/client-portal` must not import `@alga-psa/licensing`. So `checkClientPortalPermissions` resolves the distributor check via `import('@enterprise/lib/license/distributionTenant')`:
- real re-export → `ee/server/src/lib/license/distributionTenant.ts`
- no-op stub → `packages/ee/src/lib/license/distributionTenant.ts`

No appliance-licensing logic ships in CE.

### Surface (11 files)
- C6 `/client-portal/licenses` page (server/src, gated) + `ClientLicensesPage` view + `getClientLicenses` action.
- "Licenses" sidebar nav, gated on `isLicenseDistributor` (computed in `checkClientPortalPermissions` via the seam, passed through the layout as a prop).
- Portal `request-services` submit honors the execution provider's `redirectUrl` (→ Stripe Checkout) — completing the form→checkout handoff.

### Rollout posture
**Inert on SaaS; dark on the Nine Minds tenant** until `ALGA_LICENSE_DISTRIBUTION_ENABLED=true`. With the flag unset (the default everywhere), nothing in the distribution stack is reachable.

### Validation
- `packages/client-portal`, `server`, `ee/server`, `packages/licensing` tsc: all clean.
- licensing unit tests: pass.

---
This is the last forward-port PR. After it merges, the full appliance-licensing + distribution feature is on `main` (dark); going live is a config step (C4 + Stripe prices + the flag), not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
