### PR TITLE
helm: opt-in OpenTelemetry observability env block

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -271,6 +271,23 @@ spec:
             {{- end }}
           {{- end }}
 
+          # ----------- OBSERVABILITY (OpenTelemetry) ----------------
+          # When enabled, the app's OTEL SDK (http+pg+redis instrumentation) exports
+          # traces to OTLP_ENDPOINT. In production this points at the Alloy collector,
+          # which fans traces out to Tempo (storage) and the metrics generator
+          # (traces_spanmetrics_* / traces_service_graph_*). See nm-kube-config/alloy
+          # and nm-kube-config/tempo-metrics-generator.
+          {{- if (default dict .Values.observability).enabled }}
+          - name: ALGA_OBSERVABILITY
+            value: "true"
+          - name: OTLP_ENDPOINT
+            value: "{{ .Values.observability.otlpEndpoint }}"
+          {{- with (default dict .Values.observability).deploymentId }}
+          - name: DEPLOYMENT_ID
+            value: "{{ . }}"
+          {{- end }}
+          {{- end }}
+
           # ----------- HOCUSPOCUS ----------------
           {{- if .Values.hocuspocus.enabled }}
           - name: REQUIRE_HOCUSPOCUS

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,6 +93,14 @@ hocuspocus:
     type: "ClusterIP"
     port: 1234
 
+# OpenTelemetry app observability (traces). Off by default; opt-in per deployment.
+# When enabled, the app exports OTLP traces to otlpEndpoint (the Alloy collector
+# in production). See templates/deployment.yaml OBSERVABILITY block.
+observability:
+  enabled: false
+  otlpEndpoint: ""
+  # deploymentId: ""   # optional; sent as the X-Deployment-Id OTLP header
+
 temporal:
   address: "temporal-frontend.temporal.svc.cluster.local:7233"
   namespace: "default"


### PR DESCRIPTION
Adds a gated `ALGA_OBSERVABILITY` + `OTLP_ENDPOINT` env block to the server Deployment, driven by a new `observability` values key (**default disabled** — no effect on deployments that don't opt in).

When enabled, the app's existing OTEL SDK (http + pg + redis instrumentation) exports traces to `OTLP_ENDPOINT`. Production enables it and points at the Alloy collector via **nm-kube-config** `alga-psa/hosted.values.yaml` (companion change), which fans traces out to Tempo + a span-metrics/service-graph generator.

## Why a chart change
The deploy workflow renders the chart from the built image's SHA, so the env block must ship in the image to take effect — the values toggle alone is insufficient.

## Verify after deploy
`service.name=alga-psa` traces appear in Tempo; `traces_spanmetrics_*` appear in Prometheus. If app traces are absent, the OTLP gRPC exporter's `/v1/traces` path may need dropping (or switch to the HTTP exporter on :4318) in `server/src/lib/telemetry/initialization.ts`.