### PR TITLE
fix(appliance): EE image missing server/scripts breaks the bootstrap tenant/admin seed

### DIFF
--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -67,6 +67,10 @@ COPY ./server/index.ts ./server/
 COPY ./server/migrations/ ./server/migrations/
 COPY ./server/seeds/ ./server/seeds/
 COPY ./server/src/ ./server/src/
+# server/scripts holds runtime entrypoints invoked at boot, notably
+# create-tenant.ts which the appliance bootstrap runs to seed the initial
+# tenant/admin. Without it the appliance install fails ERR_MODULE_NOT_FOUND.
+COPY ./server/scripts/ ./server/scripts/
 
 # Copy EE-specific files
 COPY ./ee/server/src /app/ee/server/src

--- a/ee/server/Dockerfile.build
+++ b/ee/server/Dockerfile.build
@@ -117,6 +117,10 @@ COPY --from=builder /app/server/index.ts ./server/
 COPY --from=builder /app/server/migrations/ ./server/migrations/
 COPY --from=builder /app/server/seeds/ ./server/seeds/
 COPY --from=builder /app/server/src/ ./server/src/
+# server/scripts holds runtime entrypoints invoked at boot, notably
+# create-tenant.ts which the appliance bootstrap runs to seed the initial
+# tenant/admin. Without it the appliance install fails ERR_MODULE_NOT_FOUND.
+COPY --from=builder /app/server/scripts/ ./server/scripts/
 COPY --from=builder /app/secrets ./secrets
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/server/node_modules ./server/node_modules


### PR DESCRIPTION
## Symptom

On a fresh gen-2 appliance install, migrations + `license_state` seed fine, but creating the initial tenant/admin crashes:

```
[..] Creating initial appliance tenant and admin user
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/server/scripts/create-tenant.ts'
```

The appliance ends up with the schema applied but **0 users** — the operator can never log in.

## Cause

The bootstrap runs `npx tsx /app/server/scripts/create-tenant.ts ...` to seed the initial tenant + admin. But **neither** EE server Dockerfile ships `server/scripts/`:
- `ee/server/Dockerfile` (prebuilt / Argo) copies `server/{src,migrations,seeds}` — not `scripts`.
- `ee/server/Dockerfile.build` (self-contained) — same omission.

## Fix

Add `COPY server/scripts/ ./server/scripts/` to both (right after `server/src`). Verified the patched image contains `create-tenant.ts` and the appliance bootstrap seeds the tenant/admin.

Found via a live appliance VM smoke of the gen-2 RC build (companion to #2609, the bootstrap-hook deadlock fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)