### PR TITLE
fix(billing): align InvoicePreviewPanel test mocks with refactored data flow

### DIFF
--- a/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx
@@ -6,11 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoicePreviewPanel from './InvoicePreviewPanel';
 
-const getInvoiceForRenderingMock = vi.fn();
+const getEnrichedInvoiceViewModelMock = vi.fn();
 const getInvoicePurchaseOrderSummaryMock = vi.fn();
 const getResolvedInvoiceTemplateIdMock = vi.fn();
+const getInvoiceAnnotationsMock = vi.fn();
 const getQuoteByConvertedInvoiceIdMock = vi.fn();
-const mapDbInvoiceToWasmViewModelMock = vi.fn();
 const templateRendererMock = vi.fn();
 const paperInvoiceMock = vi.fn();
 const routerPushMock = vi.fn();
@@ -22,17 +22,17 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
-  getInvoiceForRendering: (...args: unknown[]) => getInvoiceForRenderingMock(...args),
+  getEnrichedInvoiceViewModel: (...args: unknown[]) => getEnrichedInvoiceViewModelMock(...args),
   getInvoicePurchaseOrderSummary: (...args: unknown[]) => getInvoicePurchaseOrderSummaryMock(...args),
   getResolvedInvoiceTemplateId: (...args: unknown[]) => getResolvedInvoiceTemplateIdMock(...args),
 }));
 
-vi.mock('@alga-psa/billing/actions/quoteActions', () => ({
-  getQuoteByConvertedInvoiceId: (...args: unknown[]) => getQuoteByConvertedInvoiceIdMock(...args),
+vi.mock('@alga-psa/billing/actions/invoiceTemplates', () => ({
+  getInvoiceAnnotations: (...args: unknown[]) => getInvoiceAnnotationsMock(...args),
 }));
 
-vi.mock('../../../lib/adapters/invoiceAdapters', () => ({
-  mapDbInvoiceToWasmViewModel: (...args: unknown[]) => mapDbInvoiceToWasmViewModelMock(...args),
+vi.mock('@alga-psa/billing/actions/quoteActions', () => ({
+  getQuoteByConvertedInvoiceId: (...args: unknown[]) => getQuoteByConvertedInvoiceIdMock(...args),
 }));
 
 vi.mock('../TemplateRenderer', () => ({
@@ -86,13 +86,9 @@ const defaultTemplates = [
   },
 ];
 
-const defaultInvoiceData = {
-  invoice_id: 'inv-1',
-  tax_source: 'internal',
-};
-
 const defaultViewModel = {
   invoiceNumber: 'INV-1001',
+  taxSource: 'internal',
   issueDate: '2026-04-01',
   dueDate: '2026-04-15',
   currencyCode: 'USD',
@@ -109,11 +105,11 @@ describe('InvoicePreviewPanel', () => {
   beforeEach(() => {
     cleanup();
     routerPushMock.mockReset();
-    getInvoiceForRenderingMock.mockReset();
+    getEnrichedInvoiceViewModelMock.mockReset();
     getInvoicePurchaseOrderSummaryMock.mockReset();
     getResolvedInvoiceTemplateIdMock.mockReset();
+    getInvoiceAnnotationsMock.mockReset();
     getQuoteByConvertedInvoiceIdMock.mockReset();
-    mapDbInvoiceToWasmViewModelMock.mockReset();
     templateRendererMock.mockReset();
     paperInvoiceMock.mockReset();
 
@@ -125,11 +121,11 @@ describe('InvoicePreviewPanel', () => {
 
     vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
-    getInvoiceForRenderingMock.mockResolvedValue(defaultInvoiceData);
+    getEnrichedInvoiceViewModelMock.mockResolvedValue(defaultViewModel);
     getInvoicePurchaseOrderSummaryMock.mockResolvedValue(null);
     getResolvedInvoiceTemplateIdMock.mockResolvedValue('tpl-resolved');
+    getInvoiceAnnotationsMock.mockResolvedValue([]);
     getQuoteByConvertedInvoiceIdMock.mockResolvedValue(null);
-    mapDbInvoiceToWasmViewModelMock.mockReturnValue(defaultViewModel);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## What changed

Updated `InvoicePreviewPanel.test.tsx` mocks and fixtures to match the component's current data flow:

- The `@alga-psa/billing/actions/invoiceQueries` mock now exposes `getEnrichedInvoiceViewModel` (replacing the removed `getInvoiceForRendering`), alongside `getInvoicePurchaseOrderSummary` and `getResolvedInvoiceTemplateId`.
- Added a mock for `@alga-psa/billing/actions/invoiceTemplates` (`getInvoiceAnnotations`), which the component now imports.
- Dropped the `mapDbInvoiceToWasmViewModel` adapter mock and the raw DB-invoice fixture — the component consumes the enriched wasm view model directly, so the fixture now resolves from `getEnrichedInvoiceViewModel` and carries `taxSource`.

## Why

`InvoicePreviewPanel` was refactored to load preview data via `getEnrichedInvoiceViewModel` + `getInvoicePurchaseOrderSummary` + `getResolvedInvoiceTemplateId`, but the test still mocked the old flow. The unmocked `getEnrichedInvoiceViewModel` was `undefined` at runtime, so the load effect threw before template resolution ran, failing both template-resolution tests ("uses the invoice-resolved template…" and "keeps an explicit template selection…").

## Notes for reviewers

Test-only change; no component code touched. Verified with:

```
cd server && npx vitest run ../packages/billing/src/components/billing-dashboard/invoicing/InvoicePreviewPanel.test.tsx --coverage.enabled=false
```

Both tests pass (2 passed).