### PR TITLE
[codex] fix QBO non-payable payment sync cursor

### DIFF
--- a/packages/billing/src/services/accountingSync/paymentApplier.test.ts
+++ b/packages/billing/src/services/accountingSync/paymentApplier.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 vi.mock('./recordExternalPayment', () => ({
   recordExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'pay-1', paymentRecorded: true })),
   reverseExternalPayment: vi.fn(async () => ({ success: true, paymentId: 'rev-1', paymentRecorded: true })),
+  isNonPayableInvoiceStatus: (status: string | null | undefined) =>
+    status === 'cancelled' || status === 'draft' || status === 'void',
   computeBalanceDue: vi.fn(
     ({ totalAmount, creditApplied, totalPaid }: { totalAmount: number; creditApplied: number; totalPaid: number }) =>
       totalAmount - creditApplied - totalPaid
@@ -387,6 +389,142 @@ function makeKnexWithInvoice(invoiceRow: any): any {
   });
   return trx;
 }
+
+describe('paymentApplier — non-payable invoice guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(recordExternalPayment).mockResolvedValue({
+      success: true,
+      paymentId: 'pay-1',
+      paymentRecorded: true
+    });
+    vi.mocked(reverseExternalPayment).mockResolvedValue({
+      success: true,
+      paymentId: 'rev-1',
+      paymentRecorded: true
+    });
+  });
+
+  it('NEW payment targeting a cancelled mapped invoice creates an exception and does not apply', async () => {
+    const invoiceMapping = {
+      id: 'imap-1',
+      alga_entity_id: 'alga-inv-1',
+      external_entity_id: 'inv-ext-001',
+      sync_status: 'synced',
+      metadata: {}
+    };
+    const cancelledInvoice = { status: 'cancelled', total_amount: 20000, credit_applied: 0 };
+
+    const ledger = makeFakeLedger(null);
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)           // credit_application echo probe
+      .mockResolvedValueOnce(null)           // payment not in ledger (NEW)
+      .mockResolvedValueOnce(invoiceMapping); // invoice mapping found
+
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeKnexWithInvoice(cancelledInvoice),
+        tenantId: 't1',
+        adapterType: 'quickbooks_online',
+        targetRealm: 'r1',
+        ledger: ledger as any,
+        exceptions,
+        stats
+      },
+      makeInvoiceChange()
+    );
+
+    expect(recordExternalPayment).not.toHaveBeenCalled();
+    expect(reverseExternalPayment).not.toHaveBeenCalled();
+    expect(ledger.insert).not.toHaveBeenCalled();
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'accounting_sync_unmapped_payment',
+        entityType: 'external_payment',
+        entityId: 'pay-ext-001',
+        context: expect.objectContaining({
+          reason: 'targets_non_payable_invoice',
+          targets: [
+            expect.objectContaining({
+              alga_invoice_id: 'alga-inv-1',
+              external_invoice_id: 'inv-ext-001',
+              invoice_status: 'cancelled'
+            })
+          ]
+        })
+      })
+    );
+    expect(stats.paymentsSkipped).toBe(1);
+    expect(stats.exceptionsCreated).toBe(1);
+  });
+
+  it('edited mapped payment targeting a draft invoice creates an exception before reversing old allocations', async () => {
+    const existing = {
+      id: 'pmap-1',
+      alga_entity_id: 'old-pay-id',
+      sync_status: 'synced',
+      metadata: {
+        sync_token: '2',
+        deleted: false,
+        allocations: [
+          { invoiceId: 'alga-inv-1', externalInvoiceId: 'inv-ext-001', amountCents: 15000, algaPaymentId: 'pay-old' }
+        ]
+      }
+    };
+    const invoiceMapping = {
+      id: 'imap-1',
+      alga_entity_id: 'alga-inv-1',
+      external_entity_id: 'inv-ext-001',
+      sync_status: 'synced',
+      metadata: {}
+    };
+
+    const ledger = makeFakeLedger(existing);
+    ledger.findByExternalId
+      .mockResolvedValueOnce(null)          // credit_application echo probe
+      .mockResolvedValueOnce(existing)      // existing payment mapping
+      .mockResolvedValueOnce(invoiceMapping); // invoice mapping found
+
+    const exceptions = makeFakeExceptions();
+    const stats = emptyCycleStats();
+
+    await applyExternalPaymentChange(
+      {
+        knex: makeKnexWithInvoice({ status: 'draft', total_amount: 20000, credit_applied: 0 }),
+        tenantId: 't1',
+        adapterType: 'quickbooks_online',
+        targetRealm: 'r1',
+        ledger: ledger as any,
+        exceptions,
+        stats
+      },
+      makeInvoiceChange({ syncToken: '4' })
+    );
+
+    expect(reverseExternalPayment).not.toHaveBeenCalled();
+    expect(recordExternalPayment).not.toHaveBeenCalled();
+    expect(ledger.update).not.toHaveBeenCalled();
+    expect(exceptions.createOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'accounting_sync_unmapped_payment',
+        context: expect.objectContaining({
+          reason: 'targets_non_payable_invoice',
+          targets: [
+            expect.objectContaining({
+              invoice_status: 'draft'
+            })
+          ]
+        })
+      })
+    );
+    expect(stats.paymentsSkipped).toBe(1);
+    expect(stats.paymentsReversed).toBe(0);
+    expect(stats.exceptionsCreated).toBe(1);
+  });
+});
 
 describe('paymentApplier — over-application guard', () => {
   beforeEach(() => {

--- a/packages/billing/src/services/accountingSync/paymentApplier.ts
+++ b/packages/billing/src/services/accountingSync/paymentApplier.ts
@@ -2,7 +2,12 @@ import { Knex } from 'knex';
 import logger from '@alga-psa/core/logger';
 import type { AccountingExternalChange } from '@alga-psa/types';
 import { SyncMappingLedger } from './syncMappingLedger';
-import { recordExternalPayment, reverseExternalPayment, computeBalanceDue } from './recordExternalPayment';
+import {
+  recordExternalPayment,
+  reverseExternalPayment,
+  computeBalanceDue,
+  isNonPayableInvoiceStatus
+} from './recordExternalPayment';
 import type { AccountingSyncCycleStats } from './accountingSync.types';
 import type { SyncExceptionService } from './syncExceptions.types';
 
@@ -29,6 +34,12 @@ interface RecordedAllocation {
   externalInvoiceId: string;
   amountCents: number;
   algaPaymentId: string;
+}
+
+interface PaymentTargetInvoiceRow {
+  status: string;
+  total_amount: number;
+  credit_applied: number | null;
 }
 
 export interface PaymentApplierDeps {
@@ -162,6 +173,27 @@ async function applyAllocations(
   return recorded;
 }
 
+async function loadTargetInvoices(
+  deps: PaymentApplierDeps,
+  allocations: PaymentAllocation[]
+): Promise<Map<string, PaymentTargetInvoiceRow>> {
+  const rows = new Map<string, PaymentTargetInvoiceRow>();
+  const invoiceIds = [...new Set(allocations.map((allocation) => allocation.invoiceId))];
+
+  for (const invoiceId of invoiceIds) {
+    const invoiceRow = await deps.knex('invoices')
+      .where({ tenant: deps.tenantId, invoice_id: invoiceId })
+      .select('status', 'total_amount', 'credit_applied')
+      .first<PaymentTargetInvoiceRow | undefined>();
+
+    if (invoiceRow) {
+      rows.set(invoiceId, invoiceRow);
+    }
+  }
+
+  return rows;
+}
+
 export async function applyExternalPaymentChange(
   deps: PaymentApplierDeps,
   change: AccountingExternalChange
@@ -246,6 +278,47 @@ export async function applyExternalPaymentChange(
     return;
   }
 
+  const targetInvoices = await loadTargetInvoices(deps, allocations);
+  const nonPayableTargets = allocations
+    .map((allocation) => ({
+      allocation,
+      invoice: targetInvoices.get(allocation.invoiceId)
+    }))
+    .filter(({ invoice }) => isNonPayableInvoiceStatus(invoice?.status));
+
+  if (nonPayableTargets.length > 0) {
+    // Apply nothing: a payment linked to a voided/draft/cancelled invoice is an
+    // operator-facing sync exception, not a cursor-blocking applier failure.
+    deps.stats.paymentsSkipped += 1;
+    const result = await deps.exceptions.createOrUpdate({
+      type: 'accounting_sync_unmapped_payment',
+      entityType: 'external_payment',
+      entityId: change.externalId,
+      title: 'QuickBooks payment targets a non-payable invoice',
+      context: {
+        external_payment_id: change.externalId,
+        reference: paymentReference(change.payload, change.externalId),
+        reason: 'targets_non_payable_invoice',
+        targets: nonPayableTargets.map(({ allocation, invoice }) => ({
+          alga_invoice_id: allocation.invoiceId,
+          external_invoice_id: allocation.externalInvoiceId,
+          invoice_status: invoice?.status ?? null
+        })),
+        total_amount: (change.payload as any)?.TotalAmt ?? null,
+        realm: deps.targetRealm
+      }
+    });
+    if (result.created) {
+      deps.stats.exceptionsCreated += 1;
+    }
+    logger.info('[accountingSync] Skipped payment for non-payable invoice', {
+      tenantId: deps.tenantId,
+      externalPaymentId: change.externalId,
+      invoiceIds: nonPayableTargets.map(({ allocation }) => allocation.invoiceId)
+    });
+    return;
+  }
+
   // ── Double-entry guard (§7) ─────────────────────────────────────────────
   // When a NEW external payment targets an invoice that Alga already shows as
   // fully settled, flag it as an over-application drift exception rather than
@@ -254,10 +327,7 @@ export async function applyExternalPaymentChange(
   // edits to existing mappings go through the reverse-and-reapply path normally.
   if (!existing) {
     for (const allocation of allocations) {
-      const invoiceRow = await deps.knex('invoices')
-        .where({ tenant: deps.tenantId, invoice_id: allocation.invoiceId })
-        .select('status', 'total_amount', 'credit_applied')
-        .first<{ status: string; total_amount: number; credit_applied: number | null } | undefined>();
+      const invoiceRow = targetInvoices.get(allocation.invoiceId);
 
       if (!invoiceRow) {
         continue; // Invoice disappeared — let the normal path handle it

--- a/packages/billing/src/services/accountingSync/recordExternalPayment.ts
+++ b/packages/billing/src/services/accountingSync/recordExternalPayment.ts
@@ -64,7 +64,11 @@ type InvoiceRow = {
   currency_code: string | null;
 };
 
-const NON_PAYABLE_STATUSES = ['cancelled', 'draft', 'void'];
+export const NON_PAYABLE_INVOICE_STATUSES = ['cancelled', 'draft', 'void'] as const;
+
+export function isNonPayableInvoiceStatus(status: string | null | undefined): boolean {
+  return NON_PAYABLE_INVOICE_STATUSES.includes(status as (typeof NON_PAYABLE_INVOICE_STATUSES)[number]);
+}
 
 async function getInvoice(knex: Knex, tenantId: string, invoiceId: string): Promise<InvoiceRow | undefined> {
   return knex('invoices')
@@ -144,7 +148,7 @@ export async function recordExternalPayment(
     return { success: false, paymentRecorded: false, error: `Invoice not found: ${input.invoiceId}` };
   }
 
-  if (NON_PAYABLE_STATUSES.includes(invoice.status)) {
+  if (isNonPayableInvoiceStatus(invoice.status)) {
     return {
       success: false,
       paymentRecorded: false,


### PR DESCRIPTION
## Summary

- Treat QBO payments linked to mapped non-payable Alga invoices as sync exceptions instead of applier failures.
- Share the non-payable invoice status helper with `recordExternalPayment` so the sync preflight and AR recorder use the same status set.
- Add behavior coverage for new and edited mapped payments targeting cancelled/draft invoices.

## Root Cause

`recordExternalPayment` correctly rejected payments for `cancelled`, `draft`, and `void` invoices, but `paymentApplier` converted that recoverable business result into a thrown error. The accounting sync cycle catches inbound applier throws at the cycle level, marks the cycle failed, and does not advance the cursor, so the same CDC payment can be fetched and fail repeatedly.

## Impact

A QBO payment linked to a non-payable exported invoice now creates a deduped `accounting_sync_unmapped_payment` task with `reason: targets_non_payable_invoice` and returns without recording or reversing payment allocations. That allows the inbound cycle to complete and advance its cursor while preserving an operator-visible exception.

## Validation

- `cd server && npx vitest run ../packages/billing/src/services/accountingSync/paymentApplier.test.ts ../packages/billing/src/services/accountingSync/accountingSyncCycleService.test.ts ../packages/billing/src/services/accountingSync/computeBalanceDue.test.ts`
- `git diff --check`