### PR TITLE
docs: audit 2026-06-12

### DIFF
--- a/docs/api/api_overview.md
+++ b/docs/api/api_overview.md
@@ -131,13 +131,14 @@ The following REST API groups are available in the Community Edition under the b
 - **Users** — Create and administer user accounts, manage passwords and two-factor authentication, and read roles, teams, and effective permissions.
 - **Billing** — Access contracts, contract lines, invoices, and billing analytics.
 - Additional endpoints: companies (clients), contacts, projects, boards, categories, priorities, statuses, time entries, schedules, and more.
+- **Workflow Registry (unversioned)** — Four endpoints outside the `/api/v1/` prefix expose the workflow engine's registered action types, node types, and JSON schema catalog. `GET /api/workflow/registry/actions` returns all registered action definitions; `GET /api/workflow/registry/nodes` lists registered node types; `GET /api/workflow/registry/designer-catalog` provides the designer's action tile catalog; and `GET /api/workflow/registry/schemas/{schemaRef}` resolves a named JSON Schema by reference. All four require the `workflow:read` RBAC permission.
 
 #### Ticket Bundling
 
 When multiple tickets describe the same underlying issue, they can be grouped under one *master* ticket using the bundle sub-resource at `/api/v1/tickets/{id}/bundle`. This feature is available to both PSA and AlgaDesk tenants.
 
 | Method | Path | Purpose |
-|--------|------|---------|
+|--------|------|--------|
 | `GET` | `/tickets/{id}/bundle` | Return the ticket's bundle role (`master`, `child`, or `standalone`), the master ticket, children, and settings |
 | `POST` | `/tickets/{id}/bundle` | Create a bundle with `{id}` as master. Requires `child_ticket_ids` (array of UUIDs); accepts optional `mode` (`link_only` or `sync_updates`, default `sync_updates`) |
 | `DELETE` | `/tickets/{id}/bundle` | Detach all children and remove bundle settings |
@@ -155,7 +156,7 @@ When multiple tickets describe the same underlying issue, they can be grouped un
 Assets and tickets can be linked to each other (the same association surfaced in the asset and ticket detail UIs). The link is a single record readable and writable from either side.
 
 | Method | Path | Purpose |
-|--------|------|---------|
+|--------|------|--------|
 | `GET` | `/assets/{id}/tickets` | List tickets linked to an asset |
 | `POST` | `/assets/{id}/tickets` | Link a ticket to an asset. Requires `ticket_id`; accepts optional `relationship_type` (default `affected`) and `notes` |
 | `DELETE` | `/assets/{id}/tickets/{ticketId}` | Remove the link between an asset and a ticket |
@@ -204,7 +205,6 @@ Assets and tickets can be linked to each other (the same association surfaced in
   - Error scenarios and handling
 
 ## 8. Future Considerations
-- **API Documentation:** OpenAPI/Swagger integration
 - **Webhook Support:** For asynchronous operations
 - **Rate Limiting:** Request throttling implementation
 - **Versioning Strategy:** API versioning guidelines


### PR DESCRIPTION
## Source PRs

- [#2679 Auth-wrap contract-line routes; extend OpenAPI](https://github.com/Nine-Minds/alga-psa/pull/2679) — merged 2026-06-11

## Edited files

- **`docs/api/api_overview.md`** — Added a *Workflow Registry (unversioned)* bullet to the Community Edition APIs list in Section 6, documenting the four `/api/workflow/registry/*` endpoints now formally registered in the OpenAPI spec (`actions`, `nodes`, `designer-catalog`, `schemas/{schemaRef}`), including their `workflow:read` permission requirement. Removed the stale "API Documentation: OpenAPI/Swagger integration" item from Future Considerations — OpenAPI 3.1 specs are already generated and live in `sdk/docs/openapi/`.

## Needs human review

- **OpenAPI spec sync to nm-store** — `sdk/docs/openapi/alga-openapi*.{json,yaml}` were regenerated by PR #2679, but `packages/nm-store/public/openapi/alga.json` in nm-store has **not** been updated to reflect the new Workflow Registry endpoints or the newly-documented `GET /api/projects`. Run `cd sdk && npm run openapi:generate` in alga-psa, then sync the result to `nm-store/packages/nm-store/public/openapi/alga.json`.

- **`nm-store` resourceHubs.ts classification** — Once the spec is synced, the build-time resource audit will flag the new "Workflow Registry" OpenAPI tag as unclassified. Decide whether these endpoints should be a public-facing hub (add a `workflow-registry` entry to `RESOURCE_HUBS` and create `reference/workflow-registry/page.tsx`) or an internal-only surface (add `workflow-registry` to `INTERNAL_RESOURCES`). Note the existing comment in that file about the `/api/workflow/registry/*` path-prefix conflict with the public `workflow` slug — `INTERNAL_PATH_PREFIXES` may also need updating.

- **PR #2679 contract-line auth** — Five contract-line route files were wrapped with `withApiKeyRouteAuth`. These routes were previously unauthenticated at the Next.js handler layer (though the API overview already documented auth as required for all endpoints). No behavioral doc change needed beyond what is already written, but if any integration relied on the prior unauthenticated behavior, it will now receive 401 responses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8BgqBn3CT3r4rKX2FzTiP)_