### PR TITLE
fix(appliance): bootstrap job deadlocks the appliance install (post-install hook vs wait-for-bootstrap init)

### DIFF
--- a/helm/templates/jobs.yaml
+++ b/helm/templates/jobs.yaml
@@ -4,10 +4,17 @@ kind: Job
 metadata:
   name: {{ include "sebastian.fullname" . }}-bootstrap
   namespace: {{ include "sebastian.namespace" . }}
+  {{- if not .Values.setup.applianceBootstrap.enabled }}
+  # SaaS: run as a post-install/upgrade hook. NOT for the appliance — the alga
+  # core Deployment's wait-for-bootstrap init blocks readiness until this job
+  # creates the `users` table, but a post-install hook only fires AFTER the
+  # install succeeds, which can't happen while readiness is blocked. That
+  # deadlocks the appliance install, so there it runs as a regular concurrent Job.
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   template:
@@ -435,5 +442,11 @@ spec:
             name: {{ include "sebastian.fullname" . }}-appliance-bootstrap
             defaultMode: 0755
       {{- end }}
+  {{- if .Values.setup.applianceBootstrap.enabled }}
+  # Appliance: this runs concurrently with db-0 coming up (not a post-install
+  # hook), so allow retries while Postgres becomes reachable.
+  backoffLimit: 6
+  {{- else }}
   backoffLimit: 0
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Symptom

A fresh gen-2 appliance install never completes. The `alga-core` Helm release times out:
> Helm install failed for release msp/alga-core with chart sebastian@0.0.1: timeout waiting for: [Deployment/msp/alga-core-sebastian status: 'InProgress']

`kubectl get jobs -n msp` → **no bootstrap job**; the alga-core pod sits `Init:0/1` forever (`wait-for-bootstrap` logs *"Waiting for appliance bootstrap migrations to finish…"*).

## Root cause — a deadlock

- The alga-core Deployment has a `wait-for-bootstrap` init container that blocks readiness **until the `users` table exists** (it polls Postgres in an unbounded `until` loop).
- `users` is created by the **bootstrap job**, which main runs as a Helm **`post-install,post-upgrade` hook**.
- A post-install hook only fires **after** the install succeeds — but the install can't succeed while the Deployment is unready. Circular → the install times out and the bootstrap job never runs.

This is a **forward-port regression**: the pre-fork / 1.0.0 chart ran the bootstrap as a *regular* Job (`-bootstrap-r{revision}`, `backoffLimit: 2`); main converted it to a post-install hook (fine for SaaS, deadlocks the appliance).

## Fix

Gate the hook annotations off when `setup.applianceBootstrap.enabled`:
- **Appliance** → regular **concurrent Job** (creates `users` while the init waits → deadlock broken), `backoffLimit: 6` to tolerate racing `db-0` startup.
- **SaaS** → unchanged (post-install hook, `backoffLimit: 0`).

## Validation

Found and reproduced on a live appliance VM smoke of the gen-2 RC build (channel `nightly`, images `c5123eef`). `helm template --set setup.applianceBootstrap.enabled=true` now renders the bootstrap Job with **no `helm.sh/hook`** annotation; re-validating end-to-end on a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)