### PR TITLE
fix(billing): render fractional invoice quantities instead of rounding to whole units

### DIFF
--- a/packages/billing/src/models/invoice.ts
+++ b/packages/billing/src/models/invoice.ts
@@ -312,6 +312,22 @@ const Invoice = {
       }
       return 0;
     };
+    // Quantities are not minor units — they can be fractional (e.g. 4.25 hours
+    // for hourly time charges), so parse them as decimals instead of truncating
+    // to whole integers the way parseMinorUnit does for cents.
+    const parseDecimal = (value: unknown): number => {
+      if (typeof value === 'number') {
+        return value;
+      }
+      if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value);
+        return Number.isNaN(parsed) ? 0 : parsed;
+      }
+      if (typeof value === 'bigint') {
+        return Number(value);
+      }
+      return 0;
+    };
     const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
     const normalizeDateLikeString = (value: unknown): string => {
       if (typeof value === 'string') {
@@ -500,7 +516,7 @@ const Invoice = {
 
     const invoiceCharges: IInvoiceCharge[] = invoiceChargesRaw.map((item) => ({
       ...item,
-      quantity: parseMinorUnit(item.quantity),
+      quantity: parseDecimal(item.quantity),
       unit_price: parseMinorUnit(item.unit_price),
       total_price: parseMinorUnit(item.total_price),
       tax_amount: parseMinorUnit(item.tax_amount),
@@ -633,7 +649,7 @@ const Invoice = {
           'ic.description as name',
           'ic.description',
           'ic.is_discount',
-          knexOrTrx.raw('CAST(ic.quantity AS INTEGER) as quantity'),
+          knexOrTrx.raw('CAST(ic.quantity AS DOUBLE PRECISION) as quantity'),
           knexOrTrx.raw('CAST(ic.unit_price AS BIGINT) as unit_price'),
           knexOrTrx.raw('CAST(ic.total_price AS BIGINT) as total_price'),
           knexOrTrx.raw('CAST(ic.tax_amount AS BIGINT) as tax_amount'),


### PR DESCRIPTION
## Bug

Invoice PDFs display line-item **quantities rounded to whole units**, so fractional-hour charges no longer reconcile with their own line totals. A line that bills 4.25h at $150/hr shows:

```
Qty 4   @ $150.00   = $637.50
```

…which reads as wrong (4 × $150 ≠ $637.50) and makes invoices confusing.

## Root cause

`getFullInvoiceById` (the source behind `getInvoiceForRendering` → `pdfGenerationService`) truncated `quantity` to an integer in **two** places, both in `packages/billing/src/models/invoice.ts`:

1. `getInvoiceCharges` selected `CAST(ic.quantity AS INTEGER) as quantity` — Postgres *rounds* (`4.25 → 4`, `9.75 → 10`, `5.50 → 6`).
2. The view-model map ran `quantity` through `parseMinorUnit`, which does `Math.trunc` / `parseInt` — correct for cents (minor units), wrong for fractional hours.

The AST renderer and the view-model adapter already format/pass decimals correctly, so the value was mangled in the data layer *before* it ever reached the template. This was latent until hourly time charges started billing fractional hours.

## Fix

- `quantity` is now `CAST(ic.quantity AS DOUBLE PRECISION)` — node-pg returns it as a real `number` (type stays `IInvoiceCharge.quantity: number`).
- Added a decimal-preserving `parseDecimal` helper and used it for `quantity` in the view-model map. Cents fields (`unit_price`, `total_price`, `tax_amount`, `net_amount`, `rate`) keep using `parseMinorUnit`.

## Testing

- Verified against **live INV001044**: the old `CAST AS INTEGER` produced `4, 10, 1, 6, 7…`; the new `CAST AS DOUBLE PRECISION` returns `4.25, 9.75, 0.50, 5.50, 6.75…` as JS `number`s. The old rounded quantities summed to 55 units while the invoice bills 53.5h — exactly the mismatch users saw.
- `packages/billing/tests/invoice.test.ts` → **21 passed**. Existing `getInvoiceCharges` tests cover the tenant-guard path (no quantity assertions affected); the adapter test uses mock data and is unaffected.

## Context

Display-layer companion to the hourly fractional-billing fix (#2641) and the storage migration (#2642). With all three, hourly invoices compute, persist, and render fractional hours correctly end-to-end.
