### PR TITLE
fix(build): repair the self-contained EE Docker build (ee/server/Dockerfile.build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,12 @@ temp
 # Volume directories
 volumes
 
+# Appliance ISO build artifacts (multi-GB; never part of an app image context)
+ee/appliance/ubuntu-iso/output
+ee/appliance/ubuntu-iso/work
+**/*.iso
+**/*.iso.sha256
+
 # Other common directories to ignore
 docs
 tests

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -17,6 +17,9 @@ WORKDIR /app
 FROM base AS deps
 # Copy package files for both root and server parts of the project
 COPY package.json package-lock.json ./
+# .npmrc carries legacy-peer-deps=true (next-auth@5 beta wants nodemailer ^7,
+# project uses ^8); without it this stage's `npm install` fails ERESOLVE on npm@11.
+COPY .npmrc ./
 COPY server/package.json ./server/
 COPY ee/server/package.json ./ee/server/
 COPY tsconfig.base.json ./
@@ -36,7 +39,11 @@ ENV AUTH_SECRET=${NEXTAUTH_SECRET_BUILD}
 COPY . .
 
 WORKDIR /app
-RUN npm install --workspace=shared
+# Full install AFTER `COPY . .` so every workspace package (packages/*, @product/*,
+# @alga-psa/*) is symlinked into node_modules. The deps-stage install ran before
+# those dirs existed, so a shared-only relink leaves @product/chat (and siblings)
+# unresolvable by the EE build (`Module not found: @product/chat/context`).
+RUN npm install
 
 # Build all upstream packages (shared + pre-built) via Nx (handles dependency ordering)
 RUN npx nx build-deps server

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:webpack": "npm run build:assemblyscript && cd server && EDITION=community NEXT_PUBLIC_EDITION=community npm run build",
     "build:prebuilt": "npm run build:assemblyscript && npx nx build-deps server && cd server && USE_PREBUILT=true npm run build",
     "build:ce": "npm run build:assemblyscript && npx nx build-deps server && cd server && USE_PREBUILT=true EDITION=community NEXT_PUBLIC_EDITION=community npm run build:turbo",
-    "build:ee": "npm run build:assemblyscript && cd server && EDITION=ee NEXT_PUBLIC_EDITION=enterprise npm run build:enterprise:turbo",
+    "build:ee": "npm run build:assemblyscript && cd server && EDITION=ee NEXT_PUBLIC_EDITION=enterprise npm run build:enterprise",
     "build:assemblyscript": "node scripts/build-assemblyscript-if-needed.mjs",
     "build:assemblyscript:force": "cd server/src/invoice-templates/assemblyscript && npm install --cache ../../../../.npm-cache && npm run build",
     "build:perf": "node scripts/build-perf-harness.mjs",


### PR DESCRIPTION
## What

`ee/server/Dockerfile.build` — the self-contained EE image build (distinct from the prebuilt Argo path) — had bitrotted and couldn't build from a clean tree. Surfaced while building the appliance's `algaCore` image locally from `main`. Three fixes + a `.dockerignore` cleanup.

## Fixes

1. **ERESOLVE in the deps stage** — `COPY .npmrc ./` so its `npm install` inherits `legacy-peer-deps=true` (the repo's `.npmrc` carries it for the known `next-auth@5`-beta-wants-`nodemailer@^7` vs project-`^8` conflict). Without it, npm@11 fails the install.
2. **`Module not found: @product/chat/context`** — root cause was **missing workspace symlinks**: the deps-stage `npm install` runs before `packages/*` are copied, and the builder stage only relinked `shared`. Added a full `npm install` after `COPY . .` so every workspace (`packages/*`, `@product/*`, `@alga-psa/*`) is symlinked.
3. **`build:ee` → webpack** — was `build:enterprise:turbo`; turbopack can't resolve `@product/chat`'s `./context` subpath export (or `@microsoft/teams-js`). Switched to `build:enterprise` (webpack), which is the shipped production build. `build:ee` is referenced only by this Dockerfile; `isEE` stays true via the `EDITION=ee NEXT_PUBLIC_EDITION=enterprise` env it already sets.

## Also

`.dockerignore` now excludes `ee/appliance/ubuntu-iso/{output,work}` + `*.iso` — those were shipping ~20GB of local ISO artifacts into every build context.

## Verification

All four appliance images build clean from `main`: `alga-psa-ee` (1.65GB), `temporal-worker`, `workflow-worker`, `email-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)