### PR TITLE
Fix ticket checklist crash: completed_at Date rendered as React child

### DIFF
--- a/packages/tickets/src/components/ticket/TicketChecklistSection.tsx
+++ b/packages/tickets/src/components/ticket/TicketChecklistSection.tsx
@@ -151,11 +151,16 @@ const TicketChecklistSection: React.FC<TicketChecklistSectionProps> = ({
 
   const timeZone = useMemo(() => getUserTimeZone(), []);
   const formatCompletedAt = useCallback(
-    (completedAt: string): string => {
+    (completedAt: string | Date): string => {
+      // Server actions return completed_at as a Date (Next preserves Dates
+      // across the action boundary), while optimistic updates use an ISO
+      // string. Normalize to a string before formatting, and never return a
+      // non-string — rendering a Date as a React child crashes the page.
+      const iso = completedAt instanceof Date ? completedAt.toISOString() : completedAt;
       try {
-        return formatDateTime(utcToLocal(completedAt, timeZone), timeZone, COMPLETED_AT_FORMAT);
+        return formatDateTime(utcToLocal(iso, timeZone), timeZone, COMPLETED_AT_FORMAT);
       } catch {
-        return completedAt;
+        return typeof iso === 'string' ? iso : '';
       }
     },
     [timeZone]


### PR DESCRIPTION
## Problem

Opening a ticket whose checklist has any **completed** item crashes the whole ticket page:

> Runtime Error: Objects are not valid as a React child (found: [object Date]).

It triggers whenever a checklist item is marked complete and the ticket is then reloaded or revisited (navigate away → back).

## Root cause

`packages/tickets/src/components/ticket/TicketChecklistSection.tsx` — `formatCompletedAt` was typed `(completedAt: string)`, but `completed_at` arrives from the checklist server actions as a **`Date`** (Next preserves `Date` instances across the server-action / RSC boundary; only the optimistic update uses an ISO string, which is why it surfaced on real server data — on mark and on revisit). When `formatDateTime`/`utcToLocal` choked on the `Date`, the `catch` did `return completedAt`, dumping the raw `Date` into JSX → React crash.

## Fix

Normalize the input to an ISO string before formatting, and guarantee a string return:

```ts
const iso = completedAt instanceof Date ? completedAt.toISOString() : completedAt;
try { return formatDateTime(utcToLocal(iso, timeZone), timeZone, COMPLETED_AT_FORMAT); }
catch { return typeof iso === 'string' ? iso : ''; }
```

## Testing

Reproduced and verified the full flow in the dev environment (Next 16 / Turbopack):

1. Create a ticket → add 3 checklist items → mark items complete → **crashed** (before fix).
2. Navigate away to the tickets list and back into the ticket → **crashed on load** (before fix).

After the fix:
- Marking items in-session: no crash.
- Reload and navigate-away-and-back: no crash; completed items render their accountability stamp ("Jun 11, 2026 6:04 PM (… ago)").
- `packages/tickets` type-check: clean.

This bug is currently live on `main`.