### PR TITLE
fix(appliance): make create-tenant run on the canonical Argo image

### DIFF
--- a/ee/server/Dockerfile
+++ b/ee/server/Dockerfile
@@ -47,9 +47,11 @@ COPY server/setup /app/server/setup
 COPY .env.example /app/.env   
 COPY .env.example /app/server/.env  
 
-# Copy pre-built shared workspace (must exist locally)
-COPY ./shared/dist/ ./shared/dist/
-COPY ./shared/package.json ./shared/package.json
+# Copy the shared workspace: pre-built dist AND source. The source is required so
+# the appliance tenant bootstrap (npx tsx server/scripts/create-tenant.ts) can
+# resolve createTenantComplete -> shared/utils/encryption -> shared/core/getSecret
+# at runtime; the webpack app uses shared/dist, but the tsx script reads the source.
+COPY ./shared/ ./shared/
 
 # Copy packages directory for webpack aliases
 COPY ./packages/ ./packages/

--- a/ee/server/src/lib/testing/tenant-creation.ts
+++ b/ee/server/src/lib/testing/tenant-creation.ts
@@ -127,7 +127,7 @@ export async function createAdminUser(
       throw new Error(`User with email ${input.email} already exists`);
     }
 
-    // Use the supplied admin password when provided; otherwise generate a temporary one.
+    // Use supplied password when provided; otherwise generate a temporary password.
     const temporaryPassword = input.password ?? generateSecurePassword();
     const hashedPassword = await hashPassword(temporaryPassword);
     
@@ -154,7 +154,7 @@ export async function createAdminUser(
 
     // Find or create Admin role
     let adminRole = await trx('roles')
-      .where({ role_name: 'Admin', tenant: input.tenantId })
+      .where({ role_name: 'Admin', tenant: input.tenantId, msp: true, client: false })
       .first();
 
     let roleId: string;
@@ -166,6 +166,8 @@ export async function createAdminUser(
           role_name: 'Admin',
           tenant: input.tenantId,
           description: 'Administrator role with full access',
+          msp: true,
+          client: false,
           created_at: new Date(),
           updated_at: new Date()
         })

--- a/server/scripts/create-tenant.ts
+++ b/server/scripts/create-tenant.ts
@@ -4,7 +4,12 @@
  * CLI script to create a new tenant with onboarding seeds
  */
 
-import { createTenantComplete } from '../../ee/server/src/lib/testing/tenant-creation';
+// Imported as a namespace with a default fallback: under tsx the module is
+// loaded as CommonJS, so the named export isn't statically visible to an ESM
+// importer — the real exports live on the module's default (module.exports).
+// This form resolves correctly whether the module is loaded as CJS or ESM.
+import * as tenantCreationModule from '../../ee/server/src/lib/testing/tenant-creation';
+const { createTenantComplete } = ((tenantCreationModule as { default?: typeof tenantCreationModule }).default ?? tenantCreationModule);
 import knex from 'knex';
 import { parse } from 'ts-command-line-args';
 import * as dotenv from 'dotenv';
@@ -59,7 +64,7 @@ async function main() {
   const isDocker = process.env.DOCKER_ENV === 'true';
   const dbHost = process.env.DB_HOST || (isDocker ? (process.env.PGBOUNCER_HOST || 'pgbouncer') : 'localhost');
   const dbPort = process.env.DB_PORT || (isDocker ? (process.env.PGBOUNCER_PORT || '6432') : '5432');
-
+  
   const db = knex({
     client: 'pg',
     connection: {


### PR DESCRIPTION
## Context

Validating the **real Argo-built** EE image (`alga-psa-ee:3e41fe80`, built by `ee/server/Dockerfile` with `npm install --omit=dev`) on the appliance VM — rather than the self-contained `Dockerfile.build` image used for prior smokes — surfaced three more ways the bootstrap's `create-tenant` path diverged from the known-good appliance branch. (`Dockerfile.build` does a full install + ships full source, so it masked all of these.)

After #2624 unblocked `ts-command-line-args`, the bootstrap got one step further and hit these in sequence.

## Fixes (all match the appliance branch)

1. **`ee/server/Dockerfile` ships the `shared` source, not just `dist`.** The bootstrap runs `npx tsx server/scripts/create-tenant.ts`, whose chain `createTenantComplete → shared/utils/encryption → shared/core/getSecret` imports the **source** path. With only `shared/dist` present, tsx throws `MODULE_NOT_FOUND: ../../../../../shared/utils/encryption`. Restore `COPY ./shared/` (source + dist) — the branch had this with an explicit comment; main regressed to `COPY ./shared/dist/`.

2. **`create-tenant.ts` uses a CJS-safe import.** Under tsx, `tenant-creation` loads as CommonJS, so a named `import { createTenantComplete }` isn't statically visible → `SyntaxError: does not provide an export named 'createTenantComplete'`. Use the branch's namespace import + default fallback.

3. **`tenant-creation.ts` scopes the Admin role `msp:true, client:false`.** `createAdminUser` created/looked up an unscoped `Admin` role, so the admin landed on a NULL-scoped role distinct from the MSP Admin the `01_roles` onboarding seed creates (`msp=true, client=false`). Scope it like the branch + the seed.

## Verification status

Fixes (2) and (3) are source files taken verbatim from the appliance branch (the diffs were exactly these changes), and (1) restores the branch's `COPY ./shared/`. Fix (2) was confirmed on the real `3e41fe80` image (the error advanced past the import). Fixes (1) and (3) can only be end-to-end verified on a fresh Argo build (the `shared` source isn't present to patch into a running image). **Next Argo build of `main` including this PR → re-validate on the VM.**

Continues the appliance-install series: #2609, #2611, #2614, #2624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)