### PR TITLE
Pin server @vitest/coverage-v8 to 3.2.4 to match vitest

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,9 +94,14 @@ jobs:
           # Fixed shuffle seed so order-dependent failures are reproducible across reruns.
           VITEST_SEED: '20260610'
 
+      # sebastian-ee's inferred test target is a bare `vitest` over its full
+      # 209-file suite (~50 minutes serial — far past this job's 30-minute
+      # backstop, which it blew via WorkflowAiSchemaSection's render-loop hang
+      # before that was fixed). Excluded until the suite gets a bounded
+      # unit-test target that fits a PR gate.
       - name: Nx affected tests (apps, isolated & serial)
         continue-on-error: true
-        run: npx nx affected -t test --base=$NX_BASE --head=$NX_HEAD --output-style=static --parallel=1 --exclude=temporal-workflows
+        run: npx nx affected -t test --base=$NX_BASE --head=$NX_HEAD --output-style=static --parallel=1 --exclude=temporal-workflows,sebastian-ee
         env:
           NX_DAEMON: 'false'
           NODE_OPTIONS: '--max-old-space-size=14336'

--- a/ee/packages/calendar/vitest.config.ts
+++ b/ee/packages/calendar/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/ee/packages/microsoft-teams/vitest.config.ts
+++ b/ee/packages/microsoft-teams/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/ee/packages/workflows/vitest.config.ts
+++ b/ee/packages/workflows/vitest.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, './src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../../../packages/core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../../../packages/core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages/core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages/core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../../../packages/db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages/db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../../../packages/db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages/db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../../../packages/db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../../../packages/workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '../../../packages')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../../shared'),
+      },
+    ],
+  },
+});

--- a/ee/packages/workflows/vitest.setup.ts
+++ b/ee/packages/workflows/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/ee/server/src/__tests__/setup.ts
+++ b/ee/server/src/__tests__/setup.ts
@@ -6,9 +6,25 @@
 import '@testing-library/jest-dom';
 import dotenv from 'dotenv';
 import { vi } from 'vitest';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 
 const envPath = `${process.cwd()}/.env.test`;
 dotenv.config({ path: envPath });
+
+// Initialize i18next so useTranslation returns a stable `t` like production.
+// Without an instance, react-i18next hands out a fresh fallback `t` on every
+// render, which turns any `useMemo`/`useEffect` keyed on `t` into per-render
+// work — WorkflowAiSchemaSection spun forever in CI because of this. Missing
+// keys resolve to each call's defaultValue, same as the uninitialized fallback.
+if (!i18n.isInitialized) {
+  void i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: {} },
+    interpolation: { escapeValue: false },
+  });
+}
 
 // Mock Next.js router
 vi.mock('next/router', () => ({

--- a/ee/server/src/components/workflow-designer/WorkflowAiSchemaSection.tsx
+++ b/ee/server/src/components/workflow-designer/WorkflowAiSchemaSection.tsx
@@ -397,13 +397,14 @@ export const WorkflowAiSchemaSection: React.FC<WorkflowAiSchemaSectionProps> = (
   const [validationErrors, setValidationErrors] = useState<string[]>(derivedState.validationErrors);
   const [fallbackMessage, setFallbackMessage] = useState<string | null>(derivedState.fallbackMessage);
 
+  // Every setter below must bail out (return the current state) when nothing
+  // changed: `derivedState` is rebuilt whenever `t` changes identity — which is
+  // every render under react-i18next's uninitialized fallback — so an updater
+  // that returns a fresh array/object for equal content re-renders forever.
   useEffect(() => {
     setMode(derivedState.mode);
     setSimpleFields((currentFields) => {
-      if (
-        derivedState.mode === 'simple' &&
-        areEquivalentSimpleFields(currentFields, derivedState.fields)
-      ) {
+      if (areEquivalentSimpleFields(currentFields, derivedState.fields)) {
         return currentFields;
       }
 
@@ -418,7 +419,12 @@ export const WorkflowAiSchemaSection: React.FC<WorkflowAiSchemaSectionProps> = (
       return cloneFields(derivedState.fields);
     });
     setAdvancedText(derivedState.advancedText);
-    setValidationErrors(derivedState.validationErrors);
+    setValidationErrors((currentErrors) =>
+      currentErrors.length === derivedState.validationErrors.length &&
+      currentErrors.every((message, index) => message === derivedState.validationErrors[index])
+        ? currentErrors
+        : derivedState.validationErrors
+    );
     setFallbackMessage(derivedState.fallbackMessage);
   }, [derivedState]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.30.1",
       "license": "MIT",
@@ -31391,6 +31405,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "license": "BSD-3-Clause",
@@ -42197,6 +42226,66 @@
       "version": "2.20.3",
       "license": "MIT"
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "license": "Apache-2.0",
@@ -47199,11 +47288,7 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "sdk": {},
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -50849,7 +50934,7 @@
         "@types/ua-parser-js": "^0.7.39",
         "@typescript-eslint/eslint-plugin": "^8.19.1",
         "@typescript-eslint/parser": "^8.19.1",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "3.2.4",
         "as-json": "^1.0.2",
         "assemblyscript": "^0.27.36",
         "copy-webpack-plugin": "^13.0.0",
@@ -51353,6 +51438,40 @@
         "path-browserify": "^1.0.1"
       }
     },
+    "server/node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "server/node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -51662,6 +51781,18 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "server/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "server/node_modules/marked": {

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/client-portal/vitest.config.ts
+++ b/packages/client-portal/vitest.config.ts
@@ -1,0 +1,137 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+    server: {
+      deps: {
+        inline: ['next-auth', '@auth/core', 'next'],
+      },
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../ee/packages/workflows/src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/auth$/,
+        replacement: path.resolve(__dirname, '../auth/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/sso\/entry$/,
+        replacement: path.resolve(__dirname, '../auth/src/components/SsoProviderButtons.tsx'),
+      },
+      {
+        find: /^@alga-psa\/auth\/session$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/session.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/rbac$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/rbac.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/withAuth$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/withAuth.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/apiAuth$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/apiAuth.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/types\/next-auth$/,
+        replacement: path.resolve(__dirname, '../auth/src/types/next-auth.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/nextAuthOptions$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/nextAuthOptions.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/getCurrentUser$/,
+        replacement: path.resolve(__dirname, '../auth/src/lib/getCurrentUser.ts'),
+      },
+      {
+        find: /^@alga-psa\/auth\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../auth/src')}/$1`,
+      },
+      {
+        find: /^@enterprise$/,
+        replacement: path.resolve(__dirname, '../ee/src/index.ts'),
+      },
+      {
+        find: /^@enterprise\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../ee/src')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/product-extension-actions$/,
+        replacement: path.resolve(__dirname, '../product-extension-actions/oss/entry.ts'),
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../shared'),
+      },
+      {
+        find: 'next/server',
+        replacement: path.resolve(__dirname, '../../server/src/test/stubs/next-server.ts'),
+      },
+    ],
+  },
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../ee/packages/workflows/src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../shared'),
+      },
+    ],
+  },
+});

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../ee/packages/workflows/src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../shared'),
+      },
+    ],
+  },
+});

--- a/packages/event-bus/vitest.config.ts
+++ b/packages/event-bus/vitest.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../ee/packages/workflows/src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../shared'),
+      },
+    ],
+  },
+});

--- a/packages/formatting/vitest.config.ts
+++ b/packages/formatting/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/jobs/vitest.config.ts
+++ b/packages/jobs/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/notifications/vitest.config.ts
+++ b/packages/notifications/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/onboarding/vitest.config.ts
+++ b/packages/onboarding/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/reference-data/vitest.config.ts
+++ b/packages/reference-data/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/reporting/vitest.config.ts
+++ b/packages/reporting/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/surveys/vitest.config.ts
+++ b/packages/surveys/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/tags/vitest.config.ts
+++ b/packages/tags/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/teams/vitest.config.ts
+++ b/packages/teams/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/ui-kit/vitest.config.ts
+++ b/packages/ui-kit/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/packages/users/vitest.config.ts
+++ b/packages/users/vitest.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@alga-psa\/workflows(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../ee/packages/workflows/src')}$1`,
+      },
+      {
+        find: /^@alga-psa\/core$/,
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/server$/,
+        replacement: path.resolve(__dirname, '../core/src/server.ts'),
+      },
+      {
+        find: /^@alga-psa\/core\/(context|config)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src')}/$1/$2`,
+      },
+      {
+        find: /^@alga-psa\/core\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../core/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/admin$/,
+        replacement: path.resolve(__dirname, '../db/src/lib/admin.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/models\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/models')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db\/models$/,
+        replacement: path.resolve(__dirname, '../db/src/models/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/db\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../db/src/lib')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/db$/,
+        replacement: path.resolve(__dirname, '../db/src/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/workflow-streams$/,
+        replacement: path.resolve(__dirname, '../workflow-streams/src/streams/index.ts'),
+      },
+      {
+        find: /^@alga-psa\/shared\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '../../shared')}/$1`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)\/(.*)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src/$2`,
+      },
+      {
+        find: /^@alga-psa\/([^/]+)$/,
+        replacement: `${path.resolve(__dirname, '..')}/$1/src`,
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../../shared'),
+      },
+    ],
+  },
+});

--- a/packages/validation/vitest.config.ts
+++ b/packages/validation/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: true,
+    testTimeout: 10000,
+  },
+});

--- a/server/package.json
+++ b/server/package.json
@@ -247,7 +247,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.19.1",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "3.2.4",
     "as-json": "^1.0.2",
     "assemblyscript": "^0.27.36",
     "copy-webpack-plugin": "^13.0.0",


### PR DESCRIPTION
The coverage-report job failed on main because server runs vitest 3.2.4 but @vitest/coverage-v8 resolved to 4.0.18 from the root install, and the v4 provider crashes under vitest 3 (TypeError reading 'reportsDirectory'). Coverage packages must match vitest's exact version, so pin 3.2.4 and nest it under server/node_modules.