### PR TITLE
docs: reflect Improvement/workflows mapping (#2633)

### DIFF
--- a/docs/workflow/workflow-system.md
+++ b/docs/workflow/workflow-system.md
@@ -114,6 +114,8 @@ The workflow system uses several database tables to store its data:
 
 11. **system_workflow_form_definitions**: Stores definitions for system-wide, reusable UI forms. These are referenced by task definitions. Key fields include `name` (unique identifier for the form), `json_schema` (defines the data structure and properties of the form), and `ui_schema` (provides hints for rendering the form).
 12. **workflow_form_definitions**: Stores tenant-specific UI form definitions, mirroring the structure of `system_workflow_form_definitions`.
+13. **workflow_data_store**: A cross-run key-value store scoped by `(tenant, namespace, key)`. Values are stored as JSON, support an optional TTL (lazily expired on read and periodically swept), and carry a revision counter for optimistic concurrency. Accessed via `store.*` workflow actions (`store.get`, `store.set`, `store.delete`, `store.increment`, `store.list`, `store.list_namespaces`).
+14. **workflow_entity_links**: Stores typed bidirectional links between two entities (identified by entity type + ID pairs). Supports forward, reverse, and bidirectional traversal. Accessed via `links.*` workflow actions (`links.upsert`, `links.lookup`, `links.delete`, `links.list`, `links.list_namespaces`).
 
 ### Human Task Forms and Dynamic Data Display
 


### PR DESCRIPTION
## Source PRs

| # | Title | Link |
| --- | --- | --- |
| #2633 | Improvement/workflows mapping | https://github.com/Nine-Minds/alga-psa/pull/2633 |

## Files changed

| File | Rationale |
| --- | --- |
| `docs/workflow/workflow-system.md` | Add items 13 (`workflow_data_store`) and 14 (`workflow_entity_links`) to the Persistence Model list, reflecting the new cross-run KV store and entity-link mapping tables introduced by migration `20260604120000_create_workflow_data_store_tables.cjs` in PR #2633. |

## Needs human review

- **TTL sweep interval**: The periodic sweep frequency for expired `workflow_data_store` entries was not confirmed from source; if there is a configured interval (e.g. a cron job), consider adding it to the description of item 13.
- **`links.*` directionality semantics**: The forward/reverse/bidirectional traversal terminology was inferred from PR context; verify against `workflowEntityLinkModel.ts` if exact API semantics matter for this doc level.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AQj6FvFgABpx2b4otVBSZf)_