### PR TITLE
Set appliance trial duration to 15 days

### DIFF
--- a/ee/appliance/status-ui/app/setup/page.tsx
+++ b/ee/appliance/status-ui/app/setup/page.tsx
@@ -280,7 +280,7 @@ export default function SetupPage() {
                         <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: disabled ? 'not-allowed' : 'pointer' }}>
                           <input type="radio" name="editionChoice" value="ee" checked={editionChoice === 'ee'} onChange={() => setEditionChoice('ee')} disabled={disabled} style={{ marginTop: '0.2rem' }} />
                           <span>
-                            <strong>Enterprise</strong> — 30-day free trial, then reverts to Essentials.
+                            <strong>Enterprise</strong> — 15-day free trial, then reverts to Essentials.
                             <br /><small style={{ color: 'var(--muted, #6b7280)' }}>Includes all features. Enter a license key below to extend beyond the trial.</small>
                           </span>
                         </label>
@@ -309,7 +309,7 @@ export default function SetupPage() {
                           aria-describedby="setup-license-key-help setup-license-key-error"
                           style={{ fontFamily: 'monospace', fontSize: '0.8rem', resize: 'vertical' }}
                         />
-                        <span id="setup-license-key-help" className={styles.helpText}>Paste the signed key from Nine Minds. Leave blank to start the 30-day trial.</span>
+                        <span id="setup-license-key-help" className={styles.helpText}>Paste the signed key from Nine Minds. Leave blank to start the 15-day trial.</span>
                         {fieldErrors.licenseKey ? <span id="setup-license-key-error" className={styles.fieldError}>{fieldErrors.licenseKey}</span> : null}
                       </div>
                     )}

--- a/helm/templates/appliance-bootstrap-configmap.yaml
+++ b/helm/templates/appliance-bootstrap-configmap.yaml
@@ -315,7 +315,7 @@ data:
 
     # Seed license_state from appliance-license-seed Secret (F082-F084).
     # ALWAYS seeds a row on a self-hosted/appliance install (defaulting to an
-    # 'ee' 30-day trial when EDITION_CHOICE is absent). A missing/empty
+    # 'ee' 15-day trial when EDITION_CHOICE is absent). A missing/empty
     # appliance-license-seed Secret previously left license_state empty, which
     # silently bricks licensing: getLicenseStatus returns selfHostMode=false, so
     # the in-app License page shows "only available for self-hosted" with NO

--- a/packages/licensing/src/lib/license-state.test.ts
+++ b/packages/licensing/src/lib/license-state.test.ts
@@ -49,18 +49,18 @@ describe('resolveSelfHostTier', () => {
   });
 
   // T010: active trial → premium
-  it('returns premium during an active 30-day trial', () => {
+  it('returns premium during an active 15-day trial', () => {
     const trialStart = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000); // 5 days ago
     const result = resolveSelfHostTier(makeRow({ trial_started_at: trialStart }));
     expect(result?.state).toBe('trial');
     expect(result?.tier).toBe('premium');
     expect(result?.daysRemaining).toBeGreaterThan(0);
-    expect(result?.daysRemaining).toBeLessThanOrEqual(25);
+    expect(result?.daysRemaining).toBeLessThanOrEqual(10);
   });
 
   // T011: trial expired → essentials
-  it('returns essentials after the 30-day trial window elapses', () => {
-    const trialStart = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000); // 31 days ago
+  it('returns essentials after the 15-day trial window elapses', () => {
+    const trialStart = new Date(Date.now() - 16 * 24 * 60 * 60 * 1000); // 16 days ago
     const result = resolveSelfHostTier(makeRow({ trial_started_at: trialStart }));
     expect(result?.state).toBe('trial_expired');
     expect(result?.tier).toBe('essentials');

--- a/packages/licensing/src/lib/license-state.ts
+++ b/packages/licensing/src/lib/license-state.ts
@@ -52,7 +52,7 @@ export interface ResolvedLicenseState {
   daysRemaining: number | null;
 }
 
-const TRIAL_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+const TRIAL_DURATION_MS = 15 * 24 * 60 * 60 * 1000;
 
 /**
  * Reads the license_state singleton from the admin DB.
@@ -88,7 +88,7 @@ export async function upsertLicenseState(
  *
  * Resolution order (per spec):
  *   1. Valid unexpired license → license.tier
- *   2. Active 30-day trial     → 'premium'
+ *   2. Active 15-day trial     → 'premium'
  *   3. Everything else         → 'essentials'
  *
  * Returns null when passed null (no row → caller falls through to SaaS logic).

--- a/server/migrations/20260530100000_create_license_state.cjs
+++ b/server/migrations/20260530100000_create_license_state.cjs
@@ -9,7 +9,7 @@
  * SaaS/Stripe resolution.
  *
  * edition_choice : 'ce' | 'ee'  — what was chosen at appliance setup
- * trial_started_at               — set when a 30-day Enterprise trial begins
+ * trial_started_at               — set when a 15-day Enterprise trial begins
  * license_token                  — the signed JWT for an active license (or null)
  * updated_at                     — last modification timestamp
  */

--- a/server/src/components/licenses/LicenseBanner.tsx
+++ b/server/src/components/licenses/LicenseBanner.tsx
@@ -46,7 +46,7 @@ export default function LicenseBanner() {
       break;
     case 'trial_available':
       // Fresh install, trial not yet used — invite, don't warn.
-      message = 'Running Essentials features. Start a free 30-day Enterprise trial to unlock all features.';
+      message = 'Running Essentials features. Start a free 15-day Enterprise trial to unlock all features.';
       urgency = 'info';
       break;
     case 'trial_expired':
@@ -70,7 +70,7 @@ export default function LicenseBanner() {
     case 'ce':
       // CE installs: only show if they haven't used their trial yet.
       if (!status.trialUsed) {
-        message = 'Running Essentials features. Start a free 30-day Enterprise trial to unlock all features.';
+        message = 'Running Essentials features. Start a free 15-day Enterprise trial to unlock all features.';
         urgency = 'info';
       }
       break;

--- a/server/src/components/licenses/LicenseManagementPage.tsx
+++ b/server/src/components/licenses/LicenseManagementPage.tsx
@@ -73,7 +73,7 @@ export default function LicenseManagementPage() {
       const result = await startTrial();
       if (result.success && result.status) {
         refresh(result.status);
-        setSuccessMsg('30-day Enterprise trial started.');
+        setSuccessMsg('15-day Enterprise trial started.');
       } else {
         setError(result.error ?? 'Failed to start trial');
       }
@@ -240,9 +240,9 @@ export default function LicenseManagementPage() {
       {/* Start trial */}
       {canStartTrial && (
         <section style={{ marginTop: '1.5rem', padding: '1rem', background: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: '0.5rem' }}>
-          <h2 style={{ fontWeight: 600, marginBottom: '0.25rem' }}>30-Day Enterprise Trial</h2>
+          <h2 style={{ fontWeight: 600, marginBottom: '0.25rem' }}>15-Day Enterprise Trial</h2>
           <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
-            Try all Enterprise features free for 30 days. No credit card required.
+            Try all Enterprise features free for 15 days. No credit card required.
             This trial is available once per installation.
           </p>
           <button
@@ -254,7 +254,7 @@ export default function LicenseManagementPage() {
               opacity: isPending ? 0.5 : 1,
             }}
           >
-            {isPending ? 'Starting…' : 'Start 30-Day Trial'}
+            {isPending ? 'Starting…' : 'Start 15-Day Trial'}
           </button>
         </section>
       )}

--- a/server/src/lib/actions/licenseManagementActions.ts
+++ b/server/src/lib/actions/licenseManagementActions.ts
@@ -109,7 +109,7 @@ export async function submitLicense(token: string): Promise<{ success: boolean; 
 }
 
 /**
- * Starts the one-time 30-day Enterprise trial.
+ * Starts the one-time 15-day Enterprise trial.
  * Blocked if: trial already used, or a valid license is already active.
  */
 export async function startTrial(): Promise<{ success: boolean; error?: string; status?: LicenseStatus }> {


### PR DESCRIPTION
## Summary
- Change self-host/appliance Enterprise trial duration from 30 days to 15 days
- Update appliance licensing UI/banner/setup copy and related comments/tests
- Leave SaaS Premium and Solo → Pro trials unchanged

## Validation
- npm -w @alga-psa/licensing test -- license-state.test.ts

Note: this is a new PR because #2678 for feat/appliance-trial-ux was already merged.