### PR TITLE
Replace drop placeholder with slim positioned drop indicator

### DIFF
--- a/packages/projects/src/components/ProjectDetail.module.css
+++ b/packages/projects/src/components/ProjectDetail.module.css
@@ -510,6 +510,38 @@ body.dragging-task .mainContent::after {
   background-color: rgba(147, 51, 234, 0.05);
 }
 
+/*
+ * Slim drop indicator for the kanban board.
+ *
+ * Unlike .dropPlaceholder (which reserves a full card-sized gap), this is
+ * absolutely positioned and consumes NO layout space. Inserting/removing it
+ * never reflows the surrounding cards, which is what previously created a
+ * hover -> reflow -> re-measure feedback loop and made the drop target flicker
+ * back and forth while dragging between columns.
+ *
+ * It is positioned (via an inline top/bottom offset) in the centre of the gap
+ * between two cards, so the "after card A" and "before card B" indicators land
+ * on the exact same pixel and there is no visible jump if the closest-card
+ * calculation switches between two adjacent cards.
+ */
+.dropIndicator {
+  position: absolute;
+  left: 2px;
+  right: 2px;
+  height: 3px;
+  border-radius: 9999px;
+  background-color: rgb(147, 51, 234);
+  box-shadow: 0 0 0 1px rgba(147, 51, 234, 0.25), 0 0 8px rgba(147, 51, 234, 0.45);
+  z-index: 5;
+  pointer-events: none;
+  animation: dropIndicatorFade 120ms ease-out;
+}
+
+@keyframes dropIndicatorFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 /* Phase drop placeholder - styled like task drop placeholder */
 .phaseDropPlaceholder {
   height: 0;

--- a/packages/projects/src/components/StatusColumn.tsx
+++ b/packages/projects/src/components/StatusColumn.tsx
@@ -433,9 +433,12 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
           const taskPriority = task.priority_id ? priorities.find(p => p.priority_id === task.priority_id) : undefined;
           return (
           <div key={task.task_id} data-task-id={task.task_id} className="relative">
-            {/* Animated drop placeholder before task */}
+            {/* Drop indicator before task. Absolutely positioned so it does not
+                reflow the surrounding cards (which previously caused the drop
+                target to flicker back and forth). Centred in the gap above the
+                card via an inline offset. */}
             {dragOverTaskId === task.task_id && dropPosition === 'before' && (
-              <div className={`${styles.dropPlaceholder} ${styles.visible}`} />
+              <div className={styles.dropIndicator} style={{ top: `-${cardGap / 2 + 1.5}px` }} />
             )}
             <TaskCard
               task={task}
@@ -469,9 +472,10 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
               teamNames={teamNames}
               teamAvatarUrls={teamAvatarUrls}
             />
-            {/* Animated drop placeholder after task */}
+            {/* Drop indicator after task. Centred in the gap below the card so it
+                lands on the same pixel as the next card's "before" indicator. */}
             {dragOverTaskId === task.task_id && dropPosition === 'after' && (
-              <div className={`${styles.dropPlaceholder} ${styles.visible}`} />
+              <div className={styles.dropIndicator} style={{ bottom: `-${cardGap / 2 + 1.5}px` }} />
             )}
           </div>
         )})}

--- a/packages/projects/src/components/project-templates/TemplateEditor.tsx
+++ b/packages/projects/src/components/project-templates/TemplateEditor.tsx
@@ -1968,13 +1968,14 @@ function TemplateStatusColumn({
         style={{ gap: `${cardGap}px` }}
       >
         {sortedTasks.map((task, index) => (
-          <div key={task.template_task_id}>
-            {/* Drop placeholder before task */}
-            <div
-              className={`${styles.dropPlaceholder} ${
-                dropIndicatorPosition === index && draggedTaskId ? styles.visible : ''
-              }`}
-            />
+          <div key={task.template_task_id} className="relative">
+            {/* Drop indicator before task. Absolutely positioned so it consumes
+                no layout space and never reflows the cards (which previously
+                caused the drop target to flicker back and forth during a drag).
+                Centred in the gap above the card. */}
+            {draggedTaskId && dropIndicatorPosition === index && (
+              <div className={styles.dropIndicator} style={{ top: `-${cardGap / 2 + 1.5}px` }} />
+            )}
             <TaskCard
               task={task}
               onDragStart={onTaskDragStart}
@@ -2002,14 +2003,17 @@ function TemplateStatusColumn({
               teamAvatarUrls={teamAvatarUrls}
               zoomLevel={zoomLevel}
             />
+            {/* Drop indicator after the last card (drop at end of column),
+                centred in the gap below the card. */}
+            {draggedTaskId && index === sortedTasks.length - 1 && dropIndicatorPosition === sortedTasks.length && (
+              <div className={styles.dropIndicator} style={{ bottom: `-${cardGap / 2 + 1.5}px` }} />
+            )}
           </div>
         ))}
-        {/* Drop placeholder at end */}
-        <div
-          className={`${styles.dropPlaceholder} ${
-            dropIndicatorPosition === sortedTasks.length && draggedTaskId ? styles.visible : ''
-          }`}
-        />
+        {/* Empty column: no card to anchor to, show a simple indicator line */}
+        {draggedTaskId && sortedTasks.length === 0 && dropIndicatorPosition === 0 && (
+          <div className={styles.dropIndicator} style={{ top: '4px' }} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Replaced the full-height drop placeholder with a slim, absolutely-positioned drop indicator to eliminate layout reflow issues that caused drop targets to flicker while dragging between kanban columns.

## Key Changes
- **New `.dropIndicator` CSS class**: A 3px-tall, absolutely-positioned indicator with purple styling and fade animation that consumes no layout space
- **Removed layout-affecting placeholder**: Replaced `.dropPlaceholder` usage with the new `.dropIndicator` that doesn't reserve card-sized gaps
- **Centered positioning**: Drop indicators are positioned via inline `top` and `bottom` offsets (calculated as `-${cardGap / 2 + 1.5}px`) so "after card A" and "before card B" indicators align on the same pixel
- **Updated StatusColumn.tsx**: Changed both "before" and "after" drop position handlers to use the new indicator with appropriate inline positioning styles

## Implementation Details
The previous approach used a full-height placeholder that reserved layout space, causing the DOM to reflow whenever the drop target changed. This reflow would re-measure card positions, potentially switching the closest-card calculation to an adjacent card, creating a flickering feedback loop.

The new approach uses absolute positioning with `pointer-events: none`, so the indicator:
- Never affects surrounding card layout
- Doesn't trigger reflows when inserted/removed
- Lands on the exact same pixel for adjacent cards, preventing visual jumps
- Includes a smooth 120ms fade-in animation for visual feedback

https://claude.ai/code/session_01Dz5QdkCDGL6LatF56k7FjB