### PR TITLE
Gate self-host license banner until after onboarding

### DIFF
--- a/server/src/app/msp/MspLayoutClient.tsx
+++ b/server/src/app/msp/MspLayoutClient.tsx
@@ -76,7 +76,13 @@ export function MspLayoutClient({
   const sessionTenant = session?.user?.tenant;
   const shortcutPreference = useKeyboardShortcutPreferenceStorage({ userId: session?.user?.id });
   const [clientNeedsOnboarding, setClientNeedsOnboarding] = useState(false);
+  const [clientOnboardingCheckComplete, setClientOnboardingCheckComplete] = useState(false);
   const shouldForceOnboarding = needsOnboarding || clientNeedsOnboarding;
+  const canShowLicenseBanner =
+    selfHostLicensing &&
+    !isOnboardingPage &&
+    !shouldForceOnboarding &&
+    clientOnboardingCheckComplete;
 
   useEffect(() => {
     if (shouldForceOnboarding && !isOnboardingPage) {
@@ -88,6 +94,7 @@ export function MspLayoutClient({
     let isCancelled = false;
 
     setClientNeedsOnboarding(false);
+    setClientOnboardingCheckComplete(false);
 
     if (needsOnboarding || isOnboardingPage || !sessionTenant) {
       return () => {
@@ -97,7 +104,12 @@ export function MspLayoutClient({
 
     void getTenantSettings()
       .then((settings) => {
-        if (isCancelled || !settings) {
+        if (isCancelled) {
+          return;
+        }
+
+        if (!settings) {
+          setClientOnboardingCheckComplete(true);
           return;
         }
 
@@ -108,10 +120,16 @@ export function MspLayoutClient({
         if (hasOnboardingFlags && !settings.onboarding_completed && !settings.onboarding_skipped) {
           setClientNeedsOnboarding(true);
           router.replace('/msp/onboarding');
+          return;
         }
+
+        setClientOnboardingCheckComplete(true);
       })
       .catch((error) => {
         console.error('Error checking onboarding status:', error);
+        if (!isCancelled) {
+          setClientOnboardingCheckComplete(true);
+        }
       });
 
     return () => {
@@ -127,7 +145,7 @@ export function MspLayoutClient({
     <AppSessionProvider session={session}>
       <ProductProvider>
         <TierProvider>
-          {selfHostLicensing && <LicenseBanner />}
+          {canShowLicenseBanner && <LicenseBanner />}
           <PostHogUserIdentifier />
           <TagProvider>
             <ClientUIStateProvider

--- a/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
+++ b/server/src/test/unit/layout/MspLayoutClient.productShell.test.tsx
@@ -55,6 +55,10 @@ vi.mock('@/context/ProductContext', () => ({
   ProductProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('@/components/licenses/LicenseBanner', () => ({
+  default: () => <div data-testid="license-banner" />,
+}));
+
 vi.mock('@alga-psa/ui/keyboard-shortcuts', () => ({
   KeyboardShortcutsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -78,6 +82,7 @@ vi.mock('@/components/product/ProductRouteBoundary', () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  mockUsePathname.mockReturnValue('/msp/tickets');
 });
 
 const mockGetTenantSettings = vi.mocked(getTenantSettings);
@@ -156,5 +161,79 @@ describe('MspLayoutClient product shell behavior', () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith('/msp/onboarding');
     });
+  });
+
+  it.each([
+    { onboarding_completed: true, onboarding_skipped: false, label: 'completed' },
+    { onboarding_completed: false, onboarding_skipped: true, label: 'skipped' },
+  ])('shows the self-host license banner after onboarding is $label', async (settings) => {
+    mockGetTenantSettings.mockResolvedValue({
+      tenant: 'tenant-1',
+      onboarding_completed: settings.onboarding_completed,
+      onboarding_skipped: settings.onboarding_skipped,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    render(
+      <MspLayoutClient
+        session={{ user: { tenant: 'tenant-1' } } as any}
+        productCode="psa"
+        needsOnboarding={false}
+        initialSidebarCollapsed={false}
+        selfHostLicensing={true}
+      >
+        <div>psa content</div>
+      </MspLayoutClient>,
+    );
+
+    expect(screen.queryByTestId('license-banner')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('license-banner')).toBeInTheDocument();
+  });
+
+  it('does not show the self-host license banner while onboarding is still required', async () => {
+    mockGetTenantSettings.mockResolvedValue({
+      tenant: 'tenant-1',
+      onboarding_completed: false,
+      onboarding_skipped: false,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    render(
+      <MspLayoutClient
+        session={{ user: { tenant: 'tenant-1' } } as any}
+        productCode="psa"
+        needsOnboarding={false}
+        initialSidebarCollapsed={false}
+        selfHostLicensing={true}
+      >
+        <div>psa content</div>
+      </MspLayoutClient>,
+    );
+
+    expect(screen.queryByTestId('license-banner')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/msp/onboarding');
+    });
+    expect(screen.queryByTestId('license-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not show the self-host license banner on the onboarding page', () => {
+    mockUsePathname.mockReturnValue('/msp/onboarding');
+
+    render(
+      <MspLayoutClient
+        session={{ user: { tenant: 'tenant-1' } } as any}
+        productCode="psa"
+        needsOnboarding={false}
+        initialSidebarCollapsed={false}
+        selfHostLicensing={true}
+      >
+        <div>onboarding content</div>
+      </MspLayoutClient>,
+    );
+
+    expect(screen.queryByTestId('license-banner')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Hides the self-host license/upgrade banner while onboarding status is still being checked
- Suppresses the banner on /msp/onboarding and when onboarding is still required
- Treats completed or skipped onboarding as eligible for the banner

## Validation
- cd server && npx vitest run src/test/unit/layout/MspLayoutClient.productShell.test.tsx
  - 8 tests passed

## Notes
This was local-only in the working tree and was not present on origin/main before this PR.