### PR TITLE
Allow business-appropriate symbols in client names

### DIFF
--- a/packages/validation/src/lib/clientFormValidation.test.ts
+++ b/packages/validation/src/lib/clientFormValidation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateClientName } from './clientFormValidation';
+
+describe('validateClientName', () => {
+  it('accepts ordinary business names', () => {
+    expect(validateClientName('Acme Corp')).toBeNull();
+    expect(validateClientName('Microsoft Corporation')).toBeNull();
+    expect(validateClientName('ABC-123 Industries')).toBeNull();
+  });
+
+  it('accepts names containing a comma', () => {
+    // Comma has always been allowed; this guards against regressions.
+    expect(validateClientName('Smith, Jones & Co')).toBeNull();
+    expect(validateClientName('Acme, Inc')).toBeNull();
+  });
+
+  it('accepts business-appropriate symbols (regression for + and friends)', () => {
+    expect(validateClientName('C++ Solutions')).toBeNull();
+    expect(validateClientName('AT&T + Co')).toBeNull();
+    expect(validateClientName('Smith, Jones + Co')).toBeNull();
+    expect(validateClientName('Yahoo!')).toBeNull();
+    expect(validateClientName('#1 Plumbing')).toBeNull();
+    expect(validateClientName('Owner/Operator Services')).toBeNull();
+    expect(validateClientName('Mail@Home')).toBeNull();
+  });
+
+  it('still rejects genuinely unsupported characters', () => {
+    expect(validateClientName('Bad$Name')).toBe('Client name contains invalid characters');
+    expect(validateClientName('Name~With^Tilde')).toBe('Client name contains invalid characters');
+  });
+
+  it('still enforces basic required/length rules', () => {
+    expect(validateClientName('')).toBe('Client name is required');
+    expect(validateClientName('A')).toBe('Client name must be at least 2 characters long');
+  });
+});

--- a/packages/validation/src/lib/clientFormValidation.ts
+++ b/packages/validation/src/lib/clientFormValidation.ts
@@ -75,7 +75,8 @@ export function validateClientName(name: string): string | null {
   }
   
   // Allow Unicode letters, numbers, spaces, and business-appropriate punctuation
-  if (!/^[\p{L}\p{N}\s\-,\.&'()]+$/u.test(nameWithoutEmojis)) {
+  // (e.g. "C++ Solutions", "AT&T + Co", "Yahoo!", "#1 Plumbing", "Owner/Operator")
+  if (!/^[\p{L}\p{N}\s\-,\.&'()+#@!\/]+$/u.test(nameWithoutEmojis)) {
     return 'Client name contains invalid characters';
   }
   

--- a/server/src/lib/utils/clientFormValidation.ts
+++ b/server/src/lib/utils/clientFormValidation.ts
@@ -75,7 +75,8 @@ export function validateClientName(name: string): string | null {
   }
   
   // Allow Unicode letters, numbers, spaces, and business-appropriate punctuation
-  if (!/^[\p{L}\p{N}\s\-,\.&'()]+$/u.test(nameWithoutEmojis)) {
+  // (e.g. "C++ Solutions", "AT&T + Co", "Yahoo!", "#1 Plumbing", "Owner/Operator")
+  if (!/^[\p{L}\p{N}\s\-,\.&'()+#@!\/]+$/u.test(nameWithoutEmojis)) {
     return 'Client name contains invalid characters';
   }
   


### PR DESCRIPTION
## Summary
Expanded the client name validation to accept additional business-appropriate punctuation and symbols that are commonly used in company names, while maintaining security by rejecting genuinely unsupported characters.

## Key Changes
- Updated the client name validation regex in both `packages/validation` and `server` to allow: `+`, `#`, `@`, `!`, and `/`
- Added comprehensive test coverage for the validation function, including:
  - Acceptance of ordinary business names
  - Regression test for comma support
  - New business-appropriate symbols (e.g., "C++ Solutions", "AT&T + Co", "Yahoo!", "#1 Plumbing", "Owner/Operator Services", "Mail@Home")
  - Continued rejection of genuinely unsupported characters (e.g., `$`, `~`, `^`)
  - Enforcement of existing required/length rules

## Implementation Details
- The regex pattern was updated from `[\p{L}\p{N}\s\-,\.&'()]+` to `[\p{L}\p{N}\s\-,\.&'()+#@!\/]+`
- Added clarifying comments with examples of now-accepted names
- Changes applied consistently across both validation modules to maintain parity
- All existing validation rules (required field, minimum 2 characters) remain unchanged

https://claude.ai/code/session_01DaktnofMAr7UL6zzQNJEea