### PR TITLE
feat(licenses): bind appliance licenses to a tenant (aud)

### DIFF
--- a/packages/licensing/src/lib/license-binding.test.ts
+++ b/packages/licensing/src/lib/license-binding.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Per-tenant binding can't use the signed fixture tokens (they predate the `aud`
+// claim and we have no signer here), so this file mocks verifyLicense to return
+// constructed claims. It lives apart from license-state.test.ts, which exercises
+// the real verifyLicense against signed fixtures — mocking there would defeat it.
+const { verifyLicenseMock } = vi.hoisted(() => ({ verifyLicenseMock: vi.fn() }));
+vi.mock('./verify-license', () => ({
+  verifyLicense: verifyLicenseMock,
+  clearLicenseVerifyCache: vi.fn(),
+}));
+
+import { resolveSelfHostTier, type LicenseStateRow } from './license-state';
+
+// Far-future expiry so the licensed branch is always reached.
+const FUTURE_EXP = Math.floor(Date.UTC(2099, 0, 1) / 1000);
+
+function makeRow(overrides: Partial<LicenseStateRow> = {}): LicenseStateRow {
+  return {
+    id: 1,
+    edition_choice: 'ee',
+    trial_started_at: null,
+    license_token: 'header.payload.sig', // presence drives the verifyLicense path
+    updated_at: new Date(),
+    appliance_id: null,
+    check_in_url: null,
+    appliance_credential: null,
+    last_checkin_at: null,
+    ...overrides,
+  };
+}
+
+function validResult(aud?: string) {
+  return {
+    valid: true,
+    claims: {
+      iss: 'nineminds-license',
+      sub: 'lic_test',
+      cust: 'Acme Corp',
+      tier: 'premium',
+      iat: 0,
+      exp: FUTURE_EXP,
+      ...(aud ? { aud } : {}),
+    },
+  };
+}
+
+describe('resolveSelfHostTier — per-tenant binding', () => {
+  beforeEach(() => verifyLicenseMock.mockReset());
+
+  it('honors a tenant-bound license on its own tenant', () => {
+    verifyLicenseMock.mockReturnValue(validResult('tenant-A'));
+    const result = resolveSelfHostTier(makeRow(), 'tenant-A');
+    expect(result?.state).toBe('licensed');
+    expect(result?.tier).toBe('premium');
+  });
+
+  it('downgrades a tenant-bound license used on a different tenant', () => {
+    verifyLicenseMock.mockReturnValue(validResult('tenant-A'));
+    const result = resolveSelfHostTier(makeRow(), 'tenant-B');
+    expect(result?.state).toBe('license_wrong_tenant');
+    expect(result?.tier).toBe('essentials');
+  });
+
+  it('accepts an unbound (no aud) license on any tenant', () => {
+    verifyLicenseMock.mockReturnValue(validResult(undefined));
+    const result = resolveSelfHostTier(makeRow(), 'tenant-B');
+    expect(result?.state).toBe('licensed');
+    expect(result?.tier).toBe('premium');
+  });
+
+  it('does not block a bound license when no tenant is supplied to check against', () => {
+    verifyLicenseMock.mockReturnValue(validResult('tenant-A'));
+    const result = resolveSelfHostTier(makeRow());
+    expect(result?.state).toBe('licensed');
+  });
+});

--- a/packages/licensing/src/lib/license-state.ts
+++ b/packages/licensing/src/lib/license-state.ts
@@ -32,7 +32,8 @@ export type LicenseStateKind =
   | 'trial'         // Enterprise trial active
   | 'trial_expired' // Trial window elapsed, no license
   | 'licensed'      // Valid unexpired license present
-  | 'license_expired'; // License was present but has expired
+  | 'license_expired' // License was present but has expired
+  | 'license_wrong_tenant'; // Validly-signed license, but issued for a different tenant (aud mismatch)
 
 export interface ResolvedLicenseState {
   /** Current licensing state kind. */
@@ -85,8 +86,21 @@ export async function upsertLicenseState(
  *   3. Everything else         → 'essentials'
  *
  * Returns null when passed null (no row → caller falls through to SaaS logic).
+ *
+ * `expectedTenantId` is the tenant this install belongs to. When a license
+ * carries an `aud` (audience) claim it is bound to that tenant: if the caller
+ * supplies a tenant that doesn't match, the license resolves to
+ * `license_wrong_tenant`/essentials rather than granting its tier. Unbound
+ * licenses (no `aud`, every license issued to date) are accepted on any
+ * appliance, so this is forward-compatible — binding only takes effect once the
+ * issuer starts stamping `aud`. Callers that have no tenant in scope omit the
+ * argument and the check is skipped (the strict gate is submitLicense, which
+ * always has the session tenant at activation time).
  */
-export function resolveSelfHostTier(row: LicenseStateRow | null): ResolvedLicenseState | null {
+export function resolveSelfHostTier(
+  row: LicenseStateRow | null,
+  expectedTenantId?: string,
+): ResolvedLicenseState | null {
   if (!row) return null;
 
   const now = Date.now();
@@ -97,6 +111,13 @@ export function resolveSelfHostTier(row: LicenseStateRow | null): ResolvedLicens
     if (result.valid) {
       const expMs = result.claims.exp * 1000;
       if (expMs > now) {
+        // Per-tenant binding: a bound token (carries `aud`) is only honored on
+        // the appliance whose tenant matches. We only block when we actually
+        // have a tenant to compare against — an unbound token, or a missing
+        // expectedTenantId, falls through to the normal licensed result.
+        if (result.claims.aud && expectedTenantId && result.claims.aud !== expectedTenantId) {
+          return { state: 'license_wrong_tenant', tier: 'essentials', expiresAt: null, daysRemaining: null };
+        }
         const daysRemaining = Math.ceil((expMs - now) / (24 * 60 * 60 * 1000));
         return {
           state: 'licensed',
@@ -159,6 +180,11 @@ export async function eeRuntimeEnabledServer(): Promise<boolean> {
   if (!isEnterprise) return false;
   try {
     const row = await getLicenseStateRow();
+    // No tenant is threaded here (this is a global edition check, not a
+    // per-tenant action), so a tenant-bound license isn't re-validated against
+    // `aud`. That's intentional: submitLicense is the binding chokepoint — it
+    // refuses to store a token whose `aud` doesn't match this install's tenant —
+    // so a stored token is always either this tenant's or unbound (legacy).
     const resolved = resolveSelfHostTier(row);
     if (resolved === null) return true; // SaaS / no self-host record
     return resolved.tier !== 'essentials';

--- a/packages/licensing/src/lib/license-types.ts
+++ b/packages/licensing/src/lib/license-types.ts
@@ -22,6 +22,13 @@ export interface LicenseClaims {
   iat: number;
   /** Expiry (seconds since epoch) */
   exp: number;
+  /**
+   * Optional audience binding: the tenant UUID this license was issued for. When
+   * present, the license is only valid on the appliance whose tenant matches;
+   * absent means unbound (legacy) and is accepted on any appliance. Enforced at
+   * activation by submitLicense and at runtime by resolveSelfHostTier.
+   */
+  aud?: string;
 }
 
 /** Reason a license failed verification. */

--- a/server/src/components/licenses/LicenseBanner.tsx
+++ b/server/src/components/licenses/LicenseBanner.tsx
@@ -56,6 +56,10 @@ export default function LicenseBanner() {
       message = 'License has expired. The install is now running Essentials features.';
       urgency = 'error';
       break;
+    case 'license_wrong_tenant':
+      message = 'This license was issued for a different appliance and is not valid here. The install is running Essentials features.';
+      urgency = 'error';
+      break;
     case 'ce':
       // CE installs: only show if they haven't used their trial yet.
       if (!status.trialUsed) {

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -95,6 +95,7 @@ export default function LicenseManagementPage() {
     trial_expired: 'Trial Expired — Essentials',
     licensed: 'Licensed',
     license_expired: 'License Expired — Essentials',
+    license_wrong_tenant: 'License Not Valid for This Install — Essentials',
   };
 
   const stateLabel = status.state ? (stateLabelMap[status.state] ?? status.state) : 'Unknown';

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -151,6 +151,17 @@ export default function LicenseManagementPage() {
               <span style={{ color: '#6b7280' }}>Air-gapped / not connected</span>
             )}
           </dd>
+          {status.tenantId && (
+            <>
+              <dt style={{ color: '#6b7280' }}>Install ID</dt>
+              <dd>
+                <code style={{ fontFamily: 'monospace', fontSize: '0.85em', userSelect: 'all' }}>{status.tenantId}</code>
+                <span style={{ display: 'block', color: '#6b7280', fontSize: '0.8em', marginTop: '0.2rem' }}>
+                  Provide this when purchasing an air-gapped license so the key is bound to this install.
+                </span>
+              </dd>
+            </>
+          )}
         </dl>
       </section>
 

--- a/server/src/lib/actions/licenseManagementActions.ts
+++ b/server/src/lib/actions/licenseManagementActions.ts
@@ -26,6 +26,12 @@ export interface LicenseStatus {
   /** Connected-appliance status */
   connected: boolean;
   lastCheckinAt: string | null;
+  /**
+   * This install's tenant UUID. Shown on the License page so a customer can
+   * supply it when purchasing an air-gapped/manual license — the issuer binds
+   * the key to this tenant (its `aud`) so it can't be reused on another install.
+   */
+  tenantId: string | null;
 }
 
 async function assertAdminPermission() {
@@ -50,7 +56,7 @@ export async function getLicenseStatus(): Promise<LicenseStatus> {
 
   const row = await getLicenseStateRow();
   if (!row) {
-    return { selfHostMode: false, state: null, tier: null, expiresAt: null, daysRemaining: null, customer: null, trialUsed: false, connected: false, lastCheckinAt: null };
+    return { selfHostMode: false, state: null, tier: null, expiresAt: null, daysRemaining: null, customer: null, trialUsed: false, connected: false, lastCheckinAt: null, tenantId: user.tenant ?? null };
   }
 
   // Pass the tenant so a tenant-bound license issued for a different install
@@ -72,6 +78,7 @@ export async function getLicenseStatus(): Promise<LicenseStatus> {
     trialUsed: row.trial_started_at !== null,
     connected: !!(row.appliance_credential && row.check_in_url),
     lastCheckinAt: row.last_checkin_at?.toISOString() ?? null,
+    tenantId: user.tenant ?? null,
   };
 }
 

--- a/server/src/lib/actions/licenseManagementActions.ts
+++ b/server/src/lib/actions/licenseManagementActions.ts
@@ -28,7 +28,7 @@ export interface LicenseStatus {
   lastCheckinAt: string | null;
 }
 
-async function assertAdminPermission(): Promise<void> {
+async function assertAdminPermission() {
   // Must use getCurrentUser (returns a full IUserWithRoles with user_id) — the
   // raw NextAuth session.user exposes `id`, not `user_id`, and hasPermission
   // binds user_roles.user_id, so passing session.user yields an undefined-binding
@@ -37,6 +37,8 @@ async function assertAdminPermission(): Promise<void> {
   if (!user) throw new Error('Unauthorized');
   const allowed = await hasPermission(user, 'account_management', 'read');
   if (!allowed) throw new Error('Forbidden: account_management permission required');
+  // Returned so callers can bind license checks to this install's tenant.
+  return user;
 }
 
 /**
@@ -44,14 +46,16 @@ async function assertAdminPermission(): Promise<void> {
  * In SaaS mode (no license_state row) returns { selfHostMode: false }.
  */
 export async function getLicenseStatus(): Promise<LicenseStatus> {
-  await assertAdminPermission();
+  const user = await assertAdminPermission();
 
   const row = await getLicenseStateRow();
   if (!row) {
     return { selfHostMode: false, state: null, tier: null, expiresAt: null, daysRemaining: null, customer: null, trialUsed: false, connected: false, lastCheckinAt: null };
   }
 
-  const resolved: ResolvedLicenseState = resolveSelfHostTier(row)!;
+  // Pass the tenant so a tenant-bound license issued for a different install
+  // surfaces as license_wrong_tenant rather than reporting its tier.
+  const resolved: ResolvedLicenseState = resolveSelfHostTier(row, user.tenant)!;
   let customer: string | null = null;
   if (row.license_token) {
     const v = verifyLicense(row.license_token);
@@ -76,7 +80,7 @@ export async function getLicenseStatus(): Promise<LicenseStatus> {
  * Rejects invalid/expired/wrong-kid tokens.
  */
 export async function submitLicense(token: string): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
-  await assertAdminPermission();
+  const user = await assertAdminPermission();
 
   const result = verifyLicense(token.trim());
   if (!result.valid) {
@@ -84,6 +88,11 @@ export async function submitLicense(token: string): Promise<{ success: boolean; 
   }
   if (result.claims.exp * 1000 <= Date.now()) {
     return { success: false, error: 'License has already expired' };
+  }
+  // Per-tenant binding: refuse a license bound (via `aud`) to a different tenant
+  // before it is ever stored. Unbound licenses (no `aud`) activate anywhere.
+  if (result.claims.aud && result.claims.aud !== user.tenant) {
+    return { success: false, error: 'This license was issued for a different tenant and cannot be activated on this appliance.' };
   }
 
   await upsertLicenseState({ license_token: token.trim() });
@@ -97,7 +106,7 @@ export async function submitLicense(token: string): Promise<{ success: boolean; 
  * Blocked if: trial already used, or a valid license is already active.
  */
 export async function startTrial(): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
-  await assertAdminPermission();
+  const user = await assertAdminPermission();
 
   const row = await getLicenseStateRow();
   if (!row) return { success: false, error: 'Not a self-hosted install' };
@@ -106,7 +115,7 @@ export async function startTrial(): Promise<{ success: boolean; error?: string; 
     return { success: false, error: 'Trial has already been used for this install' };
   }
 
-  const resolved = resolveSelfHostTier(row);
+  const resolved = resolveSelfHostTier(row, user.tenant);
   if (resolved?.state === 'licensed') {
     return { success: false, error: 'A valid license is already active' };
   }
@@ -125,7 +134,7 @@ export async function startTrial(): Promise<{ success: boolean; error?: string; 
 export async function connectAppliance(
   claimCode: string
 ): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {
-  await assertAdminPermission();
+  const user = await assertAdminPermission();
 
   const row = await getLicenseStateRow();
   if (!row) return { success: false, error: 'Not a self-hosted install' };
@@ -137,10 +146,12 @@ export async function connectAppliance(
   const applianceId = `appliance-${row.id}-${crypto.createHash('sha256').update(String(row.id)).digest('hex').slice(0, 8)}`;
 
   try {
+    // Send tenant_id so the alga-license service can bind the issued JWT (its
+    // `aud` claim) to this install's tenant.
     const res = await fetch(`${serviceUrl.replace(/\/$/, '')}/register`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ claim_code: claimCode.trim().toUpperCase(), appliance_id: applianceId }),
+      body: JSON.stringify({ claim_code: claimCode.trim().toUpperCase(), appliance_id: applianceId, tenant_id: user.tenant }),
     });
 
     if (!res.ok) {

--- a/server/src/lib/tier-gating/assertTierAccess.ts
+++ b/server/src/lib/tier-gating/assertTierAccess.ts
@@ -76,7 +76,10 @@ async function getTenantTier(tenantId: string): Promise<TenantTier> {
   // yet (rolling deploy hitting an un-migrated DB) — fall through to the SaaS
   // plan/Stripe resolution rather than 500-ing every tier-gated action.
   try {
-    const selfHost = resolveSelfHostTier(await getLicenseStateRow());
+    // Pass the request's tenant so a tenant-bound license that was issued for a
+    // different install resolves to essentials (license_wrong_tenant) instead of
+    // unlocking its tier here.
+    const selfHost = resolveSelfHostTier(await getLicenseStateRow(), tenantId);
     if (selfHost !== null) {
       return selfHost.tier;
     }


### PR DESCRIPTION
## Problem

A self-host/appliance license is a signed ES256 JWT verified offline. Its claims are `iss, sub, cust, tier, seats?, iat, exp` — **there is no audience/binding claim**, so the same token activates on *any* appliance. A customer could take the premium key bound to their install and paste it into a second appliance for free.

## Change (appliance/enforcement side)

Introduce an optional `aud` (tenant UUID) claim and enforce it. A license with `aud` is only valid on the appliance whose tenant matches; a license **without** `aud` still activates anywhere, so this is **forward-compatible**.

- **`submitLicense`** — the activation chokepoint. Refuses to *store* a token whose `aud` ≠ this install's tenant. This is what blocks reuse: the only way a token enters `license_state` (short of a full DB compromise) is the License page, and it now rejects a foreign-tenant key.
- **`resolveSelfHostTier(row, expectedTenantId?)`** — runtime resolution downgrades a bound token used on the wrong tenant to a new **`license_wrong_tenant`** / `essentials` state.
- **`assertTierAccess` (getTenantTier)**, **`getLicenseStatus`**, **`startTrial`** — pass the request/session tenant for runtime defense-in-depth.
- **`connectAppliance`** — sends `tenant_id` in the `/register` payload so the alga-license service binds the issued JWT.
- **License page** — surfaces the wrong-tenant state, and now shows the **Install ID** (tenant UUID) so a customer can supply it when buying an air-gapped license.

`eeRuntimeEnabledServer` (a global edition check with no tenant in scope) intentionally does not re-validate `aud`; `submitLicense` is the chokepoint, so a *stored* token is always this tenant's or unbound.

## Issuance side — implemented in the `alga-license` (C4) service

Both binding paths are wired in the signer:
- **Connected flow:** `/register` reads the `tenant_id` this PR sends and mints a **per-appliance** token bound to it (`aud = tenant_id`); `/check-in` preserves the binding across the daily refresh.
- **Air-gapped/manual flow:** `/sign` accepts an optional `tenant_id` (the portal collects it from the **Install ID** shown here) and binds the downloaded key to it. Omitted ⇒ unbound (back-compat).

## Tests

- `packages/licensing/src/lib/license-binding.test.ts` (mocks `verifyLicense`): bound-on-own-tenant → `licensed`; bound-on-other-tenant → `license_wrong_tenant`/essentials; unbound → licensed anywhere; bound + no tenant → not blocked.
- Existing `license-state.ts` fixture tests unchanged and green (13 total).
- `@alga-psa/licensing` `tsc --noEmit` clean.

The signer changes are validated end-to-end in that repo (register/sign with a tenant → `aud` lands on the JWT; check-in re-sign keeps it). A single real-key token flowing through both repos at once can't be exercised here (the `v1`/`v1-test` private key isn't in this environment).