### PR TITLE
Gate linked ticket/task visibility by assignee

### DIFF
--- a/packages/projects/src/actions/projectActions.ts
+++ b/packages/projects/src/actions/projectActions.ts
@@ -42,7 +42,7 @@ import { deleteEntityWithValidation } from '@alga-psa/core';
 import { deleteEntityTags, deleteEntitiesTags } from '@alga-psa/tags/lib/tagCleanup';
 import { permissionError } from '@alga-psa/ui/lib/errorHandling';
 import type { ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
-import { filterAuthorizedTicketIds } from './projectTaskActions';
+import { filterAuthorizedTicketIds, applyTicketLinkRestriction } from './projectTaskActions';
 import {
   BuiltinAuthorizationKernelProvider,
   BundleAuthorizationKernelProvider,
@@ -1644,7 +1644,7 @@ export const getProjectDetails = withAuth(async (user, { tenant }, projectId: st
                 ticketLinks.map((link) => link.ticket_id)
             )
         );
-        const authorizedTicketLinks = ticketLinks.filter((link) => allowedTicketIds.has(link.ticket_id));
+        const authorizedTicketLinks = ticketLinks.map((link) => applyTicketLinkRestriction(link, allowedTicketIds));
 
         const contact = project.contact_name ? {
             full_name: project.contact_name

--- a/packages/projects/src/actions/projectActions.ts
+++ b/packages/projects/src/actions/projectActions.ts
@@ -42,7 +42,8 @@ import { deleteEntityWithValidation } from '@alga-psa/core';
 import { deleteEntityTags, deleteEntitiesTags } from '@alga-psa/tags/lib/tagCleanup';
 import { permissionError } from '@alga-psa/ui/lib/errorHandling';
 import type { ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
-import { filterAuthorizedTicketIds, applyTicketLinkRestriction } from './projectTaskActions';
+import { filterAuthorizedTicketIds } from './projectTaskActions';
+import { applyTicketLinkRestriction } from '../lib/taskTicketMapping';
 import {
   BuiltinAuthorizationKernelProvider,
   BundleAuthorizationKernelProvider,

--- a/packages/projects/src/actions/projectAuthorization.contract.test.ts
+++ b/packages/projects/src/actions/projectAuthorization.contract.test.ts
@@ -109,16 +109,19 @@ describe('project authorization kernel contracts', () => {
     expect(projectTaskActionsSource).toContain('if (!allowedTicketIds.has(link.ticket_id)) {');
   });
 
-  it('F033: linked ticket payloads in project structural surfaces apply ticket-resource intersection semantics', () => {
+  it('F033: linked ticket payloads in project structural surfaces apply assignee-set restriction semantics', () => {
     expect(projectTaskActionsSource).toContain('export async function filterAuthorizedTicketIds(');
+    expect(projectTaskActionsSource).toContain('export async function buildTicketAssigneeSetByTicketId(');
     expect(projectTaskActionsSource).toContain('async function assertTicketReadAllowedById(');
-    expect(projectTaskActionsSource).toContain('resource: { type: \'ticket\', action: \'read\', id: ticket.ticket_id }');
+    expect(projectTaskActionsSource).toContain('if (await isProjectReadAdmin(user, trx)) {');
+    expect(projectTaskActionsSource).toContain('const assigneesByTicket = await buildTicketAssigneeSetByTicketId(trx, tenant, uniqueTicketIds);');
+    expect(projectTaskActionsSource).toContain('export function applyTicketLinkRestriction(');
     expect(projectTaskActionsSource).toContain('await assertTicketReadAllowedById(trx, tenant, user as IUserWithRoles, ticketId);');
     expect(projectTaskActionsSource).toContain('const allowedTicketIds = await filterAuthorizedTicketIds(');
-    expect(projectTaskActionsSource).toContain('const authorizedTicketLinksArray = ticketLinksArray.filter((link) => allowedTicketIds.has(link.ticket_id));');
+    expect(projectTaskActionsSource).toContain('applyTicketLinkRestriction(link, allowedTicketIds)');
     expect(projectActionsSource).toContain('const allowedTicketIds = await withTransaction(knex, async (trx: Knex.Transaction) =>');
     expect(projectActionsSource).toContain('ticketLinks.map((link) => link.ticket_id)');
-    expect(projectActionsSource).toContain('const authorizedTicketLinks = ticketLinks.filter((link) => allowedTicketIds.has(link.ticket_id));');
+    expect(projectActionsSource).toContain('const authorizedTicketLinks = ticketLinks.map((link) => applyTicketLinkRestriction(link, allowedTicketIds));');
     expect(projectActionsSource).toContain('ticketLinks: authorizedTicketLinks,');
   });
 });

--- a/packages/projects/src/actions/projectAuthorization.contract.test.ts
+++ b/packages/projects/src/actions/projectAuthorization.contract.test.ts
@@ -115,7 +115,8 @@ describe('project authorization kernel contracts', () => {
     expect(projectTaskActionsSource).toContain('async function assertTicketReadAllowedById(');
     expect(projectTaskActionsSource).toContain('if (await isProjectReadAdmin(user, trx)) {');
     expect(projectTaskActionsSource).toContain('const assigneesByTicket = await buildTicketAssigneeSetByTicketId(trx, tenant, uniqueTicketIds);');
-    expect(projectTaskActionsSource).toContain('export function applyTicketLinkRestriction(');
+    expect(readSource('../lib/taskTicketMapping.ts')).toContain('export function applyTicketLinkRestriction(');
+    expect(projectTaskActionsSource).toContain("import { applyTicketLinkRestriction } from '../lib/taskTicketMapping';");
     expect(projectTaskActionsSource).toContain('await assertTicketReadAllowedById(trx, tenant, user as IUserWithRoles, ticketId);');
     expect(projectTaskActionsSource).toContain('const allowedTicketIds = await filterAuthorizedTicketIds(');
     expect(projectTaskActionsSource).toContain('applyTicketLinkRestriction(link, allowedTicketIds)');

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -38,6 +38,7 @@ import {
 } from '../schemas/project.schemas';
 import { OrderingService } from '../lib/orderingUtils';
 import { buildProjectTaskWebhookChanges } from '../lib/projectTaskWebhookChanges';
+import { applyTicketLinkRestriction } from '../lib/taskTicketMapping';
 import { validateAndFixOrderKeys } from './regenerateOrderKeys';
 import {
   buildProjectTaskAssignedPayload,
@@ -422,26 +423,6 @@ export async function buildTaskAssigneeSetByTaskId(
     }
 
     return result;
-}
-
-/**
- * Returns a copy of a ticket-link row with non-essential fields nulled when
- * the caller isn't allowed to see the ticket in full. Caller is expected to
- * compute `allowedTicketIds` via filterAuthorizedTicketIds.
- */
-export function applyTicketLinkRestriction(
-    link: IProjectTicketLinkWithDetails,
-    allowedTicketIds: Set<string>
-): IProjectTicketLinkWithDetails {
-    if (allowedTicketIds.has(link.ticket_id)) {
-        return { ...link, restricted: false };
-    }
-    return {
-        ...link,
-        status_name: null,
-        is_closed: null,
-        restricted: true,
-    };
 }
 
 export async function filterAuthorizedTicketIds(

--- a/packages/projects/src/actions/projectTaskActions.ts
+++ b/packages/projects/src/actions/projectTaskActions.ts
@@ -290,36 +290,157 @@ async function createProjectReadAuthorizer(
     };
 }
 
-type KernelAuthorizationContext = {
-    subject: AuthorizationSubject;
-    authorizationKernel: ReturnType<typeof createAuthorizationKernel>;
-    requestCache: RequestLocalAuthorizationCache;
-};
+async function isProjectReadAdmin(
+    user: IUserWithRoles,
+    trx: Knex.Transaction
+): Promise<boolean> {
+    return hasPermission(user, 'project', 'read', trx);
+}
 
-async function createKernelAuthorizationContext(
+/**
+ * Builds the per-ticket assignee set: primary assignee + ticket_resources
+ * additional agents + members of the ticket's assigned_team_id. Used to gate
+ * non-admin (no project:read) access to linked tickets.
+ */
+export async function buildTicketAssigneeSetByTicketId(
     trx: Knex.Transaction,
     tenant: string,
-    user: IUserWithRoles
-): Promise<KernelAuthorizationContext> {
-    const subject = await resolveAuthorizationSubjectForUser(trx, tenant, user);
-    const authorizationKernel = createAuthorizationKernel({
-        builtinProvider: new BuiltinAuthorizationKernelProvider(),
-        bundleProvider: new BundleAuthorizationKernelProvider({
-            resolveRules: async (input) => {
-                try {
-                    return await resolveBundleNarrowingRulesForEvaluation(trx, input);
-                } catch {
-                    return [];
-                }
-            },
-        }),
-        rbacEvaluator: async () => true,
-    });
+    ticketIds: string[]
+): Promise<Map<string, Set<string>>> {
+    const result = new Map<string, Set<string>>();
+    const uniqueIds = Array.from(new Set(ticketIds.filter(Boolean)));
+    if (uniqueIds.length === 0) {
+        return result;
+    }
 
+    const tickets = await trx('tickets')
+        .where({ tenant })
+        .whereIn('ticket_id', uniqueIds)
+        .select<{ ticket_id: string; assigned_to: string | null; assigned_team_id: string | null }[]>(
+            'ticket_id',
+            'assigned_to',
+            'assigned_team_id'
+        );
+
+    for (const ticket of tickets) {
+        const set = new Set<string>();
+        if (ticket.assigned_to) set.add(ticket.assigned_to);
+        result.set(ticket.ticket_id, set);
+    }
+
+    const additional = await trx('ticket_resources')
+        .where({ tenant })
+        .whereIn('ticket_id', uniqueIds)
+        .whereNotNull('additional_user_id')
+        .select<{ ticket_id: string; additional_user_id: string }[]>('ticket_id', 'additional_user_id');
+    for (const row of additional) {
+        result.get(row.ticket_id)?.add(row.additional_user_id);
+    }
+
+    const teamIds = Array.from(new Set(tickets.map((t) => t.assigned_team_id).filter((id): id is string => Boolean(id))));
+    if (teamIds.length > 0) {
+        const members = await trx('team_members')
+            .where({ tenant })
+            .whereIn('team_id', teamIds)
+            .select<{ team_id: string; user_id: string }[]>('team_id', 'user_id');
+        const membersByTeam = new Map<string, string[]>();
+        for (const row of members) {
+            const ids = membersByTeam.get(row.team_id) ?? [];
+            ids.push(row.user_id);
+            membersByTeam.set(row.team_id, ids);
+        }
+        for (const ticket of tickets) {
+            if (!ticket.assigned_team_id) continue;
+            const teamMembers = membersByTeam.get(ticket.assigned_team_id) ?? [];
+            const set = result.get(ticket.ticket_id);
+            if (!set) continue;
+            for (const id of teamMembers) set.add(id);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Builds the per-task assignee set: primary assignee + task_resources
+ * additional agents + members of the task's assigned_team_id.
+ */
+export async function buildTaskAssigneeSetByTaskId(
+    trx: Knex.Transaction,
+    tenant: string,
+    taskIds: string[]
+): Promise<Map<string, Set<string>>> {
+    const result = new Map<string, Set<string>>();
+    const uniqueIds = Array.from(new Set(taskIds.filter(Boolean)));
+    if (uniqueIds.length === 0) {
+        return result;
+    }
+
+    const tasks = await trx('project_tasks')
+        .where({ tenant })
+        .whereIn('task_id', uniqueIds)
+        .select<{ task_id: string; assigned_to: string | null; assigned_team_id: string | null }[]>(
+            'task_id',
+            'assigned_to',
+            'assigned_team_id'
+        );
+
+    for (const task of tasks) {
+        const set = new Set<string>();
+        if (task.assigned_to) set.add(task.assigned_to);
+        result.set(task.task_id, set);
+    }
+
+    const additional = await trx('task_resources')
+        .where({ tenant })
+        .whereIn('task_id', uniqueIds)
+        .whereNotNull('additional_user_id')
+        .select<{ task_id: string; additional_user_id: string }[]>('task_id', 'additional_user_id');
+    for (const row of additional) {
+        result.get(row.task_id)?.add(row.additional_user_id);
+    }
+
+    const teamIds = Array.from(new Set(tasks.map((t) => t.assigned_team_id).filter((id): id is string => Boolean(id))));
+    if (teamIds.length > 0) {
+        const members = await trx('team_members')
+            .where({ tenant })
+            .whereIn('team_id', teamIds)
+            .select<{ team_id: string; user_id: string }[]>('team_id', 'user_id');
+        const membersByTeam = new Map<string, string[]>();
+        for (const row of members) {
+            const ids = membersByTeam.get(row.team_id) ?? [];
+            ids.push(row.user_id);
+            membersByTeam.set(row.team_id, ids);
+        }
+        for (const task of tasks) {
+            if (!task.assigned_team_id) continue;
+            const teamMembers = membersByTeam.get(task.assigned_team_id) ?? [];
+            const set = result.get(task.task_id);
+            if (!set) continue;
+            for (const id of teamMembers) set.add(id);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Returns a copy of a ticket-link row with non-essential fields nulled when
+ * the caller isn't allowed to see the ticket in full. Caller is expected to
+ * compute `allowedTicketIds` via filterAuthorizedTicketIds.
+ */
+export function applyTicketLinkRestriction(
+    link: IProjectTicketLinkWithDetails,
+    allowedTicketIds: Set<string>
+): IProjectTicketLinkWithDetails {
+    if (allowedTicketIds.has(link.ticket_id)) {
+        return { ...link, restricted: false };
+    }
     return {
-        subject,
-        authorizationKernel,
-        requestCache: new RequestLocalAuthorizationCache(),
+        ...link,
+        status_name: null,
+        is_closed: null,
+        restricted: true,
     };
 }
 
@@ -334,52 +455,18 @@ export async function filterAuthorizedTicketIds(
         return new Set();
     }
 
-    if (!await hasPermission(user, 'ticket', 'read', trx)) {
-        return new Set();
+    if (await isProjectReadAdmin(user, trx)) {
+        return new Set(uniqueTicketIds);
     }
 
-    const context = await createKernelAuthorizationContext(trx, tenant, user);
-    const tickets = await trx('tickets')
-        .where({ tenant })
-        .whereIn('ticket_id', uniqueTicketIds)
-        .select(
-            'ticket_id',
-            'entered_by',
-            'assigned_to',
-            'assigned_team_id',
-            'client_id',
-            'board_id',
-            'status_id'
-        );
-
-    const decisions = await Promise.all(
-        tickets.map((ticket) =>
-            context.authorizationKernel.authorizeResource({
-                subject: context.subject,
-                resource: { type: 'ticket', action: 'read', id: ticket.ticket_id },
-                record: {
-                    id: ticket.ticket_id,
-                    ownerUserId: ticket.entered_by ?? null,
-                    assignedUserIds: ticket.assigned_to ? [ticket.assigned_to] : [],
-                    clientId: ticket.client_id ?? null,
-                    boardId: ticket.board_id ?? undefined,
-                    teamIds: ticket.assigned_team_id ? [ticket.assigned_team_id] : [],
-                    statusId: ticket.status_id,
-                },
-                requestCache: context.requestCache,
-                knex: trx,
-            })
-        )
-    );
-
-    const allowedIds = new Set<string>();
-    tickets.forEach((ticket, index) => {
-        if (decisions[index]?.allowed) {
-            allowedIds.add(ticket.ticket_id);
+    const assigneesByTicket = await buildTicketAssigneeSetByTicketId(trx, tenant, uniqueTicketIds);
+    const allowed = new Set<string>();
+    for (const ticketId of uniqueTicketIds) {
+        if (assigneesByTicket.get(ticketId)?.has(user.user_id)) {
+            allowed.add(ticketId);
         }
-    });
-
-    return allowedIds;
+    }
+    return allowed;
 }
 
 async function assertTicketReadAllowedById(
@@ -1056,7 +1143,7 @@ export const getTaskTicketLinksAction = withAuth(async (
                 user as IUserWithRoles,
                 links.map((link) => link.ticket_id)
             );
-            return links.filter((link) => allowedTicketIds.has(link.ticket_id));
+            return links.map((link) => applyTicketLinkRestriction(link, allowedTicketIds));
         });
     } catch (error) {
         console.error('Error getting task ticket links:', error);
@@ -1079,20 +1166,30 @@ export const getLinkedTasksForTicketAction = withAuth(async (
                 return linkedTasks;
             }
 
-            const authorizeProjectRead = await createProjectReadAuthorizer(trx, tenant, user as IUserWithRoles);
-            const projects = await trx('projects')
-                .where({ tenant })
-                .whereIn('project_id', Array.from(new Set(linkedTasks.map((task) => task.project_id).filter(Boolean))))
-                .select('project_id', 'client_id', 'assigned_to');
+            const isAdmin = await isProjectReadAdmin(user as IUserWithRoles, trx);
+            if (isAdmin) {
+                return linkedTasks.map((task) => ({ ...task, restricted: false }));
+            }
 
-            const allowedProjectIds = new Set<string>();
-            await Promise.all(projects.map(async (project) => {
-                if (await authorizeProjectRead(project)) {
-                    allowedProjectIds.add(project.project_id);
+            const assigneesByTask = await buildTaskAssigneeSetByTaskId(
+                trx,
+                tenant,
+                linkedTasks.map((task) => task.task_id)
+            );
+            return linkedTasks.map((task) => {
+                const isAssigned = assigneesByTask.get(task.task_id)?.has(user.user_id) ?? false;
+                if (isAssigned) {
+                    return { ...task, restricted: false };
                 }
-            }));
-
-            return linkedTasks.filter((task) => allowedProjectIds.has(task.project_id));
+                return {
+                    ...task,
+                    project_name: null,
+                    phase_name: null,
+                    status_name: null,
+                    is_closed: null,
+                    restricted: true,
+                };
+            });
         });
     } catch (error) {
         console.error('Error getting linked tasks for ticket:', error);
@@ -1178,7 +1275,9 @@ export const getTasksForPhase = withAuth(async (
                 user as IUserWithRoles,
                 ticketLinksArray.map((link) => link.ticket_id)
             );
-            const authorizedTicketLinksArray = ticketLinksArray.filter((link) => allowedTicketIds.has(link.ticket_id));
+            const authorizedTicketLinksArray = ticketLinksArray.map((link) =>
+                applyTicketLinkRestriction(link, allowedTicketIds)
+            );
 
             // Convert arrays to maps
             const ticketLinks: { [taskId: string]: IProjectTicketLinkWithDetails[] } = {};
@@ -2143,7 +2242,7 @@ export const getTaskWithDetails = withAuth(async (
                 user as IUserWithRoles,
                 ticketLinks.map((link) => link.ticket_id)
             );
-            const authorizedTicketLinks = ticketLinks.filter((link) => allowedTicketIds.has(link.ticket_id));
+            const authorizedTicketLinks = ticketLinks.map((link) => applyTicketLinkRestriction(link, allowedTicketIds));
 
             return {
                 ...task,
@@ -2683,7 +2782,9 @@ export const getAllProjectTasksForListView = withAuth(async (
             user as IUserWithRoles,
             ticketLinksArray.map((link) => link.ticket_id)
         );
-        const authorizedTicketLinksArray = ticketLinksArray.filter((link) => allowedTicketIds.has(link.ticket_id));
+        const authorizedTicketLinksArray = ticketLinksArray.map((link) =>
+            applyTicketLinkRestriction(link, allowedTicketIds)
+        );
 
         // 5. Convert arrays to maps keyed by task_id
         const ticketLinks: Record<string, IProjectTicketLinkWithDetails[]> = {};

--- a/packages/projects/src/components/TaskTicketLinks.tsx
+++ b/packages/projects/src/components/TaskTicketLinks.tsx
@@ -13,7 +13,7 @@ import { ITicketListItem, ITicket, ITicketCategory, IStatus } from '@alga-psa/ty
 import { IProjectTicketLinkWithDetails } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
-import { Link, Plus, ExternalLink, Trash2, X } from 'lucide-react';
+import { Link, Lock, Plus, ExternalLink, Trash2, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { handleError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
@@ -185,7 +185,8 @@ const TaskTicketLinks = forwardRef<TaskTicketLinksRef, TaskTicketLinksProps>(fun
       if (!user) return;
 
       const filters: ITicketListFilters = {
-        boardFilterState: 'all'
+        boardFilterState: 'all',
+        assignedToMe: true
       };
       const tickets = await getTicketsForList(filters);
       setAvailableTickets(tickets || []);
@@ -579,23 +580,36 @@ const TaskTicketLinks = forwardRef<TaskTicketLinksRef, TaskTicketLinksProps>(fun
         {(taskTicketLinks || []).map((link): React.JSX.Element => (
           <div key={link.link_id} className="flex items-center justify-between p-2 bg-gray-50 rounded">
             <div className="flex flex-col">
-              <span>{link.ticket_number} - {link.title}</span>
-              {link.status_name && (
+              <span className="flex items-center gap-1">
+                {link.restricted && (
+                  <span
+                    title={linkT('restrictedTooltip', 'Limited details — you are not assigned to this ticket')}
+                    aria-label={linkT('restrictedTooltip', 'Limited details — you are not assigned to this ticket')}
+                    className="inline-flex"
+                  >
+                    <Lock className="h-3.5 w-3.5 text-gray-500" />
+                  </span>
+                )}
+                <span>{link.ticket_number} - {link.title}</span>
+              </span>
+              {!link.restricted && link.status_name && (
                 <span className="text-xs text-gray-500 mt-0.5">
                   {link.status_name}
                 </span>
               )}
             </div>
             <div className="flex items-center space-x-2">
-              <Button
-                id={`view-ticket-${link.ticket_id}-button`}
-                type="button"
-                variant="ghost"
-                onClick={() => onViewTicket(link.ticket_id)}
-                className="flex items-center text-sm"
-              >
-                <ExternalLink className="h-4 w-4 mr-1" />
-              </Button>
+              {!link.restricted && (
+                <Button
+                  id={`view-ticket-${link.ticket_id}-button`}
+                  type="button"
+                  variant="ghost"
+                  onClick={() => onViewTicket(link.ticket_id)}
+                  className="flex items-center text-sm"
+                >
+                  <ExternalLink className="h-4 w-4 mr-1" />
+                </Button>
+              )}
               <Button
                 id={`delete-link-${link.link_id}-button`}
                 type="button"

--- a/packages/projects/src/components/TicketLinkedTasksBadge.tsx
+++ b/packages/projects/src/components/TicketLinkedTasksBadge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { ClipboardList, ExternalLink, Loader2 } from 'lucide-react';
+import { ClipboardList, ExternalLink, Loader2, Lock } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Popover, PopoverTrigger, PopoverContent } from '@alga-psa/ui/components/Popover';
 import { useDrawer } from '@alga-psa/ui';
@@ -127,34 +127,56 @@ export default function TicketLinkedTasksBadge({
           <h4 className="text-sm font-medium">{t('dialogs.ticketLinkedTasks.title', 'Linked Project Tasks')}</h4>
         </div>
         <div className="max-h-60 overflow-y-auto">
-          {linkedTasks.map((task) => (
-            <button
-              key={task.link_id}
-              type="button"
-              className="w-full text-left px-3 py-2 hover:bg-[rgb(var(--color-border-100))] flex items-center justify-between gap-2 border-b border-[rgb(var(--color-border-100))] last:border-b-0"
-              onClick={() => handleOpenTask(task)}
-              disabled={openingTaskId === task.task_id}
-            >
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium truncate">{task.task_name}</div>
-                <div className="text-xs text-[rgb(var(--color-text-400))] truncate">
-                  {task.project_name} &middot; {task.phase_name}
+          {linkedTasks.map((task) => {
+            const restrictedLabel = t(
+              'dialogs.ticketLinkedTasks.restrictedTooltip',
+              'Limited details — you are not assigned to this task'
+            );
+            if (task.restricted) {
+              return (
+                <div
+                  key={task.link_id}
+                  className="w-full text-left px-3 py-2 flex items-center justify-between gap-2 border-b border-[rgb(var(--color-border-100))] last:border-b-0"
+                  title={restrictedLabel}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium truncate">{task.task_name}</div>
+                  </div>
+                  <div className="flex-shrink-0" aria-label={restrictedLabel}>
+                    <Lock className="h-4 w-4 text-[rgb(var(--color-text-400))]" />
+                  </div>
                 </div>
-                {task.status_name && (
-                  <span className="text-xs text-[rgb(var(--color-text-400))]">
-                    {task.status_name}
-                  </span>
-                )}
-              </div>
-              <div className="flex-shrink-0">
-                {openingTaskId === task.task_id ? (
-                  <Loader2 className="h-4 w-4 animate-spin text-[rgb(var(--color-text-400))]" />
-                ) : (
-                  <ExternalLink className="h-4 w-4 text-[rgb(var(--color-text-400))]" />
-                )}
-              </div>
-            </button>
-          ))}
+              );
+            }
+            return (
+              <button
+                key={task.link_id}
+                type="button"
+                className="w-full text-left px-3 py-2 hover:bg-[rgb(var(--color-border-100))] flex items-center justify-between gap-2 border-b border-[rgb(var(--color-border-100))] last:border-b-0"
+                onClick={() => handleOpenTask(task)}
+                disabled={openingTaskId === task.task_id}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium truncate">{task.task_name}</div>
+                  <div className="text-xs text-[rgb(var(--color-text-400))] truncate">
+                    {task.project_name} &middot; {task.phase_name}
+                  </div>
+                  {task.status_name && (
+                    <span className="text-xs text-[rgb(var(--color-text-400))]">
+                      {task.status_name}
+                    </span>
+                  )}
+                </div>
+                <div className="flex-shrink-0">
+                  {openingTaskId === task.task_id ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-[rgb(var(--color-text-400))]" />
+                  ) : (
+                    <ExternalLink className="h-4 w-4 text-[rgb(var(--color-text-400))]" />
+                  )}
+                </div>
+              </button>
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>

--- a/packages/projects/src/lib/taskTicketMapping.ts
+++ b/packages/projects/src/lib/taskTicketMapping.ts
@@ -1,3 +1,25 @@
+import type { IProjectTicketLinkWithDetails } from '@alga-psa/types';
+
+/**
+ * Returns a copy of a ticket-link row with non-essential fields nulled when
+ * the caller isn't allowed to see the ticket in full. Caller is expected to
+ * compute `allowedTicketIds` via filterAuthorizedTicketIds.
+ */
+export function applyTicketLinkRestriction(
+  link: IProjectTicketLinkWithDetails,
+  allowedTicketIds: Set<string>
+): IProjectTicketLinkWithDetails {
+  if (allowedTicketIds.has(link.ticket_id)) {
+    return { ...link, restricted: false };
+  }
+  return {
+    ...link,
+    status_name: null,
+    is_closed: null,
+    restricted: true,
+  };
+}
+
 /**
  * Extract plain text from a BlockNote JSON string.
  * Falls back to returning the raw value if it's not valid BlockNote JSON.

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -1274,6 +1274,28 @@ export const getTicketsForList = withAuth(async (user, { tenant }, filters: ITic
       });
     }
 
+    if (validatedFilters.assignedToMe) {
+      const hasProjectRead = await hasPermission(user, 'project', 'read', trx);
+      if (!hasProjectRead) {
+        const callerUserId = (user as IUserWithRoles).user_id;
+        query = query.where(function(this: any) {
+          this.where('t.assigned_to', callerUserId)
+            .orWhereIn('t.ticket_id', function(this: any) {
+              this.select('ticket_id')
+                .from('ticket_resources')
+                .where('tenant', tenant)
+                .andWhere('additional_user_id', callerUserId);
+            })
+            .orWhereIn('t.assigned_team_id', function(this: any) {
+              this.select('team_id')
+                .from('team_members')
+                .where('tenant', tenant)
+                .andWhere('user_id', callerUserId);
+            });
+        });
+      }
+    }
+
       const sortBy = validatedFilters.sortBy ?? 'entered_at';
       const sortDirection: 'asc' | 'desc' = validatedFilters.sortDirection ?? 'desc';
       const sortColumnMap: Record<string, { column?: string; rawExpression?: string }> = {

--- a/packages/tickets/src/schemas/ticket.schema.ts
+++ b/packages/tickets/src/schemas/ticket.schema.ts
@@ -146,6 +146,7 @@ export const ticketListFiltersSchema = z.object({
   assignedToIds: z.array(z.string().uuid()).optional(),
   assignedTeamIds: z.array(z.string().uuid()).optional(),
   includeUnassigned: z.boolean().optional(),
+  assignedToMe: z.boolean().optional(),
   // Due date filters
   dueDateFilter: z
     .enum(['all', 'overdue', 'upcoming', 'today', 'no_due_date', 'before', 'after', 'custom'])

--- a/packages/types/src/interfaces/project.interfaces.ts
+++ b/packages/types/src/interfaces/project.interfaces.ts
@@ -162,8 +162,9 @@ export interface IProjectTicketLink extends TenantEntity {
 export interface IProjectTicketLinkWithDetails extends IProjectTicketLink {
   ticket_number: string;
   title: string;
-  status_name: string;
-  is_closed: boolean;
+  status_name: string | null;
+  is_closed: boolean | null;
+  restricted?: boolean;
 }
 
 export interface ITicketLinkedTask {
@@ -171,11 +172,12 @@ export interface ITicketLinkedTask {
   task_id: string;
   task_name: string;
   project_id: string;
-  project_name: string;
+  project_name: string | null;
   phase_id: string;
-  phase_name: string;
+  phase_name: string | null;
   status_name: string | null;
-  is_closed: boolean;
+  is_closed: boolean | null;
+  restricted?: boolean;
 }
 
 export interface ITaskChecklistItem extends TenantEntity {

--- a/packages/types/src/interfaces/ticket.interfaces.ts
+++ b/packages/types/src/interfaces/ticket.interfaces.ts
@@ -109,6 +109,7 @@ export interface ITicketListFilters {
   assignedToIds?: string[];        // Array of user IDs to filter by
   assignedTeamIds?: string[];      // Array of team IDs to filter by
   includeUnassigned?: boolean;     // Include tickets with no assignee
+  assignedToMe?: boolean;          // Restrict to tickets where caller is assignee (incl. additional agents + team membership). Server bypasses for project:read admins.
   // Due date filters
   dueDateFilter?: 'all' | 'overdue' | 'upcoming' | 'today' | 'no_due_date' | 'before' | 'after' | 'custom';
   dueDateFrom?: string;            // ISO date string for custom range start

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Wählen Sie aus, wo dieses neue Dokument gespeichert werden soll"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Eingeschränkte Details — Sie sind diesem Ticket nicht zugewiesen",
     "title": "Verknüpfte Tickets",
     "linkExistingTitle": "Vorhandenes Ticket verknüpfen",
     "createTicket": "Ticket erstellen",
@@ -720,6 +721,7 @@
       "allPriorities": "Alle Prioritäten"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Eingeschränkte Details — Sie sind dieser Aufgabe nicht zugewiesen",
       "title": "Verknüpfte Projektaufgaben",
       "loadFailed": "Aufgabe konnte nicht geladen werden",
       "phaseNotFound": "Aufgabenphase nicht gefunden",

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -433,6 +433,7 @@
   },
   "taskTicketLinks": {
     "title": "Associated Tickets",
+    "restrictedTooltip": "Limited details — you are not assigned to this ticket",
     "linkExistingTitle": "Link Existing Ticket",
     "createTicket": "Create Ticket",
     "linkTicket": "Link Ticket",
@@ -727,7 +728,8 @@
       "task": "Task",
       "tasks": "Tasks",
       "badgeCount": "{{count}} Task",
-      "badgeCount_other": "{{count}} Tasks"
+      "badgeCount_other": "{{count}} Tasks",
+      "restrictedTooltip": "Limited details — you are not assigned to this task"
     },
     "bulkMoveTask": {
       "title": "Move Tasks",

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Elija dónde guardar este nuevo documento"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Detalles limitados — no estás asignado a este ticket",
     "title": "Tickets asociados",
     "linkExistingTitle": "Vincular ticket existente",
     "createTicket": "Crear ticket",
@@ -720,6 +721,7 @@
       "allPriorities": "Todas las prioridades"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Detalles limitados — no estás asignado a esta tarea",
       "title": "Tareas de proyecto vinculadas",
       "loadFailed": "No se pudo cargar la tarea",
       "phaseNotFound": "No se encontró la fase de la tarea",

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Choisissez où enregistrer ce nouveau document"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Détails limités — vous n'êtes pas assigné à ce ticket",
     "title": "Tickets associés",
     "linkExistingTitle": "Lier un ticket existant",
     "createTicket": "Créer un ticket",
@@ -720,6 +721,7 @@
       "allPriorities": "Toutes les priorités"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Détails limités — vous n'êtes pas assigné à cette tâche",
       "title": "Tâches de projet liées",
       "loadFailed": "Échec du chargement de la tâche",
       "phaseNotFound": "Phase de tâche introuvable",

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Scegli dove salvare questo nuovo documento"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Dettagli limitati — non sei assegnato a questo ticket",
     "title": "Ticket associati",
     "linkExistingTitle": "Collega ticket esistente",
     "createTicket": "Crea ticket",
@@ -720,6 +721,7 @@
       "allPriorities": "Tutte le priorità"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Dettagli limitati — non sei assegnato a questa attività",
       "title": "Attività di progetto collegate",
       "loadFailed": "Impossibile caricare l'attività",
       "phaseNotFound": "Fase attività non trovata",

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Kies waar u dit nieuwe document wilt opslaan"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Beperkte details — je bent niet toegewezen aan dit kaartje",
     "title": "Bijbehorende kaartjes",
     "linkExistingTitle": "Koppel bestaand ticket",
     "createTicket": "Ticket aanmaken",
@@ -720,6 +721,7 @@
       "allPriorities": "Alle prioriteiten"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Beperkte details — je bent niet toegewezen aan deze taak",
       "title": "Gekoppelde projecttaken",
       "loadFailed": "Taak laden mislukt",
       "phaseNotFound": "Taakfase niet gevonden",

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Wybierz, gdzie zapisać ten nowy dokument"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Ograniczone szczegóły — nie jesteś przypisany do tego biletu",
     "title": "Powiązane bilety",
     "linkExistingTitle": "Połącz istniejący bilet",
     "createTicket": "Utwórz bilet",
@@ -720,6 +721,7 @@
       "allPriorities": "Wszystkie priorytety"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Ograniczone szczegóły — nie jesteś przypisany do tego zadania",
       "title": "Powiązane zadania projektowe",
       "loadFailed": "Nie udało się załadować zadania",
       "phaseNotFound": "Nie znaleziono fazy zadania",

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "Choose where to save this new document"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "Detalhes limitados — você não está atribuído a este ticket",
     "title": "Associated Tickets",
     "linkExistingTitle": "Link Existing Ticket",
     "createTicket": "Create Ticket",
@@ -720,6 +721,7 @@
       "allPriorities": "All Priorities"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "Detalhes limitados — você não está atribuído a esta tarefa",
       "title": "Linked Project Tasks",
       "loadFailed": "Failed to load task",
       "phaseNotFound": "Task phase not found",

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "11111"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "11111",
     "title": "11111",
     "linkExistingTitle": "11111",
     "createTicket": "11111",
@@ -720,6 +721,7 @@
       "allPriorities": "11111"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "11111",
       "title": "11111",
       "loadFailed": "11111",
       "phaseNotFound": "11111",

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -432,6 +432,7 @@
     "selectFolderDescription": "55555"
   },
   "taskTicketLinks": {
+    "restrictedTooltip": "55555",
     "title": "55555",
     "linkExistingTitle": "55555",
     "createTicket": "55555",
@@ -720,6 +721,7 @@
       "allPriorities": "55555"
     },
     "ticketLinkedTasks": {
+      "restrictedTooltip": "55555",
       "title": "55555",
       "loadFailed": "55555",
       "phaseNotFound": "55555",


### PR DESCRIPTION
  Replace the kernel-based read check with a simpler project:read-admin-
  or-assignee model. Non-admins now see linked tickets/tasks they aren't
  assigned to as restricted placeholders (title only, status nulled, lock
  icon, no navigation) via applyTicketLinkRestriction instead of having
  the rows silently dropped. Assignee sets include primary assignee,
  ticket_resources/task_resources additional agents, and assigned-team
  members.

  Add an assignedToMe filter to getTicketsForList so the link picker only
  offers tickets the caller can access, mirroring the visibility gate.
  Make status_name/is_closed/project_name/phase_name nullable and add a
  restricted flag on the link interfaces. Update the F033 contract test
  to the new semantics and add restrictedTooltip across all 10 locales.

  "Curiouser and curiouser!" cried the additional agent, for though the
  ticket wore a tidy little 🔒 and would not open its status to her, its
  number and title peeked out all the same — and the team_members table,
  ever so politely, whispered which doors her key still fit. 🐇🎟️