### PR TITLE
fix(workflow): restore configurability of project actions with missing scope pickers

### DIFF
--- a/shared/workflow/runtime/actions/businessOperations/projects.ts
+++ b/shared/workflow/runtime/actions/businessOperations/projects.ts
@@ -244,7 +244,10 @@ const assignTaskInputSchema = z.object({
 });
 
 const duplicateTaskInputSchema = z.object({
+  project_id: withWorkflowPicker(uuidSchema.optional(), 'Optional project id for source task picker scope', 'project'),
+  phase_id: withWorkflowPicker(uuidSchema.optional(), 'Optional phase id for source task picker scope', 'project-phase', ['project_id']),
   source_task_id: withWorkflowPicker(uuidSchema, 'Source project task id', 'project-task', ['project_id', 'phase_id']),
+  target_project_id: withWorkflowPicker(uuidSchema.optional(), 'Optional target project id', 'project'),
   target_phase_id: withWorkflowPicker(uuidSchema, 'Target project phase id', 'project-phase', ['target_project_id']),
   target_project_status_mapping_id: withWorkflowPicker(
     uuidSchema.optional(),
@@ -2019,6 +2022,7 @@ export function registerProjectActions(): void {
     id: 'projects.update_phase',
     version: 1,
     inputSchema: z.object({
+      project_id: withWorkflowPicker(uuidSchema.optional(), 'Optional project id for phase picker scope', 'project'),
       phase_id: withWorkflowPicker(uuidSchema, 'Project phase id', 'project-phase', ['project_id']),
       patch: phaseUpdatePatchSchema,
     }),
@@ -2081,6 +2085,8 @@ export function registerProjectActions(): void {
     id: 'projects.update_task',
     version: 1,
     inputSchema: z.object({
+      project_id: withWorkflowPicker(uuidSchema.optional(), 'Optional project id for task picker scope', 'project'),
+      phase_id: withWorkflowPicker(uuidSchema.optional(), 'Optional phase id for task picker scope', 'project-phase', ['project_id']),
       task_id: withWorkflowPicker(uuidSchema, 'Project task id', 'project-task', ['project_id', 'phase_id']),
       patch: taskUpdatePatchSchema,
     }),


### PR DESCRIPTION
## Summary

Three "Business Operations" project workflow actions could not be configured in the workflow designer. Their task/phase/status pickers stayed permanently disabled (e.g. *"Choose a fixed Project first to load phase options"*) because they declared picker dependencies on project/phase scope fields that were never present in their input schemas — so there was no upstream picker to resolve those dependencies.

Affected actions (all in `shared/workflow/runtime/actions/businessOperations/projects.ts`):

- **Duplicate Project Task** (`projects.duplicate_task`) — phase/status pickers blocked
- **Update Project Phase** (`projects.update_phase`) — phase picker blocked (sole selector → action fully unusable)
- **Update Project Task** (`projects.update_task`) — task picker blocked (sole selector → action fully unusable)

## Fix

Added the missing optional scope picker fields, mirroring the existing `move_task` / `assign_task` / `delete_task` / `delete_phase` schemas:

- `duplicate_task`: `project_id` + `phase_id` (scope source task) and `target_project_id` (enables target phase/status)
- `update_phase`: `project_id` (enables phase picker)
- `update_task`: `project_id` + `phase_id` (enables task picker)

The fields are UI-only — the handlers continue to infer real scope from the selected phase/task, so runtime behavior is unchanged. All other project action schemas that declare picker dependencies were audited and are correct.

## Testing

- Verified in the running app that the previously-disabled pickers are now selectable.
- TypeScript diagnostics clean for the changed file.