### PR TITLE
docs: update client portal overview for active-domain CNAME skip (2026-06-16)

### DIFF
--- a/docs/features/client-portal/client_portal_overview.md
+++ b/docs/features/client-portal/client_portal_overview.md
@@ -129,7 +129,7 @@ if (pathname.startsWith(clientPortalPrefix) && !isAuthPage) {
 
 - **OTT Issuance**: Successful logins on the canonical host call `issuePortalDomainOtt()` to generate a short-lived, single-use token that stores the client user's session snapshot.
 - **Handoff Page**: `/auth/client-portal/handoff` displays a lightweight loading state while exchanging the OTT for an Auth.js cookie via `/api/client-portal/domain-session`.
-- **DNS Verification**: The exchange endpoint compares the vanity host's active CNAME records against `verification_details.expected_cname` and rejects handoffs when drift is detected.
+- **DNS Verification**: The exchange endpoint verifies CNAME alignment only when the portal domain's status is not yet `active`. Domains already in `active` status skip DNS re-verification: they were CNAME-validated at registration time and are kept live by cert-manager renewal. Skipping the re-check also prevents login failures on custom domains fronted by a reverse proxy (e.g. Cloudflare "orange cloud") that hides the CNAME from public DNS resolution even though traffic and TLS are healthy. The `PORTAL_DOMAIN_DNS_CHECK` environment variable still governs whether verification runs for non-active domains.
 - **Cookie Minting**: `buildSessionCookie()` guarantees Auth.js-compatible cookie attributes (`__Secure-` prefix, `Lax` SameSite, `Secure`, `HttpOnly`).
 - **Cleanup**: Expired or consumed OTTs can be pruned with `pnpm cli portal-domain sessions prune [--tenant <tenantId>] [--minutes 10] [--dry-run]`.
 


### PR DESCRIPTION
## Source PRs in alga-psa

| # | Title | Merged |
|---|-------|--------|
| [#2706](https://github.com/Nine-Minds/alga-psa/pull/2706) | Skip runtime CNAME re-check for active portal domains | 2026-06-15T15:31:54Z |
| [#2707](https://github.com/Nine-Minds/alga-psa/pull/2707) | Dedupe standard_statuses display_order per item_type | 2026-06-15T17:39:02Z |
| [#2709](https://github.com/Nine-Minds/alga-psa/pull/2709) | Drop Enterprise add-on gate from Hudu integration | 2026-06-15T21:03:35Z |

## Files edited

| File | Rationale |
|------|-----------|
| `docs/features/client-portal/client_portal_overview.md` | The DNS Verification bullet in the Vanity Domain Session Handoff section previously said the exchange endpoint always checks CNAME records on handoff. PR #2706 changed this: domains already in `active` status skip re-verification because they were validated at registration and are kept live by cert-manager renewal. This also fixes login failures for proxy-fronted custom domains (e.g. Cloudflare "orange cloud") where the CNAME is hidden from public DNS even though traffic and TLS are healthy. The updated bullet describes the conditional behaviour and the `PORTAL_DOMAIN_DNS_CHECK` env var scope. |

## Needs human review

**PR #2707 — Dedupe standard_statuses display_order per item_type**
- This is a bug-fix migration for legacy installs that had duplicate `display_order` values in `standard_statuses`, causing board/project status seeding to fail. The fix is internal (a one-time idempotent renumbering) and no user-facing or developer-facing doc describes the uniqueness constraint. No doc edit was needed, but operators running legacy installs should be aware that the next migration run will silently renumber status ordering. If a "Upgrading" or "Migrations" guide is added in future, this context belongs there.

**PR #2709 — Drop Enterprise add-on gate from Hudu integration**
- The user-visible behavior change is that EE users with the INTEGRATIONS tier no longer need a separate Enterprise add-on to use the Hudu integration. However, the existing docs (`docs/integrations/hudu.md`, `packages/nm-store/src/site/content/docs/1020-hudu-it-documentation-integration.md`) never mentioned the Enterprise add-on requirement — they only say the feature is "Enterprise Edition". Since no stale add-on language was present in any in-scope doc, no edit was made. If a prerequisites or tier-requirements section is ever added to the Hudu integration guides, it should reflect: EE edition + INTEGRATIONS tier + `hudu-integration` feature flag (no separate add-on purchase required).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsTnaiTYoqABVDkXEqxLy)_