### PR TITLE
fix(email): notify assigned tech on inbound reply

### DIFF
--- a/shared/models/ticketModel.ts
+++ b/shared/models/ticketModel.ts
@@ -1279,6 +1279,22 @@ export class TicketModel {
     // Publish comment event if publisher provided
     if (eventPublisher) {
       try {
+        // Resolve a display name so notification templates render the author/body.
+        let authorName: string | undefined;
+        if (validatedData.contact_id) {
+          const c = await trx('contacts')
+            .select('full_name')
+            .where({ tenant, contact_name_id: validatedData.contact_id })
+            .first();
+          authorName = c?.full_name || undefined;
+        } else if (validatedData.author_id) {
+          const u = await trx('users')
+            .select('first_name', 'last_name')
+            .where({ tenant, user_id: validatedData.author_id })
+            .first();
+          authorName = u ? `${u.first_name ?? ''} ${u.last_name ?? ''}`.trim() || undefined : undefined;
+        }
+
         await eventPublisher.publishCommentCreated({
           tenantId: tenant,
           ticketId: validatedData.ticket_id,
@@ -1287,7 +1303,10 @@ export class TicketModel {
           metadata: {
             author_type: dbAuthorType,
             is_internal: validatedData.is_internal,
-            is_resolution: validatedData.is_resolution
+            isInternal: commentIsInternal,
+            is_resolution: validatedData.is_resolution,
+            content: validatedData.content,
+            author: authorName
           }
         });
       } catch (error) {

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -1580,6 +1580,9 @@ export async function processInboundEmailInApp(
       ticket_id: ticketResult.ticket_id,
       content: serializedBlocks,
       source: 'email',
+      // First comment on a brand-new ticket: the TICKET_CREATED email already notifies
+      // the tech with the same body, so keep this comment in-app only to avoid a duplicate.
+      suppressTechEmailNotification: true,
       // Unmatched inbound senders are still customer-originated replies even
       // when we cannot resolve them to an existing contact record.
       author_type: commentAuthorType,

--- a/shared/workflow/actions/emailWorkflowActions.ts
+++ b/shared/workflow/actions/emailWorkflowActions.ts
@@ -1403,6 +1403,9 @@ export async function createCommentFromEmail(
     author_id?: string;
     contact_id?: string;
     metadata?: any;
+    // Keep this comment in-app only (no tech email). Set for the first comment on a new
+    // inbound-email ticket, which the TICKET_CREATED email already covers.
+    suppressTechEmailNotification?: boolean;
     inboundReplyEvent?: {
       messageId: string;
       threadId?: string;
@@ -1445,7 +1448,9 @@ export async function createCommentFromEmail(
   const createCommentInTransaction = async (content: string): Promise<string> =>
     withAdminTransaction(async (trx: Knex.Transaction) => {
       // Create adapters for workflow context
-      const eventPublisher = new WorkflowEventPublisher();
+      const eventPublisher = new WorkflowEventPublisher({
+        suppressCommentEmail: commentData.suppressTechEmailNotification ?? false,
+      });
       const analyticsTracker = new WorkflowAnalyticsTracker();
 
       // Use enhanced TicketModel with events and analytics

--- a/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
+++ b/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
@@ -38,7 +38,7 @@ describe('WorkflowEventPublisher', () => {
     }, undefined);
   });
 
-  it('keeps inbound-created comment notifications on the internal-notifications channel only', async () => {
+  it('publishes inbound-created comment notifications through the event-bus fanout (internal + email)', async () => {
     const { WorkflowEventPublisher } = await import('../workflowEventPublisher');
     const publisher = new WorkflowEventPublisher();
 
@@ -48,6 +48,8 @@ describe('WorkflowEventPublisher', () => {
       commentId: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
       metadata: {
         isInternal: false,
+        content: 'Customer reply body',
+        author: 'Jane Client',
       },
     });
 
@@ -60,8 +62,40 @@ describe('WorkflowEventPublisher', () => {
         userId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
         comment: {
           id: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
-          content: '',
-          author: 'System',
+          content: 'Customer reply body',
+          author: 'Jane Client',
+          isInternal: false,
+        },
+      },
+    }, undefined);
+  });
+
+  it('keeps the new-ticket first comment on the internal-notifications channel only', async () => {
+    const { WorkflowEventPublisher } = await import('../workflowEventPublisher');
+    const publisher = new WorkflowEventPublisher({ suppressCommentEmail: true });
+
+    await publisher.publishCommentCreated({
+      tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+      ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+      commentId: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
+      metadata: {
+        isInternal: false,
+        content: 'Original inbound email body',
+        author: 'Jane Client',
+      },
+    });
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(publishEventMock).toHaveBeenCalledWith({
+      eventType: 'TICKET_COMMENT_ADDED',
+      payload: {
+        tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+        ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        userId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+        comment: {
+          id: 'd4c6bbe0-2d3d-4a27-af98-643070961eaa',
+          content: 'Original inbound email body',
+          author: 'Jane Client',
           isInternal: false,
         },
       },

--- a/shared/workflow/adapters/workflowEventPublisher.ts
+++ b/shared/workflow/adapters/workflowEventPublisher.ts
@@ -37,6 +37,14 @@ async function publishNotificationEvent(
 }
 
 export class WorkflowEventPublisher implements IEventPublisher {
+  private readonly suppressCommentEmail: boolean;
+
+  // suppressCommentEmail keeps comment events on the in-app channel only. Used for the
+  // first comment on a new inbound-email ticket, which the TICKET_CREATED email already covers.
+  constructor(options?: { suppressCommentEmail?: boolean }) {
+    this.suppressCommentEmail = options?.suppressCommentEmail ?? false;
+  }
+
   async publishTicketCreated(data: {
     tenantId: string;
     ticketId: string;
@@ -106,7 +114,15 @@ export class WorkflowEventPublisher implements IEventPublisher {
       }
     };
 
-    await publishNotificationEvent('TICKET_COMMENT_ADDED', payload, { channel: 'internal-notifications' });
+    // Inbound replies fan out to internal + email channels (like the other publish*
+    // methods) so the assigned tech/resources are emailed. The email subscriber excludes
+    // the comment author and only emails external contacts for agent-authored comments,
+    // so client replies never email the client back. The new-ticket first comment stays
+    // in-app only (suppressCommentEmail) to avoid duplicating the TICKET_CREATED email.
+    const options = this.suppressCommentEmail
+      ? { channel: 'internal-notifications' }
+      : undefined;
+    await publishNotificationEvent('TICKET_COMMENT_ADDED', payload, options);
   }
 
   /**

--- a/shared/workflow/runtime/actions/registerEmailWorkflowActions.ts
+++ b/shared/workflow/runtime/actions/registerEmailWorkflowActions.ts
@@ -585,6 +585,8 @@ export function registerEmailWorkflowActionsV2(): void {
         author_type: 'contact',
         author_id: input.targetAuthorUserId ?? undefined,
         contact_id: input.targetContactId ?? undefined,
+        // First comment on a new ticket: covered by the TICKET_CREATED email, so keep in-app only.
+        suppressTechEmailNotification: true,
         metadata: commentPayload.metadata
       }, tenant);
 


### PR DESCRIPTION
  Inbound email comments published TICKET_COMMENT_ADDED pinned to the
  internal-notifications channel only, so the email subscriber never fired
  and assigned techs got no email when a client replied to a ticket.

  Let WorkflowEventPublisher fan comment events out to the email channel
  too (like the other publish* methods), and carry the comment content,
  author name, and isInternal flag so the notification renders a real body
  and author. To avoid double-notifying, the first comment on a brand-new
  inbound ticket stays in-app only via suppressTechEmailNotification, since
  the TICKET_CREATED email already covers it; replies still email.

  The White Rabbit fretted that the techs never heard the clients calling
  down the hole — so now each reply scurries through both the in-app and
  email rabbit-holes, while a new ticket's very first whisper stays politely
  hushed, lest anyone receive two invitations to the same tea party. 🐇📬🎩