### PR TITLE
perf(projects): speed up the project task list view

### DIFF
--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -444,6 +444,8 @@ export const TaskCard: React.FC<TaskCardProps> = ({
             teams={teams}
             getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
             getTeamAvatarUrlsBatch={getTeamAvatarUrlsBatchAction}
+            initialUserAvatarUrls={avatarUrls}
+            initialTeamAvatarUrls={teamAvatarUrls}
           />
         </div>
         {task.assigned_team_id && teamNames[task.assigned_team_id] && (

--- a/packages/projects/src/components/TaskListView.tsx
+++ b/packages/projects/src/components/TaskListView.tsx
@@ -712,23 +712,61 @@ export default function TaskListView({
     includeUnassignedAgents
   );
 
+  // The first-phase default must apply only once, on initial load. Re-applying
+  // it whenever phaseGroups changes (which happens on every task edit/move/
+  // add/delete) would collapse the view back to the first phase and discard
+  // phases the user has opened. A ref tracks whether we've initialized.
+  const didInitialiseExpansion = useRef(false);
+  // When a filter activates we expand all matching phases; we stash the user's
+  // prior expansion so it can be restored verbatim once the filter clears.
+  const preFilterExpansion = useRef<{ phases: Set<string>; statuses: Set<string> } | null>(null);
+
   useEffect(() => {
-    const phasesToExpand = new Set<string>();
-    const statusesToExpand = new Set<string>();
+    const collectGroups = (groups: PhaseGroup[]) => {
+      const phasesToExpand = new Set<string>();
+      const statusesToExpand = new Set<string>();
+      groups.forEach(group => {
+        phasesToExpand.add(group.phase.phase_id);
+        group.statusGroups.forEach(statusGroup => {
+          statusesToExpand.add(`${group.phase.phase_id}:${statusGroup.status.project_status_mapping_id}`);
+        });
+      });
+      return { phasesToExpand, statusesToExpand };
+    };
 
     const groupsWithTasks = phaseGroups.filter(group => group.totalTasks > 0);
-    const groupsToExpand = hasActiveFilter ? groupsWithTasks : groupsWithTasks.slice(0, 1);
 
-    groupsToExpand.forEach(group => {
-      phasesToExpand.add(group.phase.phase_id);
-      group.statusGroups.forEach(statusGroup => {
-        const statusKey = `${group.phase.phase_id}:${statusGroup.status.project_status_mapping_id}`;
-        statusesToExpand.add(statusKey);
-      });
-    });
+    if (hasActiveFilter) {
+      // Remember what the user had open before we override it, but only on the
+      // transition into a filtered state (not on every keystroke afterwards).
+      if (!preFilterExpansion.current) {
+        preFilterExpansion.current = {
+          phases: new Set(expandedPhases),
+          statuses: new Set(expandedStatuses),
+        };
+      }
+      const { phasesToExpand, statusesToExpand } = collectGroups(groupsWithTasks);
+      setExpandedPhases(phasesToExpand);
+      setExpandedStatuses(statusesToExpand);
+      return;
+    }
 
-    setExpandedPhases(phasesToExpand);
-    setExpandedStatuses(statusesToExpand);
+    // Filter just cleared: restore whatever the user had open beforehand.
+    if (preFilterExpansion.current) {
+      setExpandedPhases(preFilterExpansion.current.phases);
+      setExpandedStatuses(preFilterExpansion.current.statuses);
+      preFilterExpansion.current = null;
+      return;
+    }
+
+    // First unfiltered render with data: expand only the first phase that has
+    // tasks, then never auto-reset again so user edits don't collapse the view.
+    if (!didInitialiseExpansion.current && groupsWithTasks.length > 0) {
+      const { phasesToExpand, statusesToExpand } = collectGroups(groupsWithTasks.slice(0, 1));
+      setExpandedPhases(phasesToExpand);
+      setExpandedStatuses(statusesToExpand);
+      didInitialiseExpansion.current = true;
+    }
   }, [phaseGroups, hasActiveFilter]);
 
   // Cleanup scroll interval on unmount

--- a/packages/projects/src/components/TaskListView.tsx
+++ b/packages/projects/src/components/TaskListView.tsx
@@ -696,24 +696,40 @@ export default function TaskListView({
     return groups;
   }, [phases, filteredTasks, statuses, statusesByPhase]);
 
-  // Auto-expand phases and statuses that have tasks
-  useEffect(() => {
-    const phasesWithTasks = new Set<string>();
-    const statusesWithTasks = new Set<string>();
+  // Auto-expand phases/statuses. By default we only expand the FIRST phase that
+  // has tasks: rendering every phase's rows at once (each with its own assignee
+  // picker, avatars, etc.) is what makes the list view slow and floods the
+  // network with per-row requests. This mirrors the kanban, which only ever
+  // renders one phase at a time. While a search/filter is active we instead
+  // expand every phase that still has matching tasks, otherwise matches in
+  // later phases would be hidden behind collapsed headers.
+  const hasActiveFilter = Boolean(
+    searchQuery.trim() ||
+    selectedPriorityFilter !== 'all' ||
+    selectedTaskTags.length > 0 ||
+    selectedAgentFilter.length > 0 ||
+    selectedTeamFilter.length > 0 ||
+    includeUnassignedAgents
+  );
 
-    phaseGroups.forEach(group => {
-      if (group.totalTasks > 0) {
-        phasesWithTasks.add(group.phase.phase_id);
-        group.statusGroups.forEach(statusGroup => {
-          const statusKey = `${group.phase.phase_id}:${statusGroup.status.project_status_mapping_id}`;
-          statusesWithTasks.add(statusKey);
-        });
-      }
+  useEffect(() => {
+    const phasesToExpand = new Set<string>();
+    const statusesToExpand = new Set<string>();
+
+    const groupsWithTasks = phaseGroups.filter(group => group.totalTasks > 0);
+    const groupsToExpand = hasActiveFilter ? groupsWithTasks : groupsWithTasks.slice(0, 1);
+
+    groupsToExpand.forEach(group => {
+      phasesToExpand.add(group.phase.phase_id);
+      group.statusGroups.forEach(statusGroup => {
+        const statusKey = `${group.phase.phase_id}:${statusGroup.status.project_status_mapping_id}`;
+        statusesToExpand.add(statusKey);
+      });
     });
 
-    setExpandedPhases(phasesWithTasks);
-    setExpandedStatuses(statusesWithTasks);
-  }, [phaseGroups]);
+    setExpandedPhases(phasesToExpand);
+    setExpandedStatuses(statusesToExpand);
+  }, [phaseGroups, hasActiveFilter]);
 
   // Cleanup scroll interval on unmount
   useEffect(() => {
@@ -1725,6 +1741,8 @@ export default function TaskListView({
                                                 teams={teams}
                                                 getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
                                                 getTeamAvatarUrlsBatch={getTeamAvatarUrlsBatchAction}
+                                                initialUserAvatarUrls={avatarUrls}
+                                                initialTeamAvatarUrls={teamAvatarUrls}
                                               />
                                             ) : (
                                               (() => {

--- a/packages/ui/src/components/UserAndTeamPicker.tsx
+++ b/packages/ui/src/components/UserAndTeamPicker.tsx
@@ -27,6 +27,13 @@ interface UserAndTeamPickerProps {
   teams: ITeam[];
   getUserAvatarUrlsBatch?: GetUserAvatarUrlsBatch;
   getTeamAvatarUrlsBatch?: GetTeamAvatarUrlsBatch;
+  // Pre-fetched avatar URLs supplied by the caller (e.g. a list/board that has
+  // already batch-loaded every assignee's avatar in a single request). When an
+  // id is present here the picker uses it for the collapsed display and skips
+  // its own per-instance fetch, which avoids a flood of one-avatar requests
+  // when many pickers mount at once.
+  initialUserAvatarUrls?: Record<string, string | null>;
+  initialTeamAvatarUrls?: Record<string, string | null>;
   disabled?: boolean;
   className?: string;
   labelStyle?: 'bold' | 'medium' | 'normal' | 'none';
@@ -76,6 +83,8 @@ const UserAndTeamPicker = ({
   teams,
   getUserAvatarUrlsBatch,
   getTeamAvatarUrlsBatch,
+  initialUserAvatarUrls,
+  initialTeamAvatarUrls,
   disabled,
   className,
   labelStyle = 'bold',
@@ -100,6 +109,13 @@ const UserAndTeamPicker = ({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const pickerId = dataAutomationId || 'user-and-team-picker';
+
+  // Resolve an avatar URL preferring locally-fetched values, then any
+  // caller-supplied pre-fetched map. Returns null when unknown.
+  const resolveUserAvatar = (userId: string): string | null =>
+    avatarUrls[userId] ?? initialUserAvatarUrls?.[userId] ?? null;
+  const resolveTeamAvatar = (teamId: string): string | null =>
+    teamAvatarUrls[teamId] ?? initialTeamAvatarUrls?.[teamId] ?? null;
 
   const applyUserTypeFilter = (user: IUser) => {
     if (userTypeFilter === null) return true;
@@ -160,7 +176,9 @@ const UserAndTeamPicker = ({
     }
 
     const teamIdsToFetch = Array.from(teamIds).filter(
-      (teamId) => !fetchedTeamIdsRef.current.has(teamId) && teamAvatarUrls[teamId] === undefined
+      (teamId) => !fetchedTeamIdsRef.current.has(teamId)
+        && teamAvatarUrls[teamId] === undefined
+        && initialTeamAvatarUrls?.[teamId] === undefined
     );
 
     if (teamIdsToFetch.length === 0) {
@@ -182,7 +200,7 @@ const UserAndTeamPicker = ({
     };
 
     void fetchTeamAvatars();
-  }, [currentTeam, isOpen, teamEntries, getTeamAvatarUrlsBatch, teamAvatarUrls]);
+  }, [currentTeam, isOpen, teamEntries, getTeamAvatarUrlsBatch, teamAvatarUrls, initialTeamAvatarUrls]);
 
   useRegisterUIComponent<ContainerComponent>({
     type: 'container',
@@ -225,7 +243,9 @@ const UserAndTeamPicker = ({
       }
 
       const userIdsToFetch = Array.from(userIds).filter(
-        userId => !fetchedUserIdsRef.current.has(userId) && avatarUrls[userId] === undefined
+        userId => !fetchedUserIdsRef.current.has(userId)
+          && avatarUrls[userId] === undefined
+          && initialUserAvatarUrls?.[userId] === undefined
       );
 
       if (userIdsToFetch.length === 0) return;
@@ -262,7 +282,7 @@ const UserAndTeamPicker = ({
     };
 
     void fetchAvatarUrls();
-  }, [currentUser, isOpen, filteredUsers, users, getUserAvatarUrlsBatch, avatarUrls]);
+  }, [currentUser, isOpen, filteredUsers, users, getUserAvatarUrlsBatch, avatarUrls, initialUserAvatarUrls]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -432,7 +452,7 @@ const UserAndTeamPicker = ({
                   <UserAvatar
                     userId={user.user_id}
                     userName={userName}
-                    avatarUrl={avatarUrls[user.user_id] || null}
+                    avatarUrl={resolveUserAvatar(user.user_id)}
                     size={size === 'xs' ? 'xs' : size === 'sm' ? 'sm' : 'md'}
                   />
                   <span>{userName}</span>
@@ -461,7 +481,7 @@ const UserAndTeamPicker = ({
                   <TeamAvatar
                     teamId={team.team_id}
                     teamName={team.team_name || 'Unnamed Team'}
-                    avatarUrl={teamAvatarUrls[team.team_id] ?? null}
+                    avatarUrl={resolveTeamAvatar(team.team_id)}
                     size="sm"
                   />
                   <div className="flex flex-col">
@@ -516,7 +536,7 @@ const UserAndTeamPicker = ({
             <UserAvatar
               userId={currentUser.user_id}
               userName={`${currentUser.first_name || ''} ${currentUser.last_name || ''}`.trim()}
-              avatarUrl={avatarUrls[currentUser.user_id] || null}
+              avatarUrl={resolveUserAvatar(currentUser.user_id)}
               size={size === 'xs' ? 'xs' : size === 'sm' ? 'sm' : 'md'}
             />
           )}
@@ -524,7 +544,7 @@ const UserAndTeamPicker = ({
             <TeamAvatar
               teamId={currentTeam.team_id}
               teamName={currentTeam.team_name || 'Unnamed Team'}
-              avatarUrl={teamAvatarUrls[currentTeam.team_id] ?? null}
+              avatarUrl={resolveTeamAvatar(currentTeam.team_id)}
               size={size === 'xs' ? 'xs' : 'sm'}
             />
           )}


### PR DESCRIPTION
## Problem

The project task **list view** loaded very slowly and flooded the network with POSTs, while the **kanban view** stayed fast. Both views render the same data and use the same per-row assignee picker — the difference was purely how much got mounted at once:

- The list view auto-expanded **every phase and status group** on load, mounting a full row for every task across the whole project.
- Each row's `UserAndTeamPicker` independently fetched its own assignee avatar **on mount**, ignoring the batch of avatars the list had already loaded. With every row mounted, that became hundreds of one-avatar POSTs.
- The kanban "got away with" the same per-card fetch simply by only ever rendering one phase at a time.

## Changes

**1. Only auto-expand the first phase by default** (`TaskListView.tsx`)
- Collapsed phases don't mount their rows or pickers, so initial render and request volume are bounded to one phase — matching how the kanban behaves.
- While a search/filter is active, all phases with matching tasks stay expanded so results in later phases aren't hidden.
- The first-phase default is applied only once (ref-guarded); editing, moving, adding, or deleting a task no longer collapses the view, and the user's expansion is stashed/restored around filter changes.

**2. Let the assignee picker reuse already-batched avatars** (`UserAndTeamPicker.tsx`)
- New optional `initialUserAvatarUrls` / `initialTeamAvatarUrls` props. When an id is already known, the picker uses it for display and skips its per-instance fetch — eliminating the per-row avatar request swarm. Backward-compatible (omit the props → unchanged behavior).
- Wired the existing batched avatar maps into the pickers in both `TaskListView` and `TaskCard` (kanban), so neither view fires per-row avatar requests.

## Notes
- Did **not** move to server-side pagination like the tickets table: the list's phase→status grouping, drag-and-drop reordering, and global cross-phase search all rely on having the data client-side. Bounding the rendered set via first-phase expansion gets most of the benefit without that rewrite.
- `npx tsc --noEmit` passes for the `projects` package.

## Testing
- [ ] Verify list view loads quickly on a large project and the POST swarm is gone (only visible-phase requests)
- [ ] Verify search/filter still expands and shows matches across all phases
- [ ] Verify opening a later phase and editing/moving/adding/deleting a task does not collapse the view
- [ ] Verify kanban still works as before