### PR TITLE
Fix billing server action privilege checks

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -7,6 +7,7 @@ import { ISO8601String } from '@alga-psa/types';
 import { toPlainDate, toISODate } from '@alga-psa/core';
 import { withTransaction } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import {
     IBillingCharge,
     IBucketCharge,
@@ -1147,6 +1148,10 @@ export const getClientTaxRate = withAuth(async (
     taxRegion: string,
     date: ISO8601String
 ): Promise<number> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const { knex } = await createTenantKnex();
     const taxRates = await withTransaction(knex, async (trx: Knex.Transaction) => {
         return await trx('tax_rates')
@@ -1172,6 +1177,10 @@ export const getAvailableBillingPeriods = withAuth(async (
     { tenant },
     options: FetchBillingPeriodsOptions = {}
 ): Promise<PaginatedBillingPeriodsResult> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const {
         page = 1,
         pageSize = 10,
@@ -1310,6 +1319,10 @@ export const getAvailableRecurringDueWork = withAuth(async (
     { tenant },
     options: FetchRecurringDueWorkOptions = {},
 ): Promise<PaginatedRecurringDueWorkResult> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const {
         page = 1,
         pageSize = 10,
@@ -1462,6 +1475,10 @@ export const getDueDate = withAuth(async (
     clientId: string,
     invoiceDate: ISO8601String
 ): Promise<ISO8601String> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const { knex } = await createTenantKnex();
     const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
         return await trx('clients')
@@ -1495,6 +1512,10 @@ export const getNextBillingDate = withAuth(async (
     clientId: string,
     currentEndDate: ISO8601String
 ): Promise<ISO8601String> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const { knex } = await createTenantKnex();
     const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
         return await trx('client_billing_cycles')
@@ -1546,6 +1567,12 @@ export async function calculatePreviewTax(
     cycleEnd: ISO8601String,
     defaultTaxRegion: string
 ): Promise<number> {
+    const { getCurrentUserAsync } = await import('../lib/authHelpers');
+    const currentUser = await getCurrentUserAsync();
+    if (!currentUser || !await hasPermission(currentUser as any, 'billing', 'read')) {
+        throw new Error('Permission denied');
+    }
+
     const taxService = new TaxService();
     let totalTax = 0;
 

--- a/packages/billing/src/actions/billingClientLocationActions.ts
+++ b/packages/billing/src/actions/billingClientLocationActions.ts
@@ -8,6 +8,7 @@
 
 import type { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { createTenantKnex, withTransaction } from '@alga-psa/db';
 import type { IClientLocation } from '@alga-psa/types';
 
@@ -45,10 +46,13 @@ export type BillingLocationSummary = Pick<
  * Used by quote/invoice/contract editors to populate location pickers.
  */
 export const getActiveClientLocationsForBilling = withAuth(async (
-  _user,
+  user,
   { tenant },
   clientId: string,
 ): Promise<BillingLocationSummary[]> => {
+  if (!await hasPermission(user, 'client', 'read')) {
+    throw new Error('Permission denied: client read required');
+  }
   if (!clientId) {
     return [];
   }

--- a/packages/billing/src/actions/billingClientsActions.ts
+++ b/packages/billing/src/actions/billingClientsActions.ts
@@ -45,8 +45,8 @@ async function assertClientContractAssignmentIsAuthorable(
   }
 }
 
-function requireClientReadPermission(user: IUserWithRoles): void {
-  if (!hasPermission(user, 'client', 'read')) {
+async function requireClientReadPermission(user: IUserWithRoles): Promise<void> {
+  if (!await hasPermission(user, 'client', 'read')) {
     throw new Error('Permission denied: Cannot read clients');
   }
 }
@@ -136,6 +136,9 @@ export const createClientContractForBilling = withAuth(async (
   { tenant },
   input: ClientContractAssignmentCreateInput
 ): Promise<IClientContract> => {
+  if (!await hasPermission(user, 'client', 'create')) {
+    throw new Error('Permission denied: Cannot create client contract assignments');
+  }
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -166,6 +169,9 @@ export const updateClientContractForBilling = withAuth(async (
   clientContractId: string,
   updateData: Partial<IClientContract>
 ): Promise<IClientContract> => {
+  if (!await hasPermission(user, 'client', 'update')) {
+    throw new Error('Permission denied: Cannot update client contract assignments');
+  }
   const { knex } = await createTenantKnex();
 
   const updated = await withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/billing/src/actions/billingCurrencyActions.ts
+++ b/packages/billing/src/actions/billingCurrencyActions.ts
@@ -3,8 +3,12 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
-export const resolveClientBillingCurrency = withAuth(async (_user, { tenant }, clientId: string, asOfDate?: string): Promise<string> => {
+export const resolveClientBillingCurrency = withAuth(async (user, { tenant }, clientId: string, asOfDate?: string): Promise<string> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: Cannot resolve client billing currency');
+  }
   const { knex } = await createTenantKnex();
   const effectiveDate = asOfDate || Temporal.Now.plainDateISO().toString();
 

--- a/packages/billing/src/actions/billingCycleActions.ts
+++ b/packages/billing/src/actions/billingCycleActions.ts
@@ -10,6 +10,7 @@ import { ISO8601String } from '@alga-psa/types';
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { toPlainDate } from '@alga-psa/core';
 
 
@@ -18,6 +19,9 @@ export const getBillingCycle = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<BillingCycleType> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   const result: { billing_cycle?: BillingCycleType | null } | undefined = await withTransaction(conn, async (trx: Knex.Transaction) => {
@@ -39,6 +43,9 @@ export const updateBillingCycle = withAuth(async (
   clientId: string,
   billingCycle: BillingCycleType
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   await withTransaction(conn, async (trx: Knex.Transaction) => {
@@ -63,6 +70,9 @@ export const canCreateNextBillingCycle = withAuth(async (
   isEarly: boolean;
   periodEndDate?: string;
 }> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   // Get the client's current billing cycle type
@@ -121,6 +131,9 @@ export const getNextBillingCycleStatusForClients = withAuth(async (
     periodEndDate?: string;
   };
 }> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   if (clientIds.length === 0) {
     return {};
   }
@@ -184,6 +197,9 @@ export const createNextBillingCycle = withAuth(async (
   clientId: string,
   effectiveDate?: string
 ): Promise<BillingCycleCreationResult> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   const client = await withTransaction(conn, async (trx: Knex.Transaction) => {
@@ -291,6 +307,9 @@ export const removeBillingCycle = withAuth(async (
   { tenant },
   cycleId: string
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex } = await createTenantKnex();
 
   // Check for existing invoices
@@ -316,6 +335,9 @@ export const hardDeleteBillingCycle = withAuth(async (
   { tenant },
   cycleId: string
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex } = await createTenantKnex();
 
   // Check for existing invoices
@@ -532,6 +554,9 @@ export const reverseRecurringInvoice = withAuth(async (
   { tenant },
   params: { invoiceId: string; billingCycleId?: string | null }
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   await hardDeleteInvoice(params.invoiceId);
 });
 
@@ -540,6 +565,9 @@ export const hardDeleteRecurringInvoice = withAuth(async (
   { tenant },
   params: { invoiceId: string; billingCycleId?: string | null }
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   await hardDeleteInvoice(params.invoiceId);
 });
 
@@ -551,6 +579,9 @@ export const getInvoicedBillingCycles = withAuth(async (
   period_start_date: ISO8601String;
   period_end_date: ISO8601String;
 })[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   // Get all billing cycles that have invoices
@@ -769,6 +800,9 @@ export const getRecurringInvoiceHistoryPaginated = withAuth(async (
   { tenant },
   options: FetchRecurringInvoiceHistoryOptions = {}
 ): Promise<PaginatedRecurringInvoiceHistoryResult> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   return fetchRecurringInvoiceHistoryPage(tenant, options);
 });
 
@@ -780,6 +814,9 @@ export const getInvoicedBillingCyclesPaginated = withAuth(async (
   { tenant },
   options: FetchInvoicedCyclesOptions = {}
 ): Promise<PaginatedInvoicedCyclesResult> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const result = await fetchRecurringInvoiceHistoryPage(tenant, options);
   return {
     cycles: result.rows,
@@ -794,6 +831,9 @@ export const getAllBillingCycles = withAuth(async (
   user,
   { tenant }
 ): Promise<{ [clientId: string]: BillingCycleType }> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: conn } = await createTenantKnex();
 
   // Get billing cycles from clients table

--- a/packages/billing/src/actions/billingCycleAnchorActions.ts
+++ b/packages/billing/src/actions/billingCycleAnchorActions.ts
@@ -17,6 +17,7 @@ import {
   type NormalizedBillingCycleAnchorSettings
 } from '../lib/billing/billingCycleAnchors';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import {
   CLIENT_CADENCE_SCHEDULE_CONTEXT,
   type ClientCadenceScheduleContext
@@ -49,6 +50,9 @@ export const getClientBillingCycleAnchor = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<ClientBillingCycleAnchorConfig> => {
+  if (!await hasPermission(user as any, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('No tenant found');
@@ -104,6 +108,9 @@ export const updateClientBillingCycleAnchor = withAuth(async (
   { tenant },
   input: UpdateClientBillingCycleAnchorInput
 ): Promise<{ success: true }> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('No tenant found');
@@ -198,6 +205,9 @@ export const previewClientBillingPeriods = withAuth(async (
   clientId: string,
   options: { count?: number; referenceDate?: ISO8601String } = {}
 ): Promise<BillingCyclePeriodPreviewResult> => {
+  if (!await hasPermission(user as any, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('No tenant found');

--- a/packages/billing/src/actions/billingScheduleActions.ts
+++ b/packages/billing/src/actions/billingScheduleActions.ts
@@ -15,6 +15,7 @@ import {
 import { ensureClientBillingSettingsRow } from './billingCycleAnchorActions';
 import { regenerateClientCadenceServicePeriodsForScheduleChange } from './clientCadenceScheduleRegeneration';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { updateClientBillingSchedule as updateClientBillingScheduleShared } from '@alga-psa/shared/billingClients';
 
 function isDateObject(val: unknown): val is Date {
@@ -41,6 +42,9 @@ export const getClientBillingScheduleSummaries = withAuth(async (
   { tenant },
   clientIds: string[]
 ): Promise<Record<string, ClientBillingScheduleConfig>> => {
+  if (!await hasPermission(user as any, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   if (clientIds.length === 0) {
     return {};
   }
@@ -95,6 +99,9 @@ export const updateClientBillingSchedule = withAuth(async (
   { tenant },
   input: UpdateClientBillingScheduleInput
 ): Promise<{ success: true }> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/billing/src/actions/billingSettingsActions.ts
+++ b/packages/billing/src/actions/billingSettingsActions.ts
@@ -51,6 +51,9 @@ export const getDefaultBillingSettings = withAuth(async (
   user,
   { tenant }
 ): Promise<BillingSettings> => {
+  if (!await hasPermission(user as any, 'billing_settings', 'read')) {
+    throw new Error('Permission denied: Cannot read billing settings');
+  }
   const { knex } = await createTenantKnex();
 
   const settings = await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -199,6 +202,9 @@ export const getClientContractLineSettings = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<BillingSettings | null> => {
+  if (!await hasPermission(user as any, 'billing_settings', 'read')) {
+    throw new Error('Permission denied: Cannot read client billing settings');
+  }
   const { knex } = await createTenantKnex();
 
   const settings = await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -232,6 +238,9 @@ export const updateClientContractLineSettings = withAuth(async (
   clientId: string,
   data: BillingSettings | null // null to remove override
 ): Promise<{ success: boolean }> => {
+  if (!await hasPermission(user as any, 'billing_settings', 'update')) {
+    throw new Error('Permission denied: Cannot update client billing settings');
+  }
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/billing/src/actions/bucketOverlayActions.ts
+++ b/packages/billing/src/actions/bucketOverlayActions.ts
@@ -41,7 +41,7 @@ export const upsertBucketOverlay = withAuth(async (
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx) => {
-    if (!hasPermission(user, 'billing', 'update')) {
+    if (!await hasPermission(user, 'billing', 'update')) {
       throw new Error('Permission denied: Cannot update bucket overlays');
     }
 
@@ -158,7 +158,7 @@ export const deleteBucketOverlay = withAuth(async (
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx) => {
-    if (!hasPermission(user, 'billing', 'delete')) {
+    if (!await hasPermission(user, 'billing', 'delete')) {
       throw new Error('Permission denied: Cannot delete bucket overlays');
     }
 
@@ -223,7 +223,7 @@ export const getBucketOverlay = withAuth(async (
   const { knex } = await createTenantKnex();
 
   return await withTransaction(knex, async (trx) => {
-    if (!hasPermission(user, 'billing', 'read')) {
+    if (!await hasPermission(user, 'billing', 'read')) {
       throw new Error('Permission denied: Cannot read bucket overlays');
     }
 

--- a/packages/billing/src/actions/categoryActions.ts
+++ b/packages/billing/src/actions/categoryActions.ts
@@ -5,8 +5,12 @@ import { ITicketCategory } from '@alga-psa/types';
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
-export const getServiceCategories = withAuth(async (_user, { tenant }): Promise<IServiceCategory[]> => {
+export const getServiceCategories = withAuth(async (user, { tenant }): Promise<IServiceCategory[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const {knex: db} = await createTenantKnex();
 
@@ -24,11 +28,14 @@ export const getServiceCategories = withAuth(async (_user, { tenant }): Promise<
   }
 });
 
-export const createServiceCategory = withAuth(async (_user, { tenant }, data: {
+export const createServiceCategory = withAuth(async (user, { tenant }, data: {
   category_name: string;
   description?: string;
   display_order?: number;
 }): Promise<IServiceCategory> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   try {
     const {knex: db} = await createTenantKnex();
 
@@ -63,7 +70,7 @@ export const createServiceCategory = withAuth(async (_user, { tenant }, data: {
 });
 
 export const updateServiceCategory = withAuth(async (
-  _user,
+  user,
   { tenant },
   categoryId: string,
   data: {
@@ -72,6 +79,9 @@ export const updateServiceCategory = withAuth(async (
     display_order?: number;
   }
 ): Promise<IServiceCategory> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   try {
     const {knex: db} = await createTenantKnex();
 
@@ -98,7 +108,10 @@ export const updateServiceCategory = withAuth(async (
   }
 });
 
-export const deleteServiceCategory = withAuth(async (_user, { tenant }, categoryId: string): Promise<void> => {
+export const deleteServiceCategory = withAuth(async (user, { tenant }, categoryId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   try {
     const {knex: db} = await createTenantKnex();
 

--- a/packages/billing/src/actions/contractActions.ts
+++ b/packages/billing/src/actions/contractActions.ts
@@ -213,11 +213,13 @@ export const getContractById = withAuth(async (user, { tenant }, contractId: str
 });
 
 export const getContractLineMappings = withAuth(async (user, { tenant }, contractId: string): Promise<IContractLineMapping[]> => {
+  await assertBillingPermission(user, 'read', 'view contract line mappings');
   const { knex } = await createTenantKnex();
   return fetchContractLineMappings(knex, tenant, contractId);
 });
 
 export const getDetailedContractLines = withAuth(async (user, { tenant }, contractId: string): Promise<DetailedContractLine[]> => {
+  await assertBillingPermission(user, 'read', 'view detailed contract lines');
   const { knex } = await createTenantKnex();
   return fetchDetailedContractLines(knex, tenant, contractId);
 });
@@ -231,7 +233,7 @@ export const addContractLine = withAuth(async (
 ): Promise<IContractLineMapping | ActionPermissionError> => {
   const { knex } = await createTenantKnex();
 
-  const canUpdate = await hasPermission(user, 'billing', 'delete');
+  const canUpdate = await hasPermission(user, 'billing', 'create');
   if (!canUpdate) {
     return permissionError('Permission denied: Cannot modify contract lines');
   }
@@ -562,6 +564,7 @@ export const deleteContract = withAuth(async (user, { tenant }, contractId: stri
 
 export const getContractLinesForContract = withAuth(async (user, { tenant }, contractId: string): Promise<any[]> => {
   try {
+    await assertBillingPermission(user, 'read', 'view contract lines');
     const { knex } = await createTenantKnex();
 
     return await Contract.getContractLines(knex, tenant, contractId);
@@ -586,6 +589,7 @@ export interface IContractSummary {
 
 export const getContractSummary = withAuth(async (user, { tenant }, contractId: string): Promise<IContractSummary> => {
   try {
+    await assertBillingPermission(user, 'read', 'view contract summary');
     const { knex } = await createTenantKnex();
 
     const templateRecord = await knex('contract_templates')
@@ -675,6 +679,7 @@ export const getContractSummary = withAuth(async (user, { tenant }, contractId: 
 
 export const getContractAssignments = withAuth(async (user, { tenant }, contractId: string): Promise<IContractAssignmentSummary[]> => {
   try {
+    await assertBillingPermission(user, 'read', 'view contract assignments');
     const { knex } = await createTenantKnex();
 
     const selection = [
@@ -825,6 +830,7 @@ export interface IContractOverview {
  */
 export const getContractOverview = withAuth(async (user, { tenant }, contractId: string): Promise<IContractOverview> => {
   try {
+    await assertBillingPermission(user, 'read', 'view contract overview');
     const { knex } = await createTenantKnex();
 
     // Check if this is a template contract

--- a/packages/billing/src/actions/contractLineAction.ts
+++ b/packages/billing/src/actions/contractLineAction.ts
@@ -55,7 +55,7 @@ export const getContractLines = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!isBypass && !hasPermission(user, 'billing', 'read')) {
+            if (!isBypass && !await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract lines');
             }
 
@@ -90,7 +90,7 @@ export const getContractLineById = withAuth(async (
         tenant_copy = tenant;
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!isBypass && !hasPermission(user, 'billing', 'read')) {
+            if (!isBypass && !await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract lines');
             }
 
@@ -156,7 +156,7 @@ export const createContractLine = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'create')) {
+            if (!await hasPermission(user, 'billing', 'create')) {
                 throw new Error('Permission denied: Cannot create contract lines');
             }
 
@@ -212,7 +212,7 @@ export const updateContractLine = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract lines');
             }
 
@@ -288,7 +288,7 @@ export const upsertContractLineTerms = withAuth(async (
     }
 
     await withTransaction(knex, async (trx: Knex.Transaction) => {
-        if (!hasPermission(user, 'billing', 'update')) {
+        if (!await hasPermission(user, 'billing', 'update')) {
             throw new Error('Permission denied: Cannot update contract line terms');
         }
 
@@ -339,7 +339,7 @@ export const deleteContractLine = withAuth(async (
         }
 
         const contractsWithClients = await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'delete')) {
+            if (!await hasPermission(user, 'billing', 'delete')) {
                 throw new Error('Permission denied: Cannot delete contract lines');
             }
 
@@ -418,7 +418,7 @@ export const getCombinedFixedPlanConfiguration = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'read')) {
+            if (!await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line configurations');
             }
 
@@ -486,7 +486,7 @@ export const getContractLineFixedConfig = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!isBypass && !hasPermission(user, 'billing', 'read')) {
+            if (!isBypass && !await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line configurations');
             }
 
@@ -520,7 +520,7 @@ export const updateContractLineFixedConfig = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract line configurations');
             }
 
@@ -583,7 +583,7 @@ export const updatePlanServiceFixedConfigRate = withAuth(async (
         }
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract line configurations');
             }
 

--- a/packages/billing/src/actions/contractLineMappingActions.ts
+++ b/packages/billing/src/actions/contractLineMappingActions.ts
@@ -337,7 +337,7 @@ export const getContractLineMappings = withAuth(async (user, { tenant }, contrac
     const { knex } = await createTenantKnex();
 
     return await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'read')) {
+      if (!await hasPermission(user, 'billing', 'read')) {
         throw new Error('Permission denied: Cannot read contract line mappings');
       }
 
@@ -380,7 +380,7 @@ export const getDetailedContractLines = withAuth(async (user, { tenant }, contra
     const { knex } = await createTenantKnex();
 
     return await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'read')) {
+      if (!await hasPermission(user, 'billing', 'read')) {
         throw new Error('Permission denied: Cannot read detailed contract lines');
       }
 
@@ -445,7 +445,7 @@ export const addContractLine = withAuth(async (
     const { knex } = await createTenantKnex();
 
     return await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'create')) {
+      if (!await hasPermission(user, 'billing', 'create')) {
         throw new Error('Permission denied: Cannot add contract lines');
       }
 
@@ -523,7 +523,7 @@ export const removeContractLine = withAuth(async (user, { tenant }, contractId: 
     const { knex } = await createTenantKnex();
 
     await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'delete')) {
+      if (!await hasPermission(user, 'billing', 'delete')) {
         throw new Error('Permission denied: Cannot remove contract lines');
       }
 
@@ -571,7 +571,7 @@ export const updateContractLineAssociation = withAuth(async (
     const { knex } = await createTenantKnex();
 
     return await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'update')) {
+      if (!await hasPermission(user, 'billing', 'update')) {
         throw new Error('Permission denied: Cannot update contract line associations');
       }
 
@@ -660,7 +660,7 @@ export const isContractLineAttached = withAuth(async (user, { tenant }, contract
     const { knex } = await createTenantKnex();
 
     return await withTransaction(knex, async (trx) => {
-      if (!hasPermission(user, 'billing', 'read')) {
+      if (!await hasPermission(user, 'billing', 'read')) {
         throw new Error('Permission denied: Cannot check contract line associations');
       }
 

--- a/packages/billing/src/actions/contractLinePresetActions.ts
+++ b/packages/billing/src/actions/contractLinePresetActions.ts
@@ -30,7 +30,7 @@ export const getContractLinePresets = withAuth(async (user, { tenant }): Promise
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'read')) {
+            if (!await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line presets');
             }
 
@@ -51,7 +51,7 @@ export const getContractLinePresetById = withAuth(async (user, { tenant }, prese
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'read')) {
+            if (!await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line presets');
             }
 
@@ -79,7 +79,7 @@ export const createContractLinePreset = withAuth(async (
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'create')) {
+            if (!await hasPermission(user, 'billing', 'create')) {
                 throw new Error('Permission denied: Cannot create contract line presets');
             }
 
@@ -117,7 +117,7 @@ export const updateContractLinePreset = withAuth(async (
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract line presets');
             }
 
@@ -158,7 +158,7 @@ export const deleteContractLinePreset = withAuth(async (user, { tenant }, preset
         const { knex } = await createTenantKnex();
 
         await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'delete')) {
+            if (!await hasPermission(user, 'billing', 'delete')) {
                 throw new Error('Permission denied: Cannot delete contract line presets');
             }
 
@@ -181,7 +181,7 @@ export const getContractLinePresetServices = withAuth(async (user, { tenant }, p
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'read')) {
+            if (!await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line preset services');
             }
 
@@ -210,7 +210,7 @@ export const updateContractLinePresetServices = withAuth(async (
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract line preset services');
             }
 
@@ -234,7 +234,7 @@ export const getContractLinePresetFixedConfig = withAuth(async (user, { tenant }
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'read')) {
+            if (!await hasPermission(user, 'billing', 'read')) {
                 throw new Error('Permission denied: Cannot read contract line preset fixed config');
             }
 
@@ -263,7 +263,7 @@ export const updateContractLinePresetFixedConfig = withAuth(async (
         const { knex } = await createTenantKnex();
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'update')) {
+            if (!await hasPermission(user, 'billing', 'update')) {
                 throw new Error('Permission denied: Cannot update contract line preset fixed config');
             }
 
@@ -303,7 +303,7 @@ export const copyPresetToContractLine = withAuth(async (
         const tenantId: string = tenant;
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'create')) {
+            if (!await hasPermission(user, 'billing', 'create')) {
                 throw new Error('Permission denied: Cannot create contract lines from presets');
             }
 
@@ -586,7 +586,7 @@ export const createCustomContractLine = withAuth(async (
         const tenantId: string = tenant;
 
         return await withTransaction(knex, async (trx: Knex.Transaction) => {
-            if (!hasPermission(user, 'billing', 'create')) {
+            if (!await hasPermission(user, 'billing', 'create')) {
                 throw new Error('Permission denied: Cannot create contract lines');
             }
 

--- a/packages/billing/src/actions/contractLineServiceActions.ts
+++ b/packages/billing/src/actions/contractLineServiceActions.ts
@@ -11,6 +11,7 @@ import * as planServiceConfigActions from './contractLineServiceConfigurationAct
 import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 async function findTemplateLine(
   trx: Knex.Transaction,
@@ -40,6 +41,9 @@ export const getContractLineServices = withAuth(async (
   { tenant },
   contractLineId: string
 ): Promise<IContractLineService[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -76,6 +80,9 @@ export const getContractLineServicesWithNames = withAuth(async (
   { tenant },
   contractLineId: string
 ): Promise<Array<IContractLineService & { service_name?: string }>> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const services = await trx('contract_line_services as cls')
@@ -105,6 +112,9 @@ export const getContractLineService = withAuth(async (
   contractLineId: string,
   serviceId: string
 ): Promise<IContractLineService | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -233,6 +243,9 @@ export const addServiceToContractLine = withAuth(async (
   configType?: 'Fixed' | 'Hourly' | 'Usage' | 'Bucket',
   typeConfig?: Partial<IContractLineServiceFixedConfig | IContractLineServiceHourlyConfig | IContractLineServiceUsageConfig | IContractLineServiceBucketConfig>
 ): Promise<string> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex: db } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -452,6 +465,9 @@ export const updateContractLineService = withAuth(async (
   },
   rateTiers?: IContractLineServiceRateTier[] // Add rateTiers here
 ): Promise<boolean> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
 
@@ -510,6 +526,9 @@ export const removeServiceFromContractLine = withAuth(async (
   contractLineId: string,
   serviceId: string
 ): Promise<boolean> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex: db } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -596,6 +615,9 @@ export const getContractLineServicesWithConfigurations = withAuth(async (
   userTypeRates?: IUserTypeRate[];
   bucketConfig?: IContractLineServiceBucketConfig | null; // Add bucketConfig to the return type
 }[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -753,6 +775,9 @@ export const getTemplateLineServicesWithConfigurations = withAuth(async (
   typeConfig: IContractLineServiceHourlyConfig | IContractLineServiceUsageConfig | IContractLineServiceBucketConfig | null;
   bucketConfig?: IContractLineServiceBucketConfig | null; // Add bucketConfig to the return type
 }[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const configurations = await trx('contract_template_line_service_configuration')

--- a/packages/billing/src/actions/contractLineServiceConfigurationActions.ts
+++ b/packages/billing/src/actions/contractLineServiceConfigurationActions.ts
@@ -11,6 +11,7 @@ import {
   IUserTypeRate
 } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 async function assertContractLineIsAuthorableByLineId(
   knex: any,
@@ -59,6 +60,9 @@ export const getConfigurationWithDetails = withAuth(async (
   { tenant },
   configId: string
 ) => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -72,6 +76,9 @@ export const getConfigurationsForPlan = withAuth(async (
   { tenant },
   contractLineId: string
 ) => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -86,6 +93,9 @@ export const getConfigurationForService = withAuth(async (
   contractLineId: string,
   serviceId: string
 ) => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -102,6 +112,9 @@ export const createConfiguration = withAuth(async (
   rateTiers?: IContractLineServiceRateTierInput[],
   userTypeRates?: Array<Omit<IUserTypeRate, 'created_at' | 'updated_at' | 'config_id' | 'rate_id'>>
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -119,6 +132,9 @@ export const updateConfiguration = withAuth(async (
   typeConfig?: Partial<IContractLineServiceUsageConfig | IContractLineServiceBucketConfig | Record<string, unknown>>,
   rateTiers?: IContractLineServiceRateTierInput[]
 ) => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -133,6 +149,9 @@ export const deleteConfiguration = withAuth(async (
   { tenant },
   configId: string
 ) => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -149,6 +168,9 @@ export const upsertPlanServiceHourlyConfiguration = withAuth(async (
   serviceId: string,
   hourlyConfigData: Partial<IContractLineServiceHourlyConfig>
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -165,6 +187,9 @@ export const upsertPlanServiceBucketConfigurationAction = withAuth(async (
   serviceId: string,
   bucketConfigData: Partial<IContractLineServiceBucketConfig>
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -189,6 +214,9 @@ export const upsertPlanServiceConfiguration = withAuth(async (
   { tenant },
   payload: UsageConfigPayload
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');
@@ -236,6 +264,9 @@ export const upsertUserTypeRatesForConfig = withAuth(async (
   configId: string,
   rates: Array<Omit<IUserTypeRate, 'rate_id' | 'config_id' | 'created_at' | 'updated_at' | 'tenant'>>
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('tenant context not found');

--- a/packages/billing/src/actions/contractPricingScheduleActions.ts
+++ b/packages/billing/src/actions/contractPricingScheduleActions.ts
@@ -3,6 +3,7 @@
 import { createTenantKnex } from '@alga-psa/db';
 import type { IContractPricingSchedule } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 async function assertContractIsAuthorable(
   knex: any,
@@ -29,6 +30,9 @@ export const getPricingSchedulesByContract = withAuth(async (
   { tenant },
   contractId: string
 ): Promise<IContractPricingSchedule[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -56,6 +60,9 @@ export const getPricingScheduleById = withAuth(async (
   { tenant },
   scheduleId: string
 ): Promise<IContractPricingSchedule | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -110,6 +117,9 @@ export const createPricingSchedule = withAuth(async (
   { tenant },
   scheduleData: Omit<IContractPricingSchedule, 'schedule_id' | 'tenant' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'>
 ): Promise<IContractPricingSchedule> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -188,6 +198,9 @@ export const updatePricingSchedule = withAuth(async (
   scheduleId: string,
   scheduleData: Partial<Omit<IContractPricingSchedule, 'schedule_id' | 'tenant' | 'contract_id' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'>>
 ): Promise<IContractPricingSchedule> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -280,6 +293,9 @@ export const deletePricingSchedule = withAuth(async (
   { tenant },
   scheduleId: string
 ): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -316,6 +332,9 @@ export const getActivePricingScheduleByContract = withAuth(async (
   contractId: string,
   date?: Date
 ): Promise<IContractPricingSchedule | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {

--- a/packages/billing/src/actions/contractReportActions.ts
+++ b/packages/billing/src/actions/contractReportActions.ts
@@ -2,6 +2,7 @@
 
 import { createTenantKnex } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import type { RenewalWorkItemStatus } from '@alga-psa/types';
 import { deriveClientContractStatus } from '@alga-psa/shared/billingClients';
 import type { Knex } from 'knex';
@@ -191,6 +192,9 @@ const mapAssignmentStatusToRevenueStatus = (
  * Shows monthly recurring revenue and year-to-date billing by contract
  */
 export const getContractRevenueReport = withAuth(async (user, { tenant }): Promise<ContractRevenue[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex();
 
@@ -282,6 +286,9 @@ export const getContractRevenueReport = withAuth(async (user, { tenant }): Promi
  * Track upcoming contract expirations and renewal opportunities
  */
 export const getContractExpirationReport = withAuth(async (user, { tenant }): Promise<ContractExpiration[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex();
 
@@ -388,6 +395,9 @@ export const getContractExpirationReport = withAuth(async (user, { tenant }): Pr
  * Monitor bucket hours usage and identify overage situations
  */
 export const getBucketUsageReport = withAuth(async (user, { tenant }): Promise<BucketUsage[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex();
 
@@ -454,6 +464,9 @@ export const getBucketUsageReport = withAuth(async (user, { tenant }): Promise<B
  * Basic profit margins and revenue vs. cost analysis by contract
  */
 export const getProfitabilityReport = withAuth(async (user, { tenant }): Promise<Profitability[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex();
 
@@ -520,6 +533,9 @@ export const getProfitabilityReport = withAuth(async (user, { tenant }): Promise
  * Get contract report summary statistics
  */
 export const getContractReportSummary = withAuth(async (user, { tenant }): Promise<ContractReportSummary> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex();
 

--- a/packages/billing/src/actions/contractWizardActions.ts
+++ b/packages/billing/src/actions/contractWizardActions.ts
@@ -1541,6 +1541,9 @@ export const listContractTemplatesForWizard = withAuth(async (
   user,
   { tenant }
 ): Promise<TemplateOption[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: Cannot list contract templates');
+  }
   const { knex } = await createTenantKnex();
 
   // currency_code removed from contract_templates - templates are now currency-neutral
@@ -1568,6 +1571,9 @@ export const getContractTemplateSnapshotForClientWizard = withAuth(async (
   { tenant },
   templateId: string
 ): Promise<ClientTemplateSnapshot> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: Cannot view contract template snapshot');
+  }
   const { knex } = await createTenantKnex();
 
   const template = await knex('contract_templates')

--- a/packages/billing/src/actions/creditActions.ts
+++ b/packages/billing/src/actions/creditActions.ts
@@ -279,7 +279,7 @@ export const validateCreditBalance = withAuth(async (
     const { knex } = await createTenantKnex();
 
     // Check permission for credit reading
-    if (!hasPermission(user, 'credit', 'read')) {
+    if (!await hasPermission(user, 'credit', 'read')) {
         throw new Error('Permission denied: Cannot read credit balance information');
     }
 
@@ -377,7 +377,7 @@ export const scheduledCreditBalanceValidation = withAuth(async (
     { tenant }
 ): Promise<void> => {
     // Check permission for credit reading (required for scheduled validation)
-    if (!hasPermission(user, 'credit', 'read')) {
+    if (!await hasPermission(user, 'credit', 'read')) {
         throw new Error('Permission denied: Cannot perform credit balance validation');
     }
 
@@ -402,7 +402,7 @@ export const createPrepaymentInvoice = withAuth(async (
     manualExpirationDate?: string
 ): Promise<IInvoice> => {
     // Check permission for credit creation
-    if (!hasPermission(user, 'credit', 'create')) {
+    if (!await hasPermission(user, 'credit', 'create')) {
         throw new Error('Permission denied: Cannot create prepayment invoices or issue credits');
     }
 
@@ -700,7 +700,7 @@ export const applyCreditToInvoice = withAuth(async (
     requestedAmount: number
 ): Promise<void> => {
     // Check permission for credit updates (applying credits modifies credit balances)
-    if (!hasPermission(user, 'credit', 'update')) {
+    if (!await hasPermission(user, 'credit', 'update')) {
         throw new Error('Permission denied: Cannot apply credits to invoices');
     }
 
@@ -984,7 +984,7 @@ export const getCreditHistory = withAuth(async (
     endDate?: string
 ): Promise<ITransaction[]> => {
     // Check permission for credit reading
-    if (!hasPermission(user, 'credit', 'read')) {
+    if (!await hasPermission(user, 'credit', 'read')) {
         throw new Error('Permission denied: Cannot read credit history');
     }
 
@@ -1033,7 +1033,7 @@ export const listClientCredits = withAuth(async (
     totalPages: number
 }> => {
     // Check permission for credit reading
-    if (!hasPermission(user, 'credit', 'read')) {
+    if (!await hasPermission(user, 'credit', 'read')) {
         throw new Error('Permission denied: Cannot read client credits');
     }
 
@@ -1137,7 +1137,7 @@ export const getCreditDetails = withAuth(async (
     invoice_service_period_end?: string | null,
 }> => {
     // Check permission for credit reading
-    if (!hasPermission(user, 'credit', 'read')) {
+    if (!await hasPermission(user, 'credit', 'read')) {
         throw new Error('Permission denied: Cannot read credit details');
     }
 
@@ -1239,7 +1239,7 @@ export const updateCreditExpiration = withAuth(async (
     userId: string
 ): Promise<ICreditTracking> => {
     // Check permission for credit updates
-    if (!hasPermission(user, 'credit', 'update')) {
+    if (!await hasPermission(user, 'credit', 'update')) {
         throw new Error('Permission denied: Cannot update credit expiration dates');
     }
 
@@ -1338,7 +1338,7 @@ export const manuallyExpireCredit = withAuth(async (
     reason?: string
 ): Promise<ICreditTracking> => {
     // Check permission for credit updates
-    if (!hasPermission(user, 'credit', 'update')) {
+    if (!await hasPermission(user, 'credit', 'update')) {
         throw new Error('Permission denied: Cannot manually expire credits');
     }
 
@@ -1461,7 +1461,7 @@ export const transferCredit = withAuth(async (
     reason?: string
 ): Promise<ICreditTracking> => {
     // Check permission for credit transfers
-    if (!hasPermission(user, 'credit', 'transfer')) {
+    if (!await hasPermission(user, 'credit', 'transfer')) {
         throw new Error('Permission denied: Cannot transfer credits between clients');
     }
 

--- a/packages/billing/src/actions/creditExpirationSettingsActions.ts
+++ b/packages/billing/src/actions/creditExpirationSettingsActions.ts
@@ -3,6 +3,7 @@
 import { createTenantKnex } from '@alga-psa/db';
 import { ICreditExpirationSettings } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { updateClientBillingSettings as updateClientBillingSettingsShared } from '@shared/billingClients/billingSettings';
 
 /**
@@ -13,6 +14,9 @@ export const getCreditExpirationSettings = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<ICreditExpirationSettings> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
   if (!tenant) throw new Error('No tenant found');
 
@@ -62,6 +66,9 @@ export const updateCreditExpirationSettings = withAuth(async (
   clientId: string,
   settings: ICreditExpirationSettings
 ): Promise<{ success: boolean; error?: string }> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   try {
     const { knex } = await createTenantKnex();
     if (!tenant) throw new Error('No tenant found');

--- a/packages/billing/src/actions/creditReconciliationActions.ts
+++ b/packages/billing/src/actions/creditReconciliationActions.ts
@@ -8,6 +8,7 @@ import { Knex } from 'knex';
 import CreditReconciliationReport from '../models/creditReconciliationReport';
 import { auditLog } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import Invoice from '../models/invoice';
 
 /**
@@ -300,6 +301,7 @@ export async function validateCreditBalanceWithoutCorrection(
  * @param providedTrx Optional transaction object
  * @returns Object containing validation results and report IDs if discrepancies were found
  */
+// Internal helper — not a direct server action endpoint
 export async function validateCreditTrackingEntries(
     clientId: string,
     providedTrx?: Knex.Transaction
@@ -603,6 +605,7 @@ export async function validateCreditTrackingRemainingAmounts(
  * @param providedTrx Optional transaction object
  * @returns Object containing validation results and report IDs if discrepancies were found
  */
+// Internal helper — not a direct server action endpoint
 export async function validateAllCreditTracking(
     clientId: string,
     providedTrx?: Knex.Transaction
@@ -788,19 +791,21 @@ export async function runScheduledCreditBalanceValidation(
  * The tenant context is set by the withAuth wrapper.
  *
  * @param reportId The ID of the reconciliation report to resolve
- * @param userId The ID of the user resolving the report
  * @param notes Optional notes about the resolution
  * @param trx Optional transaction object
  * @returns The resolved report
  */
 export const resolveReconciliationReport = withAuth(async (
-    _user,
+    user,
     { tenant },
     reportId: string,
-    userId: string,
     notes?: string,
     trx?: Knex.Transaction
 ): Promise<ICreditReconciliationReport> => {
+    if (!await hasPermission(user as any, 'billing', 'update')) {
+        throw new Error('Permission denied: billing update required');
+    }
+    const userId = user.user_id;
     const { knex } = await createTenantKnex();
 
     const executeWithTransaction = async (transaction: Knex.Transaction) => {
@@ -945,10 +950,9 @@ export const resolveReconciliationReport = withAuth(async (
  * @returns Summary of validation results
  */
 export const validateClientCredit = withAuth(async (
-    _user,
+    user,
     _ctx,
-    clientId: string,
-    userId: string = 'system'
+    clientId: string
 ): Promise<{
     totalClients: number;
     balanceValidCount: number;
@@ -957,9 +961,12 @@ export const validateClientCredit = withAuth(async (
     inconsistentTrackingCount: number;
     errorCount: number;
 }> => {
+    if (!await hasPermission(user as any, 'billing', 'read')) {
+        throw new Error('Permission denied: billing read required');
+    }
     if (!clientId) {
         throw new Error('Client ID is required for client-specific validation');
     }
 
-    return await runScheduledCreditBalanceValidation(clientId, userId);
+    return await runScheduledCreditBalanceValidation(clientId, user.user_id);
 });

--- a/packages/billing/src/actions/creditReconciliationFixActions.ts
+++ b/packages/billing/src/actions/creditReconciliationFixActions.ts
@@ -9,12 +9,12 @@ import CreditReconciliationReport from '../models/creditReconciliationReport';
 import { auditLog } from '@alga-psa/db';
 import { resolveReconciliationReport } from './creditReconciliationActions';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 /**
  * Create a credit tracking entry for a missing entry
  *
  * @param reportId The ID of the reconciliation report
- * @param userId The ID of the user applying the fix
  * @param notes Notes explaining the reason for the fix
  * @returns The resolved report
  */
@@ -22,9 +22,12 @@ export const createMissingCreditTrackingEntry = withAuth(async (
   user,
   { tenant },
   reportId: string,
-  userId: string,
   notes: string
 ): Promise<ICreditReconciliationReport> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
+  const userId = user.user_id;
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('Tenant context is required for creating credit tracking entry');
@@ -88,7 +91,6 @@ export const createMissingCreditTrackingEntry = withAuth(async (
       // Resolve the reconciliation report
       const resolvedReport = await resolveReconciliationReport(
         reportId,
-        userId,
         notes,
         trx
       );
@@ -120,7 +122,6 @@ export const createMissingCreditTrackingEntry = withAuth(async (
  * Update the remaining amount in a credit tracking entry
  *
  * @param reportId The ID of the reconciliation report
- * @param userId The ID of the user applying the fix
  * @param notes Notes explaining the reason for the fix
  * @returns The resolved report
  */
@@ -128,9 +129,12 @@ export const updateCreditTrackingRemainingAmount = withAuth(async (
   user,
   { tenant },
   reportId: string,
-  userId: string,
   notes: string
 ): Promise<ICreditReconciliationReport> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
+  const userId = user.user_id;
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('Tenant context is required for updating credit tracking remaining amount');
@@ -193,7 +197,6 @@ export const updateCreditTrackingRemainingAmount = withAuth(async (
       // Resolve the reconciliation report
       const resolvedReport = await resolveReconciliationReport(
         reportId,
-        userId,
         notes,
         trx
       );
@@ -225,7 +228,6 @@ export const updateCreditTrackingRemainingAmount = withAuth(async (
  * Apply a custom credit adjustment
  *
  * @param reportId The ID of the reconciliation report
- * @param userId The ID of the user applying the fix
  * @param notes Notes explaining the reason for the fix
  * @param amount The custom adjustment amount (optional, defaults to the report difference)
  * @returns The resolved report
@@ -234,10 +236,13 @@ export const applyCustomCreditAdjustment = withAuth(async (
   user,
   { tenant },
   reportId: string,
-  userId: string,
   notes: string,
   amount?: number
 ): Promise<ICreditReconciliationReport> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
+  const userId = user.user_id;
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('Tenant context is required for applying credit adjustment');
@@ -360,7 +365,6 @@ export const applyCustomCreditAdjustment = withAuth(async (
  * Mark a reconciliation report as resolved without making any changes
  *
  * @param reportId The ID of the reconciliation report
- * @param userId The ID of the user resolving the report
  * @param notes Notes explaining the reason for not making changes
  * @returns The resolved report
  */
@@ -368,9 +372,12 @@ export const markReportAsResolvedNoAction = withAuth(async (
   user,
   { tenant },
   reportId: string,
-  userId: string,
   notes: string
 ): Promise<ICreditReconciliationReport> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
+  const userId = user.user_id;
   const { knex } = await createTenantKnex();
   if (!tenant) {
     throw new Error('Tenant context is required for resolving reconciliation report');
@@ -451,7 +458,6 @@ export const markReportAsResolvedNoAction = withAuth(async (
  * Apply the appropriate fix based on the fix type
  *
  * @param reportId The ID of the reconciliation report
- * @param userId The ID of the user applying the fix
  * @param fixType The type of fix to apply
  * @param notes Notes explaining the reason for the fix
  * @param customData Additional data for custom fixes
@@ -459,29 +465,28 @@ export const markReportAsResolvedNoAction = withAuth(async (
  */
 export async function applyReconciliationFix(
   reportId: string,
-  userId: string,
   fixType: string,
   notes: string,
   customData?: any
 ): Promise<ICreditReconciliationReport> {
   switch (fixType) {
     case 'create_tracking_entry':
-      return await createMissingCreditTrackingEntry(reportId, userId, notes);
+      return await createMissingCreditTrackingEntry(reportId, notes);
 
     case 'update_remaining_amount':
-      return await updateCreditTrackingRemainingAmount(reportId, userId, notes);
+      return await updateCreditTrackingRemainingAmount(reportId, notes);
 
     case 'apply_adjustment':
-      return await applyCustomCreditAdjustment(reportId, userId, notes);
+      return await applyCustomCreditAdjustment(reportId, notes);
 
     case 'custom_adjustment':
       if (!customData?.amount && customData?.amount !== 0) {
         throw new Error('Custom adjustment amount is required');
       }
-      return await applyCustomCreditAdjustment(reportId, userId, notes, customData.amount);
+      return await applyCustomCreditAdjustment(reportId, notes, customData.amount);
 
     case 'no_action':
-      return await markReportAsResolvedNoAction(reportId, userId, notes);
+      return await markReportAsResolvedNoAction(reportId, notes);
 
     default:
       throw new Error(`Unknown fix type: ${fixType}`);

--- a/packages/billing/src/actions/externalTaxImportActions.ts
+++ b/packages/billing/src/actions/externalTaxImportActions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { createTenantKnex } from '@alga-psa/db';
 import {
   getExternalTaxImportService,
@@ -19,6 +20,9 @@ export const importExternalTaxForInvoice = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<SingleImportResult> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const service = getExternalTaxImportService();
   return service.importTaxForInvoice(invoiceId, user.user_id);
 });
@@ -31,6 +35,9 @@ export const batchImportExternalTaxes = withAuth(async (
   user,
   { tenant }
 ): Promise<BatchImportResult> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const service = getExternalTaxImportService();
   return service.batchImportPendingTaxes(user.user_id);
 });
@@ -44,6 +51,9 @@ export const getExternalTaxImportHistory = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<IExternalTaxImport[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const service = getExternalTaxImportService();
   return service.getImportHistory(invoiceId);
 });
@@ -56,6 +66,9 @@ export const getInvoiceTaxReconciliation = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<ReconciliationResult | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const service = getExternalTaxImportService();
   return service.reconcileTaxDifferences(invoiceId);
 });
@@ -87,6 +100,9 @@ export const getInvoicesPendingExternalTax = withAuth(async (
     adapter_type?: string;
   }>
 > => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   const invoices = await knex('invoices as i')

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -984,7 +984,7 @@ export const getPurchaseOrderOverageForSelectionInput = withAuth(async (
 ): Promise<PurchaseOrderOverageResult | null> => {
   const { knex } = await createTenantKnex();
 
-  if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+  if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
     throw new Error('Permission denied: Cannot generate invoices');
   }
 
@@ -1003,7 +1003,7 @@ export const getPurchaseOrderOverageForBillingCycle = withAuth(async (
   const { knex } = await createTenantKnex();
 
   const billingCycle = await withTransaction(knex, async (trx: Knex.Transaction) => {
-    if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+    if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
       throw new Error('Permission denied: Cannot generate invoices');
     }
 
@@ -1400,7 +1400,7 @@ export const previewGroupedInvoicesForSelectionInputs = withAuth(async (
   let normalizedGroupedSelections = groupedSelections;
 
   try {
-    if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+    if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
       throw new Error('Permission denied: Cannot preview invoices');
     }
     if (!Array.isArray(groupedSelections) || groupedSelections.length === 0) {
@@ -1462,7 +1462,7 @@ export const previewInvoiceForSelectionInput = withAuth(async (
   let normalizedSelectorInput = selectorInput;
 
   try {
-    if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+    if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
       throw new Error('Permission denied: Cannot preview invoices');
     }
     normalizedSelectorInput = await normalizeRecurringSelectorInput({
@@ -1495,7 +1495,7 @@ export const previewInvoice = withAuth(async (
   let selectorInput: IRecurringDueSelectionInput | null = null;
 
   try {
-    if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+    if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
       throw new Error('Permission denied: Cannot preview invoices');
     }
 
@@ -1573,7 +1573,7 @@ export const generateInvoice = withAuth(async (
 
   const billingCycle = await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Check permissions within transaction
-    if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+    if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
       throw new Error('Permission denied: Cannot generate invoices');
     }
 
@@ -1628,6 +1628,10 @@ export const generateInvoiceForSelectionInput = withAuth(async (
   options: { allowPoOverage?: boolean } = {},
   bridgeMetadata?: RecurringBridgeMetadata,
 ): Promise<InvoiceViewModel | null> => {
+  if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
+    throw new Error('Permission denied: invoice create or generate required');
+  }
+
   const { knex } = await createTenantKnex();
   let normalizedSelectorInput = selectorInput;
 
@@ -1826,6 +1830,10 @@ export const generateInvoiceForSelectionInputs = withAuth(async (
   options: { allowPoOverage?: boolean } = {},
   bridgeMetadata?: RecurringBridgeMetadata,
 ): Promise<InvoiceViewModel | null> => {
+  if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
+    throw new Error('Permission denied: invoice create or generate required');
+  }
+
   const { knex } = await createTenantKnex();
   if (!Array.isArray(selectorInputs) || selectorInputs.length === 0) {
     throw new Error('No recurring execution windows selected');
@@ -1867,7 +1875,7 @@ export const generateInvoiceNumber = withAuth(async (
   _trx?: Knex.Transaction
 ): Promise<string> => {
   // Check permissions
-  if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+  if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
     throw new Error('Permission denied: Cannot generate invoice numbers');
   }
 
@@ -1886,7 +1894,7 @@ export const generateInvoicePDF = withAuth(async (
   const { knex } = await createTenantKnex();
 
   // Check permissions
-  if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+  if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
     throw new Error('Permission denied: Cannot generate invoice PDFs');
   }
 
@@ -1924,7 +1932,7 @@ export const downloadInvoicePDF = withAuth(async (
     const { knex } = await createTenantKnex();
 
     // Check permissions
-    if (!hasPermission(user, 'invoice', 'read')) {
+    if (!await hasPermission(user, 'invoice', 'read')) {
       throw new Error('Permission denied: Cannot download invoice PDFs');
     }
 
@@ -2047,7 +2055,7 @@ export const createInvoiceFromBillingResult = withAuth(async (
       invoiceData.invoice_number = invoiceNumber;
       const [insertedInvoice] = await withTransaction(knex, async (trx: Knex.Transaction) => {
         // Check permissions within transaction
-        if (!hasPermission(user, 'invoice', 'create') && !hasPermission(user, 'invoice', 'generate')) {
+        if (!await hasPermission(user, 'invoice', 'create') && !await hasPermission(user, 'invoice', 'generate')) {
           throw new Error('Permission denied: Cannot create invoices');
         }
 

--- a/packages/billing/src/actions/invoiceJobActions.ts
+++ b/packages/billing/src/actions/invoiceJobActions.ts
@@ -14,6 +14,7 @@ import type { IContact } from '@alga-psa/types';
 import Handlebars from 'handlebars';
 import fs from 'fs/promises';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { getClientById } from '@alga-psa/shared/billingClients/clients';
 
 interface InitialJobData extends JobData {
@@ -32,6 +33,9 @@ export const scheduleInvoiceZipAction = withAuth(async (
   { tenant },
   invoiceIds: string[]
 ) => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   const jobService = await JobService.create();
@@ -85,6 +89,9 @@ export const scheduleInvoiceEmailAction = withAuth(async (
   { tenant },
   invoiceIds: string[]
 ) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
 
   const jobService = await JobService.create();
@@ -182,6 +189,9 @@ export const getInvoiceEmailRecipientAction = withAuth(async (
   { tenant },
   invoiceIds: string[]
 ): Promise<GetInvoiceEmailRecipientsResult> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!invoiceIds || invoiceIds.length === 0) {
@@ -377,6 +387,9 @@ export const sendInvoiceEmailAction = withAuth(async (
   invoiceIds: string[],
   customMessage?: string
 ): Promise<SendInvoiceEmailsResult> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!invoiceIds || invoiceIds.length === 0) {

--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -25,6 +25,7 @@ import {
 import { validateInvoiceFinalization } from './taxSourceActions';
 import { withAuth } from '@alga-psa/auth';
 import { getSession } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 // Interface definitions specific to manual updates (might move to interfaces file later)
 export interface ManualInvoiceUpdate {
@@ -138,6 +139,9 @@ export const updateDraftInvoiceProperties = withAuth(async (
   invoiceId: string,
   input: DraftInvoicePropertiesUpdateInput
 ): Promise<DraftInvoicePropertiesUpdateResult> => {
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    throw new Error('Permission denied: invoice update required');
+  }
   const trimmedInvoiceNumber = input.invoiceNumber?.trim();
 
   if (!trimmedInvoiceNumber) {
@@ -237,6 +241,9 @@ export const finalizeInvoice = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<void> => {
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    throw new Error('Permission denied: invoice update required');
+  }
   const { knex } = await createTenantKnex();
 
   await finalizeInvoiceWithKnex(invoiceId, knex, tenant, user.user_id);
@@ -541,6 +548,9 @@ export const unfinalizeInvoice = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<void> => {
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    throw new Error('Permission denied: invoice update required');
+  }
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -602,6 +612,9 @@ export const updateInvoiceManualItems = withAuth(async (
   invoiceId: string,
   changes: ManualItemsUpdate
 ): Promise<InvoiceViewModel> => {
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    throw new Error('Permission denied: invoice update required');
+  }
   const session = await getSession();
   const billingEngine = new BillingEngine();
 
@@ -870,6 +883,9 @@ export const addManualItemsToInvoice = withAuth(async (
   invoiceId: string,
   items: IInvoiceCharge[]
 ): Promise<InvoiceViewModel> => {
+  if (!await hasPermission(user, 'invoice', 'update')) {
+    throw new Error('Permission denied: invoice update required');
+  }
   const session = await getSession();
 
   if (!session?.user?.id) {
@@ -986,6 +1002,9 @@ export const hardDeleteInvoice = withAuth(async (
   { tenant },
   invoiceId: string
 ) => {
+  if (!await hasPermission(user, 'invoice', 'delete')) {
+    throw new Error('Permission denied: invoice delete required');
+  }
   const { knex } = await createTenantKnex();
   let voidedCreditNotes: Array<{
     creditNoteId: string;

--- a/packages/billing/src/actions/invoiceQueries.ts
+++ b/packages/billing/src/actions/invoiceQueries.ts
@@ -14,6 +14,7 @@ import { toPlainDate } from '@alga-psa/core';
 import Invoice from '@alga-psa/billing/models/invoice';
 import { getClientContractPurchaseOrderContext, getPurchaseOrderConsumedCents } from '@alga-psa/billing/services/purchaseOrderService';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 // Types for paginated invoice fetching
 export interface FetchInvoicesOptions {
@@ -98,6 +99,10 @@ export const fetchInvoicesPaginated = withAuth(async (
   { tenant },
   options: FetchInvoicesOptions = {}
 ): Promise<PaginatedInvoicesResult> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   const {
     page = 1,
     pageSize = 10,
@@ -356,6 +361,10 @@ export const fetchInvoicesByClient = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<InvoiceViewModel[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   try {
     console.log(`Fetching invoices for client: ${clientId}`);
 
@@ -469,6 +478,10 @@ export const fetchInvoicesByContract = withAuth(async (
   { tenant },
   contractId: string
 ): Promise<InvoiceViewModel[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   try {
     const { knex } = await createTenantKnex();
 
@@ -547,6 +560,10 @@ export const getInvoiceForRendering = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<InvoiceViewModel> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   try {
     console.log('Fetching full invoice details for rendering:', invoiceId);
 
@@ -566,6 +583,10 @@ export const getEnrichedInvoiceViewModel = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<import('@alga-psa/types').WasmInvoiceViewModel | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   const { knex } = await createTenantKnex();
   const dbInvoiceData = await Invoice.getFullInvoiceById(knex, tenant, invoiceId);
   if (!dbInvoiceData) {
@@ -638,6 +659,10 @@ export const getInvoicePurchaseOrderSummary = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<InvoicePurchaseOrderSummary | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   const { knex } = await createTenantKnex();
 
   const invoice = await knex('invoices')
@@ -686,6 +711,10 @@ export const getInvoiceLineItems = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<IInvoiceCharge[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
+
   try {
     const { knex } = await createTenantKnex();
     console.log('Fetching line items for invoice:', invoiceId);

--- a/packages/billing/src/actions/invoiceTemplatePreview.ts
+++ b/packages/billing/src/actions/invoiceTemplatePreview.ts
@@ -3,6 +3,7 @@
 
 import crypto from 'crypto';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import type { WasmInvoiceViewModel } from '@alga-psa/types';
 import type { DesignerWorkspaceSnapshot } from '../components/invoice-designer/state/designerStore';
 import { exportWorkspaceToTemplateAst } from '../components/invoice-designer/ast/workspaceAst';
@@ -52,7 +53,11 @@ type AuthoritativePreviewResult = {
 };
 
 export const runAuthoritativeInvoiceTemplatePreview = withAuth(
-  async (_user, _context, input: AuthoritativePreviewInput): Promise<AuthoritativePreviewResult> => {
+  async (user, _context, input: AuthoritativePreviewInput): Promise<AuthoritativePreviewResult> => {
+    if (!await hasPermission(user, 'billing', 'read')) {
+      throw new Error('Permission denied: billing read required');
+    }
+
     const hasWorkspaceNodes =
       Boolean(input?.workspace?.nodesById) &&
       typeof input.workspace.nodesById === 'object' &&

--- a/packages/billing/src/actions/invoiceTemplates.ts
+++ b/packages/billing/src/actions/invoiceTemplates.ts
@@ -17,6 +17,7 @@ import {
 import type { TemplateAst, WasmInvoiceViewModel, RenderOutput } from '@alga-psa/types';
 import { v4 as uuidv4 } from 'uuid';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 import { evaluateTemplateAst } from '../lib/invoice-template-ast/evaluator';
 import { renderEvaluatedTemplateAst } from '../lib/invoice-template-ast/react-renderer';
@@ -75,6 +76,10 @@ export const getInvoiceTemplates = withAuth(async (
     user,
     { tenant }
 ): Promise<IInvoiceTemplate[]> => {
+    if (!await hasPermission(user, 'billing', 'read')) {
+        throw new Error('Permission denied: billing read required');
+    }
+
     const { knex } = await createTenantKnex();
     return withTransaction(knex, async (trx: Knex.Transaction) => {
         // Returns all standard templates and tenant-specific templates.
@@ -94,6 +99,10 @@ export const setDefaultTemplate = withAuth(async (
     { tenant },
     payload: SetDefaultTemplatePayload
 ): Promise<void> => {
+    if (!await hasPermission(user, 'billing', 'update')) {
+        throw new Error('Permission denied: billing update required');
+    }
+
     const { knex } = await createTenantKnex();
 
     await withTransaction(knex, async (trx: Knex.Transaction) => {
@@ -158,6 +167,10 @@ export const setClientTemplate = withAuth(async (
     clientId: string,
     templateId: string | null
 ): Promise<void> => {
+    if (!await hasPermission(user, 'billing', 'update')) {
+        throw new Error('Permission denied: billing update required');
+    }
+
     const { knex } = await createTenantKnex();
     await withTransaction(knex, async (trx: Knex.Transaction) => {
       return await trx('clients')
@@ -175,6 +188,10 @@ export const saveInvoiceTemplate = withAuth(async (
     { tenant },
     template: Omit<IInvoiceTemplate, 'tenant'> & { isClone?: boolean }
 ): Promise<{ success: boolean; template?: IInvoiceTemplate; error?: string }> => {
+    if (!await hasPermission(user, 'billing', 'update')) {
+        throw new Error('Permission denied: billing update required');
+    }
+
     const { knex } = await createTenantKnex();
 
     if (!(template as any)?.templateAst) {
@@ -368,6 +385,10 @@ export const deleteInvoiceTemplate = withAuth(async (
     { tenant },
     templateId: string
 ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean; error?: string }> => {
+    if (!await hasPermission(user, 'billing', 'delete')) {
+        throw new Error('Permission denied: billing delete required');
+    }
+
     const { knex } = await createTenantKnex();
 
     try {

--- a/packages/billing/src/actions/manualInvoiceActions.ts
+++ b/packages/billing/src/actions/manualInvoiceActions.ts
@@ -10,6 +10,7 @@ import * as invoiceService from '../services/invoiceService';
 import Invoice from '../models/invoice';
 import { withAuth } from '@alga-psa/auth';
 import { getSession } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { getAnalyticsAsync } from '../lib/authHelpers';
 
 import { getInitialInvoiceTaxSource } from './taxSourceActions';
@@ -44,6 +45,10 @@ export const generateManualInvoice = withAuth(async (
   { tenant },
   request: ManualInvoiceRequest
 ): Promise<ManualInvoiceResult> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
+
   // Validate session and tenant context
   const { session, knex } = await invoiceService.validateSessionAndTenant();
   const { clientId, items, expirationDate, isPrepayment } = request;
@@ -149,6 +154,10 @@ export const updateManualInvoice = withAuth(async (
   invoiceId: string,
   request: ManualInvoiceRequest
 ): Promise<InvoiceViewModel> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
+
   const { session, knex } = await invoiceService.validateSessionAndTenant();
   const { clientId, items } = request;
 

--- a/packages/billing/src/actions/materialActions.ts
+++ b/packages/billing/src/actions/materialActions.ts
@@ -5,8 +5,12 @@ import { Knex } from 'knex';
 import { createTenantKnex } from '@alga-psa/db';
 import { ITicketMaterial, IProjectMaterial } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
-export const listTicketMaterials = withAuth(async (_user, { tenant }, ticketId: string): Promise<ITicketMaterial[]> => {
+export const listTicketMaterials = withAuth(async (user, { tenant }, ticketId: string): Promise<ITicketMaterial[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const rows = await trx('ticket_materials as tm')
@@ -24,7 +28,7 @@ export const listTicketMaterials = withAuth(async (_user, { tenant }, ticketId: 
   });
 });
 
-export const addTicketMaterial = withAuth(async (_user, { tenant }, input: {
+export const addTicketMaterial = withAuth(async (user, { tenant }, input: {
   ticket_id: string;
   client_id: string;
   service_id: string;
@@ -33,6 +37,9 @@ export const addTicketMaterial = withAuth(async (_user, { tenant }, input: {
   currency_code: string;
   description?: string | null;
 }): Promise<ITicketMaterial> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const [row] = await trx('ticket_materials')
@@ -52,7 +59,10 @@ export const addTicketMaterial = withAuth(async (_user, { tenant }, input: {
   });
 });
 
-export const deleteTicketMaterial = withAuth(async (_user, { tenant }, ticketMaterialId: string): Promise<void> => {
+export const deleteTicketMaterial = withAuth(async (user, { tenant }, ticketMaterialId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const row = await trx('ticket_materials')
@@ -71,7 +81,10 @@ export const deleteTicketMaterial = withAuth(async (_user, { tenant }, ticketMat
   });
 });
 
-export const listProjectMaterials = withAuth(async (_user, { tenant }, projectId: string): Promise<IProjectMaterial[]> => {
+export const listProjectMaterials = withAuth(async (user, { tenant }, projectId: string): Promise<IProjectMaterial[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const rows = await trx('project_materials as pm')
@@ -89,7 +102,7 @@ export const listProjectMaterials = withAuth(async (_user, { tenant }, projectId
   });
 });
 
-export const addProjectMaterial = withAuth(async (_user, { tenant }, input: {
+export const addProjectMaterial = withAuth(async (user, { tenant }, input: {
   project_id: string;
   client_id: string;
   service_id: string;
@@ -98,6 +111,9 @@ export const addProjectMaterial = withAuth(async (_user, { tenant }, input: {
   currency_code: string;
   description?: string | null;
 }): Promise<IProjectMaterial> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const [row] = await trx('project_materials')
@@ -117,7 +133,10 @@ export const addProjectMaterial = withAuth(async (_user, { tenant }, input: {
   });
 });
 
-export const deleteProjectMaterial = withAuth(async (_user, { tenant }, projectMaterialId: string): Promise<void> => {
+export const deleteProjectMaterial = withAuth(async (user, { tenant }, projectMaterialId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     const row = await trx('project_materials')

--- a/packages/billing/src/actions/paymentActions.ts
+++ b/packages/billing/src/actions/paymentActions.ts
@@ -1,7 +1,8 @@
 'use server';
 
 import logger from '@alga-psa/core/logger';
-import type { PaymentDetails, PaymentLinkResult, WebhookProcessingResult } from '@alga-psa/types';
+import type { PaymentDetails, PaymentLinkResult } from '@alga-psa/types';
+import { getCurrentUserAsync } from '../lib/authHelpers';
 
 function isEnterpriseBuild(): boolean {
   return process.env.EDITION === 'ee' || process.env.NEXT_PUBLIC_EDITION === 'enterprise';
@@ -36,7 +37,16 @@ async function getPaymentService(tenantId: string): Promise<any | null> {
   }
 }
 
-export async function hasEnabledPaymentProvider(tenantId: string): Promise<boolean> {
+async function getAuthenticatedTenantId(): Promise<string> {
+  const currentUser = await getCurrentUserAsync();
+  if (!currentUser) {
+    throw new Error('Unauthorized: No authenticated user found');
+  }
+  return currentUser.tenant;
+}
+
+export async function hasEnabledPaymentProvider(): Promise<boolean> {
+  const tenantId = await getAuthenticatedTenantId();
   const paymentService = await getPaymentService(tenantId);
   if (!paymentService) return false;
 
@@ -49,9 +59,9 @@ export async function hasEnabledPaymentProvider(tenantId: string): Promise<boole
 }
 
 export async function getOrCreateInvoicePaymentLink(
-  tenantId: string,
   invoiceId: string
 ): Promise<PaymentLinkResult | null> {
+  const tenantId = await getAuthenticatedTenantId();
   const paymentService = await getPaymentService(tenantId);
   if (!paymentService) return null;
 
@@ -62,17 +72,16 @@ export async function getOrCreateInvoicePaymentLink(
 }
 
 export async function getOrCreateInvoicePaymentLinkUrl(
-  tenantId: string,
   invoiceId: string
 ): Promise<string | null> {
-  const link = await getOrCreateInvoicePaymentLink(tenantId, invoiceId);
+  const link = await getOrCreateInvoicePaymentLink(invoiceId);
   return link?.url || null;
 }
 
 export async function getInvoicePaymentStatus(
-  tenantId: string,
   invoiceId: string
 ): Promise<PaymentDetails | null> {
+  const tenantId = await getAuthenticatedTenantId();
   const paymentService = await getPaymentService(tenantId);
   if (!paymentService) return null;
 
@@ -83,9 +92,9 @@ export async function getInvoicePaymentStatus(
 }
 
 export async function getActiveInvoicePaymentLinkUrl(
-  tenantId: string,
   invoiceId: string
 ): Promise<string | null> {
+  const tenantId = await getAuthenticatedTenantId();
   const paymentService = await getPaymentService(tenantId);
   if (!paymentService) return null;
 
@@ -111,29 +120,4 @@ export async function getInvoicePaymentLinkUrlForEmail(
 
   const link = await paymentService.getOrCreatePaymentLink(invoiceId);
   return link?.url || null;
-}
-
-export async function processStripePaymentWebhookPayload(
-  tenantId: string,
-  payload: string
-): Promise<WebhookProcessingResult> {
-  if (!isEnterpriseBuild()) {
-    return { success: false, error: 'Payment integration not available' } as WebhookProcessingResult;
-  }
-
-  try {
-    const ee = await loadEnterprisePayments();
-    if (!ee?.PaymentService || !ee?.createStripePaymentProvider) {
-      return { success: false, error: 'Payment integration not available' } as WebhookProcessingResult;
-    }
-
-    const paymentService = await ee.PaymentService.create(tenantId);
-    const provider = ee.createStripePaymentProvider(tenantId);
-    const webhookEvent = provider.parseWebhookEvent(payload);
-
-    return paymentService.processWebhookEvent(webhookEvent);
-  } catch (error) {
-    logger.error('[billing/paymentActions] processStripePaymentWebhookPayload failed', { tenantId, error });
-    return { success: false, error: 'Payment webhook processing failed' } as WebhookProcessingResult;
-  }
 }

--- a/packages/billing/src/actions/paymentWebhookHelpers.ts
+++ b/packages/billing/src/actions/paymentWebhookHelpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Payment webhook helpers — NOT a Next.js server action module.
+ *
+ * WARNING: processStripePaymentWebhookPayload is a webhook receiver and must be
+ * called from a verified webhook handler only, never as a Next.js server action.
+ * This function intentionally lives outside any 'use server' file so it cannot
+ * be accidentally exposed as a callable server action.
+ */
+
+import logger from '@alga-psa/core/logger';
+import type { WebhookProcessingResult } from '@alga-psa/types';
+
+function isEnterpriseBuild(): boolean {
+  return process.env.EDITION === 'ee' || process.env.NEXT_PUBLIC_EDITION === 'enterprise';
+}
+
+async function loadEnterprisePayments(): Promise<{
+  PaymentService: any;
+  createStripePaymentProvider: any;
+} | null> {
+  try {
+    const mod = await import('@enterprise/lib/payments');
+    return {
+      PaymentService: (mod as any).PaymentService,
+      createStripePaymentProvider: (mod as any).createStripePaymentProvider,
+    };
+  } catch (error) {
+    logger.debug('[billing/paymentWebhookHelpers] enterprise payments module not available', { error });
+    return null;
+  }
+}
+
+/**
+ * Process a verified Stripe webhook payload.
+ *
+ * This function MUST only be called from a webhook route handler that has already
+ * verified the Stripe-Signature header. It must never be exposed as a server action.
+ */
+export async function processStripePaymentWebhookPayload(
+  tenantId: string,
+  payload: string
+): Promise<WebhookProcessingResult> {
+  if (!isEnterpriseBuild()) {
+    return { success: false, error: 'Payment integration not available' } as WebhookProcessingResult;
+  }
+
+  try {
+    const ee = await loadEnterprisePayments();
+    if (!ee?.PaymentService || !ee?.createStripePaymentProvider) {
+      return { success: false, error: 'Payment integration not available' } as WebhookProcessingResult;
+    }
+
+    const paymentService = await ee.PaymentService.create(tenantId);
+    const provider = ee.createStripePaymentProvider(tenantId);
+    const webhookEvent = provider.parseWebhookEvent(payload);
+
+    return paymentService.processWebhookEvent(webhookEvent);
+  } catch (error) {
+    logger.error('[billing/paymentWebhookHelpers] processStripePaymentWebhookPayload failed', { tenantId, error });
+    return { success: false, error: 'Payment webhook processing failed' } as WebhookProcessingResult;
+  }
+}

--- a/packages/billing/src/actions/quoteActions.ts
+++ b/packages/billing/src/actions/quoteActions.ts
@@ -922,6 +922,10 @@ export const saveQuoteAsTemplate = withAuth(async (
   { tenant },
   quoteId: string
 ): Promise<IQuote | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const denied = await requireBillingCreatePermission(user);
   if (denied) {
     return denied;
@@ -1036,6 +1040,10 @@ export const submitQuoteForApproval = withAuth(async (
   { tenant },
   quoteId: string
 ): Promise<IQuote | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const denied = await requireBillingUpdatePermission(user);
   if (denied) {
     return denied;
@@ -1100,9 +1108,12 @@ export const updateQuoteApprovalSettings = withAuth(async (
   { tenant },
   approvalRequired: boolean
 ): Promise<QuoteApprovalWorkflowSettings | ActionPermissionError> => {
-  const denied = await requireSettingsUpdatePermission(user);
-  if (denied) {
-    return denied;
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    return permissionError('Permission denied: Cannot update quote approval settings');
   }
 
   const { knex } = await createTenantKnex();
@@ -1221,6 +1232,10 @@ export const sendQuote = withAuth(async (
   quoteId: string,
   input: SendQuoteInput = {}
 ): Promise<IQuote | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const denied = await requireBillingUpdatePermission(user);
   if (denied) {
     return denied;
@@ -1332,6 +1347,10 @@ export const resendQuote = withAuth(async (
   quoteId: string,
   input: SendQuoteInput = {}
 ): Promise<IQuote | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const denied = await requireBillingUpdatePermission(user);
   if (denied) {
     return denied;
@@ -1417,6 +1436,10 @@ export const sendQuoteReminder = withAuth(async (
   quoteId: string,
   input: SendQuoteInput = {}
 ): Promise<IQuote | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const denied = await requireBillingUpdatePermission(user);
   if (denied) {
     return denied;
@@ -1501,6 +1524,10 @@ export const convertQuoteToContract = withAuth(async (
   { tenant },
   quoteId: string,
 ): Promise<{ quote: IQuote; contract: IContract } | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const createDenied = await requireBillingCreatePermission(user);
   if (createDenied) {
     return createDenied;
@@ -1530,6 +1557,10 @@ export const convertQuoteToInvoice = withAuth(async (
   { tenant },
   quoteId: string,
 ): Promise<{ quote: IQuote; invoice: IInvoice } | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const createDenied = await requireBillingCreatePermission(user);
   if (createDenied) {
     return createDenied;
@@ -1559,6 +1590,10 @@ export const convertQuoteToBoth = withAuth(async (
   { tenant },
   quoteId: string,
 ): Promise<{ quote: IQuote; contract: IContract; invoice: IInvoice } | ActionPermissionError> => {
+  if ((user as any).user_type === 'client') {
+    throw new Error('Permission denied: operation not available in client portal');
+  }
+
   const createDenied = await requireBillingCreatePermission(user);
   if (createDenied) {
     return createDenied;

--- a/packages/billing/src/actions/quoteDocumentTemplates.ts
+++ b/packages/billing/src/actions/quoteDocumentTemplates.ts
@@ -75,7 +75,11 @@ export const setDefaultQuoteDocumentTemplate = withAuth(async (
   user,
   { tenant },
   payload: SetDefaultQuoteTemplatePayload
-): Promise<void> => {
+): Promise<void | ActionPermissionError> => {
+  if (!await hasPermission(user as any, 'billing', 'update')) {
+    return permissionError('Permission denied: Cannot set default quote document template');
+  }
+
   const { knex } = await createTenantKnex();
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/billing/src/actions/quoteRecipientActions.ts
+++ b/packages/billing/src/actions/quoteRecipientActions.ts
@@ -6,13 +6,17 @@ import type { IContact } from '@alga-psa/types';
 import type { ContactFilterStatus } from '@alga-psa/shared/ticketClients/types';
 import { getContactsByClient as getContactsByClientModel } from '@alga-psa/shared/ticketClients/contacts';
 import { withAuth } from '@alga-psa/auth/withAuth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 export const getQuoteRecipientContacts = withAuth(async (
-  _user,
+  user,
   { tenant },
   clientId: string,
   status: ContactFilterStatus = 'active',
 ): Promise<IContact[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   return withTransaction(knex, async (trx: Knex.Transaction) => {

--- a/packages/billing/src/actions/recurringBillingRunActions.ts
+++ b/packages/billing/src/actions/recurringBillingRunActions.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
-import { getCurrentUserAsync } from '../lib/authHelpers';
+import { getCurrentUserAsync, hasPermissionAsync } from '../lib/authHelpers';
 import {
   generateInvoiceForSelectionInput,
   generateInvoiceForSelectionInputs,
@@ -78,6 +78,15 @@ export async function selectClientCadenceRecurringRunTargets(
   pageSize: number;
   totalPages: number;
 }> {
+  const currentUser = await getCurrentUserAsync();
+  if (!currentUser) {
+    throw new Error('Unauthorized: No authenticated user found');
+  }
+
+  if (!await hasPermissionAsync(currentUser, 'billing', 'read')) {
+    throw new Error('Permission denied');
+  }
+
   const recurringDueWork = await getAvailableRecurringDueWork(options);
   const targets = mapClientCadenceInvoiceCandidatesToRecurringRunTargets(
     recurringDueWork.invoiceCandidates,
@@ -108,6 +117,10 @@ export async function generateInvoicesAsRecurringBillingRun(params: {
   const currentUser = await getCurrentUserAsync();
   if (!currentUser) {
     throw new Error('Unauthorized: No authenticated user found');
+  }
+
+  if (!await hasPermissionAsync(currentUser, 'invoice', 'create') && !await hasPermissionAsync(currentUser, 'invoice', 'generate')) {
+    throw new Error('Permission denied');
   }
 
   const targets = normalizeRecurringBillingRunTargets(params);
@@ -250,6 +263,10 @@ export async function generateGroupedInvoicesAsRecurringBillingRun(params: {
   const currentUser = await getCurrentUserAsync();
   if (!currentUser) {
     throw new Error('Unauthorized: No authenticated user found');
+  }
+
+  if (!await hasPermissionAsync(currentUser, 'invoice', 'create') && !await hasPermissionAsync(currentUser, 'invoice', 'generate')) {
+    throw new Error('Permission denied');
   }
 
   const groupedTargets = normalizeRecurringBillingRunGroupedTargets(params);

--- a/packages/billing/src/actions/serviceActions.ts
+++ b/packages/billing/src/actions/serviceActions.ts
@@ -514,7 +514,11 @@ export const deleteService = withAuth(async (
     _user,
     { tenant },
     serviceId: string
-  ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
+  ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean } | ActionPermissionError> => {
+    if (!await hasPermission(_user, 'service', 'delete')) {
+      return permissionError('Permission denied: Cannot delete services');
+    }
+
     try {
         const { knex } = await createTenantKnex();
         const existing = await knex('service_catalog')
@@ -785,7 +789,11 @@ export const createServiceType = withAuth(async (
   user,
   { tenant },
   data: Omit<IServiceType, 'id' | 'created_at' | 'updated_at' | 'tenant'>
-): Promise<IServiceType> => {
+): Promise<IServiceType | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'create')) {
+    return permissionError('Permission denied: Cannot create service types');
+  }
+
   try {
       // ServiceTypeModel is imported at the top of the file
       // Tenant context is handled within the model method
@@ -807,7 +815,11 @@ export const updateServiceType = withAuth(async (
   { tenant },
   id: string,
   data: Partial<Omit<IServiceType, 'id' | 'tenant' | 'created_at' | 'updated_at'>>
-): Promise<IServiceType> => {
+): Promise<IServiceType | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'update')) {
+    return permissionError('Permission denied: Cannot update service types');
+  }
+
   try {
       // ServiceTypeModel is imported at the top of the file
       // Tenant context is handled within the model method
@@ -841,7 +853,11 @@ export const getAllServiceTypes = withAuth(async (user, { tenant }): Promise<ISe
   }
 });
 
-export const deleteServiceType = withAuth(async (user, { tenant }, id: string): Promise<void> => {
+export const deleteServiceType = withAuth(async (user, { tenant }, id: string): Promise<void | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'delete')) {
+    return permissionError('Permission denied: Cannot delete service types');
+  }
+
   try {
     // ServiceTypeModel is imported at the top of the file
 
@@ -899,7 +915,11 @@ export const createServiceTypeInline = withAuth(async (
   user,
   { tenant },
   name: string
-): Promise<IServiceType> => {
+): Promise<IServiceType | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'create')) {
+    return permissionError('Permission denied: Cannot create service types');
+  }
+
   try {
     const { knex: db } = await createTenantKnex();
 
@@ -966,7 +986,11 @@ export const createServiceTypeInline = withAuth(async (
 /**
  * Update a service type name (inline editing)
  */
-export const updateServiceTypeInline = withAuth(async (user, { tenant }, id: string, name: string): Promise<IServiceType> => {
+export const updateServiceTypeInline = withAuth(async (user, { tenant }, id: string, name: string): Promise<IServiceType | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'update')) {
+    return permissionError('Permission denied: Cannot update service types');
+  }
+
   try {
     // ServiceTypeModel is imported at the top of the file
     const { knex: db } = await createTenantKnex();
@@ -990,7 +1014,11 @@ export const updateServiceTypeInline = withAuth(async (user, { tenant }, id: str
 /**
  * Delete a service type (inline deletion with usage check)
  */
-export const deleteServiceTypeInline = withAuth(async (user, { tenant }, id: string): Promise<void> => {
+export const deleteServiceTypeInline = withAuth(async (user, { tenant }, id: string): Promise<void | ActionPermissionError> => {
+  if (!await hasPermission(user, 'service', 'delete')) {
+    return permissionError('Permission denied: Cannot delete service types');
+  }
+
   // This is the same as deleteServiceType but renamed for clarity
   return deleteServiceType(id);
 });

--- a/packages/billing/src/actions/serviceCategoryActions.ts
+++ b/packages/billing/src/actions/serviceCategoryActions.ts
@@ -6,6 +6,7 @@ import { IServiceCategory } from '@alga-psa/types';
 import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 
 export const getServiceCategories = withAuth(async (user, { tenant }) => {
@@ -24,6 +25,9 @@ export const getServiceCategories = withAuth(async (user, { tenant }) => {
 });
 
 export const createServiceCategory = withAuth(async (user, { tenant }, categoryName: string, description?: string) => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   if (!categoryName || categoryName.trim() === '') {
     throw new Error('Category name is required');
   }
@@ -67,6 +71,9 @@ export const createServiceCategory = withAuth(async (user, { tenant }, categoryN
 });
 
 export const deleteServiceCategory = withAuth(async (user, { tenant }, categoryId: string) => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   if (!categoryId) {
     throw new Error('Category ID is required');
   }
@@ -110,6 +117,9 @@ export const deleteServiceCategory = withAuth(async (user, { tenant }, categoryI
 });
 
 export const updateServiceCategory = withAuth(async (user, { tenant }, categoryId: string, categoryData: Partial<IServiceCategory>) => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   if (!categoryId) {
     throw new Error('Category ID is required');
   }

--- a/packages/billing/src/actions/serviceRateTierActions.ts
+++ b/packages/billing/src/actions/serviceRateTierActions.ts
@@ -7,11 +7,15 @@ import { withTransaction } from '@alga-psa/db'
 import { createTenantKnex } from '@alga-psa/db'
 import { Knex } from 'knex'
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 /**
  * Get all rate tiers for a specific service
  */
-export const getServiceRateTiers = withAuth(async (_user, { tenant }, serviceId: string): Promise<IServiceRateTier[]> => {
+export const getServiceRateTiers = withAuth(async (user, { tenant }, serviceId: string): Promise<IServiceRateTier[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex()
     const tiers = await withTransaction(knex, async (trx) => {
@@ -27,7 +31,10 @@ export const getServiceRateTiers = withAuth(async (_user, { tenant }, serviceId:
 /**
  * Get a specific rate tier by ID
  */
-export const getServiceRateTierById = withAuth(async (_user, { tenant }, tierId: string): Promise<IServiceRateTier | null> => {
+export const getServiceRateTierById = withAuth(async (user, { tenant }, tierId: string): Promise<IServiceRateTier | null> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   try {
     const { knex } = await createTenantKnex()
     const tier = await withTransaction(knex, async (trx) => {
@@ -44,10 +51,13 @@ export const getServiceRateTierById = withAuth(async (_user, { tenant }, tierId:
  * Create a new rate tier
  */
 export const createServiceRateTier = withAuth(async (
-  _user,
+  user,
   { tenant },
   tierData: ICreateServiceRateTier
 ): Promise<IServiceRateTier> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex: db } = await createTenantKnex()
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
@@ -67,11 +77,14 @@ export const createServiceRateTier = withAuth(async (
  * Update an existing rate tier
  */
 export const updateServiceRateTier = withAuth(async (
-  _user,
+  user,
   { tenant },
   tierId: string,
   tierData: IUpdateServiceRateTier
 ): Promise<IServiceRateTier | null> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex: db } = await createTenantKnex()
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
@@ -93,7 +106,10 @@ export const updateServiceRateTier = withAuth(async (
 /**
  * Delete a rate tier
  */
-export const deleteServiceRateTier = withAuth(async (_user, { tenant }, tierId: string): Promise<void> => {
+export const deleteServiceRateTier = withAuth(async (user, { tenant }, tierId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex: db } = await createTenantKnex()
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
@@ -113,7 +129,10 @@ export const deleteServiceRateTier = withAuth(async (_user, { tenant }, tierId: 
 /**
  * Delete all rate tiers for a service
  */
-export const deleteServiceRateTiersByServiceId = withAuth(async (_user, { tenant }, serviceId: string): Promise<void> => {
+export const deleteServiceRateTiersByServiceId = withAuth(async (user, { tenant }, serviceId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex: db } = await createTenantKnex()
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
@@ -131,11 +150,14 @@ export const deleteServiceRateTiersByServiceId = withAuth(async (_user, { tenant
  * This will replace all existing tiers for the service
  */
 export const updateServiceRateTiers = withAuth(async (
-  _user,
+  user,
   { tenant },
   serviceId: string,
   tiers: Omit<ICreateServiceRateTier, 'service_id'>[]
 ): Promise<IServiceRateTier[]> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex: db } = await createTenantKnex()
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {

--- a/packages/billing/src/actions/taxRateActions.ts
+++ b/packages/billing/src/actions/taxRateActions.ts
@@ -19,7 +19,7 @@ export type DeleteTaxRateResult = DeletionValidationResult & { success: boolean;
 export const getTaxRates = withAuth(async (user, { tenant }): Promise<ITaxRate[]> => {
   try {
     await assertPsaOnlyTenantAccess(tenant, 'billing_actions');
-    if (!hasPermission(user, 'billing', 'read')) {
+    if (!await hasPermission(user, 'billing', 'read')) {
       throw new Error('Permission denied: Cannot read tax rates');
     }
 
@@ -38,7 +38,7 @@ export const getTaxRates = withAuth(async (user, { tenant }): Promise<ITaxRate[]
 export const addTaxRate = withAuth(async (user, { tenant }, taxRateData: Omit<ITaxRate, 'tax_rate_id'>): Promise<ITaxRate> => {
   try {
     await assertPsaOnlyTenantAccess(tenant, 'billing_actions');
-    if (!hasPermission(user, 'billing', 'create')) {
+    if (!await hasPermission(user, 'billing', 'create')) {
       throw new Error('Permission denied: Cannot create tax rates');
     }
 
@@ -74,7 +74,7 @@ export const addTaxRate = withAuth(async (user, { tenant }, taxRateData: Omit<IT
 export const updateTaxRate = withAuth(async (user, { tenant }, taxRateData: ITaxRate): Promise<ITaxRate> => {
   try {
     await assertPsaOnlyTenantAccess(tenant, 'billing_actions');
-    if (!hasPermission(user, 'billing', 'update')) {
+    if (!await hasPermission(user, 'billing', 'update')) {
       throw new Error('Permission denied: Cannot update tax rates');
     }
 
@@ -135,9 +135,12 @@ export const updateTaxRate = withAuth(async (user, { tenant }, taxRateData: ITax
   }
 });
 
-export const deleteTaxRate = withAuth(async (_user, { tenant }, taxRateId: string): Promise<DeleteTaxRateResult> => {
+export const deleteTaxRate = withAuth(async (user, { tenant }, taxRateId: string): Promise<DeleteTaxRateResult> => {
   try {
     await assertPsaOnlyTenantAccess(tenant, 'billing_actions');
+    if (!await hasPermission(user, 'billing', 'delete')) {
+      throw new Error('Permission denied: billing delete required');
+    }
     const { knex } = await createTenantKnex();
     const result = await deleteEntityWithValidation('tax_rate', taxRateId, knex, tenant, async (trx, tenantId) => {
       // Fail-fast tenant guard: confirm the tax rate belongs to this tenant before touching
@@ -202,6 +205,9 @@ export const deleteTaxRate = withAuth(async (_user, { tenant }, taxRateId: strin
   }
 });
 
-export const confirmDeleteTaxRate = withAuth(async (_user, _ctx, taxRateId: string): Promise<DeleteTaxRateResult> => {
+export const confirmDeleteTaxRate = withAuth(async (user, _ctx, taxRateId: string): Promise<DeleteTaxRateResult> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   return deleteTaxRate(taxRateId);
 });

--- a/packages/billing/src/actions/taxSettingsActions.ts
+++ b/packages/billing/src/actions/taxSettingsActions.ts
@@ -16,7 +16,7 @@ export const getClientTaxSettings = withAuth(async (user, { tenant }, clientId: 
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
       const taxSettings = await trx<IClientTaxSettings>('client_tax_settings')
-        .where({ client_id: clientId })
+        .where({ client_id: clientId, tenant })
         .first();
 
     // Removed fetching of components, thresholds, holidays based on tax_rate_id (Phase 1.2)
@@ -41,6 +41,9 @@ export const updateClientTaxSettings = withAuth(async (
   clientId: string,
   taxSettings: Omit<IClientTaxSettings, 'tenant'>
 ): Promise<IClientTaxSettings | null> => {
+  if (!(await hasPermission(user, 'billing', 'update'))) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex: db } = await createTenantKnex();
   return withTransaction(db, async (trx: Knex.Transaction) => {
     try {
@@ -171,6 +174,9 @@ export const createTaxRegion = withAuth(async (
     is_active?: boolean;
   }
 ): Promise<ITaxRegion> => {
+  if (!(await hasPermission(user, 'billing', 'create'))) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
   const { region_code, region_name, is_active = true } = data; // Default is_active to true
 
@@ -223,7 +229,7 @@ export const updateTaxRegion = withAuth(async (
   data: { region_code?: string; region_name?: string; is_active?: boolean }
 ): Promise<ITaxRegion> => {
   try {
-    if (!(hasPermission(user, 'billing', 'update'))) {
+    if (!(await hasPermission(user, 'billing', 'update'))) {
       throw new Error('Permission denied: Cannot update tax regions');
     }
 
@@ -376,6 +382,9 @@ export const createTaxComponent = withAuth(async (
   { tenant },
   component: Omit<ITaxComponent, 'tax_component_id' | 'tenant'>
 ): Promise<ITaxComponent> => {
+  if (!(await hasPermission(user, 'billing', 'create'))) {
+    throw new Error('Permission denied: billing create required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [createdComponent] = await knex<ITaxComponent>('tax_components')
@@ -396,10 +405,13 @@ export const updateTaxComponent = withAuth(async (
   componentId: string,
   component: Partial<ITaxComponent>
 ): Promise<ITaxComponent> => {
+  if (!(await hasPermission(user, 'billing', 'update'))) {
+    throw new Error('Permission denied: billing update required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [updatedComponent] = await knex<ITaxComponent>('tax_components')
-      .where({ tax_component_id: componentId })
+      .where({ tax_component_id: componentId, tenant })
       .update(component)
       .returning('*');
 
@@ -411,10 +423,13 @@ export const updateTaxComponent = withAuth(async (
 });
 
 export const deleteTaxComponent = withAuth(async (user, { tenant }, componentId: string): Promise<void> => {
+  if (!(await hasPermission(user, 'billing', 'delete'))) {
+    throw new Error('Permission denied: billing delete required');
+  }
   try {
     const { knex } = await createTenantKnex();
     await knex('tax_components')
-      .where({ tax_component_id: componentId })
+      .where({ tax_component_id: componentId, tenant })
       .del();
   } catch (error) {
     console.error('Error deleting tax component:', error);
@@ -427,6 +442,9 @@ export const createTaxRateThreshold = withAuth(async (
   { tenant },
   threshold: Omit<ITaxRateThreshold, 'tax_rate_threshold_id'>
 ): Promise<ITaxRateThreshold> => {
+  if (!(await hasPermission(user, 'billing', 'create'))) {
+    throw new Error('Permission denied: billing create required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [createdThreshold] = await knex<ITaxRateThreshold>('tax_rate_thresholds')
@@ -446,6 +464,9 @@ export const updateTaxRateThreshold = withAuth(async (
   thresholdId: string,
   threshold: Partial<ITaxRateThreshold>
 ): Promise<ITaxRateThreshold> => {
+  if (!(await hasPermission(user, 'billing', 'update'))) {
+    throw new Error('Permission denied: billing update required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [updatedThreshold] = await knex<ITaxRateThreshold>('tax_rate_thresholds')
@@ -461,6 +482,9 @@ export const updateTaxRateThreshold = withAuth(async (
 });
 
 export const deleteTaxRateThreshold = withAuth(async (user, { tenant }, thresholdId: string): Promise<void> => {
+  if (!(await hasPermission(user, 'billing', 'delete'))) {
+    throw new Error('Permission denied: billing delete required');
+  }
   try {
     const { knex } = await createTenantKnex();
     await knex('tax_rate_thresholds')
@@ -477,6 +501,9 @@ export const createTaxHoliday = withAuth(async (
   { tenant },
   holiday: Omit<ITaxHoliday, 'tax_holiday_id'>
 ): Promise<ITaxHoliday> => {
+  if (!(await hasPermission(user, 'billing', 'create'))) {
+    throw new Error('Permission denied: billing create required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [createdHoliday] = await knex<ITaxHoliday>('tax_holidays')
@@ -496,6 +523,9 @@ export const updateTaxHoliday = withAuth(async (
   holidayId: string,
   holiday: Partial<ITaxHoliday>
 ): Promise<ITaxHoliday> => {
+  if (!(await hasPermission(user, 'billing', 'update'))) {
+    throw new Error('Permission denied: billing update required');
+  }
   try {
     const { knex } = await createTenantKnex();
     const [updatedHoliday] = await knex<ITaxHoliday>('tax_holidays')
@@ -511,6 +541,9 @@ export const updateTaxHoliday = withAuth(async (
 });
 
 export const deleteTaxHoliday = withAuth(async (user, { tenant }, holidayId: string): Promise<void> => {
+  if (!(await hasPermission(user, 'billing', 'delete'))) {
+    throw new Error('Permission denied: billing delete required');
+  }
   try {
     const { knex } = await createTenantKnex();
     await knex('tax_holidays')
@@ -522,6 +555,8 @@ export const deleteTaxHoliday = withAuth(async (user, { tenant }, holidayId: str
   }
 });
 
+// Internal helper — not a direct server action endpoint. Called only from already-authenticated
+// contexts (e.g. during client creation). Does not need its own withAuth/hasPermission wrapper.
 export async function createDefaultTaxSettings(clientId: string): Promise<IClientTaxSettings> {
   const taxService = new TaxService();
   return taxService.createDefaultTaxSettings(clientId);
@@ -542,7 +577,7 @@ export const updateClientTaxExemptStatus = withAuth(async (
   taxExemptionCertificate?: string
 ): Promise<{ is_tax_exempt: boolean; tax_exemption_certificate?: string }> => {
   try {
-    if (!(hasPermission(user, 'client', 'update'))) {
+    if (!(await hasPermission(user, 'client', 'update'))) {
       throw new Error('Permission denied: Cannot update client tax settings');
     }
 
@@ -714,7 +749,7 @@ export const updateTenantTaxSettings = withAuth(async (
   }
 ): Promise<void> => {
   try {
-    if (!(hasPermission(user, 'billing', 'update'))) {
+    if (!(await hasPermission(user, 'billing', 'update'))) {
       throw new Error('Permission denied: Cannot update tenant tax settings');
     }
 
@@ -815,7 +850,7 @@ export const dismissTaxDelegationNudge = withAuth(async (
   user,
   { tenant }
 ): Promise<void> => {
-  if (!(hasPermission(user, 'billing', 'update'))) {
+  if (!(await hasPermission(user, 'billing', 'update'))) {
     throw new Error('Permission denied: Cannot dismiss tax delegation banner');
   }
   if (!tenant) {

--- a/packages/billing/src/actions/taxSourceActions.ts
+++ b/packages/billing/src/actions/taxSourceActions.ts
@@ -4,6 +4,7 @@ import { createTenantKnex } from '@alga-psa/db';
 import type { TaxSource } from '@alga-psa/types';
 import { getTaxImportState } from '@alga-psa/types';
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 
 /**
  * Client-specific tax source resolution result.
@@ -26,6 +27,9 @@ export const getEffectiveTaxSourceForClient = withAuth(async (
   { tenant },
   clientId: string
 ): Promise<ClientTaxSourceInfo> => {
+  if (!await hasPermission(_user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -112,6 +116,9 @@ export const validateInvoiceFinalization = withAuth(async (
   { tenant },
   invoiceId: string
 ): Promise<InvoiceFinalizationValidation> => {
+  if (!await hasPermission(_user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {
@@ -155,6 +162,9 @@ export const updateInvoiceTaxSource = withAuth(async (
   invoiceId: string,
   newTaxSource: TaxSource
 ): Promise<{ success: boolean; error?: string }> => {
+  if (!await hasPermission(_user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
 
   if (!tenant) {

--- a/packages/billing/src/actions/usageActions.ts
+++ b/packages/billing/src/actions/usageActions.ts
@@ -7,10 +7,14 @@ import { ICreateUsageRecord, IUpdateUsageRecord, IUsageFilter, IUsageRecord } fr
 import { revalidatePath } from 'next/cache';
 import { findOrCreateCurrentBucketUsageRecord, updateBucketUsageMinutes } from '../services/bucketUsageService'; // Import bucket service functions
 import { withAuth } from '@alga-psa/auth';
+import { hasPermission } from '@alga-psa/auth/rbac';
 import { getAnalyticsAsync } from '../lib/authHelpers';
 
 
-export const createUsageRecord = withAuth(async (_user, { tenant }, data: ICreateUsageRecord): Promise<IUsageRecord> => {
+export const createUsageRecord = withAuth(async (user, { tenant }, data: ICreateUsageRecord): Promise<IUsageRecord> => {
+  if (!await hasPermission(user, 'billing', 'create')) {
+    throw new Error('Permission denied: billing create required');
+  }
   const { knex } = await createTenantKnex();
 
   return await knex.transaction(async (trx) => {
@@ -100,7 +104,10 @@ export const createUsageRecord = withAuth(async (_user, { tenant }, data: ICreat
   });
 });
 
-export const updateUsageRecord = withAuth(async (_user, { tenant }, data: IUpdateUsageRecord): Promise<IUsageRecord> => {
+export const updateUsageRecord = withAuth(async (user, { tenant }, data: IUpdateUsageRecord): Promise<IUsageRecord> => {
+  if (!await hasPermission(user, 'billing', 'update')) {
+    throw new Error('Permission denied: billing update required');
+  }
   const { knex } = await createTenantKnex();
 
   return await knex.transaction(async (trx) => {
@@ -213,7 +220,10 @@ export const updateUsageRecord = withAuth(async (_user, { tenant }, data: IUpdat
   });
 });
 
-export const deleteUsageRecord = withAuth(async (_user, { tenant }, usageId: string): Promise<void> => {
+export const deleteUsageRecord = withAuth(async (user, { tenant }, usageId: string): Promise<void> => {
+  if (!await hasPermission(user, 'billing', 'delete')) {
+    throw new Error('Permission denied: billing delete required');
+  }
   const { knex } = await createTenantKnex();
 
   await knex.transaction(async (trx) => {
@@ -287,7 +297,10 @@ export const deleteUsageRecord = withAuth(async (_user, { tenant }, usageId: str
   revalidatePath('/msp/billing');
 });
 
-export const getUsageRecords = withAuth(async (_user, { tenant }, filter?: IUsageFilter): Promise<IUsageRecord[]> => {
+export const getUsageRecords = withAuth(async (user, { tenant }, filter?: IUsageFilter): Promise<IUsageRecord[]> => {
+  if (!await hasPermission(user, 'billing', 'read')) {
+    throw new Error('Permission denied: billing read required');
+  }
   const { knex } = await createTenantKnex();
 
   let query = knex('usage_tracking')

--- a/packages/billing/src/components/billing-dashboard/CreditReconciliation.tsx
+++ b/packages/billing/src/components/billing-dashboard/CreditReconciliation.tsx
@@ -263,14 +263,8 @@ const CreditReconciliation: React.FC = () => {
     try {
       setRunningValidation(true);
 
-      const sessionUser = session?.user as any;
-      const currentUserId = sessionUser?.id ?? sessionUser?.user_id;
-      if (!currentUserId) {
-        throw new Error('User not authenticated');
-      }
-
       // Call the server action to run validation for the selected client
-      const result = await validateClientCredit(selectedClient, String(currentUserId));
+      const result = await validateClientCredit(selectedClient);
 
       console.log('Validation result:', result);
 

--- a/packages/billing/src/components/billing-dashboard/DiscrepancyDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/DiscrepancyDetail.tsx
@@ -186,15 +186,8 @@ const DiscrepancyDetail: React.FC = () => {
       setIsResolvingReport(true);
       setResolutionError(null);
 
-      const sessionUser = session?.user as any;
-      const currentUserId = sessionUser?.id ?? sessionUser?.user_id;
-      if (!currentUserId) {
-        throw new Error('User not authenticated');
-      }
-
       const resolvedReport = await resolveReconciliationReport(
         report.report_id,
-        String(currentUserId),
         resolutionNotes
       );
 
@@ -217,16 +210,9 @@ const DiscrepancyDetail: React.FC = () => {
     try {
       setIsApplyingFix(true);
 
-      const sessionUser = session?.user as any;
-      const currentUserId = sessionUser?.id ?? sessionUser?.user_id;
-      if (!currentUserId) {
-        throw new Error('User not authenticated');
-      }
-
       // Call the server action to apply the fix
       const resolvedReport = await applyReconciliationFix(
         report.report_id,
-        String(currentUserId),
         fixType,
         notes,
         customData

--- a/packages/billing/src/components/billing-dashboard/ReconciliationResolution.tsx
+++ b/packages/billing/src/components/billing-dashboard/ReconciliationResolution.tsx
@@ -380,10 +380,8 @@ const ReconciliationResolution: React.FC<ReconciliationResolutionProps> = ({
         : parseFloat(customAmount);
 
       // In a real implementation, this would call the server action
-      const userId = 'current-user-id'; // This would come from authentication
       const resolvedReport = await resolveReconciliationReport(
         report.report_id,
-        userId,
         approval.notes
       );
       

--- a/packages/billing/src/components/settings/billing/ServiceCatalogManager.tsx
+++ b/packages/billing/src/components/settings/billing/ServiceCatalogManager.tsx
@@ -14,6 +14,7 @@ import { getServiceCategories } from '@alga-psa/billing/actions';
 // Import action to get tax rates
 import { getTaxRates } from '@alga-psa/billing/actions';
 import { IService, IServiceCategory, IServiceType, IServicePrice, DeletionValidationResult } from '@alga-psa/types'; // Added IServiceType, IServicePrice
+import { isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 // Import ITaxRate interface
 import { ITaxRate } from '@alga-psa/types'; // Corrected import path if needed
 import { Card, CardContent, CardHeader } from '@alga-psa/ui/components/Card';
@@ -365,6 +366,11 @@ const ServiceCatalogManager: React.FC = () => {
       setIsDeleteProcessing(true);
 
       const result = await deleteService(serviceToDelete);
+
+      if (isActionPermissionError(result)) {
+        // Permission error — surface it to the user if desired
+        return;
+      }
 
       if (!result.success) {
         setDeleteValidation(result);

--- a/packages/billing/tests/billingCurrencyActions.defaultCurrencyFallback.test.ts
+++ b/packages/billing/tests/billingCurrencyActions.defaultCurrencyFallback.test.ts
@@ -61,6 +61,10 @@ vi.mock('@alga-psa/auth', () => ({
   withAuth: (fn: unknown) => fn,
 }));
 
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
 describe('resolveClientBillingCurrency — fallback chain', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/billing/tests/invoiceModification.manualRecurringGuard.test.ts
+++ b/packages/billing/tests/invoiceModification.manualRecurringGuard.test.ts
@@ -59,6 +59,10 @@ vi.mock('@alga-psa/auth', () => ({
   getSession: vi.fn(async () => ({ user: { id: 'user-1' } })),
 }));
 
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@alga-psa/db', async () => {
   const actual = await vi.importActual<any>('@alga-psa/db');
   return {

--- a/packages/billing/tests/invoiceModification.recurringDeletionGuard.test.ts
+++ b/packages/billing/tests/invoiceModification.recurringDeletionGuard.test.ts
@@ -44,6 +44,10 @@ vi.mock('@alga-psa/auth', () => ({
   getSession: vi.fn(async () => ({ user: { id: 'user-1' } })),
 }));
 
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@alga-psa/db', async () => {
   const actual = await vi.importActual<any>('@alga-psa/db');
   return {

--- a/packages/billing/tests/invoiceModification.updateDraftInvoiceProperties.test.ts
+++ b/packages/billing/tests/invoiceModification.updateDraftInvoiceProperties.test.ts
@@ -82,6 +82,10 @@ vi.mock('@alga-psa/auth', () => ({
   getSession: vi.fn(async () => ({ user: { id: 'user-1' } })),
 }));
 
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@alga-psa/db', async () => {
   const actual = await vi.importActual<any>('@alga-psa/db');
   return {

--- a/packages/billing/tests/usageActions.effectiveDate.test.ts
+++ b/packages/billing/tests/usageActions.effectiveDate.test.ts
@@ -8,6 +8,10 @@ vi.mock('@alga-psa/auth', () => ({
   withAuth: (fn: any) => fn,
 }));
 
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: (...args: any[]) => createTenantKnexMock(...args),
 }));

--- a/packages/client-portal/src/actions/clientPaymentActions.ts
+++ b/packages/client-portal/src/actions/clientPaymentActions.ts
@@ -95,7 +95,7 @@ export const getClientPortalInvoicePaymentLink = withAuth(async (
       return { success: false, error: 'Invoice is cancelled' };
     }
 
-    const paymentUrl = await getOrCreateInvoicePaymentLinkUrl(tenantId, invoiceId);
+    const paymentUrl = await getOrCreateInvoicePaymentLinkUrl(invoiceId);
     if (!paymentUrl) {
       return { success: false, error: 'payment_not_configured' };
     }
@@ -240,10 +240,10 @@ export const verifyClientPortalPayment = withAuth(async (
     }
 
     // Check payment status from the payment provider
-    const paymentStatus = await getInvoicePaymentStatus(tenantId, invoiceId);
+    const paymentStatus = await getInvoicePaymentStatus(invoiceId);
 
     // Get the most current payment URL (if needed for retry)
-    const paymentUrl = await getActiveInvoicePaymentLinkUrl(tenantId, invoiceId);
+    const paymentUrl = await getActiveInvoicePaymentLinkUrl(invoiceId);
 
     if (!paymentStatus) {
       return {


### PR DESCRIPTION
## Summary
- Added RBAC permission checks across billing server actions that were missing authorization guards.
- Fixed tenant and identity handling in tax, credit reconciliation, payment, and quote action paths.
- Moved Stripe payment webhook payload processing out of a `use server` module into a helper.
- Updated related UI callers and tests for the new server-side identity/permission behavior.

## Verification
- `git diff --cached --check` before commit

## Notes
- Excluded local pseudo-locale edits in `server/public/locales/xx/msp/integrations.json` and `server/public/locales/yy/msp/integrations.json` from this PR.