### PR TITLE
perf(images): slim workflow-worker + email-service via multi-stage runtime

### DIFF
--- a/services/email-service/Dockerfile
+++ b/services/email-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19-alpine
+FROM node:20.19-alpine AS builder
 
 RUN apk add --no-cache \
     postgresql-client \
@@ -65,6 +65,26 @@ RUN npm run build
 
 COPY services/email-service/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+# Trim build-time-only bulk in the builder so the runtime COPY captures the
+# already-trimmed tree (deleting after the COPY would not reclaim space).
+# server/ is type-imports-only at build; the email service never loads it.
+RUN rm -rf /app/server /app/node_modules/server \
+    && npm cache clean --force 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Runtime stage: clean image with only the runtime tree (drops intermediate
+# build layers + server/ source).
+# ---------------------------------------------------------------------------
+FROM node:20.19-alpine AS runtime
+
+RUN apk add --no-cache \
+    postgresql-client \
+    curl \
+    bash
+
+WORKDIR /app
+COPY --from=builder /app /app
 
 ENV NODE_ENV=production
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/workflow-worker/Dockerfile
+++ b/services/workflow-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19-bullseye-slim
+FROM node:20.19-bullseye-slim AS builder
 
 # Install required system dependencies
 RUN apt-get update && apt-get install -y \
@@ -122,6 +122,33 @@ RUN npm run build
 # Copy and make entrypoint executable
 COPY services/workflow-worker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+# Trim build-time-only bulk HERE (in the builder), so the runtime COPY below
+# captures the already-trimmed tree — deleting after the COPY would not reclaim
+# space. server/ is type-imports-only at build; the worker's dist never loads it.
+RUN rm -rf /app/server /app/node_modules/server \
+    && npm cache clean --force 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Runtime stage: a fresh image with only what the worker needs at runtime.
+# The builder above keeps every workspace's source + devDeps + intermediate
+# layers (~10GB). The worker runs `node dist/.../index.js`, which resolves
+# @alga-psa/* via node_modules -> packages/*/dist, and does NOT load server/
+# (build-time type imports only) or the UI/build libs. Copying the final /app
+# into a clean stage drops the intermediate layers; removing server/ source
+# reclaims ~2GB more.
+# ---------------------------------------------------------------------------
+FROM node:20.19-bullseye-slim AS runtime
+
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    redis-tools \
+    curl \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app /app
 
 ENV NODE_ENV=production
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## What

`workflow-worker` and `email-service` were single-stage Docker builds that shipped the entire monorepo — full build `node_modules`, the copied `server/` source (2.2GB, type-imports-only at build), and all intermediate layers — landing at **10.4GB / 10.5GB**.

Split each into `builder` + `runtime` stages. The runtime stage copies the final `/app` from the builder (dropping intermediate layers); the builder first trims `server/` (the workers' built `dist` never loads it — verified by grepping the dist's `require()`s). `node_modules` is left intact to avoid breaking any lazily-required runtime dependency.

## Result

| Image | Before | After |
|---|---|---|
| workflow-worker | 10.4GB | **5.39GB** |
| email-service | 10.5GB | **4.81GB** |

Both validated: `node .` starts and reaches its run loop (worker spins up the v2 runtime workers; email-service starts IMAP and reaches DB connect) — so all modules resolve at runtime.

## Note

A further `node_modules` prune (UI/build libs a backend worker can't need — `next`, `@rspack`, `monaco-editor`, `ffprobe-static`, `@react-icons` ≈ 1.2GB) is possible but riskier (lazy requires), so it's deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)