### PR TITLE
fix(billing): widen invoice_charge_details.quantity to numeric(10,2)

### DIFF
--- a/server/migrations/20260606120000_invoice_charge_details_quantity_to_decimal.cjs
+++ b/server/migrations/20260606120000_invoice_charge_details_quantity_to_decimal.cjs
@@ -1,0 +1,43 @@
+/**
+ * Widen invoice_charge_details.quantity from integer to numeric(10,2).
+ *
+ * Hourly time charges now bill fractional hours (e.g. 4.25h) instead of
+ * rounding each time entry up to a whole hour. invoice_charges.quantity and the
+ * invoice_items view were already numeric(10,2) (migration 20250225165701), but
+ * the detail/breakdown table — formerly invoice_item_details, renamed to
+ * invoice_charge_details — was missed and still rejected fractional quantities
+ * with `invalid input syntax for type integer: "4.25"` when persisting the
+ * recurring service-period detail row.
+ *
+ * `rate` on this table stays integer: it stores whole cents.
+ *
+ * Citus note: invoice_charge_details is a distributed table. Force sequential
+ * multi-shard modification first so the type change applies cleanly across all
+ * shards within the migration transaction.
+ */
+
+const isCitusEnabled = async (knex) => {
+  const r = await knex.raw("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'citus') AS enabled");
+  return Boolean(r.rows?.[0]?.enabled);
+};
+
+exports.up = async function (knex) {
+  if (await isCitusEnabled(knex)) {
+    await knex.raw("SET LOCAL citus.multi_shard_modify_mode TO 'sequential'");
+  }
+
+  await knex.raw(
+    'ALTER TABLE invoice_charge_details ALTER COLUMN quantity TYPE numeric(10,2) USING quantity::numeric(10,2)'
+  );
+};
+
+exports.down = async function (knex) {
+  if (await isCitusEnabled(knex)) {
+    await knex.raw("SET LOCAL citus.multi_shard_modify_mode TO 'sequential'");
+  }
+
+  // Best-effort revert: fractional quantities are rounded back to whole units.
+  await knex.raw(
+    'ALTER TABLE invoice_charge_details ALTER COLUMN quantity TYPE integer USING round(quantity)::integer'
+  );
+};


### PR DESCRIPTION
## Follow-up to #2641

#2641 made hourly time charges bill **fractional hours** (e.g. `4.25h`) instead of rounding each entry up to a whole hour. That change is merged, but generating an invoice now fails when persisting the recurring service-period detail row:

```
invalid input syntax for type integer: "4.25"
```

## Root cause

`invoice_charges.quantity` and the `invoice_items` view are already `numeric(10,2)` (migration `20250225165701`), but the detail/breakdown table — `invoice_charge_details` (renamed from `invoice_item_details`) — was missed by that migration and is still `integer`, so it rejects fractional quantities.

This is the only remaining integer `quantity` sink (verified by sweeping every `invoice%` table's `quantity`/`rate` columns).

## Fix

New migration `20260606120000_invoice_charge_details_quantity_to_decimal.cjs` converts `invoice_charge_details.quantity` to `numeric(10,2)`.

- `rate` stays `integer` — it stores whole cents.
- Citus-safe: forces `citus.multi_shard_modify_mode = sequential` before the `ALTER`, matching the existing billing-DDL pattern in `20260519120000_drop_billing_method_from_service_types.cjs`.

## Testing

- Migration parses and exports `up`/`down`; core DDL is a standard `ALTER COLUMN ... TYPE numeric(10,2)`.
- No local Citus available to exercise the distributed `ALTER` here — please let it run in **staging** and do one invoice-generation smoke test (the fractional-hour path from #2641) before production deploy.

## Note

Without this, the fractional-hours fix from #2641 cannot persist an invoice. Ship this before (or with) the next deploy.
