### PR TITLE
Fix QBO error code mapping for stale object and duplicate name

### DIFF
--- a/packages/integrations/src/lib/qbo/qboClientService.ts
+++ b/packages/integrations/src/lib/qbo/qboClientService.ts
@@ -540,9 +540,12 @@ export class QboClientService {
     if (qboError) {
       message += `: ${qboError.Message ?? 'Unknown QBO Error'} (Code: ${qboError.code ?? 'N/A'}, Detail: ${qboError.Detail ?? 'N/A'})`;
 
-      if (qboError.code === '6240') {
+      if (qboError.code === '5010') {
         code = 'QBO_STALE_OBJECT';
         message = `QBO ${entityType || 'entity'} has been updated since it was last read. Please refresh and try again. (SyncToken mismatch)`;
+      } else if (qboError.code === '6240') {
+        code = 'QBO_DUPLICATE_NAME';
+        message = `A QBO ${entityType || 'entity'} with this name already exists. Please use a different name. (Duplicate Name Exists)`;
       } else if (qboError.code?.startsWith('2')) {
         code = 'QBO_VALIDATION_ERROR';
       } else if (qboError.code?.startsWith('4') || qboError.code?.startsWith('5')) {


### PR DESCRIPTION
QBO error code 5010 is the stale object / SyncToken mismatch error, but it previously fell into the startsWith('5') branch and was mislabeled QBO_AUTH_ERROR. Code 6240 is "Duplicate Name Exists", but was mapped to QBO_STALE_OBJECT with SyncToken guidance.

Map 5010 to QBO_STALE_OBJECT (checked before the 5xxx auth branch) and 6240 to QBO_DUPLICATE_NAME with an accurate message.

https://claude.ai/code/session_01XWjaCGCvFnktM9pEEEcR2j