### PR TITLE
fix(appliance): restore create-tenant appliance-awareness (admin password + DB host)

### DIFF
--- a/ee/server/src/lib/testing/tenant-creation.ts
+++ b/ee/server/src/lib/testing/tenant-creation.ts
@@ -30,6 +30,7 @@ export interface TenantCreationInput {
     firstName: string;
     lastName: string;
     email: string;
+    password?: string;
   };
   companyName?: string;
   clientName?: string;
@@ -113,6 +114,7 @@ export async function createAdminUser(
     lastName: string;
     email: string;
     clientId?: string;
+    password?: string;
   }
 ): Promise<CreateAdminUserResult> {
   return await db.transaction(async (trx) => {
@@ -125,8 +127,8 @@ export async function createAdminUser(
       throw new Error(`User with email ${input.email} already exists`);
     }
 
-    // Generate temporary password
-    const temporaryPassword = generateSecurePassword();
+    // Use the supplied admin password when provided; otherwise generate a temporary one.
+    const temporaryPassword = input.password ?? generateSecurePassword();
     const hashedPassword = await hashPassword(temporaryPassword);
     
     // Create user
@@ -261,6 +263,7 @@ export async function createTenantComplete(
       lastName: input.adminUser.lastName,
       email: input.adminUser.email,
       clientId: tenantResult.clientId,
+      password: input.adminUser.password,
     });
 
     // Step 3: Setup tenant data

--- a/server/scripts/create-tenant.ts
+++ b/server/scripts/create-tenant.ts
@@ -83,17 +83,45 @@ async function main() {
       productCode = args.productCode;
     }
 
+    const suppliedPassword = args.password ?? process.env.INITIAL_ADMIN_PASSWORD;
+
     const result = await createTenantComplete(db, {
       tenantName: args.tenant,
       adminUser: {
         firstName: args.firstName || 'Admin',
         lastName: args.lastName || 'User',
-        email: args.email
+        email: args.email,
+        password: suppliedPassword
       },
       companyName: resolvedCompanyName,
       clientName: resolvedClientName,
       productCode
     });
+
+    // Put the new tenant into the onboarding-pending state so the admin lands in
+    // the in-app onboarding wizard on first login. createTenantComplete (the
+    // testing/CLI tenant path) does not create a tenant_settings row the way the
+    // SaaS provisioning path does, so without this the OnboardingProvider redirect
+    // (which requires onboarding_completed=false AND onboarding_skipped=false)
+    // never fires. Idempotent + best-effort so it never blocks tenant creation.
+    try {
+      const now = new Date();
+      await db('tenant_settings')
+        .insert({
+          tenant: result.tenantId,
+          onboarding_completed: false,
+          onboarding_skipped: false,
+          onboarding_data: null,
+          settings: null,
+          created_at: now,
+          updated_at: now
+        })
+        .onConflict('tenant')
+        .ignore();
+      console.log('Onboarding: tenant_settings initialized (onboarding pending)');
+    } catch (settingsError) {
+      console.warn('Warning: failed to initialize tenant_settings for onboarding:', settingsError);
+    }
 
     console.log('\n✅ Tenant created successfully!');
     console.log(`Tenant ID: ${result.tenantId}`);
@@ -101,7 +129,11 @@ async function main() {
     console.log(`Client ID: ${result.clientId}`);
     console.log(`Admin Email: ${args.email}`);
     console.log(`Product Code: ${productCode ?? '(default)'}`);
-    console.log(`Temporary Password: ${result.temporaryPassword}`);
+    if (suppliedPassword) {
+      console.log('Admin Password: [provided]');
+    } else {
+      console.log(`Temporary Password: ${result.temporaryPassword}`);
+    }
 
   } catch (error) {
     console.error('\n❌ Failed to create tenant:', error);

--- a/server/scripts/create-tenant.ts
+++ b/server/scripts/create-tenant.ts
@@ -57,17 +57,17 @@ async function main() {
   // Create database connection
   // For local development, use localhost instead of Docker service names
   const isDocker = process.env.DOCKER_ENV === 'true';
-  const dbHost = isDocker ? (process.env.PGBOUNCER_HOST || 'pgbouncer') : 'localhost';
-  const dbPort = isDocker ? (process.env.PGBOUNCER_PORT || '6432') : '5432';
-  
+  const dbHost = process.env.DB_HOST || (isDocker ? (process.env.PGBOUNCER_HOST || 'pgbouncer') : 'localhost');
+  const dbPort = process.env.DB_PORT || (isDocker ? (process.env.PGBOUNCER_PORT || '6432') : '5432');
+
   const db = knex({
     client: 'pg',
     connection: {
       host: dbHost,
       port: parseInt(dbPort),
       database: process.env.DB_NAME_SERVER || 'server',
-      user: process.env.DB_USER || 'postgres',
-      password: process.env.DB_PASSWORD_ADMIN || process.env.POSTGRES_PASSWORD || 'abcd1234!'
+      user: process.env.DB_USER_ADMIN || process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD_ADMIN || process.env.DB_PASSWORD_SUPERUSER || process.env.POSTGRES_PASSWORD || 'abcd1234!'
     }
   });
 


### PR DESCRIPTION
Two forward-port regressions in `server/scripts/create-tenant.ts` (+ `ee/server/src/lib/testing/tenant-creation.ts`) that each **block a fresh appliance install**. Main's copies diverged from the appliance branch's appliance-aware versions; the bootstrap (`helm/templates/appliance-bootstrap-configmap.yaml`) relies on both behaviors. Both caught by a live VM smoke of the RC build and verified fixed end-to-end.

## 1. Admin password from setup was dropped

The bootstrap passes the operator-chosen password as `INITIAL_ADMIN_PASSWORD`, but `create-tenant` / `createTenantComplete` only ever generated a random temporary password — so the admin couldn't log in with the password they entered in setup (the real one was only in the Job logs).

- `tenant-creation.ts`: `createTenantComplete`/`createAdminUser` accept an optional `adminUser.password`, used as `input.password ?? generateSecurePassword()` (no-password callers keep generated-temp behavior).
- `create-tenant.ts`: read `args.password ?? process.env.INITIAL_ADMIN_PASSWORD`; seed the `tenant_settings` onboarding row so the admin lands in the first-login wizard; print `Admin Password: [provided]` instead of echoing a supplied password.

## 2. create-tenant connected to localhost, not the bootstrap's DB

The bootstrap pod sets `DB_HOST`/`DB_HOST_ADMIN` (`db.msp.svc...`), but main's create-tenant only read `DOCKER_ENV ? PGBOUNCER_HOST : localhost` — never `DB_HOST`. With `DOCKER_ENV` unset it hit `localhost:5432` and failed (empty pg error) while same-pod migrations succeeded; the Job then died after `license_state` without seeding the admin. (`pgbouncer` isn't up during bootstrap anyway — it depends on alga-core, which depends on this Job.)

- `create-tenant.ts`: prefer `process.env.DB_HOST`/`DB_PORT`; fall back through `DB_USER_ADMIN` and `DB_PASSWORD_SUPERUSER`.

## Verified

Clean registry-metadata appliance install (channel `nightly`): bootstrap Job **completes on the first attempt** (migrations → create-tenant → 8 onboarding seeds → `Appliance setup completed`), the appliance's `bootstrapReady`/`loginReady` tiers go green, and a real `POST /api/auth/callback/credentials` with the operator-chosen password returns `302` + an authenticated session. Companion fixes: #2609 (bootstrap deadlock), #2611 (image missing `server/scripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)