### PR TITLE
Fix Tactical RMM endpoint paths and clarify instance URL

### DIFF
--- a/docs/integrations/tactical-rmm.md
+++ b/docs/integrations/tactical-rmm.md
@@ -99,5 +99,3 @@ It validates the `X-Alga-Webhook-Secret` header against the tenant's stored
 
 - [Asset Management System](../features/asset_management.md) — the asset model that
   device sync writes into.
-- [Hudu Integration](./hudu.md) — another way to bring a client's external systems
-  into AlgaPSA.

--- a/docs/integrations/tactical-rmm.md
+++ b/docs/integrations/tactical-rmm.md
@@ -1,0 +1,103 @@
+# Tactical RMM Integration (Admin Guide)
+
+AlgaPSA connects to [Tactical RMM](https://tacticalrmm.com/), an open-source RMM
+platform, to bring your monitored devices into AlgaPSA as assets and to turn
+Tactical alerts into AlgaPSA records. The core integration reads from Tactical: it
+syncs clients and agents, ingests alerts by webhook and backfill, and pulls cached
+software inventory. It is available in both Community and Enterprise editions.
+Enterprise Edition adds remote actions that run scripts and commands on agents from
+workflows. Each tenant connects a single Tactical instance.
+
+## Before you connect (on the Tactical server)
+
+Set two things on Tactical first, or the connection test and sync will fail.
+
+- **Enable the Beta API.** AlgaPSA syncs inventory through Tactical's beta API,
+  which is off by default. Set `BETA_API_ENABLED = True` in Tactical and restart
+  it. While it is off, the inventory endpoints return `404`.
+- **Use the API host, not the dashboard.** Tactical serves its API on the `api.`
+  subdomain, for example `https://api.example.com`. The dashboard host (`rmm.`)
+  serves the web app and answers every path with its own HTML, so a connection
+  pointed there looks like it succeeds but syncs nothing.
+
+## Connect to Tactical RMM
+
+Go to **Settings → Integrations → RMM → Tactical RMM**. Enter the Tactical **API
+host** as the Instance URL, then choose how AlgaPSA authenticates:
+
+- **API key.** Paste a Tactical API key. AlgaPSA sends it as the `X-API-KEY`
+  header.
+- **Username and password (Knox token).** Enter Tactical credentials. AlgaPSA logs
+  in for a Knox token and refreshes it automatically. If the account uses TOTP,
+  AlgaPSA asks for the current code.
+
+Save, then click **Test Connection**. AlgaPSA stores the credentials as tenant
+secrets (`tacticalrmm_api_key`, or `tacticalrmm_username`, `tacticalrmm_password`,
+and `tacticalrmm_knox_token`) and never returns them to the browser, so the form
+shows only a masked value. The connection itself lives in `rmm_integrations` under
+provider `tacticalrmm`, which records the instance URL, auth mode, active state,
+and last sync time.
+
+**Disconnect** clears the stored secrets and marks the connection inactive. It
+keeps your organization mappings, so reconnecting later does not start over.
+
+## Sync clients and map them to AlgaPSA
+
+Click **Sync Clients** to pull Tactical Clients into AlgaPSA. Each one becomes a
+row in `rmm_organization_mappings`. In the **Organization Mapping** section, assign
+each Tactical Client to an AlgaPSA client and use the **Auto-sync** toggle to
+control whether that organization's devices import. Map a Tactical Client to an
+AlgaPSA client before you sync devices, so its agents land on the right client.
+
+## Sync devices into assets
+
+Click **Sync Devices** to import agents from the organizations you mapped with
+Auto-sync on. AlgaPSA creates or updates one asset per agent, tags the asset with
+its source (`rmm_provider = 'tacticalrmm'`, plus the Tactical agent id and
+organization id), and links the agent to the asset in
+`tenant_external_entity_mappings` under `integration_type = 'tacticalrmm'`.
+
+Each asset shows the agent's status as `online`, `offline`, or `overdue`.
+Tactical's `overdue` state stays distinct from offline. AlgaPSA also stores the
+last-seen time and cached vitals such as current user, uptime, and LAN/WAN IP when
+Tactical reports them. When an agent disappears from Tactical, AlgaPSA leaves its
+asset in place rather than deactivating it.
+
+## Receive alerts
+
+Tactical pushes alerts to AlgaPSA over a webhook. In the **Webhooks** section, copy
+the **Webhook URL** and **Header Secret**, then add an alert-action webhook in
+Tactical that posts to that URL and sends the `X-Alga-Webhook-Secret` header. The
+settings page shows a payload template; only `agent_id` is required.
+
+When an alert arrives, AlgaPSA records it in `rmm_alerts`, links it to the matching
+asset, and refreshes that agent. An event whose type contains `resolve` marks the
+alert resolved; anything else opens or updates an active alert. Click **Sync
+Alerts** to backfill currently active alerts from Tactical for history.
+
+## Ingest software inventory
+
+Click **Ingest Software** to pull Tactical's cached software inventory in bulk for
+your mapped agents. AlgaPSA writes it to the software catalog and links it to each
+asset. This reads Tactical's cached data and does not trigger a per-agent refresh.
+
+## Remote actions (Enterprise Edition)
+
+Enterprise Edition can drive Tactical from workflows. A workflow can list and
+inspect agents, run a script or a shell command on an agent, and reboot an agent,
+all through the same stored credentials. These actions run on the endpoint, so
+scope them carefully.
+
+## Permissions
+
+Connecting, disconnecting, syncing, and editing mappings require the
+`system_settings` permission. The webhook endpoint does not use a login session.
+It validates the `X-Alga-Webhook-Secret` header against the tenant's stored
+`tacticalrmm_webhook_secret`.
+
+## Related topics
+
+- [Asset Management System](../features/asset_management.md) — the asset model that
+  device sync writes into.
+- [Hudu Integration](./hudu.md) — another way to bring a client's external systems
+  into AlgaPSA.

--- a/ee/docs/plans/2026-02-13-tacticalrmm-integration/PRD.md
+++ b/ee/docs/plans/2026-02-13-tacticalrmm-integration/PRD.md
@@ -50,8 +50,9 @@ Primary user: MSP admin / system admin configuring integrations.
 
 Flows:
 1. Configure Tactical:
+   - On the Tactical server, enable the Beta API: set `BETA_API_ENABLED = True` and restart Tactical.
    - Open Settings -> Integrations -> RMM -> Tactical RMM.
-   - Enter instance base URL.
+   - Enter the Tactical **API host** as the instance URL: the `api.` subdomain (e.g. `https://api.example.com`), not the dashboard (`rmm.`) URL.
    - Choose auth mode:
      - API key: paste key, save, verify.
      - Username/password: enter creds, if TOTP required prompt for code, login, store token.
@@ -123,23 +124,27 @@ Flows:
 
 ## Data / API / Integrations
 
-Tactical endpoints (assume base URL `https://<tactical-host>`):
+Point the integration at the Tactical **API host** (the `api.` subdomain), for example `https://api.example.com`. Do not use the dashboard host (`rmm.`). The dashboard serves the single-page app and returns its HTML with a `200` for every path, so sync reads zero records and silently does nothing.
+
+Tactical's **Beta API must be enabled** for inventory sync. Set `BETA_API_ENABLED = True` in Tactical and restart it. While it is off, the `/beta/v1/*` endpoints return `404` and both the connection test and sync fail.
+
+Tactical endpoints (base URL `https://<tactical-api-host>`, served at the root with no `/api` prefix):
 
 - Auth (username/password):
-  - `POST /api/v2/checkcreds/` `{ username, password }` -> `{ totp: true }` or short-lived token
-  - `POST /api/v2/login/` `{ username, password, twofactor? }` -> Knox token response
+  - `POST /v2/checkcreds/` `{ username, password }` -> `{ totp: true }` or short-lived token
+  - `POST /v2/login/` `{ username, password, twofactor? }` -> Knox token response
   - Auth header: `Authorization: Token <knox_token>`
 - Auth (api key):
   - Auth header: `X-API-KEY: <key>`
-- Inventory (beta API):
-  - `GET /api/beta/v1/client/`
-  - `GET /api/beta/v1/site/?page_size=1000&page=N`
-  - `GET /api/beta/v1/agent/?client_id=<client_pk>&page_size=1000&page=N`
+- Inventory (beta API, requires `BETA_API_ENABLED`):
+  - `GET /beta/v1/client/`
+  - `GET /beta/v1/site/?page_size=1000&page=N`
+  - `GET /beta/v1/agent/?client_id=<client_pk>&page_size=1000&page=N`
 - Alerts:
-  - `PATCH /api/alerts/` with filter body for backfill/top-N
+  - `PATCH /alerts/` with filter body for backfill/top-N
 - Software:
-  - `GET /api/software/` bulk cached software inventory
-  - `PUT /api/software/<agent_id>/` per-agent refresh (non-goal by default)
+  - `GET /software/` bulk cached software inventory
+  - `PUT /software/<agent_id>/` per-agent refresh (non-goal by default)
 
 Alga DB tables involved:
 - `rmm_integrations` (one row per tenant+provider; store instance_url, is_active, settings JSON including webhook secret and auth mode).

--- a/ee/docs/plans/2026-02-13-tacticalrmm-integration/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-02-13-tacticalrmm-integration/SCRATCHPAD.md
@@ -35,6 +35,9 @@ Prefer short bullets. Append new entries as you learn things, and also *update e
 - (2026-02-13) Tactical has an additional status state `overdue`. Current Alga types/UI generally assume `online|offline|unknown`, so Tactical likely requires a small type/UI expansion.
 - (2026-02-13) Tactical beta agent list serializer is `__all__` model fields; computed `status` may not appear on list responses. Prefer computing status from last_seen/offline_time/overdue_time for list-based sync.
 - (2026-02-13) Fleet-scale software inventory ingestion should use bulk `GET /api/software/` (cached) rather than per-agent refresh `PUT /api/software/<agent_id>/`.
+- (2026-06-17) CORRECTION, verified against a live Tactical (v0.0.203): stock Tactical serves its API at the **root** of the `api.` host, not under `/api/`. The integration's paths were wrong by an `/api/` prefix and were corrected in code, tests, and the EE workflow runtime: `/api/beta/v1/...` -> `/beta/v1/...`, `/api/v2/...` -> `/v2/...`, `/api/alerts/` -> `/alerts/`, `/api/software/` -> `/software/`. Two more gotchas surfaced during manual testing:
+  - The instance URL must be the `api.` host. The `rmm.` (dashboard) host serves the SPA `index.html` with a `200` for every path, so sync parses zero records and looks like a no-op. The settings UI default placeholder used `https://rmm.example.com`, which steered users wrong; it now uses `https://api.example.com`.
+  - The beta API is off by default. `BETA_API_ENABLED` gates `path("beta/v1/", ...)` in Tactical's `urls.py`, so `/beta/v1/*` returns `404` until you set `BETA_API_ENABLED = True` and restart Tactical.
 
 ## Commands / Runbooks
 

--- a/ee/packages/workflows/src/runtime/actions/__tests__/tacticalRmmWorkflowClient.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/tacticalRmmWorkflowClient.test.ts
@@ -77,8 +77,8 @@ describe('FetchTacticalWorkflowClient (T008)', () => {
 
     expect(scripts).toEqual([{ id: 1, name: 's' }]);
     expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Token stale-token');
-    expect(fetchMock.mock.calls[1][0]).toBe('https://api.tactical.example.com/api/v2/checkcreds/');
-    expect(fetchMock.mock.calls[2][0]).toBe('https://api.tactical.example.com/api/v2/login/');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://api.tactical.example.com/v2/checkcreds/');
+    expect(fetchMock.mock.calls[2][0]).toBe('https://api.tactical.example.com/v2/login/');
     expect(fetchMock.mock.calls[3][1].headers.Authorization).toBe('Token fresh-token');
     expect(secretMocks.setTenantSecret).toHaveBeenCalledWith('tenant-1', 'tacticalrmm_knox_token', 'fresh-token');
   });
@@ -104,7 +104,7 @@ describe('FetchTacticalWorkflowClient (T008)', () => {
 
     const agents = await client.listAgents();
     expect(agents.map((a) => a.agent_id)).toEqual(['a1', 'a2']);
-    expect(fetchMock.mock.calls[0][0]).toContain('/api/beta/v1/agent/?');
+    expect(fetchMock.mock.calls[0][0]).toContain('/beta/v1/agent/?');
     expect(fetchMock.mock.calls[0][0]).toContain('page=1');
     expect(fetchMock.mock.calls[1][0]).toContain('page=2');
 

--- a/ee/packages/workflows/src/runtime/actions/tacticalRmmWorkflowRuntimeSupport.ts
+++ b/ee/packages/workflows/src/runtime/actions/tacticalRmmWorkflowRuntimeSupport.ts
@@ -108,7 +108,7 @@ export class FetchTacticalWorkflowClient implements TacticalWorkflowClient {
       throw new Error('Tactical RMM Knox credentials are not configured for this tenant');
     }
 
-    const checkResponse = await fetch(`${this.baseUrl}/api/v2/checkcreds/`, {
+    const checkResponse = await fetch(`${this.baseUrl}/v2/checkcreds/`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
@@ -121,7 +121,7 @@ export class FetchTacticalWorkflowClient implements TacticalWorkflowClient {
       throw new Error('Tactical RMM account requires TOTP; Knox token cannot be refreshed automatically');
     }
 
-    const loginResponse = await fetch(`${this.baseUrl}/api/v2/login/`, {
+    const loginResponse = await fetch(`${this.baseUrl}/v2/login/`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
@@ -186,7 +186,7 @@ export class FetchTacticalWorkflowClient implements TacticalWorkflowClient {
     const agents: Record<string, unknown>[] = [];
     let pageNum = 1;
     for (;;) {
-      const data = await this.request('/api/beta/v1/agent/', {
+      const data = await this.request('/beta/v1/agent/', {
         query: { ...params, page_size: pageSize, page: pageNum }
       });
       if (Array.isArray(data)) {
@@ -202,7 +202,7 @@ export class FetchTacticalWorkflowClient implements TacticalWorkflowClient {
   }
 
   async getAgent(agentId: string): Promise<Record<string, unknown>> {
-    const data = await this.request(`/api/beta/v1/agent/${encodeURIComponent(agentId)}/`);
+    const data = await this.request(`/beta/v1/agent/${encodeURIComponent(agentId)}/`);
     if (!data || typeof data !== 'object' || Array.isArray(data)) {
       throw new Error(`Tactical RMM agent ${agentId} returned an unexpected response`);
     }

--- a/packages/integrations/src/actions/integrations/tacticalRmmActions.ts
+++ b/packages/integrations/src/actions/integrations/tacticalRmmActions.ts
@@ -468,7 +468,7 @@ export const testTacticalRmmConnection = withAuth(async (
       const apiKey = await secretProvider.getTenantSecret(tenant, TACTICAL_API_KEY_SECRET);
       if (!apiKey) return { success: false, error: 'API key is not configured' };
 
-      await axios.get(new URL('/api/beta/v1/client/', instanceUrl).toString(), {
+      await axios.get(new URL('/beta/v1/client/', instanceUrl).toString(), {
         headers: { 'X-API-KEY': apiKey },
         timeout: 15_000,
       });
@@ -479,7 +479,7 @@ export const testTacticalRmmConnection = withAuth(async (
         return { success: false, error: 'Username/password are not configured' };
       }
 
-      const check = await axios.post(new URL('/api/v2/checkcreds/', instanceUrl).toString(), {
+      const check = await axios.post(new URL('/v2/checkcreds/', instanceUrl).toString(), {
         username,
         password,
       }, { timeout: 15_000 });
@@ -502,7 +502,7 @@ export const testTacticalRmmConnection = withAuth(async (
 
       const doLogin = async (): Promise<string> => {
         const login = await axios.post(
-          new URL('/api/v2/login/', instanceUrl).toString(),
+          new URL('/v2/login/', instanceUrl).toString(),
           buildLoginPayload(),
           { timeout: 15_000 }
         );
@@ -513,7 +513,7 @@ export const testTacticalRmmConnection = withAuth(async (
       };
 
       const verifyToken = async (token: string): Promise<void> => {
-        await axios.get(new URL('/api/beta/v1/client/', instanceUrl).toString(), {
+        await axios.get(new URL('/beta/v1/client/', instanceUrl).toString(), {
           headers: { Authorization: `Token ${token}` },
           timeout: 15_000,
         });
@@ -591,7 +591,7 @@ export const syncTacticalRmmOrganizations = withAuth(async (
       authMode,
     });
 
-    const remoteClients = await client.listAllBeta<any>({ path: '/api/beta/v1/client/' });
+    const remoteClients = await client.listAllBeta<any>({ path: '/beta/v1/client/' });
 
     const existingRows = await knex('rmm_organization_mappings')
       .where({ tenant, integration_id: integration.integration_id })
@@ -818,7 +818,7 @@ export const syncTacticalRmmDevices = withAuth(async (
       .andWhere('auto_sync_assets', true)
       .select(['external_organization_id', 'client_id']);
 
-    const sites = await client.listAllBeta<any>({ path: '/api/beta/v1/site/' });
+    const sites = await client.listAllBeta<any>({ path: '/beta/v1/site/' });
     const siteById = new Map<string, any>();
     for (const s of sites) {
       const id = String((s as any).id ?? (s as any).pk ?? '');
@@ -834,7 +834,7 @@ export const syncTacticalRmmDevices = withAuth(async (
       const algaClientId = String((org as any).client_id);
 
       const agents = await client.listAllBeta<any>({
-        path: '/api/beta/v1/agent/',
+        path: '/beta/v1/agent/',
         params: { client_id: externalOrgId },
       });
 
@@ -1481,7 +1481,7 @@ export const ingestTacticalRmmSoftwareInventory = withAuth(async (
       authMode,
     });
 
-    const res = await client.request<any>({ method: 'GET', path: '/api/software/' });
+    const res = await client.request<any>({ method: 'GET', path: '/software/' });
 
     const rows: any[] = Array.isArray(res)
       ? res
@@ -1579,7 +1579,7 @@ export const syncTacticalRmmSingleAgent = withAuth(async (
       authMode,
     });
 
-    const agent = await client.request<any>({ method: 'GET', path: `/api/beta/v1/agent/${encodeURIComponent(agentId)}/` });
+    const agent = await client.request<any>({ method: 'GET', path: `/beta/v1/agent/${encodeURIComponent(agentId)}/` });
 
     const mapping = await knex('tenant_external_entity_mappings')
       .where({

--- a/packages/integrations/src/components/settings/integrations/TacticalRmmIntegrationSettings.tsx
+++ b/packages/integrations/src/components/settings/integrations/TacticalRmmIntegrationSettings.tsx
@@ -431,15 +431,182 @@ export function TacticalRmmIntegrationSettings() {
             <Label htmlFor="tacticalrmm-instance-url">{t('integrations.rmm.tactical.fields.instanceUrl', { defaultValue: 'Instance URL' })}</Label>
             <Input
               id="tacticalrmm-instance-url"
-              placeholder="https://rmm.example.com"
+              placeholder="https://api.example.com"
               value={instanceUrl}
               onChange={(e) => setInstanceUrl(e.target.value)}
               disabled={loading || saving || disconnecting}
             />
             <div className="text-xs text-muted-foreground">
-              {t('integrations.rmm.tactical.fields.instanceUrlHelp', { defaultValue: 'Use your Tactical base URL (no trailing /api).' })}
+              {t('integrations.rmm.tactical.fields.instanceUrlHelp', { defaultValue: 'Use your Tactical API host — the api. subdomain, e.g. https://api.example.com. Not the dashboard (rmm.) URL, and no trailing /api.' })}
             </div>
           </div>
+
+          <Alert variant="info">
+            <AlertDescription className="text-xs">
+              {t('integrations.rmm.tactical.fields.betaApiNote', { defaultValue: "Requires Tactical's Beta API to be enabled on the server: set BETA_API_ENABLED = True in Tactical, then restart it. Without the Beta API, the connection test and sync will fail." })}
+            </AlertDescription>
+          </Alert>
+
+          <div className="space-y-2">
+            <Label htmlFor="tacticalrmm-auth-mode">{t('integrations.rmm.tactical.auth.mode', { defaultValue: 'Authentication' })}</Label>
+            <CustomSelect
+              id="tacticalrmm-auth-mode"
+              className="!w-auto"
+              value={authMode}
+              onValueChange={(v) => {
+                setAuthMode(v as TacticalRmmAuthMode);
+                setTotpRequired(false);
+                setTotpCode('');
+                setError(null);
+                setSuccess(null);
+              }}
+              options={[
+                { value: 'api_key', label: t('integrations.rmm.tactical.auth.apiKey', { defaultValue: 'API key' }) },
+                { value: 'knox', label: t('integrations.rmm.tactical.auth.knoxOption', { defaultValue: 'Username/password (Knox token)' }) },
+              ]}
+            />
+          </div>
+
+          {authMode === 'api_key' ? (
+            <div className="space-y-2">
+              <Label htmlFor="tacticalrmm-api-key">{t('integrations.rmm.tactical.auth.apiKey', { defaultValue: 'API key' })}</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="tacticalrmm-api-key"
+                  type={showApiKey ? 'text' : 'password'}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={credentialsStatus?.apiKeyMasked ? credentialsStatus.apiKeyMasked : t('integrations.rmm.tactical.auth.enterApiKey', { defaultValue: 'Enter API key' })}
+                  disabled={loading || saving || disconnecting}
+                />
+                <Button
+                  id="tacticalrmm-toggle-api-key-visibility"
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowApiKey((s) => !s)}
+                  disabled={loading || saving || disconnecting}
+                >
+                  {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </div>
+              {credentialsStatus?.hasApiKey && (
+                <div className="text-xs text-muted-foreground">
+                  {t('integrations.rmm.tactical.auth.saved', { defaultValue: 'Saved: {{value}}', value: credentialsStatus.apiKeyMasked })}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="tacticalrmm-username">{t('integrations.rmm.tactical.auth.username', { defaultValue: 'Username' })}</Label>
+                <Input
+                  id="tacticalrmm-username"
+                  className="!w-auto"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder={t('integrations.rmm.tactical.auth.enterUsername', { defaultValue: 'Enter username' })}
+                  disabled={loading || saving || disconnecting}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tacticalrmm-password">{t('integrations.rmm.tactical.auth.password', { defaultValue: 'Password' })}</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="tacticalrmm-password"
+                    type={showPassword ? 'text' : 'password'}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder={credentialsStatus?.hasKnoxCredentials
+                      ? t('integrations.rmm.tactical.auth.savedEnterToUpdate', { defaultValue: 'Saved (enter to update)' })
+                      : t('integrations.rmm.tactical.auth.enterPassword', { defaultValue: 'Enter password' })}
+                    disabled={loading || saving || disconnecting}
+                  />
+                  <Button
+                    id="tacticalrmm-toggle-password-visibility"
+                    type="button"
+                    variant="outline"
+                    onClick={() => setShowPassword((s) => !s)}
+                    disabled={loading || saving || disconnecting}
+                  >
+                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </Button>
+                </div>
+              </div>
+              {totpRequired && (
+                <div className="space-y-2">
+                  <Label htmlFor="tacticalrmm-totp">{t('integrations.rmm.tactical.auth.totp', { defaultValue: 'TOTP code' })}</Label>
+                  <Input
+                    id="tacticalrmm-totp"
+                    value={totpCode}
+                    onChange={(e) => setTotpCode(e.target.value)}
+                    placeholder="123456"
+                    disabled={testing || disconnecting}
+                  />
+                </div>
+              )}
+
+              {credentialsStatus?.hasKnoxToken && (
+                <div className="text-xs text-muted-foreground">
+                  {t('integrations.rmm.tactical.auth.knoxTokenSaved', { defaultValue: 'Knox token saved: {{value}}', value: credentialsStatus.knoxTokenMasked })}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              id="tacticalrmm-save-config"
+              type="button"
+              onClick={handleSave}
+              disabled={!canSave || saving || loading || disconnecting}
+            >
+              <Save className="h-4 w-4 mr-2" />
+              {saving
+                ? t('integrations.rmm.tactical.actions.saving', { defaultValue: 'Saving...' })
+                : t('integrations.rmm.tactical.actions.save', { defaultValue: 'Save' })}
+            </Button>
+
+            <Button
+              id="tacticalrmm-test-connection"
+              type="button"
+              variant="secondary"
+              onClick={handleTestConnection}
+              disabled={testing || loading || disconnecting || (totpRequired && !totpCode.trim())}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2 ${testing ? 'animate-spin' : ''}`} />
+              {testing
+                ? t('integrations.rmm.tactical.actions.testing', { defaultValue: 'Testing...' })
+                : t('integrations.rmm.tactical.actions.testConnection', { defaultValue: 'Test Connection' })}
+            </Button>
+
+            <Button
+              id="tacticalrmm-disconnect"
+              type="button"
+              variant="destructive"
+              onClick={handleDisconnect}
+              disabled={disconnecting || loading}
+            >
+              <Unlink className="h-4 w-4 mr-2" />
+              {disconnecting
+                ? t('integrations.rmm.tactical.actions.disconnecting', { defaultValue: 'Disconnecting...' })
+                : t('integrations.rmm.tactical.actions.disconnect', { defaultValue: 'Disconnect' })}
+            </Button>
+          </div>
+
+          {!loading && credentialsStatus && (
+            <div className="text-xs text-muted-foreground">
+              {credentialsStatus.hasApiKey || credentialsStatus.hasKnoxCredentials
+                ? t('integrations.rmm.tactical.statusLine.configured', { defaultValue: 'Status: Configured' })
+                : t('integrations.rmm.tactical.statusLine.notConfigured', { defaultValue: 'Status: Not configured' })}
+            </div>
+          )}
+
+          {loading && (
+            <div className="text-sm text-muted-foreground flex items-center gap-2">
+              <RefreshCw className="h-4 w-4 animate-spin" />
+              {t('integrations.rmm.tactical.loadingSettings', { defaultValue: 'Loading Tactical RMM settings...' })}
+            </div>
+          )}
 
           <div className="rounded-md border bg-background p-4">
             <div className="flex items-start justify-between gap-3">
@@ -585,7 +752,7 @@ export function TacticalRmmIntegrationSettings() {
               <div className="space-y-1">
                 <div className="text-sm font-medium">{t('integrations.rmm.tactical.sections.softwareInventory', { defaultValue: 'Software Inventory' })}</div>
                 <div className="text-xs text-muted-foreground">
-                  {t('integrations.rmm.tactical.sections.softwareInventoryDescription', { defaultValue: 'Optional: ingest cached software inventory via Tactical /api/software/ (no per-agent refresh calls).' })}
+                  {t('integrations.rmm.tactical.sections.softwareInventoryDescription', { defaultValue: 'Optional: ingest cached software inventory via Tactical /software/ (no per-agent refresh calls).' })}
                 </div>
               </div>
               <Button
@@ -692,164 +859,6 @@ export function TacticalRmmIntegrationSettings() {
             )}
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="tacticalrmm-auth-mode">{t('integrations.rmm.tactical.auth.mode', { defaultValue: 'Authentication' })}</Label>
-            <CustomSelect
-              id="tacticalrmm-auth-mode"
-              value={authMode}
-              onValueChange={(v) => {
-                setAuthMode(v as TacticalRmmAuthMode);
-                setTotpRequired(false);
-                setTotpCode('');
-                setError(null);
-                setSuccess(null);
-              }}
-              options={[
-                { value: 'api_key', label: t('integrations.rmm.tactical.auth.apiKey', { defaultValue: 'API key' }) },
-                { value: 'knox', label: t('integrations.rmm.tactical.auth.knoxOption', { defaultValue: 'Username/password (Knox token)' }) },
-              ]}
-            />
-          </div>
-
-          {authMode === 'api_key' ? (
-            <div className="space-y-2">
-              <Label htmlFor="tacticalrmm-api-key">{t('integrations.rmm.tactical.auth.apiKey', { defaultValue: 'API key' })}</Label>
-              <div className="flex items-center gap-2">
-                <Input
-                  id="tacticalrmm-api-key"
-                  type={showApiKey ? 'text' : 'password'}
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  placeholder={credentialsStatus?.apiKeyMasked ? credentialsStatus.apiKeyMasked : t('integrations.rmm.tactical.auth.enterApiKey', { defaultValue: 'Enter API key' })}
-                  disabled={loading || saving || disconnecting}
-                />
-                <Button
-                  id="tacticalrmm-toggle-api-key-visibility"
-                  type="button"
-                  variant="outline"
-                  onClick={() => setShowApiKey((s) => !s)}
-                  disabled={loading || saving || disconnecting}
-                >
-                  {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </Button>
-              </div>
-              {credentialsStatus?.hasApiKey && (
-                <div className="text-xs text-muted-foreground">
-                  {t('integrations.rmm.tactical.auth.saved', { defaultValue: 'Saved: {{value}}', value: credentialsStatus.apiKeyMasked })}
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="tacticalrmm-username">{t('integrations.rmm.tactical.auth.username', { defaultValue: 'Username' })}</Label>
-                <Input
-                  id="tacticalrmm-username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder={t('integrations.rmm.tactical.auth.enterUsername', { defaultValue: 'Enter username' })}
-                  disabled={loading || saving || disconnecting}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="tacticalrmm-password">{t('integrations.rmm.tactical.auth.password', { defaultValue: 'Password' })}</Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="tacticalrmm-password"
-                    type={showPassword ? 'text' : 'password'}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder={credentialsStatus?.hasKnoxCredentials
-                      ? t('integrations.rmm.tactical.auth.savedEnterToUpdate', { defaultValue: 'Saved (enter to update)' })
-                      : t('integrations.rmm.tactical.auth.enterPassword', { defaultValue: 'Enter password' })}
-                    disabled={loading || saving || disconnecting}
-                  />
-                  <Button
-                    id="tacticalrmm-toggle-password-visibility"
-                    type="button"
-                    variant="outline"
-                    onClick={() => setShowPassword((s) => !s)}
-                    disabled={loading || saving || disconnecting}
-                  >
-                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </Button>
-                </div>
-              </div>
-              {totpRequired && (
-                <div className="space-y-2">
-                  <Label htmlFor="tacticalrmm-totp">{t('integrations.rmm.tactical.auth.totp', { defaultValue: 'TOTP code' })}</Label>
-                  <Input
-                    id="tacticalrmm-totp"
-                    value={totpCode}
-                    onChange={(e) => setTotpCode(e.target.value)}
-                    placeholder="123456"
-                    disabled={testing || disconnecting}
-                  />
-                </div>
-              )}
-
-              {credentialsStatus?.hasKnoxToken && (
-                <div className="text-xs text-muted-foreground">
-                  {t('integrations.rmm.tactical.auth.knoxTokenSaved', { defaultValue: 'Knox token saved: {{value}}', value: credentialsStatus.knoxTokenMasked })}
-                </div>
-              )}
-            </div>
-          )}
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              id="tacticalrmm-save-config"
-              type="button"
-              onClick={handleSave}
-              disabled={!canSave || saving || loading || disconnecting}
-            >
-              <Save className="h-4 w-4 mr-2" />
-              {saving
-                ? t('integrations.rmm.tactical.actions.saving', { defaultValue: 'Saving...' })
-                : t('integrations.rmm.tactical.actions.save', { defaultValue: 'Save' })}
-            </Button>
-
-            <Button
-              id="tacticalrmm-test-connection"
-              type="button"
-              variant="secondary"
-              onClick={handleTestConnection}
-              disabled={testing || loading || disconnecting || (totpRequired && !totpCode.trim())}
-            >
-              <RefreshCw className={`h-4 w-4 mr-2 ${testing ? 'animate-spin' : ''}`} />
-              {testing
-                ? t('integrations.rmm.tactical.actions.testing', { defaultValue: 'Testing...' })
-                : t('integrations.rmm.tactical.actions.testConnection', { defaultValue: 'Test Connection' })}
-            </Button>
-
-            <Button
-              id="tacticalrmm-disconnect"
-              type="button"
-              variant="destructive"
-              onClick={handleDisconnect}
-              disabled={disconnecting || loading}
-            >
-              <Unlink className="h-4 w-4 mr-2" />
-              {disconnecting
-                ? t('integrations.rmm.tactical.actions.disconnecting', { defaultValue: 'Disconnecting...' })
-                : t('integrations.rmm.tactical.actions.disconnect', { defaultValue: 'Disconnect' })}
-            </Button>
-          </div>
-
-          {!loading && credentialsStatus && (
-            <div className="text-xs text-muted-foreground">
-              {credentialsStatus.hasApiKey || credentialsStatus.hasKnoxCredentials
-                ? t('integrations.rmm.tactical.statusLine.configured', { defaultValue: 'Status: Configured' })
-                : t('integrations.rmm.tactical.statusLine.notConfigured', { defaultValue: 'Status: Not configured' })}
-            </div>
-          )}
-
-          {loading && (
-            <div className="text-sm text-muted-foreground flex items-center gap-2">
-              <RefreshCw className="h-4 w-4 animate-spin" />
-              {t('integrations.rmm.tactical.loadingSettings', { defaultValue: 'Loading Tactical RMM settings...' })}
-            </div>
-          )}
         </div>
       </CardContent>
     </Card>

--- a/packages/integrations/src/lib/rmm/tacticalrmm/alertFetcher.ts
+++ b/packages/integrations/src/lib/rmm/tacticalrmm/alertFetcher.ts
@@ -5,7 +5,7 @@ import { buildTacticalClientForTenant } from './buildClient';
 /**
  * Lists currently-active TacticalRMM alerts for reconciliation, using the
  * same filterable alerts endpoint the manual backfill verified (PATCH
- * /api/alerts/ with a status filter; permissive about response shape).
+ * /alerts/ with a status filter; permissive about response shape).
  */
 export const tacticalRmmAlertFetcher: RmmActiveAlertFetcher = {
   async fetchActiveAlerts({ tenantId, integrationId }) {
@@ -14,7 +14,7 @@ export const tacticalRmmAlertFetcher: RmmActiveAlertFetcher = {
 
     const res = await client.request<any>({
       method: 'PATCH',
-      path: '/api/alerts/',
+      path: '/alerts/',
       data: { status: 'active' },
     });
     const alerts: any[] = Array.isArray(res)

--- a/packages/integrations/src/lib/rmm/tacticalrmm/syncSingleAgent.ts
+++ b/packages/integrations/src/lib/rmm/tacticalrmm/syncSingleAgent.ts
@@ -107,7 +107,7 @@ export async function syncTacticalSingleAgentForTenant(args: {
 
   const agent = await client.request<any>({
     method: 'GET',
-    path: `/api/beta/v1/agent/${encodeURIComponent(agentId)}/`,
+    path: `/beta/v1/agent/${encodeURIComponent(agentId)}/`,
   });
 
   const mapping = await knex('tenant_external_entity_mappings')

--- a/packages/integrations/src/lib/rmm/tacticalrmm/tacticalApiClient.ts
+++ b/packages/integrations/src/lib/rmm/tacticalrmm/tacticalApiClient.ts
@@ -135,7 +135,7 @@ export class TacticalRmmClient {
   }
 
   async checkCreds(input: { username: string; password: string }): Promise<{ totp: boolean }> {
-    const res = await axios.post(new URL('/api/v2/checkcreds/', this.ax.defaults.baseURL!).toString(), input, {
+    const res = await axios.post(new URL('/v2/checkcreds/', this.ax.defaults.baseURL!).toString(), input, {
       timeout: 30_000,
     });
     return { totp: Boolean((res.data as any)?.totp) };
@@ -144,7 +144,7 @@ export class TacticalRmmClient {
   async login(input: { username: string; password: string; totpCode?: string }): Promise<{ token: string }> {
     const payload: Record<string, any> = { username: input.username, password: input.password };
     if (input.totpCode) payload.twofactor = input.totpCode;
-    const res = await axios.post(new URL('/api/v2/login/', this.ax.defaults.baseURL!).toString(), payload, {
+    const res = await axios.post(new URL('/v2/login/', this.ax.defaults.baseURL!).toString(), payload, {
       timeout: 30_000,
     });
     const token: string | undefined =

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "Instanz-URL",
-          "instanceUrlHelp": "Verwenden Sie Ihre Tactical-Basis-URL (ohne abschließendes /api)."
+          "instanceUrlHelp": "Verwenden Sie den Tactical-API-Host — die Subdomain api., z. B. https://api.example.com. Nicht die Dashboard-URL (rmm.) und kein abschließendes /api.",
+          "betaApiNote": "Erfordert, dass die Beta-API von Tactical auf dem Server aktiviert ist: Setzen Sie BETA_API_ENABLED = True in Tactical und starten Sie es neu. Ohne die Beta-API schlagen Verbindungstest und Synchronisierung fehl."
         },
         "lastError": "Letzter Fehler: {{error}}",
         "loadingSettings": "Tactical-RMM-Einstellungen werden geladen...",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "Instance URL",
-          "instanceUrlHelp": "Use your Tactical base URL (no trailing /api)."
+          "instanceUrlHelp": "Use your Tactical API host — the api. subdomain, e.g. https://api.example.com. Not the dashboard (rmm.) URL, and no trailing /api.",
+          "betaApiNote": "Requires Tactical's Beta API to be enabled on the server: set BETA_API_ENABLED = True in Tactical, then restart it. Without the Beta API, the connection test and sync will fail."
         },
         "lastError": "Last error: {{error}}",
         "loadingSettings": "Loading Tactical RMM settings...",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "URL de instancia",
-          "instanceUrlHelp": "Utilice su URL base de Tactical (sin /api al final)."
+          "instanceUrlHelp": "Use el host de la API de Tactical — el subdominio api., p. ej. https://api.example.com. No la URL del panel (rmm.) y sin /api al final.",
+          "betaApiNote": "Requiere que la API Beta de Tactical esté habilitada en el servidor: establezca BETA_API_ENABLED = True en Tactical y reinícielo. Sin la API Beta, la prueba de conexión y la sincronización fallarán."
         },
         "lastError": "Último error: {{error}}",
         "loadingSettings": "Cargando configuración de Tactical RMM...",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "URL d'instance",
-          "instanceUrlHelp": "Utilisez votre URL de base Tactical (sans /api final)."
+          "instanceUrlHelp": "Utilisez l'hôte de l'API Tactical — le sous-domaine api., par ex. https://api.example.com. Pas l'URL du tableau de bord (rmm.) et sans /api à la fin.",
+          "betaApiNote": "Nécessite l'activation de l'API Bêta de Tactical sur le serveur : définissez BETA_API_ENABLED = True dans Tactical, puis redémarrez-le. Sans l'API Bêta, le test de connexion et la synchronisation échoueront."
         },
         "lastError": "Dernière erreur : {{error}}",
         "loadingSettings": "Chargement des paramètres Tactical RMM...",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "URL dell'istanza",
-          "instanceUrlHelp": "Usa l'URL di base di Tactical (senza /api finale)."
+          "instanceUrlHelp": "Usa l'host dell'API di Tactical — il sottodominio api., ad es. https://api.example.com. Non l'URL della dashboard (rmm.) e senza /api finale.",
+          "betaApiNote": "Richiede che l'API Beta di Tactical sia abilitata sul server: imposta BETA_API_ENABLED = True in Tactical, quindi riavvialo. Senza l'API Beta, il test di connessione e la sincronizzazione falliranno."
         },
         "lastError": "Ultimo errore: {{error}}",
         "loadingSettings": "Caricamento impostazioni Tactical RMM...",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "Instance-URL",
-          "instanceUrlHelp": "Gebruik uw Tactical-basis-URL (zonder /api aan het einde)."
+          "instanceUrlHelp": "Gebruik de Tactical API-host — het subdomein api., bijv. https://api.example.com. Niet de dashboard-URL (rmm.) en geen afsluitende /api.",
+          "betaApiNote": "Vereist dat de Beta-API van Tactical op de server is ingeschakeld: stel BETA_API_ENABLED = True in Tactical in en start het opnieuw op. Zonder de Beta-API mislukken de verbindingstest en de synchronisatie."
         },
         "lastError": "Laatste fout: {{error}}",
         "loadingSettings": "Tactical RMM-instellingen worden geladen...",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "URL instancji",
-          "instanceUrlHelp": "Użyj bazowego URL Tactical (bez końcowego /api)."
+          "instanceUrlHelp": "Użyj hosta API Tactical — subdomeny api., np. https://api.example.com. Nie adresu URL panelu (rmm.) i bez końcowego /api.",
+          "betaApiNote": "Wymaga włączenia interfejsu API Beta w Tactical na serwerze: ustaw BETA_API_ENABLED = True w Tactical, a następnie uruchom ponownie. Bez API Beta test połączenia i synchronizacja nie powiodą się."
         },
         "lastError": "Ostatni błąd: {{error}}",
         "loadingSettings": "Ładowanie ustawień Tactical RMM...",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "URL da instância",
-          "instanceUrlHelp": "Use sua URL base do Tactical (sem /api no final)."
+          "instanceUrlHelp": "Use o host da API do Tactical — o subdomínio api., por ex. https://api.example.com. Não a URL do painel (rmm.) e sem /api no final.",
+          "betaApiNote": "Requer que a API Beta do Tactical esteja ativada no servidor: defina BETA_API_ENABLED = True no Tactical e reinicie-o. Sem a API Beta, o teste de conexão e a sincronização falharão."
         },
         "lastError": "Último erro: {{error}}",
         "loadingSettings": "Carregando configurações do Tactical RMM...",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "11111",
-          "instanceUrlHelp": "11111"
+          "instanceUrlHelp": "11111",
+          "betaApiNote": "55555"
         },
         "lastError": "11111 {{error}} 11111",
         "loadingSettings": "11111",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -1509,7 +1509,8 @@
         },
         "fields": {
           "instanceUrl": "55555",
-          "instanceUrlHelp": "55555"
+          "instanceUrlHelp": "55555",
+          "betaApiNote": "11111"
         },
         "lastError": "55555 {{error}} 55555",
         "loadingSettings": "55555",

--- a/server/src/test/e2e/integrations-tactical-disconnect.playwright.test.ts
+++ b/server/src/test/e2e/integrations-tactical-disconnect.playwright.test.ts
@@ -102,7 +102,7 @@ function startMockTacticalServer(expectedApiKey: string): Promise<{
 
     res.setHeader('content-type', 'application/json');
 
-    if (method === 'GET' && url.pathname === '/api/beta/v1/client/') {
+    if (method === 'GET' && url.pathname === '/beta/v1/client/') {
       calls.clientList += 1;
       const apiKey = String(req.headers['x-api-key'] || '');
       calls.lastApiKey = apiKey;

--- a/server/src/test/e2e/integrations-tactical-knox-login-no-totp.playwright.test.ts
+++ b/server/src/test/e2e/integrations-tactical-knox-login-no-totp.playwright.test.ts
@@ -97,21 +97,21 @@ function startMockTacticalServer(): Promise<{
 
     res.setHeader('content-type', 'application/json');
 
-    if (method === 'POST' && url.pathname === '/api/v2/checkcreds/') {
+    if (method === 'POST' && url.pathname === '/v2/checkcreds/') {
       calls.checkcreds += 1;
       res.statusCode = 200;
       res.end(JSON.stringify({ totp: false }));
       return;
     }
 
-    if (method === 'POST' && url.pathname === '/api/v2/login/') {
+    if (method === 'POST' && url.pathname === '/v2/login/') {
       calls.login += 1;
       res.statusCode = 200;
       res.end(JSON.stringify({ token }));
       return;
     }
 
-    if (method === 'GET' && url.pathname === '/api/beta/v1/client/') {
+    if (method === 'GET' && url.pathname === '/beta/v1/client/') {
       calls.clientList += 1;
       const auth = req.headers.authorization || '';
       calls.lastClientListAuth = auth;

--- a/server/src/test/e2e/integrations-tactical-knox-login-with-totp.playwright.test.ts
+++ b/server/src/test/e2e/integrations-tactical-knox-login-with-totp.playwright.test.ts
@@ -99,14 +99,14 @@ function startMockTacticalServer(): Promise<{
 
     res.setHeader('content-type', 'application/json');
 
-    if (method === 'POST' && url.pathname === '/api/v2/checkcreds/') {
+    if (method === 'POST' && url.pathname === '/v2/checkcreds/') {
       calls.checkcreds += 1;
       res.statusCode = 200;
       res.end(JSON.stringify({ totp: true }));
       return;
     }
 
-    if (method === 'POST' && url.pathname === '/api/v2/login/') {
+    if (method === 'POST' && url.pathname === '/v2/login/') {
       calls.login += 1;
       let body = '';
       req.on('data', (chunk) => {
@@ -124,7 +124,7 @@ function startMockTacticalServer(): Promise<{
       return;
     }
 
-    if (method === 'GET' && url.pathname === '/api/beta/v1/client/') {
+    if (method === 'GET' && url.pathname === '/beta/v1/client/') {
       calls.clientList += 1;
       const auth = req.headers.authorization || '';
       calls.lastClientListAuth = auth;

--- a/server/src/test/unit/tacticalrmm/tacticalApiClient.knox401Retry.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalApiClient.knox401Retry.test.ts
@@ -28,7 +28,7 @@ describe('TacticalRmmClient Knox 401 retry guard', () => {
     });
 
     await expect(
-      client.request({ method: 'GET', path: '/api/beta/v1/client/' })
+      client.request({ method: 'GET', path: '/beta/v1/client/' })
     ).rejects.toThrow();
 
     // One refresh attempt max (even though both attempts 401).

--- a/server/src/test/unit/tacticalrmm/tacticalApiClient.pagination.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalApiClient.pagination.test.ts
@@ -26,7 +26,7 @@ describe('TacticalRmmClient.listAllBeta pagination', () => {
       });
 
     const res = await client.listAllBeta<{ id: number }>({
-      path: '/api/beta/v1/site/',
+      path: '/beta/v1/site/',
       pageSize: 5000,
     });
 
@@ -50,14 +50,14 @@ describe('TacticalRmmClient.listAllBeta pagination', () => {
       .spyOn(client, 'request')
       .mockImplementation(async (args: any) => {
         expect(args.method).toBe('GET');
-        expect(args.path).toBe('/api/beta/v1/client/');
+        expect(args.path).toBe('/beta/v1/client/');
         expect(args.params?.page).toBe(1);
         expect(args.params?.page_size).toBe(1000);
         return [{ id: 1 }, { id: 2 }] as any;
       });
 
     const res = await client.listAllBeta<{ id: number }>({
-      path: '/api/beta/v1/client/',
+      path: '/beta/v1/client/',
     });
 
     expect(res.map((r) => r.id)).toEqual([1, 2]);

--- a/server/src/test/unit/tacticalrmm/tacticalDeviceSync.fullSync.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalDeviceSync.fullSync.test.ts
@@ -196,8 +196,8 @@ vi.mock('@alga-psa/integrations/lib/rmm/tacticalrmm/tacticalApiClient', async ()
 
   class TacticalRmmClientMock {
     async listAllBeta(args: { path: string; params?: any }) {
-      if (args.path === '/api/beta/v1/site/') return tacticalSites;
-      if (args.path === '/api/beta/v1/agent/') {
+      if (args.path === '/beta/v1/site/') return tacticalSites;
+      if (args.path === '/beta/v1/agent/') {
         const clientId = String(args.params?.client_id ?? '');
         return tacticalAgentsByClientId[clientId] ?? [];
       }

--- a/server/src/test/unit/tacticalrmm/tacticalDeviceSync.paginationSmoke.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalDeviceSync.paginationSmoke.test.ts
@@ -183,13 +183,13 @@ vi.mock('@alga-psa/integrations/lib/rmm/tacticalrmm/tacticalApiClient', async ()
       const path = String(args.path);
       const page = Number(args?.params?.page || 1);
 
-      if (path === '/api/beta/v1/site/') {
+      if (path === '/beta/v1/site/') {
         if (page === 1) return { results: [{ id: 's1', name: 'HQ' }], next: 'page2' };
         if (page === 2) return { results: [{ id: 's2', name: 'Branch' }], next: null };
         throw new Error(`Unexpected site page: ${page}`);
       }
 
-      if (path === '/api/beta/v1/agent/') {
+      if (path === '/beta/v1/agent/') {
         const clientId = String(args?.params?.client_id ?? '');
         if (clientId !== '100') throw new Error(`Unexpected client_id: ${clientId}`);
 
@@ -292,8 +292,8 @@ describe('Tactical device sync paging (smoke)', () => {
     expect(res.items_created).toBe(5);
 
     // Ensure we made multiple page requests for both sites and agents, with page_size capped to 1000.
-    const siteCalls = requestCalls.filter((c) => c.path === '/api/beta/v1/site/');
-    const agentCalls = requestCalls.filter((c) => c.path === '/api/beta/v1/agent/');
+    const siteCalls = requestCalls.filter((c) => c.path === '/beta/v1/site/');
+    const agentCalls = requestCalls.filter((c) => c.path === '/beta/v1/agent/');
     expect(siteCalls.map((c) => c.params.page)).toEqual([1, 2]);
     expect(agentCalls.map((c) => c.params.page)).toEqual([1, 2, 3]);
     expect(requestCalls.every((c) => Number(c.params.page_size) === 1000)).toBe(true);

--- a/server/src/test/unit/tacticalrmm/tacticalEvents.published.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalEvents.published.test.ts
@@ -54,7 +54,7 @@ vi.mock('@alga-psa/integrations/lib/rmm/tacticalrmm/tacticalApiClient', async ()
 
   class TacticalRmmClientMock {
     async listAllBeta(args: any) {
-      if (String(args?.path) === '/api/beta/v1/client/') {
+      if (String(args?.path) === '/beta/v1/client/') {
         if (throwOnClientList) throw throwOnClientList;
         return remoteClients;
       }

--- a/server/src/test/unit/tacticalrmm/tacticalRmmConnection.apiKey401.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalRmmConnection.apiKey401.test.ts
@@ -69,7 +69,7 @@ describe('Tactical RMM connection test (API key)', () => {
 
     expect(getSpy).toHaveBeenCalledTimes(1);
     expect(getSpy).toHaveBeenCalledWith(
-      'https://tactical.example/api/beta/v1/client/',
+      'https://tactical.example/beta/v1/client/',
       expect.objectContaining({
         headers: { 'X-API-KEY': 'api_abcdefghijklmnop' },
         timeout: 15_000,

--- a/server/src/test/unit/tacticalrmm/tacticalRmmConnection.knoxReauth.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalRmmConnection.knoxReauth.test.ts
@@ -69,12 +69,12 @@ describe('Tactical RMM connection test (Knox) re-auth on 401', () => {
   it('retries login once when token verification returns 401, using Authorization: Token ...', async () => {
     const postSpy = vi.spyOn(axios, 'post').mockImplementation(async (url: any, data: any) => {
       const u = String(url);
-      if (u.endsWith('/api/v2/checkcreds/')) {
+      if (u.endsWith('/v2/checkcreds/')) {
         return { data: { totp: false } } as any;
       }
-      if (u.endsWith('/api/v2/login/')) {
+      if (u.endsWith('/v2/login/')) {
         // Return token1 then token2.
-        const current = (postSpy as any).mock.calls.filter((c: any[]) => String(c[0]).endsWith('/api/v2/login/')).length;
+        const current = (postSpy as any).mock.calls.filter((c: any[]) => String(c[0]).endsWith('/v2/login/')).length;
         return { data: { token: current === 1 ? 'token1' : 'token2' } } as any;
       }
       throw new Error(`Unexpected POST: ${u}`);
@@ -98,8 +98,8 @@ describe('Tactical RMM connection test (Knox) re-auth on 401', () => {
     expect(res.success).toBe(true);
 
     // checkcreds once, login twice
-    expect(postSpy.mock.calls.filter((c) => String(c[0]).endsWith('/api/v2/checkcreds/')).length).toBe(1);
-    expect(postSpy.mock.calls.filter((c) => String(c[0]).endsWith('/api/v2/login/')).length).toBe(2);
+    expect(postSpy.mock.calls.filter((c) => String(c[0]).endsWith('/v2/checkcreds/')).length).toBe(1);
+    expect(postSpy.mock.calls.filter((c) => String(c[0]).endsWith('/v2/login/')).length).toBe(2);
 
     // verify token called twice with proper header.
     expect(getSpy).toHaveBeenCalledTimes(2);

--- a/server/src/test/unit/tacticalrmm/tacticalRmmConnection.knoxTotpPayload.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalRmmConnection.knoxTotpPayload.test.ts
@@ -64,8 +64,8 @@ describe('Tactical RMM connection test (Knox) TOTP payload behavior', () => {
     vi.spyOn(axios, 'post').mockImplementation(async (url: any, data: any) => {
       const u = String(url);
       posted.push({ url: u, data });
-      if (u.endsWith('/api/v2/checkcreds/')) return { data: { totp: true } } as any;
-      if (u.endsWith('/api/v2/login/')) return { data: { token: 'token_totp' } } as any;
+      if (u.endsWith('/v2/checkcreds/')) return { data: { totp: true } } as any;
+      if (u.endsWith('/v2/login/')) return { data: { token: 'token_totp' } } as any;
       throw new Error(`Unexpected POST: ${u}`);
     });
     vi.spyOn(axios, 'get').mockResolvedValue({ data: [] } as any);
@@ -77,7 +77,7 @@ describe('Tactical RMM connection test (Knox) TOTP payload behavior', () => {
     const res = await testTacticalRmmConnection({} as any, { tenant: 'tenant_1' }, { totpCode: '123456' });
     expect(res.success).toBe(true);
 
-    const login = posted.find((p) => p.url.endsWith('/api/v2/login/'));
+    const login = posted.find((p) => p.url.endsWith('/v2/login/'));
     expect(login?.data?.twofactor).toBe('123456');
   });
 
@@ -86,8 +86,8 @@ describe('Tactical RMM connection test (Knox) TOTP payload behavior', () => {
     vi.spyOn(axios, 'post').mockImplementation(async (url: any, data: any) => {
       const u = String(url);
       posted.push({ url: u, data });
-      if (u.endsWith('/api/v2/checkcreds/')) return { data: { totp: false } } as any;
-      if (u.endsWith('/api/v2/login/')) return { data: { token: 'token_plain' } } as any;
+      if (u.endsWith('/v2/checkcreds/')) return { data: { totp: false } } as any;
+      if (u.endsWith('/v2/login/')) return { data: { token: 'token_plain' } } as any;
       throw new Error(`Unexpected POST: ${u}`);
     });
     vi.spyOn(axios, 'get').mockResolvedValue({ data: [] } as any);
@@ -99,7 +99,7 @@ describe('Tactical RMM connection test (Knox) TOTP payload behavior', () => {
     const res = await testTacticalRmmConnection({} as any, { tenant: 'tenant_1' });
     expect(res.success).toBe(true);
 
-    const login = posted.find((p) => p.url.endsWith('/api/v2/login/'));
+    const login = posted.find((p) => p.url.endsWith('/v2/login/'));
     expect(login?.data?.twofactor).toBeUndefined();
   });
 });

--- a/server/src/test/unit/tacticalrmm/tacticalSoftwareIngest.bulk.test.ts
+++ b/server/src/test/unit/tacticalrmm/tacticalSoftwareIngest.bulk.test.ts
@@ -39,7 +39,7 @@ vi.mock('@alga-psa/integrations/lib/rmm/tacticalrmm/tacticalApiClient', async ()
   class TacticalRmmClientMock {
     async request(args: any) {
       requestCalls.push({ method: String(args.method), path: String(args.path) });
-      if (args.method === 'GET' && args.path === '/api/software/') return tacticalSoftwareRows;
+      if (args.method === 'GET' && args.path === '/software/') return tacticalSoftwareRows;
       throw new Error(`Unexpected Tactical request: ${args.method} ${args.path}`);
     }
     async listAllBeta(_args: any) {
@@ -198,7 +198,7 @@ describe('Tactical software inventory ingest (bulk)', () => {
     vi.useRealTimers();
   });
 
-  it('ingests via GET /api/software/ without per-agent refresh calls and writes normalized software tables', async () => {
+  it('ingests via GET /software/ without per-agent refresh calls and writes normalized software tables', async () => {
     const { ingestTacticalRmmSoftwareInventory } = await import(
       '@alga-psa/integrations/actions/integrations/tacticalRmmActions'
     );
@@ -206,7 +206,7 @@ describe('Tactical software inventory ingest (bulk)', () => {
     const res = await ingestTacticalRmmSoftwareInventory({ user_id: 'u1' } as any, { tenant: 'tenant_1' });
     expect(res.success).toBe(true);
 
-    expect(requestCalls).toEqual([{ method: 'GET', path: '/api/software/' }]);
+    expect(requestCalls).toEqual([{ method: 'GET', path: '/software/' }]);
     expect(requestCalls.some((c) => c.method === 'PUT')).toBe(false);
 
     expect(res.items_processed).toBe(3);


### PR DESCRIPTION
  Instance URL is now the api. subdomain itself, so drop the
  leading /api prefix from every Tactical endpoint — checkcreds,
  login, beta/v1 agent/client/site, software, and alerts — across
  the client, actions, workflow runtime, and single-agent sync.

  Add a Beta API requirement note (info Alert) and sharpen the
  instance URL help text in settings, with locale strings for all
  languages. Update unit/e2e tests to the prefix-less paths.

  "But which road do I take?" asked Alice. "The one without
  /api," said the Cat, "for all the others only lead back to the
  dashboard." 🐈🗺️ ✨