### PR TITLE
fix(billing): bill hourly time entries in fractional hours, not whole-hour ceiling

### DIFF
--- a/packages/billing/src/lib/billing/billingEngine.ts
+++ b/packages/billing/src/lib/billing/billingEngine.ts
@@ -1192,7 +1192,10 @@ export class BillingEngine {
           largestUnit: "minutes",
         }).minutes,
       );
-      const duration = Math.ceil(durationMinutes / 60);
+      // Bill the actual elapsed hours. Unresolved (non-contract) entries have no
+      // contract-line rounding config, so fall back to exact time rather than
+      // Math.ceil to a whole hour, which overbilled every partial-hour entry.
+      const duration = durationMinutes / 60;
       const rate = Math.ceil(entry.custom_rate ?? entry.default_rate ?? 0);
       const total = Math.round(duration * rate);
       const { taxRegion: serviceTaxRegion, isTaxable } =
@@ -3268,8 +3271,14 @@ export class BillingEngine {
           }
         }
 
-        // Convert to hours
-        const duration = Math.ceil(durationMinutes / 60);
+        // Convert to hours. Bill the fractional hours that remain after the
+        // minimum-billable-time and round-up-to-nearest rules above. Previously
+        // this used Math.ceil(durationMinutes / 60), which forced every entry up
+        // to a whole hour and silently overrode the configured rounding
+        // increment (e.g. a 4h10m entry on a 15-minute increment was rounded to
+        // 4h15m and then ceiled to 5h). The rate is per hour, so the quantity
+        // must carry the partial hour.
+        const duration = durationMinutes / 60;
 
         // Resolve rate, preferring overrides over the currency-specific catalog price.
         // Order: per-entry custom rate → per-user-type rate (contract-line config) → service_prices

--- a/server/src/test/unit/billingEngine.test.ts
+++ b/server/src/test/unit/billingEngine.test.ts
@@ -1297,6 +1297,65 @@ describe('BillingEngine', () => {
         expect(timeEntriesBuilder.where).toHaveBeenCalled();
       });
 
+      it('bills fractional hours for partial-hour entries instead of rounding up to a whole hour', async () => {
+        // Regression for the hourly over-billing bug: a 2h15m entry must bill
+        // 2.25h, not a whole-hour Math.ceil to 3h. The hourly rate is per hour,
+        // so the partial hour has to be carried into the quantity/total.
+        const mockTimeEntries = [
+          {
+            entry_id: 'entry-partial-hour',
+            work_item_id: 'service1',
+            service_id: 'service1',
+            service_name: 'Service 1',
+            user_id: 'user1',
+            start_time: new Date('2023-01-01T10:00:00.000Z'),
+            end_time: new Date('2023-01-01T12:15:00.000Z'), // 135 minutes = 2.25 hours
+            user_rate: null,
+            default_rate: 120,
+            currency_rate: 120,
+            tax_rate_id: null,
+            contract_line_id: 'contract_line_1',
+          },
+        ];
+
+        const baseKnex = (billingEngine as any).knex;
+        const timeEntriesBuilder = buildChainableQuery();
+        timeEntriesBuilder.select.mockImplementation(() => {
+          timeEntriesBuilder.__setResolveValue(
+            mockTimeEntries.filter(
+              (entry) => entry.contract_line_id === 'contract_line_1'
+            )
+          );
+          return timeEntriesBuilder;
+        });
+
+        const contractLineBuilder = buildChainableQuery({
+          selectResult: [],
+          firstResult: { contract_line_id: 'test_contract_line_id', contract_line_type: 'Bucket' },
+          thenResult: []
+        });
+
+        (billingEngine as any).knex = vi.fn((table: string) => {
+          if (table === 'time_entries') return timeEntriesBuilder;
+          if (table === 'contract_lines') return contractLineBuilder;
+          return baseKnex(table);
+        });
+        (billingEngine as any).knex.raw = baseKnex.raw;
+
+        const result = await (billingEngine as any).calculateTimeBasedCharges(
+          mockClientId,
+          { startDate: mockStartDate, endDate: mockEndDate },
+          { service_category: 'test_category', contract_line_id: 'test_contract_line_id', client_contract_line_id: 'contract_line_1' }
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].duration).toBeCloseTo(2.25, 5);
+        expect(result[0].total).toBe(270); // 2.25h * 120/hr
+        // Must NOT round each entry up to a whole hour.
+        expect(result[0].duration).not.toBe(3);
+        expect(result[0].total).not.toBe(360);
+      });
+
       it('T032: unassigned time entry with a single eligible service-line match is allocated once', async () => {
         const baseKnex = (billingEngine as any).knex;
         const timeEntriesBuilder = buildChainableQuery({


### PR DESCRIPTION
## Bug

Hourly time-based billing rounds **every time entry up to a whole hour**, silently overriding the contract line's configured rounding increment (e.g. `round_up_to_nearest = 15` minutes). The hourly rate is per hour, so the partial hour must be carried into the billed quantity — instead it was discarded by a `Math.ceil`.

### Root cause

In `packages/billing/src/lib/billing/billingEngine.ts`, both hourly paths converted minutes to hours with:

```ts
const duration = Math.ceil(durationMinutes / 60);
```

- **Contract-line path** (`calculateTimeBasedCharges`): correctly applied `minimum_billable_time` and `round_up_to_nearest` first, then the `Math.ceil(.../60)` re-rounded the result up to a full hour. A 4h10m entry on a 15-minute increment became 4h15m (255 min) and was then ceiled to **5h**.
- **Unresolved / non-contract path** (`calculateUnresolvedNonContractCharges`): no rounding config at all — just `Math.ceil` to a whole hour. A 1-minute entry billed as a full hour.

Because `quantity` is always coerced to a whole number, every partial-hour entry overbills by up to ~59 minutes.

### Observed impact (motivating case: INV001042)

A draft recurring invoice billed **59 hours** when the underlying time entries totalled **52.67 actual hours** — each of 13 entries was ceiled to the next whole hour:

| | hours | @ $150 |
|---|---|---|
| Actual billable time | 52.67 | $7,900 |
| Whole-hour ceiling (bug) | **59.00** | **$8,850** |
| Overcharge | +6.33 | +$950 |

## Fix

### 1. Engine — bill fractional hours
Bill the fractional hours that remain after the min/round-up rules:

```ts
const duration = durationMinutes / 60;
```

Applied to **both** hourly paths. `net_amount` / `total_price` are taken from the engine's computed `total` (`Math.round(duration * rate)`), so the billed cents are exact; with a 15-minute increment every quantity is a clean multiple of `0.25` and `quantity * unit_price == total`.

### 2. Schema — allow fractional quantity on the detail table
`invoice_charges.quantity` and the `invoice_items` view were already `numeric(10,2)` (migration `20250225165701`), but persisting the fractional quantity then failed with:

```
invalid input syntax for type integer: "4.25"
```

…because `invoice_charge_details.quantity` (the recurring service-period breakdown row, renamed from `invoice_item_details`) was still `integer` and had been missed by that earlier migration. New migration `20260606120000_invoice_charge_details_quantity_to_decimal.cjs` converts it to `numeric(10,2)` (Citus-safe: forces sequential multi-shard modify mode, matching the existing billing-DDL pattern). `rate` stays `integer` — it stores whole cents.

> The migration must deploy together with the code change.

## Testing

- Added a regression unit test in `server/src/test/unit/billingEngine.test.ts`: a 2h15m entry now bills `2.25h` (`$270` @ $150/hr), and explicitly **not** `3h` / `$360`.
- `npx vitest run src/test/unit/billingEngine.test.ts` → **28 passed**.
- Migration parses and exports up/down; core DDL is standard `ALTER COLUMN ... TYPE numeric(10,2)`. Recommend a staging run + invoice-generation smoke test before production deploy (no local Citus available to exercise the distributed ALTER here).

## Notes / follow-up (not in this PR)

- Existing invoices generated before this fix (e.g. INV001042) were computed with the old logic; this change only affects newly generated charges. Re-generation/correction of affected drafts is a separate cleanup.
- Several entries on INV001042 were also pulled from a timesheet whose period didn't contain them (a separate, already-fixed data-integrity issue) — worth fixing those entries' dates before regenerating.
