### PR TITLE
fix(secrets): neutralize Node 26 fs.Stats BigInt crash (unblocks Node 26 for the appliance image)

### DIFF
--- a/packages/core/src/lib/secrets/VaultSecretProvider.ts
+++ b/packages/core/src/lib/secrets/VaultSecretProvider.ts
@@ -1,3 +1,9 @@
+// Neutralise Node 26's throwing fs.Stats Temporal *Instant getters BEFORE
+// node-vault loads — it transitively runs bluebird's promisifyAll(require('fs'))
+// (via postman-request -> stream-length), which crashes at module load on
+// Node 26.2.x. This side-effect import MUST stay above the node-vault import;
+// ESM evaluates imports in source order, so it runs first on every load path.
+import './fixNode26FsStats';
 import vault from 'node-vault';
 import logger from '../logger';
 import type { ISecretProvider } from './ISecretProvider';

--- a/packages/core/src/lib/secrets/fixNode26FsStats.ts
+++ b/packages/core/src/lib/secrets/fixNode26FsStats.ts
@@ -1,0 +1,61 @@
+/**
+ * Node 26 (26.2.x) added Temporal `*Instant` getters to `fs.Stats.prototype`
+ * (atimeInstant / mtimeInstant / ctimeInstant / birthtimeInstant). On the bare
+ * prototype the backing fields are NaN, so *reading* one of these getters throws
+ * `RangeError: The number NaN cannot be converted to a BigInt`. Any library that
+ * enumerates the Stats prototype and reads property values then crashes at module
+ * load — notably bluebird's `promisifyAll(require('fs'))`, pulled in transitively
+ * via `node-vault -> postman-request -> stream-length`, which 500'd every auth/DB
+ * SSR route on the appliance when the base image floated to Node 26.2.0.
+ *
+ * This neutralises only the failure mode: each getter is wrapped so that if the
+ * underlying read throws (prototype / NaN), it returns `undefined` instead of
+ * throwing. Real Stats objects (valid backing data) still return their real
+ * `Temporal.Instant`. It is idempotent and a no-op on Node versions that don't
+ * define these getters.
+ *
+ * Imported (as a side effect) at the top of VaultSecretProvider.ts so it runs
+ * before `node-vault` — the only module that drags in the offending chain.
+ */
+import fs from 'node:fs';
+
+const PATCHED = Symbol.for('alga.node26FsStatsInstantGuard');
+
+// The Node 26 getters whose BigInt conversion throws when read on the prototype.
+const THROWING_INSTANT_GETTERS = [
+  'atimeInstant',
+  'mtimeInstant',
+  'ctimeInstant',
+  'birthtimeInstant',
+] as const;
+
+export function neutralizeNode26FsStatsBigIntGetters(): void {
+  const proto = (fs.Stats?.prototype as unknown) as Record<PropertyKey, unknown> | undefined;
+  if (!proto || proto[PATCHED]) {
+    return;
+  }
+
+  for (const name of THROWING_INSTANT_GETTERS) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+    if (!descriptor || typeof descriptor.get !== 'function') {
+      continue;
+    }
+    const originalGet = descriptor.get;
+    Object.defineProperty(proto, name, {
+      configurable: true,
+      enumerable: descriptor.enumerable,
+      get(this: unknown) {
+        try {
+          return originalGet.call(this);
+        } catch {
+          return undefined;
+        }
+      },
+    });
+  }
+
+  Object.defineProperty(proto, PATCHED, { value: true, enumerable: false, configurable: true });
+}
+
+// Apply on import so a bare `import './fixNode26FsStats'` is sufficient.
+neutralizeNode26FsStatsBigIntGetters();


### PR DESCRIPTION
## What

Resolves the open question from the appliance forward-port (#2602 / #2604): the `ee/server` Dockerfile node-pin conflict (`node:26.1.0` on main vs `node:20` on the 1.0.0 branch). Instead of downgrading the shared SaaS image to Node 20, this **fixes the underlying crash** so the image runs cleanly on any Node 26.x.

## Root cause

Node 26.2.x added Temporal `*Instant` getters to `fs.Stats.prototype` (`atimeInstant`/`mtimeInstant`/`ctimeInstant`/`birthtimeInstant`). On the bare prototype the backing fields are `NaN`, so *reading* one throws `RangeError: The number NaN cannot be converted to a BigInt`. bluebird's `promisifyAll(require('fs'))` — pulled in transitively via `node-vault → postman-request → stream-length` — enumerates those prototype getters at module load and crashed every auth/DB SSR route (500s) when the appliance base image floated to Node 26.2.0. That's why the 1.0.0 branch pinned `node:20`.

## Fix

- **`fixNode26FsStats.ts`** (new) — a small, idempotent guard that wraps the four throwing getters so a throwing read returns `undefined` instead of crashing. **Real `Stats` objects still return their `Temporal.Instant`** (only the NaN-on-prototype case is neutralized). No-op on Node versions without these getters.
- **`VaultSecretProvider.ts`** — imports the guard as its **first side-effect import**, above `import vault from 'node-vault'`. ESM evaluates imports in source order, so the guard runs before `node-vault` (and its bluebird chain) on **every** load path. `node-vault` is already lazy-loaded only when the `vault` provider is configured, so this is **zero overhead** for `env`/`filesystem` deployments (the appliance uses `filesystem`, SaaS uses `env`).

## Why not just keep the pin

Main already survives because (a) it lazy-loads `node-vault` and (b) `26.1.0` predates the bug. But the getter hazard persists in Node 26.x, so a base-image bump could silently re-brick auth on a shipped appliance. This removes the hazard at the source, so the pin is no longer load-bearing and the `node:20` downgrade is unnecessary. **No Dockerfile change** — main's `node:26.1.0` stays.

## Verification (real Node 26.3.0)

- Prototype getters **throw before** the guard, **return `undefined` after**.
- `fs.statSync('.').mtimeInstant` (real stat) is **preserved**.
- Aggressive prototype-chain enumeration (the exact bluebird crash mechanism) **completes** after the guard.
- Guard is idempotent across re-imports.
- `@alga-psa/core` and `ee/server` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)