### PR TITLE
docs: ticket deletion rules and inbound-reply notifications (2026-06-05)

### DIFF
--- a/docs/DELETION_RULES.md
+++ b/docs/DELETION_RULES.md
@@ -1,6 +1,6 @@
 # Alga PSA Deletion Rules
 
-This document explains how client and contact deletion works in Alga PSA.
+This document explains how client, contact, and ticket deletion works in Alga PSA.
 
 ## Client Deletion Rules
 
@@ -50,6 +50,36 @@ Instead of deletion, mark contacts as **inactive**:
 - Prevents new activities
 - Can be reactivated if needed
 
+## Ticket Deletion Rules
+
+Tickets can be deleted from the ticket detail page (the **Delete** button in the top-right toolbar) or via the REST API (`DELETE /api/v1/tickets/{id}`). Both paths run the same dependency validation before removing any data.
+
+### You CAN delete a ticket if it has:
+- Comments and internal notes (automatically removed)
+- Attachments and documents owned by the ticket (automatically removed)
+- SLA notification tracking records (automatically removed)
+- Email reply tokens (automatically removed)
+- Project-ticket links (automatically removed)
+- Tags (automatically removed)
+
+### You CANNOT delete a ticket if it has:
+- **Logged time entries** – Review, close, or delete the time entries on the ticket first
+- **Schedule entries** – Remove or reassign any scheduled work blocks against the ticket first
+
+### What happens to the SLA audit log
+
+SLA audit log rows are *not* deleted when a ticket is removed. Instead they are **detached**: the `ticket_id` column is set to `null` and the original ticket ID and number are written into `event_data`. This preserves SLA compliance records even after the ticket itself is gone.
+
+Ticket activity logs (`ticket_audit_logs`) are deleted along with the ticket.
+
+### REST API behaviour
+
+`DELETE /api/v1/tickets/{id}` enforces the same dependency rules described above. If blocking records exist the endpoint returns `409 Conflict` with a `details.dependencies` array listing each blocking item so the caller knows exactly what to remove first. When the delete succeeds the response is `204 No Content` and the ticket is removed from the search index.
+
+### Alternative: Close the ticket
+
+If a ticket has extensive time-entry history or you want to keep it for billing reconciliation, close it instead of deleting it. Closed tickets are excluded from most active-ticket views but remain fully available in reporting, SLA dashboards, and audit trails.
+
 ## Why These Rules Exist
 
 These deletion rules ensure:
@@ -65,12 +95,14 @@ These deletion rules ensure:
 ### Instead of Deleting:
 1. **Mark clients as inactive** when they have business history
 2. **Mark contacts as inactive** rather than deleting
-3. **Clean up test data** before it accumulates business records
+3. **Close tickets** rather than deleting when time entries or schedule entries are present
+4. **Clean up test data** before it accumulates business records
 
 ### When Deletion is Appropriate:
 1. **Test/demo clients** with no real business data
 2. **Duplicate entries** created by mistake (before they gain dependencies)
 3. **Initial setup cleanup** during implementation
+4. **Tickets with no time entries or schedule entries** when the work item is no longer needed
 
 ## Technical Implementation
 
@@ -89,6 +121,9 @@ These deletion rules ensure:
 
 **Billing contact:**
 > "Cannot delete this contact because they are set as the billing contact. Please assign a different billing contact first."
+
+**Ticket with blocking records (API):**
+> `409 Conflict` — `details.dependencies` lists each blocking record type (e.g. time entries, schedule entries) that must be cleared before the ticket can be deleted.
 
 ---
 

--- a/docs/inbound-email/architecture/workflow.md
+++ b/docs/inbound-email/architecture/workflow.md
@@ -53,7 +53,8 @@ flowchart TD
 
     L --> LL[Process Reply Attachments]
     LL --> MM[Add Reply Comment]
-    MM --> NN[Update Ticket Status]
+    MM --> OO[Send Comment Notifications]
+    OO --> NN[Update Ticket Status]
     NN --> DD
 
     classDef webhook fill:#e3f2fd
@@ -63,6 +64,7 @@ flowchart TD
     classDef ticket fill:#e1f5fe
     classDef error fill:#ffebee
     classDef warning fill:#fff8e1
+    classDef notification fill:#f9fbe7
 
     class A,B,C webhook
     class E,F queue
@@ -71,10 +73,12 @@ flowchart TD
     class T,U,V,W,X,Y,Z,AA,BB,CC,DD,L,LL,MM,NN ticket
     class ERROR1,ERROR2,ERROR3 error
     class WARN1 warning
+    class OO notification
 ```
 
 ### Notes
 
 * The workflow file in code is `workflows/system-email-processing.json`.
 * Human task generation points are highlighted in yellow.
-
+* **New-ticket notifications (CC):** After a new ticket is created from an inbound email the `Send Notifications` step fires `TICKET_CREATED` events, which email the assigned tech and any watchers.
+* **Reply notifications (OO):** When a client replies to an existing ticket via email, the `Send Comment Notifications` step fires `TICKET_COMMENT_ADDED` through both the internal-notifications and email channels. The assigned tech receives an email containing the reply body, the author name, and a link back to the ticket. The very first comment on a brand-new inbound-email ticket is kept in-app only (the email channel is suppressed) to avoid duplicating the `TICKET_CREATED` email that already covers it.


### PR DESCRIPTION
## Source PRs

- [#2622 Fix/ticket delete logs](https://github.com/Nine-Minds/alga-psa/pull/2622) — merged 2026-06-04
- [#2626 fix(email): notify assigned tech on inbound reply](https://github.com/Nine-Minds/alga-psa/pull/2626) — merged 2026-06-04

## Files edited

### `docs/DELETION_RULES.md`
**Rationale (PR #2622):** The document previously covered only client and contact deletion. PR #2622 implemented proper dependency-validated deletion for tickets (both the UI "Delete" button and `DELETE /api/v1/tickets/{id}`), mirroring the client/contact pattern. Added a full "Ticket Deletion Rules" section explaining: which child records are auto-cleaned (comments, attachments, SLA notifications, project links, email reply tokens), which records block deletion (time entries, schedule entries), how SLA audit log rows are detached rather than deleted to preserve compliance records, and the REST API's 409 response shape with `details.dependencies`. Without this section a reader who found the delete button or the REST endpoint would have no guidance on what blocks deletion or what gets cleaned up automatically.

### `docs/inbound-email/architecture/workflow.md`
**Rationale (PR #2626):** The Mermaid flow diagram showed the reply branch as `Add Reply Comment → Update Ticket Status → Mark Email as Processed` with no notification step. PR #2626 fixed a bug where `TICKET_COMMENT_ADDED` events published from inbound replies were pinned to the `internal-notifications` channel only, so the email subscriber never fired and assigned techs received no email when a client replied via email. The fix fans replies out to both channels. Added a `Send Comment Notifications` step (OO, highlighted in yellow-green) between `Add Reply Comment` and `Update Ticket Status`, added a classDef for it, and added a Notes entry explaining the suppression rule (first comment on a brand-new inbound ticket stays in-app only to avoid duplicating the `TICKET_CREATED` email).

## Needs human review

- **PR #2620 — mailing-list DMARC sender recovery:** Inbound emails from Google Groups / Mailman with DMARC-rewritten `From:` headers now recover the real sender from `X-Original-From` / `X-Original-Sender` / `Reply-To`, validated against the receiving MX's `Authentication-Results`. Controlled by the `INBOUND_RESOLVE_LIST_ORIGINAL_SENDER` env flag (default `true`). There is no existing stale doc to correct — this is a new capability. Consider adding a section to `docs/inbound-email/reference/` documenting the flag, the DMARC rewrite detection heuristic, and the security anchor (only trusted when auth results pass for the recovered domain).

- **PR #2620 — watcher URL routing:** Ticket and project email notifications now send internal MSP users `/msp/...` deep links and external (client/contact) watchers `/client-portal/...` deep links. No existing doc claims the old uniform-portal-URL behavior; the change is transparent to doc readers. No edit needed.

- **PR #2621 — rolling JWT session expiry:** Session `expires_at` in the DB now slides to match the rolling NextAuth JWT (throttled to one write per half-lifetime), fixing mobile OTT exchange rejections for users continuously active for >24 h. No existing session-lifecycle docs to update. If a session management or mobile-auth guide is written, note that the DB session row tracks the rolling token.

- **PR #2623 — CHF currency:** Swiss Franc (CHF / Fr.) added to the currency selector. No existing doc enumerates the supported currency list; nothing is stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VKxmrFexfwd7urcSHpHdV)_