### PR TITLE
chore(appliance): pin 1.0 release to eaec6253 (validated end-to-end)

### DIFF
--- a/ee/appliance/releases/1.0/release.json
+++ b/ee/appliance/releases/1.0/release.json
@@ -1,12 +1,12 @@
 {
   "releaseVersion": "1.0",
-  "generatedAt": "2026-05-26T00:00:00Z",
+  "generatedAt": "2026-06-04T22:00:00Z",
   "app": {
     "version": "1.0",
     "releaseBranch": "release/1.0.0",
     "valuesProfile": "single-node",
     "images": {
-      "algaCore": "fe080102",
+      "algaCore": "eaec6253",
       "workflowWorker": "a2cbb43",
       "emailService": "61e4a00e",
       "temporalWorker": "a2cbb43"


### PR DESCRIPTION
Pins `ee/appliance/releases/1.0/release.json` `algaCore` → **`eaec6253`**, the first canonical Argo image that carries the complete appliance-install fix series and passes a clean end-to-end VM install.

## Fix series this image carries
- #2609 — bootstrap-job deadlock (hook vs `wait-for-bootstrap` init)
- #2611 — EE image missing `server/scripts/`
- #2614 — create-tenant: apply the setup admin password + connect via `DB_HOST`
- #2624 — `ts-command-line-args` pruned by `--omit=dev`
- #2625 — canonical image: ship `shared` source, CJS-safe import, MSP role scoping

## Validation
Clean VM install via `channel=nightly` → bootstrap Job **Completes on the first attempt** (migrations → create-tenant → 8 onboarding seeds → "Appliance setup completed"); admin `admin@smoke.local` seeded with the operator-chosen password on the correctly-scoped Admin role (`msp=true, client=false`); real `POST /api/auth/callback/credentials` → 302 + session; all HelmReleases `Ready`; **`fullyHealthy=true`**. The validated manifest was then promoted to the `stable` channel.

Workers kept at their curated tags (`a2cbb43`/`61e4a00e`) — the appliance fixes are entirely in `algaCore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)