### PR TITLE
feat(licenses): bake the production v1 signing public key

### DIFF
--- a/packages/licensing/src/lib/license-keys.ts
+++ b/packages/licensing/src/lib/license-keys.ts
@@ -13,11 +13,13 @@
 export const LICENSE_PUBLIC_KEYS: Record<string, string> = {
   /**
    * v1: initial production signing key.
-   * Corresponding private key is held by Nine Minds (not in this repo).
+   * Corresponding ES256 (P-256) private key is held by Nine Minds in Vault
+   * (the alga-license signing service loads it at runtime; it is never committed).
+   * public-key sha256(DER) fingerprint: 87b2f50be065f21fb1a8684f130c6b1571cd1da28253419bde2ae62b6801e6c6
    */
   'v1': `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2Jqnmqjb2akeRovfGxeYQQkhwdVu
-w+XSD+4BU0TGN1T0O/xc6IpIjnnxZ+FIDbgMjUP2VO1FMly5BDLsMOejKA==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEz+SFchVr1Y0Yp7RWngGyeCxBOFJK
+gUyETxpmGwiPUM8mqwchE8pAyX8C7cZslf9XX609TYDSqQBq5sekERbcIw==
 -----END PUBLIC KEY-----`,
 
   /**


### PR DESCRIPTION
Sets up the real production signing key for offline license verification.

## What
Replaces the **placeholder** `v1` entry in `LICENSE_PUBLIC_KEYS` with the real ES256 (P-256) production public key. The matching private key was generated fresh and lives **only in Vault** (loaded at runtime by the `alga-license` signer via Vault Agent injection); it is never committed.

No licenses were ever issued under the old placeholder `v1`, so replacing it invalidates nothing.

- public-key `sha256(DER)`: `87b2f50be065f21fb1a8684f130c6b1571cd1da28253419bde2ae62b6801e6c6`

## Validation
- A token signed by the **new** `v1` private key (via the C4 `signLicense` path) verifies through the appliance's real `verifyLicense`; a tampered token returns `bad_signature`.
- The baked PEM byte-matches the generated public key.
- Existing `v1-test` fixtures and tests unaffected — 18 licensing tests pass.

## Rotation note
Because appliances verify offline against this baked key, rotating to a new `kid` (e.g. `v2`) requires shipping the new public key in an appliance release and waiting for fleet uptake **before** the signer starts using it. This entry is the floor; future kids are added alongside it.