### PR TITLE
Dedupe standard_statuses display_order per item_type

### DIFF
--- a/server/migrations/20260615120000_dedupe_standard_status_display_order.cjs
+++ b/server/migrations/20260615120000_dedupe_standard_status_display_order.cjs
@@ -1,0 +1,42 @@
+/**
+ * Renumber standard_statuses.display_order to be unique and gapless within each
+ * item_type (1..N ordered by current display_order, then name). Legacy installs
+ * carried duplicate display_orders that broke board/project status seeding into
+ * the per-board `statuses` unique index. All rows are kept; idempotent.
+ */
+exports.up = async function(knex) {
+  console.log('Starting migration: dedupe_standard_status_display_order');
+
+  const rows = await knex('standard_statuses')
+    .select('standard_status_id', 'item_type', 'display_order', 'name')
+    .orderBy([
+      { column: 'item_type', order: 'asc' },
+      { column: 'display_order', order: 'asc' },
+      { column: 'name', order: 'asc' },
+    ]);
+
+  const nextOrderByType = {};
+  let updated = 0;
+
+  for (const row of rows) {
+    const next = (nextOrderByType[row.item_type] || 0) + 1;
+    nextOrderByType[row.item_type] = next;
+
+    if (row.display_order !== next) {
+      await knex('standard_statuses')
+        .where({ standard_status_id: row.standard_status_id })
+        .update({ display_order: next });
+      updated++;
+    }
+  }
+
+  console.log(
+    `Renumbered ${updated} standard_statuses row(s) across ${Object.keys(nextOrderByType).length} item type(s)`
+  );
+  console.log('Migration completed successfully');
+};
+
+exports.down = async function() {
+  // Not reversible: original duplicate ordering is not recoverable.
+  console.log('Rollback skipped: standard_statuses display_order normalization is not reversible');
+};


### PR DESCRIPTION
  Legacy installs carried duplicate display_orders within an item_type
  (e.g. ticket "New"/"Open" both at 1), which broke board and project
  status seeding against the per-board statuses unique index and failed
  imports with "Failed to import boards". Add an idempotent migration that
  renumbers each item_type's rows to a unique, gapless 1..N sequence
  ordered by current display_order then name, keeping every row.

  "Why, sometimes I've believed as many as six impossible statuses before
  breakfast — but never two of them sharing seat number one," said the
  Queen, and so the catalog learned at last to count to N. 🎩♟️ 🐇