### PR TITLE
feat(billing): add Swiss Franc (CHF) currency option

### DIFF
--- a/packages/core/src/constants/currency.ts
+++ b/packages/core/src/constants/currency.ts
@@ -13,6 +13,7 @@ export const CURRENCY_OPTIONS: CurrencyOption[] = [
   { value: 'NZD', label: 'NZD (NZ$)', symbol: 'NZ$' },
   { value: 'ARS', label: 'ARS ($)', symbol: '$' },
   { value: 'JPY', label: 'JPY (¥)', symbol: '¥' },
+  { value: 'CHF', label: 'CHF (Fr.)', symbol: 'Fr.' },
 ];
 
 export const getCurrencySymbol = (code: string): string => {

--- a/server/src/constants/currency.ts
+++ b/server/src/constants/currency.ts
@@ -14,6 +14,7 @@ export const CURRENCY_OPTIONS: CurrencyOption[] = [
   { value: 'NZD', label: 'NZD (NZ$)', symbol: 'NZ$' },
   { value: 'ARS', label: 'ARS ($)', symbol: '$' },
   { value: 'JPY', label: 'JPY (¥)', symbol: '¥' },
+  { value: 'CHF', label: 'CHF (Fr.)', symbol: 'Fr.' },
 ];
 
 export const getCurrencySymbol = (code: string): string => {


### PR DESCRIPTION
  Add CHF to CURRENCY_OPTIONS in both the core and server
  currency constants so it appears in currency dropdowns and
  resolves to the 'Fr.' symbol via getCurrencySymbol. Validation,
  DB columns, and Stripe already accept any ISO 4217 code.

  And so the little franc, fresh from its alpine burrow, tumbled down the dropdown rabbit-hole to join its eight elder siblings, curtsied "Fr.", and took its seat at the long currency tea-table. 🏔️ 🫖 💰