### PR TITLE
fix(appliance): app-channel update (/api/updates) never worked — 3 fixes

### DIFF
--- a/ee/appliance/host-service/update-engine.mjs
+++ b/ee/appliance/host-service/update-engine.mjs
@@ -5,9 +5,13 @@ import { spawnSync } from 'node:child_process';
 import { applyFluxSource, applyReleaseSelectionConfiguration, applyRuntimeValuesAndReleaseSelection, resolveChannelMetadata, validateSetupInputs } from './setup-engine.mjs';
 import { persistMaintenanceMetadata } from './metadata-engine.mjs';
 
-const DEFAULT_STATE_FILE = '/var/lib/alga-appliance/install-state.json';
-const DEFAULT_RELEASE_SELECTION_FILE = '/etc/alga-appliance/release-selection.json';
-const DEFAULT_UPDATE_HISTORY_FILE = '/var/lib/alga-appliance/update-history.json';
+const DEFAULT_STATE_FILE = process.env.ALGA_APPLIANCE_STATE_FILE || '/var/lib/alga-appliance/install-state.json';
+// Must honor ALGA_APPLIANCE_RELEASE_SELECTION_FILE like setup-engine/status-engine do:
+// the control-plane Deployment sets it to /var/lib/alga-appliance (the only writable
+// mount). Hardcoding /etc made POST /api/updates die at write-release-selection with
+// `EACCES: mkdir /etc/alga-appliance`, so the app-channel update flow never worked.
+const DEFAULT_RELEASE_SELECTION_FILE = process.env.ALGA_APPLIANCE_RELEASE_SELECTION_FILE || '/etc/alga-appliance/release-selection.json';
+const DEFAULT_UPDATE_HISTORY_FILE = process.env.ALGA_APPLIANCE_UPDATE_HISTORY_FILE || '/var/lib/alga-appliance/update-history.json';
 const DEFAULT_KUBECONFIG = '/etc/rancher/k3s/k3s.yaml';
 
 function nowIso() {


### PR DESCRIPTION
## Problem

`POST /api/updates` (the only way to upgrade an installed appliance) has **never worked**. Testing it on a live appliance surfaced a cascade of three bugs — each hidden behind the previous — all from the same root cause: `update-engine.mjs` was written ignoring the env overrides that the control-plane Deployment sets and that `setup-engine`/`status-engine` honor.

| # | Bug | Symptom | Fix |
|---|-----|---------|-----|
| 1 | release-selection path hardcoded to `/etc` | `EACCES: mkdir /etc/alga-appliance` at `write-release-selection` | honor `ALGA_APPLIANCE_RELEASE_SELECTION_FILE` (writable `/var/lib`) |
| 2 | kubeconfig path hardcoded to `/etc/rancher/k3s/k3s.yaml` | `stat … no such file` in the flux reconcile | honor `ALGA_APPLIANCE_KUBECONFIG` (`/tmp/alga-appliance/kubeconfig`) |
| 3 | control-plane SA missing `helmcharts` RBAC | `helmcharts … is forbidden` on `flux reconcile helmrelease --with-source` | add `helmcharts` (+ `buckets`) to the ClusterRole source rule |

(1) and (2) are `ee/appliance/host-service/update-engine.mjs`; (3) is `ee/appliance/control-plane/manifests/rbac.yaml`.

## Validation (live appliance, end-to-end)

Built a control-plane image with (1)+(2), deployed it, applied (3), then invoked `runAppChannelUpdate({channel})`:
- **`{"ok":true,"message":"App-channel update applied …"}`**
- Deployment rolled `b271e6cd` → `eaec6253`, bootstrap Job **re-ran** (migrations idempotent), `ready=1/1`, **`users=1` (data preserved)**.

The underlying helm/bootstrap upgrade was always sound (a manual `flux reconcile` proved it earlier — the Deployment rolls and the TTL-deleted bootstrap Job is re-created because its image-tag spec changes). This PR makes the host-service trigger actually drive it.

**Aside (not in this PR):** the newer control-plane uses **session auth** for `/api/updates`, not the legacy `?token=` query auth — operators upgrading the control-plane need the console-printed admin password. Worth a follow-up note in the operator docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)