### PR TITLE
 Drop Enterprise add-on gate from Hudu integration

### DIFF
--- a/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetImportActions.test.ts
@@ -30,7 +30,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 let assetsRows: Array<{ asset_id: string; asset_name: string; serial_number: string | null }> = [];
@@ -110,10 +109,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -229,7 +224,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduAssetLayoutMap.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetLayoutMap.test.ts
@@ -20,7 +20,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 const knexCallableMock = vi.fn();
@@ -52,10 +51,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -115,7 +110,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduAssetMappingActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetMappingActions.test.ts
@@ -31,7 +31,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 let assetsRows: Array<{ asset_id: string; asset_name: string; serial_number: string | null }> = [];
@@ -64,10 +63,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -139,7 +134,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduAssetSyncActions.test.ts
@@ -34,7 +34,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 let assetsRows: Array<{
@@ -94,10 +93,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -169,7 +164,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
@@ -16,7 +16,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const getTenantSecretMock = vi.fn();
 const setTenantSecretMock = vi.fn();
@@ -47,10 +46,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('@alga-psa/core/secrets', () => ({
@@ -101,7 +96,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   getTenantSecretMock.mockResolvedValue(null);
   setTenantSecretMock.mockResolvedValue(undefined);

--- a/ee/server/src/__tests__/unit/huduDataActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduDataActions.test.ts
@@ -21,7 +21,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const knexCallableMock = vi.fn();
 const createTenantKnexMock = vi.fn();
@@ -69,10 +68,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -196,7 +191,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduFlagGuard.test.ts
+++ b/ee/server/src/__tests__/unit/huduFlagGuard.test.ts
@@ -4,10 +4,8 @@ const getCurrentUserMock = vi.fn();
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 class TierAccessErrorMock extends Error {}
-class AddOnAccessErrorMock extends Error {}
 
 vi.mock('@alga-psa/user-composition/actions', () => ({
   getCurrentUser: getCurrentUserMock,
@@ -28,11 +26,6 @@ vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   TierAccessError: TierAccessErrorMock,
 }));
 
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
-  AddOnAccessError: AddOnAccessErrorMock,
-}));
-
 const internalUser = {
   user_id: 'user-1',
   tenant: 'tenant-1',
@@ -50,13 +43,11 @@ describe('T001: requireHuduUiFlagEnabled', () => {
     hasPermissionMock.mockReset();
     isEnabledMock.mockReset();
     assertTierAccessMock.mockReset();
-    assertAddOnAccessMock.mockReset();
 
     // Happy-path defaults; individual tests override as needed.
     getCurrentUserMock.mockResolvedValue(internalUser);
     hasPermissionMock.mockResolvedValue(true);
     assertTierAccessMock.mockResolvedValue(undefined);
-    assertAddOnAccessMock.mockResolvedValue(undefined);
     isEnabledMock.mockResolvedValue(true);
   });
 
@@ -86,20 +77,7 @@ describe('T001: requireHuduUiFlagEnabled', () => {
     expect(payload.success).toBe(false);
   });
 
-  it('returns a 403 blocked response when EE add-on/tier access is denied (EE off)', async () => {
-    assertAddOnAccessMock.mockRejectedValue(new AddOnAccessErrorMock('Enterprise add-on required'));
-    const { requireHuduUiFlagEnabled } = await importGuard();
-
-    const result = await requireHuduUiFlagEnabled('read');
-
-    expect(result).toBeInstanceOf(Response);
-    const response = result as Response;
-    expect(response.status).toBe(403);
-    // Never evaluates the flag once EE access is denied.
-    expect(isEnabledMock).not.toHaveBeenCalled();
-  });
-
-  it('returns a 403 blocked response when the integrations tier is denied (EE off)', async () => {
+  it('returns a 403 blocked response when the integrations tier is denied', async () => {
     assertTierAccessMock.mockRejectedValue(new TierAccessErrorMock('Integrations tier required'));
     const { requireHuduUiFlagEnabled } = await importGuard();
 

--- a/ee/server/src/__tests__/unit/huduGlobalDocsActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduGlobalDocsActions.test.ts
@@ -19,7 +19,6 @@ const currentUserRef: { value: Record<string, unknown> | null } = { value: inter
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const knexCallableMock = vi.fn();
 const createTenantKnexMock = vi.fn();
@@ -50,10 +49,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -132,7 +127,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 
   getHuduIntegrationMock.mockResolvedValue(integrationRow());
@@ -281,10 +275,10 @@ describe('T242: guard chain + disconnected state', () => {
     expect(createTenantKnexMock).not.toHaveBeenCalled();
   });
 
-  it('rejects when the Enterprise add-on is missing', async () => {
-    assertAddOnAccessMock.mockRejectedValue(new Error('Enterprise add-on required'));
+  it('rejects when the integrations tier is missing', async () => {
+    assertTierAccessMock.mockRejectedValue(new Error('Integrations tier required'));
 
-    await expect(listHuduArticlesAcrossCompanies()).rejects.toThrow(/Enterprise add-on required/);
+    await expect(listHuduArticlesAcrossCompanies()).rejects.toThrow(/Integrations tier required/);
     expect(isEnabledMock).not.toHaveBeenCalled();
   });
 

--- a/ee/server/src/__tests__/unit/huduMappingActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduMappingActions.test.ts
@@ -18,7 +18,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 let clientsRows: Array<{ client_id: string; client_name: string }> = [];
@@ -53,10 +52,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -103,7 +98,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/__tests__/unit/huduPermissions.test.ts
+++ b/ee/server/src/__tests__/unit/huduPermissions.test.ts
@@ -1,6 +1,6 @@
 /**
  * T090/T091/T093 (Phase 1) + T249/F238 (Phase 2) — permissions sweep: every
- * Hudu server action enforces its guard chain (RBAC, EE tier + add-on,
+ * Hudu server action enforces its guard chain (RBAC, EE tier,
  * `hudu-integration` flag) at the correct level. Phase 1 modules gate on
  * system_settings (update = connect/disconnect/test/sync/map, read = status/
  * mappings/data/reveal/context); Phase 2 layout-map actions reuse
@@ -29,7 +29,6 @@ let authenticatedUser: typeof internalUser | null = internalUser;
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const createTenantKnexMock = vi.fn();
 
@@ -67,10 +66,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -179,7 +174,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
   createTenantKnexMock.mockResolvedValue({ knex: vi.fn(), tenant: TENANT });
 });
 
@@ -276,12 +270,12 @@ describe('T093/T249: every action rejects when the hudu-integration flag is off'
   });
 });
 
-describe('T093/T249: every action rejects when EE access is denied', () => {
-  it.each(allEntries)('$name rejects when the Enterprise add-on is missing', async ({ run }) => {
-    assertAddOnAccessMock.mockRejectedValue(new Error('Enterprise add-on required'));
+describe('T093/T249: every action rejects when the integrations tier is denied', () => {
+  it.each(allEntries)('$name rejects when the integrations tier is missing', async ({ run }) => {
+    assertTierAccessMock.mockRejectedValue(new Error('Integrations tier required'));
 
-    await expect(run()).rejects.toThrow(/Enterprise add-on required/);
-    // EE access is checked before the flag is even consulted.
+    await expect(run()).rejects.toThrow(/Integrations tier required/);
+    // Tier access is checked before the flag is even consulted.
     expect(isEnabledMock).not.toHaveBeenCalled();
     expect(createTenantKnexMock).not.toHaveBeenCalled();
   });

--- a/ee/server/src/__tests__/unit/huduRegression.test.ts
+++ b/ee/server/src/__tests__/unit/huduRegression.test.ts
@@ -43,7 +43,6 @@ const internalUser = { user_id: 'user-1', tenant: TENANT, user_type: 'internal' 
 const hasPermissionMock = vi.fn();
 const isEnabledMock = vi.fn();
 const assertTierAccessMock = vi.fn();
-const assertAddOnAccessMock = vi.fn();
 
 const knexCallableMock = vi.fn();
 const createTenantKnexMock = vi.fn();
@@ -88,10 +87,6 @@ vi.mock('server/src/lib/feature-flags/featureFlags', () => ({
 
 vi.mock('server/src/lib/tier-gating/assertTierAccess', () => ({
   assertTierAccess: assertTierAccessMock,
-}));
-
-vi.mock('server/src/lib/tier-gating/assertAddOnAccess', () => ({
-  assertAddOnAccess: assertAddOnAccessMock,
 }));
 
 vi.mock('server/src/lib/db', () => ({
@@ -171,7 +166,6 @@ beforeEach(() => {
   hasPermissionMock.mockResolvedValue(true);
   isEnabledMock.mockResolvedValue(true);
   assertTierAccessMock.mockResolvedValue(undefined);
-  assertAddOnAccessMock.mockResolvedValue(undefined);
 
   createTenantKnexMock.mockResolvedValue({ knex: knexCallableMock, tenant: TENANT });
 

--- a/ee/server/src/app/api/integrations/hudu/_guards.ts
+++ b/ee/server/src/app/api/integrations/hudu/_guards.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { AddOnAccessError, assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { TierAccessError, assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 
 type HuduGuardPermission = 'read' | 'update';
@@ -11,7 +10,7 @@ type HuduGuardPermission = 'read' | 'update';
 /**
  * Hudu UI flag guard — mirrors requireEntraUiFlagEnabled.
  *
- * Requires EE (Enterprise add-on + integrations tier) and the
+ * Requires the integrations tier and the
  * `hudu-integration` feature flag. Returns a Response (401/403/404) when the
  * caller is unauthorized or the integration is disabled, otherwise resolves the
  * tenant + user ids for the handler. Hudu reuses the existing `system_settings`
@@ -55,9 +54,8 @@ export async function requireHuduUiFlagEnabled(
 
   try {
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
   } catch (error) {
-    if (error instanceof TierAccessError || error instanceof AddOnAccessError) {
+    if (error instanceof TierAccessError) {
       return NextResponse.json(
         {
           success: false,

--- a/ee/server/src/lib/actions/integrations/huduActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduActions.ts
@@ -5,7 +5,7 @@
  *
  * connect / test / getStatus / disconnect for the per-tenant Hudu connection.
  * Gating mirrors requireHuduUiFlagEnabled (and the Entra action gating): EE
- * tier + Enterprise add-on, `system_settings` RBAC (read=view, update=manage),
+ * tier, `system_settings` RBAC (read=view, update=manage),
  * and the `hudu-integration` feature flag — enforced on every action.
  *
  * SECURITY: the api key is only ever written to the secret provider
@@ -19,9 +19,8 @@ import logger from '@alga-psa/core/logger';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { HuduClient } from '../../integrations/hudu/huduClient';
@@ -85,7 +84,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetImportActions.ts
@@ -3,7 +3,7 @@
 /**
  * Hudu asset import server actions (F214–F218, EE-only).
  *
- * Sibling of huduAssetMappingActions.ts — same EE tier + Enterprise add-on +
+ * Sibling of huduAssetMappingActions.ts — same EE tier +
  * `hudu-integration` flag chain, but RBAC-gated on `asset` CREATE (FR6).
  * The Hudu asset list rides the Phase 1 fetch+cache path
  * (getHuduCompanyAssets); asset creation goes through the existing
@@ -15,9 +15,8 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -131,7 +130,6 @@ function withHuduAssetCreateAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetMappingActions.ts
@@ -5,7 +5,7 @@
  *
  * Sibling of huduMappingActions.ts, but RBAC-gated on the `asset` resource
  * (FR16/FR6/FR10: mapping is a Technician flow — read=view, update=mutate)
- * instead of system_settings. Same EE tier + Enterprise add-on +
+ * instead of system_settings. Same EE tier +
  * `hudu-integration` flag chain otherwise.
  *
  * The Hudu asset list is fetched through the Phase 1 path
@@ -16,9 +16,8 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -100,7 +99,6 @@ function withHuduAssetAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduAssetSyncActions.ts
@@ -18,10 +18,9 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { updateAsset } from '@alga-psa/assets/actions/assetActions';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -65,7 +64,6 @@ function withHuduAssetAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduDataActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduDataActions.ts
@@ -4,7 +4,7 @@
  * Hudu reference-data server actions (EE-only): per-mapped-company assets /
  * articles / asset-password lists (F060–F066) and the on-demand password
  * reveal (F067/F068). Gating mirrors huduActions (withHuduSettingsAccess):
- * EE tier + Enterprise add-on, `system_settings` RBAC, `hudu-integration`
+ * EE tier, `system_settings` RBAC, `hudu-integration`
  * flag. All actions — including reveal — use the READ gate: PRD flow 4 makes
  * viewing/revealing credentials a Technician flow, and the compensating
  * control for reveal is the mandatory fail-closed audit, not a stricter gate.
@@ -20,9 +20,8 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -100,7 +99,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduGlobalDocsActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduGlobalDocsActions.ts
@@ -6,16 +6,15 @@
  * fan-out (NFR2) — with the user's search term passed through to Hudu and
  * each article's company resolved to its Alga client via the companies cache
  * + client mapping rows. Gating mirrors the sibling action wrappers (EE tier
- * + Enterprise add-on + `hudu-integration` flag) but on `client` read RBAC:
+ * + `hudu-integration` flag) but on `client` read RBAC:
  * browsing articles is a Technician flow, not settings administration.
  */
 
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { createHuduClient, HuduRequestError } from '../../integrations/hudu/huduClient';
@@ -68,7 +67,6 @@ function withHuduClientReadAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduLayoutMapActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduLayoutMapActions.ts
@@ -4,7 +4,7 @@
  * Hudu asset-layout→asset-type map server actions (EE-only, Phase 2 FR11).
  *
  * get/set for `hudu_integrations.settings.asset_layout_type_map`. Gating
- * mirrors huduActions (withHuduSettingsAccess): EE tier + Enterprise add-on,
+ * mirrors huduActions (withHuduSettingsAccess): EE tier,
  * `system_settings` RBAC (read=view, update=persist), and the
  * `hudu-integration` flag — enforced on every action.
  */
@@ -12,9 +12,8 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import { createAssetType, listAssetTypes } from '@alga-psa/assets/lib/assetTypeRegistry';
@@ -77,7 +76,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,

--- a/ee/server/src/lib/actions/integrations/huduMappingActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduMappingActions.ts
@@ -5,7 +5,7 @@
  *
  * sync / list / set / clear for company mappings in the SHARED CE table
  * `tenant_external_entity_mappings`. Gating mirrors huduActions
- * (withHuduSettingsAccess): EE tier + Enterprise add-on, `system_settings`
+ * (withHuduSettingsAccess): EE tier, `system_settings`
  * RBAC (read=list, update=mutate), and the `hudu-integration` flag — NOT the
  * billing_settings-gated externalMappingActions wrappers (OQ3).
  *
@@ -17,9 +17,8 @@
 import logger from '@alga-psa/core/logger';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 import type { IUserWithRoles } from '@alga-psa/types';
-import { ADD_ONS, TIER_FEATURES } from '@alga-psa/types';
+import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
-import { assertAddOnAccess } from 'server/src/lib/tier-gating/assertAddOnAccess';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
 import type { Knex } from 'knex';
@@ -95,7 +94,6 @@ function withHuduSettingsAccess<TArgs extends unknown[], TResult>(
     }
 
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    await assertAddOnAccess(ADD_ONS.ENTERPRISE);
 
     const enabled = await featureFlags.isEnabled('hudu-integration', {
       userId: user.user_id,


### PR DESCRIPTION
  Remove the assertAddOnAccess(ADD_ONS.ENTERPRISE) check from all 9
  Hudu enforcement sites (8 server-action wrappers + the API route
  guard) and their now-unused imports. Hudu access is now gated by EE
  edition, system_settings RBAC, the INTEGRATIONS tier, and the
  hudu-integration feature flag — the add-on is no longer required.

  Update guard doc-comments accordingly and strip the dead
  assertAddOnAccess mock scaffolding from the unit tests; the
  "add-on missing" rejection cases are repurposed as integrations-tier
  denial checks so the guard-chain coverage stays complete.

  "But I don't want to go among Enterprise add-ons," said Alice.
  "Oh, you can't help that," grinned the Cheshire Cat, fading gate by
  gate until only the feature flag remained, hanging in the air like a
  smile. 🐱🚪✨