### PR TITLE
docs: update API overview and ITIL SLA notes (2026-06-03)

### DIFF
--- a/docs/api/api_overview.md
+++ b/docs/api/api_overview.md
@@ -118,8 +118,33 @@ API keys can be managed through the user interface by navigating to your User Pr
 ## 6. Available APIs
 
 ### Community Edition APIs
-- [Future CE APIs will be documented here]
+
+The following REST API groups are available in the Community Edition under the base path `/api/v1/`:
+
 - [API Rate Limiting and Webhooks](api-rate-limiting-and-webhooks.md)
+- **Tickets** — Create, read, update, and close service tickets; manage comments, time entries, assignments, and files. Includes ticket bundling (see below).
+- **Assets** — Register hardware assets, schedule maintenance, map relationships between devices, and drive RMM actions.
+- **Users** — Create and administer user accounts, manage passwords and two-factor authentication, and read roles, teams, and effective permissions.
+- **Billing** — Access contracts, contract lines, invoices, and billing analytics.
+- Additional endpoints: companies (clients), contacts, projects, boards, categories, priorities, statuses, time entries, schedules, and more.
+
+#### Ticket Bundling
+
+When multiple tickets describe the same underlying issue, they can be grouped under one *master* ticket using the bundle sub-resource at `/api/v1/tickets/{id}/bundle`. This feature is available to both PSA and AlgaDesk tenants.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/tickets/{id}/bundle` | Return the ticket's bundle role (`master`, `child`, or `standalone`), the master ticket, children, and settings |
+| `POST` | `/tickets/{id}/bundle` | Create a bundle with `{id}` as master. Requires `child_ticket_ids` (array of UUIDs); accepts optional `mode` (`link_only` or `sync_updates`, default `sync_updates`) |
+| `DELETE` | `/tickets/{id}/bundle` | Detach all children and remove bundle settings |
+| `POST` | `/tickets/{id}/bundle/children` | Add additional child tickets to an existing bundle |
+| `DELETE` | `/tickets/{id}/bundle/children/{childId}` | Remove one child; bundle settings are cleaned up when the last child is removed |
+| `POST` | `/tickets/{id}/bundle/promote` | Promote a child ticket to become the new master |
+| `PUT` | `/tickets/{id}/bundle/settings` | Update `mode` and/or `reopen_on_child_reply` for the bundle |
+
+**Bundle modes:**
+- `link_only` — links tickets visually without propagating state changes to children
+- `sync_updates` — propagates the master ticket's status changes to all children (default)
 
 ### Enterprise Edition APIs
 - **Tenant Provisioning API:** Enables partner-driven tenant management. See [tenant_provisioning_api.md](tenant_provisioning_api.md) for details.

--- a/docs/itil/itil-integration.md
+++ b/docs/itil/itil-integration.md
@@ -34,8 +34,8 @@ The ITIL integration enhances Alga PSA's ticketing system with comprehensive ITI
 #### ITIL Priority Matrix
 The system uses a standard 5×5 Impact × Urgency matrix to calculate priority:
 
-| Impact \\ Urgency | High (1) | Medium-High (2) | Medium (3) | Medium-Low (4) | Low (5) |
-|-------------------|----------|------------------|------------|----------------|---------|
+| Impact \ Urgency | High (1) | Medium-High (2) | Medium (3) | Medium-Low (4) | Low (5) |
+|-------------------|----------|------------------|------------|----------------|--------|
 | **High (1)**      | Critical | High            | High       | Medium         | Medium  |
 | **Medium-High (2)** | High   | High            | Medium     | Medium         | Low     |
 | **Medium (3)**    | High     | Medium          | Medium     | Low            | Low     |
@@ -108,12 +108,14 @@ The system uses a standard 5×5 Impact × Urgency matrix to calculate priority:
 #### Priority-Based SLA Targets
 
 | Priority | Target Resolution Time |
-|----------|----------------------|
+|----------|-----------------------|
 | Critical | 1 hour              |
 | High     | 4 hours             |
 | Medium   | 24 hours (1 day)    |
 | Low      | 72 hours (3 days)   |
 | Planning | 168 hours (1 week)  |
+
+> **Product note:** The "ITIL Standard" SLA policy is automatically created only for Alga PSA tenants. AlgaDesk tenants that select ITIL priority mode still benefit from the Impact × Urgency priority matrix for ticket classification and prioritisation, but the SLA policy is not auto-created and SLA breach notifications are not emitted. This prevents AlgaDesk — which does not include SLA management — from generating spurious breach alerts. All other ITIL workflows (priority calculation, categories, escalation) apply equally to both products.
 
 #### Escalation Thresholds
 
@@ -183,7 +185,7 @@ server/src/
 1. **Set Impact and Urgency**: Select appropriate impact and urgency levels
 2. **Auto-Priority Calculation**: Priority is automatically calculated using the matrix
 3. **Category Selection**: Choose from standard ITIL categories
-4. **SLA Assignment**: SLA targets are automatically assigned based on priority
+4. **SLA Assignment**: SLA targets are automatically assigned based on priority (Alga PSA only — see [SLA Management](#sla-management))
 
 ### Using ITIL Fields Component
 
@@ -250,8 +252,8 @@ const escalationRules = {
 ```json
 {
   "ticketId": "uuid",
-  "impact": 1-5,
-  "urgency": 1-5
+  "impact": 1,
+  "urgency": 5
 }
 ```
 
@@ -391,6 +393,7 @@ Manages the complete ITIL incident lifecycle:
 - Verify priority calculation is working
 - Check database constraints
 - Review workflow execution logs
+- Note: SLA auto-configuration only applies to Alga PSA tenants, not AlgaDesk
 
 #### Escalation Not Triggering
 - Confirm escalation workflow is active


### PR DESCRIPTION
## Source PRs

- [#2615 Fix public API responses, add ticket bundling](https://github.com/Nine-Minds/alga-psa/pull/2615) — merged 2026-06-02
- [#2610 Skip ITIL SLA auto-config for AlgaDesk tenants](https://github.com/Nine-Minds/alga-psa/pull/2610) — merged 2026-06-02

## Files edited

### `docs/api/api_overview.md`
**Rationale (PR #2615):** Section 6 still read "Future CE APIs will be documented here" despite the ticket bundling REST API (7 new endpoints) and several other CE API groups being live. Replaced the placeholder with a list of available CE API groups and added a full table documenting the `/tickets/{id}/bundle` sub-resource — including all seven endpoints, their methods, and the two bundle modes (`link_only` / `sync_updates`). A consumer reading the old doc would have no idea the bundling API existed; the new doc explains what it does and how to use it.

### `docs/itil/itil-integration.md`
**Rationale (PR #2610):** The SLA Management section described the "ITIL Standard" SLA policy as being automatically created whenever a tenant enables ITIL priorities — no product distinction was made. PR #2610 introduced a gate: AlgaDesk tenants skip the SLA policy entirely because SLA is a PSA-only capability, and auto-creating it would emit breach notifications the product cannot handle. Added a blockquote note to the SLA targets table and a matching item in the Troubleshooting section so an operator managing an AlgaDesk tenant knows to expect no SLA auto-config. The usage note for "Creating ITIL-Enabled Tickets" was also updated to point back to the new note.

## Needs human review

- **OpenAPI spec sync (PR #2615):** The alga-psa OpenAPI specs (`sdk/docs/openapi/alga-openapi.{ce,ee,}.{json,yaml}`) were regenerated in PR #2615 to include the 7 new bundle endpoints. The nm-store consumer copy at `packages/nm-store/public/openapi/alga.json` may be stale and should be re-synced. Please regenerate via `cd sdk && npm run openapi:generate` and copy the result.

- **Breaking: Asset and ContractLine response shape (PR #2615):** The double-wrapped success response bug (`{ data: { data: ... } }` → `{ data: ... }`) was fixed for Asset and ContractLine endpoints. Any existing integration parsing the old nested format will break. If there is a changelog or migration guide, this deserves a breaking-change callout.

- **Breaking: user object `image` → `icon` field rename (PR #2615):** The `image` field on user objects returned from `/api/v1` endpoints was renamed to `icon` (matching the actual database column). Clients reading `user.image` from any API response will now find the field absent. No docs currently document this field by name, but release notes / the OpenAPI spec update covers it implicitly.

- **`GET /api/v1/test-auth` behavior change (PR #2574):** This debug endpoint now returns only `{ userId, tenant, apiKeyId }` instead of the full context object, and returns 404 in production by default unless `ENABLE_API_TEST_AUTH=true` is set. If any developer guide or onboarding doc references this endpoint, it needs updating.

- **Error response redaction (PR #2574):** `error.details` in all API error responses now passes through `redactSensitiveFields()`, replacing any field whose name matches a list of credential-like patterns (e.g., `password`, `api_key`, `two_factor_secret`) with the string `[REDACTED]`. This is a security hardening change that is unlikely to affect normal integrations but may be worth noting in developer-facing error-handling documentation.

- **Search index entries in nm-store:** The ticket bundling concept is new and may benefit from entries in `packages/nm-store/src/lib/developer-portal/search/{concepts,guides}.ts` to make it discoverable from the developer portal search.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn2Fo5mPGGw9Va9wD2sznc)_