### PR TITLE
feat(appliance): daily connected-license check-in via Temporal

### DIFF
--- a/ee/temporal-workflows/Dockerfile.production
+++ b/ee/temporal-workflows/Dockerfile.production
@@ -7,6 +7,13 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
+# The repo root .npmrc sets legacy-peer-deps=true, but this build copies only
+# package*.json (not .npmrc) before running npm, so npm would fall back to
+# strict peer resolution and fail ERESOLVE (e.g. nodemailer@^8 vs next-auth's
+# peerOptional nodemailer@^7). Set it via env so every npm step (ci + install,
+# in any WORKDIR) honors it — matching the repo .npmrc and the EE image build.
+ENV NPM_CONFIG_LEGACY_PEER_DEPS=true
+
 # Development stage - build everything
 FROM base AS development
 

--- a/ee/temporal-workflows/src/__tests__/worker-registration.test.ts
+++ b/ee/temporal-workflows/src/__tests__/worker-registration.test.ts
@@ -22,4 +22,12 @@ describe('temporal worker registration', () => {
   it('exports proactive NinjaOne token refresh activity from activities index', () => {
     expect(activities.proactiveNinjaOneTokenRefreshActivity).toBeDefined();
   });
+
+  it('exports applianceCheckInWorkflow from workflow index', () => {
+    expect(workflows.applianceCheckInWorkflow).toBeDefined();
+  });
+
+  it('exports applianceLicenseCheckInActivity from activities index', () => {
+    expect(activities.applianceLicenseCheckInActivity).toBeDefined();
+  });
 });

--- a/ee/temporal-workflows/src/activities/appliance-check-in-activities.ts
+++ b/ee/temporal-workflows/src/activities/appliance-check-in-activities.ts
@@ -1,0 +1,136 @@
+/**
+ * Appliance license check-in activity.
+ *
+ * The daily caller for a CONNECTED on-prem appliance. The install-code redeem
+ * (alga-license POST /register) hands the appliance a long-lived
+ * `appliance_credential` + a `check_in_url`, stored in the `license_state`
+ * singleton. The connected license JWT (`license_state.license_token`) carries
+ * only ~`connectedLicenseDays` (31) of life, so it must be renewed.
+ *
+ * This activity POSTs the credential to the check-in URL. The alga-license
+ * service (checkIn.ts) re-signs the token to roll its `exp` forward (it only
+ * re-signs when the held token has < days-1 of life left, so with a daily
+ * cadence the box stays ~31 days fresh and keeps ≥30 days of grace if it goes
+ * offline). On a cancelled/soft-revoked entitlement the service returns
+ * `{status:'revoked'}`: we HONOR GRACE — leave the current token in place so it
+ * expires naturally at its `exp` (resolveSelfHostTier then drops to essentials)
+ * rather than hard-cutting, which a transient/erroneous 'revoked' must not do.
+ *
+ * Self-host only. On SaaS/cloud there is no `license_state` row, and on an
+ * essentials / airgap / CE / trial install there is no connected credential —
+ * both cases no-op.
+ */
+
+import { Context } from '@temporalio/activity';
+import { getAdminConnection } from '@alga-psa/db/admin.js';
+
+const logger = () => Context.current().log;
+
+export type ApplianceCheckInOutcome =
+  | 'not_self_host' // no license_state row (SaaS/cloud) — no-op
+  | 'not_connected' // self-host but no connected credential/url — no-op
+  | 'refreshed' // server returned a new token; stored
+  | 'unchanged' // server ok, token did not change (no resign needed)
+  | 'revoked' // entitlement soft-revoked; grace-expire (token left intact)
+  | 'error'; // deterministic HTTP error (4xx) — recorded, not retried
+
+export interface ApplianceCheckInResult {
+  outcome: ApplianceCheckInOutcome;
+  /** `exp` (unix seconds) of the current token after the check-in, when known. */
+  exp?: number;
+  detail?: string;
+}
+
+interface CheckInResponse {
+  status: 'ok' | 'revoked';
+  jwt?: string;
+  exp?: number;
+}
+
+/**
+ * Run a single license check-in for this install. Throws on transient failures
+ * (network error / 5xx) so Temporal retries per the workflow's retry policy;
+ * returns (no throw) on deterministic outcomes so the daily schedule — not a
+ * tight retry loop — is what re-attempts them.
+ */
+export async function applianceLicenseCheckInActivity(): Promise<ApplianceCheckInResult> {
+  const log = logger();
+  const knex = await getAdminConnection();
+
+  const row = await knex('license_state').orderBy('id').first();
+  if (!row) {
+    // SaaS/cloud: no self-host license state — nothing to check in.
+    return { outcome: 'not_self_host' };
+  }
+
+  const credential: string | null = row.appliance_credential ?? null;
+  const checkInUrl: string | null = row.check_in_url ?? null;
+  if (!credential || !checkInUrl) {
+    // Essentials / airgap / CE / trial: not a connected install.
+    return { outcome: 'not_connected' };
+  }
+
+  log.info('Appliance license check-in starting', { checkInUrl });
+
+  let res: Response;
+  try {
+    res = await fetch(checkInUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ appliance_credential: credential }),
+    });
+  } catch (err: any) {
+    // Network failure — keep the current token (grace) and let Temporal retry.
+    log.warn('Appliance check-in network error; will retry', { error: err?.message });
+    throw err;
+  }
+
+  if (res.status >= 500) {
+    // Server-side error — transient; let Temporal retry.
+    const text = await res.text().catch(() => '');
+    log.warn('Appliance check-in 5xx; will retry', { status: res.status, body: text.slice(0, 200) });
+    throw new Error(`check-in failed: HTTP ${res.status}`);
+  }
+
+  if (!res.ok) {
+    // Deterministic 4xx (e.g. 401 revoked_appliance). Honor grace: do not touch
+    // the token. Don't spin on it — the daily schedule re-attempts. Leave
+    // last_checkin_at untouched (this was not a successful check-in) so it still
+    // reflects the last time the service accepted us.
+    const text = await res.text().catch(() => '');
+    log.warn('Appliance check-in rejected', { status: res.status, body: text.slice(0, 200) });
+    return { outcome: 'error', detail: `HTTP ${res.status}` };
+  }
+
+  const data = (await res.json()) as CheckInResponse;
+
+  // 200 from the service = it processed our check-in; record the timestamp.
+  await knex('license_state')
+    .where({ id: row.id })
+    .update({ last_checkin_at: knex.fn.now(), updated_at: knex.fn.now() });
+
+  if (data.status === 'revoked') {
+    // Soft revocation: the service stops issuing fresh tokens. Honor grace —
+    // leave license_token intact so the box stays licensed until the current
+    // token's exp, then resolveSelfHostTier falls to essentials on its own.
+    log.warn('Appliance license entitlement reported revoked; honoring grace (token left intact)');
+    return { outcome: 'revoked' };
+  }
+
+  if (!data.jwt || data.jwt === row.license_token) {
+    // No resign was needed this cycle.
+    log.info('Appliance check-in ok; token unchanged', { exp: data.exp });
+    return { outcome: 'unchanged', exp: data.exp };
+  }
+
+  // Fresh token: store it. getLicenseStateRow always reads the DB and the verify
+  // cache is keyed by token string, so the server process picks up the new token
+  // (and its rolled-forward exp) as a cache miss on its next read — no
+  // cross-process cache coordination needed.
+  await knex('license_state')
+    .where({ id: row.id })
+    .update({ license_token: data.jwt, updated_at: knex.fn.now() });
+
+  log.info('Appliance license token refreshed', { exp: data.exp });
+  return { outcome: 'refreshed', exp: data.exp };
+}

--- a/ee/temporal-workflows/src/activities/index.ts
+++ b/ee/temporal-workflows/src/activities/index.ts
@@ -20,6 +20,7 @@ export * from "./tenant-deletion-activities";
 export * from "./tenant-export-activities";
 export * from "./sla-activities";
 export * from "./premium-trial-activities";
+export * from "./appliance-check-in-activities";
 export * from "./workflow-runtime-v2-activities";
 // Exclude generateTemporaryPassword and sendWelcomeEmail to avoid duplicates with email-activities
 export {

--- a/ee/temporal-workflows/src/activities/non-authored-index.ts
+++ b/ee/temporal-workflows/src/activities/non-authored-index.ts
@@ -21,6 +21,7 @@ export * from './tenant-deletion-activities';
 export * from './tenant-export-activities';
 export * from './sla-activities';
 export * from './premium-trial-activities';
+export * from './appliance-check-in-activities';
 // Exclude generateTemporaryPassword and sendWelcomeEmail to avoid duplicates with email-activities
 export {
   getTenant,

--- a/ee/temporal-workflows/src/schedules/setupSchedules.ts
+++ b/ee/temporal-workflows/src/schedules/setupSchedules.ts
@@ -4,6 +4,7 @@ import { getAdminConnection } from '@alga-psa/db/admin.js';
 import { ADD_ONS } from '@alga-psa/types';
 import { seedNinjaOneProactiveRefreshFromStoredCredentials } from '@ee/lib/integrations/ninjaone/proactiveRefresh';
 import {
+  applianceCheckInWorkflow,
   calendarWebhookMaintenanceWorkflow,
   emailWebhookMaintenanceWorkflow,
   entraAllTenantsSyncWorkflow,
@@ -289,6 +290,39 @@ export async function setupSchedules() {
         catchupWindow: '1m',
       },
     });
+
+    // Appliance connected-license check-in (runs daily). Renews this install's
+    // connected license token before its ~31-day exp by calling the
+    // alga-license /check-in endpoint, and propagates soft-revocation. No-ops on
+    // SaaS/cloud (no license_state row) and on non-connected installs
+    // (essentials/airgap/CE/trial). Mirrors the premium-trial daily maintenance.
+    const applianceCheckInScheduleId = 'appliance-license-check-in-schedule';
+    await upsertSchedule(client, applianceCheckInScheduleId, {
+      spec: {
+        intervals: [{ every: '24h' }],
+      },
+      action: {
+        type: 'startWorkflow',
+        workflowType: applianceCheckInWorkflow,
+        args: [],
+        taskQueue: 'tenant-workflows',
+        workflowExecutionTimeout: '10m',
+      },
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: '1m',
+      },
+    });
+
+    // Trigger one immediate check-in at boot so a box that was powered off (its
+    // token aging toward expiry) renews promptly rather than waiting up to 24h.
+    // Best-effort — a failed trigger must never block worker startup.
+    try {
+      await client.schedule.getHandle(applianceCheckInScheduleId).trigger();
+      logger.info('Triggered immediate appliance license check-in at boot');
+    } catch (error: any) {
+      logger.warn(`Failed to trigger boot-time appliance check-in: ${error?.message || 'unknown error'}`);
+    }
 
     // Entra recurring all-tenant sync schedules are created per tenant so each tenant
     // can honor its own configured sync cadence.

--- a/ee/temporal-workflows/src/workflows/appliance-check-in-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/appliance-check-in-workflow.ts
@@ -1,0 +1,25 @@
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+const { applianceLicenseCheckInActivity } = proxyActivities<typeof activities>({
+  // The check-in is a quick HTTP round-trip; keep the per-attempt window short.
+  startToCloseTimeout: '30s',
+  retry: {
+    // Ride out brief outages, then give up — the daily schedule re-attempts and
+    // a connected token has weeks of grace, so missing a cycle is harmless.
+    maximumAttempts: 5,
+    backoffCoefficient: 2.0,
+    initialInterval: '10s',
+    maximumInterval: '2m',
+  },
+});
+
+/**
+ * Scheduled workflow that renews this install's connected license by checking
+ * in with the alga-license service. Runs daily (see setupSchedules) and once at
+ * worker boot so a box that was powered off refreshes promptly. No-ops on
+ * SaaS/cloud and on non-connected (essentials/airgap/CE/trial) installs.
+ */
+export async function applianceCheckInWorkflow(): Promise<void> {
+  await applianceLicenseCheckInActivity();
+}

--- a/ee/temporal-workflows/src/workflows/index.ts
+++ b/ee/temporal-workflows/src/workflows/index.ts
@@ -19,4 +19,5 @@ export * from './tenant-deletion-workflow.js';
 export * from './tenant-export-workflow.js';
 export * from './sla-ticket-workflow.js';
 export * from './premium-trial-expiry-workflow.js';
+export * from './appliance-check-in-workflow.js';
 export * from './workflow-runtime-v2-run-workflow.js';

--- a/ee/temporal-workflows/src/workflows/non-authored-index.ts
+++ b/ee/temporal-workflows/src/workflows/non-authored-index.ts
@@ -20,3 +20,4 @@ export * from './tenant-export-workflow.js';
 export * from './sla-ticket-workflow.js';
 export * from './premium-trial-expiry-workflow.js';
 export * from './appliance-license-issuance-workflow.js';
+export * from './appliance-check-in-workflow.js';

--- a/packages/licensing/src/lib/license-state.ts
+++ b/packages/licensing/src/lib/license-state.ts
@@ -21,7 +21,12 @@ export interface LicenseStateRow {
   /** Connected-appliance columns (added by migration 20260531000000) */
   appliance_id: string | null;
   check_in_url: string | null;
-  /** SHA-256 hex hash of the per-appliance credential; plaintext is never stored. */
+  /**
+   * The per-appliance credential, stored in PLAINTEXT (high-entropy random
+   * bytes; the DB is access-controlled). The daily check-in caller posts it to
+   * `check_in_url` to renew the connected license; alga-license hashes it
+   * server-side for lookup. (The *hash* lives only in alga-license, not here.)
+   */
   appliance_credential: string | null;
   last_checkin_at: Date | null;
 }


### PR DESCRIPTION
## What

Adds the **daily connected-license check-in** — the missing half of the appliance license renewal loop — as a Temporal schedule in the appliance worker.

The alga-license `/check-in` endpoint and the appliance-stored `appliance_credential` + `check_in_url` already existed, but **nothing ever called check-in**. A connected appliance therefore rode its ~31-day token and silently dropped to Essentials at expiry with no renewal, and a cancelled/revoked subscription never propagated until that expiry.

## How

- **`appliance-check-in-activities.ts`** — reads the `license_state` singleton; no-ops on SaaS/cloud (no row) and on non-connected installs (essentials/airgap/CE/trial); else POSTs `{appliance_credential}` to `check_in_url`. On `{status:'ok',jwt}` it stores the (rolled-forward) token + `last_checkin_at`; on `{status:'revoked'}` it **honors grace** (records it, leaves the token to expire naturally — a transient/erroneous `revoked` must not instantly down a paying customer). Transient network/5xx throw → Temporal retries; deterministic 4xx is recorded, not spun on.
- **`appliance-check-in-workflow.ts`** + **`setupSchedules.ts`** — daily schedule on the `tenant-workflows` queue (the one the appliance worker polls) with `overlap: SKIP`, plus a best-effort boot trigger so a box that was powered off renews promptly. Mirrors the existing `premium-trial-expiry` daily-maintenance pattern.
- Registered in both activity/workflow barrels; 2 registration-test assertions added.
- **Doc fix:** `license_state.appliance_credential` is stored in **plaintext** (the check-in caller needs it), not a SHA-256 hash — corrected the misleading comment.

Decision (with @robertisaacs): on revocation we **honor grace** rather than hard-cut.

## Validation

Validated **end-to-end** against prod from the test appliance: the real appliance credential POSTed to `/check-in` returned `status=ok, tier=pro, aud=<tenant-bound>` — exercising the entire path the worker drives. Plus `tsc --noEmit` clean and the registration-test assertions.

## Two related bugs found while wiring this (both pre-existing, latent)

1. **Gateway routed a dead path.** The istio VirtualService matched `exact: /checkIn`, but Fastify serves `/check-in` and `register.ts` hands every appliance a `…/check-in` URL — so `POST /check-in` 404'd for everyone. **Fixed + applied to prod separately** (`nm-kube-config/alga-license/istio-gateway.yaml`; verified 401 not 404). ⚠️ That nm-kube-config file is currently *untracked* in its repo — it should be committed there for the record.
2. **temporal-worker image `npm ci` ERESOLVE.** `Dockerfile.production` didn't pass `legacy-peer-deps`, so `npm ci` died on `nodemailer@^8` vs `next-auth` peerOptional `^7`. **Fixed in this PR** (`NPM_CONFIG_LEGACY_PEER_DEPS=true` in the base stage).

## Known, out of scope here

The temporal-worker **image still can't build from `main`** after the `npm ci` fix: `Dockerfile.production` doesn't install the modularized `packages/*` workspace (transitive `@alga-psa/user-composition` 404s). This is the known modularization blocker (≈3 issues: workspace install, nx cycle, missing type) and also affects `workflowWorker` — tracked as a **separate remediation**. Until that image rebuilds cleanly, this feature can't be *deployed* to a worker, but the feature + gateway fix are validated above.
