### PR TITLE
Add feature flag gating for Huntress RMM integration

### DIFF
--- a/ee/server/src/lib/actions/integrations/huntressActions.ts
+++ b/ee/server/src/lib/actions/integrations/huntressActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { revalidatePath } from 'next/cache';
+import { isFeatureFlagEnabled } from '@alga-psa/core';
 import logger from '@alga-psa/core/logger';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth, hasPermission } from '@alga-psa/auth';
@@ -34,12 +35,20 @@ import {
 import type { RmmOrganizationMapping } from '../../../interfaces/rmm.interfaces';
 
 const SETTINGS_PATH = '/msp/settings';
+const HUNTRESS_FEATURE_FLAG = 'huntress-rmm-integration';
 
 function withHuntressAccess<TArgs extends unknown[], TResult>(
   handler: (user: any, context: { tenant: string }, ...args: TArgs) => Promise<TResult>
 ) {
   return withAuth(async (user, context, ...args: TArgs): Promise<TResult> => {
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
+    const flagEnabled = await isFeatureFlagEnabled(HUNTRESS_FEATURE_FLAG, {
+      tenantId: (context as { tenant: string }).tenant,
+      userId: (user as { user_id?: string } | undefined)?.user_id,
+    });
+    if (!flagEnabled) {
+      throw new Error('The Huntress integration is not enabled for this tenant');
+    }
     return handler(user, context as { tenant: string }, ...args);
   });
 }

--- a/ee/server/src/lib/integrations/huntress/scheduling.ts
+++ b/ee/server/src/lib/integrations/huntress/scheduling.ts
@@ -4,6 +4,7 @@
  * has elapsed. Registered from initializeApp in enterprise builds.
  */
 
+import { isFeatureFlagEnabled } from '@alga-psa/core';
 import logger from '@alga-psa/core/logger';
 import { getAdminConnection } from '@alga-psa/db/admin';
 import { runWithTenant } from '@/lib/db';
@@ -12,6 +13,7 @@ import { isPollDue, parseHuntressSettings } from './settings';
 import { runHuntressIncidentPoll } from './incidents/incidentPoller';
 
 export const HUNTRESS_POLL_JOB_NAME = 'huntress-incident-poll-dispatch';
+const HUNTRESS_FEATURE_FLAG = 'huntress-rmm-integration';
 const DISPATCH_INTERVAL = process.env.HUNTRESS_POLL_DISPATCH_INTERVAL || '5 minutes';
 
 export async function dispatchHuntressPolls(now: Date = new Date()): Promise<void> {
@@ -23,6 +25,11 @@ export async function dispatchHuntressPolls(now: Date = new Date()): Promise<voi
   for (const row of integrations) {
     const settings = parseHuntressSettings(row.settings);
     if (!isPollDue(row.last_incremental_sync_at, settings.pollIntervalMinutes, now)) continue;
+
+    const flagEnabled = await isFeatureFlagEnabled(HUNTRESS_FEATURE_FLAG, {
+      tenantId: String(row.tenant),
+    });
+    if (!flagEnabled) continue;
 
     try {
       await runWithTenant(String(row.tenant), async () => {

--- a/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.tsx
+++ b/packages/integrations/src/components/settings/integrations/RmmIntegrationsSetup.tsx
@@ -159,9 +159,11 @@ export default function RmmIntegrationsSetup() {
   const tacticalFlag = useFeatureFlag('tactical-rmm-integration', { defaultValue: false });
   const taniumFlag = useFeatureFlag('tanium-rmm-integration', { defaultValue: false });
   const levelIoFlag = useFeatureFlag('levelio-rmm-integration', { defaultValue: false });
+  const huntressFlag = useFeatureFlag('huntress-rmm-integration', { defaultValue: false });
   const isTacticalEnabled = !!tacticalFlag?.enabled;
   const isTaniumEnabled = !!taniumFlag?.enabled;
   const isLevelIoEnabled = !!levelIoFlag?.enabled;
+  const isHuntressEnabled = !!huntressFlag?.enabled;
 
   const options = useMemo<RmmIntegrationOption[]>(
     () => {
@@ -170,7 +172,8 @@ export default function RmmIntegrationsSetup() {
         enabledFeatureFlags: {
           'tactical-rmm-integration': isTacticalEnabled,
           'tanium-rmm-integration': isTaniumEnabled,
-          'levelio-rmm-integration': isLevelIoEnabled
+          'levelio-rmm-integration': isLevelIoEnabled,
+          'huntress-rmm-integration': isHuntressEnabled
         }
       });
 
@@ -185,7 +188,7 @@ export default function RmmIntegrationsSetup() {
         })
         .filter((option): option is RmmIntegrationOption => option !== null);
     },
-    [isEEAvailable, isTacticalEnabled, isTaniumEnabled, isLevelIoEnabled]
+    [isEEAvailable, isTacticalEnabled, isTaniumEnabled, isLevelIoEnabled, isHuntressEnabled]
   );
 
   const [selected, setSelected] = useState<RmmProvider | null>(

--- a/packages/integrations/src/lib/rmm/providerRegistry.test.ts
+++ b/packages/integrations/src/lib/rmm/providerRegistry.test.ts
@@ -30,12 +30,12 @@ describe('RMM provider registry', () => {
     });
   });
 
-  it('exposes Huntress metadata gated by enterprise without a feature flag', () => {
+  it('exposes Huntress metadata gated by enterprise and feature flag', () => {
     const huntress = getRmmProviderMetadata('huntress');
     expect(huntress).toBeDefined();
     expect(huntress?.title).toBe('Huntress');
     expect(huntress?.requiresEnterprise).toBe(true);
-    expect(huntress?.featureFlagKey).toBeUndefined();
+    expect(huntress?.featureFlagKey).toBe('huntress-rmm-integration');
     expect(huntress?.capabilities).toEqual({
       connection: true,
       scopeSync: true,

--- a/packages/integrations/src/lib/rmm/providerRegistry.ts
+++ b/packages/integrations/src/lib/rmm/providerRegistry.ts
@@ -21,12 +21,12 @@ export interface RmmProviderMetadata {
   badge?: RmmProviderBadge;
   capabilities: RmmProviderCapabilityFlags;
   requiresEnterprise: boolean;
-  featureFlagKey?: 'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration';
+  featureFlagKey?: 'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration' | 'huntress-rmm-integration';
 }
 
 export interface RmmProviderAvailabilityContext {
   isEnterprise: boolean;
-  enabledFeatureFlags: Partial<Record<'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration', boolean>>;
+  enabledFeatureFlags: Partial<Record<'tactical-rmm-integration' | 'tanium-rmm-integration' | 'levelio-rmm-integration' | 'huntress-rmm-integration', boolean>>;
 }
 
 const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
@@ -105,7 +105,8 @@ const RMM_PROVIDER_REGISTRY: RmmProviderMetadata[] = [
       events: false,
       remoteActions: false
     },
-    requiresEnterprise: true
+    requiresEnterprise: true,
+    featureFlagKey: 'huntress-rmm-integration'
   }
 ];
 


### PR DESCRIPTION
## Summary
This PR adds feature flag gating to the Huntress RMM integration, bringing it in line with other RMM integrations (Tactical, Tanium, LevelIO). The integration is now controlled by the `huntress-rmm-integration` feature flag at both the server-side action and scheduling layers, as well as in the UI.

## Key Changes
- **Server-side action gating**: Added feature flag check in `withHuntressAccess` wrapper to prevent unauthorized access to Huntress integration actions
- **Scheduling gating**: Added feature flag validation in `dispatchHuntressPolls` to skip polling for tenants without the feature enabled
- **UI integration**: Updated `RmmIntegrationsSetup` component to check the `huntress-rmm-integration` feature flag before displaying the Huntress option
- **Provider registry**: Added `huntress-rmm-integration` as the feature flag key for Huntress in the RMM provider metadata
- **Type safety**: Updated type definitions in `providerRegistry.ts` to include the new feature flag in the union type
- **Tests**: Updated test expectations to reflect that Huntress is now gated by a feature flag

## Implementation Details
- The feature flag check uses the standard `isFeatureFlagEnabled` utility with appropriate context (tenantId and userId where applicable)
- Consistent error handling: server-side throws an error if the flag is disabled, while the scheduler silently skips disabled tenants
- The UI respects the feature flag state to conditionally show/hide the Huntress integration option

https://claude.ai/code/session_01XrPUzRzqCfa74Htk4rcqP3