### PR TITLE
Move SLA side effects after commit to fix deadlock

### DIFF
--- a/docs/architecture/db-transaction-guardrails.md
+++ b/docs/architecture/db-transaction-guardrails.md
@@ -1,0 +1,82 @@
+# DB transaction guardrails and after-commit work
+
+Rules and safety nets introduced by the SLA close/reopen deadlock fix
+(`.ai/sla_close_deadlock_proper_fix_plan.md` has the full investigation).
+
+## Rules for transactional code
+
+1. **One DB writer per ticket row per logical operation.** SLA column
+   mutations happen exactly once, in the caller's transaction. The SLA
+   "backend" (`ISlaBackend`) schedules external side effects only — it never
+   re-does a DB write. The CE `PgBossSlaBackend` mutation hooks are no-ops.
+2. **No network or cross-connection work inside an open transaction.** Event
+   publishing and backend scheduling run after commit:
+   - `registerAfterCommit(trx, hook, label?)` (`@alga-psa/db`) queues work
+     that the transaction-owning `withTransaction` frame flushes after a
+     successful commit, in registration order. Hooks are dropped on rollback.
+     Nested `withTransaction` frames share the owner's `trx`, so their hooks
+     flush once, at the outer commit. Pass a `label` (e.g.
+     `"TICKET_CLOSED ticket=<id>"`) so a failed hook is traceable in logs.
+     Hook failures are logged and swallowed: events are at-most-once — a
+     publish that fails after commit is lost (no outbox), the committed write
+     stands.
+   - SLA write functions return `backendActions`; callers dispatch them with
+     `dispatchSlaBackendActions()` (`@alga-psa/sla`) after their transaction
+     resolves.
+3. **SLA writes are serialized per ticket.** Every SLA write entry point
+   takes `pg_advisory_xact_lock(hashtext('sla:<tenant>:<ticket>'))` first
+   (`acquireTicketSlaLock`). Transaction-scoped, so it is safe under
+   pgbouncer transaction pooling and self-releases at commit/rollback.
+
+## Event bus poison resistance
+
+- Handler success is tracked per `(event, handler)` (Redis set
+  `processed_event_handlers:<tenant>`), so one failing handler's redelivery
+  never re-runs co-subscribers that already succeeded (e.g. outbound
+  webhooks on the shared default-channel streams). Subscribers that share a
+  stream with same-named handler functions must pass a distinct
+  `subscriberId` to `subscribe()`.
+- Messages delivered more than `eventBus.maxDeliveries` times (default 10,
+  env `REDIS_STREAM_MAX_DELIVERIES`) are moved to `<stream>:dead-letter`
+  and acked. Dead-letter entries keep the original payload plus
+  `sourceStream`/`sourceMessageId`/`deliveries`/`deadLetteredAt` for
+  inspection and replay. The write is idempotent (marker set
+  `dead_lettered_messages:<stream>`, 3-day TTL), so an xAdd-succeeded /
+  xAck-failed retry does not duplicate the entry. Monitor dead-letter
+  volume.
+- A handler that throws gets a bounded retry (redelivery up to the cap),
+  not an infinite storm.
+
+## Postgres timeouts (defense in depth)
+
+Migration `20260609120000_set_app_role_db_guardrail_timeouts.cjs` sets on
+the app role (`DB_USER_SERVER`, default `app_user`):
+
+- `idle_in_transaction_session_timeout = 60s` — a session idle
+  mid-transaction is aborted and releases its locks. This fires on a single
+  continuous 60s idle gap between statements, not on total transaction
+  duration; steady statement loops are unaffected. 60s (not lower) leaves
+  headroom for a slow external call awaited between statements — waiters
+  are already protected by lock_timeout regardless of how long the holder
+  sits.
+- `lock_timeout = 8s` — statements fail fast instead of queueing behind a
+  stuck lock holder.
+
+These are role-level GUCs (not pool `afterCreate` SETs) because pgbouncer
+runs `pool_mode = transaction`: session-level SETs issued at connection
+creation do not reliably follow a client across backend remapping, while
+role GUCs resolve server-side at backend session start. The admin/migration
+role is deliberately excluded so long-running DDL stays legal.
+
+`pgbouncer/pgbouncer.ini.template` keeps `idle_transaction_timeout = 120`
+as a last-resort reaper for whatever the role GUCs don't cover. It must
+stay above the role GUC so the gentler server-side abort fires before
+pgbouncer kills the connection.
+
+Verify on a deployment:
+
+```sql
+-- as the app user, through pgbouncer
+SHOW idle_in_transaction_session_timeout;  -- 60s
+SHOW lock_timeout;                         -- 8s
+```

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,6 +19,10 @@ export { getAdminConnection, destroyAdminConnection, refreshAdminConnection, wit
 // Tenant Connection
 export { getConnection, withTransaction, createTenantKnex, runWithTenant, getTenantContext, setTenantContext, resetTenantConnectionPool, destroyTenantConnection, refreshTenantConnection, withTenantTransactionRetryReadOnly, retryOnTenantReadOnly } from './lib/tenant';
 
+// After-commit hooks (flushed by the transaction-owning withTransaction frame)
+export { registerAfterCommit } from './lib/afterCommit';
+export type { AfterCommitHook } from './lib/afterCommit';
+
 // Read-only error helpers (for callers building their own retry strategies)
 export { isReadOnlyError, READ_ONLY_ERROR_RE, retryOnReadOnly } from './lib/readOnlyRetry';
 export { resolveTenantId, requireTenantId } from './lib/tenantId';

--- a/packages/db/src/lib/afterCommit.test.ts
+++ b/packages/db/src/lib/afterCommit.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/core/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function createOwnedTrx() {
+  return {
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+  } as any;
+}
+
+function createKnex(trx: any) {
+  return {
+    transaction: vi.fn(async (cb: any) => {
+      try {
+        const result = await cb(trx);
+        await trx.commit();
+        return result;
+      } catch (error) {
+        await trx.rollback(error);
+        throw error;
+      }
+    }),
+  } as any;
+}
+
+describe('registerAfterCommit', () => {
+  it('runs hooks in registration order after commit, before withTransaction returns', async () => {
+    const { withTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const order: string[] = [];
+
+    const result = await withTransaction(knex, async (t) => {
+      registerAfterCommit(t, () => {
+        order.push('hook-1');
+      });
+      registerAfterCommit(t, async () => {
+        order.push('hook-2');
+      });
+      order.push('callback-done');
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(order).toEqual(['callback-done', 'hook-1', 'hook-2']);
+    expect(trx.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops hooks when the transaction rolls back', async () => {
+    const { withTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const hook = vi.fn();
+
+    await expect(
+      withTransaction(knex, async (t) => {
+        registerAfterCommit(t, hook);
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    expect(hook).not.toHaveBeenCalled();
+    expect(trx.rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('attaches nested-frame hooks to the owning frame and flushes once, at outer commit', async () => {
+    const { withTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const order: string[] = [];
+
+    await withTransaction(knex, async (outerTrx) => {
+      await withTransaction(outerTrx, async (nestedTrx) => {
+        expect(nestedTrx).toBe(outerTrx);
+        registerAfterCommit(nestedTrx, () => {
+          order.push('nested-hook');
+        });
+      });
+      // The nested frame returned without owning the commit: its hook must
+      // not have run yet.
+      order.push('after-nested-frame');
+    });
+
+    expect(order).toEqual(['after-nested-frame', 'nested-hook']);
+  });
+
+  it('swallows hook failures, logs the label, and keeps running the remaining hooks', async () => {
+    const { withTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const logger = (await import('@alga-psa/core/logger')).default;
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const secondHook = vi.fn();
+
+    const result = await withTransaction(knex, async (t) => {
+      registerAfterCommit(
+        t,
+        () => {
+          throw new Error('hook failed');
+        },
+        'TICKET_CLOSED ticket=t-1'
+      );
+      registerAfterCommit(t, secondHook);
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(secondHook).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      '[db/afterCommit] after-commit hook failed',
+      expect.objectContaining({ label: 'TICKET_CLOSED ticket=t-1', error: 'hook failed' })
+    );
+  });
+
+  it('flushes each hook exactly once', async () => {
+    const { withTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const { flushAfterCommitHooks } = await import('./afterCommit');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const hook = vi.fn();
+
+    await withTransaction(knex, async (t) => {
+      registerAfterCommit(t, hook);
+    });
+    await flushAfterCommitHooks(trx);
+
+    expect(hook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/db/src/lib/afterCommit.ts
+++ b/packages/db/src/lib/afterCommit.ts
@@ -1,0 +1,70 @@
+/**
+ * @alga-psa/db - After-commit hooks
+ *
+ * registerAfterCommit(trx, hook) queues work (event publishing, backend
+ * scheduling — anything that must not run inside an open transaction) to run
+ * once the transaction that owns `trx` commits. The owning withTransaction /
+ * withTenantTransactionRetryReadOnly frame flushes the queue after
+ * knex.transaction() resolves and before returning to its caller; on
+ * rollback the queue is dropped untouched.
+ *
+ * Nested withTransaction frames share the caller's `trx` object, so hooks
+ * registered anywhere in the nesting attach to the same queue and flush
+ * exactly once, when the outermost (owning) frame commits.
+ */
+
+import type { Knex as KnexType } from './knex-turbopack';
+import logger from '@alga-psa/core/logger';
+
+export type AfterCommitHook = () => void | Promise<void>;
+
+interface HookEntry {
+  hook: AfterCommitHook;
+  label?: string;
+}
+
+const afterCommitHooks = new WeakMap<object, HookEntry[]>();
+
+/**
+ * `label` identifies the hook in the failure log (e.g. "TICKET_CLOSED
+ * ticket=<id>"); without it a failed hook is untraceable.
+ */
+export function registerAfterCommit(
+  trx: KnexType.Transaction,
+  hook: AfterCommitHook,
+  label?: string
+): void {
+  const entry: HookEntry = { hook, label };
+  const hooks = afterCommitHooks.get(trx);
+  if (hooks) {
+    hooks.push(entry);
+  } else {
+    afterCommitHooks.set(trx, [entry]);
+  }
+}
+
+/**
+ * Run and clear the hooks queued on `trx`, in registration order. Only the
+ * transaction-owning frame may call this, and only after a successful
+ * commit. Hook failures are logged and swallowed: the transaction is already
+ * committed, so a failing hook must not fail the operation or stop the
+ * remaining hooks.
+ */
+export async function flushAfterCommitHooks(trx: object): Promise<void> {
+  const hooks = afterCommitHooks.get(trx);
+  if (!hooks?.length) {
+    return;
+  }
+  afterCommitHooks.delete(trx);
+
+  for (const { hook, label } of hooks) {
+    try {
+      await hook();
+    } catch (error) {
+      logger.error('[db/afterCommit] after-commit hook failed', {
+        label,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/packages/db/src/lib/tenant.ts
+++ b/packages/db/src/lib/tenant.ts
@@ -10,6 +10,7 @@ import { getKnexConfig } from './knexfile';
 import logger from '@alga-psa/core/logger';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { isReadOnlyError, retryOnReadOnly } from './readOnlyRetry';
+import { flushAfterCommitHooks } from './afterCommit';
 
 type PoolConfig = KnexType.PoolConfig & {
   afterCreate?: (connection: any, done: (err: Error | null, connection: any) => void) => void;
@@ -139,7 +140,7 @@ export async function withTransaction<T>(
   if (typeof tenantIdOrKnexOrTrx === 'string') {
     const tenantId = tenantIdOrKnexOrTrx;
     const knex = await getConnection(tenantId);
-    return tenantContext.run(tenantId, () => knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx))));
+    return ownTransaction(knex, tenantId, callback);
   }
 
   const maybeTrx = tenantIdOrKnexOrTrx as unknown as {
@@ -150,6 +151,9 @@ export async function withTransaction<T>(
   const tenantId = getTenantContext();
 
   if (typeof maybeTrx?.commit === 'function' && typeof maybeTrx?.rollback === 'function') {
+    // Nested frame: reuse the caller's trx and do NOT own the commit.
+    // After-commit hooks registered in here attach to the shared trx and
+    // flush only when the outermost owning frame commits.
     if (tenantId) {
       return tenantContext.run(tenantId, () => callback(tenantIdOrKnexOrTrx as KnexType.Transaction));
     }
@@ -157,11 +161,32 @@ export async function withTransaction<T>(
   }
 
   const knex = tenantIdOrKnexOrTrx as KnexType;
-  if (tenantId) {
-    return tenantContext.run(tenantId, () => knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx))));
-  }
+  return ownTransaction(knex, tenantId, callback);
+}
 
-  return knex.transaction(callback);
+/**
+ * Run `callback` in a new transaction this frame owns: open it (inside the
+ * tenant context when one applies), and after a successful commit flush any
+ * hooks registered via registerAfterCommit() before returning.
+ */
+async function ownTransaction<T>(
+  knex: KnexType,
+  tenantId: string | undefined,
+  callback: (trx: KnexType.Transaction) => Promise<T>
+): Promise<T> {
+  const run = async (): Promise<T> => {
+    let owned: KnexType.Transaction | undefined;
+    const result = await knex.transaction((trx) => {
+      owned = trx;
+      return tenantId ? tenantContext.run(tenantId, () => callback(trx)) : callback(trx);
+    });
+    if (owned) {
+      await flushAfterCommitHooks(owned);
+    }
+    return result;
+  };
+
+  return tenantId ? tenantContext.run(tenantId, run) : run();
 }
 
 /**
@@ -184,9 +209,7 @@ export async function withTenantTransactionRetryReadOnly<T>(
 ): Promise<T> {
   try {
     const knex = await getConnection(tenantId);
-    return await tenantContext.run(tenantId, () =>
-      knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx)))
-    );
+    return await ownTransaction(knex, tenantId, callback);
   } catch (err) {
     if (!isReadOnlyError(err)) throw err;
     logger.warn(
@@ -195,9 +218,7 @@ export async function withTenantTransactionRetryReadOnly<T>(
     );
     await refreshTenantConnection();
     const knex = await getConnection(tenantId);
-    return await tenantContext.run(tenantId, () =>
-      knex.transaction((trx) => tenantContext.run(tenantId, () => callback(trx)))
-    );
+    return await ownTransaction(knex, tenantId, callback);
   }
 }
 

--- a/packages/event-bus/src/config/redisConfig.ts
+++ b/packages/event-bus/src/config/redisConfig.ts
@@ -22,6 +22,8 @@ const RedisConfigSchema = z.object({
     blockingTimeout: z.number().int().nonnegative().default(5000), // ms
     claimTimeout: z.number().int().positive().default(30000), // ms
     batchSize: z.number().int().positive().default(10),
+    // Deliveries (initial read + claims) before a message is dead-lettered.
+    maxDeliveries: z.number().int().positive().default(10),
     reconnectStrategy: z.object({
       retries: z.number().int().positive().default(10),
       initialDelay: z.number().int().positive().default(100), // ms
@@ -43,6 +45,7 @@ const validateConfig = () => {
         blockingTimeout: parseInt(process.env.REDIS_STREAM_BLOCKING_TIMEOUT || '5000', 10),
         claimTimeout: parseInt(process.env.REDIS_STREAM_CLAIM_TIMEOUT || '30000', 10),
         batchSize: parseInt(process.env.REDIS_STREAM_BATCH_SIZE || '10', 10),
+        maxDeliveries: parseInt(process.env.REDIS_STREAM_MAX_DELIVERIES || '10', 10),
         reconnectStrategy: {
           retries: parseInt(process.env.REDIS_RECONNECT_RETRIES || '10', 10),
           initialDelay: parseInt(process.env.REDIS_RECONNECT_INITIAL_DELAY || '100', 10),

--- a/packages/event-bus/src/eventBus.ts
+++ b/packages/event-bus/src/eventBus.ts
@@ -171,6 +171,10 @@ export class EventBus {
   private static createdConsumerGroups: Set<string> = new Set<string>();
   // Map<EventType, Map<Channel, Handlers>> so channel-specific consumers do not step on each other.
   private handlers: Map<EventType, Map<string, Set<EventHandler>>>;
+  // Stable per-handler ids for per-(event, handler) processed tracking.
+  // Subscribers sharing a stream with same-named handlers must pass an
+  // explicit subscriberId to disambiguate.
+  private handlerIds: WeakMap<EventHandler, string> = new WeakMap();
   private initialized: boolean = false;
   private consumerName: string;
   private processingEvents: boolean = false;
@@ -299,6 +303,28 @@ export class EventBus {
     const client = await getClient();
     const setKey = this.getProcessedSetKey(event.payload.tenantId);
     await client.sAdd(setKey, event.id);
+    // Set expiration to prevent unbounded growth (3 days)
+    await client.expire(setKey, 60 * 60 * 24 * 3);
+  }
+
+  private getHandlerKey(handler: EventHandler): string {
+    return this.handlerIds.get(handler) || handler.name || 'anonymous';
+  }
+
+  private getProcessedHandlersSetKey(tenantId: string): string {
+    return `processed_event_handlers:${tenantId}`;
+  }
+
+  private async isHandlerProcessed(event: Event, handlerKey: string): Promise<boolean> {
+    const client = await getClient();
+    const setKey = this.getProcessedHandlersSetKey(event.payload.tenantId);
+    return await client.sIsMember(setKey, `${event.id}:${handlerKey}`);
+  }
+
+  private async markHandlerProcessed(event: Event, handlerKey: string): Promise<void> {
+    const client = await getClient();
+    const setKey = this.getProcessedHandlersSetKey(event.payload.tenantId);
+    await client.sAdd(setKey, `${event.id}:${handlerKey}`);
     // Set expiration to prevent unbounded growth (3 days)
     await client.expire(setKey, 60 * 60 * 24 * 3);
   }
@@ -460,24 +486,40 @@ export class EventBus {
       }
 
       const event = eventSchema.parse(rawEvent) as Event;
-      const handler = subscription.handlers.values().next().value as EventHandler | undefined;
+      const handlers = Array.from(subscription.handlers);
 
-      if (handler) {
+      if (handlers.length > 0) {
         const isProcessed = await this.isEventProcessed(event);
         if (!isProcessed) {
-          try {
-            await handler(event);
-            await this.markEventProcessed(event);
-          } catch (error) {
-            logger.error('[EventBus] Error in event handler:', {
-              error,
-              eventType: baseEvent.eventType,
-              handler: handler.name,
-              channel: subscription.channel
-            });
-            // Don't acknowledge message on error to allow retry
+          // Invoke every registered handler for (eventType, channel) — not
+          // just the first — and track success per (event, handler) so a
+          // failing handler's redelivery never re-runs co-subscribers that
+          // already succeeded.
+          let anyFailure = false;
+          for (const handler of handlers) {
+            const handlerKey = this.getHandlerKey(handler);
+            try {
+              if (await this.isHandlerProcessed(event, handlerKey)) {
+                continue;
+              }
+              await handler(event);
+              await this.markHandlerProcessed(event, handlerKey);
+            } catch (error) {
+              anyFailure = true;
+              logger.error('[EventBus] Error in event handler:', {
+                error,
+                eventType: baseEvent.eventType,
+                handler: handler.name,
+                channel: subscription.channel
+              });
+            }
+          }
+
+          if (anyFailure) {
+            // Don't acknowledge message on any failure to allow retry.
             return;
           }
+          await this.markEventProcessed(event);
         } else {
           logger.info('[EventBus] Skipping already processed event:', {
             eventId: event.id,
@@ -541,9 +583,16 @@ export class EventBus {
           );
 
           if (pendingMessages && pendingMessages.length > 0) {
-            const claimIds = pendingMessages
-              .filter(msg => msg.millisecondsSinceLastDelivery > config.eventBus.claimTimeout)
-              .map(msg => msg.id);
+            const stalePending = pendingMessages.filter(
+              msg => msg.millisecondsSinceLastDelivery > config.eventBus.claimTimeout
+            );
+            // Fresh xReadGroup deliveries carry no delivery counter, but
+            // xPendingRange does — enforce the dead-letter cap here so no
+            // message can redeliver forever.
+            const deliveriesById = new Map(
+              stalePending.map(msg => [msg.id, msg.deliveriesCounter])
+            );
+            const claimIds = stalePending.map(msg => msg.id);
 
             if (claimIds.length > 0) {
               const claimed = await client.xClaim(
@@ -557,6 +606,11 @@ export class EventBus {
               const subscription = subscriptionLookup.get(stream);
               if (subscription && Array.isArray(claimed) && claimed.length > 0) {
                 for (const message of claimed as Array<{ id: string; message: Record<string, string> }>) {
+                  const deliveries = deliveriesById.get(message.id) ?? 0;
+                  if (deliveries > config.eventBus.maxDeliveries) {
+                    await this.deadLetterMessage(client, config, stream, message, deliveries);
+                    continue;
+                  }
                   await this.processStreamMessage(client, config, stream, subscription, message);
                 }
               }
@@ -569,16 +623,77 @@ export class EventBus {
     }
   }
 
+  /**
+   * Move a message that exceeded the delivery cap onto the stream's
+   * dead-letter sibling and ack it so it stops storming the consumer group.
+   * Dead-letter volume should be monitored; entries carry the original
+   * payload for manual inspection/replay.
+   */
+  private async deadLetterMessage(
+    client: Awaited<ReturnType<typeof createRedisClient>>,
+    config: ReturnType<typeof getRedisConfig>,
+    stream: string,
+    message: { id: string; message: Record<string, string> },
+    deliveries: number
+  ): Promise<void> {
+    const deadLetterStream = `${stream}:dead-letter`;
+    // Marker set makes the xAdd idempotent: if a previous attempt wrote the
+    // dead-letter entry but failed to ack, the retry only re-acks instead of
+    // writing a duplicate entry.
+    const markerKey = `dead_lettered_messages:${stream}`;
+    try {
+      if (!(await client.sIsMember(markerKey, message.id))) {
+        await client.xAdd(
+          deadLetterStream,
+          '*',
+          {
+            ...message.message,
+            sourceStream: stream,
+            sourceMessageId: message.id,
+            deliveries: String(deliveries),
+            deadLetteredAt: new Date().toISOString()
+          },
+          {
+            TRIM: {
+              strategy: 'MAXLEN',
+              threshold: config.eventBus.maxStreamLength,
+              strategyModifier: '~'
+            }
+          }
+        );
+        await client.sAdd(markerKey, message.id);
+        await client.expire(markerKey, 60 * 60 * 24 * 3);
+      }
+      await client.xAck(stream, config.eventBus.consumerGroup, message.id);
+      logger.error('[EventBus] Dead-lettered message after exceeding max deliveries', {
+        stream,
+        deadLetterStream,
+        messageId: message.id,
+        deliveries,
+        maxDeliveries: config.eventBus.maxDeliveries
+      });
+    } catch (error) {
+      logger.error('[EventBus] Failed to dead-letter message', {
+        stream,
+        messageId: message.id,
+        error
+      });
+    }
+  }
+
   public async subscribe(
     eventType: EventType,
     handler: EventHandler,
-    options?: { channel?: string }
+    options?: { channel?: string; subscriberId?: string }
   ): Promise<void> {
     await this.initialize();
 
     const channel = options?.channel || this.defaultChannel;
     const handlers = this.getChannelHandlers(eventType, channel, true)!;
     handlers.add(handler);
+    if (options?.subscriberId) {
+      this.handlerIds.set(handler, options.subscriberId);
+    }
 
     const stream = this.getStreamKey(eventType, channel);
     await this.ensureStreamAndGroup(stream);

--- a/packages/event-bus/src/index.poison.test.ts
+++ b/packages/event-bus/src/index.poison.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+type FakeRedisClient = EventEmitter & {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  quit: () => Promise<void>;
+  xGroupCreate: () => Promise<void>;
+  xReadGroup: (...args: any[]) => Promise<any>;
+  xAdd: (...args: any[]) => Promise<string>;
+  xAck: (...args: any[]) => Promise<number>;
+  xPending: (...args: any[]) => Promise<{ pending: number }>;
+  xPendingRange: (...args: any[]) => Promise<any[]>;
+  xClaim: (...args: any[]) => Promise<any>;
+  sIsMember: (...args: any[]) => Promise<boolean>;
+  sAdd: (...args: any[]) => Promise<number>;
+  expire: (...args: any[]) => Promise<number>;
+};
+
+async function flushMicrotasks(limit: number = 50) {
+  for (let i = 0; i < limit; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+function mockModules(opts: {
+  pendingRounds: Array<{
+    deliveriesCounter: number;
+  }>;
+  message: { id: string; event: Record<string, unknown> };
+  onAck: () => void;
+  onDeadLetter: (stream: string, fields: Record<string, string>) => void;
+  processed: Set<string>;
+}) {
+  vi.doMock('@alga-psa/core/logger', () => ({
+    default: {
+      info: () => undefined,
+      warn: () => undefined,
+      debug: () => undefined,
+      error: () => undefined,
+    },
+  }));
+
+  vi.doMock('redis', () => ({
+    createClient: () => {
+      const client = new EventEmitter() as FakeRedisClient;
+      let round = 0;
+
+      client.connect = vi.fn(async () => {
+        client.emit('connect');
+        client.emit('ready');
+      });
+      client.disconnect = vi.fn(() => {
+        client.emit('end');
+      });
+      client.quit = vi.fn(async () => {
+        client.emit('end');
+      });
+
+      client.xGroupCreate = vi.fn(async () => undefined);
+      client.xReadGroup = vi.fn(async () => null);
+      client.xAdd = vi.fn(async (stream: string, _id: string, fields: Record<string, string>) => {
+        opts.onDeadLetter(stream, fields);
+        return '1-1';
+      });
+      client.xAck = vi.fn(async () => {
+        opts.onAck();
+        return 1;
+      });
+
+      client.xPending = vi.fn(async () =>
+        round < opts.pendingRounds.length ? { pending: 1 } : { pending: 0 }
+      );
+      client.xPendingRange = vi.fn(async () => {
+        if (round >= opts.pendingRounds.length) {
+          return [];
+        }
+        const entry = opts.pendingRounds[round];
+        round += 1;
+        return [
+          {
+            id: opts.message.id,
+            consumer: 'consumer-old',
+            millisecondsSinceLastDelivery: 30001,
+            deliveriesCounter: entry.deliveriesCounter,
+          },
+        ];
+      });
+      client.xClaim = vi.fn(async () => [
+        {
+          id: opts.message.id,
+          message: { event: JSON.stringify(opts.message.event), channel: 'global' },
+        },
+      ]);
+
+      client.sIsMember = vi.fn(async (_key: string, member: string) => opts.processed.has(member));
+      client.sAdd = vi.fn(async (_key: string, member: string) => {
+        opts.processed.add(member);
+        return 1;
+      });
+      client.expire = vi.fn(async () => 1);
+
+      return client;
+    },
+  }));
+}
+
+describe('EventBus poison resistance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('dead-letters and acks a message that exceeded max deliveries without running handlers', async () => {
+    const tenantId = randomUUID();
+    const eventType = 'UNKNOWN';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const handler = vi.fn(async () => undefined);
+    let didAck = false;
+    const deadLetters: Array<{ stream: string; fields: Record<string, string> }> = [];
+
+    mockModules({
+      // deliveriesCounter beyond the default maxDeliveries (10)
+      pendingRounds: [{ deliveriesCounter: 11 }],
+      message: { id: '1-0', event },
+      onAck: () => {
+        didAck = true;
+      },
+      onDeadLetter: (stream, fields) => {
+        deadLetters.push({ stream, fields });
+      },
+      processed: new Set<string>(),
+    });
+
+    const { getEventBus } = await import('./index');
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, handler, { subscriberId: 'victim' });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 50 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(didAck).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0].stream).toMatch(/:dead-letter$/);
+    expect(deadLetters[0].fields.sourceMessageId).toBe('1-0');
+    expect(deadLetters[0].fields.deliveries).toBe('11');
+
+    await eventBus.close();
+  });
+
+  it('does not re-invoke a sibling handler that already succeeded when another handler fails', async () => {
+    const tenantId = randomUUID();
+    const eventType = 'UNKNOWN';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const succeeding = vi.fn(async () => undefined);
+    let failures = 0;
+    const failingOnce = vi.fn(async () => {
+      failures += 1;
+      if (failures === 1) {
+        throw new Error('transient failure');
+      }
+    });
+
+    let didAck = false;
+
+    mockModules({
+      // two delivery rounds: first fails one handler, second succeeds
+      pendingRounds: [{ deliveriesCounter: 1 }, { deliveriesCounter: 2 }],
+      message: { id: '2-0', event },
+      onAck: () => {
+        didAck = true;
+      },
+      onDeadLetter: () => undefined,
+      processed: new Set<string>(),
+    });
+
+    const { getEventBus } = await import('./index');
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, succeeding, { subscriberId: 'sibling-ok' });
+    await eventBus.subscribe(eventType as any, failingOnce, { subscriberId: 'sibling-flaky' });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 100 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(didAck).toBe(true);
+    // The succeeded sibling ran exactly once; only the failed handler retried.
+    expect(succeeding).toHaveBeenCalledTimes(1);
+    expect(failingOnce).toHaveBeenCalledTimes(2);
+
+    await eventBus.close();
+  });
+});

--- a/packages/sla/src/services/__tests__/slaBackendFactory.test.ts
+++ b/packages/sla/src/services/__tests__/slaBackendFactory.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PgBossSlaBackend } from '../backends/PgBossSlaBackend';
 
 const loadFactory = async () => {
   vi.resetModules();
   return import('../backends/SlaBackendFactory');
 };
 
+// vi.resetModules() gives the factory a fresh module graph, so class identity
+// can't be compared against a statically imported class — assert by name.
 describe('SlaBackendFactory', () => {
   const originalEdition = process.env.EDITION;
 
@@ -15,19 +16,20 @@ describe('SlaBackendFactory', () => {
 
   afterEach(() => {
     process.env.EDITION = originalEdition;
+    vi.doUnmock('@enterprise/lib/sla/TemporalSlaBackend');
   });
 
   it('returns PgBossSlaBackend when isEnterprise is false', async () => {
     process.env.EDITION = 'ce';
     const { SlaBackendFactory } = await loadFactory();
     const backend = await SlaBackendFactory.getBackend();
-    expect(backend).toBeInstanceOf(PgBossSlaBackend);
+    expect(backend.constructor.name).toBe('PgBossSlaBackend');
     SlaBackendFactory.getInstance().reset();
   });
 
   it('returns TemporalSlaBackend when isEnterprise is true and Temporal available', async () => {
     process.env.EDITION = 'ee';
-    vi.mock('@enterprise/lib/sla/TemporalSlaBackend', () => ({
+    vi.doMock('@enterprise/lib/sla/TemporalSlaBackend', () => ({
       TemporalSlaBackend: class TemporalSlaBackendMock {},
     }));
 
@@ -39,7 +41,7 @@ describe('SlaBackendFactory', () => {
 
   it('falls back to PgBossSlaBackend when Temporal unavailable in EE', async () => {
     process.env.EDITION = 'enterprise';
-    vi.mock('@enterprise/lib/sla/TemporalSlaBackend', () => ({
+    vi.doMock('@enterprise/lib/sla/TemporalSlaBackend', () => ({
       TemporalSlaBackend: class TemporalSlaBackendMock {
         constructor() {
           throw new Error('Temporal unavailable');
@@ -49,7 +51,7 @@ describe('SlaBackendFactory', () => {
 
     const { SlaBackendFactory } = await loadFactory();
     const backend = await SlaBackendFactory.getBackend();
-    expect(backend).toBeInstanceOf(PgBossSlaBackend);
+    expect(backend.constructor.name).toBe('PgBossSlaBackend');
     SlaBackendFactory.getInstance().reset();
   });
 });

--- a/packages/sla/src/services/__tests__/slaBackendIntegration.test.ts
+++ b/packages/sla/src/services/__tests__/slaBackendIntegration.test.ts
@@ -5,17 +5,26 @@ function createAdvancedMockTrx() {
   const mockData: Record<string, any> = {};
 
   const createChain = (table: string) => {
+    const rows = () => {
+      const value = mockData[table];
+      if (value === undefined || value === null) return [];
+      return Array.isArray(value) ? value : [value];
+    };
     const chain: any = {
       where: vi.fn().mockImplementation(() => chain),
       select: vi.fn().mockImplementation(() => chain),
-      first: vi.fn().mockImplementation(() => Promise.resolve(mockData[table] || null)),
+      orderBy: vi.fn().mockImplementation(() => chain),
+      first: vi.fn().mockImplementation(() => Promise.resolve(rows()[0] ?? null)),
       update: vi.fn().mockImplementation(() => Promise.resolve(1)),
       insert: vi.fn().mockImplementation(() => Promise.resolve([1])),
+      // Awaiting the chain itself (e.g. `await trx(t).where(...)`) yields rows.
+      then: (resolve: any, reject: any) => Promise.resolve(rows()).then(resolve, reject),
     };
     return chain;
   };
 
   const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn(async () => ({ rows: [] }));
   trx.setData = (table: string, data: any) => {
     mockData[table] = data;
   };
@@ -23,6 +32,18 @@ function createAdvancedMockTrx() {
   return trx as Knex.Transaction & {
     setData: (table: string, data: any) => void;
   };
+}
+
+function seedPolicy(trx: ReturnType<typeof createAdvancedMockTrx>) {
+  trx.setData('clients', { sla_policy_id: 'policy-1' });
+  trx.setData('sla_policies', { sla_policy_id: 'policy-1', policy_name: 'Policy' });
+  trx.setData('sla_policy_targets', [{
+    sla_policy_id: 'policy-1',
+    priority_id: 'priority-1',
+    response_time_minutes: 60,
+    resolution_time_minutes: 120,
+    is_24x7: true,
+  }]);
 }
 
 describe('SLA backend integration', () => {
@@ -36,7 +57,7 @@ describe('SLA backend integration', () => {
     process.env.EDITION = originalEdition;
   });
 
-  it('EE ticket start triggers Temporal workflow', async () => {
+  it('EE ticket start triggers Temporal workflow after commit dispatch', async () => {
     process.env.EDITION = 'ee';
 
     const startSpy = vi.fn();
@@ -52,20 +73,13 @@ describe('SLA backend integration', () => {
     }));
 
     const { startSlaForTicket } = await import('../slaService');
+    const { dispatchSlaBackendActions } = await import('../slaBackendActions');
     const { SlaBackendFactory } = await import('../backends/SlaBackendFactory');
 
     const trx = createAdvancedMockTrx();
-    trx.setData('clients', { sla_policy_id: 'policy-1' });
-    trx.setData('sla_policies', { sla_policy_id: 'policy-1', policy_name: 'Policy' });
-    trx.setData('sla_policy_targets', [{
-      sla_policy_id: 'policy-1',
-      priority_id: 'priority-1',
-      response_time_minutes: 60,
-      resolution_time_minutes: 120,
-      is_24x7: true,
-    }]);
+    seedPolicy(trx);
 
-    await startSlaForTicket(
+    const result = await startSlaForTicket(
       trx,
       'tenant-1',
       'ticket-1',
@@ -75,11 +89,17 @@ describe('SLA backend integration', () => {
       new Date('2024-01-01T00:00:00Z')
     );
 
+    // No backend work inside the transaction; the action carries it instead.
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toHaveLength(1);
+
+    await dispatchSlaBackendActions(result.backendActions);
     expect(startSpy).toHaveBeenCalledTimes(1);
+
     SlaBackendFactory.getInstance().reset();
   });
 
-  it('CE ticket start does not construct Temporal backend', async () => {
+  it('CE dispatch does not construct Temporal backend', async () => {
     process.env.EDITION = 'ce';
 
     const constructorSpy = vi.fn();
@@ -92,20 +112,13 @@ describe('SLA backend integration', () => {
     }));
 
     const { startSlaForTicket } = await import('../slaService');
+    const { dispatchSlaBackendActions } = await import('../slaBackendActions');
     const { SlaBackendFactory } = await import('../backends/SlaBackendFactory');
 
     const trx = createAdvancedMockTrx();
-    trx.setData('clients', { sla_policy_id: 'policy-1' });
-    trx.setData('sla_policies', { sla_policy_id: 'policy-1', policy_name: 'Policy' });
-    trx.setData('sla_policy_targets', [{
-      sla_policy_id: 'policy-1',
-      priority_id: 'priority-1',
-      response_time_minutes: 60,
-      resolution_time_minutes: 120,
-      is_24x7: true,
-    }]);
+    seedPolicy(trx);
 
-    await startSlaForTicket(
+    const result = await startSlaForTicket(
       trx,
       'tenant-1',
       'ticket-2',
@@ -114,12 +127,13 @@ describe('SLA backend integration', () => {
       'priority-1',
       new Date('2024-01-01T00:00:00Z')
     );
+    await dispatchSlaBackendActions(result.backendActions);
 
     expect(constructorSpy).not.toHaveBeenCalled();
     SlaBackendFactory.getInstance().reset();
   });
 
-  it('EE falls back to PgBoss when Temporal unavailable', async () => {
+  it('EE dispatch falls back to PgBoss when Temporal unavailable', async () => {
     process.env.EDITION = 'ee';
 
     vi.doMock('@enterprise/lib/sla/TemporalSlaBackend', () => ({
@@ -131,38 +145,32 @@ describe('SLA backend integration', () => {
     }));
 
     const { startSlaForTicket } = await import('../slaService');
+    const { dispatchSlaBackendActions } = await import('../slaBackendActions');
     const { SlaBackendFactory } = await import('../backends/SlaBackendFactory');
 
     const trx = createAdvancedMockTrx();
-    trx.setData('clients', { sla_policy_id: 'policy-1' });
-    trx.setData('sla_policies', { sla_policy_id: 'policy-1', policy_name: 'Policy' });
-    trx.setData('sla_policy_targets', [{
-      sla_policy_id: 'policy-1',
-      priority_id: 'priority-1',
-      response_time_minutes: 60,
-      resolution_time_minutes: 120,
-      is_24x7: true,
-    }]);
+    seedPolicy(trx);
 
-    await expect(
-      startSlaForTicket(
-        trx,
-        'tenant-1',
-        'ticket-3',
-        'client-1',
-        'board-1',
-        'priority-1',
-        new Date('2024-01-01T00:00:00Z')
-      )
-    ).resolves.toBeDefined();
+    const result = await startSlaForTicket(
+      trx,
+      'tenant-1',
+      'ticket-3',
+      'client-1',
+      'board-1',
+      'priority-1',
+      new Date('2024-01-01T00:00:00Z')
+    );
+
+    await expect(dispatchSlaBackendActions(result.backendActions)).resolves.toBeUndefined();
 
     SlaBackendFactory.getInstance().reset();
   });
 
-  it('SLA policy change cancels old workflow and starts new one', async () => {
+  it('SLA policy change cancels old workflow and starts new one on dispatch', async () => {
     process.env.EDITION = 'ce';
 
     const { handlePolicyChange } = await import('../slaService');
+    const { dispatchSlaBackendActions } = await import('../slaBackendActions');
     const { SlaBackendFactory } = await import('../backends/SlaBackendFactory');
 
     const backendMock = {
@@ -205,7 +213,12 @@ describe('SLA backend integration', () => {
     trx.setData('business_hours_entries', []);
     trx.setData('holidays', []);
 
-    await handlePolicyChange(trx, 'tenant-1', 'ticket-1', 'policy-1');
+    const { backendActions } = await handlePolicyChange(trx, 'tenant-1', 'ticket-1', 'policy-1');
+
+    expect(backendMock.cancelSla).not.toHaveBeenCalled();
+    expect(backendActions.map(a => a.kind)).toEqual(['cancel', 'start']);
+
+    await dispatchSlaBackendActions(backendActions);
 
     expect(backendMock.cancelSla).toHaveBeenCalledWith('tenant-1', 'ticket-1');
     expect(backendMock.startSlaTracking).toHaveBeenCalled();

--- a/packages/sla/src/services/__tests__/slaBackendSignals.test.ts
+++ b/packages/sla/src/services/__tests__/slaBackendSignals.test.ts
@@ -4,25 +4,36 @@ import {
   startSlaForTicket,
   recordFirstResponse,
   recordResolution,
+  handlePriorityChange,
 } from '../slaService';
 import { pauseSla, resumeSla } from '../slaPauseService';
+import { dispatchSlaBackendActions } from '../slaBackendActions';
 import { SlaBackendFactory } from '../backends/SlaBackendFactory';
 
 function createAdvancedMockTrx() {
   const mockData: Record<string, any> = {};
 
   const createChain = (table: string) => {
+    const rows = () => {
+      const value = mockData[table];
+      if (value === undefined || value === null) return [];
+      return Array.isArray(value) ? value : [value];
+    };
     const chain: any = {
       where: vi.fn().mockImplementation(() => chain),
       select: vi.fn().mockImplementation(() => chain),
-      first: vi.fn().mockImplementation(() => Promise.resolve(mockData[table] || null)),
+      orderBy: vi.fn().mockImplementation(() => chain),
+      first: vi.fn().mockImplementation(() => Promise.resolve(rows()[0] ?? null)),
       update: vi.fn().mockImplementation(() => Promise.resolve(1)),
       insert: vi.fn().mockImplementation(() => Promise.resolve([1])),
+      // Awaiting the chain itself (e.g. `await trx(t).where(...)`) yields rows.
+      then: (resolve: any, reject: any) => Promise.resolve(rows()).then(resolve, reject),
     };
     return chain;
   };
 
   const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn(async () => ({ rows: [] }));
   trx.setData = (table: string, data: any) => {
     mockData[table] = data;
   };
@@ -32,7 +43,11 @@ function createAdvancedMockTrx() {
   };
 }
 
-describe('SLA backend signaling', () => {
+// The SLA write functions are pure DB mutators: they must never reach the
+// backend (network / second connection) while the caller's transaction is
+// open. They describe the warranted side effect as a backendActions entry and
+// the caller dispatches it after commit via dispatchSlaBackendActions().
+describe('SLA backend actions', () => {
   const TENANT_ID = 'tenant-1';
   const TICKET_ID = 'ticket-1';
   const CLIENT_ID = 'client-1';
@@ -50,15 +65,18 @@ describe('SLA backend signaling', () => {
     getSlaStatus: vi.fn(),
   };
 
+  let getBackendSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    vi.spyOn(SlaBackendFactory, 'getBackend').mockResolvedValue(backendMock as any);
+    getBackendSpy = vi.spyOn(SlaBackendFactory, 'getBackend').mockResolvedValue(backendMock as any);
     backendMock.startSlaTracking.mockClear();
     backendMock.pauseSla.mockClear();
     backendMock.resumeSla.mockClear();
     backendMock.completeSla.mockClear();
+    backendMock.cancelSla.mockClear();
   });
 
-  it('startSlaForTicket calls backend.startSlaTracking()', async () => {
+  it('startSlaForTicket returns a start action without touching the backend', async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('clients', { sla_policy_id: POLICY_ID });
     trx.setData('sla_policies', { sla_policy_id: POLICY_ID, policy_name: 'Policy' });
@@ -79,7 +97,7 @@ describe('SLA backend signaling', () => {
     trx.setData('business_hours_entries', []);
     trx.setData('holidays', []);
 
-    await startSlaForTicket(
+    const result = await startSlaForTicket(
       trx,
       TENANT_ID,
       TICKET_ID,
@@ -89,10 +107,95 @@ describe('SLA backend signaling', () => {
       new Date('2024-01-01T00:00:00Z')
     );
 
-    expect(backendMock.startSlaTracking).toHaveBeenCalledTimes(1);
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toHaveLength(1);
+    expect(result.backendActions?.[0]).toMatchObject({
+      kind: 'start',
+      ticketId: TICKET_ID,
+      policyId: POLICY_ID,
+    });
   });
 
-  it("recordFirstResponse calls backend.completeSla('response')", async () => {
+  it('handlePriorityChange returns cancel+start actions without touching the backend', async () => {
+    const trx = createAdvancedMockTrx();
+    trx.setData('tickets', {
+      sla_policy_id: POLICY_ID,
+      sla_started_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+      sla_response_at: null,
+      sla_resolution_at: null,
+      sla_resolution_due_at: null,
+      sla_total_pause_minutes: 0,
+      client_id: CLIENT_ID,
+      board_id: BOARD_ID,
+      priority_id: PRIORITY_ID,
+      due_date: null,
+    });
+    trx.setData('sla_policies', { sla_policy_id: POLICY_ID, policy_name: 'Policy' });
+    trx.setData('sla_policy_targets', [{
+      sla_policy_id: POLICY_ID,
+      priority_id: 'priority-2',
+      response_time_minutes: 30,
+      resolution_time_minutes: 120,
+      is_24x7: true,
+    }]);
+    trx.setData('business_hours_schedules', {
+      schedule_id: SCHEDULE_ID,
+      schedule_name: 'Default',
+      timezone: 'UTC',
+      is_default: true,
+      is_24x7: true,
+    });
+    trx.setData('business_hours_entries', []);
+    trx.setData('holidays', []);
+
+    const result = await handlePriorityChange(trx, TENANT_ID, TICKET_ID, 'priority-2');
+
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([
+      { kind: 'cancel', tenantId: TENANT_ID, ticketId: TICKET_ID },
+      expect.objectContaining({ kind: 'start', ticketId: TICKET_ID, policyId: POLICY_ID }),
+    ]);
+  });
+
+  it('handlePriorityChange returns no actions when both SLA stages are already recorded', async () => {
+    const trx = createAdvancedMockTrx();
+    trx.setData('tickets', {
+      sla_policy_id: POLICY_ID,
+      sla_started_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+      sla_response_at: new Date('2024-01-01T00:30:00Z').toISOString(),
+      sla_resolution_at: new Date('2024-01-01T02:00:00Z').toISOString(),
+      sla_resolution_due_at: null,
+      sla_total_pause_minutes: 0,
+      client_id: CLIENT_ID,
+      board_id: BOARD_ID,
+      priority_id: PRIORITY_ID,
+      due_date: null,
+    });
+    trx.setData('sla_policies', { sla_policy_id: POLICY_ID, policy_name: 'Policy' });
+    trx.setData('sla_policy_targets', [{
+      sla_policy_id: POLICY_ID,
+      priority_id: 'priority-2',
+      response_time_minutes: 30,
+      resolution_time_minutes: 120,
+      is_24x7: true,
+    }]);
+    trx.setData('business_hours_schedules', {
+      schedule_id: SCHEDULE_ID,
+      schedule_name: 'Default',
+      timezone: 'UTC',
+      is_default: true,
+      is_24x7: true,
+    });
+    trx.setData('business_hours_entries', []);
+    trx.setData('holidays', []);
+
+    const result = await handlePriorityChange(trx, TENANT_ID, TICKET_ID, 'priority-2');
+
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([]);
+  });
+
+  it("recordFirstResponse returns a complete('response') action without touching the backend", async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {
       sla_policy_id: POLICY_ID,
@@ -101,11 +204,28 @@ describe('SLA backend signaling', () => {
       sla_total_pause_minutes: 0,
     });
 
-    await recordFirstResponse(trx, TENANT_ID, TICKET_ID, new Date());
-    expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'response', true);
+    const result = await recordFirstResponse(trx, TENANT_ID, TICKET_ID, new Date());
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([
+      { kind: 'complete', ticketId: TICKET_ID, type: 'response', met: true },
+    ]);
   });
 
-  it("recordResolution calls backend.completeSla('resolution')", async () => {
+  it('recordFirstResponse returns no action when there is no response due date', async () => {
+    const trx = createAdvancedMockTrx();
+    trx.setData('tickets', {
+      sla_policy_id: POLICY_ID,
+      sla_response_at: null,
+      sla_response_due_at: null,
+      sla_total_pause_minutes: 0,
+    });
+
+    const result = await recordFirstResponse(trx, TENANT_ID, TICKET_ID, new Date());
+    expect(result.success).toBe(true);
+    expect(result.backendActions).toBeUndefined();
+  });
+
+  it("recordResolution returns a complete('resolution') action without touching the backend", async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {
       sla_policy_id: POLICY_ID,
@@ -114,11 +234,14 @@ describe('SLA backend signaling', () => {
       sla_total_pause_minutes: 0,
     });
 
-    await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
-    expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'resolution', true);
+    const result = await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([
+      { kind: 'complete', ticketId: TICKET_ID, type: 'resolution', met: true },
+    ]);
   });
 
-  it("recordResolution still completes the backend when met is null", async () => {
+  it('recordResolution still emits a complete action when met is null', async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {
       sla_policy_id: POLICY_ID,
@@ -127,11 +250,13 @@ describe('SLA backend signaling', () => {
       sla_total_pause_minutes: 0,
     });
 
-    await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
-    expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'resolution', null);
+    const result = await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
+    expect(result.backendActions).toEqual([
+      { kind: 'complete', ticketId: TICKET_ID, type: 'resolution', met: null },
+    ]);
   });
 
-  it('pauseSla signals backend.pauseSla()', async () => {
+  it('pauseSla returns a pause action without touching the backend', async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {
       sla_policy_id: POLICY_ID,
@@ -139,11 +264,14 @@ describe('SLA backend signaling', () => {
       status_id: 'status-1',
     });
 
-    await pauseSla(trx, TENANT_ID, TICKET_ID, 'status_pause');
-    expect(backendMock.pauseSla).toHaveBeenCalledWith(TICKET_ID, 'status_pause');
+    const result = await pauseSla(trx, TENANT_ID, TICKET_ID, 'status_pause');
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([
+      { kind: 'pause', ticketId: TICKET_ID, reason: 'status_pause' },
+    ]);
   });
 
-  it('resumeSla signals backend.resumeSla()', async () => {
+  it('resumeSla returns a resume action without touching the backend', async () => {
     const trx = createAdvancedMockTrx();
     trx.setData('tickets', {
       sla_policy_id: POLICY_ID,
@@ -152,7 +280,43 @@ describe('SLA backend signaling', () => {
       status_id: 'status-1',
     });
 
-    await resumeSla(trx, TENANT_ID, TICKET_ID);
-    expect(backendMock.resumeSla).toHaveBeenCalledWith(TICKET_ID);
+    const result = await resumeSla(trx, TENANT_ID, TICKET_ID);
+    expect(getBackendSpy).not.toHaveBeenCalled();
+    expect(result.backendActions).toEqual([{ kind: 'resume', ticketId: TICKET_ID }]);
+  });
+
+  describe('dispatchSlaBackendActions', () => {
+    it('translates actions to backend calls', async () => {
+      await dispatchSlaBackendActions([
+        { kind: 'pause', ticketId: TICKET_ID, reason: 'status_pause' },
+        { kind: 'resume', ticketId: TICKET_ID },
+        { kind: 'complete', ticketId: TICKET_ID, type: 'resolution', met: true },
+        { kind: 'cancel', tenantId: TENANT_ID, ticketId: TICKET_ID },
+      ]);
+
+      expect(backendMock.pauseSla).toHaveBeenCalledWith(TICKET_ID, 'status_pause');
+      expect(backendMock.resumeSla).toHaveBeenCalledWith(TICKET_ID);
+      expect(backendMock.completeSla).toHaveBeenCalledWith(TICKET_ID, 'resolution', true);
+      expect(backendMock.cancelSla).toHaveBeenCalledWith(TENANT_ID, TICKET_ID);
+    });
+
+    it('handles undefined and empty action lists without touching the backend', async () => {
+      await dispatchSlaBackendActions(undefined);
+      await dispatchSlaBackendActions([]);
+      expect(getBackendSpy).not.toHaveBeenCalled();
+    });
+
+    it('swallows backend failures and continues with remaining actions', async () => {
+      backendMock.pauseSla.mockRejectedValueOnce(new Error('temporal down'));
+
+      await expect(
+        dispatchSlaBackendActions([
+          { kind: 'pause', ticketId: TICKET_ID, reason: 'status_pause' },
+          { kind: 'resume', ticketId: TICKET_ID },
+        ])
+      ).resolves.toBeUndefined();
+
+      expect(backendMock.resumeSla).toHaveBeenCalledWith(TICKET_ID);
+    });
   });
 });

--- a/packages/sla/src/services/__tests__/slaCeLifecycle.test.ts
+++ b/packages/sla/src/services/__tests__/slaCeLifecycle.test.ts
@@ -12,6 +12,13 @@ vi.mock('../backends/SlaBackendFactory', () => ({
   },
 }));
 
+// Cut the unbuilt-workspace-dist import chain (notifications → workflow-streams);
+// sendSlaNotification is spied on below, so the internals never run.
+vi.mock(
+  '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions',
+  () => ({ createNotificationFromTemplateInternal: vi.fn() })
+);
+
 function createAdvancedMockTrx() {
   const mockData: Record<string, any> = {};
 
@@ -19,6 +26,11 @@ function createAdvancedMockTrx() {
 
   const createChain = (tableName: string) => {
     const table = normalizeTable(tableName);
+    const rows = () => {
+      const value = mockData[table];
+      if (value === undefined || value === null) return [];
+      return Array.isArray(value) ? value : [value];
+    };
     const chain: any = {
       where: vi.fn().mockImplementation(() => chain),
       whereNotNull: vi.fn().mockImplementation(() => chain),
@@ -26,20 +38,8 @@ function createAdvancedMockTrx() {
       join: vi.fn().mockImplementation(() => chain),
       leftJoin: vi.fn().mockImplementation(() => chain),
       orderBy: vi.fn().mockImplementation(() => chain),
-      select: vi.fn().mockImplementation(() => {
-        const value = mockData[table];
-        if (value === undefined) {
-          return Promise.resolve([]);
-        }
-        return Promise.resolve(Array.isArray(value) ? value : [value]);
-      }),
-      first: vi.fn().mockImplementation(() => {
-        const value = mockData[table];
-        if (value === undefined) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(Array.isArray(value) ? value[0] : value);
-      }),
+      select: vi.fn().mockImplementation(() => chain),
+      first: vi.fn().mockImplementation(() => Promise.resolve(rows()[0] ?? null)),
       update: vi.fn().mockImplementation((updates: Record<string, any>) => {
         const value = mockData[table];
         if (Array.isArray(value)) {
@@ -61,11 +61,14 @@ function createAdvancedMockTrx() {
         return Promise.resolve([1]);
       }),
       delete: vi.fn().mockResolvedValue(1),
+      // Awaiting the chain itself (e.g. `await trx(t).where(...)`) yields rows.
+      then: (resolve: any, reject: any) => Promise.resolve(rows()).then(resolve, reject),
     };
     return chain;
   };
 
   const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn(async () => ({ rows: [] }));
   trx.setData = (table: string, data: any) => {
     mockData[table] = data;
   };
@@ -96,10 +99,6 @@ describe('CE SLA lifecycle', () => {
 
   it('runs create, poll-based notification, pause/resume, response, and resolution flow', async () => {
     vi.useFakeTimers();
-
-    const sendNotificationSpy = vi
-      .spyOn(notificationService, 'sendSlaNotification')
-      .mockResolvedValue({ success: true, recipientCount: 1, inAppSent: 1, emailSent: 0, errors: [] });
 
     const trx = createAdvancedMockTrx();
     const createdAt = new Date('2024-01-01T00:00:00Z');
@@ -183,28 +182,26 @@ describe('CE SLA lifecycle', () => {
     );
 
     expect(notificationResult.notifiedThreshold).toBe(50);
-    expect(sendNotificationSpy).toHaveBeenCalled();
+    // A non-null result proves the notification pipeline ran for the crossing.
+    expect(notificationResult.result).not.toBeNull();
+    expect(notificationResult.result?.success).toBe(true);
 
-    await pauseSla(trx, 'tenant-1', 'ticket-1', 'status_pause', 'user-1', {
-      skipBackend: true,
-    });
+    await pauseSla(trx, 'tenant-1', 'ticket-1', 'status_pause', 'user-1');
 
     vi.advanceTimersByTime(5 * 60 * 1000);
 
-    await resumeSla(trx, 'tenant-1', 'ticket-1', 'user-1', {
-      skipBackend: true,
-    });
+    await resumeSla(trx, 'tenant-1', 'ticket-1', 'user-1');
 
-    await recordFirstResponse(trx, 'tenant-1', 'ticket-1', new Date(), 'user-1', {
-      skipBackend: true,
-    });
+    await recordFirstResponse(trx, 'tenant-1', 'ticket-1', new Date(), 'user-1');
 
-    await recordResolution(trx, 'tenant-1', 'ticket-1', new Date(), 'user-1', {
-      skipBackend: true,
-    });
+    await recordResolution(trx, 'tenant-1', 'ticket-1', new Date(), 'user-1');
 
     const finalTicket = trx.getData('tickets')[0];
     expect(finalTicket.sla_response_at).toBeTruthy();
     expect(finalTicket.sla_resolution_at).toBeTruthy();
+
+    // The write functions are pure DB mutators now: nothing in the lifecycle
+    // above may reach the backend while the transaction is open.
+    expect(getBackendMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/sla/src/services/__tests__/slaLock.test.ts
+++ b/packages/sla/src/services/__tests__/slaLock.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Knex } from 'knex';
+import {
+  startSlaForTicket,
+  recordFirstResponse,
+  recordResolution,
+  handlePriorityChange,
+  handlePolicyChange,
+} from '../slaService';
+import {
+  pauseSla,
+  resumeSla,
+  handleStatusChange,
+  handleResponseStateChange,
+} from '../slaPauseService';
+import { acquireTicketSlaLock } from '../slaLock';
+
+const TENANT_ID = 'tenant-1';
+const TICKET_ID = 'ticket-1';
+const LOCK_SQL = 'select pg_advisory_xact_lock(hashtext(?))';
+const LOCK_KEY = `sla:${TENANT_ID}:${TICKET_ID}`;
+
+function createTrackingTrx() {
+  const mockData: Record<string, any> = {};
+  const sequence: string[] = [];
+
+  const createChain = (table: string) => {
+    const rows = () => {
+      const value = mockData[table];
+      if (value === undefined || value === null) return [];
+      return Array.isArray(value) ? value : [value];
+    };
+    const chain: any = {
+      where: vi.fn().mockImplementation(() => chain),
+      select: vi.fn().mockImplementation(() => chain),
+      orderBy: vi.fn().mockImplementation(() => chain),
+      first: vi.fn().mockImplementation(() => {
+        sequence.push(`read:${table}`);
+        return Promise.resolve(rows()[0] ?? null);
+      }),
+      update: vi.fn().mockImplementation(() => {
+        sequence.push(`write:${table}`);
+        return Promise.resolve(1);
+      }),
+      insert: vi.fn().mockImplementation(() => {
+        sequence.push(`write:${table}`);
+        return Promise.resolve([1]);
+      }),
+      then: (resolve: any, reject: any) => {
+        sequence.push(`read:${table}`);
+        return Promise.resolve(rows()).then(resolve, reject);
+      },
+    };
+    return chain;
+  };
+
+  const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn().mockImplementation((sql: string, bindings?: any[]) => {
+    sequence.push(`raw:${sql}:${(bindings ?? []).join(',')}`);
+    return Promise.resolve({ rows: [] });
+  });
+  trx.setData = (table: string, data: any) => {
+    mockData[table] = data;
+  };
+  trx.getSequence = () => sequence;
+
+  return trx as Knex.Transaction & {
+    setData: (table: string, data: any) => void;
+    getSequence: () => string[];
+  };
+}
+
+function expectLockTakenFirst(trx: ReturnType<typeof createTrackingTrx>) {
+  expect(trx.raw).toHaveBeenCalledWith(LOCK_SQL, [LOCK_KEY]);
+  const sequence = trx.getSequence();
+  expect(sequence[0]).toBe(`raw:${LOCK_SQL}:${LOCK_KEY}`);
+}
+
+describe('acquireTicketSlaLock', () => {
+  it('takes a transaction-scoped advisory lock keyed on tenant and ticket', async () => {
+    const trx = createTrackingTrx();
+    await acquireTicketSlaLock(trx, TENANT_ID, TICKET_ID);
+    expectLockTakenFirst(trx);
+  });
+});
+
+describe('per-ticket serialization of SLA writes', () => {
+  const seedTicket = (trx: ReturnType<typeof createTrackingTrx>, extra: Record<string, any> = {}) => {
+    trx.setData('tickets', {
+      sla_policy_id: 'policy-1',
+      sla_started_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+      sla_response_at: null,
+      sla_response_due_at: new Date('2024-01-01T01:00:00Z').toISOString(),
+      sla_resolution_at: null,
+      sla_resolution_due_at: new Date('2024-01-01T04:00:00Z').toISOString(),
+      sla_paused_at: null,
+      sla_total_pause_minutes: 0,
+      status_id: 'status-1',
+      priority_id: 'priority-1',
+      client_id: 'client-1',
+      board_id: 'board-1',
+      response_state: null,
+      due_date: null,
+      ...extra,
+    });
+  };
+
+  it('startSlaForTicket locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await startSlaForTicket(trx, TENANT_ID, TICKET_ID, 'client-1', 'board-1', 'priority-1');
+    expectLockTakenFirst(trx);
+  });
+
+  it('recordFirstResponse locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await recordFirstResponse(trx, TENANT_ID, TICKET_ID, new Date());
+    expectLockTakenFirst(trx);
+  });
+
+  it('recordResolution locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await recordResolution(trx, TENANT_ID, TICKET_ID, new Date());
+    expectLockTakenFirst(trx);
+  });
+
+  it('handlePriorityChange locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await handlePriorityChange(trx, TENANT_ID, TICKET_ID, 'priority-2');
+    expectLockTakenFirst(trx);
+  });
+
+  it('handlePolicyChange locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await handlePolicyChange(trx, TENANT_ID, TICKET_ID, null);
+    expectLockTakenFirst(trx);
+  });
+
+  it('pauseSla locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await pauseSla(trx, TENANT_ID, TICKET_ID, 'status_pause');
+    expectLockTakenFirst(trx);
+  });
+
+  it('resumeSla locks before any read or write', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx, { sla_paused_at: new Date('2024-01-01T00:30:00Z').toISOString() });
+    await resumeSla(trx, TENANT_ID, TICKET_ID);
+    expectLockTakenFirst(trx);
+  });
+
+  it('handleStatusChange locks before reading pause state', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await handleStatusChange(trx, TENANT_ID, TICKET_ID, 'status-1', 'status-2');
+    expectLockTakenFirst(trx);
+  });
+
+  it('handleResponseStateChange locks before reading pause state', async () => {
+    const trx = createTrackingTrx();
+    seedTicket(trx);
+    await handleResponseStateChange(trx, TENANT_ID, TICKET_ID, null, 'awaiting_client');
+    expectLockTakenFirst(trx);
+  });
+});

--- a/packages/sla/src/services/__tests__/slaPauseService.test.ts
+++ b/packages/sla/src/services/__tests__/slaPauseService.test.ts
@@ -99,6 +99,10 @@ function createAdvancedMockTrx() {
   };
 
   const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn().mockImplementation((sql: string, bindings?: any[]) => {
+    calls.push({ table: '__raw', method: 'raw', args: [sql, bindings] });
+    return Promise.resolve({ rows: [] });
+  });
   trx.setData = (table: string, data: any) => {
     mockData[table] = data;
   };

--- a/packages/sla/src/services/__tests__/slaService.test.ts
+++ b/packages/sla/src/services/__tests__/slaService.test.ts
@@ -47,6 +47,10 @@ function createAdvancedMockTrx() {
   };
 
   const trx = ((table: string) => createChain(table)) as any;
+  trx.raw = vi.fn().mockImplementation((sql: string, bindings?: any[]) => {
+    calls.push({ table: '__raw', method: 'raw', args: [sql, bindings] });
+    return Promise.resolve({ rows: [] });
+  });
   trx.setData = (table: string, data: any) => {
     mockData[table] = data;
   };
@@ -121,18 +125,19 @@ describe('slaService', () => {
       expect(result.recorded_at).toEqual(respondedAt);
     });
 
-    it('should account for pause time when determining if SLA met', async () => {
+    it('compares directly against the stored due date (already shifted on resume)', async () => {
+      // Pause time is applied by shifting sla_response_due_at forward at
+      // resume time; recording must NOT add sla_total_pause_minutes again.
       const trx = createAdvancedMockTrx();
 
       trx.setData('tickets', {
         sla_policy_id: POLICY_ID,
         sla_response_at: null,
         sla_response_due_at: new Date('2024-01-15T11:00:00Z').toISOString(),
-        sla_total_pause_minutes: 120, // 2 hours paused
+        sla_total_pause_minutes: 120, // already reflected in the due date
       });
 
-      // Response at 12:30 would be late without pause, but with 2hr pause it's on time
-      const respondedAt = new Date('2024-01-15T12:30:00Z');
+      const respondedAt = new Date('2024-01-15T12:30:00Z'); // after stored due
 
       const result = await recordFirstResponse(
         trx,
@@ -143,7 +148,32 @@ describe('slaService', () => {
       );
 
       expect(result.success).toBe(true);
-      // Due at 11:00 + 2hr pause = effective due at 13:00, response at 12:30 = met
+      // 12:30 > 11:00 stored due — pause minutes are not double-counted.
+      expect(result.met).toBe(false);
+    });
+
+    it('honors a due date that was shifted forward by a pause', async () => {
+      const trx = createAdvancedMockTrx();
+
+      trx.setData('tickets', {
+        sla_policy_id: POLICY_ID,
+        sla_response_at: null,
+        // Original due 11:00, shifted +2h at resume.
+        sla_response_due_at: new Date('2024-01-15T13:00:00Z').toISOString(),
+        sla_total_pause_minutes: 120,
+      });
+
+      const respondedAt = new Date('2024-01-15T12:30:00Z'); // before shifted due
+
+      const result = await recordFirstResponse(
+        trx,
+        TENANT_ID,
+        TICKET_ID,
+        respondedAt,
+        USER_ID
+      );
+
+      expect(result.success).toBe(true);
       expect(result.met).toBe(true);
     });
 
@@ -303,18 +333,19 @@ describe('slaService', () => {
       expect(result.recorded_at).toEqual(resolvedAt);
     });
 
-    it('should account for pause time when determining if SLA met', async () => {
+    it('compares directly against the stored due date (already shifted on resume)', async () => {
+      // Pause time is applied by shifting sla_resolution_due_at forward at
+      // resume time; recording must NOT add sla_total_pause_minutes again.
       const trx = createAdvancedMockTrx();
 
       trx.setData('tickets', {
         sla_policy_id: POLICY_ID,
         sla_resolution_at: null,
         sla_resolution_due_at: new Date('2024-01-15T18:00:00Z').toISOString(),
-        sla_total_pause_minutes: 180, // 3 hours paused
+        sla_total_pause_minutes: 180, // already reflected in the due date
       });
 
-      // Resolved at 20:00 would be late without pause, but with 3hr pause it's on time
-      const resolvedAt = new Date('2024-01-15T20:00:00Z');
+      const resolvedAt = new Date('2024-01-15T20:00:00Z'); // after stored due
 
       const result = await recordResolution(
         trx,
@@ -325,7 +356,32 @@ describe('slaService', () => {
       );
 
       expect(result.success).toBe(true);
-      // Due at 18:00 + 3hr pause = effective due at 21:00, resolved at 20:00 = met
+      // 20:00 > 18:00 stored due — pause minutes are not double-counted.
+      expect(result.met).toBe(false);
+    });
+
+    it('honors a due date that was shifted forward by a pause', async () => {
+      const trx = createAdvancedMockTrx();
+
+      trx.setData('tickets', {
+        sla_policy_id: POLICY_ID,
+        sla_resolution_at: null,
+        // Original due 18:00, shifted +3h at resume.
+        sla_resolution_due_at: new Date('2024-01-15T21:00:00Z').toISOString(),
+        sla_total_pause_minutes: 180,
+      });
+
+      const resolvedAt = new Date('2024-01-15T20:00:00Z'); // before shifted due
+
+      const result = await recordResolution(
+        trx,
+        TENANT_ID,
+        TICKET_ID,
+        resolvedAt,
+        USER_ID
+      );
+
+      expect(result.success).toBe(true);
       expect(result.met).toBe(true);
     });
 
@@ -618,7 +674,9 @@ describe('slaService', () => {
       expect(status!.resolution_remaining_minutes).toBeUndefined();
     });
 
-    it('should include total pause minutes in status', async () => {
+    it('reports only the ongoing pause in total_pause_minutes', async () => {
+      // Completed pauses are already reflected in the shifted due dates, so
+      // the status only surfaces the current (ongoing) pause duration.
       const trx = createAdvancedMockTrx();
 
       const now = new Date();
@@ -632,14 +690,15 @@ describe('slaService', () => {
         sla_resolution_due_at: new Date(now.getTime() + 28800000).toISOString(),
         sla_resolution_at: null,
         sla_resolution_met: null,
-        sla_paused_at: null,
-        sla_total_pause_minutes: 45, // 45 minutes of total pause time
+        sla_paused_at: new Date(now.getTime() - 45 * 60000).toISOString(), // paused 45 min ago
+        sla_total_pause_minutes: 120, // completed pauses, already in due dates
         priority_id: PRIORITY_ID,
       });
 
       const status = await getSlaStatus(trx, TENANT_ID, TICKET_ID);
 
       expect(status).not.toBeNull();
+      expect(status!.is_paused).toBe(true);
       expect(status!.total_pause_minutes).toBe(45);
     });
   });

--- a/packages/sla/src/services/backends/PgBossSlaBackend.ts
+++ b/packages/sla/src/services/backends/PgBossSlaBackend.ts
@@ -1,5 +1,4 @@
-import { createTenantKnex, getConnection, getTenantContext, withTransaction } from '@alga-psa/db';
-import type { Knex } from 'knex';
+import { createTenantKnex, getConnection, getTenantContext } from '@alga-psa/db';
 import type { ISlaBackend } from './ISlaBackend';
 import type {
   IBusinessHoursScheduleWithEntries,
@@ -7,9 +6,15 @@ import type {
   ISlaStatus,
   SlaPauseReason,
 } from '../../types';
-import { pauseSla, resumeSla } from '../slaPauseService';
-import { getSlaStatus, recordFirstResponse, recordResolution } from '../slaService';
+import { getSlaStatus } from '../slaService';
 
+/**
+ * CE backend. The SLA columns are persisted by the caller before any backend
+ * method runs, and CE timers/notifications are driven by polling, so every
+ * mutation hook is a no-op. These methods must never write the tickets row:
+ * re-doing the write on a second connection while the caller's transaction
+ * holds the row lock self-deadlocks until pgbouncer reaps the session.
+ */
 export class PgBossSlaBackend implements ISlaBackend {
   async startSlaTracking(
     _ticketId: string,
@@ -18,41 +23,23 @@ export class PgBossSlaBackend implements ISlaBackend {
     _schedule: IBusinessHoursScheduleWithEntries,
     _notificationThresholds?: number[]
   ): Promise<void> {
-    // No-op placeholder; CE polling handles SLA timers.
+    // No-op; CE polling handles SLA timers.
   }
 
-  async pauseSla(ticketId: string, reason: SlaPauseReason): Promise<void> {
-    await this.withTicketTransaction(ticketId, async (trx, tenant) => {
-      await pauseSla(trx, tenant, ticketId, reason, undefined, {
-        skipBackend: true,
-      });
-    });
+  async pauseSla(_ticketId: string, _reason: SlaPauseReason): Promise<void> {
+    // No-op; sla_paused_at is already persisted by the caller.
   }
 
-  async resumeSla(ticketId: string): Promise<void> {
-    await this.withTicketTransaction(ticketId, async (trx, tenant) => {
-      await resumeSla(trx, tenant, ticketId, undefined, {
-        skipBackend: true,
-      });
-    });
+  async resumeSla(_ticketId: string): Promise<void> {
+    // No-op; pause bookkeeping is already persisted by the caller.
   }
 
   async completeSla(
-    ticketId: string,
-    type: 'response' | 'resolution',
+    _ticketId: string,
+    _type: 'response' | 'resolution',
     _met: boolean | null
   ): Promise<void> {
-    await this.withTicketTransaction(ticketId, async (trx, tenant) => {
-      if (type === 'response') {
-        await recordFirstResponse(trx, tenant, ticketId, new Date(), undefined, {
-          skipBackend: true,
-        });
-        return;
-      }
-      await recordResolution(trx, tenant, ticketId, new Date(), undefined, {
-        skipBackend: true,
-      });
-    });
+    // No-op; sla_response_at/sla_resolution_at are already persisted by the caller.
   }
 
   async cancelSla(_tenantId: string, _ticketId: string): Promise<void> {
@@ -67,19 +54,6 @@ export class PgBossSlaBackend implements ISlaBackend {
 
     const { knex } = await createTenantKnex(tenant);
     return getSlaStatus(knex, tenant, ticketId);
-  }
-
-  private async withTicketTransaction(
-    ticketId: string,
-    fn: (trx: Knex.Transaction, tenant: string) => Promise<void>
-  ): Promise<void> {
-    const tenant = await this.resolveTenant(ticketId);
-    if (!tenant) {
-      return;
-    }
-
-    const { knex } = await createTenantKnex(tenant);
-    await withTransaction(knex, async (trx) => fn(trx, tenant));
   }
 
   private async resolveTenant(ticketId: string): Promise<string | null> {

--- a/packages/sla/src/services/backends/__tests__/pgBossSlaBackend.test.ts
+++ b/packages/sla/src/services/backends/__tests__/pgBossSlaBackend.test.ts
@@ -1,22 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Knex } from 'knex';
 
-vi.mock('@alga-psa/db', () => ({
-  createTenantKnex: vi.fn(async () => ({ knex: {} })),
-  withTransaction: vi.fn(async (_knex: unknown, fn: (trx: Knex.Transaction) => Promise<void>) => {
-    await fn({} as Knex.Transaction);
-  }),
-  getConnection: vi.fn(async () => ({
-    select: vi.fn(),
-  })),
-  getTenantContext: vi.fn(() => 'tenant-test'),
+const {
+  createTenantKnexMock,
+  withTransactionMock,
+  getConnectionMock,
+  pauseSlaMock,
+  resumeSlaMock,
+  recordFirstResponseMock,
+  recordResolutionMock,
+  getSlaStatusMock,
+} = vi.hoisted(() => ({
+  createTenantKnexMock: vi.fn(async () => ({ knex: {} })),
+  withTransactionMock: vi.fn(),
+  getConnectionMock: vi.fn(async () => ({ select: vi.fn() })),
+  pauseSlaMock: vi.fn(),
+  resumeSlaMock: vi.fn(),
+  recordFirstResponseMock: vi.fn(),
+  recordResolutionMock: vi.fn(),
+  getSlaStatusMock: vi.fn(async () => ({ status: 'on_track' })),
 }));
 
-const pauseSlaMock = vi.fn();
-const resumeSlaMock = vi.fn();
-const recordFirstResponseMock = vi.fn();
-const recordResolutionMock = vi.fn();
-const getSlaStatusMock = vi.fn(async () => ({ status: 'on_track' }));
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: createTenantKnexMock,
+  withTransaction: withTransactionMock,
+  getConnection: getConnectionMock,
+  getTenantContext: vi.fn(() => 'tenant-test'),
+}));
 
 vi.mock('../../slaPauseService', () => ({
   pauseSla: pauseSlaMock,
@@ -31,8 +40,15 @@ vi.mock('../../slaService', () => ({
 
 import { PgBossSlaBackend } from '../PgBossSlaBackend';
 
+// The mutation hooks must be genuine no-ops. The SLA columns are persisted by
+// the caller before the backend runs; re-doing the write on a second pooled
+// connection while the caller's transaction holds the tickets row lock
+// self-deadlocks until pgbouncer reaps the session.
 describe('PgBossSlaBackend', () => {
   beforeEach(() => {
+    createTenantKnexMock.mockClear();
+    withTransactionMock.mockClear();
+    getConnectionMock.mockClear();
     pauseSlaMock.mockClear();
     resumeSlaMock.mockClear();
     recordFirstResponseMock.mockClear();
@@ -40,7 +56,17 @@ describe('PgBossSlaBackend', () => {
     getSlaStatusMock.mockClear();
   });
 
-  it('startSlaTracking returns without error', async () => {
+  const expectNoDbWork = () => {
+    expect(withTransactionMock).not.toHaveBeenCalled();
+    expect(createTenantKnexMock).not.toHaveBeenCalled();
+    expect(getConnectionMock).not.toHaveBeenCalled();
+    expect(pauseSlaMock).not.toHaveBeenCalled();
+    expect(resumeSlaMock).not.toHaveBeenCalled();
+    expect(recordFirstResponseMock).not.toHaveBeenCalled();
+    expect(recordResolutionMock).not.toHaveBeenCalled();
+  };
+
+  it('startSlaTracking is a no-op', async () => {
     const backend = new PgBossSlaBackend();
     await expect(
       backend.startSlaTracking('ticket-1', 'policy-1', [], {
@@ -53,35 +79,37 @@ describe('PgBossSlaBackend', () => {
         holidays: [],
       })
     ).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
-  it('pauseSla calls slaPauseService.pauseSla()', async () => {
+  it('pauseSla is a no-op (no transaction, no service delegation)', async () => {
     const backend = new PgBossSlaBackend();
-    await backend.pauseSla('ticket-1', 'status_pause');
-    expect(pauseSlaMock).toHaveBeenCalledTimes(1);
+    await expect(backend.pauseSla('ticket-1', 'status_pause')).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
-  it('resumeSla calls slaPauseService.resumeSla()', async () => {
+  it('resumeSla is a no-op (no transaction, no service delegation)', async () => {
     const backend = new PgBossSlaBackend();
-    await backend.resumeSla('ticket-1');
-    expect(resumeSlaMock).toHaveBeenCalledTimes(1);
+    await expect(backend.resumeSla('ticket-1')).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
-  it("completeSla('response') calls slaService.recordFirstResponse()", async () => {
+  it("completeSla('response') is a no-op (no transaction, no service delegation)", async () => {
     const backend = new PgBossSlaBackend();
-    await backend.completeSla('ticket-1', 'response', true);
-    expect(recordFirstResponseMock).toHaveBeenCalledTimes(1);
+    await expect(backend.completeSla('ticket-1', 'response', true)).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
-  it("completeSla('resolution') calls slaService.recordResolution()", async () => {
+  it("completeSla('resolution') is a no-op (no transaction, no service delegation)", async () => {
     const backend = new PgBossSlaBackend();
-    await backend.completeSla('ticket-1', 'resolution', true);
-    expect(recordResolutionMock).toHaveBeenCalledTimes(1);
+    await expect(backend.completeSla('ticket-1', 'resolution', null)).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
-  it('cancelSla returns without error', async () => {
+  it('cancelSla is a no-op', async () => {
     const backend = new PgBossSlaBackend();
     await expect(backend.cancelSla('tenant-1', 'ticket-1')).resolves.toBeUndefined();
+    expectNoDbWork();
   });
 
   it('getSlaStatus delegates to slaService.getSlaStatus()', async () => {

--- a/packages/sla/src/services/index.ts
+++ b/packages/sla/src/services/index.ts
@@ -28,6 +28,15 @@ export {
   type RecordSlaEventResult
 } from './slaService';
 
+// Backend actions returned by the SLA write functions; dispatch after commit
+export {
+  dispatchSlaBackendActions,
+  type SlaBackendAction
+} from './slaBackendActions';
+
+// Per-ticket SLA write serialization
+export { acquireTicketSlaLock } from './slaLock';
+
 // SLA pause/resume service
 export {
   pauseSla,

--- a/packages/sla/src/services/slaBackendActions.ts
+++ b/packages/sla/src/services/slaBackendActions.ts
@@ -1,0 +1,77 @@
+/**
+ * SLA Backend Actions
+ *
+ * The SLA service functions are pure DB mutators: they describe the backend
+ * side effects they warrant (Temporal timers in EE, no-ops in CE) as
+ * SlaBackendAction values instead of invoking the backend inside the caller's
+ * transaction. Callers dispatch the returned actions with
+ * dispatchSlaBackendActions() after their transaction commits, so no network
+ * or cross-connection work ever runs while a ticket row lock is held.
+ */
+
+import {
+  IBusinessHoursScheduleWithEntries,
+  ISlaPolicyTarget,
+  SlaPauseReason
+} from '../types';
+import { SlaBackendFactory } from './backends/SlaBackendFactory';
+
+export type SlaBackendAction =
+  | {
+      kind: 'start';
+      ticketId: string;
+      policyId: string;
+      targets: ISlaPolicyTarget[];
+      schedule: IBusinessHoursScheduleWithEntries;
+      notificationThresholds?: number[];
+    }
+  | { kind: 'pause'; ticketId: string; reason: SlaPauseReason }
+  | { kind: 'resume'; ticketId: string }
+  | { kind: 'complete'; ticketId: string; type: 'response' | 'resolution'; met: boolean | null }
+  | { kind: 'cancel'; tenantId: string; ticketId: string };
+
+/**
+ * Dispatch backend actions returned by the SLA service functions.
+ *
+ * Call this only after the transaction that produced the actions has
+ * committed. Failures are logged and swallowed per action: backend
+ * scheduling is best-effort and must never undo a committed SLA write.
+ */
+export async function dispatchSlaBackendActions(
+  actions: SlaBackendAction[] | undefined
+): Promise<void> {
+  if (!actions?.length) {
+    return;
+  }
+
+  for (const action of actions) {
+    try {
+      const backend = await SlaBackendFactory.getBackend();
+      switch (action.kind) {
+        case 'start':
+          await backend.startSlaTracking(
+            action.ticketId,
+            action.policyId,
+            action.targets,
+            action.schedule,
+            action.notificationThresholds
+          );
+          break;
+        case 'pause':
+          await backend.pauseSla(action.ticketId, action.reason);
+          break;
+        case 'resume':
+          await backend.resumeSla(action.ticketId);
+          break;
+        case 'complete':
+          await backend.completeSla(action.ticketId, action.type, action.met);
+          break;
+        case 'cancel':
+          await backend.cancelSla(action.tenantId, action.ticketId);
+          break;
+      }
+    } catch (error) {
+      console.warn(`Failed to dispatch SLA backend action '${action.kind}':`, error);
+    }
+  }
+}

--- a/packages/sla/src/services/slaLock.ts
+++ b/packages/sla/src/services/slaLock.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+/**
+ * Serialize SLA writes per ticket.
+ *
+ * Concurrent SLA writers (status-change pause vs. resolution recording,
+ * redeliveries, multiple replicas) mutate disjoint columns of the same
+ * tickets row and can otherwise interleave their read-then-write sections.
+ * A transaction-scoped advisory lock keyed on (tenant, ticket) serializes
+ * them without holding the row lock any longer than the write itself.
+ *
+ * pg_advisory_xact_lock releases automatically at commit/rollback and is
+ * safe under pgbouncer transaction pooling (unlike session-scoped advisory
+ * locks). Acquisitions are reentrant within the same transaction.
+ */
+export async function acquireTicketSlaLock(
+  trx: Knex.Transaction,
+  tenant: string,
+  ticketId: string
+): Promise<void> {
+  await trx.raw('select pg_advisory_xact_lock(hashtext(?))', [`sla:${tenant}:${ticketId}`]);
+}

--- a/packages/sla/src/services/slaNotificationService.ts
+++ b/packages/sla/src/services/slaNotificationService.ts
@@ -18,6 +18,7 @@
  */
 
 import { Knex } from 'knex';
+import { registerAfterCommit } from '@alga-psa/db';
 import { SlaNotificationChannel, SlaNotificationType } from '../types';
 import { formatRemainingTime } from './businessHoursCalculator';
 import { createNotificationFromTemplateInternal } from '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions';
@@ -63,6 +64,7 @@ export interface NotificationResult {
   success: boolean;
   recipientCount: number;
   inAppSent: number;
+  /** Emails queued; the SMTP send runs after the caller's transaction commits. */
   emailSent: number;
   errors: string[];
 }
@@ -507,7 +509,10 @@ async function sendInAppNotification(
 }
 
 /**
- * Send an email notification using the email notification service.
+ * Queue an email notification to send after the caller's transaction commits.
+ * SMTP is network I/O and must never run while the transaction is open (a
+ * slow server would trip idle_in_transaction_session_timeout and roll back
+ * the in-app notifications). A true return means queued, not delivered.
  */
 async function sendEmailNotification(
   trx: Knex.Transaction,
@@ -517,7 +522,8 @@ async function sendEmailNotification(
   data: Record<string, unknown>
 ): Promise<boolean> {
   try {
-    if (!recipient.email) {
+    const emailAddress = recipient.email;
+    if (!emailAddress) {
       return false;
     }
 
@@ -533,18 +539,23 @@ async function sendEmailNotification(
       return false;
     }
 
-    await emailService.sendNotification({
-      tenant,
-      userId: recipient.user_id,
-      subtypeId: subtype.id,
-      emailAddress: recipient.email,
-      templateName,
-      data: data as Record<string, string | number | boolean>
-    });
+    registerAfterCommit(
+      trx,
+      () =>
+        emailService.sendNotification({
+          tenant,
+          userId: recipient.user_id,
+          subtypeId: subtype.id,
+          emailAddress,
+          templateName,
+          data: data as Record<string, string | number | boolean>
+        }),
+      `sla-notification-email ${templateName} user=${recipient.user_id}`
+    );
 
     return true;
   } catch (error) {
-    console.error('Error sending email notification:', error);
+    console.error('Error queueing email notification:', error);
     return false;
   }
 }

--- a/packages/sla/src/services/slaPauseService.ts
+++ b/packages/sla/src/services/slaPauseService.ts
@@ -22,7 +22,8 @@
 
 import { Knex } from 'knex';
 import { SlaPauseReason } from '../types';
-import { SlaBackendFactory } from './backends/SlaBackendFactory';
+import { SlaBackendAction } from './slaBackendActions';
+import { acquireTicketSlaLock } from './slaLock';
 
 /**
  * Result of a pause/resume operation
@@ -33,6 +34,8 @@ export interface PauseResult {
   is_now_paused: boolean;
   pause_duration_minutes?: number;
   error?: string;
+  /** Dispatch with dispatchSlaBackendActions() after the transaction commits. */
+  backendActions?: SlaBackendAction[];
 }
 
 /**
@@ -55,10 +58,11 @@ export async function pauseSla(
   tenant: string,
   ticketId: string,
   reason: SlaPauseReason,
-  triggeredBy?: string,
-  options?: { skipBackend?: boolean }
+  triggeredBy?: string
 ): Promise<PauseResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Get current ticket state
     const ticket = await trx('tickets')
       .where({ tenant, ticket_id: ticketId })
@@ -95,16 +99,12 @@ export async function pauseSla(
       triggered_by: triggeredBy
     });
 
-    if (!options?.skipBackend) {
-      try {
-        const backend = await SlaBackendFactory.getBackend();
-        await backend.pauseSla(ticketId, reason);
-      } catch (error) {
-        console.warn('Failed to pause SLA backend:', error);
-      }
-    }
-
-    return { success: true, was_paused: false, is_now_paused: true };
+    return {
+      success: true,
+      was_paused: false,
+      is_now_paused: true,
+      backendActions: [{ kind: 'pause', ticketId, reason }]
+    };
   } catch (error) {
     console.error('Error pausing SLA:', error);
     return {
@@ -134,10 +134,11 @@ export async function resumeSla(
   trx: Knex.Transaction,
   tenant: string,
   ticketId: string,
-  triggeredBy?: string,
-  options?: { skipBackend?: boolean }
+  triggeredBy?: string
 ): Promise<PauseResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Get current ticket state (including due dates for shifting)
     const ticket = await trx('tickets')
       .where({ tenant, ticket_id: ticketId })
@@ -213,20 +214,12 @@ export async function resumeSla(
       triggered_by: triggeredBy
     });
 
-    if (!options?.skipBackend) {
-      try {
-        const backend = await SlaBackendFactory.getBackend();
-        await backend.resumeSla(ticketId);
-      } catch (error) {
-        console.warn('Failed to resume SLA backend:', error);
-      }
-    }
-
     return {
       success: true,
       was_paused: true,
       is_now_paused: false,
-      pause_duration_minutes: pauseDurationMinutes
+      pause_duration_minutes: pauseDurationMinutes,
+      backendActions: [{ kind: 'resume', ticketId }]
     };
   } catch (error) {
     console.error('Error resuming SLA:', error);
@@ -262,6 +255,10 @@ export async function handleStatusChange(
   triggeredBy?: string
 ): Promise<PauseResult> {
   try {
+    // Take the per-ticket lock before reading pause state so concurrent
+    // SLA writers can't interleave between this read and the pause/resume.
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Check if new status is configured to pause SLA
     const newStatusConfig = await trx('status_sla_pause_config')
       .where({ tenant, status_id: newStatusId })
@@ -352,6 +349,8 @@ export async function handleResponseStateChange(
   triggeredBy?: string
 ): Promise<PauseResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Get SLA settings
     const slaSettings = await trx('sla_settings')
       .where({ tenant })
@@ -498,6 +497,8 @@ export async function syncPauseState(
   triggeredBy?: string
 ): Promise<PauseResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     const { paused, reason } = await shouldSlaBePaused(trx, tenant, ticketId);
 
     const ticket = await trx('tickets')

--- a/packages/sla/src/services/slaService.ts
+++ b/packages/sla/src/services/slaService.ts
@@ -30,7 +30,8 @@ import {
   isWithinBusinessHours,
   formatRemainingTime
 } from './businessHoursCalculator';
-import { SlaBackendFactory } from './backends/SlaBackendFactory';
+import { SlaBackendAction } from './slaBackendActions';
+import { acquireTicketSlaLock } from './slaLock';
 
 /**
  * Result of starting SLA tracking for a ticket
@@ -42,6 +43,8 @@ export interface StartSlaResult {
   sla_response_due_at: Date | null;
   sla_resolution_due_at: Date | null;
   error?: string;
+  /** Dispatch with dispatchSlaBackendActions() after the transaction commits. */
+  backendActions?: SlaBackendAction[];
 }
 
 /**
@@ -52,6 +55,8 @@ export interface RecordSlaEventResult {
   met: boolean | null;
   recorded_at: Date;
   error?: string;
+  /** Dispatch with dispatchSlaBackendActions() after the transaction commits. */
+  backendActions?: SlaBackendAction[];
 }
 
 /**
@@ -81,6 +86,8 @@ export async function startSlaForTicket(
   createdAt: Date = new Date()
 ): Promise<StartSlaResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // 1. Resolve the SLA policy for this ticket
     const policy = await resolveSlaPolicy(trx, tenant, clientId, boardId);
 
@@ -165,35 +172,30 @@ export async function startSlaForTicket(
       resolution_due_at: resolutionDueAt?.toISOString()
     });
 
-    try {
-      // Query configured notification thresholds for this policy
-      const thresholdRows = await trx('sla_notification_thresholds')
-        .where({ tenant, sla_policy_id: policy.sla_policy_id })
-        .select('threshold_percent')
-        .orderBy('threshold_percent', 'asc');
+    // Query configured notification thresholds for this policy
+    const thresholdRows = await trx('sla_notification_thresholds')
+      .where({ tenant, sla_policy_id: policy.sla_policy_id })
+      .select('threshold_percent')
+      .orderBy('threshold_percent', 'asc');
 
-      const notificationThresholds = thresholdRows.map(
-        (r: { threshold_percent: number }) => r.threshold_percent
-      );
-
-      const backend = await SlaBackendFactory.getBackend();
-      await backend.startSlaTracking(
-        ticketId,
-        policy.sla_policy_id,
-        [target],
-        schedule,
-        notificationThresholds
-      );
-    } catch (error) {
-      console.warn('Failed to start SLA backend tracking:', error);
-    }
+    const notificationThresholds = thresholdRows.map(
+      (r: { threshold_percent: number }) => r.threshold_percent
+    );
 
     return {
       success: true,
       sla_policy_id: policy.sla_policy_id,
       sla_started_at: createdAt,
       sla_response_due_at: responseDueAt,
-      sla_resolution_due_at: resolutionDueAt
+      sla_resolution_due_at: resolutionDueAt,
+      backendActions: [{
+        kind: 'start',
+        ticketId,
+        policyId: policy.sla_policy_id,
+        targets: [target],
+        schedule,
+        notificationThresholds
+      }]
     };
   } catch (error) {
     console.error('Error starting SLA for ticket:', error);
@@ -225,10 +227,11 @@ export async function recordFirstResponse(
   tenant: string,
   ticketId: string,
   respondedAt: Date = new Date(),
-  respondedBy?: string,
-  options?: { skipBackend?: boolean }
+  respondedBy?: string
 ): Promise<RecordSlaEventResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Get current ticket SLA state
     const ticket = await trx('tickets')
       .where({ tenant, ticket_id: ticketId })
@@ -273,16 +276,14 @@ export async function recordFirstResponse(
       met
     });
 
-    if (!options?.skipBackend && met !== null) {
-      try {
-        const backend = await SlaBackendFactory.getBackend();
-        await backend.completeSla(ticketId, 'response', met);
-      } catch (error) {
-        console.warn('Failed to complete SLA backend response:', error);
-      }
-    }
-
-    return { success: true, met, recorded_at: respondedAt };
+    return {
+      success: true,
+      met,
+      recorded_at: respondedAt,
+      ...(met !== null
+        ? { backendActions: [{ kind: 'complete' as const, ticketId, type: 'response' as const, met }] }
+        : {})
+    };
   } catch (error) {
     console.error('Error recording first response:', error);
     return {
@@ -311,10 +312,11 @@ export async function recordResolution(
   tenant: string,
   ticketId: string,
   resolvedAt: Date = new Date(),
-  resolvedBy?: string,
-  options?: { skipBackend?: boolean }
+  resolvedBy?: string
 ): Promise<RecordSlaEventResult> {
   try {
+    await acquireTicketSlaLock(trx, tenant, ticketId);
+
     // Get current ticket SLA state
     const ticket = await trx('tickets')
       .where({ tenant, ticket_id: ticketId })
@@ -359,16 +361,12 @@ export async function recordResolution(
       met
     });
 
-    if (!options?.skipBackend) {
-      try {
-        const backend = await SlaBackendFactory.getBackend();
-        await backend.completeSla(ticketId, 'resolution', met);
-      } catch (error) {
-        console.warn('Failed to complete SLA backend resolution:', error);
-      }
-    }
-
-    return { success: true, met, recorded_at: resolvedAt };
+    return {
+      success: true,
+      met,
+      recorded_at: resolvedAt,
+      backendActions: [{ kind: 'complete', ticketId, type: 'resolution', met }]
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     console.error('Error recording resolution:', error);
@@ -527,7 +525,9 @@ export async function handlePriorityChange(
   ticketId: string,
   newPriorityId: string,
   changedBy?: string
-): Promise<void> {
+): Promise<{ backendActions: SlaBackendAction[] }> {
+  await acquireTicketSlaLock(trx, tenant, ticketId);
+
   // Get current ticket state
   const ticket = await trx('tickets')
     .where({ tenant, ticket_id: ticketId })
@@ -546,18 +546,18 @@ export async function handlePriorityChange(
     .first();
 
   if (!ticket || !ticket.sla_policy_id || !ticket.sla_started_at) {
-    return;
+    return { backendActions: [] };
   }
 
   const oldPriorityId = ticket.priority_id;
 
   // Get the policy with targets
   const policy = await getSlaPolicyWithTargets(trx, tenant, ticket.sla_policy_id);
-  if (!policy) return;
+  if (!policy) return { backendActions: [] };
 
   // Get new target
   const newTarget = policy.targets.find(t => t.priority_id === newPriorityId);
-  if (!newTarget) return;
+  if (!newTarget) return { backendActions: [] };
 
   // Get business hours schedule
   const schedule = await getBusinessHoursSchedule(trx, tenant, policy, newTarget);
@@ -614,13 +614,26 @@ export async function handlePriorityChange(
     total_pause_minutes_applied: ticket.sla_total_pause_minutes,
     changed_by: changedBy
   });
+
+  // Restart backend timers on the recalculated deadlines. When both stages
+  // are already recorded nothing was recalculated, so leave the backend alone.
+  if (!newResponseDue && !newResolutionDue) {
+    return { backendActions: [] };
+  }
+
+  return {
+    backendActions: [
+      { kind: 'cancel', tenantId: tenant, ticketId },
+      { kind: 'start', ticketId, policyId: policy.sla_policy_id, targets: [newTarget], schedule }
+    ]
+  };
 }
 
 /**
  * Update SLA tracking when the SLA policy changes for a ticket.
  *
- * Cancels the existing SLA backend workflow and starts a new one with the
- * updated policy targets.
+ * Returns backend actions (cancel the existing workflow, start a new one
+ * with the updated targets) for the caller to dispatch after commit.
  */
 export async function handlePolicyChange(
   trx: Knex.Transaction,
@@ -628,7 +641,9 @@ export async function handlePolicyChange(
   ticketId: string,
   newPolicyId: string | null,
   changedBy?: string
-): Promise<void> {
+): Promise<{ backendActions: SlaBackendAction[] }> {
+  await acquireTicketSlaLock(trx, tenant, ticketId);
+
   const ticket = await trx('tickets')
     .where({ tenant, ticket_id: ticketId })
     .select(
@@ -643,7 +658,7 @@ export async function handlePolicyChange(
     .first();
 
   if (!ticket) {
-    return;
+    return { backendActions: [] };
   }
 
   if (!newPolicyId) {
@@ -659,19 +674,12 @@ export async function handlePolicyChange(
       changed_by: changedBy
     });
 
-    try {
-      const backend = await SlaBackendFactory.getBackend();
-      await backend.cancelSla(tenant, ticketId);
-    } catch (error) {
-      console.warn('Failed to cancel SLA backend on policy clear:', error);
-    }
-
-    return;
+    return { backendActions: [{ kind: 'cancel', tenantId: tenant, ticketId }] };
   }
 
   const policy = await getSlaPolicyWithTargets(trx, tenant, newPolicyId);
   if (!policy) {
-    return;
+    return { backendActions: [] };
   }
 
   const target = policy.targets.find(t => t.priority_id === ticket.priority_id);
@@ -683,7 +691,7 @@ export async function handlePolicyChange(
         sla_response_due_at: null,
         sla_resolution_due_at: null
       });
-    return;
+    return { backendActions: [] };
   }
 
   const schedule = await getBusinessHoursSchedule(trx, tenant, policy, target);
@@ -733,13 +741,12 @@ export async function handlePolicyChange(
     changed_by: changedBy
   });
 
-  try {
-    const backend = await SlaBackendFactory.getBackend();
-    await backend.cancelSla(tenant, ticketId);
-    await backend.startSlaTracking(ticketId, policy.sla_policy_id, [target], schedule);
-  } catch (error) {
-    console.warn('Failed to restart SLA backend on policy change:', error);
-  }
+  return {
+    backendActions: [
+      { kind: 'cancel', tenantId: tenant, ticketId },
+      { kind: 'start', ticketId, policyId: policy.sla_policy_id, targets: [target], schedule }
+    ]
+  };
 }
 
 // ============================================================================

--- a/packages/sla/vitest.config.ts
+++ b/packages/sla/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
     alias: {
       '@alga-psa/types': path.resolve(__dirname, '../types/src'),
       '@alga-psa/notifications/notifications/email': path.resolve(__dirname, '../notifications/src/notifications/email'),
+      '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions': path.resolve(
+        __dirname,
+        '../notifications/src/actions/internal-notification-actions/internalNotificationActions'
+      ),
+      '@alga-psa/email': path.resolve(__dirname, '../email/src'),
     },
   },
 });

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -16,7 +16,7 @@ import type {
   IUserWithRoles,
   TicketResponseState,
 } from '@alga-psa/types';
-import { withTransaction } from '@alga-psa/db';
+import { withTransaction, registerAfterCommit } from '@alga-psa/db';
 import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { revalidatePath } from 'next/cache';
@@ -306,8 +306,8 @@ async function updateTicketResponseStateFromComment(
       .where({ ticket_id: ticketId, tenant })
       .update({ response_state: newState });
 
-    try {
-      await publishEvent({
+    registerAfterCommit(trx, () =>
+      publishEvent({
         eventType: 'TICKET_RESPONSE_STATE_CHANGED',
         payload: {
           tenantId: tenant,
@@ -317,10 +317,9 @@ async function updateTicketResponseStateFromComment(
           newState,
           trigger: 'comment',
         },
-      });
-    } catch (eventError) {
-      console.error('[updateTicketResponseStateFromComment] Failed to publish event:', eventError);
-    }
+      }),
+      `TICKET_RESPONSE_STATE_CHANGED ticket=${ticketId}`
+    );
   }
 
   return { previousState, newState };
@@ -2341,23 +2340,27 @@ export async function updateTicketInTransaction(
       updatedTicket.closed_by = null;
     }
 
-    // Publish appropriate event based on the update
+    // Publish appropriate event based on the update — after the save
+    // transaction commits, so subscribers never contend with our row locks.
     if (newStatus?.is_closed && !oldStatus?.is_closed) {
       // Ticket was closed
-      await publishWorkflowEvent({
-        eventType: 'TICKET_CLOSED',
-        payload: {
-          ticketId: id,
-          userId: user.user_id,
-          closedByUserId: user.user_id,
-          closedAt: occurredAt,
-          changes: structuredChanges,
-        },
-        ctx: workflowCtx,
-        eventName: 'Ticket Closed',
-        fromState: currentTicket.status_id,
-        toState: updatedTicket.status_id,
-      });
+      registerAfterCommit(trx, () =>
+        publishWorkflowEvent({
+          eventType: 'TICKET_CLOSED',
+          payload: {
+            ticketId: id,
+            userId: user.user_id,
+            closedByUserId: user.user_id,
+            closedAt: occurredAt,
+            changes: structuredChanges,
+          },
+          ctx: workflowCtx,
+          eventName: 'Ticket Closed',
+          fromState: currentTicket.status_id,
+          toState: updatedTicket.status_id,
+        }),
+        `TICKET_CLOSED ticket=${id}`
+      );
 
       const slaCompletionEvent = buildTicketResolutionSlaStageCompletionEvent({
         tenantId: tenant,
@@ -2367,56 +2370,68 @@ export async function updateTicketInTransaction(
         closedAt: occurredAt,
       });
       if (slaCompletionEvent) {
-        await publishWorkflowEvent({
-          eventType: slaCompletionEvent.eventType,
-          payload: slaCompletionEvent.payload,
-          ctx: workflowCtx,
-          idempotencyKey: slaCompletionEvent.idempotencyKey,
-        });
+        registerAfterCommit(trx, () =>
+          publishWorkflowEvent({
+            eventType: slaCompletionEvent.eventType,
+            payload: slaCompletionEvent.payload,
+            ctx: workflowCtx,
+            idempotencyKey: slaCompletionEvent.idempotencyKey,
+          }),
+          `${slaCompletionEvent.eventType} ticket=${id}`
+        );
       }
     } else if (updateData.assigned_to && updateData.assigned_to !== currentTicket.assigned_to) {
       // Ticket was assigned - userId should be the user being assigned, not the one making the update
-      await publishWorkflowEvent({
-        eventType: 'TICKET_ASSIGNED',
-        payload: {
-          ticketId: id,
-          userId: updateData.assigned_to, // Legacy: assigned user
-          assignedByUserId: user.user_id,
-          previousAssigneeId: currentTicket.assigned_to ?? undefined,
-          previousAssigneeType: currentTicket.assigned_to ? 'user' : undefined,
-          newAssigneeId: updateData.assigned_to,
-          newAssigneeType: 'user',
-          assignedAt: occurredAt,
-          changes: structuredChanges,
-        },
-        ctx: workflowCtx,
-        eventName: 'Ticket Assigned',
-      });
+      registerAfterCommit(trx, () =>
+        publishWorkflowEvent({
+          eventType: 'TICKET_ASSIGNED',
+          payload: {
+            ticketId: id,
+            userId: updateData.assigned_to, // Legacy: assigned user
+            assignedByUserId: user.user_id,
+            previousAssigneeId: currentTicket.assigned_to ?? undefined,
+            previousAssigneeType: currentTicket.assigned_to ? 'user' : undefined,
+            newAssigneeId: updateData.assigned_to,
+            newAssigneeType: 'user',
+            assignedAt: occurredAt,
+            changes: structuredChanges,
+          },
+          ctx: workflowCtx,
+          eventName: 'Ticket Assigned',
+        }),
+        `TICKET_ASSIGNED ticket=${id}`
+      );
     } else {
       // Regular update
-      await publishWorkflowEvent({
-        eventType: 'TICKET_UPDATED',
-        payload: {
-          ticketId: id,
-          userId: user.user_id,
-          updatedByUserId: user.user_id,
-          changes: structuredChanges,
-        },
-        ctx: workflowCtx,
-        eventName: 'Ticket Updated',
-      });
+      registerAfterCommit(trx, () =>
+        publishWorkflowEvent({
+          eventType: 'TICKET_UPDATED',
+          payload: {
+            ticketId: id,
+            userId: user.user_id,
+            updatedByUserId: user.user_id,
+            changes: structuredChanges,
+          },
+          ctx: workflowCtx,
+          eventName: 'Ticket Updated',
+        }),
+        `TICKET_UPDATED ticket=${id}`
+      );
     }
 
-    await publishTicketUpdate({
-      tenantId: tenant,
-      ticketId: id,
-      updatedFields,
-      updatedBy: {
-        userId: user.user_id,
-        displayName: formatLiveUpdateDisplayName(user),
-      },
-      updatedAt: toIsoTimestamp(updatedTicket.updated_at, occurredAt),
-    });
+    registerAfterCommit(trx, () =>
+      publishTicketUpdate({
+        tenantId: tenant,
+        ticketId: id,
+        updatedFields,
+        updatedBy: {
+          userId: user.user_id,
+          displayName: formatLiveUpdateDisplayName(user),
+        },
+        updatedAt: toIsoTimestamp(updatedTicket.updated_at, occurredAt),
+      }),
+      `ticket-live-update ticket=${id}`
+    );
 
     // Write a unified activity-timeline row for this update. We pick the
     // most specific event type so the UI can render a tight, human-readable
@@ -2474,8 +2489,8 @@ export async function updateTicketInTransaction(
 
     // Publish response state change event if response_state was explicitly changed
     if ('response_state' in updateData && updateData.response_state !== currentTicket.response_state) {
-      try {
-        await publishEvent({
+      registerAfterCommit(trx, () =>
+        publishEvent({
           eventType: 'TICKET_RESPONSE_STATE_CHANGED',
           payload: {
             tenantId: tenant,
@@ -2485,10 +2500,9 @@ export async function updateTicketInTransaction(
             newState: updateData.response_state || null,
             trigger: 'manual',
           },
-        });
-      } catch (error) {
-        console.warn('[updateTicketWithCache] Failed to publish TICKET_RESPONSE_STATE_CHANGED:', error);
-      }
+        }),
+        `TICKET_RESPONSE_STATE_CHANGED ticket=${id}`
+      );
     }
 
     // If this is a bundle master in sync_updates mode, propagate selected workflow updates to children.
@@ -2524,16 +2538,19 @@ export async function updateTicketInTransaction(
           .update(propagate);
 
         for (const childPublish of childPublishes) {
-          await publishTicketUpdate({
-            tenantId: tenant,
-            ticketId: childPublish.ticketId,
-            updatedFields: childPublish.updatedFields,
-            updatedBy: {
-              userId: user.user_id,
-              displayName: formatLiveUpdateDisplayName(user),
-            },
-            updatedAt: propagate.updated_at,
-          });
+          registerAfterCommit(trx, () =>
+            publishTicketUpdate({
+              tenantId: tenant,
+              ticketId: childPublish.ticketId,
+              updatedFields: childPublish.updatedFields,
+              updatedBy: {
+                userId: user.user_id,
+                displayName: formatLiveUpdateDisplayName(user),
+              },
+              updatedAt: propagate.updated_at,
+            }),
+            `ticket-live-update ticket=${childPublish.ticketId}`
+          );
         }
       }
     }
@@ -2762,22 +2779,25 @@ export const addTicketCommentWithCache = withAuth(async (
       }
     }
 
-    // Publish comment added event
-    await publishEvent({
-      eventType: 'TICKET_COMMENT_ADDED',
-      payload: {
-        tenantId: tenant,
-        ticketId: ticketId,
-        userId: user.user_id,
-        comment: {
-          id: newComment.comment_id,
-          content: content,
-          author: `${user.first_name} ${user.last_name}`,
-          isInternal,
-          authorType,
+    // Publish comment added event after the comment transaction commits.
+    registerAfterCommit(trx, () =>
+      publishEvent({
+        eventType: 'TICKET_COMMENT_ADDED',
+        payload: {
+          tenantId: tenant,
+          ticketId: ticketId,
+          userId: user.user_id,
+          comment: {
+            id: newComment.comment_id,
+            content: content,
+            author: `${user.first_name} ${user.last_name}`,
+            isInternal,
+            authorType,
+          }
         }
-      }
-    });
+      }),
+      `TICKET_COMMENT_ADDED ticket=${ticketId}`
+    );
 
     // Publish workflow v2 ticket message events (additive).
     try {
@@ -2799,22 +2819,29 @@ export const addTicketCommentWithCache = withAuth(async (
       });
 
       for (const ev of events) {
-        await publishWorkflowEvent({ eventType: ev.eventType, payload: ev.payload, ctx: workflowCtx });
+        registerAfterCommit(
+          trx,
+          () => publishWorkflowEvent({ eventType: ev.eventType, payload: ev.payload, ctx: workflowCtx }),
+          `${ev.eventType} ticket=${ticketId}`
+        );
       }
     } catch (eventError) {
-      console.error('[addTicketCommentWithCache] Failed to publish workflow ticket message events:', eventError);
+      console.error('[addTicketCommentWithCache] Failed to build workflow ticket message events:', eventError);
     }
 
-    await publishTicketUpdate({
-      tenantId: tenant,
-      ticketId,
-      updatedFields: ['comments'],
-      updatedBy: {
-        userId: user.user_id,
-        displayName: formatLiveUpdateDisplayName(user),
-      },
-      updatedAt: toIsoTimestamp(newComment.created_at, new Date().toISOString()),
-    });
+    registerAfterCommit(trx, () =>
+      publishTicketUpdate({
+        tenantId: tenant,
+        ticketId,
+        updatedFields: ['comments'],
+        updatedBy: {
+          userId: user.user_id,
+          displayName: formatLiveUpdateDisplayName(user),
+        },
+        updatedAt: toIsoTimestamp(newComment.created_at, new Date().toISOString()),
+      }),
+      `ticket-live-update ticket=${ticketId}`
+    );
 
     // Activity-timeline row for the MSP-side "add comment" flow. This path
     // is hit by the ticket detail UI, so source is always 'ui'. Internal

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -16,7 +16,7 @@ import Ticket from '../models/ticket';
 import { revalidatePath } from 'next/cache';
 import { getTicketAttributes } from '@alga-psa/auth/actions';
 import { hasPermission } from '@alga-psa/auth/rbac';
-import { withTransaction } from '@alga-psa/db';
+import { withTransaction, registerAfterCommit } from '@alga-psa/db';
 import { createTenantKnex } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { deleteEntityWithValidation } from '@alga-psa/core';
@@ -294,14 +294,15 @@ export const createTicketFromAsset = withAuth(async (user, { tenant }, data: Cre
     try {
         const {knex: db} = await createTenantKnex();
 
-        const result = await db.transaction(async (trx) => {
+        const result = await withTransaction(db, async (trx) => {
             // Server-specific: Check permissions
             if (!await hasPermission(user, 'ticket', 'create', trx)) {
                 throw new Error('Permission denied: Cannot create ticket');
             }
 
-            // Server-specific: Create adapters for dependency injection
-            const eventPublisher = new TicketModelEventPublisher();
+            // Server-specific: Create adapters for dependency injection.
+            // Passing trx defers event publishing until the commit.
+            const eventPublisher = new TicketModelEventPublisher(trx);
             const analyticsTracker = new TicketModelAnalyticsTracker();
 
             // Use shared TicketModel for asset ticket creation
@@ -341,18 +342,21 @@ export const createTicketFromAsset = withAuth(async (user, { tenant }, data: Cre
               enteredAt: fullTicket.entered_at,
             });
             if (enteredSlaEvent) {
-              await publishWorkflowEvent({
-                eventType: enteredSlaEvent.eventType,
-                payload: enteredSlaEvent.payload,
-                ctx: {
-                  tenantId: tenant,
-                  actor: { actorType: 'USER' as const, actorUserId: user.user_id },
-                  occurredAt: (fullTicket.entered_at instanceof Date
-                    ? fullTicket.entered_at.toISOString()
-                    : fullTicket.entered_at) || new Date().toISOString(),
-                },
-                idempotencyKey: enteredSlaEvent.idempotencyKey,
-              });
+              registerAfterCommit(trx, () =>
+                publishWorkflowEvent({
+                  eventType: enteredSlaEvent.eventType,
+                  payload: enteredSlaEvent.payload,
+                  ctx: {
+                    tenantId: tenant,
+                    actor: { actorType: 'USER' as const, actorUserId: user.user_id },
+                    occurredAt: (fullTicket.entered_at instanceof Date
+                      ? fullTicket.entered_at.toISOString()
+                      : fullTicket.entered_at) || new Date().toISOString(),
+                  },
+                  idempotencyKey: enteredSlaEvent.idempotencyKey,
+                }),
+                `${enteredSlaEvent.eventType} ticket=${ticketResult.ticket_id}`
+              );
             }
 
             return convertDates(fullTicket);
@@ -374,7 +378,7 @@ export const addTicket = withAuth(async (user, { tenant }, data: FormData): Prom
   try {
     const {knex: db} = await createTenantKnex();
 
-    return await db.transaction(async (trx) => {
+    return await withTransaction(db, async (trx) => {
       // Server-specific: Check permissions
       if (!await hasPermission(user, 'ticket', 'create', trx)) {
         throw new Error('Permission denied: Cannot create ticket');
@@ -438,8 +442,9 @@ export const addTicket = withAuth(async (user, { tenant }, data: FormData): Prom
         ticket_origin: TICKET_ORIGINS.INTERNAL,
       };
 
-      // Server-specific: Create adapters for dependency injection
-      const eventPublisher = new TicketModelEventPublisher();
+      // Server-specific: Create adapters for dependency injection.
+      // Passing trx defers event publishing until the commit.
+      const eventPublisher = new TicketModelEventPublisher(trx);
       const analyticsTracker = new TicketModelAnalyticsTracker();
 
       // Use shared TicketModel with retry logic
@@ -469,15 +474,18 @@ export const addTicket = withAuth(async (user, { tenant }, data: FormData): Prom
 
       // Server-specific: Handle assigned ticket event
       if (createTicketInput.assigned_to) {
-        await publishEvent({
-          eventType: 'TICKET_ASSIGNED',
-          payload: {
-            tenantId: tenant,
-            ticketId: ticketResult.ticket_id,
-            userId: createTicketInput.assigned_to,  // The user being assigned to the ticket
-            assignedByUserId: user.user_id  // The user who created and assigned the ticket
-          }
-        });
+        registerAfterCommit(trx, () =>
+          publishEvent({
+            eventType: 'TICKET_ASSIGNED',
+            payload: {
+              tenantId: tenant,
+              ticketId: ticketResult.ticket_id,
+              userId: createTicketInput.assigned_to,  // The user being assigned to the ticket
+              assignedByUserId: user.user_id  // The user who created and assigned the ticket
+            }
+          }),
+          `TICKET_ASSIGNED ticket=${ticketResult.ticket_id}`
+        );
       }
 
       // Server-specific: Get full ticket data for return
@@ -528,18 +536,21 @@ export const addTicket = withAuth(async (user, { tenant }, data: FormData): Prom
         enteredAt: fullTicket.entered_at,
       });
       if (enteredSlaEvent) {
-        await publishWorkflowEvent({
-          eventType: enteredSlaEvent.eventType,
-          payload: enteredSlaEvent.payload,
-          ctx: {
-            tenantId: tenant,
-            actor: { actorType: 'USER' as const, actorUserId: user.user_id },
-            occurredAt: (fullTicket.entered_at instanceof Date
-              ? fullTicket.entered_at.toISOString()
-              : fullTicket.entered_at) || new Date().toISOString(),
-          },
-          idempotencyKey: enteredSlaEvent.idempotencyKey,
-        });
+        registerAfterCommit(trx, () =>
+          publishWorkflowEvent({
+            eventType: enteredSlaEvent.eventType,
+            payload: enteredSlaEvent.payload,
+            ctx: {
+              tenantId: tenant,
+              actor: { actorType: 'USER' as const, actorUserId: user.user_id },
+              occurredAt: (fullTicket.entered_at instanceof Date
+                ? fullTicket.entered_at.toISOString()
+                : fullTicket.entered_at) || new Date().toISOString(),
+            },
+            idempotencyKey: enteredSlaEvent.idempotencyKey,
+          }),
+          `${enteredSlaEvent.eventType} ticket=${ticketResult.ticket_id}`
+        );
       }
 
       // Server-specific: Revalidate cache paths

--- a/packages/tickets/src/lib/adapters/TicketModelEventPublisher.ts
+++ b/packages/tickets/src/lib/adapters/TicketModelEventPublisher.ts
@@ -1,7 +1,17 @@
 import type { IEventPublisher } from '@alga-psa/types';
+import type { Knex } from 'knex';
+import { registerAfterCommit } from '@alga-psa/db';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 
 export class TicketModelEventPublisher implements IEventPublisher {
+  /**
+   * When constructed with the creating transaction, publishes are deferred
+   * until that transaction commits (via registerAfterCommit), so subscribers
+   * never race the still-open creation transaction. Requires the transaction
+   * to be owned by a withTransaction frame.
+   */
+  constructor(private readonly trx?: Knex.Transaction) {}
+
   async publishTicketCreated(data: { tenantId: string; ticketId: string; userId?: string; metadata?: Record<string, any> }): Promise<void> {
     await this.safePublishEvent('TICKET_CREATED', {
       tenantId: data.tenantId,
@@ -62,13 +72,13 @@ export class TicketModelEventPublisher implements IEventPublisher {
   }
 
   private async safePublishEvent(eventType: string, payload: any): Promise<void> {
-    try {
-      const actorUserId =
-        typeof payload?.assignedByUserId === 'string' && payload.assignedByUserId
-          ? payload.assignedByUserId
-          : (typeof payload?.userId === 'string' ? payload.userId : undefined);
+    const actorUserId =
+      typeof payload?.assignedByUserId === 'string' && payload.assignedByUserId
+        ? payload.assignedByUserId
+        : (typeof payload?.userId === 'string' ? payload.userId : undefined);
 
-      await publishWorkflowEvent({
+    const publish = () =>
+      publishWorkflowEvent({
         eventType: eventType as any,
         payload,
         ctx: {
@@ -76,6 +86,14 @@ export class TicketModelEventPublisher implements IEventPublisher {
           actor: actorUserId ? { actorType: 'USER', actorUserId } : { actorType: 'SYSTEM' }
         }
       });
+
+    if (this.trx) {
+      registerAfterCommit(this.trx, publish, `${eventType} ticket=${payload?.ticketId ?? 'unknown'}`);
+      return;
+    }
+
+    try {
+      await publish();
     } catch (error) {
       console.error(`Failed to publish ${eventType} event:`, error);
     }

--- a/pgbouncer/pgbouncer.ini.template
+++ b/pgbouncer/pgbouncer.ini.template
@@ -17,5 +17,9 @@ max_db_connections = 100
 max_user_connections = 100
 server_reset_query = DISCARD ALL
 ignore_startup_parameters = extra_float_digits
-idle_transaction_timeout = 300
+; Last-resort reaper for stuck transactions. Postgres-side role GUCs
+; (idle_in_transaction_session_timeout=60s on the app role) fire first;
+; this only catches sessions those don't cover, and must stay above the
+; role GUC so the gentler server-side abort wins over a connection kill.
+idle_transaction_timeout = 120
 server_idle_timeout = 600

--- a/server/migrations/20260609120000_set_app_role_db_guardrail_timeouts.cjs
+++ b/server/migrations/20260609120000_set_app_role_db_guardrail_timeouts.cjs
@@ -1,0 +1,55 @@
+/**
+ * Defense-in-depth DB guardrails for the application role.
+ *
+ * A stuck transaction holding a tickets row lock used to stall every later
+ * write to that row until pgbouncer's idle_transaction_timeout (300s) reaped
+ * the session. The root cause (SLA backend re-entrant write deadlock) is
+ * fixed in code; these role-level GUCs make any *future* stuck transaction
+ * self-abort in seconds instead of minutes:
+ *
+ * - idle_in_transaction_session_timeout=60s: a session idle mid-transaction
+ *   is aborted, releasing its locks. 60s (not lower) so a legitimate slow
+ *   external call awaited between statements (SMTP/HTTP timeouts are
+ *   routinely 30-60s) doesn't abort the transaction; waiters are already
+ *   protected by lock_timeout regardless of how long the holder sits.
+ * - lock_timeout=8s: a statement waiting on a lock fails fast instead of
+ *   queueing behind a stuck holder.
+ *
+ * Role-level (not pool afterCreate) because pgbouncer runs in transaction
+ * pooling mode: session-level SETs issued at connection creation do not
+ * reliably follow the client across backend remapping, while role GUCs
+ * resolve server-side at backend session start. Applied to the app role
+ * only — the admin/migration role keeps unlimited timeouts so long DDL
+ * stays legal.
+ */
+
+// DO blocks cannot take bound parameters; sanitize and inline the role name.
+const APP_ROLE = (process.env.DB_USER_SERVER || 'app_user').replace(/[^a-zA-Z0-9_]/g, '');
+
+exports.up = async function (knex) {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${APP_ROLE}') THEN
+        EXECUTE format('ALTER ROLE %I SET idle_in_transaction_session_timeout = ''60s''', '${APP_ROLE}');
+        EXECUTE format('ALTER ROLE %I SET lock_timeout = ''8s''', '${APP_ROLE}');
+      ELSE
+        RAISE NOTICE 'Role ${APP_ROLE} not found; skipping DB guardrail timeouts';
+      END IF;
+    END
+    $$;
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${APP_ROLE}') THEN
+        EXECUTE format('ALTER ROLE %I RESET idle_in_transaction_session_timeout', '${APP_ROLE}');
+        EXECUTE format('ALTER ROLE %I RESET lock_timeout', '${APP_ROLE}');
+      END IF;
+    END
+    $$;
+  `);
+};

--- a/server/src/config/redisConfig.ts
+++ b/server/src/config/redisConfig.ts
@@ -22,6 +22,8 @@ const RedisConfigSchema = z.object({
     blockingTimeout: z.number().int().nonnegative().default(5000), // ms
     claimTimeout: z.number().int().positive().default(30000), // ms
     batchSize: z.number().int().positive().default(10),
+    // Deliveries (initial read + claims) before a message is dead-lettered.
+    maxDeliveries: z.number().int().positive().default(10),
     reconnectStrategy: z.object({
       retries: z.number().int().positive().default(10),
       initialDelay: z.number().int().positive().default(100), // ms
@@ -43,6 +45,7 @@ const validateConfig = () => {
         blockingTimeout: parseInt(process.env.REDIS_STREAM_BLOCKING_TIMEOUT || '5000', 10),
         claimTimeout: parseInt(process.env.REDIS_STREAM_CLAIM_TIMEOUT || '30000', 10),
         batchSize: parseInt(process.env.REDIS_STREAM_BATCH_SIZE || '10', 10),
+        maxDeliveries: parseInt(process.env.REDIS_STREAM_MAX_DELIVERIES || '10', 10),
         reconnectStrategy: {
           retries: parseInt(process.env.REDIS_RECONNECT_RETRIES || '10', 10),
           initialDelay: parseInt(process.env.REDIS_RECONNECT_INITIAL_DELAY || '100', 10),

--- a/server/src/lib/eventBus/index.poison.test.ts
+++ b/server/src/lib/eventBus/index.poison.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+type FakeRedisClient = EventEmitter & {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  quit: () => Promise<void>;
+  xGroupCreate: () => Promise<void>;
+  xReadGroup: (...args: any[]) => Promise<any>;
+  xAdd: (...args: any[]) => Promise<string>;
+  xAck: (...args: any[]) => Promise<number>;
+  xPending: (...args: any[]) => Promise<{ pending: number }>;
+  xPendingRange: (...args: any[]) => Promise<any[]>;
+  xClaim: (...args: any[]) => Promise<any>;
+  sIsMember: (...args: any[]) => Promise<boolean>;
+  sAdd: (...args: any[]) => Promise<number>;
+  expire: (...args: any[]) => Promise<number>;
+};
+
+async function flushMicrotasks(limit: number = 50) {
+  for (let i = 0; i < limit; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+function mockRedisModule(opts: {
+  pendingRounds: Array<{
+    deliveriesCounter: number;
+  }>;
+  message: { id: string; event: Record<string, unknown> };
+  onAck: () => void;
+  onDeadLetter: (stream: string, fields: Record<string, string>) => void;
+  processed: Set<string>;
+}) {
+  vi.doMock('redis', () => ({
+    createClient: () => {
+      const client = new EventEmitter() as FakeRedisClient;
+      let round = 0;
+
+      client.connect = vi.fn(async () => {
+        client.emit('connect');
+        client.emit('ready');
+      });
+      client.disconnect = vi.fn(() => {
+        client.emit('end');
+      });
+      client.quit = vi.fn(async () => {
+        client.emit('end');
+      });
+
+      client.xGroupCreate = vi.fn(async () => undefined);
+      client.xReadGroup = vi.fn(async () => null);
+      client.xAdd = vi.fn(async (stream: string, _id: string, fields: Record<string, string>) => {
+        opts.onDeadLetter(stream, fields);
+        return '1-1';
+      });
+      client.xAck = vi.fn(async () => {
+        opts.onAck();
+        return 1;
+      });
+
+      client.xPending = vi.fn(async () =>
+        round < opts.pendingRounds.length ? { pending: 1 } : { pending: 0 }
+      );
+      client.xPendingRange = vi.fn(async () => {
+        if (round >= opts.pendingRounds.length) {
+          return [];
+        }
+        const entry = opts.pendingRounds[round];
+        round += 1;
+        return [
+          {
+            id: opts.message.id,
+            consumer: 'consumer-old',
+            millisecondsSinceLastDelivery: 30001,
+            deliveriesCounter: entry.deliveriesCounter,
+          },
+        ];
+      });
+      client.xClaim = vi.fn(async () => [
+        {
+          id: opts.message.id,
+          message: { event: JSON.stringify(opts.message.event), channel: 'global' },
+        },
+      ]);
+
+      client.sIsMember = vi.fn(async (_key: string, member: string) => opts.processed.has(member));
+      client.sAdd = vi.fn(async (_key: string, member: string) => {
+        opts.processed.add(member);
+        return 1;
+      });
+      client.expire = vi.fn(async () => 1);
+
+      return client;
+    },
+  }));
+}
+
+describe('EventBus poison resistance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('dead-letters and acks a message that exceeded max deliveries without running handlers', async () => {
+    const tenantId = randomUUID();
+    const eventType = 'UNKNOWN';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const handler = vi.fn(async () => undefined);
+    let didAck = false;
+    const deadLetters: Array<{ stream: string; fields: Record<string, string> }> = [];
+
+    mockRedisModule({
+      // deliveriesCounter beyond the default maxDeliveries (10)
+      pendingRounds: [{ deliveriesCounter: 11 }],
+      message: { id: '1-0', event },
+      onAck: () => {
+        didAck = true;
+      },
+      onDeadLetter: (stream, fields) => {
+        deadLetters.push({ stream, fields });
+      },
+      processed: new Set<string>(),
+    });
+
+    const { getEventBus } = await import('./index');
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, handler, { subscriberId: 'victim' });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 50 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(didAck).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0].stream).toMatch(/:dead-letter$/);
+    expect(deadLetters[0].fields.sourceMessageId).toBe('1-0');
+    expect(deadLetters[0].fields.deliveries).toBe('11');
+
+    await eventBus.close();
+  });
+
+  it('does not re-invoke a sibling handler that already succeeded when another handler fails', async () => {
+    const tenantId = randomUUID();
+    const eventType = 'UNKNOWN';
+    const event = {
+      id: randomUUID(),
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: { tenantId },
+    };
+
+    const succeeding = vi.fn(async () => undefined);
+    let failures = 0;
+    const failingOnce = vi.fn(async () => {
+      failures += 1;
+      if (failures === 1) {
+        throw new Error('transient failure');
+      }
+    });
+
+    let didAck = false;
+
+    mockRedisModule({
+      // two delivery rounds: first fails one handler, second succeeds
+      pendingRounds: [{ deliveriesCounter: 1 }, { deliveriesCounter: 2 }],
+      message: { id: '2-0', event },
+      onAck: () => {
+        didAck = true;
+      },
+      onDeadLetter: () => undefined,
+      processed: new Set<string>(),
+    });
+
+    const { getEventBus } = await import('./index');
+    const eventBus = getEventBus();
+    await eventBus.subscribe(eventType as any, succeeding, { subscriberId: 'sibling-ok' });
+    await eventBus.subscribe(eventType as any, failingOnce, { subscriberId: 'sibling-flaky' });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 100 && !didAck; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks(10);
+    }
+
+    expect(didAck).toBe(true);
+    // The succeeded sibling ran exactly once; only the failed handler retried.
+    expect(succeeding).toHaveBeenCalledTimes(1);
+    expect(failingOnce).toHaveBeenCalledTimes(2);
+
+    await eventBus.close();
+  });
+});

--- a/server/src/lib/eventBus/index.ts
+++ b/server/src/lib/eventBus/index.ts
@@ -176,6 +176,10 @@ export class EventBus {
   private static createdConsumerGroups: Set<string> = new Set<string>();
   // Map<EventType, Map<Channel, Handlers>> so channel-specific consumers do not step on each other.
   private handlers: Map<EventType, Map<string, Set<EventHandler>>>;
+  // Stable per-handler ids for per-(event, handler) processed tracking.
+  // Subscribers sharing a stream with same-named handlers must pass an
+  // explicit subscriberId to disambiguate (e.g. sla vs survey TICKET_CLOSED).
+  private handlerIds: WeakMap<EventHandler, string> = new WeakMap();
   private initialized: boolean = false;
   private consumerName: string;
   private processingEvents: boolean = false;
@@ -304,6 +308,28 @@ export class EventBus {
     const client = await getClient();
     const setKey = this.getProcessedSetKey(event.payload.tenantId);
     await client.sAdd(setKey, event.id);
+    // Set expiration to prevent unbounded growth (3 days)
+    await client.expire(setKey, 60 * 60 * 24 * 3);
+  }
+
+  private getHandlerKey(handler: EventHandler): string {
+    return this.handlerIds.get(handler) || handler.name || 'anonymous';
+  }
+
+  private getProcessedHandlersSetKey(tenantId: string): string {
+    return `processed_event_handlers:${tenantId}`;
+  }
+
+  private async isHandlerProcessed(event: Event, handlerKey: string): Promise<boolean> {
+    const client = await getClient();
+    const setKey = this.getProcessedHandlersSetKey(event.payload.tenantId);
+    return await client.sIsMember(setKey, `${event.id}:${handlerKey}`);
+  }
+
+  private async markHandlerProcessed(event: Event, handlerKey: string): Promise<void> {
+    const client = await getClient();
+    const setKey = this.getProcessedHandlersSetKey(event.payload.tenantId);
+    await client.sAdd(setKey, `${event.id}:${handlerKey}`);
     // Set expiration to prevent unbounded growth (3 days)
     await client.expire(setKey, 60 * 60 * 24 * 3);
   }
@@ -474,11 +500,18 @@ export class EventBus {
           // versions only ran the first handler, which silently dropped any
           // additional subscribers (e.g. webhooks vs. SLA both listening on
           // TICKET_COMMENT_ADDED:global). Failures from one handler must not
-          // block the others.
+          // block the others, and success is tracked per (event, handler) so
+          // a redelivery caused by one failing handler never re-runs
+          // co-subscribers that already succeeded (e.g. outbound webhooks).
           let anyFailure = false;
           for (const handler of handlers) {
+            const handlerKey = this.getHandlerKey(handler);
             try {
+              if (await this.isHandlerProcessed(event, handlerKey)) {
+                continue;
+              }
               await handler(event);
+              await this.markHandlerProcessed(event, handlerKey);
             } catch (error) {
               anyFailure = true;
               logger.error('[EventBus] Error in event handler:', {
@@ -558,9 +591,16 @@ export class EventBus {
           );
 
           if (pendingMessages && pendingMessages.length > 0) {
-            const claimIds = pendingMessages
-              .filter(msg => msg.millisecondsSinceLastDelivery > config.eventBus.claimTimeout)
-              .map(msg => msg.id);
+            const stalePending = pendingMessages.filter(
+              msg => msg.millisecondsSinceLastDelivery > config.eventBus.claimTimeout
+            );
+            // Fresh xReadGroup deliveries carry no delivery counter, but
+            // xPendingRange does — enforce the dead-letter cap here so no
+            // message can redeliver forever.
+            const deliveriesById = new Map(
+              stalePending.map(msg => [msg.id, msg.deliveriesCounter])
+            );
+            const claimIds = stalePending.map(msg => msg.id);
 
             if (claimIds.length > 0) {
               const claimed = await client.xClaim(
@@ -574,6 +614,11 @@ export class EventBus {
               const subscription = subscriptionLookup.get(stream);
               if (subscription && Array.isArray(claimed) && claimed.length > 0) {
                 for (const message of claimed as Array<{ id: string; message: Record<string, string> }>) {
+                  const deliveries = deliveriesById.get(message.id) ?? 0;
+                  if (deliveries > config.eventBus.maxDeliveries) {
+                    await this.deadLetterMessage(client, config, stream, message, deliveries);
+                    continue;
+                  }
                   await this.processStreamMessage(client, config, stream, subscription, message);
                 }
               }
@@ -586,16 +631,77 @@ export class EventBus {
     }
   }
 
+  /**
+   * Move a message that exceeded the delivery cap onto the stream's
+   * dead-letter sibling and ack it so it stops storming the consumer group.
+   * Dead-letter volume should be monitored; entries carry the original
+   * payload for manual inspection/replay.
+   */
+  private async deadLetterMessage(
+    client: Awaited<ReturnType<typeof createRedisClient>>,
+    config: ReturnType<typeof getRedisConfig>,
+    stream: string,
+    message: { id: string; message: Record<string, string> },
+    deliveries: number
+  ): Promise<void> {
+    const deadLetterStream = `${stream}:dead-letter`;
+    // Marker set makes the xAdd idempotent: if a previous attempt wrote the
+    // dead-letter entry but failed to ack, the retry only re-acks instead of
+    // writing a duplicate entry.
+    const markerKey = `dead_lettered_messages:${stream}`;
+    try {
+      if (!(await client.sIsMember(markerKey, message.id))) {
+        await client.xAdd(
+          deadLetterStream,
+          '*',
+          {
+            ...message.message,
+            sourceStream: stream,
+            sourceMessageId: message.id,
+            deliveries: String(deliveries),
+            deadLetteredAt: new Date().toISOString()
+          },
+          {
+            TRIM: {
+              strategy: 'MAXLEN',
+              threshold: config.eventBus.maxStreamLength,
+              strategyModifier: '~'
+            }
+          }
+        );
+        await client.sAdd(markerKey, message.id);
+        await client.expire(markerKey, 60 * 60 * 24 * 3);
+      }
+      await client.xAck(stream, config.eventBus.consumerGroup, message.id);
+      logger.error('[EventBus] Dead-lettered message after exceeding max deliveries', {
+        stream,
+        deadLetterStream,
+        messageId: message.id,
+        deliveries,
+        maxDeliveries: config.eventBus.maxDeliveries
+      });
+    } catch (error) {
+      logger.error('[EventBus] Failed to dead-letter message', {
+        stream,
+        messageId: message.id,
+        error
+      });
+    }
+  }
+
   public async subscribe(
     eventType: EventType,
     handler: EventHandler,
-    options?: { channel?: string }
+    options?: { channel?: string; subscriberId?: string }
   ): Promise<void> {
     await this.initialize();
 
     const channel = options?.channel || this.defaultChannel;
     const handlers = this.getChannelHandlers(eventType, channel, true)!;
     handlers.add(handler);
+    if (options?.subscriberId) {
+      this.handlerIds.set(handler, options.subscriberId);
+    }
 
     const stream = this.getStreamKey(eventType, channel);
     await this.ensureStreamAndGroup(stream);

--- a/server/src/lib/eventBus/subscribers/slaSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/slaSubscriber.ts
@@ -29,7 +29,9 @@ import {
   recordFirstResponse,
   recordResolution,
   handlePriorityChange,
-  handlePolicyChange
+  handlePolicyChange,
+  dispatchSlaBackendActions,
+  type SlaBackendAction
 } from '@alga-psa/sla';
 import {
   handleStatusChange,
@@ -44,11 +46,14 @@ export async function registerSlaSubscriber(): Promise<void> {
     return;
   }
 
-  await getEventBus().subscribe('TICKET_CREATED', handleTicketCreatedEvent);
-  await getEventBus().subscribe('TICKET_UPDATED', handleTicketUpdatedEvent);
-  await getEventBus().subscribe('TICKET_CLOSED', handleTicketClosedEvent);
-  await getEventBus().subscribe('TICKET_COMMENT_ADDED', handleTicketCommentAddedEvent);
-  await getEventBus().subscribe('TICKET_RESPONSE_STATE_CHANGED', handleResponseStateChangedEvent);
+  // subscriberId disambiguates per-(event, handler) processed tracking from
+  // other subscribers on the same default-channel streams (survey/webhook
+  // handlers share function names like handleTicketClosedEvent).
+  await getEventBus().subscribe('TICKET_CREATED', handleTicketCreatedEvent, { subscriberId: 'sla' });
+  await getEventBus().subscribe('TICKET_UPDATED', handleTicketUpdatedEvent, { subscriberId: 'sla' });
+  await getEventBus().subscribe('TICKET_CLOSED', handleTicketClosedEvent, { subscriberId: 'sla' });
+  await getEventBus().subscribe('TICKET_COMMENT_ADDED', handleTicketCommentAddedEvent, { subscriberId: 'sla' });
+  await getEventBus().subscribe('TICKET_RESPONSE_STATE_CHANGED', handleResponseStateChangedEvent, { subscriberId: 'sla' });
 
   isRegistered = true;
   logger.info('[SlaSubscriber] Registered SLA event handlers');
@@ -82,54 +87,69 @@ async function handleTicketCreatedEvent(event: unknown): Promise<void> {
     await runWithTenant(tenantId, async () => {
       const { knex } = await createTenantKnex();
 
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
-        // The TICKET_CREATED event is published inside the creation
-        // transaction, so the row may not be visible yet on a separate
-        // connection. Wait briefly for the transaction to commit.
-        await new Promise(resolve => setTimeout(resolve, 500));
-
-        const ticket = await trx('tickets')
+      // The main creation paths publish TICKET_CREATED after their
+      // transaction commits, so the row is normally visible immediately.
+      // Some paths still publish in-transaction; retry the read briefly
+      // (outside any transaction, so no locks are held while waiting).
+      let ticket: { client_id: string; board_id: string; priority_id: string; entered_at: string | Date | null } | undefined;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        if (attempt > 0) {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+        ticket = await knex('tickets')
           .where({ tenant: tenantId, ticket_id: ticketId })
           .select('client_id', 'board_id', 'priority_id', 'entered_at')
           .first();
-
-        if (!ticket) {
-          logger.warn('[SlaSubscriber] Ticket not found for TICKET_CREATED', { tenantId, ticketId });
-          return;
+        if (ticket) {
+          break;
         }
+      }
 
-        const result = await startSlaForTicket(
+      if (!ticket) {
+        // Throw so the bus redelivers (bounded by maxDeliveries, then
+        // dead-letter) instead of acking and silently never starting SLA.
+        // Genuinely deleted tickets end up in the dead-letter stream.
+        throw new Error(`Ticket not found for TICKET_CREATED: ${ticketId}`);
+      }
+      const createdTicket = ticket;
+
+      const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const startResult = await startSlaForTicket(
           trx,
           tenantId,
           ticketId,
-          ticket.client_id,
-          ticket.board_id,
-          ticket.priority_id,
-          ticket.entered_at ? new Date(ticket.entered_at) : new Date()
+          createdTicket.client_id,
+          createdTicket.board_id,
+          createdTicket.priority_id,
+          createdTicket.entered_at ? new Date(createdTicket.entered_at) : new Date()
         );
 
-        if (result.success && result.sla_policy_id) {
+        if (startResult.success && startResult.sla_policy_id) {
           logger.info('[SlaSubscriber] Started SLA tracking for ticket', {
             tenantId,
             ticketId,
-            policyId: result.sla_policy_id,
-            responseDueAt: result.sla_response_due_at?.toISOString(),
-            resolutionDueAt: result.sla_resolution_due_at?.toISOString()
+            policyId: startResult.sla_policy_id,
+            responseDueAt: startResult.sla_response_due_at?.toISOString(),
+            resolutionDueAt: startResult.sla_resolution_due_at?.toISOString()
           });
-        } else if (!result.success) {
+        } else if (!startResult.success) {
           logger.error('[SlaSubscriber] Failed to start SLA tracking', {
             tenantId,
             ticketId,
-            error: result.error
+            error: startResult.error
           });
         }
         // If no policy assigned, that's normal - just log at debug level
+        return startResult;
       });
+
+      await dispatchSlaBackendActions(result?.backendActions);
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_CREATED event', {
       error: error instanceof Error ? error.message : 'Unknown error'
     });
+    throw error;
   }
 }
 
@@ -150,7 +170,9 @@ async function handleTicketUpdatedEvent(event: unknown): Promise<void> {
     await runWithTenant(tenantId, async () => {
       const { knex } = await createTenantKnex();
 
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
+      const backendActions = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const collected: SlaBackendAction[] = [];
+
         // Handle priority change
         if (changes.priority_id) {
           const priorityChange = changes.priority_id as { old?: string; new?: string };
@@ -161,13 +183,14 @@ async function handleTicketUpdatedEvent(event: unknown): Promise<void> {
               newPriorityId: priorityChange.new
             });
 
-            await handlePriorityChange(
+            const priorityResult = await handlePriorityChange(
               trx,
               tenantId,
               ticketId,
               priorityChange.new,
               userId
             );
+            collected.push(...priorityResult.backendActions);
           }
         }
 
@@ -190,6 +213,7 @@ async function handleTicketUpdatedEvent(event: unknown): Promise<void> {
               statusChange.new,
               userId
             );
+            collected.push(...(result.backendActions ?? []));
 
             if (result.was_paused !== result.is_now_paused) {
               logger.info('[SlaSubscriber] SLA pause state changed', {
@@ -213,16 +237,21 @@ async function handleTicketUpdatedEvent(event: unknown): Promise<void> {
               toPolicyId: policyChange.new
             });
 
-            await handlePolicyChange(
+            const policyResult = await handlePolicyChange(
               trx,
               tenantId,
               ticketId,
               policyChange.new ?? null,
               userId
             );
+            collected.push(...policyResult.backendActions);
           }
         }
+
+        return collected;
       });
+
+      await dispatchSlaBackendActions(backendActions);
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_UPDATED event', {
@@ -241,7 +270,7 @@ async function handleTicketClosedEvent(event: unknown): Promise<void> {
   logger.info('[SlaSubscriber] Handling TICKET_CLOSED', { tenantId, ticketId });
 
   try {
-    await withTenantTransactionRetryReadOnly(tenantId, async (trx: Knex.Transaction) => {
+    const result = await withTenantTransactionRetryReadOnly(tenantId, async (trx: Knex.Transaction) => {
       // Get the closed_at time from the ticket
       const ticket = await trx('tickets')
         .where({ tenant: tenantId, ticket_id: ticketId })
@@ -250,7 +279,7 @@ async function handleTicketClosedEvent(event: unknown): Promise<void> {
 
       const closedAt = ticket?.closed_at ? new Date(ticket.closed_at) : new Date();
 
-      const result = await recordResolution(
+      const resolutionResult = await recordResolution(
         trx,
         tenantId,
         ticketId,
@@ -258,31 +287,33 @@ async function handleTicketClosedEvent(event: unknown): Promise<void> {
         userId
       );
 
-      if (result.success && result.met !== null) {
+      if (resolutionResult.success && resolutionResult.met !== null) {
         logger.info('[SlaSubscriber] Recorded ticket resolution', {
           tenantId,
           ticketId,
-          met: result.met,
-          resolvedAt: result.recorded_at.toISOString()
+          met: resolutionResult.met,
+          resolvedAt: resolutionResult.recorded_at.toISOString()
         });
-        return;
+        return resolutionResult;
       }
 
-      if (result.success && result.met === null) {
+      if (resolutionResult.success && resolutionResult.met === null) {
         logger.info('[SlaSubscriber] TICKET_CLOSED handled but no SLA tracked', {
           tenantId,
           ticketId
         });
-        return;
+        return resolutionResult;
       }
 
       logger.error('[SlaSubscriber] recordResolution returned failure', {
         tenantId,
         ticketId,
-        error: result.error
+        error: resolutionResult.error
       });
-      throw new Error(result.error || 'recordResolution failed');
+      throw new Error(resolutionResult.error || 'recordResolution failed');
     });
+
+    await runWithTenant(tenantId, () => dispatchSlaBackendActions(result.backendActions));
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_CLOSED event', {
       tenantId,
@@ -320,8 +351,8 @@ async function handleTicketCommentAddedEvent(event: unknown): Promise<void> {
     await runWithTenant(tenantId, async () => {
       const { knex } = await createTenantKnex();
 
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
-        const result = await recordFirstResponse(
+      const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const responseResult = await recordFirstResponse(
           trx,
           tenantId,
           ticketId,
@@ -329,15 +360,19 @@ async function handleTicketCommentAddedEvent(event: unknown): Promise<void> {
           userId
         );
 
-        if (result.success && result.met !== null) {
+        if (responseResult.success && responseResult.met !== null) {
           logger.info('[SlaSubscriber] Recorded first response', {
             tenantId,
             ticketId,
-            met: result.met,
-            respondedAt: result.recorded_at.toISOString()
+            met: responseResult.met,
+            respondedAt: responseResult.recorded_at.toISOString()
           });
         }
+
+        return responseResult;
       });
+
+      await dispatchSlaBackendActions(result.backendActions);
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_COMMENT_ADDED event', {
@@ -395,8 +430,8 @@ async function handleResponseStateChangedEvent(event: unknown): Promise<void> {
         return;
       }
 
-      await withTransaction(knex, async (trx: Knex.Transaction) => {
-        const result = await handleResponseStateChange(
+      const result = await withTransaction(knex, async (trx: Knex.Transaction) => {
+        const changeResult = await handleResponseStateChange(
           trx,
           tenantId,
           ticketId,
@@ -405,15 +440,19 @@ async function handleResponseStateChangedEvent(event: unknown): Promise<void> {
           userId ?? undefined
         );
 
-        if (result.was_paused !== result.is_now_paused) {
+        if (changeResult.was_paused !== changeResult.is_now_paused) {
           logger.info('[SlaSubscriber] SLA pause state changed due to response state', {
             tenantId,
             ticketId,
-            wasPaused: result.was_paused,
-            isNowPaused: result.is_now_paused
+            wasPaused: changeResult.was_paused,
+            isNowPaused: changeResult.is_now_paused
           });
         }
+
+        return changeResult;
       });
+
+      await dispatchSlaBackendActions(result.backendActions);
     });
   } catch (error) {
     logger.error('[SlaSubscriber] Failed to handle TICKET_RESPONSE_STATE_CHANGED event', {

--- a/server/src/lib/eventBus/subscribers/surveySubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/surveySubscriber.ts
@@ -28,8 +28,8 @@ export async function registerSurveySubscriber(): Promise<void> {
     return;
   }
 
-  await getEventBus().subscribe('TICKET_CLOSED', handleTicketClosedEvent);
-  await getEventBus().subscribe('PROJECT_CLOSED', handleProjectClosedEvent);
+  await getEventBus().subscribe('TICKET_CLOSED', handleTicketClosedEvent, { subscriberId: 'survey' });
+  await getEventBus().subscribe('PROJECT_CLOSED', handleProjectClosedEvent, { subscriberId: 'survey' });
   isRegistered = true;
   logger.info('[SurveySubscriber] Registered survey event handlers');
 }

--- a/server/src/lib/eventBus/subscribers/webhookSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/webhookSubscriber.ts
@@ -29,7 +29,7 @@ export async function registerWebhookSubscriber(): Promise<void> {
   }
 
   for (const eventType of WEBHOOK_TICKET_EVENT_TYPES) {
-    await getEventBus().subscribe(eventType, handleTicketEvent);
+    await getEventBus().subscribe(eventType, handleTicketEvent, { subscriberId: 'webhook' });
   }
 
   isRegistered = true;

--- a/server/src/test/unit/sla/slaSubscriber.test.ts
+++ b/server/src/test/unit/sla/slaSubscriber.test.ts
@@ -9,6 +9,7 @@ const loggerMock = vi.hoisted(() => ({
 
 const withTenantTransactionRetryReadOnlyMock = vi.hoisted(() => vi.fn());
 const recordResolutionMock = vi.hoisted(() => vi.fn());
+const dispatchSlaBackendActionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@alga-psa/core/logger', () => ({
   default: loggerMock,
@@ -16,7 +17,7 @@ vi.mock('@alga-psa/core/logger', () => ({
 
 vi.mock('@alga-psa/db', () => ({
   createTenantKnex: vi.fn(),
-  runWithTenant: vi.fn(),
+  runWithTenant: vi.fn(async (_tenantId: string, fn: () => Promise<unknown>) => fn()),
   withTransaction: vi.fn(),
   withTenantTransactionRetryReadOnly: (
     tenantId: string,
@@ -32,6 +33,7 @@ vi.mock('@alga-psa/sla', () => ({
   handlePolicyChange: vi.fn(),
   handleStatusChange: vi.fn(),
   handleResponseStateChange: vi.fn(),
+  dispatchSlaBackendActions: (...args: unknown[]) => dispatchSlaBackendActionsMock(...args),
 }));
 
 import { __testHooks } from '../../../lib/eventBus/subscribers/slaSubscriber';
@@ -61,6 +63,7 @@ describe('slaSubscriber TICKET_CLOSED handling', () => {
     loggerMock.debug.mockReset();
     recordResolutionMock.mockReset();
     withTenantTransactionRetryReadOnlyMock.mockReset();
+    dispatchSlaBackendActionsMock.mockReset();
   });
 
   it('rethrows recordResolution failures so the event bus can retry', async () => {
@@ -93,5 +96,46 @@ describe('slaSubscriber TICKET_CLOSED handling', () => {
         error: 'transient failure',
       })
     );
+    // Nothing committed, so no backend action may be dispatched.
+    expect(dispatchSlaBackendActionsMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches backend actions only after the transaction resolves', async () => {
+    const trx = createClosedTicketTrx();
+    const callOrder: string[] = [];
+    withTenantTransactionRetryReadOnlyMock.mockImplementation(async (_tenantId, callback) => {
+      const result = await callback(trx);
+      callOrder.push('transaction-resolved');
+      return result;
+    });
+    dispatchSlaBackendActionsMock.mockImplementation(async () => {
+      callOrder.push('dispatch');
+    });
+
+    const backendActions = [
+      { kind: 'complete', ticketId: '00000000-0000-0000-0000-000000000003', type: 'resolution', met: true },
+    ];
+    recordResolutionMock.mockResolvedValue({
+      success: true,
+      met: true,
+      recorded_at: new Date('2026-04-28T22:24:44Z'),
+      backendActions,
+    });
+
+    const event = {
+      id: '00000000-0000-0000-0000-000000000005',
+      eventType: 'TICKET_CLOSED' as const,
+      timestamp: '2026-04-28T22:24:45Z',
+      payload: {
+        tenantId: '00000000-0000-0000-0000-000000000002',
+        ticketId: '00000000-0000-0000-0000-000000000003',
+        userId: '00000000-0000-0000-0000-000000000004',
+      },
+    };
+
+    await __testHooks.handleTicketClosedEvent(event);
+
+    expect(dispatchSlaBackendActionsMock).toHaveBeenCalledWith(backendActions);
+    expect(callOrder).toEqual(['transaction-resolved', 'dispatch']);
   });
 });


### PR DESCRIPTION
  The CE PgBoss SLA backend re-entered ticket writes on a second
  connection while the caller's transaction held the tickets row lock,
  self-deadlocking until pgbouncer reaped the session.

  - Make PgBossSlaBackend mutation hooks no-ops; SLA write functions now return backendActions that callers dispatch after commit
  - Add registerAfterCommit() to @alga-psa/db; ticket event publishes and SLA notification emails are deferred until the owning withTransaction frame commits (labeled for traceable failure logs)
  - Serialize per-ticket SLA writers with a transaction-scoped advisory lock (pg_advisory_xact_lock, pgbouncer-safe)
  - Event bus: run every subscribed handler, track success per (event, handler), and dead-letter messages after maxDeliveries with an idempotent marker so retries never duplicate DLQ entries
  - Defense in depth: app-role GUCs (idle_in_transaction 60s, lock_timeout 8s) plus pgbouncer reaper raised to 120s as last resort

  "You can't publish before you commit," said the White Rabbit, tapping
  pg_advisory_xact_lock against his pocket watch, "and any message that
  knocks more than ten times gets escorted down the dead-letter rabbit
  hole — no duplicates, we're quite idempotent here." 🐇⏱️ 💌