### PR TITLE
fix(time-entry): remove obsolete tax region requirement on save

### DIFF
--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -118,14 +118,9 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
         toast.error(t('messages.invalidService'));
         return;
       }
-
-      const hasTaxableRate = selectedService.tax_rate_id != null &&
-        selectedService.tax_percentage != null &&
-        selectedService.tax_percentage > 0;
-      if (hasTaxableRate && !entry.tax_region) {
-        toast.error(t('messages.taxRegionRequired'));
-        return;
-      }
+      // Tax region is no longer collected at time entry. Billing derives it from
+      // the service's tax_rate_id (falling back to the client default), so there
+      // is nothing to validate here. See billingEngine.getTaxInfoFromService.
     }
 
     if (!validateTimeEntry(entry)) {


### PR DESCRIPTION
## Summary

Removes an obsolete client-side validation that blocked saving a time entry whenever the selected service had a taxable rate but the entry had no `tax_region`.

This was the **only** place in the codebase enforcing a tax region on time entries, and it guarded a field that the UI no longer lets users set and that billing never reads.

## Why this is safe

The requirement is a leftover from the original (Oct 2024) tax model, where time entries carried their own `tax_region` string and billing used it directly.

The **April 2025 tax-region overhaul** moved region authority onto the service's `tax_rate_id`:

- The region picker was removed from `TimeEntryEditForm` (comment there: *"Tax details are now determined by the backend based on service_id's tax_rate_id"*).
- `billingEngine.getTaxInfoFromService()` derives the region from the service's `tax_rate_id`, falling back to the client default (`getClientDefaultTaxRegionCode`), then to zero tax.
- The time entry's own `tax_region` column is **never read** during billing — `billingEngine.ts:1198-1206` passes only `service_id` and `tax_rate_id` to `getTaxInfoFromService`, and the charge's region is the *derived* `effectiveTaxRegion`.

So the dialog was demanding a value the form no longer collects, to satisfy a billing path that doesn't consume it. Whenever no `defaultTaxRegion` happened to be pre-populated, saving was blocked for no functional reason — the bug this branch fixes.

Removing the guard aligns time entries with **usage records** and **manual invoice items**, which never collect a tax region at entry time and resolve it at billing.

## Changes

- `TimeEntryDialog.tsx`: remove the `hasTaxableRate && !entry.tax_region` check; keep the service-existence validation. Added a comment pointing to where tax region is actually resolved.

## Notes

- The `messages.taxRegionRequired` i18n key is now unused in code (still present in locale JSON files). Left in place to keep this diff focused; can be cleaned up separately.
- No server-side change needed — server schemas already treat `tax_region` as optional and there was never server-side enforcement.

## Test plan

- [ ] Add a billable time entry for a service with a taxable rate and no tax region → saves successfully.
- [ ] Generate an invoice from that entry → tax is computed from the service's `tax_rate_id` (or client default), unchanged from before.
