### PR TITLE
Add view-other-users to activities table

### DIFF
--- a/ee/packages/workflows/src/actions/activity-actions/activityAggregationActions.ts
+++ b/ee/packages/workflows/src/actions/activity-actions/activityAggregationActions.ts
@@ -16,7 +16,7 @@ import {
   workflowTaskToActivity,
 } from '@alga-psa/types';
 import { getAllScheduleEntries } from '@alga-psa/core';
-import { withAuth } from '@alga-psa/auth';
+import { withAuth, hasPermission } from '@alga-psa/auth';
 import { ISO8601String } from '@alga-psa/types';
 import { IProjectTask } from '@alga-psa/types';
 
@@ -140,6 +140,39 @@ async function filterScheduleEntriesByClient<T extends ScheduleEntryWorkItemLink
 }
 
 /**
+ * Resolve whose activities to fetch. Defaults to the caller; when filters.targetUserId
+ * names another internal user, require the same gate the schedule calendar uses to view
+ * other users' calendars (user_schedule:update or user_schedule:read_all).
+ */
+async function resolveActivityTarget(
+  user: any,
+  tenantId: string,
+  targetUserId?: string
+): Promise<{ userId: string; viewingOther: boolean }> {
+  if (!targetUserId || targetUserId === user.user_id) {
+    return { userId: user.user_id, viewingOther: false };
+  }
+
+  const { knex, tenant } = await createTenantKnex(tenantId);
+  const [canUpdate, canReadAll] = await Promise.all([
+    hasPermission(user, 'user_schedule', 'update', knex),
+    hasPermission(user, 'user_schedule', 'read_all', knex),
+  ]);
+  if (!canUpdate && !canReadAll) {
+    throw new Error("Permission denied: cannot view another user's activities");
+  }
+
+  const target = await knex('users')
+    .where({ tenant, user_id: targetUserId, user_type: 'internal' })
+    .first();
+  if (!target) {
+    throw new Error('User not found');
+  }
+
+  return { userId: targetUserId, viewingOther: true };
+}
+
+/**
  * Fetch all activities for a user with optional filters and pagination
  */
 export const fetchUserActivities = withAuth(async (
@@ -151,38 +184,50 @@ export const fetchUserActivities = withAuth(async (
 ): Promise<ActivityResponse> => {
   const tenantId: string = tenant;
 
+  // Determine whose activities to fetch (self, or another user if permitted).
+  const { userId: effectiveUserId, viewingOther } =
+    await resolveActivityTarget(user, tenantId, filters.targetUserId);
+
   // Fetch activities from different sources based on filters
   const activities: Activity[] = [];
   const promises: Promise<Activity[]>[] = [];
 
   // Only fetch requested activity types or all if not specified
   // Note: An empty array is truthy, so we need to check length explicitly
-  const typesToFetch = filters.types && filters.types.length > 0
+  let typesToFetch = filters.types && filters.types.length > 0
     ? filters.types
     : Object.values(ActivityType);
 
+  // Notifications and time entries are personal; never expose them when viewing
+  // another user's activities.
+  if (viewingOther) {
+    typesToFetch = typesToFetch.filter(
+      (type) => type !== ActivityType.NOTIFICATION && type !== ActivityType.TIME_ENTRY
+    );
+  }
+
   if (typesToFetch.includes(ActivityType.SCHEDULE)) {
-    promises.push(fetchScheduleActivities(user.user_id, tenantId, filters));
+    promises.push(fetchScheduleActivities(effectiveUserId, tenantId, filters));
   }
 
   if (typesToFetch.includes(ActivityType.PROJECT_TASK)) {
-    promises.push(fetchProjectActivities(user.user_id, tenantId, filters));
+    promises.push(fetchProjectActivities(effectiveUserId, tenantId, filters));
   }
 
   if (typesToFetch.includes(ActivityType.TICKET)) {
-    promises.push(fetchTicketActivities(user.user_id, tenantId, filters));
+    promises.push(fetchTicketActivities(effectiveUserId, tenantId, filters));
   }
 
   if (typesToFetch.includes(ActivityType.TIME_ENTRY)) {
-    promises.push(fetchTimeEntryActivities(user.user_id, tenantId, filters));
+    promises.push(fetchTimeEntryActivities(effectiveUserId, tenantId, filters));
   }
 
   if (typesToFetch.includes(ActivityType.WORKFLOW_TASK)) {
-    promises.push(fetchWorkflowTaskActivities(user.user_id, tenantId, filters));
+    promises.push(fetchWorkflowTaskActivities(effectiveUserId, tenantId, filters));
   }
 
   if (typesToFetch.includes(ActivityType.NOTIFICATION)) {
-    promises.push(fetchNotificationActivities(user.user_id, tenantId, filters));
+    promises.push(fetchNotificationActivities(effectiveUserId, tenantId, filters));
   }
 
   // Wait for all fetches to complete
@@ -209,12 +254,12 @@ export const fetchUserActivities = withAuth(async (
     pageNumber: page
   };
 
-  // Update cache key to include pagination
-  const cacheKey = `user-activities:${user.user_id}:${JSON.stringify(filters)}:page${page}:size${pageSize}`;
-  
+  // Update cache key to include pagination (keyed on whose activities these are)
+  const cacheKey = `user-activities:${effectiveUserId}:${JSON.stringify(filters)}:page${page}:size${pageSize}`;
+
   // Create tags for cache invalidation
   const tags = [
-    `user:${user.user_id}`,
+    `user:${effectiveUserId}`,
     ...typesToFetch.map(type => `type:${type}`)
   ];
   

--- a/ee/packages/workflows/src/actions/activity-actions/activityServerActions.ts
+++ b/ee/packages/workflows/src/actions/activity-actions/activityServerActions.ts
@@ -12,6 +12,7 @@ import {
   WorkflowTaskActivity,
   NotificationActivity,
   scheduleEntryToActivity,
+  IUser,
   IUserWithRoles
 } from "@alga-psa/types";
 import type { Knex } from "knex";
@@ -406,8 +407,12 @@ export const createAdHocActivity = withAuth(async (
 });
 
 /**
- * Ensure the caller may modify the given ad-hoc entry: they must be an assignee,
- * or hold user_schedule:update to act on another user's entries.
+ * Ensure the caller may modify the given ad-hoc entry: they must be an assignee, or
+ * hold the "view/manage other users' schedule" capability (user_schedule:update or
+ * user_schedule:read_all) to act on another user's entries. This mirrors the gate used
+ * to view another user's activities, so a manager who can see a report's ad-hoc to-do
+ * can also mark it done or convert it (creating the ticket/task is separately gated by
+ * the relevant ticket:create / project_task:create permission).
  */
 async function assertCanModifyAdHoc(
   trx: Knex.Transaction,
@@ -419,8 +424,11 @@ async function assertCanModifyAdHoc(
     .where({ tenant, entry_id: entryId, user_id: user.user_id })
     .first();
   if (!isAssignee) {
-    const canManageOthers = await hasPermission(user, "user_schedule", "update", trx);
-    if (!canManageOthers) {
+    const [canUpdate, canReadAll] = await Promise.all([
+      hasPermission(user, "user_schedule", "update", trx),
+      hasPermission(user, "user_schedule", "read_all", trx),
+    ]);
+    if (!canUpdate && !canReadAll) {
       throw new Error("Permission denied: cannot modify another user's ad-hoc item");
     }
   }
@@ -600,4 +608,53 @@ export const deleteAdHocActivity = withAuth(async (
   });
 
   revalidatePath("/msp/user-activities");
+});
+
+export interface ActivityViewableUsersResult {
+  /** Whether the caller may view other users' activities at all. */
+  canViewOthers: boolean;
+  /** Internal users (excluding the caller) whose activities may be viewed. */
+  users: IUser[];
+}
+
+/**
+ * List the internal users whose activities the caller may view, and whether the caller has
+ * that capability at all. Gated by the same permission the schedule calendar uses to view
+ * other users' calendars (user_schedule:update or user_schedule:read_all). When the caller
+ * lacks it, returns canViewOthers=false and an empty list so the UI can hide the selector.
+ *
+ * Returns IUser-shaped rows (safe columns only) so the UI can render them with UserPicker,
+ * including avatars.
+ */
+export const getActivityViewableUsers = withAuth(async (
+  user,
+  { tenant }
+): Promise<ActivityViewableUsersResult> => {
+  const { knex } = await createTenantKnex(tenant);
+
+  const [canUpdate, canReadAll] = await Promise.all([
+    hasPermission(user, "user_schedule", "update", knex),
+    hasPermission(user, "user_schedule", "read_all", knex),
+  ]);
+  if (!canUpdate && !canReadAll) {
+    return { canViewOthers: false, users: [] };
+  }
+
+  // Select only non-sensitive columns (never hashed_password / two_factor_secret).
+  const rows = await knex("users")
+    .where({ tenant, user_type: "internal", is_inactive: false })
+    .whereNot({ user_id: user.user_id })
+    .orderBy([{ column: "first_name" }, { column: "last_name" }])
+    .select(
+      "user_id",
+      "first_name",
+      "last_name",
+      "email",
+      "username",
+      "user_type",
+      "is_inactive",
+      "tenant"
+    );
+
+  return { canViewOthers: true, users: rows as IUser[] };
 });

--- a/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
+++ b/ee/packages/workflows/src/components/user-activities/ActivitiesDataTableSection.tsx
@@ -12,6 +12,7 @@ import {
   IStatus,
   ITag,
   ItemType,
+  IUser,
   ProjectWithPhases,
   TaggedEntityType,
 } from '@alga-psa/types';
@@ -27,8 +28,17 @@ import { ShareActionsMenu, type ShareAction } from '@alga-psa/ui/components/Shar
 import { RefreshCw, List, LayoutList, Printer, Settings2 } from 'lucide-react';
 import ViewSwitcher, { ViewSwitcherOption } from '@alga-psa/ui/components/ViewSwitcher';
 import './userActivitiesPrint.css';
-import { fetchActivities, getUserActivityGroups, createAdHocActivity, type ActivityGroup } from '@alga-psa/workflows/actions';
+import {
+  fetchActivities,
+  getUserActivityGroups,
+  createAdHocActivity,
+  getActivityViewableUsers,
+  type ActivityGroup,
+} from '@alga-psa/workflows/actions';
+import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
 import { Input } from '@alga-psa/ui/components/Input';
+import { Label } from '@alga-psa/ui/components/Label';
+import UserPicker from '@alga-psa/ui/components/UserPicker';
 import { Plus } from 'lucide-react';
 import { ActivitiesDataTable } from './ActivitiesDataTable';
 import { GroupedActivitiesView } from './GroupedActivitiesView';
@@ -111,6 +121,29 @@ function formatActivityPrintDate(dateString?: string): string {
   const [isAddingAdHoc, setIsAddingAdHoc] = useState(false);
   const { openActivityDrawer } = useActivityDrawer();
   const ctx = useActivityCrossFeature();
+
+  // "Viewing": whose activities to show. Empty string = the current user. Other values
+  // require the caller to hold the schedule "view others" permission (resolved server-side).
+  const [targetUserId, setTargetUserId] = useState<string>('');
+  const [viewableUsers, setViewableUsers] = useState<IUser[]>([]);
+  const [canViewOthers, setCanViewOthers] = useState(false);
+
+  // Load the users whose activities this user may view (empty/forbidden → selector hidden).
+  useEffect(() => {
+    let cancelled = false;
+    getActivityViewableUsers()
+      .then((result) => {
+        if (cancelled) return;
+        setCanViewOthers(result.canViewOthers);
+        setViewableUsers(result.users);
+      })
+      .catch((err) => console.error('Error loading viewable users:', err));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const viewingOther = canViewOthers && targetUserId !== '';
 
   // Flat vs grouped mode (persisted per user)
   const { value: listViewMode, setValue: setListViewMode } = useUserPreference<ListViewMode>(
@@ -295,7 +328,8 @@ function formatActivityPrintDate(dateString?: string): string {
       : Object.values(ActivityType),
     sortBy,
     sortDirection,
-  }), [filters, sortBy, sortDirection]);
+    targetUserId: targetUserId || undefined,
+  }), [filters, sortBy, sortDirection, targetUserId]);
 
   const loadActivities = useCallback(async () => {
     try {
@@ -357,6 +391,11 @@ function formatActivityPrintDate(dateString?: string): string {
     setSavedFilters(newFilters);
     setCurrentPage(1);
   }, [setSavedFilters]);
+
+  const handleTargetUserChange = useCallback((value: string) => {
+    setTargetUserId(value);
+    setCurrentPage(1);
+  }, []);
 
   const preparePrintActivities = useCallback(async () => {
     if (listViewMode === 'grouped') {
@@ -489,32 +528,57 @@ function formatActivityPrintDate(dateString?: string): string {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="mb-4 flex items-center gap-2">
-          <Input
-            id={`${id}-add-adhoc-input`}
-            value={adHocTitle}
-            onChange={(e) => setAdHocTitle(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                void handleAddAdHoc();
-              }
-            }}
-            placeholder={t('table.adHoc.addPlaceholder', { defaultValue: 'Add Activity' })}
-            className="h-9 max-w-sm text-sm"
-            disabled={isAddingAdHoc}
-          />
-          <Button
-            id={`${id}-add-adhoc-button`}
-            variant="default"
-            size="sm"
-            onClick={() => void handleAddAdHoc()}
-            disabled={isAddingAdHoc || adHocTitle.trim().length === 0}
-          >
-            <Plus className="h-4 w-4 mr-1" />
-            {t('table.adHoc.addButton', { defaultValue: 'Add' })}
-          </Button>
-        </div>
+        {(canViewOthers || !viewingOther) && (
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            {!viewingOther && (
+              <>
+                <Input
+                  id={`${id}-add-adhoc-input`}
+                  value={adHocTitle}
+                  onChange={(e) => setAdHocTitle(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void handleAddAdHoc();
+                    }
+                  }}
+                  placeholder={t('table.adHoc.addPlaceholder', { defaultValue: 'Add Activity' })}
+                  className="h-9 max-w-sm text-sm"
+                  disabled={isAddingAdHoc}
+                />
+                <Button
+                  id={`${id}-add-adhoc-button`}
+                  variant="default"
+                  size="sm"
+                  onClick={() => void handleAddAdHoc()}
+                  disabled={isAddingAdHoc || adHocTitle.trim().length === 0}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  {t('table.adHoc.addButton', { defaultValue: 'Add' })}
+                </Button>
+              </>
+            )}
+            {canViewOthers && (
+              <div className="ml-auto flex items-center gap-2">
+                <Label htmlFor={`${id}-viewing-user`} className="text-sm font-medium whitespace-nowrap mb-0">
+                  {t('table.viewingUser.label', { defaultValue: 'Viewing:' })}
+                </Label>
+                <UserPicker
+                  id={`${id}-viewing-user`}
+                  value={targetUserId}
+                  onValueChange={handleTargetUserChange}
+                  users={viewableUsers}
+                  getUserAvatarUrlsBatch={getUserAvatarUrlsBatchAction}
+                  userTypeFilter="internal"
+                  placeholder={t('table.viewingUser.me', { defaultValue: 'My activities' })}
+                  unassignedLabel={t('table.viewingUser.me', { defaultValue: 'My activities' })}
+                  buttonWidth="fit"
+                  size="sm"
+                />
+              </div>
+            )}
+          </div>
+        )}
         <ActivitiesTableFilters
           filters={filters}
           onChange={handleFilterChange}

--- a/packages/types/src/interfaces/activity.interfaces.ts
+++ b/packages/types/src/interfaces/activity.interfaces.ts
@@ -242,6 +242,12 @@ export interface ActivityFilters {
   sortBy?: ActivitySortBy;
   /** Sort direction for the sortBy column. Defaults to 'asc'. */
   sortDirection?: 'asc' | 'desc';
+  /**
+   * View another user's activities instead of the caller's own. Requires the caller to
+   * hold user_schedule:update or user_schedule:read_all (the same gate the schedule
+   * calendar uses to view other users' calendars). Ignored when equal to the caller.
+   */
+  targetUserId?: string;
 }
 
 /**

--- a/packages/ui/src/components/UserPicker.tsx
+++ b/packages/ui/src/components/UserPicker.tsx
@@ -31,6 +31,8 @@ interface UserPickerProps {
   labelStyle?: 'bold' | 'medium' | 'normal' | 'none';
   buttonWidth?: 'fit' | 'full';
   placeholder?: string;
+  /** Label for the "clear selection" option (value=''). Defaults to 'Not assigned'. */
+  unassignedLabel?: string;
   userTypeFilter?: string | string[] | null; // null means no filtering, string/array for specific types
   modal?: boolean;
 }
@@ -78,6 +80,7 @@ const UserPicker = ({
   labelStyle = 'bold',
   buttonWidth = 'fit',
   placeholder = 'Not assigned',
+  unassignedLabel = 'Not assigned',
   userTypeFilter = 'internal',
   modal = true,
   'data-automation-id': dataAutomationId,
@@ -276,6 +279,16 @@ const UserPicker = ({
 
     const dropdownWidth = Math.max(buttonRect.width, 220);
 
+    // Clamp horizontally so a trigger near the right edge doesn't open a dropdown that
+    // overflows (and gets clipped) off-screen. Anchor to the trigger's left, but shift
+    // left as needed to keep the menu fully within the viewport.
+    const viewportWidth = window.innerWidth;
+    const edgeMargin = 8;
+    let left = buttonRect.left;
+    if (left + dropdownWidth > viewportWidth - edgeMargin) {
+      left = Math.max(edgeMargin, viewportWidth - edgeMargin - dropdownWidth);
+    }
+
     // More aggressive check for limited space below
     // If there's less than 250px below or the dropdown would be cut off, position it above
     if (spaceBelow < 250 || spaceBelow < estimatedDropdownHeight) {
@@ -284,14 +297,14 @@ const UserPicker = ({
         setDropdownPosition('top');
         setDropdownCoords({
           top: buttonRect.top - 2,
-          left: buttonRect.left,
+          left,
           width: dropdownWidth
         });
       } else {
         setDropdownPosition('bottom');
         setDropdownCoords({
           top: buttonRect.bottom + 2,
-          left: buttonRect.left,
+          left,
           width: dropdownWidth
         });
       }
@@ -299,7 +312,7 @@ const UserPicker = ({
       setDropdownPosition('bottom');
       setDropdownCoords({
         top: buttonRect.bottom + 2,
-        left: buttonRect.left,
+        left,
         width: dropdownWidth
       });
     }
@@ -382,15 +395,15 @@ const UserPicker = ({
             e.stopPropagation();
           }}
         >
-          {/* Not assigned option */}
+          {/* Not assigned / clear option */}
           <OptionButton
             id={`${pickerId}-option-unassigned`}
-            label="Not assigned"
+            label={unassignedLabel}
             onClick={() => handleSelectUser('unassigned')}
             className="relative flex items-center px-3 py-2 text-sm rounded text-gray-900 cursor-pointer hover:bg-gray-100 focus:bg-gray-100"
             parentId={pickerId}
           >
-            Not assigned
+            {unassignedLabel}
           </OptionButton>
 
           {/* User options */}

--- a/server/public/locales/de/msp/user-activities.json
+++ b/server/public/locales/de/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Als nicht erledigt markieren",
       "convertToTicket": "In Ticket umwandeln",
       "convertToTask": "In Projektaufgabe umwandeln"
+    },
+    "viewingUser": {
+      "label": "Anzeigen:",
+      "me": "Meine Aktivitäten"
     }
   },
   "card": {

--- a/server/public/locales/en/msp/user-activities.json
+++ b/server/public/locales/en/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Mark as not done",
       "convertToTicket": "Convert to ticket",
       "convertToTask": "Convert to project task"
+    },
+    "viewingUser": {
+      "label": "Viewing:",
+      "me": "My activities"
     }
   },
   "card": {

--- a/server/public/locales/es/msp/user-activities.json
+++ b/server/public/locales/es/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Marcar como no hecho",
       "convertToTicket": "Convertir en ticket",
       "convertToTask": "Convertir en tarea de proyecto"
+    },
+    "viewingUser": {
+      "label": "Viendo:",
+      "me": "Mis actividades"
     }
   },
   "card": {

--- a/server/public/locales/fr/msp/user-activities.json
+++ b/server/public/locales/fr/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Marquer comme non terminé",
       "convertToTicket": "Convertir en ticket",
       "convertToTask": "Convertir en tâche de projet"
+    },
+    "viewingUser": {
+      "label": "Affichage :",
+      "me": "Mes activités"
     }
   },
   "card": {

--- a/server/public/locales/it/msp/user-activities.json
+++ b/server/public/locales/it/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Segna come non completato",
       "convertToTicket": "Converti in ticket",
       "convertToTask": "Converti in attività di progetto"
+    },
+    "viewingUser": {
+      "label": "Visualizzazione:",
+      "me": "Le mie attività"
     }
   },
   "card": {

--- a/server/public/locales/nl/msp/user-activities.json
+++ b/server/public/locales/nl/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Markeren als niet voltooid",
       "convertToTicket": "Omzetten naar ticket",
       "convertToTask": "Omzetten naar projecttaak"
+    },
+    "viewingUser": {
+      "label": "Weergeven:",
+      "me": "Mijn activiteiten"
     }
   },
   "card": {

--- a/server/public/locales/pl/msp/user-activities.json
+++ b/server/public/locales/pl/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Oznacz jako nieukończone",
       "convertToTicket": "Konwertuj na zgłoszenie",
       "convertToTask": "Konwertuj na zadanie projektu"
+    },
+    "viewingUser": {
+      "label": "Wyświetlanie:",
+      "me": "Moje aktywności"
     }
   },
   "card": {

--- a/server/public/locales/pt/msp/user-activities.json
+++ b/server/public/locales/pt/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "Marcar como não concluído",
       "convertToTicket": "Converter em ticket",
       "convertToTask": "Converter em tarefa de projeto"
+    },
+    "viewingUser": {
+      "label": "Visualizando:",
+      "me": "Minhas atividades"
     }
   },
   "card": {

--- a/server/public/locales/xx/msp/user-activities.json
+++ b/server/public/locales/xx/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "11111",
       "convertToTicket": "11111",
       "convertToTask": "11111"
+    },
+    "viewingUser": {
+      "label": "11111",
+      "me": "11111"
     }
   },
   "card": {

--- a/server/public/locales/yy/msp/user-activities.json
+++ b/server/public/locales/yy/msp/user-activities.json
@@ -70,6 +70,10 @@
       "markNotDone": "55555",
       "convertToTicket": "55555",
       "convertToTask": "55555"
+    },
+    "viewingUser": {
+      "label": "55555",
+      "me": "55555"
     }
   },
   "card": {

--- a/server/src/interfaces/activity.interfaces.ts
+++ b/server/src/interfaces/activity.interfaces.ts
@@ -192,6 +192,8 @@ export interface ActivityFilters {
   workItemType?: string;
   executionId?: string;
   includeHidden?: boolean;
+  /** View another user's activities (requires user_schedule:update or user_schedule:read_all). */
+  targetUserId?: string;
 }
 
 /**


### PR DESCRIPTION
  Let a permitted manager/PM switch the User Activities table from their
  own activities to another internal user's, gated by the same permission
  the schedule calendar uses to view other users' calendars
  (user_schedule:update or user_schedule:read_all):

  - ActivityFilters gains targetUserId; fetchUserActivities resolves the effective user, enforces the gate, strips personal notifications/time entries, and keys its cache per viewed user.
  - assertCanModifyAdHoc also accepts read_all, so a viewer with ticket/project_task create rights can convert someone else's ad-hoc to-do; new getActivityViewableUsers() feeds the picker.
  - Swap the toolbar selector to UserPicker (avatars + search), inline on the right; add an unassignedLabel prop ("My activities") and clamp the dropdown horizontally so a flush-right trigger no longer clips.
  - Add table.viewingUser locale keys across all languages.

  And so, like the Cheshire Cat grinning down from another bough, a manager
  may now peer at a colleague's whole list of to-dos — yet should they
  reach to pluck one down the rabbit hole into a proper ticket, the old
  guards at the gate still demand the right papers before the card-painters
  let them pass. 🐈🍄🎩