### PR TITLE
Improve appliance setup token UX

### DIFF
--- a/ee/appliance/status-ui/app/page.tsx
+++ b/ee/appliance/status-ui/app/page.tsx
@@ -1,14 +1,38 @@
-'use client';
+"use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Activity, Boxes, ScrollText, Server, SlidersHorizontal } from 'lucide-react';
-import { AlgaLogo } from './AlgaLogo';
-import { LogoutButton } from './auth/LogoutButton';
-import styles from './status.module.css';
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Activity,
+  Boxes,
+  ScrollText,
+  Server,
+  SlidersHorizontal,
+} from "lucide-react";
+import { AlgaLogo } from "./AlgaLogo";
+import { LogoutButton } from "./auth/LogoutButton";
+import styles from "./status.module.css";
 
-type RawTierMap = Record<string, boolean | { ready?: boolean; status?: string }>;
-type Blocker = { severity?: string; component?: string; layer?: string; reason?: string; nextAction?: string; loginBlocking?: boolean };
-type EventItem = { type?: string; reason?: string; namespace?: string; involvedObject?: string; message?: string; timestamp?: string | null };
+type RawTierMap = Record<
+  string,
+  boolean | { ready?: boolean; status?: string }
+>;
+type Blocker = {
+  severity?: string;
+  component?: string;
+  layer?: string;
+  reason?: string;
+  nextAction?: string;
+  loginBlocking?: boolean;
+};
+type EventItem = {
+  type?: string;
+  reason?: string;
+  namespace?: string;
+  involvedObject?: string;
+  message?: string;
+  timestamp?: string | null;
+};
+type SetupConfigResponse = { mode?: string };
 type StatusResponse = {
   status?: string;
   // True when setup is blocked on a correctable install code; the UI offers a
@@ -17,75 +41,201 @@ type StatusResponse = {
   rollup?: { state?: string; message?: string; nextAction?: string } | null;
   currentPhase?: string;
   urls?: { statusUrl?: string | null; loginUrl?: string | null };
-  activeOperations?: Array<{ component?: string; image?: string | null; message?: string; elapsedSeconds?: number | null }>;
+  activeOperations?: Array<{
+    component?: string;
+    image?: string | null;
+    message?: string;
+    elapsedSeconds?: number | null;
+  }>;
   tiers?: RawTierMap;
   readinessTiers?: RawTierMap;
   topBlockers?: Blocker[];
-  failures?: Array<{ category?: string; phase?: string; suspectedCause?: string; suggestedNextStep?: string }>;
-  bootstrap?: { job?: { name?: string | null; state?: string; failed?: boolean; completed?: boolean }; logs?: { available?: boolean; tail?: string[]; detectedErrors?: string[] } };
+  failures?: Array<{
+    category?: string;
+    phase?: string;
+    suspectedCause?: string;
+    suggestedNextStep?: string;
+  }>;
+  bootstrap?: {
+    job?: {
+      name?: string | null;
+      state?: string;
+      failed?: boolean;
+      completed?: boolean;
+    };
+    logs?: { available?: boolean; tail?: string[]; detectedErrors?: string[] };
+  };
   recentEvents?: EventItem[];
-  installState?: { status?: string; phase?: string; lastAction?: string; updatedAt?: string };
-  kubernetes?: { nodes?: Array<{ name?: string; ready?: boolean }>; podCount?: number; jobCount?: number; helmReleaseCount?: number; warnings?: string[] };
-  diagnostics?: Array<{ name?: string; ok?: boolean; status?: number; command?: string; stdout?: string; stderr?: string }>;
+  installState?: {
+    status?: string;
+    phase?: string;
+    lastAction?: string;
+    updatedAt?: string;
+  };
+  kubernetes?: {
+    nodes?: Array<{ name?: string; ready?: boolean }>;
+    podCount?: number;
+    jobCount?: number;
+    helmReleaseCount?: number;
+    warnings?: string[];
+  };
+  diagnostics?: Array<{
+    name?: string;
+    ok?: boolean;
+    status?: number;
+    command?: string;
+    stdout?: string;
+    stderr?: string;
+  }>;
 };
 
 type NamespaceItem = { name: string; phase?: string };
 type Deployment = {
-  namespace: string; name: string; readyReplicas: number; replicas: number; updatedReplicas: number; availableReplicas: number;
-  generation: number; observedGeneration: number; strategy?: string; images?: string[]; revision?: string | null;
-  conditions?: Array<{ type?: string; status?: string; reason?: string; message?: string }>;
-  replicaSets?: Array<{ name: string; revision?: string | null; replicas: number; readyReplicas: number; availableReplicas: number; createdAt?: string | null; images?: string[] }>;
+  namespace: string;
+  name: string;
+  readyReplicas: number;
+  replicas: number;
+  updatedReplicas: number;
+  availableReplicas: number;
+  generation: number;
+  observedGeneration: number;
+  strategy?: string;
+  images?: string[];
+  revision?: string | null;
+  conditions?: Array<{
+    type?: string;
+    status?: string;
+    reason?: string;
+    message?: string;
+  }>;
+  replicaSets?: Array<{
+    name: string;
+    revision?: string | null;
+    replicas: number;
+    readyReplicas: number;
+    availableReplicas: number;
+    createdAt?: string | null;
+    images?: string[];
+  }>;
 };
 type Pod = {
-  namespace: string; name: string; phase: string; reason?: string | null; ready: boolean; readyContainers: number; totalContainers: number;
-  restarts: number; node?: string | null; podIP?: string | null; createdAt?: string | null;
-  containers: Array<{ name: string; image?: string; ready?: boolean; restarts?: number; state?: Record<string, unknown> | null }>;
+  namespace: string;
+  name: string;
+  phase: string;
+  reason?: string | null;
+  ready: boolean;
+  readyContainers: number;
+  totalContainers: number;
+  restarts: number;
+  node?: string | null;
+  podIP?: string | null;
+  createdAt?: string | null;
+  containers: Array<{
+    name: string;
+    image?: string;
+    ready?: boolean;
+    restarts?: number;
+    state?: Record<string, unknown> | null;
+  }>;
 };
 
-type Tab = 'overview' | 'deployments' | 'pods' | 'logs';
+type Tab = "overview" | "deployments" | "pods" | "logs";
 type LogLoadOptions = { preserveScroll?: boolean; scrollToEnd?: boolean };
 
-function apiPath(path: string, params: Record<string, string | number | boolean | null | undefined> = {}) {
+function apiPath(
+  path: string,
+  params: Record<string, string | number | boolean | null | undefined> = {},
+) {
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    if (value !== null && value !== undefined && value !== '') search.set(key, String(value));
+    if (value !== null && value !== undefined && value !== "")
+      search.set(key, String(value));
   }
   const qs = search.toString();
   return qs ? `${path}?${qs}` : path;
 }
 
 function badgeClass(value?: string | boolean) {
-  const normalized = String(value ?? 'unknown');
-  if (['loading'].includes(normalized)) return styles.loading;
-  if (['true', 'fully_healthy', 'ready_to_log_in', 'ready_with_background_issues', 'healthy', 'Running', 'Succeeded', 'ready', 'True'].includes(normalized)) return styles.ready;
-  if (['installing', 'progressing', 'unknown', 'Pending', 'ContainerCreating', 'PodInitializing', 'setup-queued', 'not_fully_healthy'].includes(normalized)) return styles.installing;
-  if (['false', 'not ready', 'warning', 'background', 'degraded_background_services', 'Unknown'].includes(normalized)) return styles.warning;
+  const normalized = String(value ?? "unknown");
+  if (["loading"].includes(normalized)) return styles.loading;
+  if (
+    [
+      "true",
+      "fully_healthy",
+      "ready_to_log_in",
+      "ready_with_background_issues",
+      "healthy",
+      "Running",
+      "Succeeded",
+      "ready",
+      "True",
+    ].includes(normalized)
+  )
+    return styles.ready;
+  if (
+    [
+      "installing",
+      "progressing",
+      "unknown",
+      "Pending",
+      "ContainerCreating",
+      "PodInitializing",
+      "setup-queued",
+      "not_fully_healthy",
+    ].includes(normalized)
+  )
+    return styles.installing;
+  if (
+    [
+      "false",
+      "not ready",
+      "warning",
+      "background",
+      "degraded_background_services",
+      "Unknown",
+    ].includes(normalized)
+  )
+    return styles.warning;
   return styles.failed;
 }
 
 function tierEntries(status: StatusResponse | null) {
   const source = status?.readinessTiers || status?.tiers || {};
   return Object.entries(source).map(([name, value]) => {
-    if (typeof value === 'boolean') return [name, { ready: value, status: value ? 'ready' : 'not ready' }] as const;
-    return [name, { ready: Boolean(value?.ready), status: value?.status || (value?.ready ? 'ready' : 'not ready') }] as const;
+    if (typeof value === "boolean")
+      return [
+        name,
+        { ready: value, status: value ? "ready" : "not ready" },
+      ] as const;
+    return [
+      name,
+      {
+        ready: Boolean(value?.ready),
+        status: value?.status || (value?.ready ? "ready" : "not ready"),
+      },
+    ] as const;
   });
 }
 
 function blockers(status: StatusResponse | null): Blocker[] {
   if (status?.topBlockers?.length) return status.topBlockers;
   return (status?.failures || []).map((failure) => ({
-    severity: failure.category === 'background-services' ? 'background' : 'critical',
+    severity:
+      failure.category === "background-services" ? "background" : "critical",
     component: failure.category,
     layer: failure.phase,
     reason: failure.suspectedCause,
     nextAction: failure.suggestedNextStep,
-    loginBlocking: failure.category !== 'background-services'
+    loginBlocking: failure.category !== "background-services",
   }));
 }
 
 function ageFrom(date?: string | null) {
-  if (!date) return '—';
-  const seconds = Math.max(0, Math.floor((Date.now() - new Date(date).getTime()) / 1000));
+  if (!date) return "—";
+  const seconds = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(date).getTime()) / 1000),
+  );
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
@@ -93,54 +243,90 @@ function ageFrom(date?: string | null) {
 }
 
 function elapsedLabel(seconds?: number | null) {
-  if (seconds === null || seconds === undefined) return 'elapsed time unavailable';
+  if (seconds === null || seconds === undefined)
+    return "elapsed time unavailable";
   if (seconds < 60) return `${Math.max(0, Math.floor(seconds))}s elapsed`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m elapsed`;
   return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m elapsed`;
 }
 
 const statusTabs = [
-  { value: 'overview', label: 'Overview', Icon: Activity },
-  { value: 'deployments', label: 'Deployments', Icon: Boxes },
-  { value: 'pods', label: 'Pods', Icon: Server },
-  { value: 'logs', label: 'Logs', Icon: ScrollText }
+  { value: "overview", label: "Overview", Icon: Activity },
+  { value: "deployments", label: "Deployments", Icon: Boxes },
+  { value: "pods", label: "Pods", Icon: Server },
+  { value: "logs", label: "Logs", Icon: ScrollText },
 ] satisfies Array<{ value: Tab; label: string; Icon: typeof Activity }>;
 
 function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function highlightLine(line: string, search: string) {
   if (!search) return line;
-  const parts = line.split(new RegExp(`(${escapeRegExp(search)})`, 'ig'));
-  return <>{parts.map((part, index) => part.toLowerCase() === search.toLowerCase() ? <mark key={index}>{part}</mark> : part)}</>;
+  const parts = line.split(new RegExp(`(${escapeRegExp(search)})`, "ig"));
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.toLowerCase() === search.toLowerCase() ? (
+          <mark key={index}>{part}</mark>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  );
 }
 
-function SkeletonRows({ rows = 6, columns = 6 }: { rows?: number; columns?: number }) {
-  return <>{Array.from({ length: rows }).map((_, row) => <tr key={row} className={styles.skeletonRow}>{Array.from({ length: columns }).map((__, col) => <td key={col}><span className={styles.skeletonCell} /></td>)}</tr>)}</>;
+function SkeletonRows({
+  rows = 6,
+  columns = 6,
+}: {
+  rows?: number;
+  columns?: number;
+}) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, row) => (
+        <tr key={row} className={styles.skeletonRow}>
+          {Array.from({ length: columns }).map((__, col) => (
+            <td key={col}>
+              <span className={styles.skeletonCell} />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
 }
 
 function SkeletonBlock({ lines = 6 }: { lines?: number }) {
-  return <div className={styles.skeletonBlock}>{Array.from({ length: lines }).map((_, index) => <span key={index} className={styles.skeletonLineDark} />)}</div>;
+  return (
+    <div className={styles.skeletonBlock}>
+      {Array.from({ length: lines }).map((_, index) => (
+        <span key={index} className={styles.skeletonLineDark} />
+      ))}
+    </div>
+  );
 }
 
 export default function StatusPage() {
-  const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [activeTab, setActiveTab] = useState<Tab>("overview");
   const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [setupMode, setSetupMode] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [recovering, setRecovering] = useState(false);
   const [recoverMsg, setRecoverMsg] = useState<string | null>(null);
   const [confirmRecover, setConfirmRecover] = useState(false);
   const [namespaces, setNamespaces] = useState<NamespaceItem[]>([]);
-  const [namespace, setNamespace] = useState('msp');
+  const [namespace, setNamespace] = useState("msp");
   const [deployments, setDeployments] = useState<Deployment[]>([]);
   const [pods, setPods] = useState<Pod[]>([]);
-  const [selectedPod, setSelectedPod] = useState('');
-  const [selectedContainer, setSelectedContainer] = useState('');
-  const [deploymentFilter, setDeploymentFilter] = useState('');
-  const [podFilter, setPodFilter] = useState('');
-  const [logFilter, setLogFilter] = useState('');
-  const [logSearch, setLogSearch] = useState('');
+  const [selectedPod, setSelectedPod] = useState("");
+  const [selectedContainer, setSelectedContainer] = useState("");
+  const [deploymentFilter, setDeploymentFilter] = useState("");
+  const [podFilter, setPodFilter] = useState("");
+  const [logFilter, setLogFilter] = useState("");
+  const [logSearch, setLogSearch] = useState("");
   const [activeMatch, setActiveMatch] = useState(0);
   const [logTail, setLogTail] = useState(200);
   const [logLines, setLogLines] = useState<string[]>([]);
@@ -152,7 +338,11 @@ export default function StatusPage() {
   const [loadingLogs, setLoadingLogs] = useState(false);
   const logPaneRef = useRef<HTMLPreElement | null>(null);
   const lineRefs = useRef<Array<HTMLDivElement | null>>([]);
-  const pendingLogScroll = useRef<null | { mode: 'preserve' | 'end'; previousScrollHeight: number; previousScrollTop: number }>(null);
+  const pendingLogScroll = useRef<null | {
+    mode: "preserve" | "end";
+    previousScrollHeight: number;
+    previousScrollTop: number;
+  }>(null);
   const statusRequestInFlight = useRef(false);
   const statusAbortController = useRef<AbortController | null>(null);
 
@@ -164,13 +354,19 @@ export default function StatusPage() {
     statusAbortController.current = controller;
     setLoadingStatus(true);
     try {
-      const response = await fetch(apiPath('/api/status'), { cache: 'no-store', signal: controller.signal });
-      if (response.status === 401) { window.location.reload(); return; }
-      if (!response.ok) throw new Error('Status API unavailable.');
+      const response = await fetch(apiPath("/api/status"), {
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      if (response.status === 401) {
+        window.location.reload();
+        return;
+      }
+      if (!response.ok) throw new Error("Status API unavailable.");
       setStatus(await response.json());
       setError(null);
     } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return;
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       if (statusAbortController.current === controller) {
@@ -186,10 +382,14 @@ export default function StatusPage() {
     setRecovering(true);
     setRecoverMsg(null);
     try {
-      const response = await fetch(apiPath('/api/recover'), { method: 'POST', cache: 'no-store' });
+      const response = await fetch(apiPath("/api/recover"), {
+        method: "POST",
+        cache: "no-store",
+      });
       const data = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(data.error || 'Failed to trigger recovery.');
-      setRecoverMsg(data.message || 'Recovery triggered.');
+      if (!response.ok)
+        throw new Error(data.error || "Failed to trigger recovery.");
+      setRecoverMsg(data.message || "Recovery triggered.");
       loadStatus();
     } catch (err) {
       setRecoverMsg(err instanceof Error ? err.message : String(err));
@@ -201,79 +401,148 @@ export default function StatusPage() {
   const loadNamespaces = useCallback(async () => {
     setLoadingNamespaces(true);
     try {
-      const response = await fetch(apiPath('/api/k8s/namespaces'), { cache: 'no-store' });
+      const response = await fetch(apiPath("/api/k8s/namespaces"), {
+        cache: "no-store",
+      });
       if (!response.ok) return;
       const data = await response.json();
       setNamespaces(data.namespaces || []);
-    } catch { /* cluster may not exist yet */ }
-    finally { setLoadingNamespaces(false); }
+    } catch {
+      /* cluster may not exist yet */
+    } finally {
+      setLoadingNamespaces(false);
+    }
   }, []);
 
   const loadPods = useCallback(async () => {
     setLoadingPods(true);
     try {
-      const response = await fetch(apiPath('/api/k8s/pods', { namespace }), { cache: 'no-store' });
+      const response = await fetch(apiPath("/api/k8s/pods", { namespace }), {
+        cache: "no-store",
+      });
       if (!response.ok) return;
       const data = await response.json();
       const nextPods = data.pods || [];
       setPods(nextPods);
       if (!selectedPod && nextPods.length) {
         setSelectedPod(nextPods[0].name);
-        setSelectedContainer(nextPods[0].containers?.[0]?.name || '');
+        setSelectedContainer(nextPods[0].containers?.[0]?.name || "");
       }
-    } catch { /* ignore transient Kubernetes failures */ }
-    finally { setLoadingPods(false); }
+    } catch {
+      /* ignore transient Kubernetes failures */
+    } finally {
+      setLoadingPods(false);
+    }
   }, [namespace, selectedPod]);
 
   const loadDeployments = useCallback(async () => {
     setLoadingDeployments(true);
     try {
-      const response = await fetch(apiPath('/api/k8s/deployments', { namespace }), { cache: 'no-store' });
+      const response = await fetch(
+        apiPath("/api/k8s/deployments", { namespace }),
+        { cache: "no-store" },
+      );
       if (!response.ok) return;
       const data = await response.json();
       setDeployments(data.deployments || []);
-    } catch { /* ignore transient Kubernetes failures */ }
-    finally { setLoadingDeployments(false); }
+    } catch {
+      /* ignore transient Kubernetes failures */
+    } finally {
+      setLoadingDeployments(false);
+    }
   }, [namespace]);
 
   function applyPendingLogScroll() {
     const pending = pendingLogScroll.current;
     const pane = logPaneRef.current;
     if (!pending || !pane) return;
-    if (pending.mode === 'end') {
+    if (pending.mode === "end") {
       pane.scrollTop = pane.scrollHeight;
     } else {
-      pane.scrollTop = pane.scrollHeight - pending.previousScrollHeight + pending.previousScrollTop;
+      pane.scrollTop =
+        pane.scrollHeight -
+        pending.previousScrollHeight +
+        pending.previousScrollTop;
     }
     pendingLogScroll.current = null;
   }
 
-  const loadLogs = useCallback(async (tail = logTail, options: LogLoadOptions = {}) => {
-    if (!selectedPod) return;
-    const pane = logPaneRef.current;
-    const previousScrollHeight = pane?.scrollHeight || 0;
-    const previousScrollTop = pane?.scrollTop || 0;
-    setLoadingLogs(true);
-    try {
-      setLogError(null);
-      const response = await fetch(apiPath('/api/k8s/logs', { namespace, pod: selectedPod, container: selectedContainer, tail }), { cache: 'no-store' });
-      if (!response.ok) throw new Error((await response.json()).error || 'Unable to read logs.');
-      const data = await response.json();
-      if (options.preserveScroll) {
-        pendingLogScroll.current = { mode: 'preserve', previousScrollHeight, previousScrollTop };
-      } else if (options.scrollToEnd) {
-        pendingLogScroll.current = { mode: 'end', previousScrollHeight, previousScrollTop };
+  const loadLogs = useCallback(
+    async (tail = logTail, options: LogLoadOptions = {}) => {
+      if (!selectedPod) return;
+      const pane = logPaneRef.current;
+      const previousScrollHeight = pane?.scrollHeight || 0;
+      const previousScrollTop = pane?.scrollTop || 0;
+      setLoadingLogs(true);
+      try {
+        setLogError(null);
+        const response = await fetch(
+          apiPath("/api/k8s/logs", {
+            namespace,
+            pod: selectedPod,
+            container: selectedContainer,
+            tail,
+          }),
+          { cache: "no-store" },
+        );
+        if (!response.ok)
+          throw new Error(
+            (await response.json()).error || "Unable to read logs.",
+          );
+        const data = await response.json();
+        if (options.preserveScroll) {
+          pendingLogScroll.current = {
+            mode: "preserve",
+            previousScrollHeight,
+            previousScrollTop,
+          };
+        } else if (options.scrollToEnd) {
+          pendingLogScroll.current = {
+            mode: "end",
+            previousScrollHeight,
+            previousScrollTop,
+          };
+        }
+        setLogLines(data.lines || []);
+        setLogTail(tail);
+        window.setTimeout(applyPendingLogScroll, 50);
+        window.setTimeout(applyPendingLogScroll, 250);
+      } catch (err) {
+        setLogError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoadingLogs(false);
       }
-      setLogLines(data.lines || []);
-      setLogTail(tail);
-      window.setTimeout(applyPendingLogScroll, 50);
-      window.setTimeout(applyPendingLogScroll, 250);
-    } catch (err) {
-      setLogError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoadingLogs(false);
+    },
+    [logTail, namespace, selectedContainer, selectedPod],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadSetupMode() {
+      try {
+        const response = await fetch(apiPath("/api/setup/config"), {
+          cache: "no-store",
+        });
+        if (response.status === 401) {
+          window.location.reload();
+          return;
+        }
+        if (!response.ok) return;
+        const data = (await response.json()) as SetupConfigResponse;
+        if (cancelled) return;
+        setSetupMode(data.mode || null);
+        if (data.mode === "setup") {
+          window.location.replace("/setup/");
+        }
+      } catch {
+        // Keep the status page usable if setup config is temporarily unavailable.
+      }
     }
-  }, [logTail, namespace, selectedContainer, selectedPod]);
+    loadSetupMode();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     loadStatus();
@@ -286,12 +555,12 @@ export default function StatusPage() {
   }, [loadNamespaces, loadStatus]);
 
   useEffect(() => {
-    if (activeTab === 'deployments') loadDeployments();
-    if (activeTab === 'pods' || activeTab === 'logs') loadPods();
+    if (activeTab === "deployments") loadDeployments();
+    if (activeTab === "pods" || activeTab === "logs") loadPods();
   }, [activeTab, loadDeployments, loadPods]);
 
   useEffect(() => {
-    if (activeTab === 'logs') loadLogs(200, { scrollToEnd: true });
+    if (activeTab === "logs") loadLogs(200, { scrollToEnd: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, namespace, selectedPod, selectedContainer]);
 
@@ -300,20 +569,46 @@ export default function StatusPage() {
   }, [logLines, loadingLogs, activeTab]);
 
   const selectedPodData = pods.find((pod) => pod.name === selectedPod);
-  const visibleDeployments = deployments.filter((deployment) => `${deployment.namespace}/${deployment.name} ${deployment.images?.join(' ')}`.toLowerCase().includes(deploymentFilter.toLowerCase()));
-  const visiblePods = pods.filter((pod) => `${pod.namespace}/${pod.name} ${pod.phase} ${pod.containers.map((c) => c.image).join(' ')}`.toLowerCase().includes(podFilter.toLowerCase()));
-  const filteredLogLines = logLines.filter((line) => !logFilter || line.toLowerCase().includes(logFilter.toLowerCase()));
-  const matchLineIndexes = useMemo(() => logSearch ? filteredLogLines.reduce<number[]>((matches, line, index) => {
-    if (line.toLowerCase().includes(logSearch.toLowerCase())) matches.push(index);
-    return matches;
-  }, []) : [], [filteredLogLines, logSearch]);
+  const visibleDeployments = deployments.filter((deployment) =>
+    `${deployment.namespace}/${deployment.name} ${deployment.images?.join(" ")}`
+      .toLowerCase()
+      .includes(deploymentFilter.toLowerCase()),
+  );
+  const visiblePods = pods.filter((pod) =>
+    `${pod.namespace}/${pod.name} ${pod.phase} ${pod.containers.map((c) => c.image).join(" ")}`
+      .toLowerCase()
+      .includes(podFilter.toLowerCase()),
+  );
+  const filteredLogLines = logLines.filter(
+    (line) =>
+      !logFilter || line.toLowerCase().includes(logFilter.toLowerCase()),
+  );
+  const matchLineIndexes = useMemo(
+    () =>
+      logSearch
+        ? filteredLogLines.reduce<number[]>((matches, line, index) => {
+            if (line.toLowerCase().includes(logSearch.toLowerCase()))
+              matches.push(index);
+            return matches;
+          }, [])
+        : [],
+    [filteredLogLines, logSearch],
+  );
   const searchMatches = matchLineIndexes.length;
-  const state = status?.rollup?.state || status?.status || status?.installState?.status || 'loading';
+  const state =
+    status?.rollup?.state ||
+    status?.status ||
+    status?.installState?.status ||
+    "loading";
   const blockerList = blockers(status);
   const runningOperations = status?.activeOperations || [];
   const primaryOperation = runningOperations[0];
-  const currentPhase = status?.currentPhase || status?.installState?.phase || 'loading';
-  const nextAction = status?.rollup?.nextAction || status?.installState?.lastAction || 'Waiting for the next appliance update';
+  const currentPhase =
+    status?.currentPhase || status?.installState?.phase || "loading";
+  const nextAction =
+    status?.rollup?.nextAction ||
+    status?.installState?.lastAction ||
+    "Waiting for the next appliance update";
 
   useEffect(() => {
     setActiveMatch(0);
@@ -330,7 +625,9 @@ export default function StatusPage() {
     const next = (activeMatch + direction + searchMatches) % searchMatches;
     setActiveMatch(next);
     window.setTimeout(() => {
-      lineRefs.current[matchLineIndexes[next]]?.scrollIntoView({ block: 'center' });
+      lineRefs.current[matchLineIndexes[next]]?.scrollIntoView({
+        block: "center",
+      });
     }, 0);
   }
 
@@ -338,10 +635,19 @@ export default function StatusPage() {
     <main className={styles.shell}>
       <aside className={styles.sidebar}>
         <div className={styles.brand}>
-          <span className={styles.logo}><AlgaLogo className={styles.logoSvg} /></span>
-          <span className={styles.brandText}><span>Alga PSA</span><small>Setup status</small></span>
+          <span className={styles.logo}>
+            <AlgaLogo className={styles.logoSvg} />
+          </span>
+          <span className={styles.brandText}>
+            <span>Alga PSA</span>
+            <small>Setup status</small>
+          </span>
         </div>
-        <nav className={styles.nav} aria-label="Alga PSA setup status tabs" role="tablist">
+        <nav
+          className={styles.nav}
+          aria-label="Alga PSA setup status tabs"
+          role="tablist"
+        >
           {statusTabs.map(({ value, label, Icon }) => (
             <button
               key={value}
@@ -350,7 +656,7 @@ export default function StatusPage() {
               id={`appliance-tab-${value}`}
               aria-selected={activeTab === value}
               aria-controls={`appliance-panel-${value}`}
-              className={activeTab === value ? styles.activeTab : ''}
+              className={activeTab === value ? styles.activeTab : ""}
               onClick={() => setActiveTab(value)}
             >
               <Icon className={styles.navIcon} aria-hidden="true" />
@@ -358,7 +664,10 @@ export default function StatusPage() {
             </button>
           ))}
         </nav>
-        <a className={styles.setupLink} href="/setup/"><SlidersHorizontal className={styles.navIcon} aria-hidden="true" /><span>Setup</span></a>
+        <a className={styles.setupLink} href="/setup/">
+          <SlidersHorizontal className={styles.navIcon} aria-hidden="true" />
+          <span>Setup</span>
+        </a>
         <LogoutButton />
       </aside>
 
@@ -366,40 +675,99 @@ export default function StatusPage() {
         <header className={styles.commandBar}>
           <div>
             <div className={styles.eyebrow}>Alga PSA appliance</div>
-            <h1>{status?.rollup?.message || error || 'Reading live appliance status…'}</h1>
+            <h1>
+              {status?.rollup?.message ||
+                error ||
+                "Reading live appliance status…"}
+            </h1>
           </div>
-          <span className={`${styles.statusPill} ${badgeClass(state)}`}>{state}</span>
+          <span className={`${styles.statusPill} ${badgeClass(state)}`}>
+            {state}
+          </span>
         </header>
 
-        {status?.setupReEditable ? (
-          <div className={styles.alert} role="alert" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
-            <span>The install code could not be redeemed — it may be invalid, expired, or already used. Re-issue a fresh code from the portal, then re-enter it to continue.</span>
-            <a className={styles.actionButton} href="/setup/">Re-enter your install code</a>
+        {setupMode === "setup" ? (
+          <div className={styles.setupCta} role="status">
+            <div>
+              <strong>Initial setup is waiting for you</strong>
+              <p>
+                Enter the setup token, then your install code, to finish
+                configuring this appliance.
+              </p>
+            </div>
+            <a className={styles.primaryButton} href="/setup/">
+              Continue setup
+            </a>
           </div>
         ) : null}
 
-        {activeTab === 'overview' ? (
-          <div id="appliance-panel-overview" role="tabpanel" aria-labelledby="appliance-tab-overview" className={styles.grid}>
+        {status?.setupReEditable ? (
+          <div className={styles.setupCta} role="alert">
+            <div>
+              <strong>Install code needs attention</strong>
+              <p>
+                The install code could not be redeemed — it may be invalid,
+                expired, or already used. Re-issue a fresh code from the portal,
+                then re-enter it to continue.
+              </p>
+            </div>
+            <a className={styles.primaryButton} href="/setup/">
+              Re-enter install code
+            </a>
+          </div>
+        ) : null}
+
+        {activeTab === "overview" ? (
+          <div
+            id="appliance-panel-overview"
+            role="tabpanel"
+            aria-labelledby="appliance-tab-overview"
+            className={styles.grid}
+          >
             <article className={`${styles.panel} ${styles.wide}`}>
               <h2>What is running now</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={4} /> : (
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={4} />
+              ) : (
                 <div className={styles.runSummary}>
                   <div className={styles.runHeader}>
                     <div>
-                      <strong>{primaryOperation?.component || currentPhase}</strong>
-                      <p className={styles.runMessage}>{primaryOperation?.message || nextAction}</p>
+                      <strong>
+                        {primaryOperation?.component || currentPhase}
+                      </strong>
+                      <p className={styles.runMessage}>
+                        {primaryOperation?.message || nextAction}
+                      </p>
                     </div>
-                    <span className={`${styles.statusPill} ${badgeClass(state)}`}>{state}</span>
+                    <span
+                      className={`${styles.statusPill} ${badgeClass(state)}`}
+                    >
+                      {state}
+                    </span>
                   </div>
                   <div className={styles.runMeta}>
                     <span>Phase: {currentPhase}</span>
-                    <span>{elapsedLabel(primaryOperation?.elapsedSeconds)}</span>
-                    <span>Login: {status?.urls?.loginUrl ? 'available' : 'not available yet'}</span>
+                    <span>
+                      {elapsedLabel(primaryOperation?.elapsedSeconds)}
+                    </span>
+                    <span>
+                      Login:{" "}
+                      {status?.urls?.loginUrl
+                        ? "available"
+                        : "not available yet"}
+                    </span>
                     <span>{status?.kubernetes?.podCount ?? 0} pods</span>
                   </div>
                   {runningOperations.length > 1 ? (
-                    <ul className={styles.runList} aria-label="Other active operations">
-                      {runningOperations.slice(1, 4).map((op, index) => <li key={`${op.component}-${index}`}>{op.component}: {op.message}</li>)}
+                    <ul
+                      className={styles.runList}
+                      aria-label="Other active operations"
+                    >
+                      {runningOperations.slice(1, 4).map((op, index) => (
+                        <li key={`${op.component}-${index}`}>
+                          {op.component}: {op.message}
+                        </li>
+                      ))}
                     </ul>
                   ) : null}
                 </div>
@@ -408,113 +776,487 @@ export default function StatusPage() {
 
             <article className={styles.panel}>
               <h2>Next checkpoint</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={4} /> : <dl className={styles.kv}>
-                <div><dt>Current phase</dt><dd>{currentPhase}</dd></div>
-                <div><dt>Next action</dt><dd>{nextAction}</dd></div>
-                <div><dt>Login URL</dt><dd>{status?.urls?.loginUrl || 'Not available yet'}</dd></div>
-                <div><dt>Cluster objects</dt><dd>{status?.kubernetes?.podCount ?? 0} pods · {status?.kubernetes?.helmReleaseCount ?? 0} releases</dd></div>
-              </dl>}
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={4} />
+              ) : (
+                <dl className={styles.kv}>
+                  <div>
+                    <dt>Current phase</dt>
+                    <dd>{currentPhase}</dd>
+                  </div>
+                  <div>
+                    <dt>Next action</dt>
+                    <dd>{nextAction}</dd>
+                  </div>
+                  <div>
+                    <dt>Login URL</dt>
+                    <dd>{status?.urls?.loginUrl || "Not available yet"}</dd>
+                  </div>
+                  <div>
+                    <dt>Cluster objects</dt>
+                    <dd>
+                      {status?.kubernetes?.podCount ?? 0} pods ·{" "}
+                      {status?.kubernetes?.helmReleaseCount ?? 0} releases
+                    </dd>
+                  </div>
+                </dl>
+              )}
             </article>
 
             <article className={styles.panel}>
               <h2>Blockers</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={3} /> : blockerList.length === 0 ? <p className={styles.muted}>No action-required blockers detected.</p> : blockerList.map((blocker, index) => (
-                <div className={`${styles.blocker} ${blocker.loginBlocking === false ? styles.backgroundBlocker : ''}`} key={index}>
-                  <strong>{blocker.component || blocker.layer}</strong><p>{blocker.reason}</p><small>{blocker.nextAction}</small>
-                </div>
-              ))}
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={3} />
+              ) : blockerList.length === 0 ? (
+                <p className={styles.muted}>
+                  No action-required blockers detected.
+                </p>
+              ) : (
+                blockerList.map((blocker, index) => (
+                  <div
+                    className={`${styles.blocker} ${blocker.loginBlocking === false ? styles.backgroundBlocker : ""}`}
+                    key={index}
+                  >
+                    <strong>{blocker.component || blocker.layer}</strong>
+                    <p>{blocker.reason}</p>
+                    <small>{blocker.nextAction}</small>
+                  </div>
+                ))
+              )}
             </article>
 
             <article className={styles.panel}>
               <h2>Readiness tiers</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={6} /> : <div className={styles.tiers}>{tierEntries(status).map(([name, tier]) => (
-                <div className={styles.tier} key={name}><strong>{name}</strong><span className={`${styles.badge} ${badgeClass(tier.ready)}`}>{tier.ready ? 'ready' : 'not ready'}</span><small>{tier.status}</small></div>
-              ))}</div>}
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={6} />
+              ) : (
+                <div className={styles.tiers}>
+                  {tierEntries(status).map(([name, tier]) => (
+                    <div className={styles.tier} key={name}>
+                      <strong>{name}</strong>
+                      <span
+                        className={`${styles.badge} ${badgeClass(tier.ready)}`}
+                      >
+                        {tier.ready ? "ready" : "not ready"}
+                      </span>
+                      <small>{tier.status}</small>
+                    </div>
+                  ))}
+                </div>
+              )}
             </article>
 
             <article className={styles.panel}>
               <h2>Active operations</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={3} /> : runningOperations.length === 0 ? <p className={styles.muted}>No active image pull or long-running pod operation detected.</p> : runningOperations.map((op, index) => (
-                <div className={styles.operation} key={index}><strong>{op.component}</strong><p>{op.message}</p></div>
-              ))}
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={3} />
+              ) : runningOperations.length === 0 ? (
+                <p className={styles.muted}>
+                  No active image pull or long-running pod operation detected.
+                </p>
+              ) : (
+                runningOperations.map((op, index) => (
+                  <div className={styles.operation} key={index}>
+                    <strong>{op.component}</strong>
+                    <p>{op.message}</p>
+                  </div>
+                ))
+              )}
             </article>
 
             <article className={styles.panel}>
               <h2>Recovery</h2>
-              <p className={styles.muted}>Re-runs the application bootstrap — database migrations, onboarding seeds, and creation of the initial tenant and admin user (only when no user exists yet). Use this if setup finished but you cannot log in because the initial account was never created.</p>
+              <p className={styles.muted}>
+                Re-runs the application bootstrap — database migrations,
+                onboarding seeds, and creation of the initial tenant and admin
+                user (only when no user exists yet). Use this if setup finished
+                but you cannot log in because the initial account was never
+                created.
+              </p>
               <div className={styles.toolbar}>
                 <button
                   type="button"
                   className={styles.actionButton}
                   disabled={recovering}
-                  onClick={() => { if (!confirmRecover) { setConfirmRecover(true); } else { setConfirmRecover(false); recoverBootstrap(); } }}
+                  onClick={() => {
+                    if (!confirmRecover) {
+                      setConfirmRecover(true);
+                    } else {
+                      setConfirmRecover(false);
+                      recoverBootstrap();
+                    }
+                  }}
                 >
-                  {recovering ? 'Triggering…' : confirmRecover ? 'Confirm re-run' : 'Re-run application bootstrap'}
+                  {recovering
+                    ? "Triggering…"
+                    : confirmRecover
+                      ? "Confirm re-run"
+                      : "Re-run application bootstrap"}
                 </button>
-                {confirmRecover && !recovering ? <button type="button" onClick={() => setConfirmRecover(false)}>Cancel</button> : null}
+                {confirmRecover && !recovering ? (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRecover(false)}
+                  >
+                    Cancel
+                  </button>
+                ) : null}
               </div>
-              {recoverMsg ? <p className={styles.helpText}>{recoverMsg}</p> : null}
+              {recoverMsg ? (
+                <p className={styles.helpText}>{recoverMsg}</p>
+              ) : null}
             </article>
 
             <article className={`${styles.panel} ${styles.wide}`}>
               <h2>Recent Kubernetes events</h2>
-              {loadingStatus && !status ? <SkeletonBlock lines={5} /> : <div className={styles.eventList}>{(status?.recentEvents || []).slice(-10).reverse().map((event, index) => (
-                <div className={styles.event} key={index}><b>{event.type} {event.reason}</b><span>{event.namespace} · {event.involvedObject}</span><p>{event.message}</p></div>
-              ))}{(status?.recentEvents || []).length === 0 ? <p className={styles.muted}>Kubernetes events are not available yet.</p> : null}</div>}
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={5} />
+              ) : (
+                <div className={styles.eventList}>
+                  {(status?.recentEvents || [])
+                    .slice(-10)
+                    .reverse()
+                    .map((event, index) => (
+                      <div className={styles.event} key={index}>
+                        <b>
+                          {event.type} {event.reason}
+                        </b>
+                        <span>
+                          {event.namespace} · {event.involvedObject}
+                        </span>
+                        <p>{event.message}</p>
+                      </div>
+                    ))}
+                  {(status?.recentEvents || []).length === 0 ? (
+                    <p className={styles.muted}>
+                      Kubernetes events are not available yet.
+                    </p>
+                  ) : null}
+                </div>
+              )}
             </article>
 
             <details className={styles.advancedSupport}>
-              <summary className={styles.advancedSummary}>Advanced support diagnostics</summary>
-              <p className={styles.helpText}>Use this raw payload when support asks for exact appliance state.</p>
-              {loadingStatus && !status ? <SkeletonBlock lines={12} /> : <pre className={styles.raw}>{JSON.stringify(status || { error }, null, 2)}</pre>}
+              <summary className={styles.advancedSummary}>
+                Advanced support diagnostics
+              </summary>
+              <p className={styles.helpText}>
+                Use this raw payload when support asks for exact appliance
+                state.
+              </p>
+              {loadingStatus && !status ? (
+                <SkeletonBlock lines={12} />
+              ) : (
+                <pre className={styles.raw}>
+                  {JSON.stringify(status || { error }, null, 2)}
+                </pre>
+              )}
             </details>
           </div>
         ) : null}
 
-        {activeTab === 'deployments' ? (
-          <section id="appliance-panel-deployments" role="tabpanel" aria-labelledby="appliance-tab-deployments" className={styles.panel}>
-            <Toolbar namespace={namespace} namespaces={namespaces} loadingNamespaces={loadingNamespaces} onNamespace={setNamespace} filter={deploymentFilter} onFilter={setDeploymentFilter} onRefresh={loadDeployments} />
-            <div className={styles.tableWrap}><table><thead><tr><th>Deployment</th><th>Ready</th><th>Revision</th><th>Strategy</th><th>Images</th><th>History</th></tr></thead><tbody>{loadingDeployments ? <SkeletonRows columns={6} rows={7} /> : visibleDeployments.length === 0 ? <tr><td colSpan={6} className={styles.emptyCell}>No deployments found.</td></tr> : visibleDeployments.map((deployment) => (
-              <tr key={`${deployment.namespace}/${deployment.name}`}><td><b>{deployment.name}</b><small>{deployment.namespace}</small></td><td><span className={`${styles.badge} ${badgeClass(deployment.readyReplicas === deployment.replicas)}`}>{deployment.readyReplicas}/{deployment.replicas}</span></td><td>{deployment.revision || '—'}</td><td>{deployment.strategy}</td><td>{deployment.images?.map((image) => <code key={image}>{image}</code>)}</td><td><div className={styles.history}>{deployment.replicaSets?.slice(0, 4).map((rs) => <span key={rs.name}>r{rs.revision || '?'} {rs.readyReplicas}/{rs.replicas} · {ageFrom(rs.createdAt)}</span>)}</div></td></tr>
-            ))}</tbody></table></div>
+        {activeTab === "deployments" ? (
+          <section
+            id="appliance-panel-deployments"
+            role="tabpanel"
+            aria-labelledby="appliance-tab-deployments"
+            className={styles.panel}
+          >
+            <Toolbar
+              namespace={namespace}
+              namespaces={namespaces}
+              loadingNamespaces={loadingNamespaces}
+              onNamespace={setNamespace}
+              filter={deploymentFilter}
+              onFilter={setDeploymentFilter}
+              onRefresh={loadDeployments}
+            />
+            <div className={styles.tableWrap}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Deployment</th>
+                    <th>Ready</th>
+                    <th>Revision</th>
+                    <th>Strategy</th>
+                    <th>Images</th>
+                    <th>History</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingDeployments ? (
+                    <SkeletonRows columns={6} rows={7} />
+                  ) : visibleDeployments.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className={styles.emptyCell}>
+                        No deployments found.
+                      </td>
+                    </tr>
+                  ) : (
+                    visibleDeployments.map((deployment) => (
+                      <tr key={`${deployment.namespace}/${deployment.name}`}>
+                        <td>
+                          <b>{deployment.name}</b>
+                          <small>{deployment.namespace}</small>
+                        </td>
+                        <td>
+                          <span
+                            className={`${styles.badge} ${badgeClass(deployment.readyReplicas === deployment.replicas)}`}
+                          >
+                            {deployment.readyReplicas}/{deployment.replicas}
+                          </span>
+                        </td>
+                        <td>{deployment.revision || "—"}</td>
+                        <td>{deployment.strategy}</td>
+                        <td>
+                          {deployment.images?.map((image) => (
+                            <code key={image}>{image}</code>
+                          ))}
+                        </td>
+                        <td>
+                          <div className={styles.history}>
+                            {deployment.replicaSets?.slice(0, 4).map((rs) => (
+                              <span key={rs.name}>
+                                r{rs.revision || "?"} {rs.readyReplicas}/
+                                {rs.replicas} · {ageFrom(rs.createdAt)}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </section>
         ) : null}
 
-        {activeTab === 'pods' ? (
-          <section id="appliance-panel-pods" role="tabpanel" aria-labelledby="appliance-tab-pods" className={styles.panel}>
-            <Toolbar namespace={namespace} namespaces={namespaces} loadingNamespaces={loadingNamespaces} onNamespace={setNamespace} filter={podFilter} onFilter={setPodFilter} onRefresh={loadPods} />
-            <div className={styles.tableWrap}><table><thead><tr><th>Pod</th><th>Status</th><th>Ready</th><th>Restarts</th><th>Node/IP</th><th>Containers</th><th>Action</th></tr></thead><tbody>{loadingPods ? <SkeletonRows columns={7} rows={8} /> : visiblePods.length === 0 ? <tr><td colSpan={7} className={styles.emptyCell}>No pods found.</td></tr> : visiblePods.map((pod) => (
-              <tr key={`${pod.namespace}/${pod.name}`} onClick={() => { setNamespace(pod.namespace); setSelectedPod(pod.name); setSelectedContainer(pod.containers[0]?.name || ''); setActiveTab('logs'); }}><td><b>{pod.name}</b><small>{pod.namespace}</small></td><td><span className={`${styles.badge} ${badgeClass(pod.phase)}`}>{pod.phase}</span></td><td>{pod.readyContainers}/{pod.totalContainers}</td><td>{pod.restarts}</td><td><small>{pod.node || '—'}<br />{pod.podIP || '—'}</small></td><td>{pod.containers.map((container) => <code key={container.name}>{container.name}</code>)}</td><td><button type="button" onClick={(event) => { event.stopPropagation(); setNamespace(pod.namespace); setSelectedPod(pod.name); setSelectedContainer(pod.containers[0]?.name || ''); setActiveTab('logs'); }}>View logs</button></td></tr>
-            ))}</tbody></table></div>
+        {activeTab === "pods" ? (
+          <section
+            id="appliance-panel-pods"
+            role="tabpanel"
+            aria-labelledby="appliance-tab-pods"
+            className={styles.panel}
+          >
+            <Toolbar
+              namespace={namespace}
+              namespaces={namespaces}
+              loadingNamespaces={loadingNamespaces}
+              onNamespace={setNamespace}
+              filter={podFilter}
+              onFilter={setPodFilter}
+              onRefresh={loadPods}
+            />
+            <div className={styles.tableWrap}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Pod</th>
+                    <th>Status</th>
+                    <th>Ready</th>
+                    <th>Restarts</th>
+                    <th>Node/IP</th>
+                    <th>Containers</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingPods ? (
+                    <SkeletonRows columns={7} rows={8} />
+                  ) : visiblePods.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className={styles.emptyCell}>
+                        No pods found.
+                      </td>
+                    </tr>
+                  ) : (
+                    visiblePods.map((pod) => (
+                      <tr
+                        key={`${pod.namespace}/${pod.name}`}
+                        onClick={() => {
+                          setNamespace(pod.namespace);
+                          setSelectedPod(pod.name);
+                          setSelectedContainer(pod.containers[0]?.name || "");
+                          setActiveTab("logs");
+                        }}
+                      >
+                        <td>
+                          <b>{pod.name}</b>
+                          <small>{pod.namespace}</small>
+                        </td>
+                        <td>
+                          <span
+                            className={`${styles.badge} ${badgeClass(pod.phase)}`}
+                          >
+                            {pod.phase}
+                          </span>
+                        </td>
+                        <td>
+                          {pod.readyContainers}/{pod.totalContainers}
+                        </td>
+                        <td>{pod.restarts}</td>
+                        <td>
+                          <small>
+                            {pod.node || "—"}
+                            <br />
+                            {pod.podIP || "—"}
+                          </small>
+                        </td>
+                        <td>
+                          {pod.containers.map((container) => (
+                            <code key={container.name}>{container.name}</code>
+                          ))}
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setNamespace(pod.namespace);
+                              setSelectedPod(pod.name);
+                              setSelectedContainer(
+                                pod.containers[0]?.name || "",
+                              );
+                              setActiveTab("logs");
+                            }}
+                          >
+                            View logs
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </section>
         ) : null}
 
-        {activeTab === 'logs' ? (
-          <section id="appliance-panel-logs" role="tabpanel" aria-labelledby="appliance-tab-logs" className={styles.panel}>
+        {activeTab === "logs" ? (
+          <section
+            id="appliance-panel-logs"
+            role="tabpanel"
+            aria-labelledby="appliance-tab-logs"
+            className={styles.panel}
+          >
             <div className={styles.logControls}>
-              <Dropdown ariaLabel="Namespace" value={namespace} disabled={loadingNamespaces} onChange={(value) => { setNamespace(value); setSelectedPod(''); }} options={[{ value: 'msp', label: 'msp' }, ...namespaces.filter((ns) => ns.name !== 'msp').map((ns) => ({ value: ns.name, label: ns.name }))]} />
-              <Dropdown ariaLabel="Pod" value={selectedPod} disabled={loadingPods} placeholder="Select pod" onChange={(value) => { setSelectedPod(value); setSelectedContainer(''); }} options={pods.map((pod) => ({ value: pod.name, label: pod.name }))} />
-              <Dropdown ariaLabel="Container" value={selectedContainer} disabled={loadingPods || !selectedPodData} placeholder="Select container" onChange={setSelectedContainer} options={(selectedPodData?.containers || []).map((container) => ({ value: container.name, label: container.name }))} />
-              <button type="button" onClick={() => loadLogs(logTail, { scrollToEnd: true })}>Refresh</button>
-              <span className={styles.muted}>tail {logTail} · scroll up for older lines</span>
+              <Dropdown
+                ariaLabel="Namespace"
+                value={namespace}
+                disabled={loadingNamespaces}
+                onChange={(value) => {
+                  setNamespace(value);
+                  setSelectedPod("");
+                }}
+                options={[
+                  { value: "msp", label: "msp" },
+                  ...namespaces
+                    .filter((ns) => ns.name !== "msp")
+                    .map((ns) => ({ value: ns.name, label: ns.name })),
+                ]}
+              />
+              <Dropdown
+                ariaLabel="Pod"
+                value={selectedPod}
+                disabled={loadingPods}
+                placeholder="Select pod"
+                onChange={(value) => {
+                  setSelectedPod(value);
+                  setSelectedContainer("");
+                }}
+                options={pods.map((pod) => ({
+                  value: pod.name,
+                  label: pod.name,
+                }))}
+              />
+              <Dropdown
+                ariaLabel="Container"
+                value={selectedContainer}
+                disabled={loadingPods || !selectedPodData}
+                placeholder="Select container"
+                onChange={setSelectedContainer}
+                options={(selectedPodData?.containers || []).map(
+                  (container) => ({
+                    value: container.name,
+                    label: container.name,
+                  }),
+                )}
+              />
+              <button
+                type="button"
+                onClick={() => loadLogs(logTail, { scrollToEnd: true })}
+              >
+                Refresh
+              </button>
+              <span className={styles.muted}>
+                tail {logTail} · scroll up for older lines
+              </span>
             </div>
             <div className={styles.logControls}>
-              <input aria-label="Filter visible log lines" value={logFilter} onChange={(event) => setLogFilter(event.target.value)} placeholder="Filter visible log lines" />
-              <input aria-label="Search and highlight log lines" value={logSearch} onChange={(event) => setLogSearch(event.target.value)} placeholder="Search and highlight" />
-              <button type="button" disabled={searchMatches === 0} onClick={() => jumpMatch(-1)}>Previous</button>
-              <button type="button" disabled={searchMatches === 0} onClick={() => jumpMatch(1)}>Next</button>
-              <span className={styles.matchCount}>{searchMatches ? `${activeMatch + 1}/${searchMatches}` : '0 matches'}</span>
+              <input
+                aria-label="Filter visible log lines"
+                value={logFilter}
+                onChange={(event) => setLogFilter(event.target.value)}
+                placeholder="Filter visible log lines"
+              />
+              <input
+                aria-label="Search and highlight log lines"
+                value={logSearch}
+                onChange={(event) => setLogSearch(event.target.value)}
+                placeholder="Search and highlight"
+              />
+              <button
+                type="button"
+                disabled={searchMatches === 0}
+                onClick={() => jumpMatch(-1)}
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                disabled={searchMatches === 0}
+                onClick={() => jumpMatch(1)}
+              >
+                Next
+              </button>
+              <span className={styles.matchCount}>
+                {searchMatches
+                  ? `${activeMatch + 1}/${searchMatches}`
+                  : "0 matches"}
+              </span>
             </div>
             {logError ? <div className={styles.alert}>{logError}</div> : null}
-            {loadingLogs && logLines.length === 0 ? <div className={styles.logPane}><SkeletonBlock lines={18} /></div> : <pre className={styles.logPane} ref={logPaneRef} onScroll={handleLogScroll}>{filteredLogLines.map((line, index) => {
-              const matchIndex = matchLineIndexes.indexOf(index);
-              const isMatch = matchIndex >= 0;
-              const isActive = isMatch && matchIndex === activeMatch;
-              return <div ref={(el) => { lineRefs.current[index] = el; }} key={`${index}-${line.slice(0, 20)}`} className={`${isMatch ? styles.matchLine : ''} ${isActive ? styles.activeMatchLine : ''}`}>{highlightLine(line, logSearch)}</div>;
-            })}</pre>}
+            {loadingLogs && logLines.length === 0 ? (
+              <div className={styles.logPane}>
+                <SkeletonBlock lines={18} />
+              </div>
+            ) : (
+              <pre
+                className={styles.logPane}
+                ref={logPaneRef}
+                onScroll={handleLogScroll}
+              >
+                {filteredLogLines.map((line, index) => {
+                  const matchIndex = matchLineIndexes.indexOf(index);
+                  const isMatch = matchIndex >= 0;
+                  const isActive = isMatch && matchIndex === activeMatch;
+                  return (
+                    <div
+                      ref={(el) => {
+                        lineRefs.current[index] = el;
+                      }}
+                      key={`${index}-${line.slice(0, 20)}`}
+                      className={`${isMatch ? styles.matchLine : ""} ${isActive ? styles.activeMatchLine : ""}`}
+                    >
+                      {highlightLine(line, logSearch)}
+                    </div>
+                  );
+                })}
+              </pre>
+            )}
           </section>
         ) : null}
-
       </section>
     </main>
   );
@@ -526,7 +1268,14 @@ type DropdownOption = { value: string; label: string };
 // unreliable inside the Electron browser pane (they fail to open or are
 // dismissed by the 15s status-poll re-render). This renders the option list in
 // the page DOM and keeps its open state across parent re-renders.
-function Dropdown({ value, options, onChange, disabled, ariaLabel, placeholder }: {
+function Dropdown({
+  value,
+  options,
+  onChange,
+  disabled,
+  ariaLabel,
+  placeholder,
+}: {
   value: string;
   options: DropdownOption[];
   onChange: (value: string) => void;
@@ -541,51 +1290,116 @@ function Dropdown({ value, options, onChange, disabled, ariaLabel, placeholder }
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(event.target as Node))
+        setOpen(false);
     };
-    const onKey = (event: KeyboardEvent) => { if (event.key === 'Escape') setOpen(false); };
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKey);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKey);
     return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKey);
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
     };
   }, [open]);
 
-  useEffect(() => { if (disabled) setOpen(false); }, [disabled]);
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
 
   return (
     <div className={styles.dropdown} ref={ref}>
-      <button type="button" className={styles.dropdownButton} aria-haspopup="listbox" aria-expanded={open} aria-label={ariaLabel} disabled={disabled} onClick={() => setOpen((prev) => !prev)}>
-        <span className={styles.dropdownLabel}>{selected?.label ?? (value || placeholder || '—')}</span>
-        <span className={styles.dropdownCaret} aria-hidden="true">▾</span>
+      <button
+        type="button"
+        className={styles.dropdownButton}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span className={styles.dropdownLabel}>
+          {selected?.label ?? (value || placeholder || "—")}
+        </span>
+        <span className={styles.dropdownCaret} aria-hidden="true">
+          ▾
+        </span>
       </button>
       {open && !disabled ? (
-        <ul className={styles.dropdownMenu} role="listbox" aria-label={ariaLabel}>
+        <ul
+          className={styles.dropdownMenu}
+          role="listbox"
+          aria-label={ariaLabel}
+        >
           {options.length === 0 ? (
-            <li className={styles.dropdownOption} aria-disabled="true">No options</li>
-          ) : options.map((option) => (
-            <li
-              key={option.value}
-              role="option"
-              aria-selected={option.value === value}
-              className={`${styles.dropdownOption} ${option.value === value ? styles.dropdownOptionActive : ''}`}
-              onClick={() => { onChange(option.value); setOpen(false); }}
-            >
-              {option.label}
+            <li className={styles.dropdownOption} aria-disabled="true">
+              No options
             </li>
-          ))}
+          ) : (
+            options.map((option) => (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={option.value === value}
+                className={`${styles.dropdownOption} ${option.value === value ? styles.dropdownOptionActive : ""}`}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+              >
+                {option.label}
+              </li>
+            ))
+          )}
         </ul>
       ) : null}
     </div>
   );
 }
 
-function Toolbar({ namespace, namespaces, loadingNamespaces, onNamespace, filter, onFilter, onRefresh }: { namespace: string; namespaces: NamespaceItem[]; loadingNamespaces?: boolean; onNamespace: (value: string) => void; filter: string; onFilter: (value: string) => void; onRefresh: () => void }) {
+function Toolbar({
+  namespace,
+  namespaces,
+  loadingNamespaces,
+  onNamespace,
+  filter,
+  onFilter,
+  onRefresh,
+}: {
+  namespace: string;
+  namespaces: NamespaceItem[];
+  loadingNamespaces?: boolean;
+  onNamespace: (value: string) => void;
+  filter: string;
+  onFilter: (value: string) => void;
+  onRefresh: () => void;
+}) {
   const options: DropdownOption[] = [
-    { value: 'all', label: 'all namespaces' },
-    { value: 'msp', label: 'msp' },
-    ...namespaces.filter((ns) => ns.name !== 'msp').map((ns) => ({ value: ns.name, label: ns.name }))
+    { value: "all", label: "all namespaces" },
+    { value: "msp", label: "msp" },
+    ...namespaces
+      .filter((ns) => ns.name !== "msp")
+      .map((ns) => ({ value: ns.name, label: ns.name })),
   ];
-  return <div className={styles.toolbar}><Dropdown ariaLabel="Namespace" value={namespace} disabled={loadingNamespaces} onChange={onNamespace} options={options} /><input aria-label="Filter by name, image, or state" value={filter} onChange={(event) => onFilter(event.target.value)} placeholder="Filter by name, image, state…" /><button type="button" onClick={onRefresh}>Refresh</button></div>;
+  return (
+    <div className={styles.toolbar}>
+      <Dropdown
+        ariaLabel="Namespace"
+        value={namespace}
+        disabled={loadingNamespaces}
+        onChange={onNamespace}
+        options={options}
+      />
+      <input
+        aria-label="Filter by name, image, or state"
+        value={filter}
+        onChange={(event) => onFilter(event.target.value)}
+        placeholder="Filter by name, image, state…"
+      />
+      <button type="button" onClick={onRefresh}>
+        Refresh
+      </button>
+    </div>
+  );
 }

--- a/ee/appliance/status-ui/app/setup/page.tsx
+++ b/ee/appliance/status-ui/app/setup/page.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { FormEvent, useEffect, useState } from 'react';
-import { Activity, SlidersHorizontal } from 'lucide-react';
-import { AlgaLogo } from '../AlgaLogo';
-import { LogoutButton } from '../auth/LogoutButton';
-import styles from '../status.module.css';
+import { FormEvent, useEffect, useState } from "react";
+import { Activity, SlidersHorizontal } from "lucide-react";
+import { AlgaLogo } from "../AlgaLogo";
+import { LogoutButton } from "../auth/LogoutButton";
+import styles from "../status.module.css";
 
 // The manual edition selector + airgap license-key entry are hidden for now: the
 // install code is the only supported entitlement path (operators re-issue a fresh
@@ -28,19 +28,40 @@ type SetupConfig = {
   };
 };
 
-type FieldErrors = Partial<Record<'installCode' | 'tenantName' | 'adminFirstName' | 'adminLastName' | 'adminEmail' | 'adminPassword' | 'adminPasswordConfirm' | 'appHostname' | 'dnsServers' | 'releaseRef' | 'licenseKey', string>>;
+type FieldErrors = Partial<
+  Record<
+    | "installCode"
+    | "tenantName"
+    | "adminFirstName"
+    | "adminLastName"
+    | "adminEmail"
+    | "adminPassword"
+    | "adminPasswordConfirm"
+    | "appHostname"
+    | "dnsServers"
+    | "releaseRef"
+    | "licenseKey",
+    string
+  >
+>;
 
 function isValidIpv4(value: string) {
-  const parts = value.split('.');
-  return parts.length === 4 && parts.every((part) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255);
+  const parts = value.split(".");
+  return (
+    parts.length === 4 &&
+    parts.every(
+      (part) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255,
+    )
+  );
 }
 
 function passwordValidationError(value: string) {
-  if (value.length < 8) return 'Use at least 8 characters.';
-  if (!/[a-z]/.test(value)) return 'Include a lowercase letter.';
-  if (!/[A-Z]/.test(value)) return 'Include an uppercase letter.';
-  if (!/\d/.test(value)) return 'Include a number.';
-  if (!/[!@#$%^&*(),.?":{}|<>]/.test(value)) return 'Include a special character.';
+  if (value.length < 8) return "Use at least 8 characters.";
+  if (!/[a-z]/.test(value)) return "Include a lowercase letter.";
+  if (!/[A-Z]/.test(value)) return "Include an uppercase letter.";
+  if (!/\d/.test(value)) return "Include a number.";
+  if (!/[!@#$%^&*(),.?":{}|<>]/.test(value))
+    return "Include a special character.";
   return null;
 }
 
@@ -48,49 +69,75 @@ function isWellFormedJwt(value: string) {
   return /^[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$/.test(value);
 }
 
-function validateSetupForm(payload: { installCode?: string; tenantName: string; adminFirstName: string; adminLastName: string; adminEmail: string; adminPassword: string; adminPasswordConfirm: string; appHostname: string; dnsMode: string; dnsServers: string; releaseRef: string; licenseKey?: string }) {
+function validateSetupForm(payload: {
+  installCode?: string;
+  tenantName: string;
+  adminFirstName: string;
+  adminLastName: string;
+  adminEmail: string;
+  adminPassword: string;
+  adminPasswordConfirm: string;
+  appHostname: string;
+  dnsMode: string;
+  dnsServers: string;
+  releaseRef: string;
+  licenseKey?: string;
+}) {
   const errors: FieldErrors = {};
 
   // The install code is the only supported entitlement path (manual edition /
   // airgap license entry is hidden), so it is required.
-  if (!payload.installCode?.trim()) errors.installCode = 'Enter the install code from your registration email.';
-  if (!payload.tenantName.trim()) errors.tenantName = 'Enter the company name for the initial tenant.';
-  if (!payload.adminFirstName.trim()) errors.adminFirstName = 'Enter the admin first name.';
-  if (!payload.adminLastName.trim()) errors.adminLastName = 'Enter the admin last name.';
-  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(payload.adminEmail.trim())) errors.adminEmail = 'Enter a valid admin email address.';
+  if (!payload.installCode?.trim())
+    errors.installCode = "Enter the install code from your registration email.";
+  if (!payload.tenantName.trim())
+    errors.tenantName = "Enter the company name for the initial tenant.";
+  if (!payload.adminFirstName.trim())
+    errors.adminFirstName = "Enter the admin first name.";
+  if (!payload.adminLastName.trim())
+    errors.adminLastName = "Enter the admin last name.";
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(payload.adminEmail.trim()))
+    errors.adminEmail = "Enter a valid admin email address.";
   const passwordError = passwordValidationError(payload.adminPassword);
   if (passwordError) errors.adminPassword = passwordError;
-  if (payload.adminPassword !== payload.adminPasswordConfirm) errors.adminPasswordConfirm = 'Passwords do not match.';
+  if (payload.adminPassword !== payload.adminPasswordConfirm)
+    errors.adminPasswordConfirm = "Passwords do not match.";
 
   if (!payload.appHostname.trim()) {
-    errors.appHostname = 'Enter the full URL users will open after setup.';
+    errors.appHostname = "Enter the full URL users will open after setup.";
   } else {
     try {
       const parsed = new URL(payload.appHostname.trim());
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        errors.appHostname = 'Use an http or https URL.';
+      if (!["http:", "https:"].includes(parsed.protocol)) {
+        errors.appHostname = "Use an http or https URL.";
       }
     } catch {
-      errors.appHostname = 'Use a full URL, for example http://192.168.1.50:3000.';
+      errors.appHostname =
+        "Use a full URL, for example http://192.168.1.50:3000.";
     }
   }
 
-  if (payload.dnsMode === 'custom') {
-    const servers = payload.dnsServers.split(',').map((value) => value.trim()).filter(Boolean);
+  if (payload.dnsMode === "custom") {
+    const servers = payload.dnsServers
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
     if (servers.length === 0) {
-      errors.dnsServers = 'Enter at least one DNS server for custom DNS.';
+      errors.dnsServers = "Enter at least one DNS server for custom DNS.";
     } else {
       const invalid = servers.filter((server) => !isValidIpv4(server));
-      if (invalid.length) errors.dnsServers = `Check these IPv4 addresses: ${invalid.join(', ')}.`;
+      if (invalid.length)
+        errors.dnsServers = `Check these IPv4 addresses: ${invalid.join(", ")}.`;
     }
   }
 
   if (payload.releaseRef && !/^[A-Za-z0-9._:@/-]+$/.test(payload.releaseRef)) {
-    errors.releaseRef = 'Use a release version (e.g. 1.0.3) or a digest (sha256:...).';
+    errors.releaseRef =
+      "Use a release version (e.g. 1.0.3) or a digest (sha256:...).";
   }
 
   if (payload.licenseKey && !isWellFormedJwt(payload.licenseKey.trim())) {
-    errors.licenseKey = 'License key format is invalid. Paste the full key as provided.';
+    errors.licenseKey =
+      "License key format is invalid. Paste the full key as provided.";
   }
 
   return errors;
@@ -112,60 +159,68 @@ export default function SetupPage() {
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [busy, setBusy] = useState(false);
-  const [channel, setChannel] = useState('stable');
-  const [tenantName, setTenantName] = useState('');
-  const [adminFirstName, setAdminFirstName] = useState('');
-  const [adminLastName, setAdminLastName] = useState('');
-  const [adminEmail, setAdminEmail] = useState('');
-  const [adminPassword, setAdminPassword] = useState('');
-  const [adminPasswordConfirm, setAdminPasswordConfirm] = useState('');
-  const [appHostname, setAppHostname] = useState('');
-  const [dnsMode, setDnsMode] = useState('system');
-  const [dnsServers, setDnsServers] = useState('');
-  const [releaseRef, setReleaseRef] = useState('');
-  const [editionChoice, setEditionChoice] = useState<'ee' | 'ce'>('ee');
-  const [licenseKey, setLicenseKey] = useState('');
-  const [installCode, setInstallCode] = useState('');
+  const [channel, setChannel] = useState("stable");
+  const [tenantName, setTenantName] = useState("");
+  const [adminFirstName, setAdminFirstName] = useState("");
+  const [adminLastName, setAdminLastName] = useState("");
+  const [adminEmail, setAdminEmail] = useState("");
+  const [adminPassword, setAdminPassword] = useState("");
+  const [adminPasswordConfirm, setAdminPasswordConfirm] = useState("");
+  const [appHostname, setAppHostname] = useState("");
+  const [dnsMode, setDnsMode] = useState("system");
+  const [dnsServers, setDnsServers] = useState("");
+  const [releaseRef, setReleaseRef] = useState("");
+  const [editionChoice, setEditionChoice] = useState<"ee" | "ce">("ee");
+  const [licenseKey, setLicenseKey] = useState("");
+  const [installCode, setInstallCode] = useState("");
 
   useEffect(() => {
     let cancelled = false;
     async function loadConfig() {
       try {
-        const response = await fetch('/api/setup/config', { cache: 'no-store' });
-        if (response.status === 401) { window.location.reload(); return; }
-        if (!response.ok) throw new Error('Unable to load setup defaults.');
+        const response = await fetch("/api/setup/config", {
+          cache: "no-store",
+        });
+        if (response.status === 401) {
+          window.location.reload();
+          return;
+        }
+        if (!response.ok) throw new Error("Unable to load setup defaults.");
         const data = (await response.json()) as SetupConfig;
         if (cancelled) return;
         setConfig(data);
-        setChannel(data.defaults?.channel || 'stable');
-        setAppHostname(data.defaults?.appHostname || '');
-        setDnsMode(data.defaults?.dnsMode || 'system');
-        setDnsServers(data.defaults?.dnsServers || '');
-        setReleaseRef(data.defaults?.releaseRef || '');
+        setChannel(data.defaults?.channel || "stable");
+        setAppHostname(data.defaults?.appHostname || "");
+        setDnsMode(data.defaults?.dnsMode || "system");
+        setDnsServers(data.defaults?.dnsServers || "");
+        setReleaseRef(data.defaults?.releaseRef || "");
         setError(null);
       } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : String(err));
       }
     }
     loadConfig();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const payload = {
-      channel: String(formData.get('channel') || channel),
-      tenantName: String(formData.get('tenantName') || ''),
-      adminFirstName: String(formData.get('adminFirstName') || ''),
-      adminLastName: String(formData.get('adminLastName') || ''),
-      adminEmail: String(formData.get('adminEmail') || ''),
-      adminPassword: String(formData.get('adminPassword') || ''),
-      adminPasswordConfirm: String(formData.get('adminPasswordConfirm') || ''),
-      appHostname: String(formData.get('appHostname') || ''),
-      dnsMode: String(formData.get('dnsMode') || dnsMode),
-      dnsServers: String(formData.get('dnsServers') || ''),
-      releaseRef: String(formData.get('releaseRef') || releaseRef),
+      channel: String(formData.get("channel") || channel),
+      tenantName: String(formData.get("tenantName") || ""),
+      adminFirstName: String(formData.get("adminFirstName") || ""),
+      adminLastName: String(formData.get("adminLastName") || ""),
+      adminEmail: String(formData.get("adminEmail") || ""),
+      adminPassword: String(formData.get("adminPassword") || ""),
+      adminPasswordConfirm: String(formData.get("adminPasswordConfirm") || ""),
+      appHostname: String(formData.get("appHostname") || ""),
+      dnsMode: String(formData.get("dnsMode") || dnsMode),
+      dnsServers: String(formData.get("dnsServers") || ""),
+      releaseRef: String(formData.get("releaseRef") || releaseRef),
       editionChoice,
       licenseKey: licenseKey.trim() || undefined,
       installCode: installCode.trim() || undefined,
@@ -177,15 +232,18 @@ export default function SetupPage() {
     setBusy(true);
     setError(null);
     try {
-      const response = await fetch('/api/setup', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
+      const response = await fetch("/api/setup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
         body: JSON.stringify(payload),
       });
-      if (response.status === 401) { window.location.reload(); return; }
+      if (response.status === 401) {
+        window.location.reload();
+        return;
+      }
       const data = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(data.error || 'Unable to save setup.');
-      window.location.href = '/';
+      if (!response.ok) throw new Error(data.error || "Unable to save setup.");
+      window.location.href = "/";
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setBusy(false);
@@ -208,12 +266,23 @@ export default function SetupPage() {
     <main className={styles.shell}>
       <aside className={styles.sidebar}>
         <div className={styles.brand}>
-          <span className={styles.logo}><AlgaLogo className={styles.logoSvg} /></span>
-          <span className={styles.brandText}><span>Alga PSA</span><small>Setup</small></span>
+          <span className={styles.logo}>
+            <AlgaLogo className={styles.logoSvg} />
+          </span>
+          <span className={styles.brandText}>
+            <span>Alga PSA</span>
+            <small>Setup</small>
+          </span>
         </div>
         <nav className={styles.nav} aria-label="Alga PSA setup pages">
-          <a className={styles.setupLink} aria-current="page" href="/setup/"><SlidersHorizontal className={styles.navIcon} aria-hidden="true" /><span>Setup</span></a>
-          <a className={styles.setupLink} href="/"><Activity className={styles.navIcon} aria-hidden="true" /><span>Status</span></a>
+          <a className={styles.setupLink} aria-current="page" href="/setup/">
+            <SlidersHorizontal className={styles.navIcon} aria-hidden="true" />
+            <span>Setup</span>
+          </a>
+          <a className={styles.setupLink} href="/">
+            <Activity className={styles.navIcon} aria-hidden="true" />
+            <span>Status</span>
+          </a>
         </nav>
         <LogoutButton />
       </aside>
@@ -223,9 +292,15 @@ export default function SetupPage() {
           <div>
             <div className={styles.eyebrow}>Guided setup</div>
             <h1>Configure your appliance</h1>
-            <p className={styles.muted}>Confirm the release channel, app URL, and DNS behavior. Advanced support settings stay tucked away unless you need them.</p>
+            <p className={styles.muted}>
+              Start with the install code from your registration email. The
+              appliance details appear after that, with support-only release
+              settings tucked under Advanced.
+            </p>
           </div>
-          <span className={`${styles.statusPill} ${styles.installing}`}>{busy ? 'Starting setup' : 'Setup'}</span>
+          <span className={`${styles.statusPill} ${styles.installing}`}>
+            {busy ? "Starting setup" : "Setup"}
+          </span>
         </header>
 
         <section className={styles.grid}>
@@ -240,173 +315,634 @@ export default function SetupPage() {
               </>
             ) : (
               <dl className={styles.kv}>
-                <div><dt>Node addresses</dt><dd>{addresses.length ? addresses.join(', ') : 'No non-loopback address detected'}</dd></div>
-                <div><dt>System resolvers</dt><dd>{resolvers.length ? resolvers.join(', ') : 'No resolver detected'}</dd></div>
+                <div>
+                  <dt>Node addresses</dt>
+                  <dd>
+                    {addresses.length
+                      ? addresses.join(", ")
+                      : "No non-loopback address detected"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>System resolvers</dt>
+                  <dd>
+                    {resolvers.length
+                      ? resolvers.join(", ")
+                      : "No resolver detected"}
+                  </dd>
+                </div>
               </dl>
             )}
           </article>
 
           <article className={`${styles.card} ${styles.full}`}>
             <h2>Setup details</h2>
-            <form id="appliance-setup-form" className={styles.form} onSubmit={submit} noValidate>
-              <div className={styles.formGrid}>
-                <div className={styles.field}>
-                  <label htmlFor="setup-install-code">Install code <small style={{ fontWeight: 'normal', color: 'var(--muted, #6b7280)' }}>(from your registration email)</small></label>
+            <form
+              id="appliance-setup-form"
+              className={styles.form}
+              onSubmit={submit}
+              noValidate
+            >
+              <div className={styles.setupStep}>
+                <div className={styles.stepHeader}>
+                  <span className={styles.stepBadge}>Step 1</span>
+                  <div>
+                    <h3>Enter your install code</h3>
+                    <p className={styles.muted}>
+                      Find this code in the registration email from Nine Minds.
+                      It binds this appliance to your tenant and applies the
+                      correct edition automatically.
+                    </p>
+                  </div>
+                </div>
+
+                <div className={`${styles.field} ${styles.fullWidthField}`}>
+                  <label htmlFor="setup-install-code">
+                    Install code{" "}
+                    <small
+                      style={{
+                        fontWeight: "normal",
+                        color: "var(--muted, #6b7280)",
+                      }}
+                    >
+                      (from your registration email)
+                    </small>
+                  </label>
                   <input
                     id="setup-install-code"
                     name="installCode"
                     value={installCode}
-                    onChange={(event) => { setInstallCode(event.target.value.toUpperCase()); clearFieldError('installCode'); }}
+                    onChange={(event) => {
+                      setInstallCode(event.target.value.toUpperCase());
+                      clearFieldError("installCode");
+                    }}
                     placeholder="K7QPM2RX"
                     disabled={disabled}
                     required
                     autoComplete="off"
                     aria-invalid={Boolean(fieldErrors.installCode)}
                     aria-describedby="setup-install-code-help setup-install-code-error"
-                    style={{ fontFamily: 'monospace', letterSpacing: '0.1em' }}
+                    style={{ fontFamily: "monospace", letterSpacing: "0.1em" }}
                   />
-                  <span id="setup-install-code-help" className={styles.helpText}>Binds this appliance to your tenant and applies your edition automatically. Lost or already-used code? Re-issue a fresh one from the portal.</span>
-                  {fieldErrors.installCode ? <span id="setup-install-code-error" className={styles.fieldError}>{fieldErrors.installCode}</span> : null}
+                  <span
+                    id="setup-install-code-help"
+                    className={styles.helpText}
+                  >
+                    Lost or already-used code? Re-issue a fresh one from the
+                    portal, then paste the new code here.
+                  </span>
+                  {fieldErrors.installCode ? (
+                    <span
+                      id="setup-install-code-error"
+                      className={styles.fieldError}
+                    >
+                      {fieldErrors.installCode}
+                    </span>
+                  ) : null}
                 </div>
+              </div>
 
-                {/* Hidden for now (SHOW_MANUAL_EDITION_AND_LICENSE) — manual edition
-                    selection + airgap license-key entry. The install code is the
-                    only supported path; kept guarded (not deleted) for easy revival. */}
-                {SHOW_MANUAL_EDITION_AND_LICENSE && (
-                  <>
-                    <div className={styles.field}>
-                      <label>Edition <small style={{ fontWeight: 'normal', color: 'var(--muted, #6b7280)' }}>(used only if no install code is entered)</small></label>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '0.25rem' }}>
-                        <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: disabled ? 'not-allowed' : 'pointer' }}>
-                          <input type="radio" name="editionChoice" value="ee" checked={editionChoice === 'ee'} onChange={() => setEditionChoice('ee')} disabled={disabled} style={{ marginTop: '0.2rem' }} />
-                          <span>
-                            <strong>Enterprise</strong> — 15-day free trial, then reverts to Essentials.
-                            <br /><small style={{ color: 'var(--muted, #6b7280)' }}>Includes all features. Enter a license key below to extend beyond the trial.</small>
-                          </span>
-                        </label>
-                        <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: disabled ? 'not-allowed' : 'pointer' }}>
-                          <input type="radio" name="editionChoice" value="ce" checked={editionChoice === 'ce'} onChange={() => setEditionChoice('ce')} disabled={disabled} style={{ marginTop: '0.2rem' }} />
-                          <span>
-                            <strong>Essentials</strong> — core open-source feature set, no trial required.
-                            <br /><small style={{ color: 'var(--muted, #6b7280)' }}>You can start an Enterprise trial later from the in-app License page.</small>
-                          </span>
-                        </label>
+              {error ? (
+                <div className={styles.alert} role="alert">
+                  {error}
+                </div>
+              ) : null}
+
+              {installCode.trim() ? (
+                <>
+                  <div className={styles.setupStep}>
+                    <div className={styles.stepHeader}>
+                      <span className={styles.stepBadge}>Step 2</span>
+                      <div>
+                        <h3>Configure the first tenant and network</h3>
+                        <p className={styles.muted}>
+                          Create the first admin account, confirm the URL users
+                          will open, and keep default networking unless support
+                          tells you otherwise.
+                        </p>
                       </div>
                     </div>
 
-                    {editionChoice === 'ee' && (
+                    <div className={styles.formGrid}>
+                      {/* Hidden for now (SHOW_MANUAL_EDITION_AND_LICENSE) — manual edition
+                          selection + airgap license-key entry. The install code is the
+                          only supported path; kept guarded (not deleted) for easy revival. */}
+                      {SHOW_MANUAL_EDITION_AND_LICENSE && (
+                        <>
+                          <div className={styles.field}>
+                            <label>
+                              Edition{" "}
+                              <small
+                                style={{
+                                  fontWeight: "normal",
+                                  color: "var(--muted, #6b7280)",
+                                }}
+                              >
+                                (used only if no install code is entered)
+                              </small>
+                            </label>
+                            <div
+                              style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "0.5rem",
+                                marginTop: "0.25rem",
+                              }}
+                            >
+                              <label
+                                style={{
+                                  display: "flex",
+                                  alignItems: "flex-start",
+                                  gap: "0.5rem",
+                                  cursor: disabled ? "not-allowed" : "pointer",
+                                }}
+                              >
+                                <input
+                                  type="radio"
+                                  name="editionChoice"
+                                  value="ee"
+                                  checked={editionChoice === "ee"}
+                                  onChange={() => setEditionChoice("ee")}
+                                  disabled={disabled}
+                                  style={{ marginTop: "0.2rem" }}
+                                />
+                                <span>
+                                  <strong>Enterprise</strong> — 15-day free
+                                  trial, then reverts to Essentials.
+                                  <br />
+                                  <small
+                                    style={{ color: "var(--muted, #6b7280)" }}
+                                  >
+                                    Includes all features. Enter a license key
+                                    below to extend beyond the trial.
+                                  </small>
+                                </span>
+                              </label>
+                              <label
+                                style={{
+                                  display: "flex",
+                                  alignItems: "flex-start",
+                                  gap: "0.5rem",
+                                  cursor: disabled ? "not-allowed" : "pointer",
+                                }}
+                              >
+                                <input
+                                  type="radio"
+                                  name="editionChoice"
+                                  value="ce"
+                                  checked={editionChoice === "ce"}
+                                  onChange={() => setEditionChoice("ce")}
+                                  disabled={disabled}
+                                  style={{ marginTop: "0.2rem" }}
+                                />
+                                <span>
+                                  <strong>Essentials</strong> — core open-source
+                                  feature set, no trial required.
+                                  <br />
+                                  <small
+                                    style={{ color: "var(--muted, #6b7280)" }}
+                                  >
+                                    You can start an Enterprise trial later from
+                                    the in-app License page.
+                                  </small>
+                                </span>
+                              </label>
+                            </div>
+                          </div>
+
+                          {editionChoice === "ee" && (
+                            <div className={styles.field}>
+                              <label htmlFor="setup-license-key">
+                                License key{" "}
+                                <small
+                                  style={{
+                                    fontWeight: "normal",
+                                    color: "var(--muted, #6b7280)",
+                                  }}
+                                >
+                                  (optional — enter if you already have one)
+                                </small>
+                              </label>
+                              <textarea
+                                id="setup-license-key"
+                                name="licenseKey"
+                                value={licenseKey}
+                                onChange={(event) => {
+                                  setLicenseKey(event.target.value);
+                                  clearFieldError("licenseKey");
+                                }}
+                                placeholder="eyJhbGci…"
+                                rows={3}
+                                disabled={disabled}
+                                aria-invalid={Boolean(fieldErrors.licenseKey)}
+                                aria-describedby="setup-license-key-help setup-license-key-error"
+                                style={{
+                                  fontFamily: "monospace",
+                                  fontSize: "0.8rem",
+                                  resize: "vertical",
+                                }}
+                              />
+                              <span
+                                id="setup-license-key-help"
+                                className={styles.helpText}
+                              >
+                                Paste the signed key from Nine Minds. Leave
+                                blank to start the 15-day trial.
+                              </span>
+                              {fieldErrors.licenseKey ? (
+                                <span
+                                  id="setup-license-key-error"
+                                  className={styles.fieldError}
+                                >
+                                  {fieldErrors.licenseKey}
+                                </span>
+                              ) : null}
+                            </div>
+                          )}
+                        </>
+                      )}
+
                       <div className={styles.field}>
-                        <label htmlFor="setup-license-key">License key <small style={{ fontWeight: 'normal', color: 'var(--muted, #6b7280)' }}>(optional — enter if you already have one)</small></label>
-                        <textarea
-                          id="setup-license-key"
-                          name="licenseKey"
-                          value={licenseKey}
-                          onChange={(event) => { setLicenseKey(event.target.value); clearFieldError('licenseKey'); }}
-                          placeholder="eyJhbGci…"
-                          rows={3}
+                        <label htmlFor="setup-tenant-name">Company name</label>
+                        <input
+                          id="setup-tenant-name"
+                          name="tenantName"
+                          value={tenantName}
+                          onChange={(event) => {
+                            setTenantName(event.target.value);
+                            clearFieldError("tenantName");
+                          }}
+                          placeholder="Acme Managed Services"
                           disabled={disabled}
-                          aria-invalid={Boolean(fieldErrors.licenseKey)}
-                          aria-describedby="setup-license-key-help setup-license-key-error"
-                          style={{ fontFamily: 'monospace', fontSize: '0.8rem', resize: 'vertical' }}
+                          required
+                          aria-invalid={Boolean(fieldErrors.tenantName)}
+                          aria-describedby="setup-tenant-name-help setup-tenant-name-error"
                         />
-                        <span id="setup-license-key-help" className={styles.helpText}>Paste the signed key from Nine Minds. Leave blank to start the 15-day trial.</span>
-                        {fieldErrors.licenseKey ? <span id="setup-license-key-error" className={styles.fieldError}>{fieldErrors.licenseKey}</span> : null}
+                        <span
+                          id="setup-tenant-name-help"
+                          className={styles.helpText}
+                        >
+                          This becomes the first tenant and default client
+                          company.
+                        </span>
+                        {fieldErrors.tenantName ? (
+                          <span
+                            id="setup-tenant-name-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.tenantName}
+                          </span>
+                        ) : null}
                       </div>
-                    )}
-                  </>
-                )}
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-channel">Release channel</label>
-                  <select id="setup-channel" name="channel" value={channel} onChange={(event) => setChannel(event.target.value)} disabled={disabled}>
-                    <option value="stable">stable (recommended)</option>
-                    <option value="nightly">nightly (testing/support-directed)</option>
-                  </select>
-                  <span className={styles.helpText}>Stable is recommended unless support asks you to test nightly.</span>
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-admin-first-name">
+                          Admin first name
+                        </label>
+                        <input
+                          id="setup-admin-first-name"
+                          name="adminFirstName"
+                          value={adminFirstName}
+                          onChange={(event) => {
+                            setAdminFirstName(event.target.value);
+                            clearFieldError("adminFirstName");
+                          }}
+                          disabled={disabled}
+                          required
+                          aria-invalid={Boolean(fieldErrors.adminFirstName)}
+                          aria-describedby="setup-admin-first-name-error"
+                        />
+                        {fieldErrors.adminFirstName ? (
+                          <span
+                            id="setup-admin-first-name-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.adminFirstName}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-tenant-name">Company name</label>
-                  <input id="setup-tenant-name" name="tenantName" value={tenantName} onChange={(event) => { setTenantName(event.target.value); clearFieldError('tenantName'); }} placeholder="Acme Managed Services" disabled={disabled} required aria-invalid={Boolean(fieldErrors.tenantName)} aria-describedby="setup-tenant-name-help setup-tenant-name-error" />
-                  <span id="setup-tenant-name-help" className={styles.helpText}>This becomes the first tenant and default client company.</span>
-                  {fieldErrors.tenantName ? <span id="setup-tenant-name-error" className={styles.fieldError}>{fieldErrors.tenantName}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-admin-last-name">
+                          Admin last name
+                        </label>
+                        <input
+                          id="setup-admin-last-name"
+                          name="adminLastName"
+                          value={adminLastName}
+                          onChange={(event) => {
+                            setAdminLastName(event.target.value);
+                            clearFieldError("adminLastName");
+                          }}
+                          disabled={disabled}
+                          required
+                          aria-invalid={Boolean(fieldErrors.adminLastName)}
+                          aria-describedby="setup-admin-last-name-error"
+                        />
+                        {fieldErrors.adminLastName ? (
+                          <span
+                            id="setup-admin-last-name-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.adminLastName}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-admin-first-name">Admin first name</label>
-                  <input id="setup-admin-first-name" name="adminFirstName" value={adminFirstName} onChange={(event) => { setAdminFirstName(event.target.value); clearFieldError('adminFirstName'); }} disabled={disabled} required aria-invalid={Boolean(fieldErrors.adminFirstName)} aria-describedby="setup-admin-first-name-error" />
-                  {fieldErrors.adminFirstName ? <span id="setup-admin-first-name-error" className={styles.fieldError}>{fieldErrors.adminFirstName}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-admin-email">Admin email</label>
+                        <input
+                          id="setup-admin-email"
+                          name="adminEmail"
+                          type="email"
+                          value={adminEmail}
+                          onChange={(event) => {
+                            setAdminEmail(event.target.value);
+                            clearFieldError("adminEmail");
+                          }}
+                          placeholder="admin@example.com"
+                          disabled={disabled}
+                          required
+                          aria-invalid={Boolean(fieldErrors.adminEmail)}
+                          aria-describedby="setup-admin-email-help setup-admin-email-error"
+                        />
+                        <span
+                          id="setup-admin-email-help"
+                          className={styles.helpText}
+                        >
+                          Use this email to sign in after setup completes.
+                        </span>
+                        {fieldErrors.adminEmail ? (
+                          <span
+                            id="setup-admin-email-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.adminEmail}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-admin-last-name">Admin last name</label>
-                  <input id="setup-admin-last-name" name="adminLastName" value={adminLastName} onChange={(event) => { setAdminLastName(event.target.value); clearFieldError('adminLastName'); }} disabled={disabled} required aria-invalid={Boolean(fieldErrors.adminLastName)} aria-describedby="setup-admin-last-name-error" />
-                  {fieldErrors.adminLastName ? <span id="setup-admin-last-name-error" className={styles.fieldError}>{fieldErrors.adminLastName}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-admin-password">
+                          Admin password
+                        </label>
+                        <input
+                          id="setup-admin-password"
+                          name="adminPassword"
+                          type="password"
+                          value={adminPassword}
+                          onChange={(event) => {
+                            setAdminPassword(event.target.value);
+                            clearFieldError("adminPassword");
+                            clearFieldError("adminPasswordConfirm");
+                          }}
+                          autoComplete="new-password"
+                          disabled={disabled}
+                          required
+                          aria-invalid={Boolean(fieldErrors.adminPassword)}
+                          aria-describedby="setup-admin-password-help setup-admin-password-error"
+                        />
+                        <span
+                          id="setup-admin-password-help"
+                          className={styles.helpText}
+                        >
+                          At least 8 characters with uppercase, lowercase,
+                          number, and special character.
+                        </span>
+                        {fieldErrors.adminPassword ? (
+                          <span
+                            id="setup-admin-password-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.adminPassword}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-admin-email">Admin email</label>
-                  <input id="setup-admin-email" name="adminEmail" type="email" value={adminEmail} onChange={(event) => { setAdminEmail(event.target.value); clearFieldError('adminEmail'); }} placeholder="admin@example.com" disabled={disabled} required aria-invalid={Boolean(fieldErrors.adminEmail)} aria-describedby="setup-admin-email-help setup-admin-email-error" />
-                  <span id="setup-admin-email-help" className={styles.helpText}>Use this email to sign in after setup completes.</span>
-                  {fieldErrors.adminEmail ? <span id="setup-admin-email-error" className={styles.fieldError}>{fieldErrors.adminEmail}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-admin-password-confirm">
+                          Confirm admin password
+                        </label>
+                        <input
+                          id="setup-admin-password-confirm"
+                          name="adminPasswordConfirm"
+                          type="password"
+                          value={adminPasswordConfirm}
+                          onChange={(event) => {
+                            setAdminPasswordConfirm(event.target.value);
+                            clearFieldError("adminPasswordConfirm");
+                          }}
+                          autoComplete="new-password"
+                          disabled={disabled}
+                          required
+                          aria-invalid={Boolean(
+                            fieldErrors.adminPasswordConfirm,
+                          )}
+                          aria-describedby="setup-admin-password-confirm-error"
+                        />
+                        {fieldErrors.adminPasswordConfirm ? (
+                          <span
+                            id="setup-admin-password-confirm-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.adminPasswordConfirm}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-admin-password">Admin password</label>
-                  <input id="setup-admin-password" name="adminPassword" type="password" value={adminPassword} onChange={(event) => { setAdminPassword(event.target.value); clearFieldError('adminPassword'); clearFieldError('adminPasswordConfirm'); }} autoComplete="new-password" disabled={disabled} required aria-invalid={Boolean(fieldErrors.adminPassword)} aria-describedby="setup-admin-password-help setup-admin-password-error" />
-                  <span id="setup-admin-password-help" className={styles.helpText}>At least 8 characters with uppercase, lowercase, number, and special character.</span>
-                  {fieldErrors.adminPassword ? <span id="setup-admin-password-error" className={styles.fieldError}>{fieldErrors.adminPassword}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-app-hostname">App URL</label>
+                        <input
+                          id="setup-app-hostname"
+                          name="appHostname"
+                          value={appHostname}
+                          onChange={(event) => {
+                            setAppHostname(event.target.value);
+                            clearFieldError("appHostname");
+                          }}
+                          placeholder="http://192.168.1.50:3000"
+                          disabled={disabled}
+                          aria-invalid={Boolean(fieldErrors.appHostname)}
+                          aria-describedby="setup-app-hostname-help setup-app-hostname-error"
+                        />
+                        <span
+                          id="setup-app-hostname-help"
+                          className={styles.helpText}
+                        >
+                          Use the full URL users will enter in their browser.
+                          The default local URL works out of the box.
+                        </span>
+                        {fieldErrors.appHostname ? (
+                          <span
+                            id="setup-app-hostname-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.appHostname}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-admin-password-confirm">Confirm admin password</label>
-                  <input id="setup-admin-password-confirm" name="adminPasswordConfirm" type="password" value={adminPasswordConfirm} onChange={(event) => { setAdminPasswordConfirm(event.target.value); clearFieldError('adminPasswordConfirm'); }} autoComplete="new-password" disabled={disabled} required aria-invalid={Boolean(fieldErrors.adminPasswordConfirm)} aria-describedby="setup-admin-password-confirm-error" />
-                  {fieldErrors.adminPasswordConfirm ? <span id="setup-admin-password-confirm-error" className={styles.fieldError}>{fieldErrors.adminPasswordConfirm}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-dns-mode">DNS mode</label>
+                        <select
+                          id="setup-dns-mode"
+                          name="dnsMode"
+                          value={dnsMode}
+                          onChange={(event) => {
+                            setDnsMode(event.target.value);
+                            clearFieldError("dnsServers");
+                          }}
+                          disabled={disabled}
+                        >
+                          <option value="system">
+                            Use DHCP/system resolvers
+                          </option>
+                          <option value="custom">Use custom DNS servers</option>
+                        </select>
+                        <span className={styles.helpText}>
+                          Keep system DNS unless this site requires specific
+                          internal resolvers.
+                        </span>
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-app-hostname">App URL</label>
-                  <input id="setup-app-hostname" name="appHostname" value={appHostname} onChange={(event) => { setAppHostname(event.target.value); clearFieldError('appHostname'); }} placeholder="http://192.168.1.50:3000" disabled={disabled} aria-invalid={Boolean(fieldErrors.appHostname)} aria-describedby="setup-app-hostname-help setup-app-hostname-error" />
-                  <span id="setup-app-hostname-help" className={styles.helpText}>Use the full URL users will enter in their browser. The default local URL works out of the box.</span>
-                  {fieldErrors.appHostname ? <span id="setup-app-hostname-error" className={styles.fieldError}>{fieldErrors.appHostname}</span> : null}
-                </div>
+                      <div className={styles.field}>
+                        <label htmlFor="setup-dns-servers">
+                          Custom DNS servers
+                        </label>
+                        <input
+                          id="setup-dns-servers"
+                          name="dnsServers"
+                          value={dnsServers}
+                          onChange={(event) => {
+                            setDnsServers(event.target.value);
+                            clearFieldError("dnsServers");
+                          }}
+                          placeholder="8.8.8.8,8.8.4.4"
+                          disabled={disabled || dnsMode !== "custom"}
+                          aria-invalid={Boolean(fieldErrors.dnsServers)}
+                          aria-describedby="setup-dns-servers-help setup-dns-servers-error"
+                        />
+                        <span
+                          id="setup-dns-servers-help"
+                          className={styles.helpText}
+                        >
+                          Comma-separated IPv4 addresses. Required only for
+                          custom DNS.
+                        </span>
+                        {fieldErrors.dnsServers ? (
+                          <span
+                            id="setup-dns-servers-error"
+                            className={styles.fieldError}
+                          >
+                            {fieldErrors.dnsServers}
+                          </span>
+                        ) : null}
+                      </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-dns-mode">DNS mode</label>
-                  <select id="setup-dns-mode" name="dnsMode" value={dnsMode} onChange={(event) => { setDnsMode(event.target.value); clearFieldError('dnsServers'); }} disabled={disabled}>
-                    <option value="system">Use DHCP/system resolvers</option>
-                    <option value="custom">Use custom DNS servers</option>
-                  </select>
-                  <span className={styles.helpText}>Keep system DNS unless this site requires specific internal resolvers.</span>
-                </div>
+                      <details className={styles.advancedSupport}>
+                        <summary className={styles.advancedSummary}>
+                          Advanced
+                        </summary>
+                        <p className={styles.helpText}>
+                          Support-directed options. Leave these defaults unless
+                          Nine Minds support asks you to change them.
+                        </p>
+                        <div className={styles.formGrid}>
+                          <div className={styles.field}>
+                            <label htmlFor="setup-channel">
+                              Release channel
+                            </label>
+                            <select
+                              id="setup-channel"
+                              name="channel"
+                              value={channel}
+                              onChange={(event) =>
+                                setChannel(event.target.value)
+                              }
+                              disabled={disabled}
+                            >
+                              <option value="stable">
+                                stable (recommended)
+                              </option>
+                              <option value="nightly">
+                                nightly (testing/support-directed)
+                              </option>
+                            </select>
+                            <span className={styles.helpText}>
+                              Stable is recommended unless support asks you to
+                              test nightly.
+                            </span>
+                          </div>
 
-                <div className={styles.field}>
-                  <label htmlFor="setup-dns-servers">Custom DNS servers</label>
-                  <input id="setup-dns-servers" name="dnsServers" value={dnsServers} onChange={(event) => { setDnsServers(event.target.value); clearFieldError('dnsServers'); }} placeholder="8.8.8.8,8.8.4.4" disabled={disabled || dnsMode !== 'custom'} aria-invalid={Boolean(fieldErrors.dnsServers)} aria-describedby="setup-dns-servers-help setup-dns-servers-error" />
-                  <span id="setup-dns-servers-help" className={styles.helpText}>Comma-separated IPv4 addresses. Required only for custom DNS.</span>
-                  {fieldErrors.dnsServers ? <span id="setup-dns-servers-error" className={styles.fieldError}>{fieldErrors.dnsServers}</span> : null}
-                </div>
-
-                <details className={styles.advancedSupport}>
-                  <summary className={styles.advancedSummary}>Advanced</summary>
-                  <p className={styles.helpText}>Optional: pin a specific release instead of following the channel. Support/testing only.</p>
-                  <div className={styles.formGrid}>
-                    <div className={styles.field}>
-                      <label htmlFor="setup-release-ref">Release pin</label>
-                      <input id="setup-release-ref" name="releaseRef" value={releaseRef} onChange={(event) => { setReleaseRef(event.target.value); clearFieldError('releaseRef'); }} placeholder="e.g. 1.0.3 or sha256:..." disabled={disabled} aria-invalid={Boolean(fieldErrors.releaseRef)} aria-describedby="setup-release-ref-help setup-release-ref-error" />
-                      <span id="setup-release-ref-help" className={styles.helpText}>Leave blank to use the selected release channel.</span>
-                      {fieldErrors.releaseRef ? <span id="setup-release-ref-error" className={styles.fieldError}>{fieldErrors.releaseRef}</span> : null}
+                          <div className={styles.field}>
+                            <label htmlFor="setup-release-ref">
+                              Release pin
+                            </label>
+                            <input
+                              id="setup-release-ref"
+                              name="releaseRef"
+                              value={releaseRef}
+                              onChange={(event) => {
+                                setReleaseRef(event.target.value);
+                                clearFieldError("releaseRef");
+                              }}
+                              placeholder="e.g. 1.0.3 or sha256:..."
+                              disabled={disabled}
+                              aria-invalid={Boolean(fieldErrors.releaseRef)}
+                              aria-describedby="setup-release-ref-help setup-release-ref-error"
+                            />
+                            <span
+                              id="setup-release-ref-help"
+                              className={styles.helpText}
+                            >
+                              Leave blank to use the selected release channel.
+                            </span>
+                            {fieldErrors.releaseRef ? (
+                              <span
+                                id="setup-release-ref-error"
+                                className={styles.fieldError}
+                              >
+                                {fieldErrors.releaseRef}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </details>
                     </div>
                   </div>
-                </details>
-              </div>
 
-              {error ? <div className={styles.alert} role="alert">{error}</div> : null}
-
-              <div className={styles.formFooter}>
-                <a className={`${styles.actionButton} ${styles.secondary}`} href="/">View status</a>
-                <button id="setup-submit" className={styles.primaryButton} type="submit" disabled={busy || !config}>{busy ? 'Starting setup…' : 'Save and continue'}</button>
-              </div>
+                  <div className={styles.formFooter}>
+                    <a
+                      className={`${styles.actionButton} ${styles.secondary}`}
+                      href="/"
+                    >
+                      View status
+                    </a>
+                    <button
+                      id="setup-submit"
+                      className={styles.primaryButton}
+                      type="submit"
+                      disabled={busy || !config}
+                    >
+                      {busy ? "Starting setup…" : "Save and continue"}
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <div className={styles.lockedSetupNotice}>
+                  <strong>Next: appliance configuration</strong>
+                  <p>
+                    After you enter the install code, we’ll reveal the company,
+                    admin, URL, and networking settings needed to finish setup.
+                  </p>
+                  <a
+                    className={`${styles.actionButton} ${styles.secondary}`}
+                    href="/"
+                  >
+                    View status instead
+                  </a>
+                </div>
+              )}
             </form>
           </article>
         </section>

--- a/ee/appliance/status-ui/app/status.module.css
+++ b/ee/appliance/status-ui/app/status.module.css
@@ -11,7 +11,8 @@
   top: 0;
   height: 100vh;
   padding: var(--space-xl) 18px;
-  border-right: 1px solid color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
+  border-right: 1px solid
+    color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
   background: var(--appliance-sidebar);
   color: var(--appliance-sidebar-text);
 }
@@ -32,7 +33,11 @@
   width: 38px;
   height: 38px;
   border-radius: var(--radius-lg);
-  background: color-mix(in oklch, var(--appliance-sidebar-text) 94%, var(--operator-purple) 6%);
+  background: color-mix(
+    in oklch,
+    var(--appliance-sidebar-text) 94%,
+    var(--operator-purple) 6%
+  );
   color: var(--operator-purple);
 }
 
@@ -47,7 +52,11 @@
 }
 
 .brandText small {
-  color: color-mix(in oklch, var(--appliance-sidebar-text) 62%, var(--appliance-sidebar));
+  color: color-mix(
+    in oklch,
+    var(--appliance-sidebar-text) 62%,
+    var(--appliance-sidebar)
+  );
   font-size: 0.72rem;
   font-weight: 520;
   letter-spacing: 0;
@@ -63,14 +72,22 @@
 .toolbar button,
 .logControls button {
   min-height: 40px;
-  border: 1px solid color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
+  border: 1px solid
+    color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
   border-radius: var(--radius-md);
   background: transparent;
-  color: color-mix(in oklch, var(--appliance-sidebar-text) 82%, var(--appliance-sidebar));
+  color: color-mix(
+    in oklch,
+    var(--appliance-sidebar-text) 82%,
+    var(--appliance-sidebar)
+  );
   padding: 9px 12px;
   font-weight: 560;
   text-align: left;
-  transition: border-color 150ms var(--ease-out-quart), background-color 150ms var(--ease-out-quart), color 150ms var(--ease-out-quart);
+  transition:
+    border-color 150ms var(--ease-out-quart),
+    background-color 150ms var(--ease-out-quart),
+    color 150ms var(--ease-out-quart);
 }
 
 .nav button,
@@ -83,7 +100,11 @@
 .navIcon {
   width: 17px;
   height: 17px;
-  color: color-mix(in oklch, var(--appliance-sidebar-text) 58%, var(--operator-purple));
+  color: color-mix(
+    in oklch,
+    var(--appliance-sidebar-text) 58%,
+    var(--operator-purple)
+  );
   flex: 0 0 auto;
 }
 
@@ -98,15 +119,27 @@
 .setupLink:hover,
 .toolbar button:hover,
 .logControls button:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--operator-purple) 55%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 55%,
+    var(--appliance-border)
+  );
   background: color-mix(in oklch, var(--operator-purple) 12%, transparent);
   color: var(--appliance-sidebar-text);
 }
 
 .activeTab,
 .setupLink[aria-current="page"] {
-  border-color: color-mix(in oklch, var(--operator-purple) 62%, var(--appliance-sidebar-text)) !important;
-  background: color-mix(in oklch, var(--operator-purple) 18%, var(--appliance-sidebar)) !important;
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 62%,
+    var(--appliance-sidebar-text)
+  ) !important;
+  background: color-mix(
+    in oklch,
+    var(--operator-purple) 18%,
+    var(--appliance-sidebar)
+  ) !important;
   color: var(--appliance-sidebar-text) !important;
 }
 
@@ -221,13 +254,21 @@
 }
 
 .ready {
-  border-color: color-mix(in oklch, var(--success) 38%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--success) 38%,
+    var(--appliance-border)
+  );
   background: var(--success-soft);
   color: color-mix(in oklch, var(--success) 64%, var(--appliance-text));
 }
 
 .installing {
-  border-color: color-mix(in oklch, var(--system-cyan) 42%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--system-cyan) 42%,
+    var(--appliance-border)
+  );
   background: var(--system-cyan-soft);
   color: color-mix(in oklch, var(--system-cyan) 46%, var(--appliance-text));
 }
@@ -239,7 +280,11 @@
 }
 
 .warning {
-  border-color: color-mix(in oklch, var(--attention-amber) 48%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--attention-amber) 48%,
+    var(--appliance-border)
+  );
   background: var(--attention-amber-soft);
   color: color-mix(in oklch, var(--attention-amber) 58%, var(--appliance-text));
 }
@@ -347,9 +392,19 @@
   border-bottom: 1px solid var(--appliance-border);
 }
 
-.kv div:last-child { border-bottom: 0; }
-.kv dt { color: var(--appliance-text-muted); font-weight: 620; }
-.kv dd { margin: 0; color: var(--appliance-text); font-weight: 600; overflow-wrap: anywhere; }
+.kv div:last-child {
+  border-bottom: 0;
+}
+.kv dt {
+  color: var(--appliance-text-muted);
+  font-weight: 620;
+}
+.kv dd {
+  margin: 0;
+  color: var(--appliance-text);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
 
 .tiers {
   display: grid;
@@ -369,7 +424,9 @@
   letter-spacing: -0.01em;
 }
 
-.tier small { color: var(--appliance-text-muted); }
+.tier small {
+  color: var(--appliance-text-muted);
+}
 
 .blocker,
 .operation,
@@ -377,11 +434,16 @@
   margin-top: var(--space-sm);
   padding: var(--space-md) 0;
   background: transparent;
-  border-top: 1px solid color-mix(in oklch, var(--attention-amber) 42%, var(--appliance-border));
+  border-top: 1px solid
+    color-mix(in oklch, var(--attention-amber) 42%, var(--appliance-border));
 }
 
 .backgroundBlocker {
-  border-color: color-mix(in oklch, var(--system-cyan) 42%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--system-cyan) 42%,
+    var(--appliance-border)
+  );
 }
 
 .blocker p,
@@ -392,8 +454,13 @@
 }
 
 .blocker small,
-.event span { color: var(--appliance-text-muted); }
-.eventList { display: grid; gap: var(--space-sm); }
+.event span {
+  color: var(--appliance-text-muted);
+}
+.eventList {
+  display: grid;
+  gap: var(--space-sm);
+}
 
 .toolbar,
 .logControls {
@@ -409,7 +476,8 @@
 .logControls select,
 .logControls input,
 .field input,
-.field select {
+.field select,
+.field textarea {
   min-height: 40px;
   border: 1px solid var(--appliance-border-strong);
   border-radius: var(--radius-md);
@@ -427,9 +495,13 @@
 
 .toolbar input::placeholder,
 .logControls input::placeholder,
-.field input::placeholder { color: var(--appliance-text-soft); }
+.field input::placeholder {
+  color: var(--appliance-text-soft);
+}
 .toolbar select:disabled,
-.logControls select:disabled { opacity: 0.58; }
+.logControls select:disabled {
+  opacity: 0.58;
+}
 .toolbar button,
 .logControls button {
   text-align: center;
@@ -441,7 +513,11 @@
 /* Custom dropdown — replaces native <select>, whose OS-level popup is
    unreliable inside the Electron browser pane and gets dismissed by polling
    re-renders. This renders the option list in-DOM instead. */
-.dropdown { position: relative; display: inline-flex; min-width: 168px; }
+.dropdown {
+  position: relative;
+  display: inline-flex;
+  min-width: 168px;
+}
 
 .dropdownButton {
   display: inline-flex;
@@ -460,12 +536,27 @@
 }
 
 .dropdownButton:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--operator-purple) 55%, var(--appliance-border));
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 55%,
+    var(--appliance-border)
+  );
 }
 
-.dropdownButton:disabled { opacity: 0.58; cursor: default; }
-.dropdownLabel { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.dropdownCaret { flex: 0 0 auto; color: var(--appliance-text-muted); font-size: 0.7rem; }
+.dropdownButton:disabled {
+  opacity: 0.58;
+  cursor: default;
+}
+.dropdownLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dropdownCaret {
+  flex: 0 0 auto;
+  color: var(--appliance-text-muted);
+  font-size: 0.7rem;
+}
 
 .dropdownMenu {
   position: absolute;
@@ -482,7 +573,8 @@
   border: 1px solid var(--appliance-border-strong);
   border-radius: var(--radius-md);
   background: var(--appliance-card);
-  box-shadow: 0 10px 26px color-mix(in oklch, var(--appliance-sidebar-text) 20%, transparent);
+  box-shadow: 0 10px 26px
+    color-mix(in oklch, var(--appliance-sidebar-text) 20%, transparent);
 }
 
 .dropdownOption {
@@ -495,8 +587,13 @@
   cursor: pointer;
 }
 
-.dropdownOption:hover { background: var(--operator-purple-soft); }
-.dropdownOptionActive { background: color-mix(in oklch, var(--operator-purple) 16%, transparent); font-weight: 650; }
+.dropdownOption:hover {
+  background: var(--operator-purple-soft);
+}
+.dropdownOptionActive {
+  background: color-mix(in oklch, var(--operator-purple) 16%, transparent);
+  font-weight: 650;
+}
 
 .tableWrap {
   overflow: auto;
@@ -533,10 +630,20 @@
   color: var(--appliance-text);
 }
 
-.tableWrap tbody tr { background: var(--appliance-card); }
-.tableWrap tbody tr:nth-child(even) { background: var(--appliance-workspace); }
-.tableWrap tbody tr:hover { background: var(--operator-purple-soft); }
-.tableWrap td small { display: block; margin-top: 3px; color: var(--appliance-text-muted); }
+.tableWrap tbody tr {
+  background: var(--appliance-card);
+}
+.tableWrap tbody tr:nth-child(even) {
+  background: var(--appliance-workspace);
+}
+.tableWrap tbody tr:hover {
+  background: var(--operator-purple-soft);
+}
+.tableWrap td small {
+  display: block;
+  margin-top: 3px;
+  color: var(--appliance-text-muted);
+}
 .tableWrap button {
   min-height: 36px;
   border: 1px solid var(--appliance-border);
@@ -546,8 +653,14 @@
   padding: 7px 10px;
   font-weight: 650;
 }
-.tableWrap button:hover { background: var(--operator-purple-soft); }
-.emptyCell { color: var(--appliance-text-muted) !important; text-align: center; padding: 28px !important; }
+.tableWrap button:hover {
+  background: var(--operator-purple-soft);
+}
+.emptyCell {
+  color: var(--appliance-text-muted) !important;
+  text-align: center;
+  padding: 28px !important;
+}
 
 .panel code,
 .card code {
@@ -574,7 +687,8 @@
 .matchCount {
   border-radius: 999px;
   background: var(--operator-purple-soft);
-  border: 1px solid color-mix(in oklch, var(--operator-purple) 34%, var(--appliance-border));
+  border: 1px solid
+    color-mix(in oklch, var(--operator-purple) 34%, var(--appliance-border));
   color: var(--operator-purple-strong);
   padding: 8px 11px;
   font-size: 0.75rem;
@@ -588,28 +702,149 @@
   overflow: auto;
   margin: 0;
   padding: var(--space-lg);
-  border: 1px solid color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
+  border: 1px solid
+    color-mix(in oklch, var(--appliance-sidebar-text) 14%, transparent);
   border-radius: var(--radius-lg);
   background: var(--appliance-sidebar);
-  color: color-mix(in oklch, var(--appliance-sidebar-text) 92%, var(--system-cyan));
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  color: color-mix(
+    in oklch,
+    var(--appliance-sidebar-text) 92%,
+    var(--system-cyan)
+  );
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
   font-size: 0.75rem;
   line-height: 1.55;
   white-space: pre-wrap;
 }
 
-.raw { min-height: 620px; }
-.logPane div { min-height: 18px; padding: 0 4px; border-radius: var(--radius-sm); scroll-margin: 160px; }
-.matchLine { background: color-mix(in oklch, var(--attention-amber) 18%, transparent); }
-.activeMatchLine { outline: 1px solid color-mix(in oklch, var(--attention-amber) 72%, var(--appliance-border)); background: color-mix(in oklch, var(--attention-amber) 27%, transparent); }
-.logPane mark { border-radius: var(--radius-sm); background: var(--attention-amber-soft); color: var(--appliance-text); padding: 0 2px; }
+.raw {
+  min-height: 620px;
+}
+.logPane div {
+  min-height: 18px;
+  padding: 0 4px;
+  border-radius: var(--radius-sm);
+  scroll-margin: 160px;
+}
+.matchLine {
+  background: color-mix(in oklch, var(--attention-amber) 18%, transparent);
+}
+.activeMatchLine {
+  outline: 1px solid
+    color-mix(in oklch, var(--attention-amber) 72%, var(--appliance-border));
+  background: color-mix(in oklch, var(--attention-amber) 27%, transparent);
+}
+.logPane mark {
+  border-radius: var(--radius-sm);
+  background: var(--attention-amber-soft);
+  color: var(--appliance-text);
+  padding: 0 2px;
+}
 
-.form { margin-top: var(--space-sm); }
-.formGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-lg); }
-.field { display: grid; gap: 7px; min-width: 0; }
-.field label { color: var(--appliance-text); font-weight: 650; letter-spacing: -0.01em; }
-.helpText { color: var(--appliance-text-muted); font-size: 0.75rem; line-height: 1.45; }
-.fieldError { color: color-mix(in oklch, var(--error) 72%, var(--appliance-text)); font-size: 0.8rem; font-weight: 600; }
+.form {
+  margin-top: var(--space-sm);
+}
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+.setupStep {
+  display: grid;
+  gap: var(--space-lg);
+  margin-top: var(--space-md);
+  padding: var(--space-lg) 0;
+  border-top: 1px solid var(--appliance-border);
+}
+.setupStep:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+.stepHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+}
+.stepHeader h3 {
+  margin: 0 0 4px;
+  color: var(--appliance-text);
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+.stepHeader p {
+  margin: 0;
+  max-width: 78ch;
+}
+.stepBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 58px;
+  border: 1px solid
+    color-mix(in oklch, var(--operator-purple) 45%, var(--appliance-border));
+  border-radius: 999px;
+  background: var(--operator-purple-soft);
+  color: var(--operator-purple-strong);
+  padding: 5px 9px;
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.fullWidthField {
+  grid-column: 1 / -1;
+}
+.lockedSetupNotice,
+.setupCta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  margin-top: var(--space-lg);
+  padding: var(--space-lg);
+  border: 1px solid
+    color-mix(in oklch, var(--operator-purple) 32%, var(--appliance-border));
+  border-radius: var(--radius-lg);
+  background: color-mix(
+    in oklch,
+    var(--operator-purple) 8%,
+    var(--appliance-card)
+  );
+}
+.lockedSetupNotice strong,
+.setupCta strong {
+  display: block;
+  color: var(--appliance-text);
+  font-size: 1rem;
+}
+.lockedSetupNotice p,
+.setupCta p {
+  max-width: 76ch;
+  margin: 5px 0 0;
+  color: var(--appliance-text-muted);
+}
+.field {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+.field label {
+  color: var(--appliance-text);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+.helpText {
+  color: var(--appliance-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+.fieldError {
+  color: color-mix(in oklch, var(--error) 72%, var(--appliance-text));
+  font-size: 0.8rem;
+  font-weight: 600;
+}
 
 .advancedSupport {
   grid-column: 1 / -1;
@@ -631,7 +866,8 @@
 .alert {
   margin: var(--space-lg) 0;
   padding: var(--space-md);
-  border: 1px solid color-mix(in oklch, var(--error) 42%, var(--appliance-border));
+  border: 1px solid
+    color-mix(in oklch, var(--error) 42%, var(--appliance-border));
   border-radius: var(--radius-lg);
   background: var(--error-soft);
   color: color-mix(in oklch, var(--error) 72%, var(--appliance-text));
@@ -661,32 +897,73 @@
   color: oklch(98% 0.008 299);
 }
 
-.primaryButton:hover:not(:disabled) { background: var(--operator-purple-strong); }
-.secondary { background: var(--appliance-panel); color: var(--appliance-text); }
+.primaryButton:hover:not(:disabled) {
+  background: var(--operator-purple-strong);
+}
+.secondary {
+  background: var(--appliance-panel);
+  color: var(--appliance-text);
+}
 
 .skeleton,
 .skeletonCell,
 .skeletonLineDark {
   display: block;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--appliance-panel), color-mix(in oklch, var(--appliance-border) 70%, var(--appliance-card)), var(--appliance-panel));
+  background: linear-gradient(
+    90deg,
+    var(--appliance-panel),
+    color-mix(in oklch, var(--appliance-border) 70%, var(--appliance-card)),
+    var(--appliance-panel)
+  );
   background-size: 220% 100%;
   animation: shimmer 1.25s infinite linear;
 }
 
-.skeletonTitle { height: 22px; width: 40%; margin-bottom: var(--space-md); }
-.skeletonLine { height: 14px; width: 90%; margin-bottom: 10px; }
-.skeletonShort { height: 14px; width: 55%; margin-bottom: 10px; }
-.skeletonBlock { display: grid; gap: 10px; }
-.skeletonLineDark { height: 16px; width: min(760px, 94%); }
-.skeletonLineDark:nth-child(2n) { width: min(520px, 80%); }
-.skeletonLineDark:nth-child(3n) { width: min(900px, 100%); }
-.skeletonCell { height: 16px; min-width: 80px; }
-.skeletonRow td { padding: 14px 11px !important; }
+.skeletonTitle {
+  height: 22px;
+  width: 40%;
+  margin-bottom: var(--space-md);
+}
+.skeletonLine {
+  height: 14px;
+  width: 90%;
+  margin-bottom: 10px;
+}
+.skeletonShort {
+  height: 14px;
+  width: 55%;
+  margin-bottom: 10px;
+}
+.skeletonBlock {
+  display: grid;
+  gap: 10px;
+}
+.skeletonLineDark {
+  height: 16px;
+  width: min(760px, 94%);
+}
+.skeletonLineDark:nth-child(2n) {
+  width: min(520px, 80%);
+}
+.skeletonLineDark:nth-child(3n) {
+  width: min(900px, 100%);
+}
+.skeletonCell {
+  height: 16px;
+  min-width: 80px;
+}
+.skeletonRow td {
+  padding: 14px 11px !important;
+}
 
 @keyframes shimmer {
-  from { background-position: 0 0; }
-  to { background-position: -220% 0; }
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: -220% 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -701,17 +978,46 @@
 }
 
 @media (max-width: 920px) {
-  .shell { grid-template-columns: 1fr; }
-  .sidebar { position: relative; height: auto; padding: var(--space-lg); }
-  .nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .workspace { padding: var(--space-lg); }
+  .shell {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    position: relative;
+    height: auto;
+    padding: var(--space-lg);
+  }
+  .nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .workspace {
+    padding: var(--space-lg);
+  }
   .panel,
   .card,
-  .wide { grid-column: span 12; }
-  .commandBar { display: grid; padding: var(--space-lg); }
-  .formGrid { grid-template-columns: 1fr; }
-  .kv div { grid-template-columns: 1fr; gap: 3px; }
-  .formFooter { justify-content: stretch; flex-direction: column-reverse; }
+  .wide {
+    grid-column: span 12;
+  }
+  .commandBar {
+    display: grid;
+    padding: var(--space-lg);
+  }
+  .formGrid {
+    grid-template-columns: 1fr;
+  }
+  .kv div {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+  .formFooter {
+    justify-content: stretch;
+    flex-direction: column-reverse;
+  }
+  .setupCta,
+  .lockedSetupNotice,
+  .stepHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
   .actionButton,
   .primaryButton,
   .nav button,
@@ -723,5 +1029,8 @@
   .logControls select,
   .logControls input,
   .field input,
-  .field select { min-height: 44px; }
+  .field select,
+  .field textarea {
+    min-height: 44px;
+  }
 }

--- a/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/PRD.md
+++ b/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/PRD.md
@@ -1,0 +1,84 @@
+# Appliance setup token and delivery UX
+
+## Problem statement
+
+Appliance operators currently need to know to open `/setup/` after authenticating to the control-plane UI. The setup form also presents too much configuration at once, even though the most important first step is entering the install code from the registration email. Separately, the public nm-store appliance order flow currently shows the install code in the browser after an email address is entered or after checkout, which allows someone to obtain a tenant-bound install secret without proving they control that email inbox.
+
+## Goals
+
+1. Make the appliance initial setup path obvious immediately after control-plane login.
+2. Guide operators through setup progressively: setup-token/password auth first, install code next, then tenant/admin/network fields.
+3. Keep support-directed release/channel controls behind an Advanced disclosure.
+4. Change nm-store appliance ordering so install codes and ISO links are delivered only by email, never displayed or returned to the browser.
+5. Preserve existing backend registration, Stripe checkout, email delivery, and reissue behavior.
+
+## Non-goals
+
+- Redesign the whole appliance status dashboard.
+- Add email verification accounts or a full customer portal.
+- Change alga-license install-code semantics.
+- Change appliance release publishing or GHCR OCI manifest resolution.
+- Change paid checkout pricing or Stripe products.
+
+## Target users and flows
+
+### Appliance operator first boot
+
+1. Operator opens the appliance control plane URL.
+2. Operator is asked for the one-time setup token printed on the appliance console.
+3. Operator sets or enters the management password.
+4. While the appliance is still in setup mode, `/` redirects to `/setup/` and/or clearly presents a Continue setup CTA.
+5. `/setup/` starts with a focused install-code step.
+6. After entering an install code, the operator sees the remaining setup form.
+7. Release channel and release pin are hidden under Advanced unless support asks for them.
+
+### nm-store Essentials order
+
+1. Visitor enters company/contact/email for the Essentials appliance.
+2. Server registers the appliance tenant and emails the install code + ISO link.
+3. Browser shows a confirmation that the email was sent or that instructions have been sent.
+4. Browser never receives or displays the install code or download URL.
+
+### nm-store paid order
+
+1. Visitor completes Stripe checkout.
+2. Thank-you page provisions the appliance tenant server-side and sends the install email.
+3. Browser shows payment success and email confirmation.
+4. Browser never displays the install code or download URL, including refresh/idempotency paths.
+
+## UX notes
+
+- On the appliance auth gate, keep the setup token prompt clear and front-and-center.
+- On the setup screen, visually separate “Step 1: Enter install code” from “Step 2: Configure appliance.”
+- The setup continuation CTA on `/` should be prominent enough that an operator who lands on status knows what to do, even if redirect does not happen due to a stale status response or manual navigation.
+- Use existing CSS modules and visual language; avoid adding a new UI framework.
+- For nm-store confirmation copy, avoid implying the email address was verified. Say “If the address is valid, we’ll send…” only where enumeration resistance matters. For initial registration, it is acceptable to say “Check your email for your install code and download link.”
+
+## Data/API notes
+
+- Appliance status UI uses `GET /api/setup/config`, `GET /api/status`, and `POST /api/setup` from `ee/appliance/host-service/server.mjs`.
+- `/api/setup/config` already returns `mode` (`setup` or `status`), which can drive redirect behavior.
+- nm-store `registerEssentialsApplianceAction` currently returns `installCode` and `downloadUrl`; change the public return shape to omit secrets.
+- nm-store `provisionApplianceFromCheckoutSession` currently returns `installCode` and `downloadUrl`; change thank-you consumption so secrets are not rendered. Prefer not returning secrets from the library where feasible, while preserving idempotency metadata server-side.
+- Existing reissue action already uses the desired constant, email-only pattern and should remain unchanged.
+
+## Risks and mitigations
+
+- **Redirect loop risk:** only redirect `/` to `/setup/` when setup config mode is exactly `setup`; do not redirect from `/setup/`.
+- **Operator blocked by accidental install-code typo:** frontend gating should only stage the UI; final validation remains server-side.
+- **Email delivery failure:** do not leak the install code as a fallback. Show support/retry guidance if email sending fails.
+- **Paid thank-you refresh:** keep Stripe subscription metadata idempotency, but do not reveal stored install code on refresh.
+- **Cross-repo change:** appliance UI is in `alga-psa`; public order UI is in `~/nm-store`. Validate each repo separately.
+
+## Acceptance criteria
+
+1. Authenticated users who visit appliance `/` in setup mode are sent to `/setup/` automatically.
+2. Appliance `/` includes a prominent Continue setup CTA when setup is still required or editable.
+3. Appliance `/setup/` initially focuses on install-code entry and hides the rest of the form until a code is entered.
+4. Release channel and release pin controls are under an Advanced disclosure on `/setup/`.
+5. nm-store Essentials registration response to the browser contains no install code or download URL.
+6. nm-store Essentials success screen confirms email delivery/instructions instead of displaying secrets.
+7. nm-store paid thank-you screen confirms payment/provisioning and email delivery/instructions instead of displaying secrets.
+8. nm-store server-side registration and reissue emails still include the install code and ISO link.
+9. Unit tests cover the no-secret browser response paths for Essentials and paid/idempotent provisioning where practical.
+10. Appliance status UI and nm-store targeted tests/builds pass or any residual failures are documented.

--- a/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/SCRATCHPAD.md
@@ -1,0 +1,38 @@
+# Scratchpad — Appliance setup token and delivery UX
+
+## 2026-06-15 discoveries
+
+- Appliance setup UI source is `ee/appliance/status-ui/app/setup/page.tsx`.
+- Appliance status landing page source is `ee/appliance/status-ui/app/page.tsx`.
+- Appliance auth gate is `ee/appliance/status-ui/app/auth/AuthGate.tsx`; it already requires the console setup token before management password setup/login.
+- Appliance host-service API is `ee/appliance/host-service/server.mjs`.
+- `GET /api/setup/config` returns `{ mode, defaults, network }`; `mode` can be `setup` or `status` and is suitable for `/` redirect behavior.
+- `POST /api/setup` persists validated setup inputs and starts `setup-engine.mjs` in the background.
+- Existing status page already shows a re-enter-code alert when `setupReEditable` is true.
+- Existing setup page already places `releaseRef` in a `<details>` Advanced disclosure, but release channel is visible in the main form.
+- nm-store repo is at `/home/robert/nm-store`.
+- nm-store appliance order page is `packages/nm-store/src/app/(frontend)/order/appliance/page.tsx`.
+- nm-store paid thank-you page is `packages/nm-store/src/app/(frontend)/order/appliance/thank-you/page.tsx`.
+- nm-store appliance server actions are `packages/nm-store/src/app/(frontend)/actions/appliance.ts`.
+- nm-store registration orchestration is `packages/nm-store/src/lib/appliance/applianceRegistration.ts`.
+- nm-store reissue action already follows the desired email-only/no-enumeration pattern.
+
+## Decisions
+
+- Do both appliance landing improvements requested by the user: auto-redirect `/` to `/setup/` while in setup mode and also add a prominent CTA on `/` for clarity/fallback.
+- Progressive disclosure on `/setup/`: install code first, then reveal the rest of setup once non-empty code is entered.
+- Release channel and release pin belong under Advanced.
+- nm-store must not return or render install code/download URL in the browser for Essentials or paid thank-you. Email remains the delivery channel.
+
+## Validation commands to try
+
+- Appliance UI package: `cd ee/appliance/status-ui && npm run build`
+- Alga root build if needed: `npm run build`
+- nm-store targeted tests: `cd /home/robert/nm-store/packages/nm-store && npx vitest run src/app/(frontend)/actions/appliance.test.ts src/lib/appliance/applianceRegistration.test.ts`
+- nm-store build if needed: `cd /home/robert/nm-store && npm run build`
+
+## Gotchas
+
+- Cross-repo work: plan lives in alga-psa, but nm-store changes are in a separate checkout.
+- Current alga-psa tree has unrelated dirty files (`package-lock.json`, release pin work, context.md, untracked appliance dirs). Avoid treating those as part of this UX task unless explicitly needed.
+- Email failures must not fall back to displaying install secrets.

--- a/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/features.json
+++ b/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/features.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "F001",
+    "description": "Add appliance status landing behavior that detects setup mode and automatically redirects authenticated users from `/` to `/setup/`.",
+    "prdRefs": ["Goals 1", "Acceptance 1"],
+    "implemented": false
+  },
+  {
+    "id": "F002",
+    "description": "Add a prominent Continue setup CTA on the appliance `/` status page for setup-required or setup-reeditable states.",
+    "prdRefs": ["Goals 1", "Acceptance 2"],
+    "implemented": false
+  },
+  {
+    "id": "F003",
+    "description": "Restructure appliance `/setup/` into a progressive flow where install code entry is shown first and remaining setup fields are hidden until a code is entered.",
+    "prdRefs": ["Goals 2", "Acceptance 3"],
+    "implemented": false
+  },
+  {
+    "id": "F004",
+    "description": "Move appliance release channel and release pin controls under an Advanced disclosure on `/setup/`.",
+    "prdRefs": ["Goals 3", "Acceptance 4"],
+    "implemented": false
+  },
+  {
+    "id": "F005",
+    "description": "Change nm-store Essentials appliance registration action to return only non-secret confirmation fields to the browser.",
+    "prdRefs": ["Goals 4", "Acceptance 5"],
+    "implemented": false
+  },
+  {
+    "id": "F006",
+    "description": "Change nm-store Essentials appliance success UI to show email confirmation/instructions without rendering install code or ISO URL.",
+    "prdRefs": ["Goals 4", "Acceptance 6"],
+    "implemented": false
+  },
+  {
+    "id": "F007",
+    "description": "Change nm-store paid appliance thank-you flow to avoid displaying install code or ISO URL for newly registered and already-provisioned sessions.",
+    "prdRefs": ["Goals 4", "Acceptance 7"],
+    "implemented": false
+  },
+  {
+    "id": "F008",
+    "description": "Preserve server-side appliance registration/reissue email behavior so emails still contain the install code and stable ISO download link.",
+    "prdRefs": ["Goals 5", "Acceptance 8"],
+    "implemented": false
+  },
+  {
+    "id": "F009",
+    "description": "Add or update tests that prove browser-facing nm-store appliance actions/provisioning do not expose install code or download URL.",
+    "prdRefs": ["Acceptance 9"],
+    "implemented": false
+  },
+  {
+    "id": "F010",
+    "description": "Run targeted validation for appliance UI and nm-store changed paths; document any residual warnings or unrelated failures.",
+    "prdRefs": ["Acceptance 10"],
+    "implemented": false
+  }
+]

--- a/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/tests.json
+++ b/ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/tests.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "T001",
+    "description": "Appliance setup-mode smoke: authenticated `/` detects `mode: setup` and navigates to `/setup/` while avoiding redirects outside setup mode.",
+    "featureIds": ["F001"],
+    "implemented": false
+  },
+  {
+    "id": "T002",
+    "description": "Appliance setup UI smoke: `/setup/` shows install-code-first guidance, hides main fields before code entry, reveals fields after code entry, and keeps release controls under Advanced.",
+    "featureIds": ["F003", "F004"],
+    "implemented": false
+  },
+  {
+    "id": "T003",
+    "description": "Appliance status UI smoke: `/` renders a prominent setup CTA when setup is reeditable or setup is not complete.",
+    "featureIds": ["F002"],
+    "implemented": false
+  },
+  {
+    "id": "T004",
+    "description": "nm-store server-action unit test: Essentials registration calls the server-side register+email helper but returns no installCode/downloadUrl to the client.",
+    "featureIds": ["F005", "F008", "F009"],
+    "implemented": false
+  },
+  {
+    "id": "T005",
+    "description": "nm-store provisioning unit test: paid checkout provisioning and already-provisioned refresh paths do not expose installCode/downloadUrl to the thank-you page contract while preserving email/idempotency behavior.",
+    "featureIds": ["F007", "F008", "F009"],
+    "implemented": false
+  },
+  {
+    "id": "T006",
+    "description": "Manual/browser review: Essentials and paid appliance order pages show only email confirmation/instructions, never raw install code or ISO URL.",
+    "featureIds": ["F006", "F007"],
+    "implemented": false
+  }
+]


### PR DESCRIPTION
## Summary
- Redirect the appliance status root to `/setup/` while the appliance is in setup mode, with a prominent setup CTA fallback.
- Make setup progressive: operators enter the registration install code first, then tenant/admin/network fields appear.
- Move release channel and release pin controls under a collapsed Advanced section.
- Add ALGA plan artifacts for the setup-token delivery UX work.

## Validation
- `cd ee/appliance/status-ui && npm run build`
- `node -e "JSON.parse(require('fs').readFileSync('ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/features.json','utf8')); JSON.parse(require('fs').readFileSync('ee/docs/plans/2026-06-15-appliance-setup-token-delivery-ux/tests.json','utf8')); console.log('plan json ok')"`
