### PR TITLE
fix(time-entry): allow logging time on bundled child tickets

### DIFF
--- a/packages/scheduling/src/actions/inboundActions.ts
+++ b/packages/scheduling/src/actions/inboundActions.ts
@@ -164,21 +164,6 @@ async function assertTimeEntryReferences(args: {
     return;
   }
 
-  if (args.workItemType === 'ticket') {
-    const ticket = await args.trx('tickets')
-      .where({ tenant: args.tenant, ticket_id: args.workItemId })
-      .first('ticket_id', 'master_ticket_id');
-    if (!ticket) {
-      throw new Error(`VALIDATION_ERROR: ticket work_item_id "${args.workItemId}" does not exist`);
-    }
-    if (ticket.master_ticket_id) {
-      throw new Error(
-        'VALIDATION_ERROR: this ticket is bundled; time entries must be added on the master ticket.',
-      );
-    }
-    return;
-  }
-
   const workItem = await args.trx(workItemTable.table)
     .where({ tenant: args.tenant, [workItemTable.idColumn]: args.workItemId })
     .first(workItemTable.idColumn);

--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -341,16 +341,6 @@ export const saveTimeEntry = withAuth(async (
 
     await assertCanActOnBehalf(user, tenant, timeEntryUserId, db);
 
-    if (validatedTimeEntry.work_item_type === 'ticket') {
-      const ticket = await db('tickets')
-        .select('ticket_id', 'master_ticket_id')
-        .where({ tenant, ticket_id: validatedTimeEntry.work_item_id })
-        .first();
-      if (ticket?.master_ticket_id) {
-        throw new Error('This ticket is bundled; time entries must be added on the master ticket.');
-      }
-    }
-
     // Extract only the fields that exist in the database schema
     const {
       entry_id,

--- a/packages/scheduling/src/actions/timeEntryWorkItemActions.ts
+++ b/packages/scheduling/src/actions/timeEntryWorkItemActions.ts
@@ -2,7 +2,7 @@
 
 import { Knex } from 'knex'; // Import Knex type
 import { createTenantKnex } from '@alga-psa/db';
-import { IWorkItem } from '@alga-psa/types';
+import { IWorkItem, IExtendedWorkItem } from '@alga-psa/types';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import { validateData } from '@alga-psa/validation';
 import { assertCanActOnBehalf } from './timeEntryDelegationAuth';
@@ -23,7 +23,7 @@ export const fetchWorkItemsForTimeSheet = withAuth(async (
   user,
   { tenant },
   timeSheetId: string
-): Promise<IWorkItem[]> => {
+): Promise<IExtendedWorkItem[]> => {
   const {knex: db} = await createTenantKnex();
 
   // Check permission for time entry reading (reading work items for time entries)
@@ -47,7 +47,7 @@ export const fetchWorkItemsForTimeSheet = withAuth(async (
 
   // Get tickets
   const tickets = await db('tickets')
-    .whereIn('ticket_id', function () {
+    .whereIn('tickets.ticket_id', function () {
       this.select('work_item_id')
         .from('time_entries')
         .where({
@@ -57,11 +57,17 @@ export const fetchWorkItemsForTimeSheet = withAuth(async (
         });
     })
     .where('tickets.tenant', tenant)
+    .leftJoin('tickets as mt', function () {
+      this.on('tickets.master_ticket_id', '=', 'mt.ticket_id')
+        .andOn('tickets.tenant', '=', 'mt.tenant');
+    })
     .select(
-      'ticket_id as work_item_id',
-      'title as name',
-      'url as description',
-      'ticket_number',
+      'tickets.ticket_id as work_item_id',
+      'tickets.title as name',
+      'tickets.url as description',
+      'tickets.ticket_number',
+      'tickets.master_ticket_id',
+      'mt.ticket_number as master_ticket_number',
       db.raw("'ticket' as type")
     );
 
@@ -178,7 +184,7 @@ export const fetchWorkItemsForTimeSheet = withAuth(async (
     }, new Map<string, Pick<IWorkItem, 'work_item_id' | 'name' | 'description' | 'type'>>()).values()
   );
 
-  return [...tickets, ...projectTasks, ...adHocEntries, ...interactions, ...nonBillableWorkItems].map((item): IWorkItem => ({
+  return [...tickets, ...projectTasks, ...adHocEntries, ...interactions, ...nonBillableWorkItems].map((item): IExtendedWorkItem => ({
     ...item,
     is_billable: item.type !== 'non_billable_category',
     ticket_number: item.type === 'ticket' ? item.ticket_number : undefined

--- a/packages/scheduling/src/actions/workItemActions.ts
+++ b/packages/scheduling/src/actions/workItemActions.ts
@@ -33,9 +33,7 @@ export interface DispatchSearchOptions extends BaseSearchOptions {
   filterUnscheduled?: boolean;
 }
 
-export interface PickerSearchOptions extends BaseSearchOptions {
-  isTimesheet?: boolean;
-}
+export interface PickerSearchOptions extends BaseSearchOptions {}
 
 interface SearchResult {
   items: Omit<IExtendedWorkItem, "tenant">[];
@@ -301,7 +299,6 @@ export const searchPickerWorkItems = withAuth(async (
     const page = options.page || 1;
     const pageSize = options.pageSize || 10;
     const offset = (page - 1) * pageSize;
-    const isTimesheet = options.isTimesheet || false;
     const availableWorkItemIds = sanitizeWorkItemIdsForUuidColumns(options.availableWorkItemIds);
 
     let ticketsQuery = db('tickets as t')

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -285,6 +285,18 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
       data-automation-type="container"
     >
       {inDrawer && <h2 className="mb-4 text-lg font-semibold">{title}</h2>}
+      {workItem.type === 'ticket' && workItem.master_ticket_id && (
+        <div className="mb-3 rounded-md bg-blue-50 dark:bg-blue-900/20 p-3 text-sm text-[rgb(var(--color-text-700))]">
+          {workItem.master_ticket_number
+            ? t('bundleNotice.withNumber', {
+                defaultValue: 'This ticket is bundled under {{number}}. Bundle time is usually logged on the master ticket.',
+                number: workItem.master_ticket_number
+              })
+            : t('bundleNotice.withoutNumber', {
+                defaultValue: 'This ticket is part of a bundle. Bundle time is usually logged on the master ticket.'
+              })}
+        </div>
+      )}
       {isLoading ? (
         <TimeEntrySkeletons />
       ) : entries[0] ? (

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeSheetTable.tsx
@@ -432,17 +432,24 @@ export function TimeSheetTable({
                                                     {workItem.contact_name && ` • ${workItem.contact_name}`}
                                                 </div>
                                             )}
-                                            <span className={`inline-flex w-max items-center px-2 py-0.5 rounded-full text-xs font-medium mt-1 ${
-                                                workItem.type === 'ticket'
-                                                    ? 'bg-[rgb(var(--color-primary-100))] text-[rgb(var(--color-primary-700))]'
-                                                    : workItem.type === 'project_task'
-                                                        ? 'bg-[rgb(var(--color-secondary-100))] text-[rgb(var(--color-secondary-700))]'
-                                                        : workItem.type === 'interaction'
-                                                            ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
-                                                            : 'bg-gray-100 dark:bg-gray-800/30 text-gray-700 dark:text-gray-300'
-                                            }`}>
-                                                {formatWorkItemType(workItem.type)}
-                                            </span>
+                                            <div className="flex flex-wrap items-center gap-1 mt-1">
+                                                <span className={`inline-flex w-max items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                                    workItem.type === 'ticket'
+                                                        ? 'bg-[rgb(var(--color-primary-100))] text-[rgb(var(--color-primary-700))]'
+                                                        : workItem.type === 'project_task'
+                                                            ? 'bg-[rgb(var(--color-secondary-100))] text-[rgb(var(--color-secondary-700))]'
+                                                            : workItem.type === 'interaction'
+                                                                ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
+                                                                : 'bg-gray-100 dark:bg-gray-800/30 text-gray-700 dark:text-gray-300'
+                                                }`}>
+                                                    {formatWorkItemType(workItem.type)}
+                                                </span>
+                                                {workItem.type === 'ticket' && workItem.master_ticket_id && (
+                                                    <span className="inline-flex w-max items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[rgb(var(--color-primary-100))] text-[rgb(var(--color-primary-700))]">
+                                                        {workItem.master_ticket_number ? `Bundled → ${workItem.master_ticket_number}` : 'Bundled'}
+                                                    </span>
+                                                )}
+                                            </div>
                                         </div>
                                         {isEditable && (
                                             <Button

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx
@@ -163,15 +163,14 @@ export function WorkItemList({
                 {t('common.types.billable', { defaultValue: 'Billable' })}
               </span>
             )}
+            {isBundledTicket && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[rgb(var(--color-primary-100))] text-[rgb(var(--color-primary-700))]">
+                {item.master_ticket_number
+                  ? t('workItemList.bundledUnder', { defaultValue: 'Bundled → {{number}}', number: item.master_ticket_number })
+                  : t('workItemList.bundled', { defaultValue: 'Bundled' })}
+              </span>
+            )}
           </div>
-          {isBundledTicket && (
-            <div className="text-sm text-[rgb(var(--color-text-600))] mt-2 italic">
-              {t('workItemList.bundledTicket', {
-                defaultValue: 'Bundled ticket — log time on the master ticket{{suffix}}.',
-                suffix: item.master_ticket_number ? ` #${item.master_ticket_number}` : ''
-              })}
-            </div>
-          )}
         </>
       );
     } else if (item.type === 'project_task') {
@@ -310,22 +309,17 @@ export function WorkItemList({
               )}
               <ul className="divide-y divide-[rgb(var(--color-border-200))]">
                 {items.map((item) => {
-                  const isDisabled = item.type === 'ticket' && !!item.master_ticket_id;
                   const isSelected = selectedWorkItemId === item.work_item_id;
                   return (
                     <li
                       key={item.work_item_id}
-                      aria-disabled={isDisabled}
                       className={[
                         'bg-[rgb(var(--color-border-50))] transition-colors duration-150',
                         isSelected ? 'bg-[rgb(var(--color-primary-50))]' : '',
-                        isDisabled
-                          ? 'opacity-50 cursor-not-allowed'
-                          : 'hover:bg-[rgb(var(--color-border-100))] cursor-pointer',
+                        'hover:bg-[rgb(var(--color-border-100))] cursor-pointer',
                       ].join(' ')}
                       onClick={(e) => {
                         e.stopPropagation();
-                        if (isDisabled) return;
                         onSelect(item);
                       }}
                     >

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemPicker.tsx
@@ -200,7 +200,6 @@ export function WorkItemPicker({ onSelect, availableWorkItems, initialWorkItemId
           end: endDate
         } : undefined,
         availableWorkItemIds: availableWorkItems.map(item => item.work_item_id),
-        isTimesheet: !!timePeriod?.period_id,
       });
       
       const itemsWithStatus = result.items.map((item: Omit<IExtendedWorkItem, "tenant">): WorkItemWithStatus => ({

--- a/packages/scheduling/src/lib/timeEntryLauncher.tsx
+++ b/packages/scheduling/src/lib/timeEntryLauncher.tsx
@@ -24,6 +24,8 @@ const buildWorkItem = (context: TimeEntryWorkItemContext): Omit<IExtendedWorkIte
     name: context.workItemName,
     description: context.timeDescription || '',
     ticket_number: context.ticketNumber,
+    master_ticket_id: context.masterTicketId,
+    master_ticket_number: context.masterTicketNumber,
     interaction_type: context.interactionType,
     client_name: context.clientName ?? undefined,
     startTime: context.startTime,

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -1827,6 +1827,7 @@ const handleClose = () => {
                     clientName: client?.client_name ?? null,
                     elapsedTime,
                     timeDescription,
+                    masterTicketNumber: bundle?.masterTicket?.ticket_number ?? null,
                 }),
                 onComplete: () => {
                     baseOnComplete();
@@ -1853,6 +1854,7 @@ const handleClose = () => {
                     clientName: client?.client_name ?? null,
                     elapsedTime: 0,
                     timeDescription: '',
+                    masterTicketNumber: bundle?.masterTicket?.ticket_number ?? null,
                 }),
                 existingEntryId: entry.entry_id,
                 onComplete: () => {

--- a/packages/tickets/src/lib/timeEntryContext.test.ts
+++ b/packages/tickets/src/lib/timeEntryContext.test.ts
@@ -31,6 +31,16 @@ describe('ticket time entry context helpers', () => {
     expect(context.timeDescription).toBe('Fixed bug');
   });
 
+  it('carries bundle info when the ticket is a bundled child', () => {
+    const context = buildTicketTimeEntryContext({
+      ticket: { ...baseTicket, master_ticket_id: 'master-1' },
+      masterTicketNumber: 'T-099',
+    });
+
+    expect(context.masterTicketId).toBe('master-1');
+    expect(context.masterTicketNumber).toBe('T-099');
+  });
+
   it('onComplete resets timer state after save', () => {
     const stopTracking = vi.fn();
     const setElapsedTime = vi.fn();

--- a/packages/tickets/src/lib/timeEntryContext.ts
+++ b/packages/tickets/src/lib/timeEntryContext.ts
@@ -5,6 +5,7 @@ interface BuildTicketTimeEntryContextParams {
   clientName?: string | null;
   elapsedTime?: number;
   timeDescription?: string;
+  masterTicketNumber?: string | null;
 }
 
 export function buildTicketTimeEntryContext({
@@ -12,12 +13,15 @@ export function buildTicketTimeEntryContext({
   clientName,
   elapsedTime,
   timeDescription,
+  masterTicketNumber,
 }: BuildTicketTimeEntryContextParams): TimeEntryWorkItemContext {
   return {
     workItemId: ticket.ticket_id ?? '',
     workItemType: 'ticket',
     workItemName: ticket.title || `Ticket ${ticket.ticket_number}`,
     ticketNumber: ticket.ticket_number,
+    masterTicketId: ticket.master_ticket_id ?? null,
+    masterTicketNumber: masterTicketNumber ?? null,
     clientName: clientName ?? null,
     elapsedTime,
     timeDescription,

--- a/packages/types/src/interfaces/scheduling.interfaces.ts
+++ b/packages/types/src/interfaces/scheduling.interfaces.ts
@@ -122,6 +122,8 @@ export interface TimeEntryWorkItemContext {
   workItemType: WorkItemType;
   workItemName: string;
   ticketNumber?: string;
+  masterTicketId?: string | null;
+  masterTicketNumber?: string | null;
   interactionType?: string;
   clientName?: string | null;
   startTime?: Date;

--- a/server/public/locales/de/msp/time-entry.json
+++ b/server/public/locales/de/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} Benutzer",
       "additionalUsersOther": "{{name}}, +{{count}} Benutzer"
     },
-    "bundledTicket": "Gebündeltes Ticket – Protokollierungszeit auf dem Master-Ticket{{suffix}}.",
+    "bundledUnder": "Gebündelt → {{number}}",
+    "bundled": "Gebündelt",
     "pagination": {
       "previous": "Zurück",
       "next": "Weiter",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Änderungen konnten nicht gespeichert werden",
     "changesSaved": "Änderungen erfolgreich gespeichert",
     "workItemDeleted": "Arbeitsposten erfolgreich gelöscht"
+  },
+  "bundleNotice": {
+    "withNumber": "Dieses Ticket ist unter {{number}} gebündelt. Die Zeit für Bündel wird üblicherweise auf dem Master-Ticket erfasst.",
+    "withoutNumber": "Dieses Ticket ist Teil eines Bündels. Die Zeit für Bündel wird üblicherweise auf dem Master-Ticket erfasst."
   }
 }

--- a/server/public/locales/en/msp/time-entry.json
+++ b/server/public/locales/en/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} user",
       "additionalUsersOther": "{{name}}, +{{count}} users"
     },
-    "bundledTicket": "Bundled ticket — log time on the master ticket{{suffix}}.",
+    "bundledUnder": "Bundled → {{number}}",
+    "bundled": "Bundled",
     "pagination": {
       "previous": "Previous",
       "next": "Next",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Failed to save changes",
     "changesSaved": "Changes saved successfully",
     "workItemDeleted": "Work item deleted successfully"
+  },
+  "bundleNotice": {
+    "withNumber": "This ticket is bundled under {{number}}. Bundle time is usually logged on the master ticket.",
+    "withoutNumber": "This ticket is part of a bundle. Bundle time is usually logged on the master ticket."
   }
 }

--- a/server/public/locales/es/msp/time-entry.json
+++ b/server/public/locales/es/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} usuario",
       "additionalUsersOther": "{{name}}, +{{count}} usuarios"
     },
-    "bundledTicket": "Boleto combinado: registra el tiempo en el boleto maestro{{suffix}}.",
+    "bundledUnder": "Agrupado → {{number}}",
+    "bundled": "Agrupado",
     "pagination": {
       "previous": "Anterior",
       "next": "Siguiente",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Error al guardar los cambios",
     "changesSaved": "Cambios guardados correctamente",
     "workItemDeleted": "Elemento de trabajo eliminado correctamente"
+  },
+  "bundleNotice": {
+    "withNumber": "Este ticket está agrupado bajo {{number}}. El tiempo del grupo se suele registrar en el ticket maestro.",
+    "withoutNumber": "Este ticket forma parte de un grupo. El tiempo del grupo se suele registrar en el ticket maestro."
   }
 }

--- a/server/public/locales/fr/msp/time-entry.json
+++ b/server/public/locales/fr/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} utilisateur",
       "additionalUsersOther": "{{name}}, +{{count}} utilisateurs"
     },
-    "bundledTicket": "Ticket groupé: enregistrez l'heure sur le ticket principal{{suffix}}.",
+    "bundledUnder": "Groupé → {{number}}",
+    "bundled": "Groupé",
     "pagination": {
       "previous": "Précédent",
       "next": "Suivant",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Échec de l'enregistrement des modifications",
     "changesSaved": "Modifications enregistrées avec succès",
     "workItemDeleted": "Élément de travail supprimé avec succès"
+  },
+  "bundleNotice": {
+    "withNumber": "Ce ticket est groupé sous {{number}}. Le temps du groupe est généralement enregistré sur le ticket principal.",
+    "withoutNumber": "Ce ticket fait partie d’un groupe. Le temps du groupe est généralement enregistré sur le ticket principal."
   }
 }

--- a/server/public/locales/it/msp/time-entry.json
+++ b/server/public/locales/it/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} utente",
       "additionalUsersOther": "{{name}}, +{{count}} utenti"
     },
-    "bundledTicket": "Biglietto in bundle: registra l'ora sul biglietto principale{{suffix}}.",
+    "bundledUnder": "In bundle → {{number}}",
+    "bundled": "In bundle",
     "pagination": {
       "previous": "Precedente",
       "next": "Successivo",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Impossibile salvare le modifiche",
     "changesSaved": "Modifiche salvate con successo",
     "workItemDeleted": "Elemento di lavoro eliminato con successo"
+  },
+  "bundleNotice": {
+    "withNumber": "Questo ticket è in bundle sotto {{number}}. Il tempo del bundle viene solitamente registrato sul ticket principale.",
+    "withoutNumber": "Questo ticket fa parte di un bundle. Il tempo del bundle viene solitamente registrato sul ticket principale."
   }
 }

--- a/server/public/locales/nl/msp/time-entry.json
+++ b/server/public/locales/nl/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} gebruiker",
       "additionalUsersOther": "{{name}}, +{{count}} gebruikers"
     },
-    "bundledTicket": "Gebundeld ticket: registreer de tijd op het hoofdticket{{suffix}}.",
+    "bundledUnder": "Gebundeld → {{number}}",
+    "bundled": "Gebundeld",
     "pagination": {
       "previous": "Vorige",
       "next": "Volgende",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Kan wijzigingen niet opslaan",
     "changesSaved": "Wijzigingen succesvol opgeslagen",
     "workItemDeleted": "Werkitem succesvol verwijderd"
+  },
+  "bundleNotice": {
+    "withNumber": "Dit ticket is gebundeld onder {{number}}. Bundeltijd wordt meestal op het hoofdticket geregistreerd.",
+    "withoutNumber": "Dit ticket maakt deel uit van een bundel. Bundeltijd wordt meestal op het hoofdticket geregistreerd."
   }
 }

--- a/server/public/locales/pl/msp/time-entry.json
+++ b/server/public/locales/pl/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} użytkownik",
       "additionalUsersOther": "{{name}}, +{{count}} użytkowników"
     },
-    "bundledTicket": "Bilet łączony — czas logowania na bilecie głównym{{suffix}}.",
+    "bundledUnder": "W pakiecie → {{number}}",
+    "bundled": "W pakiecie",
     "pagination": {
       "previous": "Wstecz",
       "next": "Dalej",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Nie udało się zapisać zmian",
     "changesSaved": "Zmiany zapisane pomyślnie",
     "workItemDeleted": "Element pracy usunięty pomyślnie"
+  },
+  "bundleNotice": {
+    "withNumber": "Ten bilet jest częścią pakietu {{number}}. Czas pakietu jest zwykle rejestrowany na bilecie głównym.",
+    "withoutNumber": "Ten bilet jest częścią pakietu. Czas pakietu jest zwykle rejestrowany na bilecie głównym."
   }
 }

--- a/server/public/locales/pt/msp/time-entry.json
+++ b/server/public/locales/pt/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "{{name}}, +{{count}} user",
       "additionalUsersOther": "{{name}}, +{{count}} users"
     },
-    "bundledTicket": "Bundled ticket — log time on the master ticket{{suffix}}.",
+    "bundledUnder": "Agrupado → {{number}}",
+    "bundled": "Agrupado",
     "pagination": {
       "previous": "Previous",
       "next": "Next",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "Falha ao salvar as alterações",
     "changesSaved": "Alterações salvas com sucesso",
     "workItemDeleted": "Item de trabalho excluído com sucesso"
+  },
+  "bundleNotice": {
+    "withNumber": "Este ticket está agrupado sob {{number}}. O tempo do grupo geralmente é registrado no ticket mestre.",
+    "withoutNumber": "Este ticket faz parte de um grupo. O tempo do grupo geralmente é registrado no ticket mestre."
   }
 }

--- a/server/public/locales/xx/msp/time-entry.json
+++ b/server/public/locales/xx/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "11111 {{name}} 11111 {{count}} 11111",
       "additionalUsersOther": "11111 {{name}} 11111 {{count}} 11111"
     },
-    "bundledTicket": "11111 {{suffix}} 11111",
+    "bundledUnder": "11111 {{number}} 11111",
+    "bundled": "11111",
     "pagination": {
       "previous": "11111",
       "next": "11111",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "11111",
     "changesSaved": "11111",
     "workItemDeleted": "11111"
+  },
+  "bundleNotice": {
+    "withNumber": "11111 {{number}} 11111",
+    "withoutNumber": "11111"
   }
 }

--- a/server/public/locales/yy/msp/time-entry.json
+++ b/server/public/locales/yy/msp/time-entry.json
@@ -160,7 +160,8 @@
       "additionalUsers": "55555 {{name}} 55555 {{count}} 55555",
       "additionalUsersOther": "55555 {{name}} 55555 {{count}} 55555"
     },
-    "bundledTicket": "55555 {{suffix}} 55555",
+    "bundledUnder": "55555 {{number}} 55555",
+    "bundled": "55555",
     "pagination": {
       "previous": "55555",
       "next": "55555",
@@ -421,5 +422,9 @@
     "saveChangesFailed": "55555",
     "changesSaved": "55555",
     "workItemDeleted": "55555"
+  },
+  "bundleNotice": {
+    "withNumber": "55555 {{number}} 55555",
+    "withoutNumber": "55555"
   }
 }

--- a/server/src/test/integration/ticketBundling.integration.test.ts
+++ b/server/src/test/integration/ticketBundling.integration.test.ts
@@ -69,11 +69,36 @@ vi.mock('server/src/lib/analytics/posthog', () => ({
 let mockSessionUserId: string | null = null;
 let mockCurrentUser: any = null;
 
-vi.mock('@alga-psa/auth', () => ({
-  getSession: vi.fn(async () => ({
-    user: mockSessionUserId ? { id: mockSessionUserId } : undefined,
-  })),
-}));
+vi.mock('@alga-psa/auth', async () => {
+  const rbac = await vi.importActual<typeof import('@alga-psa/auth/rbac')>('@alga-psa/auth/rbac');
+  const requireMockUser = () => {
+    if (!mockCurrentUser) {
+      throw new Error('User not authenticated');
+    }
+    return mockCurrentUser;
+  };
+  return {
+    ...rbac,
+    getSession: vi.fn(async () => ({
+      user: mockSessionUserId ? { id: mockSessionUserId } : undefined,
+    })),
+    withAuth: (action: any) => async (...args: any[]) => {
+      const user = requireMockUser();
+      const { runWithTenant } = await import('@alga-psa/db');
+      return runWithTenant(user.tenant, () => action(user, { tenant: user.tenant }, ...args));
+    },
+    withOptionalAuth: (action: any) => async (...args: any[]) => {
+      const user = mockCurrentUser;
+      if (!user) return action(null, null, ...args);
+      const { runWithTenant } = await import('@alga-psa/db');
+      return runWithTenant(user.tenant, () => action(user, { tenant: user.tenant }, ...args));
+    },
+    withAuthCheck: (action: any) => async (...args: any[]) => {
+      const user = requireMockUser();
+      return action(user, ...args);
+    },
+  };
+});
 
 vi.mock('@alga-psa/users/actions', async () => {
   return {
@@ -144,8 +169,8 @@ describe('Ticket bundling integration', () => {
       '@alga-psa/tickets/actions/optimizedTicketActions'
     ));
 
-    ({ updateComment, createComment } = await import('@/lib/actions/comment-actions/commentActions'));
-    ({ saveTimeEntry } = await import('@/lib/actions/timeEntryCrudActions'));
+    ({ updateComment, createComment } = await import('@alga-psa/tickets/actions/comment-actions/commentActions'));
+    ({ saveTimeEntry } = await import('@alga-psa/scheduling/actions/timeEntryActions'));
 
     tenantId = await ensureTenant(db, 'Ticket bundling test tenant');
     otherTenantId = await createTenant(db, 'Other tenant');
@@ -240,20 +265,25 @@ describe('Ticket bundling integration', () => {
       is_inactive: false,
     };
 
-    await expect(
-      runWithTenant(tenantId, async () => {
+    mockCurrentUser = noPermUser;
+    try {
+      await expect(
+        runWithTenant(tenantId, async () => {
+          await bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
+        })
+      ).rejects.toThrow(/permission denied/i);
+
+      await grantUserPermissions(db, tenantId, noPermUserId, [
+        { resource: 'ticket', action: 'update' },
+        { resource: 'ticket', action: 'read' },
+      ]);
+
+      await runWithTenant(tenantId, async () => {
         await bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
-      })
-    ).rejects.toThrow(/permission denied/i);
-
-    await grantUserPermissions(db, tenantId, noPermUserId, [
-      { resource: 'ticket', action: 'update' },
-      { resource: 'ticket', action: 'read' },
-    ]);
-
-    await runWithTenant(tenantId, async () => {
-      await bundleTicketsAction({ masterTicketId: masterId, childTicketIds: [childId], mode: 'link_only' }, noPermUser as any);
-    });
+      });
+    } finally {
+      mockCurrentUser = internalUser;
+    }
 
     const linkedChild = await db('tickets').where({ tenant: tenantId, ticket_id: childId }).first();
     expect(linkedChild?.master_ticket_id).toBe(masterId);
@@ -495,8 +525,20 @@ describe('Ticket bundling integration', () => {
       } as any);
     });
 
+    // The reopen utility resets the master to the tenant's default open ticket
+    // status (tenant-wide, not board-scoped), so compute that expectation the
+    // same way rather than assuming it matches this suite's chosen status.
+    const tenantDefaultOpenStatus = await db('statuses')
+      .where({ tenant: tenantId, is_closed: false })
+      .andWhere(function () {
+        this.where('item_type', 'ticket').orWhere('status_type', 'ticket');
+      })
+      .orderBy('is_default', 'desc')
+      .orderBy('order_number', 'asc')
+      .first<{ status_id: string }>('status_id');
+
     const reopenedMaster = await db('tickets').where({ tenant: tenantId, ticket_id: masterId }).first();
-    expect(reopenedMaster?.status_id).toBe(statusOpenId);
+    expect(reopenedMaster?.status_id).toBe(tenantDefaultOpenStatus?.status_id);
     expect(reopenedMaster?.closed_at).toBeNull();
     expect(reopenedMaster?.is_closed).toBe(false);
   });
@@ -535,9 +577,36 @@ describe('Ticket bundling integration', () => {
     expect(masterCommentHasChild).toBe(false);
   });
 
-  it('blocks time entries on bundled children and allows time entries on masters', async () => {
+  it('allows time entries on both bundled children and masters', async () => {
     const clientA = await createClient(db, tenantId, `Client A ${uuidv4().slice(0, 6)}`);
     const contactA = await createContact(db, tenantId, clientA, `a-${uuidv4().slice(0, 6)}@example.com`);
+
+    const existingService = await db('service_catalog')
+      .where({ tenant: tenantId, is_active: true })
+      .first('service_id');
+    let serviceId = existingService?.service_id as string | undefined;
+    if (!serviceId) {
+      const serviceTypeId = uuidv4();
+      serviceId = uuidv4();
+      await db('service_types').insert({
+        id: serviceTypeId,
+        tenant: tenantId,
+        name: `Hourly Type ${uuidv4().slice(0, 6)}`,
+        is_active: true,
+        order_number: 9999,
+      });
+      await db('service_catalog').insert({
+        service_id: serviceId,
+        tenant: tenantId,
+        service_name: `Time Entry Service ${uuidv4().slice(0, 6)}`,
+        custom_service_type_id: serviceTypeId,
+        billing_method: 'per_unit',
+        item_kind: 'service',
+        is_active: true,
+        default_rate: 10000,
+        unit_of_measure: 'hour',
+      });
+    }
 
     const masterId = uuidv4();
     const childId = uuidv4();
@@ -552,44 +621,30 @@ describe('Ticket bundling integration', () => {
     const start = new Date();
     const end = new Date(start.getTime() + 30 * 60_000);
 
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await saveTimeEntry({
-          work_item_id: childId,
-          work_item_type: 'ticket',
-          start_time: start.toISOString(),
-          end_time: end.toISOString(),
-          created_at: start.toISOString(),
-          updated_at: start.toISOString(),
-          billable_duration: 30,
-          notes: 'test',
-          user_id: internalUser.user_id,
-          approval_status: 'DRAFT',
-        } as any);
-      })
-    ).rejects.toThrow(/must be added on the master/i);
+    for (const ticketId of [childId, masterId]) {
+      await expect(
+        runWithTenant(tenantId, async () => {
+          await saveTimeEntry({
+            work_item_id: ticketId,
+            work_item_type: 'ticket',
+            start_time: start.toISOString(),
+            end_time: end.toISOString(),
+            created_at: start.toISOString(),
+            updated_at: start.toISOString(),
+            billable_duration: 30,
+            notes: 'test',
+            user_id: internalUser.user_id,
+            approval_status: 'DRAFT',
+            service_id: serviceId,
+          } as any);
+        })
+      ).resolves.toBeUndefined();
 
-    await expect(
-      runWithTenant(tenantId, async () => {
-        await saveTimeEntry({
-          work_item_id: masterId,
-          work_item_type: 'ticket',
-          start_time: start.toISOString(),
-          end_time: end.toISOString(),
-          created_at: start.toISOString(),
-          updated_at: start.toISOString(),
-          billable_duration: 30,
-          notes: 'test',
-          user_id: internalUser.user_id,
-          approval_status: 'DRAFT',
-        } as any);
-      })
-    ).resolves.toBeUndefined();
-
-    const entry = await db('time_entries')
-      .where({ tenant: tenantId, user_id: internalUser.user_id, work_item_id: masterId, work_item_type: 'ticket' })
-      .first();
-    expect(entry).toBeTruthy();
+      const entry = await db('time_entries')
+        .where({ tenant: tenantId, user_id: internalUser.user_id, work_item_id: ticketId, work_item_type: 'ticket' })
+        .first();
+      expect(entry).toBeTruthy();
+    }
   });
 });
 
@@ -602,11 +657,15 @@ async function ensureTenant(connection: Knex, name: string): Promise<string> {
 }
 
 async function ensureTicketReferenceData(connection: Knex, tenant: string, createdByUserId: string): Promise<void> {
-  const existingBoard = await connection('boards').where({ tenant }).first<{ board_id: string }>('board_id');
-  if (!existingBoard?.board_id) {
+  let boardId = (await connection('boards')
+    .where({ tenant })
+    .orderBy('is_default', 'desc')
+    .first<{ board_id: string }>('board_id'))?.board_id;
+  if (!boardId) {
+    boardId = uuidv4();
     await connection('boards').insert({
       tenant,
-      board_id: uuidv4(),
+      board_id: boardId,
       board_name: 'Test Board',
       display_order: 0,
       is_default: true,
@@ -616,8 +675,9 @@ async function ensureTicketReferenceData(connection: Knex, tenant: string, creat
     });
   }
 
+  // Ticket statuses are board-scoped; ensure the chosen board has open and closed statuses.
   const hasTicketStatuses = await connection('statuses')
-    .where({ tenant, status_type: 'ticket', is_closed: false })
+    .where({ tenant, status_type: 'ticket', is_closed: false, board_id: boardId })
     .first<{ status_id: string }>('status_id');
   if (!hasTicketStatuses?.status_id) {
     await connection('statuses').insert({
@@ -625,6 +685,7 @@ async function ensureTicketReferenceData(connection: Knex, tenant: string, creat
       status_id: uuidv4(),
       name: 'Open',
       status_type: 'ticket',
+      board_id: boardId,
       order_number: 1,
       created_by: createdByUserId,
       created_at: connection.fn.now(),
@@ -634,7 +695,7 @@ async function ensureTicketReferenceData(connection: Knex, tenant: string, creat
   }
 
   const hasClosedTicketStatus = await connection('statuses')
-    .where({ tenant, status_type: 'ticket', is_closed: true })
+    .where({ tenant, status_type: 'ticket', is_closed: true, board_id: boardId })
     .first<{ status_id: string }>('status_id');
   if (!hasClosedTicketStatus?.status_id) {
     await connection('statuses').insert({
@@ -642,6 +703,7 @@ async function ensureTicketReferenceData(connection: Knex, tenant: string, creat
       status_id: uuidv4(),
       name: 'Closed',
       status_type: 'ticket',
+      board_id: boardId,
       order_number: 99,
       created_by: createdByUserId,
       created_at: connection.fn.now(),
@@ -666,20 +728,40 @@ async function ensureTicketReferenceData(connection: Knex, tenant: string, creat
 }
 
 async function loadTicketReferenceData(connection: Knex, tenant: string) {
-  const board = await connection('boards').where({ tenant }).first<{ board_id: string }>('board_id');
-  const openStatus = await connection('statuses')
-    .where({ tenant, is_closed: false })
-    .andWhere(function () {
-      this.where('item_type', 'ticket').orWhere('status_type', 'ticket');
+  // Ticket statuses are board-scoped, so pick a board that has both an open
+  // and a closed ticket status, then select statuses from that board only.
+  const ticketStatusFilter = function (this: Knex.QueryBuilder) {
+    this.where('item_type', 'ticket').orWhere('status_type', 'ticket');
+  };
+  const board = await connection('boards as b')
+    .where('b.tenant', tenant)
+    .whereExists(function () {
+      this.select(connection.raw('1'))
+        .from('statuses as s_open')
+        .whereRaw('s_open.tenant = b.tenant')
+        .whereRaw('s_open.board_id = b.board_id')
+        .where('s_open.is_closed', false)
+        .andWhere(ticketStatusFilter);
     })
+    .whereExists(function () {
+      this.select(connection.raw('1'))
+        .from('statuses as s_closed')
+        .whereRaw('s_closed.tenant = b.tenant')
+        .whereRaw('s_closed.board_id = b.board_id')
+        .where('s_closed.is_closed', true)
+        .andWhere(ticketStatusFilter);
+    })
+    .orderBy('b.is_default', 'desc')
+    .first<{ board_id: string }>('b.board_id as board_id');
+  const openStatus = await connection('statuses')
+    .where({ tenant, is_closed: false, board_id: board?.board_id })
+    .andWhere(ticketStatusFilter)
     .orderBy('is_default', 'desc')
     .orderBy('order_number', 'asc')
     .first<{ status_id: string }>('status_id');
   const closedStatus = await connection('statuses')
-    .where({ tenant, is_closed: true })
-    .andWhere(function () {
-      this.where('item_type', 'ticket').orWhere('status_type', 'ticket');
-    })
+    .where({ tenant, is_closed: true, board_id: board?.board_id })
+    .andWhere(ticketStatusFilter)
     .orderBy('is_default', 'desc')
     .orderBy('order_number', 'asc')
     .first<{ status_id: string }>('status_id');

--- a/server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts
+++ b/server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts
@@ -19,11 +19,15 @@ describe('bundled ticket selection (static)', () => {
     expect(pickerSrc).toMatch(/master_ticket_number/);
   });
 
-  it('disables bundled tickets in the work item picker list with an explanation', () => {
+  it('renders bundled tickets as selectable with an informational badge', () => {
     const src = readRepoFile(
       'packages/scheduling/src/components/time-management/time-entry/time-sheet/WorkItemList.tsx'
     );
-    expect(src).toMatch(/item\.type\s*===\s*'ticket'\s*&&\s*!!item\.master_ticket_id/);
-    expect(src).toContain('Bundled ticket — log time on the master ticket');
+    // Bundled children stay selectable — no disable gating in the list.
+    expect(src).not.toContain('aria-disabled');
+    expect(src).not.toContain('Bundled ticket — log time on the master ticket');
+    // An informational badge points at the master instead.
+    expect(src).toMatch(/workItemList\.bundledUnder/);
+    expect(src).toContain('Bundled → {{number}}');
   });
 });


### PR DESCRIPTION
## Summary

Reverses the master-only time entry policy for ticket bundles: time may now be logged on **any** ticket in a bundle. The UI steers users toward the master with informational badges and a non-blocking notice instead of hard server-side guards.

### Why

The hard block made correct billing impossible for cross-client bundles — billing attribution derives from the ticket's `client_id`, so with master-only logging all billable time landed on the master's client and there was no way to bill the other clients in the bundle. It also produced a trail of lifecycle bugs, all of which this change eliminates:

- `POST /api/v1/time-entries` bypassed the guard entirely (no check in `TimeEntryService`)
- A ticket already resident on a timesheet could be bundled afterward; the row stayed but adding time failed with a generic "Failed to save time entry" (Next.js strips server-action error messages in production), and the quick-add path swallowed it completely
- Editing an existing entry on a now-bundled child was blocked, but deleting it was allowed
- `promoteBundleMaster` stranded the old master's entries on a ticket where edits were rejected
- The dispatch picker had no bundle awareness at all

### Changes

- **Guards removed**: `saveTimeEntry` and the inbound automation path no longer reject bundled children (ticket existence still validated)
- **Picker**: bundled children selectable again, with a `Bundled → #NNN` pill (matching the ticket list badge) instead of the disable treatment
- **Timesheet grid**: `fetchWorkItemsForTimeSheet` now returns `master_ticket_id`/`master_ticket_number`, and rows render the bundle badge — the grid is no longer blind to post-hoc bundling
- **Time entry dialog**: non-blocking notice ("This ticket is bundled under #NNN. Bundle time is usually logged on the master ticket.") whenever the target is a bundled child, including launches from the ticket screen (bundle info wired through `TimeEntryWorkItemContext`)
- **Cleanup**: removed the dead `isTimesheet` picker flag; new strings added to all 10 locales

### Test suite repairs (pre-existing drift)

The bundling integration suite could not run on main — it predated several migrations. Fixed alongside: the `@alga-psa/auth` mock lacked `withAuth`, two dynamic imports pointed at moved modules, status reference data ignored board scoping, `saveTimeEntry` now requires `service_id`, the permission test still passed the user as an argument instead of setting the session user, and the reopen-on-reply assertion now matches the util's actual contract (tenant default open status).

## Test plan

- `server/src/test/integration/ticketBundling.integration.test.ts` — **8/8 pass** (fresh DB, full migrations + seeds), including the flipped test `allows time entries on both bundled children and masters`
- `server/src/test/unit/scheduling/bundledTicketsWorkItemPickerBehavior.test.ts` — pass (selectable-with-badge assertions)
- `packages/tickets/src/lib/timeEntryContext.test.ts` — pass, incl. new bundle-fields case
- `tsc --noEmit` clean on `packages/scheduling`, `packages/tickets`, `packages/types`

### Follow-ups noted (out of scope)

- `maybeReopenBundleMasterFromChildReply` picks the tenant-wide default open status, not board-scoped, and bypasses board validation via raw update
- `sync_updates` propagates `status_id` to children but not the `is_closed` denorm flag