### PR TITLE
Fix renewal queue query after tenant column rename

### DIFF
--- a/ee/server/src/__tests__/integration/helpers/workflowSeedHelper.ts
+++ b/ee/server/src/__tests__/integration/helpers/workflowSeedHelper.ts
@@ -45,7 +45,7 @@ export async function ensureSystemEmailWorkflow(db: Knex, tenantId?: string): Pr
 
   const workflowId = tenantWorkflowId(resolvedTenantId);
   const existing = await db('workflow_definitions')
-    .where({ workflow_id: workflowId, tenant_id: resolvedTenantId })
+    .where({ workflow_id: workflowId, tenant: resolvedTenantId })
     .first();
   if (existing) {
     return;
@@ -55,7 +55,7 @@ export async function ensureSystemEmailWorkflow(db: Knex, tenantId?: string): Pr
   const now = new Date().toISOString();
   const record: Record<string, any> = {
     workflow_id: workflowId,
-    tenant_id: resolvedTenantId,
+    tenant: resolvedTenantId,
     name: definition.name,
     description: definition.description ?? null,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-basic.playwright.test.ts
@@ -93,7 +93,7 @@ async function seedWorkflowDefinitions(db: Knex, count: number): Promise<{ ids: 
     names.push(name);
     return {
       workflow_id: workflowId,
-      tenant_id: tenantId,
+      tenant: tenantId,
       name,
       description: null,
       payload_schema_ref: definition.payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-contract-inference.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-contract-inference.playwright.test.ts
@@ -194,7 +194,7 @@ async function createWorkflowWithTrigger(
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: payloadSchemaRef,

--- a/ee/server/src/__tests__/integration/workflow-designer-dead-letter.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-dead-letter.playwright.test.ts
@@ -71,7 +71,7 @@ async function createWorkflowDefinition(db: ReturnType<typeof createTestDbConnec
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -102,7 +102,7 @@ async function createWorkflowRun(db: ReturnType<typeof createTestDbConnection>, 
     run_id: run.runId,
     workflow_id: run.workflowId,
     workflow_version: run.version,
-    tenant_id: run.tenantId,
+    tenant: run.tenantId,
     status: run.status,
     node_path: null,
     input_json: null,

--- a/ee/server/src/__tests__/integration/workflow-designer-e2e.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-e2e.playwright.test.ts
@@ -86,7 +86,7 @@ async function createWorkflowDefinition(db: Knex, name: string, steps: Record<st
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -117,7 +117,7 @@ async function createWorkflowRun(db: Knex, run: RunSeed): Promise<void> {
     run_id: run.runId,
     workflow_id: run.workflowId,
     workflow_version: run.version,
-    tenant_id: run.tenantId,
+    tenant: run.tenantId,
     status: run.status,
     node_path: run.nodePath ?? null,
     input_json: null,

--- a/ee/server/src/__tests__/integration/workflow-designer-events.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-events.playwright.test.ts
@@ -87,7 +87,7 @@ async function createWorkflowDefinition(db: Knex, name: string, version = 1): Pr
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -107,7 +107,7 @@ async function createWorkflowRun(db: Knex, run: RunSeed): Promise<void> {
     run_id: run.runId,
     workflow_id: run.workflowId,
     workflow_version: run.version,
-    tenant_id: run.tenantId,
+    tenant: run.tenantId,
     status: run.status,
     node_path: null,
     input_json: null,
@@ -121,7 +121,7 @@ async function createWorkflowRun(db: Knex, run: RunSeed): Promise<void> {
 async function createWorkflowEvent(db: Knex, event: EventSeed): Promise<void> {
   await db('workflow_runtime_events').insert({
     event_id: event.eventId,
-    tenant_id: event.tenantId,
+    tenant: event.tenantId,
     event_name: event.eventName,
     correlation_key: event.correlationKey ?? null,
     payload: event.payload ?? null,

--- a/ee/server/src/__tests__/integration/workflow-designer-runs.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-designer-runs.playwright.test.ts
@@ -111,7 +111,7 @@ async function createWorkflowDefinition(
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -142,7 +142,7 @@ async function createWorkflowRun(db: Knex, run: RunSeed): Promise<void> {
     run_id: run.runId,
     workflow_id: run.workflowId,
     workflow_version: run.version,
-    tenant_id: run.tenantId,
+    tenant: run.tenantId,
     status: run.status,
     node_path: run.nodePath ?? null,
     input_json: run.inputJson ?? null,
@@ -297,7 +297,7 @@ async function createWorkflowRunLog(db: Knex, log: LogSeed): Promise<void> {
   await db('workflow_run_logs').insert({
     log_id: log.logId,
     run_id: log.runId,
-    tenant_id: log.tenantId,
+    tenant: log.tenantId,
     step_path: log.stepPath ?? null,
     level: log.level,
     message: log.message,

--- a/ee/server/src/__tests__/integration/workflow-external-schedules.actions.integration.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-external-schedules.actions.integration.test.ts
@@ -14,7 +14,8 @@ import { createTestDbConnection } from '@main-test-utils/dbConfig';
 const require = createRequire(import.meta.url);
 
 let db: Knex;
-let tenantId = 'tenant-workflow-schedules';
+const WORKFLOW_SCHEDULES_TENANT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+let tenantId = WORKFLOW_SCHEDULES_TENANT;
 
 const hasPermissionMock = vi.fn(async () => true);
 const runner = {
@@ -73,7 +74,7 @@ async function seedWorkflow(params?: {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: tenantId,
+    tenant: tenantId,
     name,
     description: null,
     payload_schema_ref: payloadSchemaRef,
@@ -179,7 +180,7 @@ describe('Workflow external schedules actions – DB integration', () => {
   }, HOOK_TIMEOUT);
 
   beforeEach(async () => {
-    tenantId = 'tenant-workflow-schedules';
+    tenantId = WORKFLOW_SCHEDULES_TENANT;
     hasPermissionMock.mockReset();
     hasPermissionMock.mockResolvedValue(true);
     runner.scheduleJobAt.mockClear();
@@ -259,7 +260,7 @@ describe('Workflow external schedules actions – DB integration', () => {
 
     await db('tenant_workflow_schedule').insert({
       id: uuidv4(),
-      tenant_id: 'other-tenant',
+      tenant: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
       workflow_id: a.workflowId,
       workflow_version: 1,
       name: 'Foreign schedule',
@@ -781,7 +782,7 @@ describe('Workflow external schedules actions – DB integration', () => {
     }
 
     const rows = await db('tenant_workflow_schedule')
-      .where({ tenant_id: tenantId, name: 'Rollback invalid payload' })
+      .where({ tenant: tenantId, name: 'Rollback invalid payload' })
       .select('*');
     expect(rows).toHaveLength(0);
   });

--- a/ee/server/src/__tests__/integration/workflow-external-schedules.migration.integration.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-external-schedules.migration.integration.test.ts
@@ -76,9 +76,10 @@ describe('Workflow external schedules migration – DB integration', () => {
     await resetToLegacyWorkflowScheduleTable();
 
     const workflowId = uuidv4();
+    const tenantA = uuidv4();
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
-      tenant_id: 'tenant-a',
+      tenant: tenantA,
       name: 'Legacy Workflow',
       description: null,
       payload_schema_ref: 'payload.Empty.v1',
@@ -92,7 +93,7 @@ describe('Workflow external schedules migration – DB integration', () => {
     const scheduleId = uuidv4();
     await db('tenant_workflow_schedule').insert({
       id: scheduleId,
-      tenant_id: 'tenant-a',
+      tenant_id: tenantA,
       workflow_id: workflowId,
       workflow_version: 1,
       trigger_type: 'recurring',

--- a/ee/server/src/__tests__/integration/workflow-ticket-created-add-comment.playwright.test.ts
+++ b/ee/server/src/__tests__/integration/workflow-ticket-created-add-comment.playwright.test.ts
@@ -425,7 +425,7 @@ test('E2E: TICKET_CREATED triggers workflow that adds a ticket comment', async (
     const eventRecord = await waitForCondition(
       async () => {
         const row = await db('workflow_runtime_events')
-          .where({ tenant_id: tenantId, event_name: 'TICKET_CREATED' })
+          .where({ tenant: tenantId, event_name: 'TICKET_CREATED' })
           .andWhereRaw(`payload->>'ticketId' = ?`, [ticketId])
           .orderBy('created_at', 'desc')
           .first(['event_id', 'matched_run_id']);
@@ -443,7 +443,7 @@ test('E2E: TICKET_CREATED triggers workflow that adds a ticket comment', async (
         if (direct?.matched_run_id) return direct.matched_run_id as string;
 
         const run = await db('workflow_runs')
-          .where({ tenant_id: tenantId, workflow_id: workflowId, event_type: 'TICKET_CREATED' })
+          .where({ tenant: tenantId, workflow_id: workflowId, event_type: 'TICKET_CREATED' })
           .orderBy('started_at', 'desc')
           .first(['run_id']);
         return run?.run_id ? (run.run_id as string) : null;

--- a/ee/server/src/__tests__/unit/workflowScheduleActions.test.ts
+++ b/ee/server/src/__tests__/unit/workflowScheduleActions.test.ts
@@ -211,7 +211,7 @@ describe('workflow schedule actions', () => {
         })
       ]
     });
-    expect(listQuery.where).toHaveBeenCalledWith('tws.tenant_id', 'tenant-1');
+    expect(listQuery.where).toHaveBeenCalledWith('tws.tenant', 'tenant-1');
   });
 
   it('T002: rejects one-time schedules that set non-any day filters', async () => {

--- a/ee/test-data/workflow-harness/_lib/biz-fixture.cjs
+++ b/ee/test-data/workflow-harness/_lib/biz-fixture.cjs
@@ -269,7 +269,7 @@ async function getLatestFixtureRun({ ctx, workflowId, tenantId, startedAfter, fi
         run_id,
         workflow_id,
         workflow_version,
-        tenant_id,
+        tenant,
         status,
         event_type,
         source_payload_schema_ref,
@@ -280,7 +280,7 @@ async function getLatestFixtureRun({ ctx, workflowId, tenantId, startedAfter, fi
         error_json
       from workflow_runs
       where workflow_id = $1
-        and tenant_id = $2
+        and tenant = $2
         and started_at >= $3
         and input_json->>'fixtureNotifyUserId' = $4
         and ($5::text is null or input_json->>'fixtureDedupeKey' = $5)
@@ -323,18 +323,18 @@ async function waitForFixtureRun(ctx, { startedAfter, fixtureNotifyUserId, fixtu
 
 async function withWorkflowPaused(ctx, workflowId, fn) {
   const tenantId = ctx.config.tenantId;
-  const rows = await ctx.db.query(`select is_paused from workflow_definitions where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
+  const rows = await ctx.db.query(`select is_paused from workflow_definitions where workflow_id = $1 and tenant = $2`, [workflowId, tenantId]);
   const wasPaused = rows[0]?.is_paused ?? false;
 
   if (!wasPaused) {
-    await ctx.dbWrite.query(`update workflow_definitions set is_paused = true where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
+    await ctx.dbWrite.query(`update workflow_definitions set is_paused = true where workflow_id = $1 and tenant = $2`, [workflowId, tenantId]);
   }
 
   try {
     return await fn();
   } finally {
     if (!wasPaused) {
-      await ctx.dbWrite.query(`update workflow_definitions set is_paused = false where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId]);
+      await ctx.dbWrite.query(`update workflow_definitions set is_paused = false where workflow_id = $1 and tenant = $2`, [workflowId, tenantId]);
     }
   }
 }

--- a/server/src/lib/jobs/handlers/processRenewalQueueHandler.ts
+++ b/server/src/lib/jobs/handlers/processRenewalQueueHandler.ts
@@ -329,7 +329,7 @@ export async function processRenewalQueueHandler(data: RenewalQueueProcessorJobD
   const workflowRunIdForTenant = hasWorkflowRunsTable
     ? (
       await knex('workflow_runs')
-        .where({ tenant_id: tenantId })
+        .where({ tenant: tenantId })
         .orderBy('updated_at', 'desc')
         .first('run_id')
     )?.run_id ?? null

--- a/server/src/lib/jobs/handlers/processRenewalQueueHandler.ts
+++ b/server/src/lib/jobs/handlers/processRenewalQueueHandler.ts
@@ -128,7 +128,9 @@ const tryCreateRenewalTicketViaWorkflowAction = async (params: {
     board_id: params.boardId,
     status_id: params.statusId,
     priority_id: params.priorityId,
-    assigned_to: params.assignedTo,
+    assignment: params.assignedTo
+      ? { primary: { type: 'user', id: params.assignedTo }, additional_user_ids: [] }
+      : undefined,
     attributes: params.attributes,
     idempotency_key: params.idempotencyKey,
   });
@@ -326,14 +328,22 @@ export async function processRenewalQueueHandler(data: RenewalQueueProcessorJobD
     .select(['cc.*', 'c.status as contract_status', 'c.contract_name', 'cl.client_name', ...defaultSelections]);
 
   const candidateRows = await contractQuery;
-  const workflowRunIdForTenant = hasWorkflowRunsTable
-    ? (
-      await knex('workflow_runs')
-        .where({ tenant: tenantId })
-        .orderBy('updated_at', 'desc')
-        .first('run_id')
-    )?.run_id ?? null
-    : null;
+  let workflowRunIdForTenant: string | null = null;
+  if (hasWorkflowRunsTable) {
+    try {
+      workflowRunIdForTenant = (
+        await knex('workflow_runs')
+          .where({ tenant: tenantId })
+          .orderBy('updated_at', 'desc')
+          .first('run_id')
+      )?.run_id ?? null;
+    } catch (error) {
+      logger.warn('Failed to resolve workflow run for renewal ticket provenance; tickets will be created directly', {
+        tenantId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
   let eligibleRows = 0;
   let upsertedCount = 0;
   let normalizedStatusCount = 0;

--- a/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
+++ b/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
@@ -318,7 +318,7 @@ describe('renewal queue scheduling wiring', () => {
     expect(renewalHandlerSource).toContain("const tenantId = typeof data.tenantId === 'string' ? data.tenantId : '';");
     expect(renewalHandlerSource).toContain("throw new Error('Tenant ID is required for renewal queue processing job');");
     expect(renewalHandlerSource).toContain("'cc.tenant': tenantId,");
-    expect(renewalHandlerSource).toContain(".where({ tenant_id: tenantId })");
+    expect(renewalHandlerSource).toContain(".where({ tenant: tenantId })");
     expect(renewalHandlerSource).toContain('tenant: tenantId,');
 
     expect(temporalRunnerSource).toContain("throw new Error('tenantId is required in job data');");

--- a/server/src/test/e2e/workflowRuntimeV2.e2e.test.ts
+++ b/server/src/test/e2e/workflowRuntimeV2.e2e.test.ts
@@ -262,7 +262,7 @@ describe('workflow runtime v2 trigger validation + launch E2E tests', () => {
     });
 
     const row = await db('workflow_runtime_events')
-      .where({ tenant_id: tenantId, event_name: 'PING_CONFLICT', correlation_key: 'k-conflict' })
+      .where({ tenant: tenantId, event_name: 'PING_CONFLICT', correlation_key: 'k-conflict' })
       .first();
 
     expect(row?.payload_schema_ref).toBe(TEST_SCHEMA_REF);

--- a/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
+++ b/server/src/test/integration/boardSpecificTicketStatusesMigration.integration.test.ts
@@ -460,7 +460,7 @@ async function seedWorkflowStatusReferences(fixture: LegacyFixture) {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: fixture.tenantId,
+    tenant: fixture.tenantId,
     name: definition.name,
     description: definition.description,
     payload_schema_ref: definition.payloadSchemaRef,
@@ -524,7 +524,7 @@ async function seedUnresolvedWorkflowStatusReference(fixture: LegacyFixture) {
 
   await db('workflow_definitions').insert({
     workflow_id: workflowId,
-    tenant_id: fixture.tenantId,
+    tenant: fixture.tenantId,
     name: definition.name,
     description: definition.description,
     payload_schema_ref: definition.payloadSchemaRef,

--- a/server/src/test/integration/workflowAuditExport.integration.test.ts
+++ b/server/src/test/integration/workflowAuditExport.integration.test.ts
@@ -129,7 +129,7 @@ describe('workflow audit export integration', () => {
 
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
-      tenant_id: tenantId,
+      tenant: tenantId,
       name: 'Quarterly Review',
       key: 'quarterly.review',
       description: null,
@@ -198,7 +198,7 @@ describe('workflow audit export integration', () => {
     const workflowId = uuidv4();
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
-      tenant_id: tenantId,
+      tenant: tenantId,
       name: 'Permissions Fixture',
       key: 'permissions.fixture',
       description: null,
@@ -222,7 +222,7 @@ describe('workflow audit export integration', () => {
     const otherTenantWorkflowId = uuidv4();
     await db('workflow_definitions').insert({
       workflow_id: otherTenantWorkflowId,
-      tenant_id: uuidv4(),
+      tenant: uuidv4(),
       name: 'Other Tenant Workflow',
       key: 'other.tenant.workflow',
       description: null,
@@ -253,7 +253,7 @@ describe('workflow audit export integration', () => {
 
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
-      tenant_id: tenantId,
+      tenant: tenantId,
       name: 'Compatibility Workflow',
       key: 'compatibility.workflow',
       description: null,
@@ -270,7 +270,7 @@ describe('workflow audit export integration', () => {
       run_id: runId,
       workflow_id: workflowId,
       workflow_version: 1,
-      tenant_id: tenantId,
+      tenant: tenantId,
       status: 'RUNNING',
       ...(hasColumn(runColumns, 'node_path') ? { node_path: null } : {}),
       ...(hasColumn(runColumns, 'input_json') ? { input_json: null } : {}),

--- a/server/src/test/integration/workflowStepQuotaService.integration.test.ts
+++ b/server/src/test/integration/workflowStepQuotaService.integration.test.ts
@@ -290,7 +290,7 @@ describe('workflowStepQuotaService', () => {
     const workflowId = uuidv4();
     await db('workflow_definitions').insert({
       workflow_id: workflowId,
-      tenant_id: tenant,
+      tenant,
       name: 'Quota Drift Workflow',
       payload_schema_ref: 'schema://none',
       draft_definition: {},
@@ -301,7 +301,7 @@ describe('workflowStepQuotaService', () => {
     const runId = uuidv4();
     await db('workflow_runs').insert({
       run_id: runId,
-      tenant_id: tenant,
+      tenant,
       workflow_id: workflowId,
       workflow_version: 1,
       status: 'RUNNING',

--- a/server/src/test/unit/workflowExternalSchedulesPublishLifecycle.unit.test.ts
+++ b/server/src/test/unit/workflowExternalSchedulesPublishLifecycle.unit.test.ts
@@ -323,7 +323,7 @@ function seedSchedule(params: {
   const id = uuidv4();
   scheduleRecords.set(id, {
     id,
-    tenant_id: 'tenant-1',
+    tenant: 'tenant-1',
     workflow_id: params.workflowId,
     workflow_version: params.workflowVersion ?? 1,
     name: params.name,

--- a/server/src/test/unit/workflowRunLauncher.unit.test.ts
+++ b/server/src/test/unit/workflowRunLauncher.unit.test.ts
@@ -299,7 +299,7 @@ describe('Workflow run launcher', () => {
       expect.objectContaining({
         workflow_id: 'workflow-1',
         workflow_version: 5,
-        tenant_id: 'tenant-1',
+        tenant: 'tenant-1',
         status: 'FAILED',
         trigger_type: 'schedule',
         trigger_fire_key: 'workflow-schedule-fire:schedule-1:job-1',

--- a/shared/workflow/runtime/services/workflowStepQuotaService.ts
+++ b/shared/workflow/runtime/services/workflowStepQuotaService.ts
@@ -370,7 +370,7 @@ export class WorkflowStepQuotaService {
 
     const ledgerRow = await knex('workflow_run_steps as s')
       .join('workflow_runs as r', 'r.run_id', 's.run_id')
-      .where('r.tenant_id', tenant)
+      .where('r.tenant', tenant)
       .andWhere('s.started_at', '>=', periodStart)
       .andWhere('s.started_at', '<', periodEnd)
       .count<{ count: string }>('s.step_id as count')

--- a/tools/workflow-harness/lib/runs.cjs
+++ b/tools/workflow-harness/lib/runs.cjs
@@ -9,7 +9,7 @@ async function getLatestRun({ db, workflowId, tenantId, startedAfter }) {
         run_id,
         workflow_id,
         workflow_version,
-        tenant_id,
+        tenant,
         status,
         event_type,
         source_payload_schema_ref,
@@ -20,7 +20,7 @@ async function getLatestRun({ db, workflowId, tenantId, startedAfter }) {
         error_json
       from workflow_runs
       where workflow_id = $1
-        and tenant_id = $2
+        and tenant = $2
         and started_at >= $3
       order by started_at desc
       limit 1
@@ -41,7 +41,7 @@ async function listRecentRuns({ db, workflowId, tenantId, limit = 5 }) {
         completed_at
       from workflow_runs
       where workflow_id = $1
-        and tenant_id = $2
+        and tenant = $2
       order by started_at desc
       limit $3
     `,

--- a/tools/workflow-harness/run.cjs
+++ b/tools/workflow-harness/run.cjs
@@ -153,7 +153,7 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
         throw new Error('--skip-import requires bundle.json to have a workflow key');
       }
       const rows = await db.query(
-        `SELECT workflow_id FROM workflow_definitions WHERE tenant_id = $1 AND key = $2`,
+        `SELECT workflow_id FROM workflow_definitions WHERE tenant = $1 AND key = $2`,
         [tenantId, workflowKey]
       );
       if (!rows || rows.length === 0) {
@@ -184,11 +184,11 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
     // This keeps event→run fanout deterministic even when many fixtures exist in the DB.
     if (workflowKey && typeof workflowKey === 'string') {
       await dbWrite.query(
-        `update workflow_definitions set is_paused = true where tenant_id = $1 and key like 'fixture.%' and key <> $2`,
+        `update workflow_definitions set is_paused = true where tenant = $1 and key like 'fixture.%' and key <> $2`,
         [tenantId, workflowKey]
       );
     }
-    await dbWrite.query(`update workflow_definitions set is_paused = $3 where workflow_id = $1 and tenant_id = $2`, [workflowId, tenantId, workflowIsPausedInBundle]);
+    await dbWrite.query(`update workflow_definitions set is_paused = $3 where workflow_id = $1 and tenant = $2`, [workflowId, tenantId, workflowIsPausedInBundle]);
 
     if (debug) {
       // eslint-disable-next-line no-console
@@ -295,7 +295,7 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
               run_id,
               workflow_id,
               workflow_version,
-              tenant_id,
+              tenant,
               status,
               event_type,
               started_at,
@@ -304,7 +304,7 @@ async function runFixture({ testDir, bundlePath, testPath, baseUrl, tenantId, co
               error_json
             from workflow_runs
             where workflow_id = $1
-              and tenant_id = $2
+              and tenant = $2
               and started_at >= $3
             order by started_at desc
             limit 1


### PR DESCRIPTION
  processRenewalQueueHandler still filtered workflow_runs
  by the dropped tenant_id column, failing renewal scans
  since the Citus colocation migration renamed it to
  tenant. Update the query and the wiring test assertion.

  "You've been walking the yellow brick road of
  workflow_runs all along," said Glinda, "but the road
  was renamed to plain `tenant` — no tenant_id slippers
  required." The renewal scans clicked their heels and
  ran home. 👠🌪️ 📜