### PR TITLE
feat(metadata): descriptive browser tab titles across routes

### DIFF
--- a/ee/server/src/app/teams/auth/popup-complete/page.tsx
+++ b/ee/server/src/app/teams/auth/popup-complete/page.tsx
@@ -1,3 +1,8 @@
+import type { Metadata } from 'next';
 import { TeamsTabPopupCompletePage } from '@alga-psa/ee-microsoft-teams/routes';
+
+export const metadata: Metadata = {
+  title: 'Teams Authentication',
+};
 
 export default TeamsTabPopupCompletePage;

--- a/ee/server/src/app/teams/tab/page.tsx
+++ b/ee/server/src/app/teams/tab/page.tsx
@@ -1,3 +1,8 @@
+import type { Metadata } from 'next';
 import { TeamsTabPage } from '@alga-psa/ee-microsoft-teams/routes';
+
+export const metadata: Metadata = {
+  title: 'Teams',
+};
 
 export default TeamsTabPage;

--- a/server/src/app/client-portal/documents/page.tsx
+++ b/server/src/app/client-portal/documents/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { ClientDocumentsPage } from '@alga-psa/client-portal/components';
+
+export const metadata: Metadata = {
+  title: 'Documents',
+};
 
 export default function DocumentsPage() {
   return <ClientDocumentsPage />;

--- a/server/src/app/client-portal/knowledge-base/layout.tsx
+++ b/server/src/app/client-portal/knowledge-base/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Knowledge Base',
+};
+
+export default function ClientPortalKnowledgeBaseLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/server/src/app/client-portal/request-services/[definitionId]/page.tsx
+++ b/server/src/app/client-portal/request-services/[definitionId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import React from 'react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -7,6 +8,10 @@ import {
   getRequestServiceDefinitionDetailAction,
   submitRequestServiceDefinitionAction,
 } from './actions';
+
+export const metadata: Metadata = {
+  title: 'Service Request',
+};
 import { ServiceRequestIcon } from '../ServiceRequestIcon';
 import { RequestServiceForm } from './RequestServiceForm';
 

--- a/server/src/app/client-portal/request-services/my-requests/[submissionId]/page.tsx
+++ b/server/src/app/client-portal/request-services/my-requests/[submissionId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import React from 'react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -5,6 +6,10 @@ import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import BackNav from '@alga-psa/ui/components/BackNav';
 import { getMyServiceRequestSubmissionDetailAction } from '../actions';
 import { getSubmissionFieldDisplay } from '../../submissionFieldPresentation';
+
+export const metadata: Metadata = {
+  title: 'Request Details',
+};
 
 interface MyRequestDetailPageProps {
   params: Promise<{

--- a/server/src/app/client-portal/request-services/my-requests/page.tsx
+++ b/server/src/app/client-portal/request-services/my-requests/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import { listMyServiceRequestSubmissionsAction } from './actions';
 import { MyRequestsTable, type MyRequestsTableRow } from './MyRequestsTable';
+
+export const metadata: Metadata = {
+  title: 'My Requests',
+};
 
 export default async function MyServiceRequestsPage() {
   const [submissions, { t }] = await Promise.all([

--- a/server/src/app/client-portal/request-services/page.tsx
+++ b/server/src/app/client-portal/request-services/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
@@ -5,6 +6,10 @@ import {
   listRequestServiceCatalogGroupsAction,
   listMyRecentServiceRequestsAction,
 } from './actions';
+
+export const metadata: Metadata = {
+  title: 'Request Services',
+};
 import { ServiceRequestCard } from './ServiceRequestCard';
 import { MyRequestsTable, type MyRequestsTableRow } from './my-requests/MyRequestsTable';
 import { enforceServerProductRoute } from '@/lib/serverProductRouteGuard';

--- a/server/src/app/msp/billing/page.tsx
+++ b/server/src/app/msp/billing/page.tsx
@@ -9,12 +9,38 @@ import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import type { Metadata } from 'next';
 import { enforceServerProductRoute } from '@/lib/serverProductRouteGuard';
 
-export const metadata: Metadata = {
-  title: 'Billing',
-};
-
 interface BillingPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+// Browser tab titles for each billing section. Billing is a single route whose
+// sections are selected via the `?tab=` query param, so the title is derived from
+// that param to mirror the active section. Keep in sync with `billingTabDefinitions`
+// in packages/billing/src/components/billing-dashboard/billingTabsConfig.ts.
+const BILLING_TAB_TITLES: Record<string, string> = {
+  quotes: 'Quotes',
+  'quote-templates': 'Quote Layouts',
+  'quote-business-templates': 'Quote Templates',
+  'client-contracts': 'Client Contracts',
+  'accounting-exports': 'Accounting Exports',
+  'contract-templates': 'Contract Templates',
+  invoicing: 'Invoicing',
+  'invoice-templates': 'Invoice Layouts',
+  'tax-rates': 'Tax Rates',
+  'contract-lines': 'Contract Line Presets',
+  'billing-cycles': 'Billing Cycles',
+  'service-periods': 'Service Periods',
+  'usage-tracking': 'Usage Tracking',
+  reports: 'Reports',
+  'service-types': 'Service Types',
+  'service-catalog': 'Services',
+  products: 'Products',
+};
+
+export async function generateMetadata({ searchParams }: BillingPageProps): Promise<Metadata> {
+  const params = await searchParams;
+  const tab = typeof params.tab === 'string' ? params.tab : undefined;
+  return { title: (tab && BILLING_TAB_TITLES[tab]) || 'Billing' };
 }
 
 const BillingPage = async ({ searchParams }: BillingPageProps) => {

--- a/server/src/app/msp/knowledge-base/page.tsx
+++ b/server/src/app/msp/knowledge-base/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from 'next';
 import { KnowledgeBasePage } from '@alga-psa/documents/components';
 import { getExperimentalFeatures } from '@alga-psa/tenancy/actions';
+
+export const metadata: Metadata = {
+  title: 'Knowledge Base',
+};
 
 export default async function KBArticlesPage() {
   let aiAssistantEnabled = false;

--- a/server/src/app/msp/knowledge-base/review/page.tsx
+++ b/server/src/app/msp/knowledge-base/review/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from 'next';
 import { KnowledgeBasePage } from '@alga-psa/documents/components';
 import { getExperimentalFeatures } from '@alga-psa/tenancy/actions';
+
+export const metadata: Metadata = {
+  title: 'Knowledge Base Review',
+};
 
 export default async function KBReviewPage() {
   let aiAssistantEnabled = false;

--- a/server/src/app/msp/platform-updates/[notificationId]/page.tsx
+++ b/server/src/app/msp/platform-updates/[notificationId]/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getActivePlatformNotifications } from '@enterprise/lib/platformNotifications/actions';
 import { PlatformUpdateDetail } from '@/components/platform-updates/PlatformUpdateDetail';
 
 export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Platform Update',
+};
 
 interface PageProps {
   params: Promise<{ notificationId: string }>;

--- a/server/src/app/msp/search/page.tsx
+++ b/server/src/app/msp/search/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import {
   searchAppAction,
   type SearchAppResult,
@@ -7,6 +8,10 @@ import { SEARCH_OBJECT_TYPES, type SearchObjectType } from '@alga-psa/types';
 import SearchPageClient from './SearchPageClient';
 
 export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Search',
+};
 
 interface SearchPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/server/src/app/msp/settings/page.tsx
+++ b/server/src/app/msp/settings/page.tsx
@@ -1,9 +1,39 @@
 import SettingsPage from '@/components/settings/SettingsPage';
 import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Settings',
+// Browser tab titles for each settings section. Settings is a single route whose
+// sections are selected via the `?tab=` query param, so the title is derived from
+// that param to mirror the active section. Keys match the tab `id`s in
+// server/src/components/settings/SettingsPage.tsx (matched case-insensitively).
+const SETTINGS_TAB_TITLES: Record<string, string> = {
+  general: 'General',
+  'experimental-features': 'Experimental Features',
+  'client-portal': 'Client Portal',
+  users: 'Users',
+  teams: 'Teams',
+  language: 'Language',
+  ticketing: 'Ticketing',
+  projects: 'Projects',
+  interactions: 'Interactions',
+  notifications: 'Notifications',
+  'time-entry': 'Time Entry',
+  billing: 'Billing',
+  secrets: 'Secrets',
+  'import-export': 'Import/Export',
+  email: 'Email',
+  integrations: 'Integrations',
+  extensions: 'Extensions',
 };
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}): Promise<Metadata> {
+  const resolvedSearchParams = await searchParams;
+  const tab = typeof resolvedSearchParams?.tab === 'string' ? resolvedSearchParams.tab.toLowerCase() : undefined;
+  return { title: (tab && SETTINGS_TAB_TITLES[tab]) || 'Settings' };
+}
 
 export default async function Page({
   searchParams,

--- a/server/src/app/share/[token]/layout.tsx
+++ b/server/src/app/share/[token]/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Shared Document',
+};
+
+export default function ShareTokenLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/server/src/app/teams/auth/popup-complete/page.tsx
+++ b/server/src/app/teams/auth/popup-complete/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import { Card } from '@alga-psa/ui/components/Card';
 import { isTeamsEnterpriseEdition, TEAMS_AVAILABILITY_MESSAGES } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Teams Authentication',
+};
 
 async function renderUnavailableCard(message: string) {
   const { t } = await getServerTranslation(undefined, 'common');

--- a/server/src/app/teams/tab/page.tsx
+++ b/server/src/app/teams/tab/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
 import { Card } from '@alga-psa/ui/components/Card';
 import { isTeamsEnterpriseEdition, TEAMS_AVAILABILITY_MESSAGES } from '@alga-psa/integrations/lib/teamsAvailabilityCore';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Teams',
+};
 
 interface TeamsTabPageProps {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;

--- a/server/src/test/unit/app/pageTitles.metadata.test.ts
+++ b/server/src/test/unit/app/pageTitles.metadata.test.ts
@@ -8,6 +8,14 @@ function read(relativePath: string): string {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
+// Recognises every form a route uses to declare title metadata, including the
+// `export { default, generateMetadata } from '...'` re-export used by extensions.
+const METADATA_EXPORT_RE = /export const metadata|export async function generateMetadata|export function generateMetadata|export \{ default, metadata \}|export \{ default, generateMetadata \}/;
+
+function hasMetadataExport(content: string): boolean {
+  return METADATA_EXPORT_RE.test(content);
+}
+
 function expectStaticTitle(relativePath: string, title: string): void {
   const content = read(relativePath);
   expect(content).toMatch(/export const metadata/);
@@ -20,9 +28,17 @@ function expectDynamicTitle(relativePath: string, title: string): void {
   expect(content).toContain(`title: '${title}'`);
 }
 
+// For routes that translate their title via generateMetadata and pass the English
+// string as the i18n `defaultValue` instead of a literal `title: '...'`.
+function expectTranslatedTitle(relativePath: string, defaultValue: string): void {
+  const content = read(relativePath);
+  expect(content).toMatch(/generateMetadata/);
+  expect(content).toContain(`defaultValue: '${defaultValue}'`);
+}
+
 function pageHasMetadata(relativePath: string): boolean {
   const pageContent = read(relativePath);
-  if (/export const metadata|export async function generateMetadata|export function generateMetadata|export \{ default, metadata \}/.test(pageContent)) {
+  if (hasMetadataExport(pageContent)) {
     return true;
   }
 
@@ -32,7 +48,7 @@ function pageHasMetadata(relativePath: string): boolean {
   }
 
   const layoutContent = read(layoutPath);
-  return /export const metadata|export async function generateMetadata|export function generateMetadata|export \{ default, metadata \}/.test(layoutContent);
+  return hasMetadataExport(layoutContent);
 }
 
 function collectPages(rootRelativePath: string): string[] {
@@ -106,7 +122,6 @@ describe('route title metadata coverage', () => {
       ['server/src/app/msp/assets/integrations/page.tsx', 'Asset Integrations'],
       ['server/src/app/msp/assets/maintenance/page.tsx', 'Asset Maintenance'],
       ['server/src/app/msp/assets/policies/page.tsx', 'Asset Policies'],
-      ['server/src/app/msp/billing/page.tsx', 'Billing'],
       ['server/src/app/msp/billing/credits/page.tsx', 'Credits'],
       ['server/src/app/msp/time-entry/page.tsx', 'Time Entry'],
       ['server/src/app/msp/time-sheet-approvals/page.tsx', 'Timesheet Approvals'],
@@ -125,7 +140,6 @@ describe('route title metadata coverage', () => {
       ['server/src/app/msp/workflow-control/page.tsx', 'Workflow Control'],
       ['server/src/app/msp/workflows/page.tsx', 'Workflows'],
       ['server/src/app/msp/automation-hub/layout.tsx', 'Automation Hub'],
-      ['server/src/app/msp/settings/page.tsx', 'Settings'],
       ['server/src/app/msp/settings/extensions/layout.tsx', 'Extension Settings'],
       ['server/src/app/msp/settings/extensions/install/layout.tsx', 'Install Extension'],
       ['server/src/app/msp/settings/integrations/qbo/callback/page.tsx', 'QuickBooks Integration'],
@@ -133,8 +147,6 @@ describe('route title metadata coverage', () => {
       ['server/src/app/msp/settings/sla/layout.tsx', 'SLA Settings'],
       ['server/src/app/msp/security-settings/page.tsx', 'Security Settings'],
       ['server/src/app/msp/extensions/layout.tsx', 'Extensions'],
-      ['server/src/app/msp/licenses/purchase/layout.tsx', 'Purchase Licenses'],
-      ['server/src/app/msp/licenses/purchase/success/layout.tsx', 'Purchase Success'],
       ['server/src/app/msp/reports/page.tsx', 'Reports'],
       ['server/src/app/msp/user-activities/page.tsx', 'User Activities'],
       ['server/src/app/msp/onboarding/layout.tsx', 'Onboarding'],
@@ -158,7 +170,6 @@ describe('route title metadata coverage', () => {
       ['server/src/app/msp/contacts/[id]/activity/page.tsx', 'Contact Activity'],
       ['server/src/app/msp/projects/[id]/page.tsx', 'Project Details'],
       ['server/src/app/msp/assets/[asset_id]/page.tsx', 'Asset Details'],
-      ['server/src/app/msp/workflows/[executionId]/page.tsx', 'Workflow Execution'],
     ] as const;
 
     for (const [relativePath, title] of dynamicMspRoutes) {
@@ -180,6 +191,34 @@ describe('route title metadata coverage', () => {
 
     for (const [relativePath, title] of staticDynamicRoutes) {
       expectStaticTitle(relativePath, title);
+    }
+  });
+
+  it('T007c: single-route tabbed pages derive the title from the ?tab= param', () => {
+    // Billing and Settings are single routes whose sections are selected via the
+    // `?tab=` query param. They use generateMetadata to mirror the active section
+    // in the browser tab title, falling back to the page name.
+    const tabbedRoutes = [
+      {
+        path: 'server/src/app/msp/billing/page.tsx',
+        fallback: 'Billing',
+        sampleTitles: ['Invoicing', 'Quotes', 'Reports'],
+      },
+      {
+        path: 'server/src/app/msp/settings/page.tsx',
+        fallback: 'Settings',
+        sampleTitles: ['Integrations', 'Users', 'Email'],
+      },
+    ] as const;
+
+    for (const { path, fallback, sampleTitles } of tabbedRoutes) {
+      const content = read(path);
+      expect(content).toMatch(/generateMetadata/);
+      expect(content).toContain('searchParams');
+      expect(content).toContain(`'${fallback}'`);
+      for (const title of sampleTitles) {
+        expect(content).toContain(`'${title}'`);
+      }
     }
   });
 
@@ -321,13 +360,48 @@ describe('route title metadata coverage', () => {
 
   it('T024: EE MSP routes export the expected titles', () => {
     expectStaticTitle('ee/server/src/app/msp/chat/page.tsx', 'Chat');
-    expectStaticTitle('ee/server/src/app/msp/licenses/purchase/layout.tsx', 'Purchase Licenses');
-    expectStaticTitle('ee/server/src/app/msp/licenses/purchase/success/layout.tsx', 'Purchase Success');
     expectStaticTitle('ee/server/src/app/msp/settings/page.tsx', 'Settings');
+  });
+
+  it('T024b: license purchase layouts translate their title via generateMetadata', () => {
+    // CE and EE share the same license purchase layouts, which localize the browser
+    // title through getServerTranslation and pass the English copy as `defaultValue`.
+    expectTranslatedTitle('server/src/app/msp/licenses/purchase/layout.tsx', 'Purchase Licenses');
+    expectTranslatedTitle('server/src/app/msp/licenses/purchase/success/layout.tsx', 'Purchase Success');
+    expectTranslatedTitle('ee/server/src/app/msp/licenses/purchase/layout.tsx', 'Purchase Licenses');
+    expectTranslatedTitle('ee/server/src/app/msp/licenses/purchase/success/layout.tsx', 'Purchase Success');
   });
 
   it('T025: EE Client Portal extension route exports a static title', () => {
     expectStaticTitle('ee/server/src/app/client-portal/extensions/[id]/page.tsx', 'Extension');
+  });
+
+  it('T027: newly covered routes export the expected titles', () => {
+    const newStaticRoutes = [
+      // MSP
+      ['server/src/app/msp/knowledge-base/page.tsx', 'Knowledge Base'],
+      ['server/src/app/msp/knowledge-base/review/page.tsx', 'Knowledge Base Review'],
+      ['server/src/app/msp/platform-updates/[notificationId]/page.tsx', 'Platform Update'],
+      ['server/src/app/msp/search/page.tsx', 'Search'],
+      // Teams (CE + EE)
+      ['server/src/app/teams/tab/page.tsx', 'Teams'],
+      ['server/src/app/teams/auth/popup-complete/page.tsx', 'Teams Authentication'],
+      ['ee/server/src/app/teams/tab/page.tsx', 'Teams'],
+      ['ee/server/src/app/teams/auth/popup-complete/page.tsx', 'Teams Authentication'],
+      // Client Portal
+      ['server/src/app/client-portal/documents/page.tsx', 'Documents'],
+      ['server/src/app/client-portal/request-services/page.tsx', 'Request Services'],
+      ['server/src/app/client-portal/request-services/[definitionId]/page.tsx', 'Service Request'],
+      ['server/src/app/client-portal/request-services/my-requests/page.tsx', 'My Requests'],
+      ['server/src/app/client-portal/request-services/my-requests/[submissionId]/page.tsx', 'Request Details'],
+      // Client components covered via a sibling layout
+      ['server/src/app/client-portal/knowledge-base/layout.tsx', 'Knowledge Base'],
+      ['server/src/app/share/[token]/layout.tsx', 'Shared Document'],
+    ] as const;
+
+    for (const [relativePath, title] of newStaticRoutes) {
+      expectStaticTitle(relativePath, title);
+    }
   });
 
   it('T026: every CE and EE page route has metadata coverage', () => {


### PR DESCRIPTION
  Derive billing and settings titles from the active ?tab= param via
  generateMetadata, so the browser tab mirrors the open section instead
  of a static "Billing"/"Settings". Add page titles to 15 previously
  untitled routes (knowledge base, search, platform updates, request
  services, teams, share, documents) — client-only pages get a
  pass-through layout. Refresh pageTitles.metadata.test: recognize the
  `export { default, generateMetadata }` re-export form, cover i18n
  translated license layouts, drop the renamed workflows route, and add
  regression coverage for the new titles.

  And so every little tab, like Alice's bottles, now wears its own
  "who-am-I" label, the Cheshire grin of an untitled page fading at last
  into honest words. 🐇🏷️ 🎩