### PR TITLE
Skip runtime CNAME re-check for active portal domains

### DIFF
--- a/server/src/app/api/client-portal/domain-session/route.test.ts
+++ b/server/src/app/api/client-portal/domain-session/route.test.ts
@@ -216,4 +216,23 @@ describe('client portal domain session exchange', () => {
     expect(consumeOttMock).toHaveBeenCalled();
     expect(resolveCnameMock).not.toHaveBeenCalled();
   });
+
+  it('skips dns verification for active domains even when enforcement is enabled', async () => {
+    process.env.PORTAL_DOMAIN_DNS_CHECK = 'true';
+    // Simulate a custom domain fronted by a proxy (e.g. Cloudflare "orange cloud")
+    // where the CNAME is no longer resolvable. An already-active domain was verified
+    // at registration time, so the login must still finalize without re-resolving DNS.
+    resolveCnameMock.mockRejectedValue(new Error('ENODATA'));
+
+    const request = buildRequest({
+      ott: 'ott-token-123',
+      returnPath: '/client-portal/tickets',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(consumeOttMock).toHaveBeenCalled();
+    expect(resolveCnameMock).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/app/api/client-portal/domain-session/route.ts
+++ b/server/src/app/api/client-portal/domain-session/route.ts
@@ -171,7 +171,13 @@ export async function POST(request: Request): Promise<Response> {
       return typeof candidate === 'string' ? candidate : null;
     })();
 
-    const enforceCname = shouldVerifyCname();
+    // Active domains were already CNAME-verified during registration and are kept
+    // live by ongoing cert-manager renewal, so we trust that state rather than
+    // re-resolving DNS on every login. Re-checking here breaks legitimate setups
+    // that front the custom domain with a proxy (e.g. Cloudflare "orange cloud"),
+    // which hides the CNAME from resolution even though traffic and TLS are healthy.
+    const isActiveDomain = portalDomain.status === 'active';
+    const enforceCname = shouldVerifyCname() && !isActiveDomain;
 
     const cnameHost = hostParts.hostname;
 
@@ -203,6 +209,7 @@ export async function POST(request: Request): Promise<Response> {
         tenant: portalDomain.tenant,
         expected: expectedCname,
         enforceCname,
+        domainStatus: portalDomain.status,
       });
     }
 


### PR DESCRIPTION
  The client-portal domain-session handoff re-resolved the custom domain's
  CNAME on every login. Domains are already CNAME-verified at registration
  and kept live by cert-manager renewal, so re-checking is redundant — and
  it broke proxied setups (e.g. Cloudflare "orange cloud") that hide the
  CNAME from resolution, returning 409 handoffFinalizeFailed despite healthy
  traffic and TLS. Now skip enforcement when status === 'active'; the OTT,
  host match, and active-status gates still guard the exchange.

  Add a test covering an active, proxy-fronted domain finalizing login with
  an unresolvable CNAME.

  "But I don't want to go among proxied domains," said the CNAME. "Oh, you can't help that," said the Cert-Manager, renewing
  all the same: "we're all orange here. I'm orange, you're orange, and a domain that's active need answer no more riddles
  to come in." 🌩️ 🐇🔑