### PR TITLE
fix(tickets): delete email_reply_tokens before comments on ticket delete

### DIFF
--- a/packages/tickets/src/lib/deleteTicketChildRecords.ts
+++ b/packages/tickets/src/lib/deleteTicketChildRecords.ts
@@ -33,6 +33,21 @@ export async function deleteTicketChildRecords(
       .delete();
   }
 
+  // Delete email reply tokens before comments. email_reply_tokens has a
+  // non-cascading FK to comments (tenant, comment_id), so any token referencing
+  // one of this ticket's comments must be removed first or the comments delete
+  // below trips the constraint. Match on comment_id as well as ticket_id to
+  // catch tokens whose ticket_id is null/stale but still point at a comment.
+  await trx('email_reply_tokens')
+    .where({ tenant })
+    .where((builder: Knex.QueryBuilder) => {
+      builder.where('ticket_id', ticketId);
+      if (commentIds.length > 0) {
+        builder.orWhereIn('comment_id', commentIds);
+      }
+    })
+    .delete();
+
   await trx('comments')
     .where({ ticket_id: ticketId, tenant })
     .delete();
@@ -42,10 +57,6 @@ export async function deleteTicketChildRecords(
     .delete();
 
   await trx('project_ticket_links')
-    .where({ ticket_id: ticketId, tenant })
-    .delete();
-
-  await trx('email_reply_tokens')
     .where({ ticket_id: ticketId, tenant })
     .delete();
 


### PR DESCRIPTION
## Problem

Deleting a ticket failed with a foreign key constraint violation (reported by a customer on TK-4352):

```
delete from "comments" where "ticket_id" = $1 and "tenant" = $2 - update or delete on
table "comments_..." violates foreign key constraint
"email_reply_tokens_tenant_comment_id_foreign_..." on table "email_reply_tokens_..."
```

`deleteTicketChildRecords` — the single shared cleanup used by **both** the MSP server-action delete path (`performTicketDelete`) and the REST API path (`TicketService.delete`) — deleted `comments` **before** `email_reply_tokens`. But `email_reply_tokens` holds a **non-cascading** FK to `comments (tenant, comment_id)`, so the comments delete tripped the constraint and the entire transaction rolled back.

## Fix

- Move the `email_reply_tokens` delete **ahead of** the `comments` delete.
- Match on `comment_id` (the already-plucked comment ids) in addition to `ticket_id`, so a token whose `ticket_id` is null/stale can't block the comments delete either.

The single-comment delete path (`commentActions.ts`) already nulls `comment_id` to satisfy the same FK (the ticket survives there). Here the whole ticket is being removed, so deleting the tokens outright is correct.

## Why this is complete

Audited every FK into `comments`:

| Referencing table | onDelete | Status |
|---|---|---|
| `email_reply_tokens.comment_id` | none (NO ACTION) | **fixed here** |
| `comment_reactions.comment_id` | none | already deleted before comments |
| `ticket_bundles.source/child_comment_id` | CASCADE | fine |
| `comments.parent_comment_id` (self-FK) | CASCADE | fine |
| `comments.thread_id` → `comment_threads` | CASCADE | fine |
| `email_sending_logs` | SET NULL | fine |

`email_reply_tokens` was the only non-cascading FK into `comments` not already handled, so this won't surface a follow-up "now it fails on table X".