### PR TITLE
[codex] Fix kanban drag animations

### DIFF
--- a/packages/projects/src/components/ProjectDetail.module.css
+++ b/packages/projects/src/components/ProjectDetail.module.css
@@ -385,6 +385,7 @@
   min-width: 350px; /* Ensure minimum width */
   max-width: 350px; /* Prevent columns from growing */
   flex-shrink: 0; /* Prevent columns from shrinking */
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
 .revealedHiddenColumn {
@@ -480,14 +481,19 @@ body.dragging-task .mainContent::after {
 
 /* Task card transitions */
 .taskCard {
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    box-shadow 0.16s ease,
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    opacity 0.12s ease,
+    transform 0.12s ease;
   position: relative;
 }
 
 .taskCard.dragging {
-  opacity: 0.4;
-  transform: scale(0.95);
-  transition: all 0.2s ease-out;
+  opacity: 0.35;
+  cursor: grabbing;
+  transition: opacity 0.1s ease;
 }
 
 /* Drop placeholder that appears between tasks */
@@ -534,12 +540,6 @@ body.dragging-task .mainContent::after {
   box-shadow: 0 0 0 1px rgba(147, 51, 234, 0.25), 0 0 8px rgba(147, 51, 234, 0.45);
   z-index: 5;
   pointer-events: none;
-  animation: dropIndicatorFade 120ms ease-out;
-}
-
-@keyframes dropIndicatorFade {
-  from { opacity: 0; }
-  to { opacity: 1; }
 }
 
 /* Phase drop placeholder - styled like task drop placeholder */
@@ -575,20 +575,15 @@ body.dragging-task .mainContent::after {
 /* Entry animation for newly dropped tasks */
 @keyframes taskEntry {
   0% {
-    opacity: 0;
-    transform: scale(0.8) translateY(-10px);
-  }
-  50% {
-    transform: scale(1.02) translateY(0);
+    opacity: 0.72;
   }
   100% {
     opacity: 1;
-    transform: scale(1) translateY(0);
   }
 }
 
 .taskCard.entering {
-  animation: taskEntry 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: taskEntry 0.16s ease-out;
 }
 
 /* Subtle bounce for nearby tasks when dropping */
@@ -615,11 +610,14 @@ body.dragging-task .mainContent::after {
   cursor: grab;
 }
 
+:global(body.dragging-task) .taskCard:hover:not(.dragging) {
+  transform: none;
+  cursor: grabbing;
+}
+
 /* Status column highlight during drag */
 .kanbanColumn.dragOver {
-  transform: scale(1.01);
-  box-shadow: 0 0 0 2px rgba(147, 51, 234, 0.3);
-  transition: all 0.3s ease-out;
+  box-shadow: inset 0 0 0 2px rgba(147, 51, 234, 0.3), 0 0 0 1px rgba(147, 51, 234, 0.15);
 }
 
 /* Loading state for async operations */

--- a/packages/projects/src/components/ProjectDetail.tsx
+++ b/packages/projects/src/components/ProjectDetail.tsx
@@ -118,6 +118,7 @@ const PROJECT_LIST_DENSITY_PRESETS: readonly ProjectListDensityPreset[] = [
 const STATUS_FALLBACK_BACKGROUNDS = ['#f3f4f6', '#e0e7ff', '#dcfce7', '#fef9c3'];
 const STATUS_FALLBACK_BADGES = ['#e5e7eb', '#c7d2fe', '#bbf7d0', '#fef08a'];
 const STATUS_FALLBACK_BORDERS = ['#d1d5db', '#a5b4fc', '#86efac', '#fde047'];
+type TaskLayoutSnapshot = Map<string, { left: number; top: number }>;
 
 // Task type icons for the filter dropdown
 const taskTypeIcons: Record<string, React.ComponentType<any>> = {
@@ -684,6 +685,7 @@ export default function ProjectDetail({
   const scrollbarThumbRef = useRef<HTMLDivElement>(null);
   const dragAbortRef = useRef<AbortController | null>(null);
   const stickyStatusStripRef = useRef<HTMLDivElement>(null);
+  const taskLayoutAnimationsRef = useRef<Map<string, Animation>>(new Map());
   const [kanbanHeaderHeight, setKanbanHeaderHeight] = useState(0);
   const [phasesPanelHeight, setPhasesPanelHeight] = useState<number | null>(null);
   const scrollIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -694,6 +696,77 @@ export default function ProjectDetail({
   });
   const phasesContainerRef = useRef<HTMLDivElement>(null);
   const pageContainerRef = useRef<HTMLDivElement>(null);
+
+  const captureTaskLayout = useCallback((): TaskLayoutSnapshot => {
+    const container = kanbanBoardRef.current;
+    const snapshot: TaskLayoutSnapshot = new Map();
+    if (!container) return snapshot;
+
+    container.querySelectorAll<HTMLElement>('[data-kanban-column-tasks="true"] [data-task-id]').forEach((element) => {
+      const taskId = element.dataset.taskId;
+      if (!taskId) return;
+
+      const rect = element.getBoundingClientRect();
+      snapshot.set(taskId, { left: rect.left, top: rect.top });
+    });
+
+    return snapshot;
+  }, []);
+
+  const playTaskLayoutAnimation = useCallback((beforeLayout: TaskLayoutSnapshot, excludedTaskIds: Set<string>) => {
+    if (beforeLayout.size === 0) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    window.requestAnimationFrame(() => {
+      const container = kanbanBoardRef.current;
+      if (!container) return;
+
+      container.querySelectorAll<HTMLElement>('[data-kanban-column-tasks="true"] [data-task-id]').forEach((element) => {
+        const taskId = element.dataset.taskId;
+        if (!taskId || excludedTaskIds.has(taskId) || typeof element.animate !== 'function') return;
+
+        const before = beforeLayout.get(taskId);
+        if (!before) return;
+
+        const after = element.getBoundingClientRect();
+        const deltaX = before.left - after.left;
+        const deltaY = before.top - after.top;
+        if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) return;
+
+        taskLayoutAnimationsRef.current.get(taskId)?.cancel();
+        element.style.willChange = 'transform';
+        const animation = element.animate(
+          [
+            { transform: `translate(${deltaX}px, ${deltaY}px)` },
+            { transform: 'translate(0, 0)' },
+          ],
+          {
+            duration: 180,
+            easing: 'cubic-bezier(0.2, 0, 0, 1)',
+          },
+        );
+
+        taskLayoutAnimationsRef.current.set(taskId, animation);
+        const clearAnimation = () => {
+          if (taskLayoutAnimationsRef.current.get(taskId) === animation) {
+            taskLayoutAnimationsRef.current.delete(taskId);
+            element.style.willChange = '';
+          }
+        };
+
+        animation.addEventListener('finish', clearAnimation, { once: true });
+        animation.addEventListener('cancel', clearAnimation, { once: true });
+      });
+    });
+  }, []);
+
+  useEffect(() => {
+    const animations = taskLayoutAnimationsRef.current;
+    return () => {
+      animations.forEach((animation) => animation.cancel());
+      animations.clear();
+    };
+  }, []);
 
   // Dynamically set min-height on pageContainer so it fills exactly the remaining
   // viewport, eliminating the dead-zone scroll caused by a static min-height: 100vh.
@@ -1688,6 +1761,12 @@ export default function ProjectDetail({
         }
       }
 
+      const movedTaskIds = new Set<string>([
+        ...statusUpdatedById.keys(),
+        ...otherPhaseTasks.map(t => t.task_id),
+      ]);
+      const beforeLayout = captureTaskLayout();
+
       if (otherPhaseTasks.length > 0) {
         // Cross-phase tasks now belong to this phase. Update the project-wide list
         // optimistically, then reload the board so they appear with correct
@@ -1703,6 +1782,7 @@ export default function ProjectDetail({
           return t;
         }));
         setStatusVersion(v => v + 1);
+        playTaskLayoutAnimation(beforeLayout, movedTaskIds);
       } else {
         // Pure same-phase status change — update in place to avoid a reload flicker
         const applyUpdate = (t: IProjectTask): IProjectTask => {
@@ -1713,6 +1793,7 @@ export default function ProjectDetail({
         };
         setProjectTasks(prev => prev.map(applyUpdate));
         setAllProjectTasks(prev => prev.map(applyUpdate));
+        playTaskLayoutAnimation(beforeLayout, movedTaskIds);
 
         setAnimatingTasks(prev => {
           const next = new Set(prev);
@@ -1791,6 +1872,7 @@ export default function ProjectDetail({
       // server round-trips before updating state, which let the card flash back
       // into its original column (at full opacity, once the drag ghost cleared)
       // until the request resolved.
+      const beforeLayout = captureTaskLayout();
       setProjectTasks(prevTasks =>
         prevTasks.map((t): IProjectTask =>
           t.task_id === draggedTaskId
@@ -1798,6 +1880,7 @@ export default function ProjectDetail({
             : t
         )
       );
+      playTaskLayoutAnimation(beforeLayout, new Set([draggedTaskId]));
       animateDroppedTask();
 
       try {
@@ -1821,11 +1904,13 @@ export default function ProjectDetail({
     } else {
       // Reorder within the same status. Update local order immediately, then
       // persist; roll back if the request fails.
+      const beforeLayout = captureTaskLayout();
       setProjectTasks(prevTasks =>
         prevTasks.map((t): IProjectTask =>
           t.task_id === draggedTaskId ? { ...t, order_key: newOrderKey } : t
         )
       );
+      playTaskLayoutAnimation(beforeLayout, new Set([draggedTaskId]));
       animateDroppedTask();
 
       try {

--- a/packages/projects/src/components/StatusColumn.tsx
+++ b/packages/projects/src/components/StatusColumn.tsx
@@ -152,9 +152,19 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    setIsDraggedOver(false);
-    setDragOverTaskId(null);
-    setDropPosition(null);
+    const column = e.currentTarget;
+    const { clientX, clientY } = e;
+
+    requestAnimationFrame(() => {
+      const elementAtPointer = document.elementFromPoint(clientX, clientY);
+      if (elementAtPointer && column.contains(elementAtPointer)) {
+        return;
+      }
+
+      setIsDraggedOver(false);
+      setDragOverTaskId(null);
+      setDropPosition(null);
+    });
   };
 
   const findClosestTask = (e: React.DragEvent): HTMLElement | null => {
@@ -344,7 +354,7 @@ export const StatusColumn: React.FC<StatusColumnProps> = ({
 
   return (
     <div
-      className={`${styles.kanbanColumn} ${isRevealedHidden ? styles.revealedHiddenColumn : ''} ${configuredColor ? '' : backgroundColor} rounded-lg border-2 border-solid transition-all duration-200 ${
+      className={`${styles.kanbanColumn} ${isRevealedHidden ? styles.revealedHiddenColumn : ''} ${configuredColor ? '' : backgroundColor} rounded-lg border-2 border-solid ${
         isDraggedOver ? 'border-purple-500 ' + styles.dragOver : (configuredColor ? '' : borderColor)
       }`}
       style={columnStyle}

--- a/packages/projects/src/components/TaskCard.tsx
+++ b/packages/projects/src/components/TaskCard.tsx
@@ -295,7 +295,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
         console.log('Using cached project tree data when selecting task for editing');
         onTaskSelected(task);
       }}
-      className={`${styles.taskCard} relative bg-white ${zoomScales.cardPadding} rounded-lg shadow-sm cursor-pointer hover:shadow-md transition-all duration-200 border flex flex-col ${zoomScales.cardGap} ${
+      className={`${styles.taskCard} relative bg-white ${zoomScales.cardPadding} rounded-lg shadow-sm cursor-pointer hover:shadow-md border flex flex-col ${zoomScales.cardGap} ${
         selected ? 'border-primary-500 ring-2 ring-primary-500' : 'border-gray-200'
       } ${
         isDragging ? styles.dragging : ''


### PR DESCRIPTION
## Summary
- Smooth out kanban drag/drop by removing scale and broad transition effects that caused visible jank while hovering between columns.
- Stabilize column drag-leave handling so moving over child elements does not clear drop state prematurely.
- Add a post-drop FLIP-style layout animation so existing cards slide into place after a card is dropped.

## Impact
Dragging tasks between project kanban columns should feel stable during hover and still provide a clear drop animation once the move is committed locally.

## Validation
- `npm -w @alga-psa/projects run typecheck`
- `npx eslint packages/projects/src/components/ProjectDetail.tsx packages/projects/src/components/StatusColumn.tsx packages/projects/src/components/TaskCard.tsx --quiet`
- `git diff --check`
- Browser-tested in the local wired Alga environment on `http://localhost:3434`, including a drag from To Do to In Progress and a destination-card slide-down animation check.