### PR TITLE
Scope hydrated ticket categories to board

### DIFF
--- a/packages/tickets/src/actions/optimizedTicketActions.contactAuthor.contract.test.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.contactAuthor.contract.test.ts
@@ -25,3 +25,13 @@ describe('MSP consolidated ticket data contact authorship contract', () => {
     expect(source).toContain('contactMap,');
   });
 });
+
+describe('MSP consolidated ticket data category scoping contract', () => {
+  it('T025: scopes hydrated ticket categories to the ticket board before client refresh', () => {
+    const source = readOptimizedTicketActionsSource();
+
+    expect(source).toContain("getTicketCategoriesByBoard so the hydrated dropdown doesn't briefly");
+    expect(source).toContain("where({ tenant, board_id: ticket.board_id })");
+    expect(source).toContain("where('is_from_itil_standard', true)");
+  });
+});

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -494,10 +494,32 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
         .where({ tenant, item_type: 'ticket' })
         .orderBy('priority_name', 'asc'),
       
-      // Categories
-      trx('categories')
-        .where({ tenant })
-        .orderBy('category_name', 'asc')
+      // Categories for the ticket's current board. This must match
+      // getTicketCategoriesByBoard so the hydrated dropdown doesn't briefly
+      // show tenant-wide categories before the client-side board fetch returns.
+      (async () => {
+        if (!ticket.board_id) {
+          return trx<ITicketCategory>('categories')
+            .where({ tenant })
+            .orderBy('category_name', 'asc');
+        }
+
+        const ticketBoard = await trx('boards')
+          .where({ tenant, board_id: ticket.board_id })
+          .select('category_type')
+          .first();
+
+        if (ticketBoard?.category_type === 'itil') {
+          return trx<ITicketCategory>('categories')
+            .where({ tenant })
+            .where('is_from_itil_standard', true)
+            .orderBy('category_name', 'asc');
+        }
+
+        return trx<ITicketCategory>('categories')
+          .where({ tenant, board_id: ticket.board_id })
+          .orderBy('category_name', 'asc');
+      })()
     ]);
 
     // --- Add Logo URL Processing for the fetched 'clients' list ---


### PR DESCRIPTION
  getConsolidatedTicketData now filters categories by the ticket's
  board_id instead of returning all tenant categories, matching
  getTicketCategoriesByBoard. ITIL boards get is_from_itil_standard
  categories; boards without an id fall back to tenant-wide. Adds a
  contract test asserting the board-scoped query shape.

  "Curiouser and curiouser!" said the dropdown, no longer painting every
  category in the tenant before tumbling down the board's own rabbit hole. 🐇🃏