### PR TITLE
docs: reflect Teams attendee picker for Online Meeting interactions

### DIFF
--- a/docs/integrations/teams-meetings-setup.md
+++ b/docs/integrations/teams-meetings-setup.md
@@ -125,6 +125,7 @@ Verification does two checks:
 - Rescheduling PATCHes the same Teams meeting.
 - Cancel / delete attempts to remove the Teams meeting as well.
 - After a recorded meeting ends, `Refresh recordings` can populate transcript documents and recording proxy links.
+- When a technician creates an **Online Meeting** interaction and turns on the **Create Teams meeting** toggle, an attendee picker appears beneath the toggle. Three tabs let the technician build the invite list: **Contacts** (scoped to the linked client if applicable), **Users** (internal staff), or a bare **Email** address typed in directly. The form pre-fills the linked contact's email or the client's default location email. All selected attendees appear in a consolidated badge list before saving. The full attendee list is submitted to Microsoft Graph when the meeting is created; each recipient receives a Teams calendar invite from the organizer account.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Source PRs

| # | Title | Link |
| --- | --- | --- |
| #2640 | Add Teams meeting attendee picker; drop schedule-entry path | https://github.com/Nine-Minds/alga-psa/pull/2640 |

## Files changed

| File | Rationale |
| --- | --- |
| `docs/integrations/teams-meetings-setup.md` | Section 7 ("Expected behavior after setup") had no mention of the attendee selection workflow. PR #2640 changed `attendees: []` to a user-built list: when the **Create Teams meeting** toggle is on inside an Online Meeting interaction, a tabbed picker (Contacts / Users / Email) now appears. The picker pre-fills the linked contact's email or the client's default location email. The full attendee list is submitted to Microsoft Graph and recipients receive a Teams calendar invite from the organizer. A new bullet documents this end-to-end behavior. |

## Needs human review

- **PR #2643 "Fix/extra pages in print"** — Pure CSS/print-layout bug fix with no user-visible behavioral change described in its PR body. No doc edits drafted; listed here for completeness.
- **Removed schedule-entry Teams path** — PR #2640 also removed the "Generate Teams meeting" toggle from the Schedule Calendar's EntryPopup (non-appointment schedule entries). No existing in-scope doc described that toggle, so no removal note was drafted. Verify this is still the case.
- **`52-adding-new-schedule-entries.md` in nm-store** — that doc lists "Interaction" as a Work Item type in the schedule entry form but does not describe Teams meeting generation from schedule entries. No change needed, but worth a quick read to confirm it is still accurate post-removal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvhfK88z7zP2Th5AvUs1rG)_