### PR TITLE
fix(huntress): drop server-side feature-flag gating

### DIFF
--- a/ee/server/src/lib/actions/integrations/huntressActions.ts
+++ b/ee/server/src/lib/actions/integrations/huntressActions.ts
@@ -6,7 +6,6 @@
  */
 
 import { revalidatePath } from 'next/cache';
-import { isFeatureFlagEnabled } from '@alga-psa/core';
 import logger from '@alga-psa/core/logger';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { withAuth, hasPermission } from '@alga-psa/auth';
@@ -35,20 +34,14 @@ import {
 import type { RmmOrganizationMapping } from '../../../interfaces/rmm.interfaces';
 
 const SETTINGS_PATH = '/msp/settings';
-const HUNTRESS_FEATURE_FLAG = 'huntress-rmm-integration';
 
+// Huntress visibility is gated in the UI via the huntress-rmm-integration
+// feature flag; server actions enforce tier + permissions only.
 function withHuntressAccess<TArgs extends unknown[], TResult>(
   handler: (user: any, context: { tenant: string }, ...args: TArgs) => Promise<TResult>
 ) {
   return withAuth(async (user, context, ...args: TArgs): Promise<TResult> => {
     await assertTierAccess(TIER_FEATURES.INTEGRATIONS);
-    const flagEnabled = await isFeatureFlagEnabled(HUNTRESS_FEATURE_FLAG, {
-      tenantId: (context as { tenant: string }).tenant,
-      userId: (user as { user_id?: string } | undefined)?.user_id,
-    });
-    if (!flagEnabled) {
-      throw new Error('The Huntress integration is not enabled for this tenant');
-    }
     return handler(user, context as { tenant: string }, ...args);
   });
 }

--- a/server/src/lib/jobs/handlers/rmmAlertPollingHandlers.ts
+++ b/server/src/lib/jobs/handlers/rmmAlertPollingHandlers.ts
@@ -24,7 +24,6 @@
  * dynamic @enterprise imports, which resolve to CE stubs in community builds.
  */
 
-import { isFeatureFlagEnabled } from '@alga-psa/core';
 import logger from '@alga-psa/core/logger';
 import { getAdminConnection } from '@alga-psa/db/admin';
 import { createTenantKnex } from '@alga-psa/db';
@@ -39,8 +38,6 @@ import type { IJobRunner } from '../interfaces';
 
 export const RMM_ALERT_RECONCILIATION_JOB = 'rmm-alert-reconciliation';
 export const HUNTRESS_INCIDENT_POLL_JOB = 'huntress-incident-poll';
-
-const HUNTRESS_FEATURE_FLAG = 'huntress-rmm-integration';
 
 const RMM_ALERT_POLLING_PROVIDERS = ['ninjaone', 'tacticalrmm'];
 
@@ -155,16 +152,6 @@ export async function huntressIncidentPollHandler(
     .first('integration_id');
   if (!row) {
     logger.info('[HuntressIncidentPollJob] Skipping: integration inactive', data);
-    return;
-  }
-
-  // Ported from the deleted huntress/scheduling.ts dispatcher: scheduled
-  // polls skip tenants without the Huntress feature flag.
-  const flagEnabled = await isFeatureFlagEnabled(HUNTRESS_FEATURE_FLAG, {
-    tenantId: data.tenantId,
-  });
-  if (!flagEnabled) {
-    logger.info('[HuntressIncidentPollJob] Skipping: feature flag disabled', data);
     return;
   }
 


### PR DESCRIPTION
  Remove the huntress-rmm-integration flag checks from the Huntress
  server actions and the incident-poll handler. The flag evaluates
  differently on the server (hashed user distinct ID) than in the
  browser, so a tenant could see the integration in the UI yet hit
  "not enabled for this tenant" on connect, and scheduled polling was
  silently skipped for everyone. Visibility is now gated solely by the
  browser useFeatureFlag in RmmIntegrationsSetup; the server enforces
  tier + settings:update only.

  And so the Cheshire Flag faded away — grin first, gate last — leaving the Huntress door to swing open for any traveler the looking-glass had already let in. 🐱🚪🔮