### PR TITLE
Gate auto-close and inbound email rules UI behind feature flags

### DIFF
--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -25,6 +25,7 @@ import { Microsoft365DiagnosticsDialog } from './admin/Microsoft365DiagnosticsDi
 import { DrawerOutlet, DrawerProvider, useDrawer } from '@alga-psa/ui';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import {
   getEmailProviders,
   deleteEmailProvider,
@@ -54,6 +55,10 @@ function EmailProviderConfigurationContent({
 }: EmailProviderConfigurationProps) {
   const { t } = useTranslation('msp/email-providers');
   const isEnterpriseEdition = isMicrosoftConsumerEnterpriseEdition();
+  // Dark-release gate for the inbound email rules UI. Off by default (PostHog
+  // returns false for an unknown flag); UI-only — rule evaluation and server
+  // actions stay live regardless.
+  const { enabled: inboundEmailRulesUiEnabled } = useFeatureFlag('inbound-email-rules');
   const [providers, setProviders] = useState<EmailProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -506,20 +511,22 @@ function EmailProviderConfigurationContent({
               defaultValue: 'Defaults',
             })}
           </Button>
-          <Button
-            id="nav-inbound-rules"
-            variant="ghost"
-            className={`justify-start w-full px-2 py-2 rounded-md ${
-              activeSection === 'rules'
-                ? 'text-[rgb(var(--color-primary-700))] font-semibold underline decoration-[rgb(var(--color-primary-600))] decoration-2 underline-offset-4 bg-primary-500/10'
-                : 'text-[rgb(var(--color-text-700))] hover:text-[rgb(var(--color-text-900))] hover:bg-[rgb(var(--color-border-50))]'
-            }`}
-            onClick={() => setActiveSection('rules')}
-          >
-            {t('configuration.nav.inboundRules', {
-              defaultValue: 'Inbound Rules',
-            })}
-          </Button>
+          {inboundEmailRulesUiEnabled && (
+            <Button
+              id="nav-inbound-rules"
+              variant="ghost"
+              className={`justify-start w-full px-2 py-2 rounded-md ${
+                activeSection === 'rules'
+                  ? 'text-[rgb(var(--color-primary-700))] font-semibold underline decoration-[rgb(var(--color-primary-600))] decoration-2 underline-offset-4 bg-primary-500/10'
+                  : 'text-[rgb(var(--color-text-700))] hover:text-[rgb(var(--color-text-900))] hover:bg-[rgb(var(--color-border-50))]'
+              }`}
+              onClick={() => setActiveSection('rules')}
+            >
+              {t('configuration.nav.inboundRules', {
+                defaultValue: 'Inbound Rules',
+              })}
+            </Button>
+          )}
         </nav>
       </div>
       <div className="flex-1 min-w-0">
@@ -546,11 +553,11 @@ function EmailProviderConfigurationContent({
               window.dispatchEvent(new CustomEvent('inbound-defaults-updated'));
             }} />
           </div>
-        ) : (
+        ) : inboundEmailRulesUiEnabled ? (
           <div className="space-y-4">
             <InboundEmailRulesManager />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -49,6 +49,7 @@ import {
 } from '@alga-psa/ui/components/DropdownMenu';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { useProduct } from '@/context/ProductContext';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 
 type TicketStatusSeedMode = 'copy_existing' | 'create_inline';
 type ManagedTicketStatus = {
@@ -190,6 +191,10 @@ const TICKET_STATUS_VALIDATION_KEYS: Record<ManagedTicketStatusValidationCode, s
 const BoardsSettings: React.FC = () => {
   const { t } = useTranslation('msp/settings');
   const { isAlgaDesk } = useProduct();
+  // Dark-release gate for the auto-close rules UI. Off by default (PostHog
+  // returns false for an unknown flag); UI-only — the auto-close engine and
+  // server actions stay live regardless.
+  const { enabled: autoCloseRulesUiEnabled } = useFeatureFlag('ticket-auto-close-rules');
   const createEmptyFormData = () => ({
     board_name: '',
     description: '',
@@ -635,7 +640,7 @@ const BoardsSettings: React.FC = () => {
         return;
       }
 
-      if (editingBoard) {
+      if (editingBoard && autoCloseRulesUiEnabled) {
         for (const rule of autoCloseRulesForm) {
           if (!rule.trigger_status_id || !rule.close_to_status_id) {
             setDialogError(t('ticketing.boards.closeRules.messages.autoCloseStatusRequired'));
@@ -680,21 +685,23 @@ const BoardsSettings: React.FC = () => {
 
         await upsertBoardCloseRules(editingBoard.board_id!, closeRulesForm);
 
-        for (const ruleId of removedAutoCloseRuleIds) {
-          await deleteBoardAutoCloseRule(ruleId);
-        }
-        for (const rule of autoCloseRulesForm) {
-          const payload = {
-            trigger_status_id: rule.trigger_status_id,
-            inactivity_days: rule.inactivity_days,
-            warning_days_before: rule.warning_days_before,
-            close_to_status_id: rule.close_to_status_id,
-            is_enabled: rule.is_enabled,
-          };
-          if (rule.rule_id) {
-            await updateBoardAutoCloseRule(rule.rule_id, payload);
-          } else {
-            await createBoardAutoCloseRule(editingBoard.board_id!, payload);
+        if (autoCloseRulesUiEnabled) {
+          for (const ruleId of removedAutoCloseRuleIds) {
+            await deleteBoardAutoCloseRule(ruleId);
+          }
+          for (const rule of autoCloseRulesForm) {
+            const payload = {
+              trigger_status_id: rule.trigger_status_id,
+              inactivity_days: rule.inactivity_days,
+              warning_days_before: rule.warning_days_before,
+              close_to_status_id: rule.close_to_status_id,
+              is_enabled: rule.is_enabled,
+            };
+            if (rule.rule_id) {
+              await updateBoardAutoCloseRule(rule.rule_id, payload);
+            } else {
+              await createBoardAutoCloseRule(editingBoard.board_id!, payload);
+            }
           }
         }
 
@@ -1418,7 +1425,7 @@ const BoardsSettings: React.FC = () => {
               </div>
             )}
 
-            {editingBoard && (
+            {editingBoard && autoCloseRulesUiEnabled && (
               <div className="space-y-3 rounded-md border border-gray-200 p-3">
                 <div className="flex items-center justify-between">
                   <div>


### PR DESCRIPTION
## Summary

Dark-releases the recently merged auto-close rules (#2669) and inbound email rules (#2670) UI surfaces behind PostHog feature flags, using the established `useFeatureFlag` pattern:

- **`ticket-auto-close-rules`** — hides the auto-close rules section in the board edit dialog (`BoardsSettings.tsx`) and skips its save-handler validation/upserts while the flag is off
- **`inbound-email-rules`** — hides the Inbound Rules nav tab and panel in the email provider configuration (`EmailProviderConfiguration.tsx`)

UI-only gating: server actions and the auto-close engine stay live regardless. Both flags resolve to `false` until enabled in PostHog.

https://claude.ai/code/session_01M1V8tSovReNXaJ6ejqb98B

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1V8tSovReNXaJ6ejqb98B)_