### PR TITLE
docs: fix asset↔ticket permissions note in api_overview (2026-06-09 drift audit)

### DIFF
--- a/docs/api/api_overview.md
+++ b/docs/api/api_overview.md
@@ -163,7 +163,7 @@ Assets and tickets can be linked to each other (the same association surfaced in
 | `POST` | `/tickets/{id}/assets` | Link an asset to a ticket. Requires `asset_id`; accepts optional `relationship_type` (default `affected`) and `notes` |
 | `DELETE` | `/tickets/{id}/assets/{assetId}` | Remove the link between a ticket and an asset |
 
-**Permissions:** the asset-side routes require `asset:update` plus `ticket:read`; the ticket-side routes require `ticket:update` plus `asset:read`. In each case you need *update* on the resource whose links you are changing and *read* on the one you reference.
+**Permissions:** the GET routes on both sides require only *read* on both resources — `asset:read` + `ticket:read`. The POST and DELETE routes need *update* on the resource whose links you are mutating and *read* on the one you reference: `asset:update` + `ticket:read` for the asset-side mutations, `ticket:update` + `asset:read` for the ticket-side mutations.
 
 ### Enterprise Edition APIs
 - **Tenant Provisioning API:** Enables partner-driven tenant management. See [tenant_provisioning_api.md](tenant_provisioning_api.md) for details.


### PR DESCRIPTION
## Source PRs in alga-psa

- [#2649 — Fix categories API, add ticket-asset endpoints](https://github.com/Nine-Minds/alga-psa/pull/2649)
- [#2650 — Add asset↔ticket link endpoints, sync API docs](https://github.com/Nine-Minds/alga-psa/pull/2650)

## Docs edited

### `docs/api/api_overview.md`

**Rationale:** The "Asset ↔ Ticket Links" section added in #2650 stated "the asset-side routes require `asset:update` plus `ticket:read`" without distinguishing the read-only GET endpoints from the mutating POST and DELETE endpoints. A developer with only `asset:read` permission trying to call `GET /assets/{id}/tickets` would read this and incorrectly conclude they need `asset:update` — an elevated permission — just to list linked tickets. The GET routes on both sides require only `asset:read` + `ticket:read`; only POST and DELETE mutations require `asset:update` (asset-side) or `ticket:update` (ticket-side). The permissions paragraph has been rewritten to make this distinction explicit.

## Needs human review

- **PR #2651 "More api work"** has an empty PR body. The diff shows new API routes for `client-contract-lines`, `contract-line-templates/{id}/create-contract-line`, `rbac/audit`, and `user/telemetry-preferences`, plus updates to `ApiContractLineController`, `ApiFinancialController`, and `ApiPermissionController`. Unable to determine user-visible behavior from filenames alone. A human should assess whether any of those surfaces warrant doc updates in `docs/api/`.

- **OpenAPI sync:** PRs #2649–#2651 regenerated `sdk/docs/openapi/alga-openapi*.{json,yaml}`. The nm-store mirror at `packages/nm-store/public/openapi/alga.json` may be stale — please re-sync after running `cd sdk && npm run openapi:generate`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8xr2oXy9Chqf97Uk2bN9T)_