### PR TITLE
fix(portal): send client portal invitations via tenant custom domain

### DIFF
--- a/packages/portal-shared/src/actions/portalInvitationActions.ts
+++ b/packages/portal-shared/src/actions/portalInvitationActions.ts
@@ -3,6 +3,7 @@
 import { createTenantKnex, runWithTenant } from '@alga-psa/db';
 import { PortalInvitationService } from '../services/PortalInvitationService';
 import { getTenantSlugForTenant } from '@alga-psa/db';
+import { getPortalDomainStatusForTenant } from '@alga-psa/tenancy/server';
 import { getSystemEmailService, TenantEmailService, sendPortalInvitationEmail } from '@alga-psa/email';
 import { UserService } from '@alga-psa/users';
 import { runAsSystem, createSystemContext } from '@alga-psa/db';
@@ -417,8 +418,21 @@ export const sendPortalInvitation = withAuth(async (
 
       const tenantSlug = await getTenantSlugForTenant(tenant);
 
+      // Prefer the tenant's active custom portal domain (vanity host) so the
+      // invitation lands on the host the client portal is served from.
+      let vanityBaseUrl = '';
+      try {
+        const portalDomain = await getPortalDomainStatusForTenant(tenant);
+        if (portalDomain.status === 'active' && portalDomain.domain) {
+          vanityBaseUrl = `https://${portalDomain.domain}`;
+        }
+      } catch (domainError) {
+        console.warn('Failed to resolve custom portal domain for invitation link:', domainError);
+      }
+
       // Generate portal setup URL with robust base URL fallback
       const baseUrl =
+        vanityBaseUrl ||
         process.env.NEXT_PUBLIC_BASE_URL ||
         process.env.NEXTAUTH_URL ||
         (process.env.HOST ? `https://${process.env.HOST}` : '');


### PR DESCRIPTION
## Summary
- Client portal invitation emails always built their setup link from the global `NEXT_PUBLIC_BASE_URL`/`NEXTAUTH_URL`, ignoring the tenant's active custom portal domain (`portal_domains`).
- `sendPortalInvitation` now resolves the tenant's portal domain via `getPortalDomainStatusForTenant` and, when status is `active`, builds the invitation link as `https://<custom-domain>/auth/portal/setup?token=…&tenant=…`. Falls back to the existing env-based base URL otherwise.
- Matches the established pattern already used by `notificationLinkResolver` and `getTenantPortalLoginLink`.

Fixes ticket alga0001972 (Shift Left Security: invitation email not using custom domain; customers couldn't set a password from the manually shared signin URL).

## Verification
- `tsc --noEmit` and `tsup` build pass for `@alga-psa/portal-shared`.
- Code-traced the custom-domain flow: middleware passes `/auth/portal/setup` through on vanity hosts, token verification derives tenant from the token (host-independent), and post-setup auto sign-in works on the vanity host (`trustHost: true`, host-scoped cookies) with the canonical signin redirect as fallback.