### PR TITLE
fix(licensing): fresh installs aren't 'Trial Expired' + immediate session tier refresh

### DIFF
--- a/packages/licensing/src/lib/license-state.test.ts
+++ b/packages/licensing/src/lib/license-state.test.ts
@@ -87,7 +87,9 @@ describe('resolveSelfHostTier', () => {
     // with no trial and no license.
     const result = resolveSelfHostTier(makeRow({ edition_choice: 'ee' }));
     expect(result?.tier).toBe('essentials');
-    expect(result?.state).toBe('trial_expired');
+    // Fresh ee install with no trial used: trial_available, NOT trial_expired —
+    // the expired state (and its banner) is reserved for an actually-elapsed trial.
+    expect(result?.state).toBe('trial_available');
   });
 
   it('license takes precedence over an active trial', () => {

--- a/packages/licensing/src/lib/license-state.ts
+++ b/packages/licensing/src/lib/license-state.ts
@@ -34,6 +34,7 @@ export interface LicenseStateRow {
 /** Derived licensing state for an install. */
 export type LicenseStateKind =
   | 'ce'            // Community Edition chosen — always essentials
+  | 'trial_available' // EE install, no license, trial not yet used — essentials, trial can be started
   | 'trial'         // Enterprise trial active
   | 'trial_expired' // Trial window elapsed, no license
   | 'licensed'      // Valid unexpired license present
@@ -163,7 +164,9 @@ export function resolveSelfHostTier(
   }
 
   // 4. EE chosen but no trial started yet — essentials until trial starts.
-  return { state: 'trial_expired', tier: 'essentials', expiresAt: null, daysRemaining: null };
+  // Distinct from trial_expired: a fresh install has NOT used its trial, and
+  // surfacing it as "expired" (banner + License page) misleads on day one.
+  return { state: 'trial_available', tier: 'essentials', expiresAt: null, daysRemaining: null };
 }
 
 /**

--- a/server/src/components/licenses/LicenseBanner.tsx
+++ b/server/src/components/licenses/LicenseBanner.tsx
@@ -42,6 +42,11 @@ export default function LicenseBanner() {
         urgency = 'info';
       }
       break;
+    case 'trial_available':
+      // Fresh install, trial not yet used — invite, don't warn.
+      message = 'Running Essentials features. Start a free 30-day Enterprise trial to unlock all features.';
+      urgency = 'info';
+      break;
     case 'trial_expired':
       message = 'Enterprise trial has expired. The install is now running Essentials features.';
       urgency = 'warning';

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useTransition } from 'react';
+import { useSession } from 'next-auth/react';
 import { getLicenseStatus, submitLicense, startTrial, connectAppliance } from '@/lib/actions/licenseManagementActions';
 import type { LicenseStatus } from '@/lib/actions/licenseManagementActions';
 
@@ -20,6 +21,7 @@ export default function LicenseManagementPage() {
   const [error, setError] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const { update: updateSession } = useSession();
 
   useEffect(() => {
     getLicenseStatus().then((s) => { setStatus(s); setLoading(false); });
@@ -28,6 +30,10 @@ export default function LicenseManagementPage() {
   function refresh(newStatus: LicenseStatus) {
     setStatus(newStatus);
     setError(null);
+    // The session JWT caches effectiveTier and only re-resolves it every
+    // 5 minutes (PLAN_CHECK_INTERVAL) — force a refresh so tier-gated features
+    // react to the license change immediately instead of after re-login/poll.
+    void updateSession();
   }
 
   function handleSubmitLicense() {
@@ -91,6 +97,7 @@ export default function LicenseManagementPage() {
 
   const stateLabelMap: Record<string, string> = {
     ce: 'Community Edition (Essentials)',
+    trial_available: 'Essentials — Enterprise Trial Available',
     trial: 'Enterprise Trial',
     trial_expired: 'Trial Expired — Essentials',
     licensed: 'Licensed',


### PR DESCRIPTION
Two self-host trial UX fixes found while assessing whether the essentials→trial journey is adequately tested (full VM smoke of that journey happening next, will report results there).

## 1. `trial_available` state for fresh installs

An EE install that never started its trial resolved to `trial_expired` (license-state case 4), so a **day-one essentials box** showed:
- the app-wide warning banner *“Enterprise trial has expired. The install is now running Essentials features.”*
- License page status *“Trial Expired — Essentials”*

Now: new `trial_available` state → info banner *“Running Essentials features. Start a free 30-day Enterprise trial to unlock all features.”* + label *“Essentials — Enterprise Trial Available”*. `trial_expired` (and its warning banner) is reserved for an actually-elapsed trial.

`LicenseStatus.state` types flow through from `LicenseStateKind`, and the only state consumers are the License page label map and `LicenseBanner` — both updated. `canStartTrial` already keyed off `trialUsed`/`licensed`, unchanged.

## 2. Immediate session tier refresh on license changes

`user.effectiveTier` is stamped into the NextAuth JWT and only re-resolved every **5 minutes** (`PLAN_CHECK_INTERVAL`), so starting a trial (or activating/connecting a license) left tier-gated features stale for up to 5 minutes or until re-login. The License page now calls `useSession().update()` after every successful license-state mutation — that's the existing `trigger === 'update'` force-refresh path in the jwt callback. (`/msp` is wrapped in `SessionProvider` via `MspLayoutClient`.)

## Tests

`packages/licensing`: 22/22 vitest, `tsc --noEmit` clean. The fresh-install assertion updated to expect `trial_available`; the elapsed-trial case still asserts `trial_expired`.