### PR TITLE
fix(portal): validate contact email in createClientPortalUser and stop masking invitation errors

### DIFF
--- a/packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts
+++ b/packages/client-portal/src/actions/portal-actions/portalInvitationActions.ts
@@ -14,6 +14,7 @@ import type {
   CompleteSetupResult as SharedCompleteSetupResult,
   InvitationHistoryItem as SharedInvitationHistoryItem,
   CreateClientPortalUserParams as SharedCreateClientPortalUserParams,
+  PortalInvitationErrorCode,
 } from '@alga-psa/portal-shared/types';
 
 export interface SendInvitationResult extends SharedSendInvitationResult {}
@@ -24,7 +25,7 @@ export interface CreateClientPortalUserParams extends SharedCreateClientPortalUs
 
 export async function createClientPortalUser(
   params: CreateClientPortalUserParams
-): Promise<{ success: boolean; userId?: string; message?: string; error?: string }> {
+): Promise<{ success: boolean; userId?: string; message?: string; error?: string; errorCode?: PortalInvitationErrorCode }> {
   return createClientPortalUserAction(params);
 }
 
@@ -46,6 +47,6 @@ export async function getPortalInvitations(contactId: string): Promise<Invitatio
 
 export async function revokePortalInvitation(
   invitationId: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; errorCode?: PortalInvitationErrorCode }> {
   return revokePortalInvitationAction(invitationId);
 }

--- a/packages/clients/src/components/contacts/ContactPortalTab.tsx
+++ b/packages/clients/src/components/contacts/ContactPortalTab.tsx
@@ -52,6 +52,14 @@ const PORTAL_INVITE_ERROR_KEYS: Partial<Record<PortalInvitationErrorCode, string
   INVITATION_NOT_FOUND: 'contactPortalTab.toast.errors.invitationNotFound',
   REVOKE_FAILED: 'contactPortalTab.toast.revokeInviteFailed'
 };
+
+// Catch-all codes whose localized message is generic ("Failed to send
+// invitation"). When the server attached a specific reason, show that instead
+// of masking it with the generic translation.
+const GENERIC_PORTAL_INVITE_ERROR_CODES: ReadonlySet<PortalInvitationErrorCode> = new Set([
+  'INVITATION_FAILED',
+  'REVOKE_FAILED'
+]);
 import { useToast } from '@alga-psa/ui';
 import SettingsTabSkeleton from '@alga-psa/ui/components/skeletons/SettingsTabSkeleton';
 import { Input } from '@alga-psa/ui/components/Input';
@@ -95,6 +103,9 @@ export function ContactPortalTab({ contact, currentUserPermissions }: ContactPor
     defaultValue: string
   ): string => {
     if (result.errorCode) {
+      if (GENERIC_PORTAL_INVITE_ERROR_CODES.has(result.errorCode) && result.error) {
+        return result.error;
+      }
       const key = PORTAL_INVITE_ERROR_KEYS[result.errorCode];
       if (key) {
         return t(key, { defaultValue: result.error ?? defaultValue });

--- a/packages/portal-shared/src/actions/portalInvitationActions.ts
+++ b/packages/portal-shared/src/actions/portalInvitationActions.ts
@@ -28,6 +28,10 @@ class PortalInvitationError extends Error {
 function normalizeCreateClientPortalUserError(
   error: unknown
 ): { message: string; errorCode: PortalInvitationErrorCode } {
+  if (error instanceof PortalInvitationError) {
+    return { message: error.message, errorCode: error.errorCode };
+  }
+
   const dbError = error as { code?: string };
   if (dbError?.code === '23505') {
     return {
@@ -138,6 +142,22 @@ export const createClientPortalUser = withAuth(async (
       if (!contact) {
         // Could not resolve contact
         throw new Error('Contact not found. Provide contact details to create a new contact.');
+      }
+
+      // Validate the resolved contact's email before creating the user account.
+      // Throwing here also rolls back a contact inserted above with a bad email.
+      const contactEmail = typeof contact.email === 'string' ? contact.email.trim() : '';
+      if (!contactEmail) {
+        throw new PortalInvitationError(
+          'Contact does not have an email address. Please add an email address to the contact before creating a portal user.',
+          'CONTACT_MISSING_EMAIL'
+        );
+      }
+      if (!isValidEmail(contactEmail)) {
+        throw new PortalInvitationError(
+          'Contact has an invalid email address. Please update the contact with a valid email address before creating a portal user.',
+          'CONTACT_INVALID_EMAIL'
+        );
       }
 
       // 2) Ensure no existing user for contact
@@ -444,9 +464,12 @@ export const sendPortalInvitation = withAuth(async (
       console.error('Transaction failed:', error);
       const errorCode: PortalInvitationErrorCode =
         error instanceof PortalInvitationError ? error.errorCode : 'INVITATION_FAILED';
+      // Leave `error` unset when there is no specific message so clients fall
+      // back to their localized generic string instead of hardcoded English.
+      const message = error instanceof Error ? error.message.trim() : '';
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Failed to send invitation',
+        error: message || undefined,
         errorCode
       };
     });
@@ -455,7 +478,10 @@ export const sendPortalInvitation = withAuth(async (
 
   } catch (error) {
     console.error('Error sending portal invitation:', error);
-    return { success: false, error: 'Failed to send invitation', errorCode: 'INVITATION_FAILED' };
+    const errorCode: PortalInvitationErrorCode =
+      error instanceof PortalInvitationError ? error.errorCode : 'INVITATION_FAILED';
+    const message = error instanceof Error ? error.message.trim() : '';
+    return { success: false, error: message || undefined, errorCode };
   }
 });
 
@@ -744,7 +770,8 @@ export const revokePortalInvitation = withAuth(async (
 
   } catch (error) {
     console.error('Error revoking portal invitation:', error);
-    return { success: false, error: 'Failed to revoke invitation', errorCode: 'REVOKE_FAILED' };
+    const message = error instanceof Error ? error.message.trim() : '';
+    return { success: false, error: message || undefined, errorCode: 'REVOKE_FAILED' };
   }
 });
 

--- a/server/src/components/settings/general/UserManagement.tsx
+++ b/server/src/components/settings/general/UserManagement.tsx
@@ -30,6 +30,14 @@ const PORTAL_INVITE_ERROR_KEYS: Partial<Record<PortalInvitationErrorCode, string
   PASSWORD_TOO_SHORT: 'users.messages.error.passwordTooShort',
   CREATE_USER_FAILED: 'users.messages.error.createClientPortalUser'
 };
+
+// Catch-all codes whose localized message is generic ("Failed to send
+// invitation"). When the server attached a specific reason, show that instead
+// of masking it with the generic translation.
+const GENERIC_PORTAL_INVITE_ERROR_CODES: ReadonlySet<PortalInvitationErrorCode> = new Set([
+  'INVITATION_FAILED',
+  'CREATE_USER_FAILED'
+]);
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
 import { ContactPicker } from '@alga-psa/ui/components/ContactPicker';
 import toast from 'react-hot-toast';
@@ -45,7 +53,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@alga-psa/ui/component
 import { Search, Eye, EyeOff } from 'lucide-react';
 import { getLicenseUsageAction } from '@alga-psa/licensing/actions';
 import { LicenseUsage } from '@alga-psa/licensing/lib/get-license-usage';
-import { validateContactName, validateEmailAddress, validatePassword, getPasswordRequirements } from '@alga-psa/validation';
+import { validateContactName, validateEmailAddress, validatePassword, getPasswordRequirements, isValidEmail } from '@alga-psa/validation';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -61,6 +69,9 @@ const UserManagement = (): React.JSX.Element => {
     defaultKey: string
   ): string => {
     if (result.errorCode) {
+      if (GENERIC_PORTAL_INVITE_ERROR_CODES.has(result.errorCode) && result.error) {
+        return result.error;
+      }
       const key = PORTAL_INVITE_ERROR_KEYS[result.errorCode];
       if (key) {
         return t(key, { defaultValue: result.error ?? undefined });
@@ -748,9 +759,13 @@ const fetchContacts = async (): Promise<void> => {
                           clientId: c.client_id || ''
                         });
 
-                        // Check if contact has email when sending invitation
-                        if (!newUser.password && (!c.email || c.email.trim() === '')) {
-                          setContactValidationError(t('users.messages.error.contactMissingEmail', { name: c.full_name }));
+                        // Check if contact has a usable email when sending invitation
+                        if (!newUser.password) {
+                          if (!c.email || c.email.trim() === '') {
+                            setContactValidationError(t('users.messages.error.contactMissingEmail', { name: c.full_name }));
+                          } else if (!isValidEmail(c.email.trim())) {
+                            setContactValidationError(t('users.messages.error.contactInvalidEmail'));
+                          }
                         }
                       }
                     } else {


### PR DESCRIPTION
## Summary

An audit of the client-portal invitation flow found one real validation gap and a chain of places where a specific email-related failure was collapsed into a generic "Failed to send invitation" message. This PR closes the gap and makes the real failure reason reach the user.

### Validation gap closed

`createClientPortalUser` created contacts via a raw `trx('contacts').insert()`, bypassing `ContactModel` and all server-side email validation — the only guard was client-side validation in `UserManagement`. It now validates the resolved contact's email inside the transaction:

- missing email → `CONTACT_MISSING_EMAIL`
- invalid format (same `isValidEmail` zod check used by `sendPortalInvitation`) → `CONTACT_INVALID_EMAIL`

Throwing inside the transaction also rolls back a just-inserted contact with a bad email, so invalid emails can no longer be persisted through this path. `normalizeCreateClientPortalUserError` passes these codes through instead of flattening them to `CREATE_USER_FAILED`.

### Generic error masking removed

- **Server:** the catch blocks in `sendPortalInvitation` and `revokePortalInvitation` previously returned hardcoded `'Failed to send invitation'` / `'Failed to revoke invitation'`, discarding the real cause (e.g. an SMTP rejection of the recipient address). They now preserve the thrown error's message and respect `PortalInvitationError` codes; when there is no meaningful message, `error` is left unset so clients fall back to their localized generic string.
- **UI:** `ContactPortalTab` and `UserManagement` passed the server's specific message only as the i18n `defaultValue`, so the generic translation always won. For catch-all codes (`INVITATION_FAILED`, `REVOKE_FAILED`, `CREATE_USER_FAILED`) they now show the specific server message when present. Specific codes like `CONTACT_INVALID_EMAIL` keep their localized translations.
- **UX:** the `UserManagement` contact picker only warned about a *missing* email; it now also flags an invalid-*format* email immediately (same validator the server applies at invite time), reusing the existing `contactInvalidEmail` translation key — no new locale strings.
- **Types:** the `@alga-psa/client-portal` wrappers for `createClientPortalUser` and `revokePortalInvitation` declared return types without `errorCode` even though the runtime value carries it; the field is now declared.

## Test plan

- [x] `tsc --noEmit` clean in `packages/portal-shared`, `packages/client-portal`, `packages/clients`, and `server`
- [ ] Manual: create a client portal user (with password) for a contact whose email is malformed → expect the specific "invalid email" message and no user/contact persisted
- [ ] Manual: send a portal invitation that fails at the email-send step → toast shows the underlying failure reason instead of the generic "Failed to send invitation"
- [ ] Manual: in Settings → User Management, select a contact with a malformed email for invitation → inline validation error appears before submitting