### PR TITLE
Auth-wrap contract-line routes; extend OpenAPI

### DIFF
--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -167,6 +167,9 @@
       "name": "Workflow Definitions"
     },
     {
+      "name": "Workflow Registry"
+    },
+    {
       "name": "Workflow Runs"
     },
     {
@@ -239,9 +242,6 @@
       "name": "platform-reports"
     },
     {
-      "name": "projects"
-    },
-    {
       "name": "public"
     },
     {
@@ -264,9 +264,6 @@
     },
     {
       "name": "webhooks"
-    },
-    {
-      "name": "workflow"
     }
   ],
   "components": {
@@ -12801,6 +12798,166 @@
         },
         "required": [
           "eventId"
+        ]
+      },
+      "WorkflowJsonSchemaDocument": {
+        "type": "object",
+        "additionalProperties": {},
+        "description": "A JSON Schema document."
+      },
+      "WorkflowRegistryAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable action identifier (e.g. \"ticket.create\")."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Action version."
+          },
+          "sideEffectful": {
+            "type": "boolean",
+            "description": "Whether executing the action mutates external state."
+          },
+          "retryHint": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Suggested retry policy, or null."
+          },
+          "idempotency": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Idempotency configuration for the action."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata (label, group, icon, etc.)."
+          },
+          "inputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action input, annotated with designer presentation metadata."
+              }
+            ]
+          },
+          "outputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action output."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example invocations, or null."
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "sideEffectful",
+          "retryHint",
+          "idempotency",
+          "ui",
+          "inputSchema",
+          "outputSchema",
+          "examples"
+        ]
+      },
+      "WorkflowRegistryNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Node type identifier."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata for the node."
+          },
+          "configSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the node configuration."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example configurations, or null."
+          },
+          "defaultRetry": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Default retry policy for the node, or null."
+          }
+        },
+        "required": [
+          "id",
+          "ui",
+          "configSchema",
+          "examples",
+          "defaultRetry"
+        ]
+      },
+      "WorkflowSchemaRefParam": {
+        "type": "object",
+        "properties": {
+          "schemaRef": {
+            "type": "string",
+            "description": "Registered schema reference; URL-encode it in the path."
+          }
+        },
+        "required": [
+          "schemaRef"
+        ]
+      },
+      "WorkflowSchemaResponse": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "The resolved schema reference."
+          },
+          "schema": {
+            "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+          }
+        },
+        "required": [
+          "ref",
+          "schema"
         ]
       },
       "FileDownloadParams": {
@@ -56085,6 +56242,414 @@
           },
           "404": {
             "description": "Event not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/actions": {
+      "get": {
+        "summary": "List workflow registry actions",
+        "description": "Lists every action registered in the workflow runtime — the building blocks workflow definitions can invoke — including JSON Schemas for each action's input and output. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered actions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryAction"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/nodes": {
+      "get": {
+        "summary": "List workflow registry node types",
+        "description": "Lists the node types available to workflow definitions (triggers, control flow, action nodes, etc.) with each node's configuration JSON Schema and default retry policy. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered node types.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryNode"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/designer-catalog": {
+      "get": {
+        "summary": "Get the workflow designer action catalog",
+        "description": "Returns the action catalog the workflow designer renders: registry actions and integration modules grouped into tiles, filtered to the integrations actually available to the tenant. Returns a bare array of catalog records (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Designer catalog tiles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Catalog tile (groupKey, tileKind, actions, UI metadata)."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/schemas/{schemaRef}": {
+      "get": {
+        "summary": "Get a workflow schema by ref",
+        "description": "Resolves a registered workflow schema reference (URL-encoded) to its JSON Schema document.",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Registered schema reference; URL-encode it in the path."
+            },
+            "required": true,
+            "description": "Registered schema reference; URL-encode it in the path.",
+            "name": "schemaRef",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolved schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowSchemaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown schema ref.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects": {
+      "get": {
+        "summary": "List projects",
+        "description": "Lists all projects for the tenant. Returns a bare array of project records (no envelope); responds 403 with an error message when the caller lacks project read permission.",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "project",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Projects for the tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Project record."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
             "content": {
               "application/json": {
                 "schema": {
@@ -100727,54 +101292,6 @@
         }
       }
     },
-    "/api/projects": {
-      "get": {
-        "summary": "GET projects",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "projects"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/public/appointment-request": {
       "post": {
         "summary": "POST public",
@@ -107256,198 +107773,6 @@
         },
         "responses": {
           "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/actions": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/designer-catalog": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/nodes": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/schemas/{schemaRef}": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -59,6 +59,7 @@ tags:
   - name: Webhooks
   - name: Work Management v1
   - name: Workflow Definitions
+  - name: Workflow Registry
   - name: Workflow Runs
   - name: Workflows v1
   - name: accounting
@@ -83,7 +84,6 @@ tags:
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
-  - name: projects
   - name: public
   - name: secrets
   - name: share
@@ -92,7 +92,6 @@ tags:
   - name: tenant-management
   - name: tickets
   - name: webhooks
-  - name: workflow
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -9005,6 +9004,116 @@ components:
           type: string
       required:
         - eventId
+    WorkflowJsonSchemaDocument:
+      type: object
+      additionalProperties: {}
+      description: A JSON Schema document.
+    WorkflowRegistryAction:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Stable action identifier (e.g. "ticket.create").
+        version:
+          type: integer
+          description: Action version.
+        sideEffectful:
+          type: boolean
+          description: Whether executing the action mutates external state.
+        retryHint:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Suggested retry policy, or null.
+        idempotency:
+          type: object
+          additionalProperties: {}
+          description: Idempotency configuration for the action.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata (label, group, icon, etc.).
+        inputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action input, annotated with designer
+                presentation metadata.
+        outputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action output.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example invocations, or null.
+      required:
+        - id
+        - version
+        - sideEffectful
+        - retryHint
+        - idempotency
+        - ui
+        - inputSchema
+        - outputSchema
+        - examples
+    WorkflowRegistryNode:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Node type identifier.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata for the node.
+        configSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the node configuration.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example configurations, or null.
+        defaultRetry:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Default retry policy for the node, or null.
+      required:
+        - id
+        - ui
+        - configSchema
+        - examples
+        - defaultRetry
+    WorkflowSchemaRefParam:
+      type: object
+      properties:
+        schemaRef:
+          type: string
+          description: Registered schema reference; URL-encode it in the path.
+      required:
+        - schemaRef
+    WorkflowSchemaResponse:
+      type: object
+      properties:
+        ref:
+          type: string
+          description: The resolved schema reference.
+        schema:
+          $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+      required:
+        - ref
+        - schema
     FileDownloadParams:
       type: object
       properties:
@@ -37749,6 +37858,267 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Event not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/actions:
+    get:
+      summary: List workflow registry actions
+      description: Lists every action registered in the workflow runtime — the
+        building blocks workflow definitions can invoke — including JSON Schemas
+        for each action's input and output. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered actions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryAction"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/nodes:
+    get:
+      summary: List workflow registry node types
+      description: Lists the node types available to workflow definitions (triggers,
+        control flow, action nodes, etc.) with each node's configuration JSON
+        Schema and default retry policy. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered node types.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryNode"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/designer-catalog:
+    get:
+      summary: Get the workflow designer action catalog
+      description: "Returns the action catalog the workflow designer renders: registry
+        actions and integration modules grouped into tiles, filtered to the
+        integrations actually available to the tenant. Returns a bare array of
+        catalog records (no envelope)."
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Designer catalog tiles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Catalog tile (groupKey, tileKind, actions, UI metadata).
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/schemas/{schemaRef}:
+    get:
+      summary: Get a workflow schema by ref
+      description: Resolves a registered workflow schema reference (URL-encoded) to
+        its JSON Schema document.
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Registered schema reference; URL-encode it in the path.
+          required: true
+          description: Registered schema reference; URL-encode it in the path.
+          name: schemaRef
+          in: path
+      responses:
+        "200":
+          description: Resolved schema.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowSchemaResponse"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Unknown schema ref.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/projects:
+    get:
+      summary: List projects
+      description: Lists all projects for the tenant. Returns a bare array of project
+        records (no envelope); responds 403 with an error message when the
+        caller lacks project read permission.
+      tags:
+        - Projects
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: project
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Projects for the tenant.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Project record.
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
           content:
             application/json:
               schema:
@@ -66897,37 +67267,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/projects:
-    get:
-      summary: GET projects
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - projects
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/public/appointment-request:
     post:
       summary: POST public
@@ -71136,130 +71475,6 @@ paths:
             description: Placeholder request body
       responses:
         "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/actions:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/designer-catalog:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/nodes:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/schemas/{schemaRef}:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
           description: Placeholder success response
           content:
             application/json:

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -167,6 +167,9 @@
       "name": "Workflow Definitions"
     },
     {
+      "name": "Workflow Registry"
+    },
+    {
       "name": "Workflow Runs"
     },
     {
@@ -242,9 +245,6 @@
       "name": "platform-reports"
     },
     {
-      "name": "projects"
-    },
-    {
       "name": "public"
     },
     {
@@ -267,9 +267,6 @@
     },
     {
       "name": "webhooks"
-    },
-    {
-      "name": "workflow"
     }
   ],
   "components": {
@@ -12804,6 +12801,166 @@
         },
         "required": [
           "eventId"
+        ]
+      },
+      "WorkflowJsonSchemaDocument": {
+        "type": "object",
+        "additionalProperties": {},
+        "description": "A JSON Schema document."
+      },
+      "WorkflowRegistryAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable action identifier (e.g. \"ticket.create\")."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Action version."
+          },
+          "sideEffectful": {
+            "type": "boolean",
+            "description": "Whether executing the action mutates external state."
+          },
+          "retryHint": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Suggested retry policy, or null."
+          },
+          "idempotency": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Idempotency configuration for the action."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata (label, group, icon, etc.)."
+          },
+          "inputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action input, annotated with designer presentation metadata."
+              }
+            ]
+          },
+          "outputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action output."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example invocations, or null."
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "sideEffectful",
+          "retryHint",
+          "idempotency",
+          "ui",
+          "inputSchema",
+          "outputSchema",
+          "examples"
+        ]
+      },
+      "WorkflowRegistryNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Node type identifier."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata for the node."
+          },
+          "configSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the node configuration."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example configurations, or null."
+          },
+          "defaultRetry": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Default retry policy for the node, or null."
+          }
+        },
+        "required": [
+          "id",
+          "ui",
+          "configSchema",
+          "examples",
+          "defaultRetry"
+        ]
+      },
+      "WorkflowSchemaRefParam": {
+        "type": "object",
+        "properties": {
+          "schemaRef": {
+            "type": "string",
+            "description": "Registered schema reference; URL-encode it in the path."
+          }
+        },
+        "required": [
+          "schemaRef"
+        ]
+      },
+      "WorkflowSchemaResponse": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "The resolved schema reference."
+          },
+          "schema": {
+            "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+          }
+        },
+        "required": [
+          "ref",
+          "schema"
         ]
       },
       "FileDownloadParams": {
@@ -56088,6 +56245,414 @@
           },
           "404": {
             "description": "Event not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/actions": {
+      "get": {
+        "summary": "List workflow registry actions",
+        "description": "Lists every action registered in the workflow runtime — the building blocks workflow definitions can invoke — including JSON Schemas for each action's input and output. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered actions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryAction"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/nodes": {
+      "get": {
+        "summary": "List workflow registry node types",
+        "description": "Lists the node types available to workflow definitions (triggers, control flow, action nodes, etc.) with each node's configuration JSON Schema and default retry policy. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered node types.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryNode"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/designer-catalog": {
+      "get": {
+        "summary": "Get the workflow designer action catalog",
+        "description": "Returns the action catalog the workflow designer renders: registry actions and integration modules grouped into tiles, filtered to the integrations actually available to the tenant. Returns a bare array of catalog records (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Designer catalog tiles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Catalog tile (groupKey, tileKind, actions, UI metadata)."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/schemas/{schemaRef}": {
+      "get": {
+        "summary": "Get a workflow schema by ref",
+        "description": "Resolves a registered workflow schema reference (URL-encoded) to its JSON Schema document.",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Registered schema reference; URL-encode it in the path."
+            },
+            "required": true,
+            "description": "Registered schema reference; URL-encode it in the path.",
+            "name": "schemaRef",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolved schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowSchemaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown schema ref.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects": {
+      "get": {
+        "summary": "List projects",
+        "description": "Lists all projects for the tenant. Returns a bare array of project records (no envelope); responds 403 with an error message when the caller lacks project read permission.",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "project",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Projects for the tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Project record."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
             "content": {
               "application/json": {
                 "schema": {
@@ -100902,54 +101467,6 @@
         }
       }
     },
-    "/api/projects": {
-      "get": {
-        "summary": "GET projects",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "projects"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/public/appointment-request": {
       "post": {
         "summary": "POST public",
@@ -107128,198 +107645,6 @@
         },
         "responses": {
           "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/actions": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/designer-catalog": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/nodes": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/schemas/{schemaRef}": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -59,6 +59,7 @@ tags:
   - name: Webhooks
   - name: Work Management v1
   - name: Workflow Definitions
+  - name: Workflow Registry
   - name: Workflow Runs
   - name: Workflows v1
   - name: accounting
@@ -84,7 +85,6 @@ tags:
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
-  - name: projects
   - name: public
   - name: secrets
   - name: share
@@ -93,7 +93,6 @@ tags:
   - name: tenant-management
   - name: tickets
   - name: webhooks
-  - name: workflow
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -9006,6 +9005,116 @@ components:
           type: string
       required:
         - eventId
+    WorkflowJsonSchemaDocument:
+      type: object
+      additionalProperties: {}
+      description: A JSON Schema document.
+    WorkflowRegistryAction:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Stable action identifier (e.g. "ticket.create").
+        version:
+          type: integer
+          description: Action version.
+        sideEffectful:
+          type: boolean
+          description: Whether executing the action mutates external state.
+        retryHint:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Suggested retry policy, or null.
+        idempotency:
+          type: object
+          additionalProperties: {}
+          description: Idempotency configuration for the action.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata (label, group, icon, etc.).
+        inputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action input, annotated with designer
+                presentation metadata.
+        outputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action output.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example invocations, or null.
+      required:
+        - id
+        - version
+        - sideEffectful
+        - retryHint
+        - idempotency
+        - ui
+        - inputSchema
+        - outputSchema
+        - examples
+    WorkflowRegistryNode:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Node type identifier.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata for the node.
+        configSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the node configuration.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example configurations, or null.
+        defaultRetry:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Default retry policy for the node, or null.
+      required:
+        - id
+        - ui
+        - configSchema
+        - examples
+        - defaultRetry
+    WorkflowSchemaRefParam:
+      type: object
+      properties:
+        schemaRef:
+          type: string
+          description: Registered schema reference; URL-encode it in the path.
+      required:
+        - schemaRef
+    WorkflowSchemaResponse:
+      type: object
+      properties:
+        ref:
+          type: string
+          description: The resolved schema reference.
+        schema:
+          $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+      required:
+        - ref
+        - schema
     FileDownloadParams:
       type: object
       properties:
@@ -37750,6 +37859,267 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Event not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/actions:
+    get:
+      summary: List workflow registry actions
+      description: Lists every action registered in the workflow runtime — the
+        building blocks workflow definitions can invoke — including JSON Schemas
+        for each action's input and output. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered actions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryAction"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/nodes:
+    get:
+      summary: List workflow registry node types
+      description: Lists the node types available to workflow definitions (triggers,
+        control flow, action nodes, etc.) with each node's configuration JSON
+        Schema and default retry policy. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered node types.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryNode"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/designer-catalog:
+    get:
+      summary: Get the workflow designer action catalog
+      description: "Returns the action catalog the workflow designer renders: registry
+        actions and integration modules grouped into tiles, filtered to the
+        integrations actually available to the tenant. Returns a bare array of
+        catalog records (no envelope)."
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Designer catalog tiles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Catalog tile (groupKey, tileKind, actions, UI metadata).
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/schemas/{schemaRef}:
+    get:
+      summary: Get a workflow schema by ref
+      description: Resolves a registered workflow schema reference (URL-encoded) to
+        its JSON Schema document.
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Registered schema reference; URL-encode it in the path.
+          required: true
+          description: Registered schema reference; URL-encode it in the path.
+          name: schemaRef
+          in: path
+      responses:
+        "200":
+          description: Resolved schema.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowSchemaResponse"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Unknown schema ref.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/projects:
+    get:
+      summary: List projects
+      description: Lists all projects for the tenant. Returns a bare array of project
+        records (no envelope); responds 403 with an error message when the
+        caller lacks project read permission.
+      tags:
+        - Projects
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: project
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Projects for the tenant.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Project record.
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
           content:
             application/json:
               schema:
@@ -67029,37 +67399,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/projects:
-    get:
-      summary: GET projects
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - projects
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/public/appointment-request:
     post:
       summary: POST public
@@ -71081,130 +71420,6 @@ paths:
             description: Placeholder request body
       responses:
         "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/actions:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/designer-catalog:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/nodes:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/schemas/{schemaRef}:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
           description: Placeholder success response
           content:
             application/json:

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -167,6 +167,9 @@
       "name": "Workflow Definitions"
     },
     {
+      "name": "Workflow Registry"
+    },
+    {
       "name": "Workflow Runs"
     },
     {
@@ -239,9 +242,6 @@
       "name": "platform-reports"
     },
     {
-      "name": "projects"
-    },
-    {
       "name": "public"
     },
     {
@@ -264,9 +264,6 @@
     },
     {
       "name": "webhooks"
-    },
-    {
-      "name": "workflow"
     }
   ],
   "components": {
@@ -12801,6 +12798,166 @@
         },
         "required": [
           "eventId"
+        ]
+      },
+      "WorkflowJsonSchemaDocument": {
+        "type": "object",
+        "additionalProperties": {},
+        "description": "A JSON Schema document."
+      },
+      "WorkflowRegistryAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable action identifier (e.g. \"ticket.create\")."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Action version."
+          },
+          "sideEffectful": {
+            "type": "boolean",
+            "description": "Whether executing the action mutates external state."
+          },
+          "retryHint": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Suggested retry policy, or null."
+          },
+          "idempotency": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Idempotency configuration for the action."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata (label, group, icon, etc.)."
+          },
+          "inputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action input, annotated with designer presentation metadata."
+              }
+            ]
+          },
+          "outputSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the action output."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example invocations, or null."
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "sideEffectful",
+          "retryHint",
+          "idempotency",
+          "ui",
+          "inputSchema",
+          "outputSchema",
+          "examples"
+        ]
+      },
+      "WorkflowRegistryNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Node type identifier."
+          },
+          "ui": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Designer UI metadata for the node."
+          },
+          "configSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+              },
+              {
+                "description": "JSON Schema for the node configuration."
+              }
+            ]
+          },
+          "examples": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Example configurations, or null."
+          },
+          "defaultRetry": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {},
+            "description": "Default retry policy for the node, or null."
+          }
+        },
+        "required": [
+          "id",
+          "ui",
+          "configSchema",
+          "examples",
+          "defaultRetry"
+        ]
+      },
+      "WorkflowSchemaRefParam": {
+        "type": "object",
+        "properties": {
+          "schemaRef": {
+            "type": "string",
+            "description": "Registered schema reference; URL-encode it in the path."
+          }
+        },
+        "required": [
+          "schemaRef"
+        ]
+      },
+      "WorkflowSchemaResponse": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "The resolved schema reference."
+          },
+          "schema": {
+            "$ref": "#/components/schemas/WorkflowJsonSchemaDocument"
+          }
+        },
+        "required": [
+          "ref",
+          "schema"
         ]
       },
       "FileDownloadParams": {
@@ -56085,6 +56242,414 @@
           },
           "404": {
             "description": "Event not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/actions": {
+      "get": {
+        "summary": "List workflow registry actions",
+        "description": "Lists every action registered in the workflow runtime — the building blocks workflow definitions can invoke — including JSON Schemas for each action's input and output. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered actions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryAction"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/nodes": {
+      "get": {
+        "summary": "List workflow registry node types",
+        "description": "Lists the node types available to workflow definitions (triggers, control flow, action nodes, etc.) with each node's configuration JSON Schema and default retry policy. Returns a bare array (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered node types.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowRegistryNode"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/designer-catalog": {
+      "get": {
+        "summary": "Get the workflow designer action catalog",
+        "description": "Returns the action catalog the workflow designer renders: registry actions and integration modules grouped into tiles, filtered to the integrations actually available to the tenant. Returns a bare array of catalog records (no envelope).",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Designer catalog tiles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Catalog tile (groupKey, tileKind, actions, UI metadata)."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow/registry/schemas/{schemaRef}": {
+      "get": {
+        "summary": "Get a workflow schema by ref",
+        "description": "Resolves a registered workflow schema reference (URL-encoded) to its JSON Schema document.",
+        "tags": [
+          "Workflow Registry"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "workflow",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Registered schema reference; URL-encode it in the path."
+            },
+            "required": true,
+            "description": "Registered schema reference; URL-encode it in the path.",
+            "name": "schemaRef",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolved schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowSchemaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown schema ref.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects": {
+      "get": {
+        "summary": "List projects",
+        "description": "Lists all projects for the tenant. Returns a bare array of project records (no envelope); responds 403 with an error message when the caller lacks project read permission.",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-rbac-resource": "project",
+          "x-rbac-action": "read"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Projects for the tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Project record."
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing/invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the required permission.",
             "content": {
               "application/json": {
                 "schema": {
@@ -100727,54 +101292,6 @@
         }
       }
     },
-    "/api/projects": {
-      "get": {
-        "summary": "GET projects",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "projects"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/public/appointment-request": {
       "post": {
         "summary": "POST public",
@@ -107256,198 +107773,6 @@
         },
         "responses": {
           "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/actions": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/designer-catalog": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/nodes": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workflow/registry/schemas/{schemaRef}": {
-      "get": {
-        "summary": "GET workflow",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "workflow"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -59,6 +59,7 @@ tags:
   - name: Webhooks
   - name: Work Management v1
   - name: Workflow Definitions
+  - name: Workflow Registry
   - name: Workflow Runs
   - name: Workflows v1
   - name: accounting
@@ -83,7 +84,6 @@ tags:
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
-  - name: projects
   - name: public
   - name: secrets
   - name: share
@@ -92,7 +92,6 @@ tags:
   - name: tenant-management
   - name: tickets
   - name: webhooks
-  - name: workflow
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -9005,6 +9004,116 @@ components:
           type: string
       required:
         - eventId
+    WorkflowJsonSchemaDocument:
+      type: object
+      additionalProperties: {}
+      description: A JSON Schema document.
+    WorkflowRegistryAction:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Stable action identifier (e.g. "ticket.create").
+        version:
+          type: integer
+          description: Action version.
+        sideEffectful:
+          type: boolean
+          description: Whether executing the action mutates external state.
+        retryHint:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Suggested retry policy, or null.
+        idempotency:
+          type: object
+          additionalProperties: {}
+          description: Idempotency configuration for the action.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata (label, group, icon, etc.).
+        inputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action input, annotated with designer
+                presentation metadata.
+        outputSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the action output.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example invocations, or null.
+      required:
+        - id
+        - version
+        - sideEffectful
+        - retryHint
+        - idempotency
+        - ui
+        - inputSchema
+        - outputSchema
+        - examples
+    WorkflowRegistryNode:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Node type identifier.
+        ui:
+          type: object
+          additionalProperties: {}
+          description: Designer UI metadata for the node.
+        configSchema:
+          allOf:
+            - $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+            - description: JSON Schema for the node configuration.
+        examples:
+          type:
+            - array
+            - "null"
+          items:
+            type: object
+            additionalProperties: {}
+          description: Example configurations, or null.
+        defaultRetry:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+          description: Default retry policy for the node, or null.
+      required:
+        - id
+        - ui
+        - configSchema
+        - examples
+        - defaultRetry
+    WorkflowSchemaRefParam:
+      type: object
+      properties:
+        schemaRef:
+          type: string
+          description: Registered schema reference; URL-encode it in the path.
+      required:
+        - schemaRef
+    WorkflowSchemaResponse:
+      type: object
+      properties:
+        ref:
+          type: string
+          description: The resolved schema reference.
+        schema:
+          $ref: "#/components/schemas/WorkflowJsonSchemaDocument"
+      required:
+        - ref
+        - schema
     FileDownloadParams:
       type: object
       properties:
@@ -37749,6 +37858,267 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Event not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/actions:
+    get:
+      summary: List workflow registry actions
+      description: Lists every action registered in the workflow runtime — the
+        building blocks workflow definitions can invoke — including JSON Schemas
+        for each action's input and output. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered actions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryAction"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/nodes:
+    get:
+      summary: List workflow registry node types
+      description: Lists the node types available to workflow definitions (triggers,
+        control flow, action nodes, etc.) with each node's configuration JSON
+        Schema and default retry policy. Returns a bare array (no envelope).
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Registered node types.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRegistryNode"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/designer-catalog:
+    get:
+      summary: Get the workflow designer action catalog
+      description: "Returns the action catalog the workflow designer renders: registry
+        actions and integration modules grouped into tiles, filtered to the
+        integrations actually available to the tenant. Returns a bare array of
+        catalog records (no envelope)."
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Designer catalog tiles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Catalog tile (groupKey, tileKind, actions, UI metadata).
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/workflow/registry/schemas/{schemaRef}:
+    get:
+      summary: Get a workflow schema by ref
+      description: Resolves a registered workflow schema reference (URL-encoded) to
+        its JSON Schema document.
+      tags:
+        - Workflow Registry
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: workflow
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            description: Registered schema reference; URL-encode it in the path.
+          required: true
+          description: Registered schema reference; URL-encode it in the path.
+          name: schemaRef
+          in: path
+      responses:
+        "200":
+          description: Resolved schema.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowSchemaResponse"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Unknown schema ref.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/projects:
+    get:
+      summary: List projects
+      description: Lists all projects for the tenant. Returns a bare array of project
+        records (no envelope); responds 403 with an error message when the
+        caller lacks project read permission.
+      tags:
+        - Projects
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-rbac-resource: project
+        x-rbac-action: read
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Projects for the tenant.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+                  description: Project record.
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: API key missing/invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the required permission.
           content:
             application/json:
               schema:
@@ -66897,37 +67267,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/projects:
-    get:
-      summary: GET projects
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - projects
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/public/appointment-request:
     post:
       summary: POST public
@@ -71136,130 +71475,6 @@ paths:
             description: Placeholder request body
       responses:
         "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/actions:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/designer-catalog:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/nodes:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/workflow/registry/schemas/{schemaRef}:
-    get:
-      summary: GET workflow
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - workflow
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
           description: Placeholder success response
           content:
             application/json:

--- a/server/src/app/api/v1/company-contract-lines/[id]/route.ts
+++ b/server/src/app/api/v1/company-contract-lines/[id]/route.ts
@@ -1,15 +1,29 @@
 /**
  * Client Contract Line by ID API Routes (DEPRECATED)
- * DELETE /api/v1/client-contract-lines/{id} - Unassign contract line from client
+ * DELETE /api/v1/company-contract-lines/{id} - Unassign contract line from client
  *
  * @deprecated This endpoint is deprecated. Use /api/v1/client-contract-lines/{id} instead.
  *
- * This endpoint is maintained for backward compatibility during the client → client migration.
+ * This endpoint is maintained for backward compatibility during the company → client migration.
  * Please migrate to /api/v1/client-contract-lines/{id} as this endpoint will be removed in a future version.
  */
 
 import { ApiContractLineController } from '@/lib/api/controllers/ApiContractLineController';
+import { handleApiError } from '@/lib/api/middleware/apiMiddleware';
+import { withApiKeyRouteAuth } from '@/lib/api/middleware/withApiKeyRouteAuth';
 
 const controller = new ApiContractLineController();
 
-export const DELETE = controller.unassignContractLineFromClient();
+export const DELETE = withApiKeyRouteAuth<{ id: string }>(async (request, { params }) => {
+  try {
+    const resolvedParams = await params;
+    const req = request as any;
+    req.params = resolvedParams;
+    return await controller.unassignContractLineFromClient()(req, { params: Promise.resolve(resolvedParams) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/company-contract-lines/route.ts
+++ b/server/src/app/api/v1/company-contract-lines/route.ts
@@ -1,19 +1,35 @@
 /**
  * Client Contract Lines API Routes (DEPRECATED)
- * GET /api/v1/client-contract-lines - List client contract lines
- * POST /api/v1/client-contract-lines - Assign contract line to client
+ * GET /api/v1/company-contract-lines - List client contract lines
+ * POST /api/v1/company-contract-lines - Assign contract line to client
  *
  * @deprecated This endpoint is deprecated. Use /api/v1/client-contract-lines instead.
  *
- * This endpoint is maintained for backward compatibility during the client → client migration.
+ * This endpoint is maintained for backward compatibility during the company → client migration.
  * Please migrate to /api/v1/client-contract-lines as this endpoint will be removed in a future version.
  */
 
 import { ApiContractLineController } from '@/lib/api/controllers/ApiContractLineController';
+import { handleApiError } from '@/lib/api/middleware/apiMiddleware';
+import { withApiKeyRouteAuth } from '@/lib/api/middleware/withApiKeyRouteAuth';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 const controller = new ApiContractLineController();
 
-export const GET = controller.listClientContractLines();
-export const POST = controller.assignContractLineToClient();
+export const GET = withApiKeyRouteAuth(async (request) => {
+  try {
+    return await controller.listClientContractLines()(request as any);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const POST = withApiKeyRouteAuth(async (request) => {
+  try {
+    return await controller.assignContractLineToClient()(request as any);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/server/src/app/api/v1/contract-line-templates/route.ts
+++ b/server/src/app/api/v1/contract-line-templates/route.ts
@@ -1,7 +1,21 @@
+/**
+ * Contract Line Templates API Routes
+ * POST /api/v1/contract-line-templates - Create a contract line template
+ */
+
 import { ApiContractLineController } from '@/lib/api/controllers/ApiContractLineController';
+import { handleApiError } from '@/lib/api/middleware/apiMiddleware';
+import { withApiKeyRouteAuth } from '@/lib/api/middleware/withApiKeyRouteAuth';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 const controller = new ApiContractLineController();
 
-export const POST = controller.createTemplate();
+export const POST = withApiKeyRouteAuth(async (request) => {
+  try {
+    return await controller.createTemplate()(request as any);
+  } catch (error) {
+    return handleApiError(error);
+  }
+});

--- a/server/src/app/api/v1/contracts/[contractId]/contract-lines/[contractLineId]/route.ts
+++ b/server/src/app/api/v1/contracts/[contractId]/contract-lines/[contractLineId]/route.ts
@@ -1,5 +1,24 @@
+/**
+ * Contract Contract Line by ID API Routes
+ * DELETE /api/v1/contracts/{contractId}/contract-lines/{contractLineId} - Detach a contract line from a contract
+ */
+
 import { ApiContractLineController } from '@/lib/api/controllers/ApiContractLineController';
+import { handleApiError } from '@/lib/api/middleware/apiMiddleware';
+import { withApiKeyRouteAuth } from '@/lib/api/middleware/withApiKeyRouteAuth';
 
 const controller = new ApiContractLineController();
 
-export const DELETE = controller.removeContractLine();
+export const DELETE = withApiKeyRouteAuth<{ contractId: string; contractLineId: string }>(async (request, { params }) => {
+  try {
+    const resolvedParams = await params;
+    const req = request as any;
+    req.params = resolvedParams;
+    return await controller.removeContractLine()(req, { params: Promise.resolve(resolvedParams) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/app/api/v1/contracts/[contractId]/contract-lines/route.ts
+++ b/server/src/app/api/v1/contracts/[contractId]/contract-lines/route.ts
@@ -1,5 +1,24 @@
+/**
+ * Contract Contract Lines API Routes
+ * POST /api/v1/contracts/{contractId}/contract-lines - Attach a contract line to a contract
+ */
+
 import { ApiContractLineController } from '@/lib/api/controllers/ApiContractLineController';
+import { handleApiError } from '@/lib/api/middleware/apiMiddleware';
+import { withApiKeyRouteAuth } from '@/lib/api/middleware/withApiKeyRouteAuth';
 
 const controller = new ApiContractLineController();
 
-export const POST = controller.addContractLine();
+export const POST = withApiKeyRouteAuth<{ contractId: string }>(async (request, { params }) => {
+  try {
+    const resolvedParams = await params;
+    const req = request as any;
+    req.params = resolvedParams;
+    return await controller.addContractLine()(req, { params: Promise.resolve(resolvedParams) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+});
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/lib/api/openapi/routes/unversionedPublicV1.ts
+++ b/server/src/lib/api/openapi/routes/unversionedPublicV1.ts
@@ -288,4 +288,90 @@ export function registerUnversionedPublicV1Routes(
   readRoute('/api/workflow/events/export', 'Export workflow events', 'Exports workflow events (JSON/CSV).', 'workflow');
   readRoute('/api/workflow/events/summary', 'Get workflow events summary', 'Returns aggregate workflow-event metrics.', 'workflow');
   readRoute('/api/workflow/events/{eventId}', 'Get a workflow event', 'Returns a single workflow event by id.', 'workflow', EventIdParam, 'Event not found.');
+
+  // ---- Workflow registry (designer building blocks; read-only) ----
+  const regTag = 'Workflow Registry';
+  const JsonSchemaDoc = registry.registerSchema(
+    'WorkflowJsonSchemaDocument',
+    zOpenApi.record(zOpenApi.unknown()).describe('A JSON Schema document.'),
+  );
+  const WorkflowRegistryAction = registry.registerSchema(
+    'WorkflowRegistryAction',
+    zOpenApi.object({
+      id: zOpenApi.string().describe('Stable action identifier (e.g. "ticket.create").'),
+      version: zOpenApi.number().int().describe('Action version.'),
+      sideEffectful: zOpenApi.boolean().describe('Whether executing the action mutates external state.'),
+      retryHint: zOpenApi.record(zOpenApi.unknown()).nullable().describe('Suggested retry policy, or null.'),
+      idempotency: zOpenApi.record(zOpenApi.unknown()).describe('Idempotency configuration for the action.'),
+      ui: zOpenApi.record(zOpenApi.unknown()).describe('Designer UI metadata (label, group, icon, etc.).'),
+      inputSchema: JsonSchemaDoc.describe('JSON Schema for the action input, annotated with designer presentation metadata.'),
+      outputSchema: JsonSchemaDoc.describe('JSON Schema for the action output.'),
+      examples: zOpenApi.array(zOpenApi.record(zOpenApi.unknown())).nullable().describe('Example invocations, or null.'),
+    }),
+  );
+  const WorkflowRegistryNode = registry.registerSchema(
+    'WorkflowRegistryNode',
+    zOpenApi.object({
+      id: zOpenApi.string().describe('Node type identifier.'),
+      ui: zOpenApi.record(zOpenApi.unknown()).describe('Designer UI metadata for the node.'),
+      configSchema: JsonSchemaDoc.describe('JSON Schema for the node configuration.'),
+      examples: zOpenApi.array(zOpenApi.record(zOpenApi.unknown())).nullable().describe('Example configurations, or null.'),
+      defaultRetry: zOpenApi.record(zOpenApi.unknown()).nullable().describe('Default retry policy for the node, or null.'),
+    }),
+  );
+
+  registry.registerRoute({
+    method: 'get', path: '/api/workflow/registry/actions',
+    summary: 'List workflow registry actions',
+    description: 'Lists every action registered in the workflow runtime — the building blocks workflow definitions can invoke — including JSON Schemas for each action\'s input and output. Returns a bare array (no envelope).',
+    tags: [regTag], security: [{ ApiKeyAuth: [] }],
+    responses: { 200: { description: 'Registered actions.', schema: zOpenApi.array(WorkflowRegistryAction) }, ...errs() },
+    extensions: ext('workflow', 'read'), edition: 'both',
+  });
+  registry.registerRoute({
+    method: 'get', path: '/api/workflow/registry/nodes',
+    summary: 'List workflow registry node types',
+    description: 'Lists the node types available to workflow definitions (triggers, control flow, action nodes, etc.) with each node\'s configuration JSON Schema and default retry policy. Returns a bare array (no envelope).',
+    tags: [regTag], security: [{ ApiKeyAuth: [] }],
+    responses: { 200: { description: 'Registered node types.', schema: zOpenApi.array(WorkflowRegistryNode) }, ...errs() },
+    extensions: ext('workflow', 'read'), edition: 'both',
+  });
+  registry.registerRoute({
+    method: 'get', path: '/api/workflow/registry/designer-catalog',
+    summary: 'Get the workflow designer action catalog',
+    description: 'Returns the action catalog the workflow designer renders: registry actions and integration modules grouped into tiles, filtered to the integrations actually available to the tenant. Returns a bare array of catalog records (no envelope).',
+    tags: [regTag], security: [{ ApiKeyAuth: [] }],
+    responses: { 200: { description: 'Designer catalog tiles.', schema: zOpenApi.array(zOpenApi.record(zOpenApi.unknown()).describe('Catalog tile (groupKey, tileKind, actions, UI metadata).')) }, ...errs() },
+    extensions: ext('workflow', 'read'), edition: 'both',
+  });
+  registry.registerRoute({
+    method: 'get', path: '/api/workflow/registry/schemas/{schemaRef}',
+    summary: 'Get a workflow schema by ref',
+    description: 'Resolves a registered workflow schema reference (URL-encoded) to its JSON Schema document.',
+    tags: [regTag], security: [{ ApiKeyAuth: [] }],
+    request: { params: registry.registerSchema('WorkflowSchemaRefParam', zOpenApi.object({
+      schemaRef: zOpenApi.string().describe('Registered schema reference; URL-encode it in the path.'),
+    })) },
+    responses: {
+      200: { description: 'Resolved schema.', schema: registry.registerSchema('WorkflowSchemaResponse', zOpenApi.object({
+        ref: zOpenApi.string().describe('The resolved schema reference.'),
+        schema: JsonSchemaDoc,
+      })) },
+      ...errs({ 404: 'Unknown schema ref.' }),
+    },
+    extensions: ext('workflow', 'read'), edition: 'both',
+  });
+
+  // ---- Projects (unversioned list used by the UI; distinct from /api/v1/projects) ----
+  registry.registerRoute({
+    method: 'get', path: '/api/projects',
+    summary: 'List projects',
+    description: 'Lists all projects for the tenant. Returns a bare array of project records (no envelope); responds 403 with an error message when the caller lacks project read permission.',
+    tags: ['Projects'], security: [{ ApiKeyAuth: [] }],
+    responses: {
+      200: { description: 'Projects for the tenant.', schema: zOpenApi.array(zOpenApi.record(zOpenApi.unknown()).describe('Project record.')) },
+      ...errs(),
+    },
+    extensions: ext('project', 'read'), edition: 'both',
+  });
 }


### PR DESCRIPTION
  Wrap the contract-line API routes (company-contract-lines
  deprecated aliases, contract-line-templates, and contract
  attach/detach) in withApiKeyRouteAuth with handleApiError,
  plus explicit nodejs runtime and force-dynamic, instead of
  exporting bare controller handlers.

  Document the workflow registry endpoints (actions, nodes,
  designer-catalog, schemas/{schemaRef}) and the unversioned
  /api/projects list in the OpenAPI registry, and regenerate
  the CE/EE spec files.

  "Not nobody, not nohow gets in to see the contract lines,"
  declared withApiKeyRouteAuth, guardian of the Emerald City
  gates — though the Wizard did publish a designer-catalog of
  every lever and node behind the curtain, in sextuplicate
  JSON and YAML. 🧙‍🔑📜