### PR TITLE
fix(migrations): force Citus sequential mode in drop_billing_method_from_service_types

### DIFF
--- a/server/migrations/20260519120000_drop_billing_method_from_service_types.cjs
+++ b/server/migrations/20260519120000_drop_billing_method_from_service_types.cjs
@@ -9,11 +9,23 @@
  * (and its own `billing_method`) is intentionally left untouched.
  *
  * Citus note: `service_types` is distributed and `standard_service_types`
- * is a reference table; `ALTER TABLE ... DROP COLUMN` is propagated to all
- * nodes/shards automatically, so no Citus-specific migration is required.
+ * is a reference table. DDL on the distributed table opens parallel
+ * connections to all shards, after which Citus refuses further DDL on
+ * another Citus table in the same transaction ("parallel DDL access").
+ * We must force sequential multi-shard modification first so the
+ * distributed + reference DDL can share one transaction.
  */
 
+const isCitusEnabled = async (knex) => {
+  const r = await knex.raw("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'citus') AS enabled");
+  return Boolean(r.rows?.[0]?.enabled);
+};
+
 exports.up = async function (knex) {
+  if (await isCitusEnabled(knex)) {
+    await knex.raw("SET LOCAL citus.multi_shard_modify_mode TO 'sequential'");
+  }
+
   await knex.raw('ALTER TABLE service_types DROP CONSTRAINT IF EXISTS billing_method_check');
   await knex.raw('ALTER TABLE service_types DROP CONSTRAINT IF EXISTS service_types_billing_method_check');
   await knex.raw('ALTER TABLE service_types DROP COLUMN IF EXISTS billing_method');
@@ -24,6 +36,10 @@ exports.up = async function (knex) {
 };
 
 exports.down = async function (knex) {
+  if (await isCitusEnabled(knex)) {
+    await knex.raw("SET LOCAL citus.multi_shard_modify_mode TO 'sequential'");
+  }
+
   // Best-effort restore only. The original per-row values are not recoverable;
   // re-add as nullable TEXT and backfill a neutral default.
   await knex.raw('ALTER TABLE standard_service_types ADD COLUMN IF NOT EXISTS billing_method TEXT');


### PR DESCRIPTION
## Problem

Running migrations against the staging CitusDB cluster failed:

```
migration failed with error: ALTER TABLE standard_service_types DROP CONSTRAINT IF EXISTS billing_method_check
  - cannot execute DDL on table "standard_service_types" because there was a parallel DDL access
    to distributed table "service_types" in the same transaction
```

## Root cause

`server/migrations/20260519120000_drop_billing_method_from_service_types.cjs` runs inside a single Knex transaction and mixes DDL on two Citus table classes:

- `service_types` — **distributed**: DDL fans out over parallel connections to every shard.
- `standard_service_types` — **reference**.

Once Citus opens the parallel shard connections for the distributed-table DDL, it refuses any further DDL on another Citus table in the same transaction — producing the error above. The migration's original comment incorrectly claimed no Citus-specific handling was required.

## Fix

Force the transaction into sequential multi-shard mode before the distributed-table DDL, gated on the `citus` extension being present (so plain-Postgres dev/CI is unaffected):

```js
if (await isCitusEnabled(knex)) {
  await knex.raw("SET LOCAL citus.multi_shard_modify_mode TO 'sequential'");
}
```

Applied to both `up` and `down`. This matches the established pattern already used across ~25 existing migrations (e.g. `20251031121500_remove_qbo_workflow_automation.cjs`). The actual DDL statements are unchanged; the stale comment was corrected.

## Notes

- Uses `SET LOCAL` because this migration keeps Knex's default per-migration transaction.
- Older billing migrations that also touch both tables already applied on staging before this one, so they don't need the change now.
- The failed run rolled back its transaction, so no partial state should remain; the migration is safe to re-run.