### PR TITLE
Wire real financial list/PDF handlers + webhook

### DIFF
--- a/packages/billing/src/services/pdfGenerationService.ts
+++ b/packages/billing/src/services/pdfGenerationService.ts
@@ -10,8 +10,6 @@ import { convertBlockContentToHTML } from '@alga-psa/formatting/blocknoteUtils';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import { buildDocumentGeneratedPayload } from '@alga-psa/workflow-streams';
 
-import { getInvoiceForRendering } from '../actions/invoiceQueries';
-import { getInvoiceTemplate, getInvoiceTemplates } from '../actions/invoiceTemplates';
 import {
   enrichInvoiceViewModelWithLocations,
   mapDbInvoiceToWasmViewModel,
@@ -27,6 +25,7 @@ import {
   getStandardTemplateAstByCode,
   STANDARD_INVOICE_BY_LOCATION_CODE,
 } from '../lib/invoice-template-ast/standardTemplates';
+import Invoice from '../models/invoice';
 import { getStandardQuoteTemplateAstByCode } from '../lib/quote-template-ast/standardTemplates';
 import { resolveQuoteTemplateAst } from '../lib/quote-template-ast/templateSelection';
 import { browserPoolService } from './browserPoolService';
@@ -183,7 +182,7 @@ export class PDFGenerationService {
     return runWithTenant(this.tenant, async () => {
       const { knex } = await createTenantKnex();
 
-      const dbInvoiceData = await getInvoiceForRendering(options.invoiceId);
+      const dbInvoiceData = await this.getInvoiceForRendering(knex, options.invoiceId);
       if (!dbInvoiceData) {
         throw new Error(`Invoice ${options.invoiceId} not found`);
       }
@@ -195,11 +194,11 @@ export class PDFGenerationService {
         if (!templateId) {
           throw new Error('No invoice templates available');
         }
-        const templates = await getInvoiceTemplates();
+        const templates = await this.getInvoiceTemplates(knex);
         const selected = templates.find((t: any) => t.template_id === templateId);
         templateAst = (selected?.templateAst ?? null) as TemplateAst | null;
         if (!templateAst) {
-          const canonical = await getInvoiceTemplate(templateId);
+          const canonical = await this.getInvoiceTemplate(knex, templateId);
           templateAst = (canonical?.templateAst ?? null) as TemplateAst | null;
         }
       }
@@ -259,7 +258,7 @@ export class PDFGenerationService {
 
     try {
       const client = await knex('clients')
-        .where({ client_id: dbInvoiceData.client_id })
+        .where({ client_id: dbInvoiceData.client_id, tenant: this.tenant })
         .first();
       if (client?.invoice_template_id) {
         templateId = client.invoice_template_id;
@@ -269,7 +268,7 @@ export class PDFGenerationService {
     }
 
     if (!templateId) {
-      const templates = await getInvoiceTemplates();
+      const templates = await this.getInvoiceTemplates(knex);
       const defaultTemplate = templates.find((t: any) => t.is_default || t.isTenantDefault) ?? templates[0];
       templateId = defaultTemplate?.template_id ?? null;
     }
@@ -282,16 +281,15 @@ export class PDFGenerationService {
     overrideTemplateId?: string
   ): Promise<{ htmlContent: string; templateAst: TemplateAst | null }> {
     return runWithTenant(this.tenant, async () => {
+      const { knex } = await createTenantKnex();
       const [dbInvoiceData, templates] = await Promise.all([
-        getInvoiceForRendering(invoiceId),
-        getInvoiceTemplates(),
+        this.getInvoiceForRendering(knex, invoiceId),
+        this.getInvoiceTemplates(knex),
       ]);
 
       if (!dbInvoiceData) {
         throw new Error(`Invoice ${invoiceId} not found`);
       }
-
-      const { knex } = await createTenantKnex();
 
       const templateId = overrideTemplateId || await this.resolveInvoiceTemplateId(knex, dbInvoiceData);
 
@@ -302,7 +300,7 @@ export class PDFGenerationService {
       const selectedTemplate = templates.find((entry: any) => entry.template_id === templateId) ?? null;
       let templateAst = (selectedTemplate?.templateAst ?? null) as TemplateAst | null;
       if (!templateAst && templateId) {
-        const canonicalTemplate = await getInvoiceTemplate(templateId);
+        const canonicalTemplate = await this.getInvoiceTemplate(knex, templateId);
         templateAst = (canonicalTemplate?.templateAst ?? null) as TemplateAst | null;
       }
 
@@ -372,6 +370,19 @@ export class PDFGenerationService {
     } catch {
       return dbData;
     }
+  }
+
+  private async getInvoiceForRendering(knex: Knex | Knex.Transaction, invoiceId: string): Promise<any> {
+    return Invoice.getFullInvoiceById(knex, this.tenant, invoiceId);
+  }
+
+  private async getInvoiceTemplates(knex: Knex | Knex.Transaction): Promise<any[]> {
+    return Invoice.getAllTemplates(knex, this.tenant);
+  }
+
+  private async getInvoiceTemplate(knex: Knex | Knex.Transaction, templateId: string): Promise<any | null> {
+    const templates = await this.getInvoiceTemplates(knex);
+    return templates.find((template: any) => template.template_id === templateId) ?? null;
   }
 
   // ---- Quote HTML ----------------------------------------------------------

--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -1969,14 +1969,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "status": {
@@ -2052,14 +2044,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
           },
@@ -2145,14 +2130,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type. Determines the optional extension data table."
           },
           "asset_tag": {
@@ -2220,14 +2197,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type to store in assets.asset_type."
           },
           "asset_tag": {
@@ -2582,14 +2551,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "asset_tag": {
@@ -3710,14 +3671,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Related asset type from joined related_assets, present in list responses."
           },
           "status": {
@@ -3852,14 +3805,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Optional asset type filters."
           },
@@ -6930,7 +6876,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "billing_cycle": {
             "type": "string",
@@ -7008,7 +6958,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "tax_id_number": {
             "type": "string"
@@ -7945,6 +7899,10 @@
                 "type": [
                   "string",
                   "null"
+                ],
+                "enum": [
+                  "company",
+                  "individual"
                 ]
               },
               "tax_id_number": {
@@ -8222,6 +8180,10 @@
                   "type": [
                     "string",
                     "null"
+                  ],
+                  "enum": [
+                    "company",
+                    "individual"
                   ]
                 },
                 "tax_id_number": {
@@ -10843,6 +10805,174 @@
         "additionalProperties": {
           "type": "string"
         }
+      },
+      "FinancialInvoiceListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches invoice_number or client name."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "sent",
+              "paid",
+              "overdue",
+              "cancelled",
+              "pending",
+              "prepayment",
+              "partially_applied"
+            ]
+          },
+          "billing_cycle_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "due_date_from": {
+            "type": "string"
+          },
+          "due_date_to": {
+            "type": "string"
+          },
+          "amount_min": {
+            "type": "string"
+          },
+          "amount_max": {
+            "type": "string"
+          },
+          "is_manual": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "has_credit_applied": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          }
+        }
+      },
+      "FinancialPaymentMethodListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches client name or card last4."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "credit_card",
+              "bank_account"
+            ]
+          },
+          "is_default": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "exclude_deleted": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ],
+            "description": "Exclude soft-deleted payment methods. Defaults to true."
+          }
+        }
+      },
+      "InvoicePdfBinary": {
+        "type": "string",
+        "format": "binary",
+        "description": "Raw PDF file bytes (application/pdf)."
       },
       "InvoiceExecutionIdQuery": {
         "type": "object",
@@ -28810,14 +28940,6 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ],
               "description": "Asset type stored in assets.asset_type."
             },
             "required": false,
@@ -29379,14 +29501,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
             },
@@ -29804,14 +29919,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Optional asset type filters."
             },
@@ -35494,7 +35602,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "company",
+                "individual"
+              ]
             },
             "required": false,
             "name": "client_type",
@@ -42729,8 +42841,8 @@
     },
     "/api/v1/financial/invoices": {
       "get": {
-        "summary": "List financial invoices (transaction list wiring)",
-        "description": "Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.",
+        "summary": "List invoices",
+        "description": "Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -42745,8 +42857,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listInvoices()"
         },
         "x-alga-products": [
           "psa"
@@ -42770,9 +42881,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -42790,9 +42903,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches invoice_number or client name."
             },
             "required": false,
+            "description": "Matches invoice_number or client name.",
             "name": "search",
             "in": "query"
           },
@@ -42831,6 +42946,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -42840,26 +42967,44 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "type",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "draft",
+                "sent",
+                "paid",
+                "overdue",
+                "cancelled",
+                "pending",
+                "prepayment",
+                "partially_applied"
+              ]
             },
             "required": false,
             "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "billing_cycle_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_to",
             "in": "query"
           },
           {
@@ -42887,7 +43032,7 @@
               ]
             },
             "required": false,
-            "name": "include_expired",
+            "name": "is_manual",
             "in": "query"
           },
           {
@@ -42899,86 +43044,13 @@
               ]
             },
             "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "name": "has_credit_applied",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated financial list returned.",
+            "description": "Paginated invoice list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -43245,8 +43317,8 @@
     },
     "/api/v1/financial/payment-methods": {
       "get": {
-        "summary": "List payment methods (transaction list wiring)",
-        "description": "Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.",
+        "summary": "List payment methods",
+        "description": "Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -43261,8 +43333,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listPaymentMethods()"
         },
         "x-alga-products": [
           "psa"
@@ -43286,9 +43357,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -43306,9 +43379,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches client name or card last4."
             },
             "required": false,
+            "description": "Matches client name or card last4.",
             "name": "search",
             "in": "query"
           },
@@ -43347,6 +43422,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -43356,15 +43443,10 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "credit_card",
+                "bank_account"
+              ]
             },
             "required": false,
             "name": "type",
@@ -43372,26 +43454,14 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
             "required": false,
-            "name": "status",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_min",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_max",
+            "name": "is_default",
             "in": "query"
           },
           {
@@ -43400,101 +43470,18 @@
               "enum": [
                 "true",
                 "false"
-              ]
+              ],
+              "description": "Exclude soft-deleted payment methods. Defaults to true."
             },
             "required": false,
-            "name": "include_expired",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "description": "Exclude soft-deleted payment methods. Defaults to true.",
+            "name": "exclude_deleted",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated list returned.",
+            "description": "Paginated payment method list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49569,8 +49556,8 @@
     },
     "/api/v1/invoices/{id}/pdf": {
       "post": {
-        "summary": "Generate invoice PDF asset",
-        "description": "Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.",
+        "summary": "Generate and download invoice PDF",
+        "description": "Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49584,7 +49571,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf"
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49604,11 +49591,11 @@
         ],
         "responses": {
           "200": {
-            "description": "PDF generation metadata returned.",
+            "description": "PDF file returned as an application/pdf attachment.",
             "content": {
-              "application/json": {
+              "application/pdf": {
                 "schema": {
-                  "$ref": "#/components/schemas/FinancialInvoiceApiSuccess"
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
                 }
               }
             }
@@ -49634,7 +49621,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49666,8 +49653,8 @@
         }
       },
       "get": {
-        "summary": "Redirect to invoice PDF download",
-        "description": "Attempts to generate/load PDF metadata and redirects to download_url when present.",
+        "summary": "Download invoice PDF",
+        "description": "Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49681,8 +49668,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf",
-          "x-redirect-response": true
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49701,8 +49687,15 @@
           }
         ],
         "responses": {
-          "307": {
-            "description": "Redirect to generated PDF URL."
+          "200": {
+            "description": "PDF file returned as an application/pdf attachment.",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid invoice id.",
@@ -49725,7 +49718,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49735,7 +49728,7 @@
             }
           },
           "404": {
-            "description": "PDF URL unavailable or invoice not found.",
+            "description": "Invoice not found.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -1324,13 +1324,6 @@ components:
           description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
-          enum: &a2
-            - workstation
-            - network_device
-            - server
-            - mobile_device
-            - printer
-            - unknown
           description: Asset type stored in assets.asset_type.
         status:
           type: string
@@ -1392,7 +1385,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Filter to these asset types. Repeat the param or pass a
             comma-separated list.
         statuses:
@@ -1459,7 +1452,6 @@ components:
           description: Client UUID from clients.client_id. Required.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type. Determines the optional extension data table.
         asset_tag:
           type: string
@@ -1513,7 +1505,6 @@ components:
           description: Client UUID to assign to the asset.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type to store in assets.asset_type.
         asset_tag:
           type: string
@@ -1771,7 +1762,6 @@ components:
           description: Client UUID from assets.client_id.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type stored in assets.asset_type.
         asset_tag:
           type: string
@@ -2587,7 +2577,6 @@ components:
             responses.
         asset_type:
           type: string
-          enum: *a2
           description: Related asset type from joined related_assets, present in list
             responses.
         status:
@@ -2685,7 +2674,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Optional asset type filters.
         statuses:
           type: array
@@ -3333,7 +3322,7 @@ components:
           description: Filter executions by parent automation rule UUID.
         status:
           type: string
-          enum: &a4
+          enum: &a3
             - pending
             - running
             - completed
@@ -3367,7 +3356,7 @@ components:
             by validation.
         trigger_type:
           type: string
-          enum: &a3
+          enum: &a2
             - time_based
             - event_based
             - condition_based
@@ -3425,7 +3414,7 @@ components:
           description: Optional rule name filter.
         status:
           type: string
-          enum: &a6
+          enum: &a5
             - active
             - inactive
             - draft
@@ -3433,11 +3422,11 @@ components:
           description: Filter by automation rule status.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Filter by trigger type.
         priority:
           type: string
-          enum: &a7
+          enum: &a6
             - low
             - normal
             - high
@@ -3610,7 +3599,7 @@ components:
           description: Trigger payload captured when execution started.
         status:
           type: string
-          enum: *a4
+          enum: *a3
           description: Current execution status.
         started_at:
           type: string
@@ -3770,13 +3759,13 @@ components:
               type: array
               items:
                 type: string
-                enum: *a3
+                enum: *a2
               description: Valid automation trigger types.
             action_types:
               type: array
               items:
                 type: string
-                enum: &a5
+                enum: &a4
                   - email_notification
                   - sms_notification
                   - webhook_call
@@ -3804,7 +3793,7 @@ components:
               type: array
               items:
                 type: string
-                enum: *a4
+                enum: *a3
               description: Valid automation execution statuses.
             priority_levels:
               type: array
@@ -3889,7 +3878,7 @@ components:
       properties:
         type:
           type: string
-          enum: *a5
+          enum: *a4
           description: Automation action type.
         config:
           type: object
@@ -3952,15 +3941,15 @@ components:
             - "null"
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Current automation rule status.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Current automation rule priority.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Trigger type used to start rule execution.
         trigger_config:
           type: object
@@ -4051,15 +4040,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4070,7 +4059,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: &a8
+          enum: &a7
             - and
             - or
         actions:
@@ -4115,15 +4104,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4134,7 +4123,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: *a8
+          enum: *a7
         actions:
           type: array
           items:
@@ -4193,7 +4182,7 @@ components:
           description: Rule UUIDs from automation_rules.rule_id.
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Status to apply to each provided rule id.
       required:
         - ids
@@ -4580,7 +4569,7 @@ components:
                 - bulk_status_update
             status:
               type: string
-              enum: *a6
+              enum: *a5
             rule_ids:
               type: array
               items:
@@ -4886,9 +4875,12 @@ components:
           type: string
         client_type:
           type: string
+          enum: &a58
+            - company
+            - individual
         billing_cycle:
           type: string
-          enum: &a58
+          enum: &a59
             - weekly
             - bi-weekly
             - monthly
@@ -4897,12 +4889,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a59
+          enum: &a60
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         account_manager_id:
@@ -4916,7 +4908,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         industry:
@@ -4942,6 +4934,9 @@ components:
           type: string
         client_type:
           type: string
+          enum:
+            - company
+            - individual
         tax_id_number:
           type: string
         notes:
@@ -5063,7 +5058,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a62
+          enum: &a63
             - asc
             - desc
         search:
@@ -5093,12 +5088,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a63
+          enum: &a64
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         client_name:
@@ -5166,7 +5161,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         limit:
@@ -5178,12 +5173,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a66
+          enum: &a67
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a67
+          enum: &a68
             - "true"
             - "false"
         client_id:
@@ -5203,7 +5198,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a68
+          enum: &a69
             - asc
             - desc
         search:
@@ -5230,17 +5225,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a69
+          enum: &a70
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         start_date_from:
@@ -5607,6 +5602,9 @@ components:
               type:
                 - string
                 - "null"
+              enum: &a8
+                - company
+                - individual
             tax_id_number:
               type:
                 - string
@@ -5806,6 +5804,7 @@ components:
                 type:
                   - string
                   - "null"
+                enum: *a8
               tax_id_number:
                 type:
                   - string
@@ -6385,7 +6384,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a72
+          enum: &a73
             - asc
             - desc
         search:
@@ -6421,19 +6420,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a73
+          enum: &a74
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         clients_count_min:
@@ -6446,19 +6445,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6940,7 +6939,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a79
+          enum: &a80
             - pdf
             - markdown
             - md
@@ -7556,7 +7555,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a80
+          enum: &a81
             - asc
             - desc
         search:
@@ -7585,22 +7584,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a81
+          enum: &a82
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         date_from:
@@ -7609,13 +7608,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a85
+          enum: &a86
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a86
+          enum: &a87
             - "true"
             - "false"
         as_of_date:
@@ -7631,27 +7630,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a87
+          enum: &a98
             - asc
             - desc
         include_items:
           type: string
-          enum: &a88
+          enum: &a99
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a89
+          enum: &a100
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a90
+          enum: &a101
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a91
+          enum: &a102
             - "true"
             - "false"
         q:
@@ -7662,11 +7661,134 @@ components:
           type: string
         format:
           type: string
-          enum: &a92
+          enum: &a103
             - json
             - csv
       additionalProperties:
         type: string
+    FinancialInvoiceListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
+        order:
+          type: string
+          enum: &a88
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches invoice_number or client name.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a89
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: &a90
+            - draft
+            - sent
+            - paid
+            - overdue
+            - cancelled
+            - pending
+            - prepayment
+            - partially_applied
+        billing_cycle_id:
+          type: string
+          format: uuid
+        due_date_from:
+          type: string
+        due_date_to:
+          type: string
+        amount_min:
+          type: string
+        amount_max:
+          type: string
+        is_manual:
+          type: string
+          enum: &a91
+            - "true"
+            - "false"
+        has_credit_applied:
+          type: string
+          enum: &a92
+            - "true"
+            - "false"
+    FinancialPaymentMethodListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
+        order:
+          type: string
+          enum: &a93
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches client name or card last4.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a94
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: &a95
+            - credit_card
+            - bank_account
+        is_default:
+          type: string
+          enum: &a96
+            - "true"
+            - "false"
+        exclude_deleted:
+          type: string
+          enum: &a97
+            - "true"
+            - "false"
+          description: Exclude soft-deleted payment methods. Defaults to true.
+    InvoicePdfBinary:
+      type: string
+      format: binary
+      description: Raw PDF file bytes (application/pdf).
     InvoiceExecutionIdQuery:
       type: object
       properties:
@@ -8627,12 +8749,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a93
+          enum: &a104
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a94
+          enum: &a105
             - "true"
             - "false"
         client_id:
@@ -8659,7 +8781,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a106
             - asc
             - desc
     PriorityIdParam:
@@ -8727,17 +8849,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a96
+          enum: &a107
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a97
+          enum: &a108
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a98
+          enum: &a109
             - "true"
             - "false"
         matchBy:
@@ -8747,7 +8869,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a99
+          enum: &a110
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -8894,7 +9016,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a100
+          enum: &a111
             - "true"
             - "false"
     WorkflowImportBody:
@@ -9880,7 +10002,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a101
+          enum: &a112
             - "true"
             - "false"
         search:
@@ -9889,7 +10011,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a102
+          enum: &a113
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -9901,7 +10023,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a103
+          enum: &a114
             - pending
             - in_progress
             - completed
@@ -9910,7 +10032,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a104
+          enum: &a115
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10635,7 +10757,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a105
+          enum: &a116
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -10950,7 +11072,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a117
             - asc
             - desc
         search:
@@ -10977,19 +11099,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a107
+          enum: &a118
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a108
+          enum: &a119
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a109
+          enum: &a120
             - "true"
             - "false"
         offset:
@@ -10998,17 +11120,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a110
+          enum: &a121
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a111
+          enum: &a122
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a112
+          enum: &a123
             - service
             - ticket
     CategoryMoveRequest:
@@ -11035,7 +11157,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a113
+          enum: &a124
             - service
             - ticket
         board_id:
@@ -11043,7 +11165,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a114
+          enum: &a125
             - "true"
             - "false"
         limit:
@@ -11057,7 +11179,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a115
+          enum: &a126
             - service
             - ticket
         board_id:
@@ -11071,7 +11193,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a116
+          enum: &a127
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11692,7 +11814,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a122
+          enum: &a133
             - asc
             - desc
         name:
@@ -11703,24 +11825,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a123
+          enum: &a134
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a124
+          enum: &a135
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a125
+          enum: &a136
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a126
+          enum: &a137
             - "true"
             - "false"
         last_delivery_from:
@@ -11754,7 +11876,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a127
+          enum: &a138
             - pending
             - delivered
             - failed
@@ -13516,7 +13638,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a128
+          enum: &a139
             - asc
             - desc
         fields:
@@ -13821,7 +13943,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a129
+          enum: &a140
             - asc
             - desc
         search:
@@ -13830,12 +13952,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a130
+          enum: &a141
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a131
+          enum: &a142
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -20026,7 +20148,6 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a2
             description: Asset type stored in assets.asset_type.
           required: false
           description: Asset type stored in assets.asset_type.
@@ -20427,7 +20548,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Filter to these asset types. Repeat the param or pass a
               comma-separated list.
           required: false
@@ -20745,7 +20866,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Optional asset type filters.
           required: false
           description: Optional asset type filters.
@@ -22853,7 +22974,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a4
+            enum: *a3
             description: Filter by execution status.
           required: false
           description: Filter by execution status.
@@ -22903,7 +23024,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by automation trigger type.
           required: false
           description: Filter by automation trigger type.
@@ -23201,7 +23322,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a6
+            enum: *a5
             description: Filter by automation rule status.
           required: false
           description: Filter by automation rule status.
@@ -23209,7 +23330,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by trigger type.
           required: false
           description: Filter by trigger type.
@@ -23217,7 +23338,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a7
+            enum: *a6
             description: Filter by priority level.
           required: false
           description: Filter by priority level.
@@ -24726,24 +24847,25 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a58
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_tax_exempt
           in: query
@@ -24770,7 +24892,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: has_credit_limit
           in: query
@@ -25304,7 +25426,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: order
           in: query
@@ -25365,13 +25487,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: has_client
           in: query
@@ -25678,7 +25800,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: include_inactive
           in: query
@@ -25738,13 +25860,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: include_inactive
           in: query
@@ -25864,7 +25986,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: order
           in: query
@@ -25916,19 +26038,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: is_contractd
           in: query
@@ -26106,7 +26228,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: order
           in: query
@@ -26158,13 +26280,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_active
           in: query
@@ -26175,7 +26297,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: has_services
           in: query
@@ -26201,7 +26323,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26209,7 +26331,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26217,7 +26339,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27540,7 +27662,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29118,7 +29240,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -29181,25 +29303,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -29215,13 +29337,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -29500,11 +29622,11 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/invoices:
     get:
-      summary: List financial invoices (transaction list wiring)
-      description: Route file maps to ApiFinancialController.list(), which is
-        transaction-oriented (resource financial/transactions) rather than
-        invoice-specific list logic. Current response is the generic transaction
-        list envelope with financial report links.
+      summary: List invoices
+      description: Returns a paginated list of invoices for the tenant. Maps to
+        ApiFinancialController.listInvoices() → FinancialService.listInvoices(),
+        filtered and sorted by the supplied query parameters. Each item carries
+        the invoice record (including client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29515,8 +29637,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listInvoices()
       x-alga-products:
         - psa
       parameters:
@@ -29532,18 +29653,26 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, invoice_number,
+              invoice_date, due_date, total_amount, status (defaults to
+              created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a88
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches invoice_number or client name.
           required: false
+          description: Matches invoice_number or client name.
           name: search
           in: query
         - schema:
@@ -29568,25 +29697,37 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a89
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: type
-          in: query
-        - schema:
-            type: string
+            enum: *a90
           required: false
           name: status
+          in: query
+        - schema:
+            type: string
+            format: uuid
+          required: false
+          name: billing_cycle_id
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_from
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_to
           in: query
         - schema:
             type: string
@@ -29600,58 +29741,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a91
           required: false
-          name: include_expired
+          name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a92
           required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          name: has_credit_applied
           in: query
       responses:
         "200":
-          description: Paginated financial list returned.
+          description: Paginated invoice list returned.
           content:
             application/json:
               schema:
@@ -29826,10 +29928,12 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/payment-methods:
     get:
-      summary: List payment methods (transaction list wiring)
-      description: Current route wiring calls ApiFinancialController.list(), which
-        lists transaction records and not payment methods. This discrepancy is
-        documented as implementation behavior.
+      summary: List payment methods
+      description: Returns a paginated list of payment methods for the tenant. Maps to
+        ApiFinancialController.listPaymentMethods() →
+        FinancialService.listPaymentMethods(). Soft-deleted methods are excluded
+        by default. Each item carries the payment method record (including
+        client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29840,8 +29944,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listPaymentMethods()
       x-alga-products:
         - psa
       parameters:
@@ -29857,18 +29960,24 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, type, is_default
+              (defaults to created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a93
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches client name or card last4.
           required: false
+          description: Matches client name or card last4.
           name: search
           in: query
         - schema:
@@ -29893,90 +30002,39 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a94
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
+            enum: *a95
           required: false
           name: type
           in: query
         - schema:
             type: string
+            enum: *a96
           required: false
-          name: status
+          name: is_default
           in: query
         - schema:
             type: string
+            enum: *a97
+            description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
-          name: amount_min
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: amount_max
-          in: query
-        - schema:
-            type: string
-            enum: *a81
-          required: false
-          name: include_expired
-          in: query
-        - schema:
-            type: string
-            enum: *a82
-          required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          description: Exclude soft-deleted payment methods. Defaults to true.
+          name: exclude_deleted
           in: query
       responses:
         "200":
-          description: Paginated list returned.
+          description: Paginated payment method list returned.
           content:
             application/json:
               schema:
@@ -30300,7 +30358,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30363,25 +30421,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30397,13 +30455,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30542,7 +30600,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30605,25 +30663,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30639,13 +30697,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30719,7 +30777,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30782,25 +30840,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30816,13 +30874,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30896,7 +30954,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30959,25 +31017,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30993,13 +31051,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31131,7 +31189,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31194,25 +31252,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31228,13 +31286,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31308,7 +31366,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31371,25 +31429,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31405,13 +31463,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31670,31 +31728,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31715,7 +31773,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -31838,31 +31896,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31883,7 +31941,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32161,31 +32219,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32206,7 +32264,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32639,31 +32697,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32684,7 +32742,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32757,31 +32815,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32802,7 +32860,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -33713,9 +33771,9 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/invoices/{id}/pdf:
     post:
-      summary: Generate invoice PDF asset
-      description: Generates/refreshes invoice PDF metadata and returns file_id plus
-        optional download_url.
+      summary: Generate and download invoice PDF
+      description: Generates the invoice PDF and returns the raw PDF file as an
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33725,7 +33783,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33741,11 +33799,11 @@ paths:
           in: path
       responses:
         "200":
-          description: PDF generation metadata returned.
+          description: PDF file returned as an application/pdf attachment.
           content:
-            application/json:
+            application/pdf:
               schema:
-                $ref: "#/components/schemas/FinancialInvoiceApiSuccess"
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33759,7 +33817,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
@@ -33777,9 +33835,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
     get:
-      summary: Redirect to invoice PDF download
-      description: Attempts to generate/load PDF metadata and redirects to
-        download_url when present.
+      summary: Download invoice PDF
+      description: Generates (when needed) and returns the invoice PDF as a raw
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33789,8 +33847,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
-        x-redirect-response: true
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33805,8 +33862,12 @@ paths:
           name: id
           in: path
       responses:
-        "307":
-          description: Redirect to generated PDF URL.
+        "200":
+          description: PDF file returned as an application/pdf attachment.
+          content:
+            application/pdf:
+              schema:
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33820,13 +33881,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "404":
-          description: PDF URL unavailable or invoice not found.
+          description: Invoice not found.
           content:
             application/json:
               schema:
@@ -34817,13 +34878,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a104
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a105
           required: false
           name: is_security_relevant
           in: query
@@ -34913,7 +34974,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a106
           required: false
           name: order
           in: query
@@ -35368,19 +35429,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a96
+            enum: *a107
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a108
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a109
           required: false
           name: updateExisting
           in: query
@@ -35441,7 +35502,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a99
+            enum: *a110
           required: false
           name: preview
           in: query
@@ -36043,7 +36104,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a100
+            enum: *a111
           required: false
           name: force
           in: query
@@ -40654,7 +40715,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -40670,7 +40731,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41031,7 +41092,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41047,7 +41108,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41591,7 +41652,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41607,7 +41668,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41680,7 +41741,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41696,7 +41757,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42199,7 +42260,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42215,7 +42276,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42464,13 +42525,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -42799,7 +42860,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42815,7 +42876,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43004,7 +43065,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43020,7 +43081,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43093,7 +43154,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43109,7 +43170,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43476,7 +43537,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43492,7 +43553,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44044,7 +44105,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44060,7 +44121,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44134,7 +44195,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44150,7 +44211,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44661,7 +44722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44677,7 +44738,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44930,13 +44991,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -45270,7 +45331,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45286,7 +45347,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -45477,7 +45538,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45493,7 +45554,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -46084,7 +46145,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a116
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46459,7 +46520,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a117
           required: false
           name: order
           in: query
@@ -46511,13 +46572,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a107
+            enum: *a118
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a119
           required: false
           name: is_child
           in: query
@@ -46528,7 +46589,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a120
           required: false
           name: active
           in: query
@@ -46544,19 +46605,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a110
+            enum: *a121
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a122
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a123
           required: false
           name: category_type
           in: query
@@ -47012,7 +47073,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47024,7 +47085,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a125
           required: false
           name: include_inactive
           in: query
@@ -47099,7 +47160,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a115
+            enum: *a126
           required: false
           name: category_type
           in: query
@@ -47123,7 +47184,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a127
           required: false
           name: include_usage
           in: query
@@ -47209,7 +47270,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a117
+      tags: &a128
         - Services
         - Service Catalog
       security:
@@ -47285,7 +47346,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a118
+            enum: &a129
               - fixed
               - hourly
               - usage
@@ -47333,7 +47394,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47362,7 +47423,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47424,7 +47485,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47473,7 +47534,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47511,7 +47572,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47572,7 +47633,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47621,7 +47682,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a119
+      tags: &a130
         - Products
         - Service Catalog
       security:
@@ -47732,7 +47793,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47761,7 +47822,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a120
+                  enum: &a131
                     - usage
                   default: usage
                 default_rate:
@@ -47900,7 +47961,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47949,7 +48010,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47987,7 +48048,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a120
+                  enum: *a131
                   default: usage
                 default_rate:
                   type: number
@@ -48126,7 +48187,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48174,7 +48235,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a121
+      tags: &a132
         - Service Types
         - Service Catalog
       security:
@@ -48235,7 +48296,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a121
+      tags: *a132
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48316,7 +48377,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a133
           required: false
           name: order
           in: query
@@ -48337,25 +48398,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a134
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a135
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a136
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a126
+            enum: *a137
           required: false
           name: has_failures
           in: query
@@ -49386,7 +49447,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a138
           required: false
           name: status
           in: query
@@ -51504,7 +51565,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51805,7 +51866,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51889,7 +51950,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51973,7 +52034,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52066,7 +52127,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52164,7 +52225,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52467,7 +52528,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52564,7 +52625,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52822,7 +52883,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52912,7 +52973,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53056,7 +53117,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53351,7 +53412,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53442,7 +53503,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53586,7 +53647,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54021,7 +54082,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54332,7 +54393,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54758,7 +54819,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54842,7 +54903,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55027,7 +55088,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55112,7 +55173,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55478,7 +55539,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55576,7 +55637,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56304,7 +56365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56446,7 +56507,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56755,7 +56816,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56898,7 +56959,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57041,7 +57102,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57198,7 +57259,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57481,7 +57542,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57625,7 +57686,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58060,7 +58121,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58263,7 +58324,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58349,7 +58410,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58792,7 +58853,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59263,7 +59324,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59991,7 +60052,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60007,13 +60068,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -60082,7 +60143,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60098,13 +60159,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61519,7 +61580,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61535,13 +61596,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61614,7 +61675,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61630,13 +61691,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -1972,14 +1972,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "status": {
@@ -2055,14 +2047,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
           },
@@ -2148,14 +2133,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type. Determines the optional extension data table."
           },
           "asset_tag": {
@@ -2223,14 +2200,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type to store in assets.asset_type."
           },
           "asset_tag": {
@@ -2585,14 +2554,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "asset_tag": {
@@ -3713,14 +3674,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Related asset type from joined related_assets, present in list responses."
           },
           "status": {
@@ -3855,14 +3808,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Optional asset type filters."
           },
@@ -6933,7 +6879,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "billing_cycle": {
             "type": "string",
@@ -7011,7 +6961,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "tax_id_number": {
             "type": "string"
@@ -7948,6 +7902,10 @@
                 "type": [
                   "string",
                   "null"
+                ],
+                "enum": [
+                  "company",
+                  "individual"
                 ]
               },
               "tax_id_number": {
@@ -8225,6 +8183,10 @@
                   "type": [
                     "string",
                     "null"
+                  ],
+                  "enum": [
+                    "company",
+                    "individual"
                   ]
                 },
                 "tax_id_number": {
@@ -10846,6 +10808,174 @@
         "additionalProperties": {
           "type": "string"
         }
+      },
+      "FinancialInvoiceListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches invoice_number or client name."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "sent",
+              "paid",
+              "overdue",
+              "cancelled",
+              "pending",
+              "prepayment",
+              "partially_applied"
+            ]
+          },
+          "billing_cycle_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "due_date_from": {
+            "type": "string"
+          },
+          "due_date_to": {
+            "type": "string"
+          },
+          "amount_min": {
+            "type": "string"
+          },
+          "amount_max": {
+            "type": "string"
+          },
+          "is_manual": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "has_credit_applied": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          }
+        }
+      },
+      "FinancialPaymentMethodListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches client name or card last4."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "credit_card",
+              "bank_account"
+            ]
+          },
+          "is_default": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "exclude_deleted": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ],
+            "description": "Exclude soft-deleted payment methods. Defaults to true."
+          }
+        }
+      },
+      "InvoicePdfBinary": {
+        "type": "string",
+        "format": "binary",
+        "description": "Raw PDF file bytes (application/pdf)."
       },
       "InvoiceExecutionIdQuery": {
         "type": "object",
@@ -28813,14 +28943,6 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ],
               "description": "Asset type stored in assets.asset_type."
             },
             "required": false,
@@ -29382,14 +29504,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
             },
@@ -29807,14 +29922,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Optional asset type filters."
             },
@@ -35497,7 +35605,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "company",
+                "individual"
+              ]
             },
             "required": false,
             "name": "client_type",
@@ -42732,8 +42844,8 @@
     },
     "/api/v1/financial/invoices": {
       "get": {
-        "summary": "List financial invoices (transaction list wiring)",
-        "description": "Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.",
+        "summary": "List invoices",
+        "description": "Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -42748,8 +42860,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listInvoices()"
         },
         "x-alga-products": [
           "psa"
@@ -42773,9 +42884,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -42793,9 +42906,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches invoice_number or client name."
             },
             "required": false,
+            "description": "Matches invoice_number or client name.",
             "name": "search",
             "in": "query"
           },
@@ -42834,6 +42949,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -42843,26 +42970,44 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "type",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "draft",
+                "sent",
+                "paid",
+                "overdue",
+                "cancelled",
+                "pending",
+                "prepayment",
+                "partially_applied"
+              ]
             },
             "required": false,
             "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "billing_cycle_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_to",
             "in": "query"
           },
           {
@@ -42890,7 +43035,7 @@
               ]
             },
             "required": false,
-            "name": "include_expired",
+            "name": "is_manual",
             "in": "query"
           },
           {
@@ -42902,86 +43047,13 @@
               ]
             },
             "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "name": "has_credit_applied",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated financial list returned.",
+            "description": "Paginated invoice list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -43248,8 +43320,8 @@
     },
     "/api/v1/financial/payment-methods": {
       "get": {
-        "summary": "List payment methods (transaction list wiring)",
-        "description": "Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.",
+        "summary": "List payment methods",
+        "description": "Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -43264,8 +43336,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listPaymentMethods()"
         },
         "x-alga-products": [
           "psa"
@@ -43289,9 +43360,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -43309,9 +43382,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches client name or card last4."
             },
             "required": false,
+            "description": "Matches client name or card last4.",
             "name": "search",
             "in": "query"
           },
@@ -43350,6 +43425,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -43359,15 +43446,10 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "credit_card",
+                "bank_account"
+              ]
             },
             "required": false,
             "name": "type",
@@ -43375,26 +43457,14 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
             "required": false,
-            "name": "status",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_min",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_max",
+            "name": "is_default",
             "in": "query"
           },
           {
@@ -43403,101 +43473,18 @@
               "enum": [
                 "true",
                 "false"
-              ]
+              ],
+              "description": "Exclude soft-deleted payment methods. Defaults to true."
             },
             "required": false,
-            "name": "include_expired",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "description": "Exclude soft-deleted payment methods. Defaults to true.",
+            "name": "exclude_deleted",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated list returned.",
+            "description": "Paginated payment method list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49572,8 +49559,8 @@
     },
     "/api/v1/invoices/{id}/pdf": {
       "post": {
-        "summary": "Generate invoice PDF asset",
-        "description": "Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.",
+        "summary": "Generate and download invoice PDF",
+        "description": "Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49587,7 +49574,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf"
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49607,11 +49594,11 @@
         ],
         "responses": {
           "200": {
-            "description": "PDF generation metadata returned.",
+            "description": "PDF file returned as an application/pdf attachment.",
             "content": {
-              "application/json": {
+              "application/pdf": {
                 "schema": {
-                  "$ref": "#/components/schemas/FinancialInvoiceApiSuccess"
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
                 }
               }
             }
@@ -49637,7 +49624,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49669,8 +49656,8 @@
         }
       },
       "get": {
-        "summary": "Redirect to invoice PDF download",
-        "description": "Attempts to generate/load PDF metadata and redirects to download_url when present.",
+        "summary": "Download invoice PDF",
+        "description": "Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49684,8 +49671,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf",
-          "x-redirect-response": true
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49704,8 +49690,15 @@
           }
         ],
         "responses": {
-          "307": {
-            "description": "Redirect to generated PDF URL."
+          "200": {
+            "description": "PDF file returned as an application/pdf attachment.",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid invoice id.",
@@ -49728,7 +49721,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49738,7 +49731,7 @@
             }
           },
           "404": {
-            "description": "PDF URL unavailable or invoice not found.",
+            "description": "Invoice not found.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -1325,13 +1325,6 @@ components:
           description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
-          enum: &a2
-            - workstation
-            - network_device
-            - server
-            - mobile_device
-            - printer
-            - unknown
           description: Asset type stored in assets.asset_type.
         status:
           type: string
@@ -1393,7 +1386,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Filter to these asset types. Repeat the param or pass a
             comma-separated list.
         statuses:
@@ -1460,7 +1453,6 @@ components:
           description: Client UUID from clients.client_id. Required.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type. Determines the optional extension data table.
         asset_tag:
           type: string
@@ -1514,7 +1506,6 @@ components:
           description: Client UUID to assign to the asset.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type to store in assets.asset_type.
         asset_tag:
           type: string
@@ -1772,7 +1763,6 @@ components:
           description: Client UUID from assets.client_id.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type stored in assets.asset_type.
         asset_tag:
           type: string
@@ -2588,7 +2578,6 @@ components:
             responses.
         asset_type:
           type: string
-          enum: *a2
           description: Related asset type from joined related_assets, present in list
             responses.
         status:
@@ -2686,7 +2675,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Optional asset type filters.
         statuses:
           type: array
@@ -3334,7 +3323,7 @@ components:
           description: Filter executions by parent automation rule UUID.
         status:
           type: string
-          enum: &a4
+          enum: &a3
             - pending
             - running
             - completed
@@ -3368,7 +3357,7 @@ components:
             by validation.
         trigger_type:
           type: string
-          enum: &a3
+          enum: &a2
             - time_based
             - event_based
             - condition_based
@@ -3426,7 +3415,7 @@ components:
           description: Optional rule name filter.
         status:
           type: string
-          enum: &a6
+          enum: &a5
             - active
             - inactive
             - draft
@@ -3434,11 +3423,11 @@ components:
           description: Filter by automation rule status.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Filter by trigger type.
         priority:
           type: string
-          enum: &a7
+          enum: &a6
             - low
             - normal
             - high
@@ -3611,7 +3600,7 @@ components:
           description: Trigger payload captured when execution started.
         status:
           type: string
-          enum: *a4
+          enum: *a3
           description: Current execution status.
         started_at:
           type: string
@@ -3771,13 +3760,13 @@ components:
               type: array
               items:
                 type: string
-                enum: *a3
+                enum: *a2
               description: Valid automation trigger types.
             action_types:
               type: array
               items:
                 type: string
-                enum: &a5
+                enum: &a4
                   - email_notification
                   - sms_notification
                   - webhook_call
@@ -3805,7 +3794,7 @@ components:
               type: array
               items:
                 type: string
-                enum: *a4
+                enum: *a3
               description: Valid automation execution statuses.
             priority_levels:
               type: array
@@ -3890,7 +3879,7 @@ components:
       properties:
         type:
           type: string
-          enum: *a5
+          enum: *a4
           description: Automation action type.
         config:
           type: object
@@ -3953,15 +3942,15 @@ components:
             - "null"
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Current automation rule status.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Current automation rule priority.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Trigger type used to start rule execution.
         trigger_config:
           type: object
@@ -4052,15 +4041,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4071,7 +4060,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: &a8
+          enum: &a7
             - and
             - or
         actions:
@@ -4116,15 +4105,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4135,7 +4124,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: *a8
+          enum: *a7
         actions:
           type: array
           items:
@@ -4194,7 +4183,7 @@ components:
           description: Rule UUIDs from automation_rules.rule_id.
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Status to apply to each provided rule id.
       required:
         - ids
@@ -4581,7 +4570,7 @@ components:
                 - bulk_status_update
             status:
               type: string
-              enum: *a6
+              enum: *a5
             rule_ids:
               type: array
               items:
@@ -4887,9 +4876,12 @@ components:
           type: string
         client_type:
           type: string
+          enum: &a58
+            - company
+            - individual
         billing_cycle:
           type: string
-          enum: &a58
+          enum: &a59
             - weekly
             - bi-weekly
             - monthly
@@ -4898,12 +4890,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a59
+          enum: &a60
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         account_manager_id:
@@ -4917,7 +4909,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         industry:
@@ -4943,6 +4935,9 @@ components:
           type: string
         client_type:
           type: string
+          enum:
+            - company
+            - individual
         tax_id_number:
           type: string
         notes:
@@ -5064,7 +5059,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a62
+          enum: &a63
             - asc
             - desc
         search:
@@ -5094,12 +5089,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a63
+          enum: &a64
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         client_name:
@@ -5167,7 +5162,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         limit:
@@ -5179,12 +5174,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a66
+          enum: &a67
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a67
+          enum: &a68
             - "true"
             - "false"
         client_id:
@@ -5204,7 +5199,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a68
+          enum: &a69
             - asc
             - desc
         search:
@@ -5231,17 +5226,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a69
+          enum: &a70
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         start_date_from:
@@ -5608,6 +5603,9 @@ components:
               type:
                 - string
                 - "null"
+              enum: &a8
+                - company
+                - individual
             tax_id_number:
               type:
                 - string
@@ -5807,6 +5805,7 @@ components:
                 type:
                   - string
                   - "null"
+                enum: *a8
               tax_id_number:
                 type:
                   - string
@@ -6386,7 +6385,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a72
+          enum: &a73
             - asc
             - desc
         search:
@@ -6422,19 +6421,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a73
+          enum: &a74
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         clients_count_min:
@@ -6447,19 +6446,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6941,7 +6940,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a79
+          enum: &a80
             - pdf
             - markdown
             - md
@@ -7557,7 +7556,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a80
+          enum: &a81
             - asc
             - desc
         search:
@@ -7586,22 +7585,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a81
+          enum: &a82
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         date_from:
@@ -7610,13 +7609,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a85
+          enum: &a86
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a86
+          enum: &a87
             - "true"
             - "false"
         as_of_date:
@@ -7632,27 +7631,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a87
+          enum: &a98
             - asc
             - desc
         include_items:
           type: string
-          enum: &a88
+          enum: &a99
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a89
+          enum: &a100
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a90
+          enum: &a101
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a91
+          enum: &a102
             - "true"
             - "false"
         q:
@@ -7663,11 +7662,134 @@ components:
           type: string
         format:
           type: string
-          enum: &a92
+          enum: &a103
             - json
             - csv
       additionalProperties:
         type: string
+    FinancialInvoiceListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
+        order:
+          type: string
+          enum: &a88
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches invoice_number or client name.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a89
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: &a90
+            - draft
+            - sent
+            - paid
+            - overdue
+            - cancelled
+            - pending
+            - prepayment
+            - partially_applied
+        billing_cycle_id:
+          type: string
+          format: uuid
+        due_date_from:
+          type: string
+        due_date_to:
+          type: string
+        amount_min:
+          type: string
+        amount_max:
+          type: string
+        is_manual:
+          type: string
+          enum: &a91
+            - "true"
+            - "false"
+        has_credit_applied:
+          type: string
+          enum: &a92
+            - "true"
+            - "false"
+    FinancialPaymentMethodListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
+        order:
+          type: string
+          enum: &a93
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches client name or card last4.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a94
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: &a95
+            - credit_card
+            - bank_account
+        is_default:
+          type: string
+          enum: &a96
+            - "true"
+            - "false"
+        exclude_deleted:
+          type: string
+          enum: &a97
+            - "true"
+            - "false"
+          description: Exclude soft-deleted payment methods. Defaults to true.
+    InvoicePdfBinary:
+      type: string
+      format: binary
+      description: Raw PDF file bytes (application/pdf).
     InvoiceExecutionIdQuery:
       type: object
       properties:
@@ -8628,12 +8750,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a93
+          enum: &a104
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a94
+          enum: &a105
             - "true"
             - "false"
         client_id:
@@ -8660,7 +8782,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a106
             - asc
             - desc
     PriorityIdParam:
@@ -8728,17 +8850,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a96
+          enum: &a107
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a97
+          enum: &a108
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a98
+          enum: &a109
             - "true"
             - "false"
         matchBy:
@@ -8748,7 +8870,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a99
+          enum: &a110
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -8895,7 +9017,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a100
+          enum: &a111
             - "true"
             - "false"
     WorkflowImportBody:
@@ -9881,7 +10003,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a101
+          enum: &a112
             - "true"
             - "false"
         search:
@@ -9890,7 +10012,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a102
+          enum: &a113
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -9902,7 +10024,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a103
+          enum: &a114
             - pending
             - in_progress
             - completed
@@ -9911,7 +10033,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a104
+          enum: &a115
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10636,7 +10758,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a105
+          enum: &a116
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -10951,7 +11073,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a117
             - asc
             - desc
         search:
@@ -10978,19 +11100,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a107
+          enum: &a118
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a108
+          enum: &a119
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a109
+          enum: &a120
             - "true"
             - "false"
         offset:
@@ -10999,17 +11121,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a110
+          enum: &a121
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a111
+          enum: &a122
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a112
+          enum: &a123
             - service
             - ticket
     CategoryMoveRequest:
@@ -11036,7 +11158,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a113
+          enum: &a124
             - service
             - ticket
         board_id:
@@ -11044,7 +11166,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a114
+          enum: &a125
             - "true"
             - "false"
         limit:
@@ -11058,7 +11180,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a115
+          enum: &a126
             - service
             - ticket
         board_id:
@@ -11072,7 +11194,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a116
+          enum: &a127
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11693,7 +11815,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a122
+          enum: &a133
             - asc
             - desc
         name:
@@ -11704,24 +11826,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a123
+          enum: &a134
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a124
+          enum: &a135
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a125
+          enum: &a136
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a126
+          enum: &a137
             - "true"
             - "false"
         last_delivery_from:
@@ -11755,7 +11877,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a127
+          enum: &a138
             - pending
             - delivered
             - failed
@@ -13517,7 +13639,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a128
+          enum: &a139
             - asc
             - desc
         fields:
@@ -13822,7 +13944,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a129
+          enum: &a140
             - asc
             - desc
         search:
@@ -13831,12 +13953,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a130
+          enum: &a141
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a131
+          enum: &a142
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -20027,7 +20149,6 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a2
             description: Asset type stored in assets.asset_type.
           required: false
           description: Asset type stored in assets.asset_type.
@@ -20428,7 +20549,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Filter to these asset types. Repeat the param or pass a
               comma-separated list.
           required: false
@@ -20746,7 +20867,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Optional asset type filters.
           required: false
           description: Optional asset type filters.
@@ -22854,7 +22975,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a4
+            enum: *a3
             description: Filter by execution status.
           required: false
           description: Filter by execution status.
@@ -22904,7 +23025,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by automation trigger type.
           required: false
           description: Filter by automation trigger type.
@@ -23202,7 +23323,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a6
+            enum: *a5
             description: Filter by automation rule status.
           required: false
           description: Filter by automation rule status.
@@ -23210,7 +23331,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by trigger type.
           required: false
           description: Filter by trigger type.
@@ -23218,7 +23339,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a7
+            enum: *a6
             description: Filter by priority level.
           required: false
           description: Filter by priority level.
@@ -24727,24 +24848,25 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a58
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_tax_exempt
           in: query
@@ -24771,7 +24893,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: has_credit_limit
           in: query
@@ -25305,7 +25427,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: order
           in: query
@@ -25366,13 +25488,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: has_client
           in: query
@@ -25679,7 +25801,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: include_inactive
           in: query
@@ -25739,13 +25861,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: include_inactive
           in: query
@@ -25865,7 +25987,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: order
           in: query
@@ -25917,19 +26039,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: is_contractd
           in: query
@@ -26107,7 +26229,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: order
           in: query
@@ -26159,13 +26281,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_active
           in: query
@@ -26176,7 +26298,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: has_services
           in: query
@@ -26202,7 +26324,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26210,7 +26332,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26218,7 +26340,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27541,7 +27663,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29119,7 +29241,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -29182,25 +29304,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -29216,13 +29338,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -29501,11 +29623,11 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/invoices:
     get:
-      summary: List financial invoices (transaction list wiring)
-      description: Route file maps to ApiFinancialController.list(), which is
-        transaction-oriented (resource financial/transactions) rather than
-        invoice-specific list logic. Current response is the generic transaction
-        list envelope with financial report links.
+      summary: List invoices
+      description: Returns a paginated list of invoices for the tenant. Maps to
+        ApiFinancialController.listInvoices() → FinancialService.listInvoices(),
+        filtered and sorted by the supplied query parameters. Each item carries
+        the invoice record (including client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29516,8 +29638,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listInvoices()
       x-alga-products:
         - psa
       parameters:
@@ -29533,18 +29654,26 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, invoice_number,
+              invoice_date, due_date, total_amount, status (defaults to
+              created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a88
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches invoice_number or client name.
           required: false
+          description: Matches invoice_number or client name.
           name: search
           in: query
         - schema:
@@ -29569,25 +29698,37 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a89
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: type
-          in: query
-        - schema:
-            type: string
+            enum: *a90
           required: false
           name: status
+          in: query
+        - schema:
+            type: string
+            format: uuid
+          required: false
+          name: billing_cycle_id
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_from
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_to
           in: query
         - schema:
             type: string
@@ -29601,58 +29742,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a91
           required: false
-          name: include_expired
+          name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a92
           required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          name: has_credit_applied
           in: query
       responses:
         "200":
-          description: Paginated financial list returned.
+          description: Paginated invoice list returned.
           content:
             application/json:
               schema:
@@ -29827,10 +29929,12 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/payment-methods:
     get:
-      summary: List payment methods (transaction list wiring)
-      description: Current route wiring calls ApiFinancialController.list(), which
-        lists transaction records and not payment methods. This discrepancy is
-        documented as implementation behavior.
+      summary: List payment methods
+      description: Returns a paginated list of payment methods for the tenant. Maps to
+        ApiFinancialController.listPaymentMethods() →
+        FinancialService.listPaymentMethods(). Soft-deleted methods are excluded
+        by default. Each item carries the payment method record (including
+        client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29841,8 +29945,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listPaymentMethods()
       x-alga-products:
         - psa
       parameters:
@@ -29858,18 +29961,24 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, type, is_default
+              (defaults to created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a93
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches client name or card last4.
           required: false
+          description: Matches client name or card last4.
           name: search
           in: query
         - schema:
@@ -29894,90 +30003,39 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a94
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
+            enum: *a95
           required: false
           name: type
           in: query
         - schema:
             type: string
+            enum: *a96
           required: false
-          name: status
+          name: is_default
           in: query
         - schema:
             type: string
+            enum: *a97
+            description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
-          name: amount_min
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: amount_max
-          in: query
-        - schema:
-            type: string
-            enum: *a81
-          required: false
-          name: include_expired
-          in: query
-        - schema:
-            type: string
-            enum: *a82
-          required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          description: Exclude soft-deleted payment methods. Defaults to true.
+          name: exclude_deleted
           in: query
       responses:
         "200":
-          description: Paginated list returned.
+          description: Paginated payment method list returned.
           content:
             application/json:
               schema:
@@ -30301,7 +30359,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30364,25 +30422,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30398,13 +30456,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30543,7 +30601,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30606,25 +30664,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30640,13 +30698,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30720,7 +30778,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30783,25 +30841,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30817,13 +30875,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30897,7 +30955,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30960,25 +31018,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30994,13 +31052,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31132,7 +31190,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31195,25 +31253,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31229,13 +31287,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31309,7 +31367,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31372,25 +31430,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31406,13 +31464,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31671,31 +31729,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31716,7 +31774,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -31839,31 +31897,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31884,7 +31942,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32162,31 +32220,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32207,7 +32265,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32640,31 +32698,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32685,7 +32743,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32758,31 +32816,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32803,7 +32861,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -33714,9 +33772,9 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/invoices/{id}/pdf:
     post:
-      summary: Generate invoice PDF asset
-      description: Generates/refreshes invoice PDF metadata and returns file_id plus
-        optional download_url.
+      summary: Generate and download invoice PDF
+      description: Generates the invoice PDF and returns the raw PDF file as an
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33726,7 +33784,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33742,11 +33800,11 @@ paths:
           in: path
       responses:
         "200":
-          description: PDF generation metadata returned.
+          description: PDF file returned as an application/pdf attachment.
           content:
-            application/json:
+            application/pdf:
               schema:
-                $ref: "#/components/schemas/FinancialInvoiceApiSuccess"
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33760,7 +33818,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
@@ -33778,9 +33836,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
     get:
-      summary: Redirect to invoice PDF download
-      description: Attempts to generate/load PDF metadata and redirects to
-        download_url when present.
+      summary: Download invoice PDF
+      description: Generates (when needed) and returns the invoice PDF as a raw
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33790,8 +33848,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
-        x-redirect-response: true
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33806,8 +33863,12 @@ paths:
           name: id
           in: path
       responses:
-        "307":
-          description: Redirect to generated PDF URL.
+        "200":
+          description: PDF file returned as an application/pdf attachment.
+          content:
+            application/pdf:
+              schema:
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33821,13 +33882,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "404":
-          description: PDF URL unavailable or invoice not found.
+          description: Invoice not found.
           content:
             application/json:
               schema:
@@ -34818,13 +34879,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a104
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a105
           required: false
           name: is_security_relevant
           in: query
@@ -34914,7 +34975,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a106
           required: false
           name: order
           in: query
@@ -35369,19 +35430,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a96
+            enum: *a107
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a108
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a109
           required: false
           name: updateExisting
           in: query
@@ -35442,7 +35503,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a99
+            enum: *a110
           required: false
           name: preview
           in: query
@@ -36044,7 +36105,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a100
+            enum: *a111
           required: false
           name: force
           in: query
@@ -40655,7 +40716,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -40671,7 +40732,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41032,7 +41093,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41048,7 +41109,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41592,7 +41653,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41608,7 +41669,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41681,7 +41742,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41697,7 +41758,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42200,7 +42261,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42216,7 +42277,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42465,13 +42526,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -42800,7 +42861,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42816,7 +42877,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43005,7 +43066,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43021,7 +43082,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43094,7 +43155,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43110,7 +43171,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43477,7 +43538,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43493,7 +43554,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44045,7 +44106,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44061,7 +44122,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44135,7 +44196,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44151,7 +44212,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44662,7 +44723,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44678,7 +44739,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44931,13 +44992,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -45271,7 +45332,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45287,7 +45348,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -45478,7 +45539,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45494,7 +45555,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -46085,7 +46146,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a116
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46460,7 +46521,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a117
           required: false
           name: order
           in: query
@@ -46512,13 +46573,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a107
+            enum: *a118
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a119
           required: false
           name: is_child
           in: query
@@ -46529,7 +46590,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a120
           required: false
           name: active
           in: query
@@ -46545,19 +46606,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a110
+            enum: *a121
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a122
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a123
           required: false
           name: category_type
           in: query
@@ -47013,7 +47074,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47025,7 +47086,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a125
           required: false
           name: include_inactive
           in: query
@@ -47100,7 +47161,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a115
+            enum: *a126
           required: false
           name: category_type
           in: query
@@ -47124,7 +47185,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a127
           required: false
           name: include_usage
           in: query
@@ -47210,7 +47271,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a117
+      tags: &a128
         - Services
         - Service Catalog
       security:
@@ -47286,7 +47347,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a118
+            enum: &a129
               - fixed
               - hourly
               - usage
@@ -47334,7 +47395,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47363,7 +47424,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47425,7 +47486,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47474,7 +47535,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47512,7 +47573,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47573,7 +47634,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47622,7 +47683,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a119
+      tags: &a130
         - Products
         - Service Catalog
       security:
@@ -47733,7 +47794,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47762,7 +47823,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a120
+                  enum: &a131
                     - usage
                   default: usage
                 default_rate:
@@ -47901,7 +47962,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47950,7 +48011,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47988,7 +48049,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a120
+                  enum: *a131
                   default: usage
                 default_rate:
                   type: number
@@ -48127,7 +48188,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48175,7 +48236,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a121
+      tags: &a132
         - Service Types
         - Service Catalog
       security:
@@ -48236,7 +48297,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a121
+      tags: *a132
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48317,7 +48378,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a133
           required: false
           name: order
           in: query
@@ -48338,25 +48399,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a134
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a135
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a136
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a126
+            enum: *a137
           required: false
           name: has_failures
           in: query
@@ -49387,7 +49448,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a138
           required: false
           name: status
           in: query
@@ -51505,7 +51566,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51806,7 +51867,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51890,7 +51951,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51974,7 +52035,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52067,7 +52128,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52165,7 +52226,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52468,7 +52529,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52565,7 +52626,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52823,7 +52884,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52913,7 +52974,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53057,7 +53118,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53352,7 +53413,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53443,7 +53504,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53587,7 +53648,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54022,7 +54083,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54333,7 +54394,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54759,7 +54820,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54843,7 +54904,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55028,7 +55089,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55113,7 +55174,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55479,7 +55540,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55577,7 +55638,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56305,7 +56366,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56447,7 +56508,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56756,7 +56817,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56899,7 +56960,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57042,7 +57103,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57199,7 +57260,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57482,7 +57543,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57626,7 +57687,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58061,7 +58122,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58264,7 +58325,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58350,7 +58411,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58793,7 +58854,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59264,7 +59325,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59992,7 +60053,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60008,13 +60069,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -60083,7 +60144,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60099,13 +60160,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61520,7 +61581,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61536,13 +61597,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61615,7 +61676,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61631,13 +61692,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -1969,14 +1969,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "status": {
@@ -2052,14 +2044,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
           },
@@ -2145,14 +2130,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type. Determines the optional extension data table."
           },
           "asset_tag": {
@@ -2220,14 +2197,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type to store in assets.asset_type."
           },
           "asset_tag": {
@@ -2582,14 +2551,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Asset type stored in assets.asset_type."
           },
           "asset_tag": {
@@ -3710,14 +3671,6 @@
           },
           "asset_type": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ],
             "description": "Related asset type from joined related_assets, present in list responses."
           },
           "status": {
@@ -3852,14 +3805,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ]
+              "description": "Asset type slug from the tenant asset type registry."
             },
             "description": "Optional asset type filters."
           },
@@ -6930,7 +6876,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "billing_cycle": {
             "type": "string",
@@ -7008,7 +6958,11 @@
             "type": "string"
           },
           "client_type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "company",
+              "individual"
+            ]
           },
           "tax_id_number": {
             "type": "string"
@@ -7945,6 +7899,10 @@
                 "type": [
                   "string",
                   "null"
+                ],
+                "enum": [
+                  "company",
+                  "individual"
                 ]
               },
               "tax_id_number": {
@@ -8222,6 +8180,10 @@
                   "type": [
                     "string",
                     "null"
+                  ],
+                  "enum": [
+                    "company",
+                    "individual"
                   ]
                 },
                 "tax_id_number": {
@@ -10843,6 +10805,174 @@
         "additionalProperties": {
           "type": "string"
         }
+      },
+      "FinancialInvoiceListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches invoice_number or client name."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "sent",
+              "paid",
+              "overdue",
+              "cancelled",
+              "pending",
+              "prepayment",
+              "partially_applied"
+            ]
+          },
+          "billing_cycle_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "due_date_from": {
+            "type": "string"
+          },
+          "due_date_to": {
+            "type": "string"
+          },
+          "amount_min": {
+            "type": "string"
+          },
+          "amount_max": {
+            "type": "string"
+          },
+          "is_manual": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "has_credit_applied": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          }
+        }
+      },
+      "FinancialPaymentMethodListQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "search": {
+            "type": "string",
+            "description": "Matches client name or card last4."
+          },
+          "created_from": {
+            "type": "string"
+          },
+          "created_to": {
+            "type": "string"
+          },
+          "updated_from": {
+            "type": "string"
+          },
+          "updated_to": {
+            "type": "string"
+          },
+          "is_active": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "credit_card",
+              "bank_account"
+            ]
+          },
+          "is_default": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "exclude_deleted": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ],
+            "description": "Exclude soft-deleted payment methods. Defaults to true."
+          }
+        }
+      },
+      "InvoicePdfBinary": {
+        "type": "string",
+        "format": "binary",
+        "description": "Raw PDF file bytes (application/pdf)."
       },
       "InvoiceExecutionIdQuery": {
         "type": "object",
@@ -28810,14 +28940,6 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "workstation",
-                "network_device",
-                "server",
-                "mobile_device",
-                "printer",
-                "unknown"
-              ],
               "description": "Asset type stored in assets.asset_type."
             },
             "required": false,
@@ -29379,14 +29501,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
             },
@@ -29804,14 +29919,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "workstation",
-                  "network_device",
-                  "server",
-                  "mobile_device",
-                  "printer",
-                  "unknown"
-                ]
+                "description": "Asset type slug from the tenant asset type registry."
               },
               "description": "Optional asset type filters."
             },
@@ -35494,7 +35602,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "company",
+                "individual"
+              ]
             },
             "required": false,
             "name": "client_type",
@@ -42729,8 +42841,8 @@
     },
     "/api/v1/financial/invoices": {
       "get": {
-        "summary": "List financial invoices (transaction list wiring)",
-        "description": "Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.",
+        "summary": "List invoices",
+        "description": "Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -42745,8 +42857,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listInvoices()"
         },
         "x-alga-products": [
           "psa"
@@ -42770,9 +42881,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -42790,9 +42903,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches invoice_number or client name."
             },
             "required": false,
+            "description": "Matches invoice_number or client name.",
             "name": "search",
             "in": "query"
           },
@@ -42831,6 +42946,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -42840,26 +42967,44 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "type",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "draft",
+                "sent",
+                "paid",
+                "overdue",
+                "cancelled",
+                "pending",
+                "prepayment",
+                "partially_applied"
+              ]
             },
             "required": false,
             "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "billing_cycle_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "due_date_to",
             "in": "query"
           },
           {
@@ -42887,7 +43032,7 @@
               ]
             },
             "required": false,
-            "name": "include_expired",
+            "name": "is_manual",
             "in": "query"
           },
           {
@@ -42899,86 +43044,13 @@
               ]
             },
             "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "name": "has_credit_applied",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated financial list returned.",
+            "description": "Paginated invoice list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -43245,8 +43317,8 @@
     },
     "/api/v1/financial/payment-methods": {
       "get": {
-        "summary": "List payment methods (transaction list wiring)",
-        "description": "Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.",
+        "summary": "List payment methods",
+        "description": "Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.",
         "tags": [
           "Financial"
         ],
@@ -43261,8 +43333,7 @@
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "financial",
           "x-rbac-action": "read",
-          "x-route-to-controller-mismatch": true,
-          "x-controller-method": "ApiFinancialController.list()"
+          "x-controller-method": "ApiFinancialController.listPaymentMethods()"
         },
         "x-alga-products": [
           "psa"
@@ -43286,9 +43357,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
             },
             "required": false,
+            "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).",
             "name": "sort",
             "in": "query"
           },
@@ -43306,9 +43379,11 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Matches client name or card last4."
             },
             "required": false,
+            "description": "Matches client name or card last4.",
             "name": "search",
             "in": "query"
           },
@@ -43347,6 +43422,18 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "is_active",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid"
             },
             "required": false,
@@ -43356,15 +43443,10 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
-            },
-            "required": false,
-            "name": "invoice_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
+              "enum": [
+                "credit_card",
+                "bank_account"
+              ]
             },
             "required": false,
             "name": "type",
@@ -43372,26 +43454,14 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
             "required": false,
-            "name": "status",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_min",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "amount_max",
+            "name": "is_default",
             "in": "query"
           },
           {
@@ -43400,101 +43470,18 @@
               "enum": [
                 "true",
                 "false"
-              ]
+              ],
+              "description": "Exclude soft-deleted payment methods. Defaults to true."
             },
             "required": false,
-            "name": "include_expired",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "expiring_soon",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_remaining",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "has_expiration",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "date_to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ]
-            },
-            "required": false,
-            "name": "group_by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
-            },
-            "required": false,
-            "name": "include_projections",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "as_of_date",
+            "description": "Exclude soft-deleted payment methods. Defaults to true.",
+            "name": "exclude_deleted",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Paginated list returned.",
+            "description": "Paginated payment method list returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49569,8 +49556,8 @@
     },
     "/api/v1/invoices/{id}/pdf": {
       "post": {
-        "summary": "Generate invoice PDF asset",
-        "description": "Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.",
+        "summary": "Generate and download invoice PDF",
+        "description": "Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49584,7 +49571,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf"
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49604,11 +49591,11 @@
         ],
         "responses": {
           "200": {
-            "description": "PDF generation metadata returned.",
+            "description": "PDF file returned as an application/pdf attachment.",
             "content": {
-              "application/json": {
+              "application/pdf": {
                 "schema": {
-                  "$ref": "#/components/schemas/FinancialInvoiceApiSuccess"
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
                 }
               }
             }
@@ -49634,7 +49621,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49666,8 +49653,8 @@
         }
       },
       "get": {
-        "summary": "Redirect to invoice PDF download",
-        "description": "Attempts to generate/load PDF metadata and redirects to download_url when present.",
+        "summary": "Download invoice PDF",
+        "description": "Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.",
         "tags": [
           "Invoices"
         ],
@@ -49681,8 +49668,7 @@
           "x-auth-mechanism": "x-api-key header validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; otherwise tenant inferred from key)",
           "x-rbac-resource": "invoice",
-          "x-rbac-action": "pdf",
-          "x-redirect-response": true
+          "x-rbac-action": "read"
         },
         "x-alga-products": [
           "psa"
@@ -49701,8 +49687,15 @@
           }
         ],
         "responses": {
-          "307": {
-            "description": "Redirect to generated PDF URL."
+          "200": {
+            "description": "PDF file returned as an application/pdf attachment.",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoicePdfBinary"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid invoice id.",
@@ -49725,7 +49718,7 @@
             }
           },
           "403": {
-            "description": "invoice:pdf permission denied.",
+            "description": "invoice:read permission denied.",
             "content": {
               "application/json": {
                 "schema": {
@@ -49735,7 +49728,7 @@
             }
           },
           "404": {
-            "description": "PDF URL unavailable or invoice not found.",
+            "description": "Invoice not found.",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -1324,13 +1324,6 @@ components:
           description: Client location UUID from client_locations.location_id.
         asset_type:
           type: string
-          enum: &a2
-            - workstation
-            - network_device
-            - server
-            - mobile_device
-            - printer
-            - unknown
           description: Asset type stored in assets.asset_type.
         status:
           type: string
@@ -1392,7 +1385,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Filter to these asset types. Repeat the param or pass a
             comma-separated list.
         statuses:
@@ -1459,7 +1452,6 @@ components:
           description: Client UUID from clients.client_id. Required.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type. Determines the optional extension data table.
         asset_tag:
           type: string
@@ -1513,7 +1505,6 @@ components:
           description: Client UUID to assign to the asset.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type to store in assets.asset_type.
         asset_tag:
           type: string
@@ -1771,7 +1762,6 @@ components:
           description: Client UUID from assets.client_id.
         asset_type:
           type: string
-          enum: *a2
           description: Asset type stored in assets.asset_type.
         asset_tag:
           type: string
@@ -2587,7 +2577,6 @@ components:
             responses.
         asset_type:
           type: string
-          enum: *a2
           description: Related asset type from joined related_assets, present in list
             responses.
         status:
@@ -2685,7 +2674,7 @@ components:
           type: array
           items:
             type: string
-            enum: *a2
+            description: Asset type slug from the tenant asset type registry.
           description: Optional asset type filters.
         statuses:
           type: array
@@ -3333,7 +3322,7 @@ components:
           description: Filter executions by parent automation rule UUID.
         status:
           type: string
-          enum: &a4
+          enum: &a3
             - pending
             - running
             - completed
@@ -3367,7 +3356,7 @@ components:
             by validation.
         trigger_type:
           type: string
-          enum: &a3
+          enum: &a2
             - time_based
             - event_based
             - condition_based
@@ -3425,7 +3414,7 @@ components:
           description: Optional rule name filter.
         status:
           type: string
-          enum: &a6
+          enum: &a5
             - active
             - inactive
             - draft
@@ -3433,11 +3422,11 @@ components:
           description: Filter by automation rule status.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Filter by trigger type.
         priority:
           type: string
-          enum: &a7
+          enum: &a6
             - low
             - normal
             - high
@@ -3610,7 +3599,7 @@ components:
           description: Trigger payload captured when execution started.
         status:
           type: string
-          enum: *a4
+          enum: *a3
           description: Current execution status.
         started_at:
           type: string
@@ -3770,13 +3759,13 @@ components:
               type: array
               items:
                 type: string
-                enum: *a3
+                enum: *a2
               description: Valid automation trigger types.
             action_types:
               type: array
               items:
                 type: string
-                enum: &a5
+                enum: &a4
                   - email_notification
                   - sms_notification
                   - webhook_call
@@ -3804,7 +3793,7 @@ components:
               type: array
               items:
                 type: string
-                enum: *a4
+                enum: *a3
               description: Valid automation execution statuses.
             priority_levels:
               type: array
@@ -3889,7 +3878,7 @@ components:
       properties:
         type:
           type: string
-          enum: *a5
+          enum: *a4
           description: Automation action type.
         config:
           type: object
@@ -3952,15 +3941,15 @@ components:
             - "null"
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Current automation rule status.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Current automation rule priority.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
           description: Trigger type used to start rule execution.
         trigger_config:
           type: object
@@ -4051,15 +4040,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4070,7 +4059,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: &a8
+          enum: &a7
             - and
             - or
         actions:
@@ -4115,15 +4104,15 @@ components:
           type: string
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Defaults to draft when omitted.
         priority:
           type: string
-          enum: *a7
+          enum: *a6
           description: Defaults to normal when omitted.
         trigger_type:
           type: string
-          enum: *a3
+          enum: *a2
         trigger_config:
           type: object
           additionalProperties: {}
@@ -4134,7 +4123,7 @@ components:
             $ref: "#/components/schemas/AutomationRuleCondition"
         condition_logic:
           type: string
-          enum: *a8
+          enum: *a7
         actions:
           type: array
           items:
@@ -4193,7 +4182,7 @@ components:
           description: Rule UUIDs from automation_rules.rule_id.
         status:
           type: string
-          enum: *a6
+          enum: *a5
           description: Status to apply to each provided rule id.
       required:
         - ids
@@ -4580,7 +4569,7 @@ components:
                 - bulk_status_update
             status:
               type: string
-              enum: *a6
+              enum: *a5
             rule_ids:
               type: array
               items:
@@ -4886,9 +4875,12 @@ components:
           type: string
         client_type:
           type: string
+          enum: &a58
+            - company
+            - individual
         billing_cycle:
           type: string
-          enum: &a58
+          enum: &a59
             - weekly
             - bi-weekly
             - monthly
@@ -4897,12 +4889,12 @@ components:
             - annually
         is_inactive:
           type: string
-          enum: &a59
+          enum: &a60
             - "true"
             - "false"
         is_tax_exempt:
           type: string
-          enum: &a60
+          enum: &a61
             - "true"
             - "false"
         account_manager_id:
@@ -4916,7 +4908,7 @@ components:
           type: string
         has_credit_limit:
           type: string
-          enum: &a61
+          enum: &a62
             - "true"
             - "false"
         industry:
@@ -4942,6 +4934,9 @@ components:
           type: string
         client_type:
           type: string
+          enum:
+            - company
+            - individual
         tax_id_number:
           type: string
         notes:
@@ -5063,7 +5058,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a62
+          enum: &a63
             - asc
             - desc
         search:
@@ -5093,12 +5088,12 @@ components:
           type: string
         is_inactive:
           type: string
-          enum: &a63
+          enum: &a64
             - "true"
             - "false"
         has_client:
           type: string
-          enum: &a64
+          enum: &a65
             - "true"
             - "false"
         client_name:
@@ -5166,7 +5161,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a65
+          enum: &a66
             - "true"
             - "false"
         limit:
@@ -5178,12 +5173,12 @@ components:
       properties:
         format:
           type: string
-          enum: &a66
+          enum: &a67
             - csv
             - json
         include_inactive:
           type: string
-          enum: &a67
+          enum: &a68
             - "true"
             - "false"
         client_id:
@@ -5203,7 +5198,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a68
+          enum: &a69
             - asc
             - desc
         search:
@@ -5230,17 +5225,17 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a69
+          enum: &a70
             - "true"
             - "false"
         has_custom_rate:
           type: string
-          enum: &a70
+          enum: &a71
             - "true"
             - "false"
         is_contractd:
           type: string
-          enum: &a71
+          enum: &a72
             - "true"
             - "false"
         start_date_from:
@@ -5607,6 +5602,9 @@ components:
               type:
                 - string
                 - "null"
+              enum: &a8
+                - company
+                - individual
             tax_id_number:
               type:
                 - string
@@ -5806,6 +5804,7 @@ components:
                 type:
                   - string
                   - "null"
+                enum: *a8
               tax_id_number:
                 type:
                   - string
@@ -6385,7 +6384,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a72
+          enum: &a73
             - asc
             - desc
         search:
@@ -6421,19 +6420,19 @@ components:
             - annually
         is_custom:
           type: string
-          enum: &a73
+          enum: &a74
             - "true"
             - "false"
         is_active:
           type: string
-          enum: &a74
+          enum: &a75
             - "true"
             - "false"
         service_category:
           type: string
         has_services:
           type: string
-          enum: &a75
+          enum: &a76
             - "true"
             - "false"
         clients_count_min:
@@ -6446,19 +6445,19 @@ components:
           type: string
         include_services:
           type: string
-          enum: &a76
+          enum: &a77
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_usage:
           type: string
-          enum: &a77
+          enum: &a78
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
         include_clients:
           type: string
-          enum: &a78
+          enum: &a79
             - "true"
             - "false"
           description: Controller-level include flag parsed directly from query string.
@@ -6940,7 +6939,7 @@ components:
       properties:
         format:
           type: string
-          enum: &a79
+          enum: &a80
             - pdf
             - markdown
             - md
@@ -7556,7 +7555,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a80
+          enum: &a81
             - asc
             - desc
         search:
@@ -7585,22 +7584,22 @@ components:
           type: string
         include_expired:
           type: string
-          enum: &a81
+          enum: &a82
             - "true"
             - "false"
         expiring_soon:
           type: string
-          enum: &a82
+          enum: &a83
             - "true"
             - "false"
         has_remaining:
           type: string
-          enum: &a83
+          enum: &a84
             - "true"
             - "false"
         has_expiration:
           type: string
-          enum: &a84
+          enum: &a85
             - "true"
             - "false"
         date_from:
@@ -7609,13 +7608,13 @@ components:
           type: string
         group_by:
           type: string
-          enum: &a85
+          enum: &a86
             - day
             - week
             - month
         include_projections:
           type: string
-          enum: &a86
+          enum: &a87
             - "true"
             - "false"
         as_of_date:
@@ -7631,27 +7630,27 @@ components:
           type: string
         order:
           type: string
-          enum: &a87
+          enum: &a98
             - asc
             - desc
         include_items:
           type: string
-          enum: &a88
+          enum: &a99
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a89
+          enum: &a100
             - "true"
             - "false"
         include_billing_cycle:
           type: string
-          enum: &a90
+          enum: &a101
             - "true"
             - "false"
         include_transactions:
           type: string
-          enum: &a91
+          enum: &a102
             - "true"
             - "false"
         q:
@@ -7662,11 +7661,134 @@ components:
           type: string
         format:
           type: string
-          enum: &a92
+          enum: &a103
             - json
             - csv
       additionalProperties:
         type: string
+    FinancialInvoiceListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
+        order:
+          type: string
+          enum: &a88
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches invoice_number or client name.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a89
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: &a90
+            - draft
+            - sent
+            - paid
+            - overdue
+            - cancelled
+            - pending
+            - prepayment
+            - partially_applied
+        billing_cycle_id:
+          type: string
+          format: uuid
+        due_date_from:
+          type: string
+        due_date_to:
+          type: string
+        amount_min:
+          type: string
+        amount_max:
+          type: string
+        is_manual:
+          type: string
+          enum: &a91
+            - "true"
+            - "false"
+        has_credit_applied:
+          type: string
+          enum: &a92
+            - "true"
+            - "false"
+    FinancialPaymentMethodListQuery:
+      type: object
+      properties:
+        page:
+          type: string
+        limit:
+          type: string
+        sort:
+          type: string
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
+        order:
+          type: string
+          enum: &a93
+            - asc
+            - desc
+        search:
+          type: string
+          description: Matches client name or card last4.
+        created_from:
+          type: string
+        created_to:
+          type: string
+        updated_from:
+          type: string
+        updated_to:
+          type: string
+        is_active:
+          type: string
+          enum: &a94
+            - "true"
+            - "false"
+        client_id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: &a95
+            - credit_card
+            - bank_account
+        is_default:
+          type: string
+          enum: &a96
+            - "true"
+            - "false"
+        exclude_deleted:
+          type: string
+          enum: &a97
+            - "true"
+            - "false"
+          description: Exclude soft-deleted payment methods. Defaults to true.
+    InvoicePdfBinary:
+      type: string
+      format: binary
+      description: Raw PDF file bytes (application/pdf).
     InvoiceExecutionIdQuery:
       type: object
       properties:
@@ -8627,12 +8749,12 @@ components:
           type: string
         is_managed:
           type: string
-          enum: &a93
+          enum: &a104
             - "true"
             - "false"
         is_security_relevant:
           type: string
-          enum: &a94
+          enum: &a105
             - "true"
             - "false"
         client_id:
@@ -8659,7 +8781,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a95
+          enum: &a106
             - asc
             - desc
     PriorityIdParam:
@@ -8727,17 +8849,17 @@ components:
       properties:
         preview:
           type: string
-          enum: &a96
+          enum: &a107
             - "true"
             - "false"
         createNew:
           type: string
-          enum: &a97
+          enum: &a108
             - "true"
             - "false"
         updateExisting:
           type: string
-          enum: &a98
+          enum: &a109
             - "true"
             - "false"
         matchBy:
@@ -8747,7 +8869,7 @@ components:
       properties:
         preview:
           type: string
-          enum: &a99
+          enum: &a110
             - "true"
             - "false"
     AccountingBatchIdParam:
@@ -8894,7 +9016,7 @@ components:
       properties:
         force:
           type: string
-          enum: &a100
+          enum: &a111
             - "true"
             - "false"
     WorkflowImportBody:
@@ -9880,7 +10002,7 @@ components:
           type: string
         active:
           type: string
-          enum: &a101
+          enum: &a112
             - "true"
             - "false"
         search:
@@ -9889,7 +10011,7 @@ components:
           type: string
         force_refresh:
           type: string
-          enum: &a102
+          enum: &a113
             - "true"
             - "false"
     QuickBooksV1SyncHistoryQuery:
@@ -9901,7 +10023,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a103
+          enum: &a114
             - pending
             - in_progress
             - completed
@@ -9910,7 +10032,7 @@ components:
             - partial
         operation_type:
           type: string
-          enum: &a104
+          enum: &a115
             - customer_sync
             - invoice_export
             - invoice_import
@@ -10635,7 +10757,7 @@ components:
           description: Opaque pagination cursor copied from a prior response's nextCursor.
         sort:
           type: string
-          enum: &a105
+          enum: &a116
             - relevance
             - recent
           description: Result ordering. "relevance" (default) ranks by full-text score;
@@ -10950,7 +11072,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a106
+          enum: &a117
             - asc
             - desc
         search:
@@ -10977,19 +11099,19 @@ components:
           format: uuid
         is_parent:
           type: string
-          enum: &a107
+          enum: &a118
             - "true"
             - "false"
         is_child:
           type: string
-          enum: &a108
+          enum: &a119
             - "true"
             - "false"
         depth:
           type: string
         active:
           type: string
-          enum: &a109
+          enum: &a120
             - "true"
             - "false"
         offset:
@@ -10998,17 +11120,17 @@ components:
           type: string
         sort_order:
           type: string
-          enum: &a110
+          enum: &a121
             - asc
             - desc
         include_hierarchy:
           type: string
-          enum: &a111
+          enum: &a122
             - "true"
             - "false"
         category_type:
           type: string
-          enum: &a112
+          enum: &a123
             - service
             - ticket
     CategoryMoveRequest:
@@ -11035,7 +11157,7 @@ components:
           minLength: 1
         category_type:
           type: string
-          enum: &a113
+          enum: &a124
             - service
             - ticket
         board_id:
@@ -11043,7 +11165,7 @@ components:
           format: uuid
         include_inactive:
           type: string
-          enum: &a114
+          enum: &a125
             - "true"
             - "false"
         limit:
@@ -11057,7 +11179,7 @@ components:
       properties:
         category_type:
           type: string
-          enum: &a115
+          enum: &a126
             - service
             - ticket
         board_id:
@@ -11071,7 +11193,7 @@ components:
           format: date-time
         include_usage:
           type: string
-          enum: &a116
+          enum: &a127
             - "true"
             - "false"
     CategoryAnalyticsResponse:
@@ -11692,7 +11814,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a122
+          enum: &a133
             - asc
             - desc
         name:
@@ -11703,24 +11825,24 @@ components:
           type: string
         is_active:
           type: string
-          enum: &a123
+          enum: &a134
             - "true"
             - "false"
         is_test_mode:
           type: string
-          enum: &a124
+          enum: &a135
             - "true"
             - "false"
         payload_format:
           type: string
-          enum: &a125
+          enum: &a136
             - json
             - xml
             - form_data
             - custom
         has_failures:
           type: string
-          enum: &a126
+          enum: &a137
             - "true"
             - "false"
         last_delivery_from:
@@ -11754,7 +11876,7 @@ components:
           type: string
         status:
           type: string
-          enum: &a127
+          enum: &a138
             - pending
             - delivered
             - failed
@@ -13516,7 +13638,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a128
+          enum: &a139
             - asc
             - desc
         fields:
@@ -13821,7 +13943,7 @@ components:
           type: string
         order:
           type: string
-          enum: &a129
+          enum: &a140
             - asc
             - desc
         search:
@@ -13830,12 +13952,12 @@ components:
           type: string
         include_items:
           type: string
-          enum: &a130
+          enum: &a141
             - "true"
             - "false"
         include_client:
           type: string
-          enum: &a131
+          enum: &a142
             - "true"
             - "false"
     QuotesContractsGenericBodyV1:
@@ -20026,7 +20148,6 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a2
             description: Asset type stored in assets.asset_type.
           required: false
           description: Asset type stored in assets.asset_type.
@@ -20427,7 +20548,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Filter to these asset types. Repeat the param or pass a
               comma-separated list.
           required: false
@@ -20745,7 +20866,7 @@ paths:
             type: array
             items:
               type: string
-              enum: *a2
+              description: Asset type slug from the tenant asset type registry.
             description: Optional asset type filters.
           required: false
           description: Optional asset type filters.
@@ -22853,7 +22974,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a4
+            enum: *a3
             description: Filter by execution status.
           required: false
           description: Filter by execution status.
@@ -22903,7 +23024,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by automation trigger type.
           required: false
           description: Filter by automation trigger type.
@@ -23201,7 +23322,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a6
+            enum: *a5
             description: Filter by automation rule status.
           required: false
           description: Filter by automation rule status.
@@ -23209,7 +23330,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a3
+            enum: *a2
             description: Filter by trigger type.
           required: false
           description: Filter by trigger type.
@@ -23217,7 +23338,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a7
+            enum: *a6
             description: Filter by priority level.
           required: false
           description: Filter by priority level.
@@ -24726,24 +24847,25 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a58
           required: false
           name: client_type
           in: query
         - schema:
             type: string
-            enum: *a58
+            enum: *a59
           required: false
           name: billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a59
+            enum: *a60
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a60
+            enum: *a61
           required: false
           name: is_tax_exempt
           in: query
@@ -24770,7 +24892,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a61
+            enum: *a62
           required: false
           name: has_credit_limit
           in: query
@@ -25304,7 +25426,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a62
+            enum: *a63
           required: false
           name: order
           in: query
@@ -25365,13 +25487,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a63
+            enum: *a64
           required: false
           name: is_inactive
           in: query
         - schema:
             type: string
-            enum: *a64
+            enum: *a65
           required: false
           name: has_client
           in: query
@@ -25678,7 +25800,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a65
+            enum: *a66
           required: false
           name: include_inactive
           in: query
@@ -25738,13 +25860,13 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a66
+            enum: *a67
           required: false
           name: format
           in: query
         - schema:
             type: string
-            enum: *a67
+            enum: *a68
           required: false
           name: include_inactive
           in: query
@@ -25864,7 +25986,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a68
+            enum: *a69
           required: false
           name: order
           in: query
@@ -25916,19 +26038,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a69
+            enum: *a70
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a70
+            enum: *a71
           required: false
           name: has_custom_rate
           in: query
         - schema:
             type: string
-            enum: *a71
+            enum: *a72
           required: false
           name: is_contractd
           in: query
@@ -26106,7 +26228,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a72
+            enum: *a73
           required: false
           name: order
           in: query
@@ -26158,13 +26280,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a73
+            enum: *a74
           required: false
           name: is_custom
           in: query
         - schema:
             type: string
-            enum: *a74
+            enum: *a75
           required: false
           name: is_active
           in: query
@@ -26175,7 +26297,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a75
+            enum: *a76
           required: false
           name: has_services
           in: query
@@ -26201,7 +26323,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a76
+            enum: *a77
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26209,7 +26331,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a77
+            enum: *a78
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -26217,7 +26339,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a78
+            enum: *a79
             description: Controller-level include flag parsed directly from query string.
           required: false
           description: Controller-level include flag parsed directly from query string.
@@ -27540,7 +27662,7 @@ paths:
           in: path
         - schema:
             type: string
-            enum: *a79
+            enum: *a80
             description: Optional export format. pdf generates a PDF; markdown or md exports
               markdown; omitted downloads the original stored file.
           required: false
@@ -29118,7 +29240,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -29181,25 +29303,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -29215,13 +29337,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -29500,11 +29622,11 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/invoices:
     get:
-      summary: List financial invoices (transaction list wiring)
-      description: Route file maps to ApiFinancialController.list(), which is
-        transaction-oriented (resource financial/transactions) rather than
-        invoice-specific list logic. Current response is the generic transaction
-        list envelope with financial report links.
+      summary: List invoices
+      description: Returns a paginated list of invoices for the tenant. Maps to
+        ApiFinancialController.listInvoices() → FinancialService.listInvoices(),
+        filtered and sorted by the supplied query parameters. Each item carries
+        the invoice record (including client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29515,8 +29637,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listInvoices()
       x-alga-products:
         - psa
       parameters:
@@ -29532,18 +29653,26 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, invoice_number,
+              invoice_date, due_date, total_amount, status (defaults to
+              created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, invoice_number,
+            invoice_date, due_date, total_amount, status (defaults to
+            created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a88
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches invoice_number or client name.
           required: false
+          description: Matches invoice_number or client name.
           name: search
           in: query
         - schema:
@@ -29568,25 +29697,37 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a89
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: type
-          in: query
-        - schema:
-            type: string
+            enum: *a90
           required: false
           name: status
+          in: query
+        - schema:
+            type: string
+            format: uuid
+          required: false
+          name: billing_cycle_id
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_from
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: due_date_to
           in: query
         - schema:
             type: string
@@ -29600,58 +29741,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a91
           required: false
-          name: include_expired
+          name: is_manual
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a92
           required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          name: has_credit_applied
           in: query
       responses:
         "200":
-          description: Paginated financial list returned.
+          description: Paginated invoice list returned.
           content:
             application/json:
               schema:
@@ -29826,10 +29928,12 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/financial/payment-methods:
     get:
-      summary: List payment methods (transaction list wiring)
-      description: Current route wiring calls ApiFinancialController.list(), which
-        lists transaction records and not payment methods. This discrepancy is
-        documented as implementation behavior.
+      summary: List payment methods
+      description: Returns a paginated list of payment methods for the tenant. Maps to
+        ApiFinancialController.listPaymentMethods() →
+        FinancialService.listPaymentMethods(). Soft-deleted methods are excluded
+        by default. Each item carries the payment method record (including
+        client_name) plus HATEOAS links.
       tags:
         - Financial
       security:
@@ -29840,8 +29944,7 @@ paths:
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: financial
         x-rbac-action: read
-        x-route-to-controller-mismatch: true
-        x-controller-method: ApiFinancialController.list()
+        x-controller-method: ApiFinancialController.listPaymentMethods()
       x-alga-products:
         - psa
       parameters:
@@ -29857,18 +29960,24 @@ paths:
           in: query
         - schema:
             type: string
+            description: Sort field. One of created_at, updated_at, type, is_default
+              (defaults to created_at).
           required: false
+          description: Sort field. One of created_at, updated_at, type, is_default
+            (defaults to created_at).
           name: sort
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a93
           required: false
           name: order
           in: query
         - schema:
             type: string
+            description: Matches client name or card last4.
           required: false
+          description: Matches client name or card last4.
           name: search
           in: query
         - schema:
@@ -29893,90 +30002,39 @@ paths:
           in: query
         - schema:
             type: string
+            enum: *a94
+          required: false
+          name: is_active
+          in: query
+        - schema:
+            type: string
             format: uuid
           required: false
           name: client_id
           in: query
         - schema:
             type: string
-            format: uuid
-          required: false
-          name: invoice_id
-          in: query
-        - schema:
-            type: string
+            enum: *a95
           required: false
           name: type
           in: query
         - schema:
             type: string
+            enum: *a96
           required: false
-          name: status
+          name: is_default
           in: query
         - schema:
             type: string
+            enum: *a97
+            description: Exclude soft-deleted payment methods. Defaults to true.
           required: false
-          name: amount_min
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: amount_max
-          in: query
-        - schema:
-            type: string
-            enum: *a81
-          required: false
-          name: include_expired
-          in: query
-        - schema:
-            type: string
-            enum: *a82
-          required: false
-          name: expiring_soon
-          in: query
-        - schema:
-            type: string
-            enum: *a83
-          required: false
-          name: has_remaining
-          in: query
-        - schema:
-            type: string
-            enum: *a84
-          required: false
-          name: has_expiration
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_from
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: date_to
-          in: query
-        - schema:
-            type: string
-            enum: *a85
-          required: false
-          name: group_by
-          in: query
-        - schema:
-            type: string
-            enum: *a86
-          required: false
-          name: include_projections
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: as_of_date
+          description: Exclude soft-deleted payment methods. Defaults to true.
+          name: exclude_deleted
           in: query
       responses:
         "200":
-          description: Paginated list returned.
+          description: Paginated payment method list returned.
           content:
             application/json:
               schema:
@@ -30300,7 +30358,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30363,25 +30421,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30397,13 +30455,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30542,7 +30600,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30605,25 +30663,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30639,13 +30697,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30719,7 +30777,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30782,25 +30840,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30816,13 +30874,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -30896,7 +30954,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -30959,25 +31017,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -30993,13 +31051,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31131,7 +31189,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31194,25 +31252,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31228,13 +31286,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31308,7 +31366,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a80
+            enum: *a81
           required: false
           name: order
           in: query
@@ -31371,25 +31429,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a81
+            enum: *a82
           required: false
           name: include_expired
           in: query
         - schema:
             type: string
-            enum: *a82
+            enum: *a83
           required: false
           name: expiring_soon
           in: query
         - schema:
             type: string
-            enum: *a83
+            enum: *a84
           required: false
           name: has_remaining
           in: query
         - schema:
             type: string
-            enum: *a84
+            enum: *a85
           required: false
           name: has_expiration
           in: query
@@ -31405,13 +31463,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a85
+            enum: *a86
           required: false
           name: group_by
           in: query
         - schema:
             type: string
-            enum: *a86
+            enum: *a87
           required: false
           name: include_projections
           in: query
@@ -31670,31 +31728,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31715,7 +31773,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -31838,31 +31896,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -31883,7 +31941,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32161,31 +32219,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32206,7 +32264,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32639,31 +32697,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32684,7 +32742,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -32757,31 +32815,31 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a87
+            enum: *a98
           required: false
           name: order
           in: query
         - schema:
             type: string
-            enum: *a88
+            enum: *a99
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a89
+            enum: *a100
           required: false
           name: include_client
           in: query
         - schema:
             type: string
-            enum: *a90
+            enum: *a101
           required: false
           name: include_billing_cycle
           in: query
         - schema:
             type: string
-            enum: *a91
+            enum: *a102
           required: false
           name: include_transactions
           in: query
@@ -32802,7 +32860,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a92
+            enum: *a103
           required: false
           name: format
           in: query
@@ -33713,9 +33771,9 @@ paths:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
   /api/v1/invoices/{id}/pdf:
     post:
-      summary: Generate invoice PDF asset
-      description: Generates/refreshes invoice PDF metadata and returns file_id plus
-        optional download_url.
+      summary: Generate and download invoice PDF
+      description: Generates the invoice PDF and returns the raw PDF file as an
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33725,7 +33783,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33741,11 +33799,11 @@ paths:
           in: path
       responses:
         "200":
-          description: PDF generation metadata returned.
+          description: PDF file returned as an application/pdf attachment.
           content:
-            application/json:
+            application/pdf:
               schema:
-                $ref: "#/components/schemas/FinancialInvoiceApiSuccess"
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33759,7 +33817,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
@@ -33777,9 +33835,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
     get:
-      summary: Redirect to invoice PDF download
-      description: Attempts to generate/load PDF metadata and redirects to
-        download_url when present.
+      summary: Download invoice PDF
+      description: Generates (when needed) and returns the invoice PDF as a raw
+        application/pdf attachment.
       tags:
         - Invoices
       security:
@@ -33789,8 +33847,7 @@ paths:
         x-auth-mechanism: x-api-key header validated in ApiBaseController.authenticate()
         x-tenant-header: x-tenant-id (optional; otherwise tenant inferred from key)
         x-rbac-resource: invoice
-        x-rbac-action: pdf
-        x-redirect-response: true
+        x-rbac-action: read
       x-alga-products:
         - psa
       parameters:
@@ -33805,8 +33862,12 @@ paths:
           name: id
           in: path
       responses:
-        "307":
-          description: Redirect to generated PDF URL.
+        "200":
+          description: PDF file returned as an application/pdf attachment.
+          content:
+            application/pdf:
+              schema:
+                $ref: "#/components/schemas/InvoicePdfBinary"
         "400":
           description: Invalid invoice id.
           content:
@@ -33820,13 +33881,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "403":
-          description: invoice:pdf permission denied.
+          description: invoice:read permission denied.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/FinancialInvoiceApiError"
         "404":
-          description: PDF URL unavailable or invoice not found.
+          description: Invoice not found.
           content:
             application/json:
               schema:
@@ -34817,13 +34878,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a93
+            enum: *a104
           required: false
           name: is_managed
           in: query
         - schema:
             type: string
-            enum: *a94
+            enum: *a105
           required: false
           name: is_security_relevant
           in: query
@@ -34913,7 +34974,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a95
+            enum: *a106
           required: false
           name: order
           in: query
@@ -35368,19 +35429,19 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a96
+            enum: *a107
           required: false
           name: preview
           in: query
         - schema:
             type: string
-            enum: *a97
+            enum: *a108
           required: false
           name: createNew
           in: query
         - schema:
             type: string
-            enum: *a98
+            enum: *a109
           required: false
           name: updateExisting
           in: query
@@ -35441,7 +35502,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a99
+            enum: *a110
           required: false
           name: preview
           in: query
@@ -36043,7 +36104,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a100
+            enum: *a111
           required: false
           name: force
           in: query
@@ -40654,7 +40715,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -40670,7 +40731,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41031,7 +41092,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41047,7 +41108,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41591,7 +41652,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41607,7 +41668,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -41680,7 +41741,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -41696,7 +41757,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42199,7 +42260,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42215,7 +42276,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -42464,13 +42525,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -42799,7 +42860,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -42815,7 +42876,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43004,7 +43065,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43020,7 +43081,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43093,7 +43154,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43109,7 +43170,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -43476,7 +43537,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -43492,7 +43553,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44044,7 +44105,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44060,7 +44121,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44134,7 +44195,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44150,7 +44211,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44661,7 +44722,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -44677,7 +44738,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -44930,13 +44991,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a103
+            enum: *a114
           required: false
           name: status
           in: query
         - schema:
             type: string
-            enum: *a104
+            enum: *a115
           required: false
           name: operation_type
           in: query
@@ -45270,7 +45331,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45286,7 +45347,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -45477,7 +45538,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a101
+            enum: *a112
           required: false
           name: active
           in: query
@@ -45493,7 +45554,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a102
+            enum: *a113
           required: false
           name: force_refresh
           in: query
@@ -46084,7 +46145,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a105
+            enum: *a116
             description: Result ordering. "relevance" (default) ranks by full-text score;
               "recent" orders by last update.
           required: false
@@ -46459,7 +46520,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a106
+            enum: *a117
           required: false
           name: order
           in: query
@@ -46511,13 +46572,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a107
+            enum: *a118
           required: false
           name: is_parent
           in: query
         - schema:
             type: string
-            enum: *a108
+            enum: *a119
           required: false
           name: is_child
           in: query
@@ -46528,7 +46589,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a109
+            enum: *a120
           required: false
           name: active
           in: query
@@ -46544,19 +46605,19 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a110
+            enum: *a121
           required: false
           name: sort_order
           in: query
         - schema:
             type: string
-            enum: *a111
+            enum: *a122
           required: false
           name: include_hierarchy
           in: query
         - schema:
             type: string
-            enum: *a112
+            enum: *a123
           required: false
           name: category_type
           in: query
@@ -47012,7 +47073,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a113
+            enum: *a124
           required: false
           name: category_type
           in: query
@@ -47024,7 +47085,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a114
+            enum: *a125
           required: false
           name: include_inactive
           in: query
@@ -47099,7 +47160,7 @@ paths:
       parameters:
         - schema:
             type: string
-            enum: *a115
+            enum: *a126
           required: false
           name: category_type
           in: query
@@ -47123,7 +47184,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a116
+            enum: *a127
           required: false
           name: include_usage
           in: query
@@ -47209,7 +47270,7 @@ paths:
         this endpoint to inspect existing service catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new service.
-      tags: &a117
+      tags: &a128
         - Services
         - Service Catalog
       security:
@@ -47285,7 +47346,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: &a118
+            enum: &a129
               - fixed
               - hourly
               - usage
@@ -47333,7 +47394,7 @@ paths:
         with GET /api/v1/service-types and category_id with GET
         /api/v1/categories/service before calling this endpoint. Use this
         endpoint for fixed, hourly, or usage-based service offerings.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47362,7 +47423,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47424,7 +47485,7 @@ paths:
     get:
       summary: Get service
       description: Returns a single service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47473,7 +47534,7 @@ paths:
     put:
       summary: Update service
       description: Updates a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47511,7 +47572,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a118
+                  enum: *a129
                 default_rate:
                   type: number
                   minimum: 0
@@ -47572,7 +47633,7 @@ paths:
     delete:
       summary: Delete service
       description: Deletes a service catalog entry by UUID.
-      tags: *a117
+      tags: *a128
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47621,7 +47682,7 @@ paths:
         this endpoint to inspect existing product catalog records and to gather
         prerequisite IDs such as custom_service_type_id and category_id before
         creating a new product.
-      tags: &a119
+      tags: &a130
         - Products
         - Service Catalog
       security:
@@ -47732,7 +47793,7 @@ paths:
         /api/v1/categories/service before calling this endpoint. Products are
         catalog entries with item_kind product and always use billing_method
         usage.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47761,7 +47822,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: &a120
+                  enum: &a131
                     - usage
                   default: usage
                 default_rate:
@@ -47900,7 +47961,7 @@ paths:
     get:
       summary: Get product
       description: Returns a single product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47949,7 +48010,7 @@ paths:
     put:
       summary: Update product
       description: Updates a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -47987,7 +48048,7 @@ paths:
                   format: uuid
                 billing_method:
                   type: string
-                  enum: *a120
+                  enum: *a131
                   default: usage
                 default_rate:
                   type: number
@@ -48126,7 +48187,7 @@ paths:
     delete:
       summary: Delete product
       description: Deletes a product catalog entry by UUID.
-      tags: *a119
+      tags: *a130
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48174,7 +48235,7 @@ paths:
       description: Returns tenant service types. Use this endpoint to resolve
         custom_service_type_id before creating or updating services and products
         in the service catalog.
-      tags: &a121
+      tags: &a132
         - Service Types
         - Service Catalog
       security:
@@ -48235,7 +48296,7 @@ paths:
     get:
       summary: Get service type
       description: Returns a single tenant service type by UUID.
-      tags: *a121
+      tags: *a132
       security:
         - ApiKeyAuth: []
       extensions:
@@ -48316,7 +48377,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a122
+            enum: *a133
           required: false
           name: order
           in: query
@@ -48337,25 +48398,25 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a123
+            enum: *a134
           required: false
           name: is_active
           in: query
         - schema:
             type: string
-            enum: *a124
+            enum: *a135
           required: false
           name: is_test_mode
           in: query
         - schema:
             type: string
-            enum: *a125
+            enum: *a136
           required: false
           name: payload_format
           in: query
         - schema:
             type: string
-            enum: *a126
+            enum: *a137
           required: false
           name: has_failures
           in: query
@@ -49386,7 +49447,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a127
+            enum: *a138
           required: false
           name: status
           in: query
@@ -51504,7 +51565,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51805,7 +51866,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51889,7 +51950,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -51973,7 +52034,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52066,7 +52127,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52164,7 +52225,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52467,7 +52528,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52564,7 +52625,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52822,7 +52883,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -52912,7 +52973,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53056,7 +53117,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53351,7 +53412,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53442,7 +53503,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -53586,7 +53647,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54021,7 +54082,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54332,7 +54393,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54758,7 +54819,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -54842,7 +54903,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55027,7 +55088,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55112,7 +55173,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55478,7 +55539,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -55576,7 +55637,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56304,7 +56365,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56446,7 +56507,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56755,7 +56816,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -56898,7 +56959,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57041,7 +57102,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57198,7 +57259,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57481,7 +57542,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -57625,7 +57686,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58060,7 +58121,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58263,7 +58324,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58349,7 +58410,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -58792,7 +58853,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59263,7 +59324,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a128
+            enum: *a139
           required: false
           name: order
           in: query
@@ -59991,7 +60052,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60007,13 +60068,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -60082,7 +60143,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -60098,13 +60159,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61519,7 +61580,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61535,13 +61596,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query
@@ -61614,7 +61675,7 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a129
+            enum: *a140
           required: false
           name: order
           in: query
@@ -61630,13 +61691,13 @@ paths:
           in: query
         - schema:
             type: string
-            enum: *a130
+            enum: *a141
           required: false
           name: include_items
           in: query
         - schema:
             type: string
-            enum: *a131
+            enum: *a142
           required: false
           name: include_client
           in: query

--- a/server/src/app/api/v1/financial/invoices/route.ts
+++ b/server/src/app/api/v1/financial/invoices/route.ts
@@ -7,7 +7,7 @@ import { ApiFinancialController } from 'server/src/lib/api/controllers/ApiFinanc
 
 export async function GET(request: Request) {
   const controller = new ApiFinancialController();
-  return await controller.list()(request as any);
+  return await controller.listInvoices()(request as any);
 }
 
 export const runtime = 'nodejs';

--- a/server/src/app/api/v1/financial/payment-methods/route.ts
+++ b/server/src/app/api/v1/financial/payment-methods/route.ts
@@ -8,7 +8,7 @@ import { ApiFinancialController } from 'server/src/lib/api/controllers/ApiFinanc
 
 export async function GET(request: Request) {
   const controller = new ApiFinancialController();
-  return await controller.list()(request as any);
+  return await controller.listPaymentMethods()(request as any);
 }
 
 export async function POST(request: Request) {

--- a/server/src/app/api/webhooks/alternative-payments/route.ts
+++ b/server/src/app/api/webhooks/alternative-payments/route.ts
@@ -1,0 +1,308 @@
+import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createTenantKnex } from '@alga-psa/db';
+import logger from '@alga-psa/core/logger';
+import { recordExternalPayment } from '@alga-psa/billing/services/accountingSync/recordExternalPayment';
+
+const PROVIDER = 'alternative_payments';
+const SUCCESS_STATUSES = new Set(['paid', 'completed', 'succeeded', 'success']);
+
+type JsonRecord = Record<string, any>;
+
+function getNested(payload: JsonRecord, path: string[]): any {
+  let current: any = payload;
+  for (const key of path) {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+function firstValue(payload: JsonRecord, paths: string[][]): any {
+  for (const path of paths) {
+    const value = getNested(payload, path);
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function extractTenantId(req: NextRequest, payload: JsonRecord): string | null {
+  return (
+    req.headers.get('x-tenant-id') ||
+    firstValue(payload, [
+      ['tenant_id'],
+      ['tenantId'],
+      ['data', 'tenant_id'],
+      ['data', 'tenantId'],
+      ['metadata', 'tenant_id'],
+      ['metadata', 'tenantId'],
+      ['data', 'metadata', 'tenant_id'],
+      ['data', 'metadata', 'tenantId'],
+    ]) ||
+    null
+  );
+}
+
+function extractEventId(payload: JsonRecord): string | null {
+  return (
+    firstValue(payload, [
+      ['event_id'],
+      ['eventId'],
+      ['id'],
+      ['data', 'event_id'],
+      ['data', 'eventId'],
+      ['data', 'id'],
+    ]) || null
+  );
+}
+
+function extractInvoiceId(payload: JsonRecord): string | null {
+  return (
+    firstValue(payload, [
+      ['invoice_id'],
+      ['invoiceId'],
+      ['data', 'invoice_id'],
+      ['data', 'invoiceId'],
+      ['metadata', 'invoice_id'],
+      ['metadata', 'invoiceId'],
+      ['data', 'metadata', 'invoice_id'],
+      ['data', 'metadata', 'invoiceId'],
+    ]) || null
+  );
+}
+
+function extractStatus(payload: JsonRecord): string | null {
+  const status = firstValue(payload, [
+    ['status'],
+    ['payment_status'],
+    ['paymentStatus'],
+    ['data', 'status'],
+    ['data', 'payment_status'],
+    ['data', 'paymentStatus'],
+  ]);
+  return status ? String(status).toLowerCase() : null;
+}
+
+function extractEventType(payload: JsonRecord): string {
+  return String(firstValue(payload, [
+    ['event_type'],
+    ['eventType'],
+    ['type'],
+    ['data', 'event_type'],
+    ['data', 'eventType'],
+    ['data', 'type'],
+  ]) || 'payment.updated');
+}
+
+function extractAmountCents(payload: JsonRecord): number | null {
+  const amount = firstValue(payload, [
+    ['amount_cents'],
+    ['amountCents'],
+    ['amount_in_cents'],
+    ['amountInCents'],
+    ['data', 'amount_cents'],
+    ['data', 'amountCents'],
+    ['data', 'amount_in_cents'],
+    ['data', 'amountInCents'],
+  ]);
+
+  const parsed = Number(amount);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : null;
+}
+
+function extractCurrency(payload: JsonRecord): string | undefined {
+  const currency = firstValue(payload, [
+    ['currency'],
+    ['data', 'currency'],
+    ['payment', 'currency'],
+    ['data', 'payment', 'currency'],
+  ]);
+  return currency ? String(currency).toUpperCase() : undefined;
+}
+
+function extractReferenceNumber(payload: JsonRecord, eventId: string): string {
+  return String(firstValue(payload, [
+    ['payment_id'],
+    ['paymentId'],
+    ['transaction_id'],
+    ['transactionId'],
+    ['data', 'payment_id'],
+    ['data', 'paymentId'],
+    ['data', 'transaction_id'],
+    ['data', 'transactionId'],
+  ]) || eventId);
+}
+
+function timingSafeEqualHex(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'hex');
+  const rightBuffer = Buffer.from(right, 'hex');
+  return leftBuffer.length === rightBuffer.length && crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function verifySignature(body: string, signature: string | null): boolean {
+  const secret = process.env.ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET;
+  if (!secret) {
+    return true;
+  }
+
+  if (!signature) {
+    return false;
+  }
+
+  const normalized = signature.startsWith('sha256=')
+    ? signature.slice('sha256='.length)
+    : signature;
+  const expected = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  return timingSafeEqualHex(normalized, expected);
+}
+
+async function insertWebhookEvent(knex: any, tenant: string, eventId: string, eventType: string, payload: JsonRecord) {
+  const hasTable = await knex.schema.hasTable('payment_webhook_events');
+  if (!hasTable) {
+    return { inserted: true, eventRecordId: null };
+  }
+
+  const inserted = await knex('payment_webhook_events')
+    .insert({
+      tenant,
+      provider_type: PROVIDER,
+      external_event_id: eventId,
+      event_type: eventType,
+      event_data: JSON.stringify(payload),
+      processed: false,
+      processing_status: 'pending',
+    })
+    .onConflict(['tenant', 'provider_type', 'external_event_id'])
+    .ignore()
+    .returning('event_id');
+
+  return {
+    inserted: inserted.length > 0,
+    eventRecordId: inserted[0]?.event_id ?? null,
+  };
+}
+
+async function updateWebhookEvent(knex: any, tenant: string, eventId: string, status: 'completed' | 'failed') {
+  const hasTable = await knex.schema.hasTable('payment_webhook_events');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex('payment_webhook_events')
+    .where({ tenant, provider_type: PROVIDER, external_event_id: eventId })
+    .update({
+      processed: status === 'completed',
+      processing_status: status,
+      processed_at: knex.fn.now(),
+    });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const signature = req.headers.get('x-alternative-payments-signature')
+    || req.headers.get('x-ap-signature')
+    || req.headers.get('x-webhook-signature');
+
+  if (!verifySignature(body, signature)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  let payload: JsonRecord;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const tenant = extractTenantId(req, payload);
+  const eventId = extractEventId(payload);
+  const eventType = extractEventType(payload);
+  const status = extractStatus(payload);
+  const invoiceId = extractInvoiceId(payload);
+  const amount = extractAmountCents(payload);
+
+  if (!tenant || !eventId) {
+    return NextResponse.json({ error: 'Missing tenant_id or event_id' }, { status: 400 });
+  }
+
+  const { knex } = await createTenantKnex(tenant);
+  const webhookEvent = await insertWebhookEvent(knex, tenant, eventId, eventType, payload);
+
+  if (!webhookEvent.inserted) {
+    return NextResponse.json({
+      received: true,
+      processed: true,
+      eventId,
+      duplicate: true,
+    });
+  }
+
+  if (!status || !SUCCESS_STATUSES.has(status)) {
+    await updateWebhookEvent(knex, tenant, eventId, 'completed');
+    return NextResponse.json({
+      received: true,
+      processed: false,
+      eventId,
+      reason: 'non_success_status',
+      status,
+    });
+  }
+
+  if (!invoiceId || !amount) {
+    await updateWebhookEvent(knex, tenant, eventId, 'failed');
+    return NextResponse.json({ error: 'Missing invoice_id or amount_cents' }, { status: 400 });
+  }
+
+  const result = await recordExternalPayment(knex, tenant, {
+    invoiceId,
+    amount,
+    provider: PROVIDER,
+    referenceNumber: extractReferenceNumber(payload, eventId),
+    currency: extractCurrency(payload),
+    paymentDate: new Date(),
+    notes: `Alternative Payments webhook ${eventId}`,
+    transactionMetadata: {
+      provider_event_id: eventId,
+      provider_event_type: eventType,
+    },
+  });
+
+  await updateWebhookEvent(knex, tenant, eventId, result.success ? 'completed' : 'failed');
+
+  if (!result.success) {
+    logger.warn('[Alternative Payments Webhook] payment processing failed', { tenant, eventId, error: result.error });
+    return NextResponse.json({
+      received: true,
+      processed: false,
+      eventId,
+      error: result.error,
+    });
+  }
+
+  return NextResponse.json({
+    received: true,
+    processed: true,
+    eventId,
+    paymentRecorded: result.paymentRecorded,
+    paymentId: result.paymentId,
+    invoiceId,
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    provider: PROVIDER,
+    message: 'Alternative Payments webhook endpoint is active',
+    signature: process.env.ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET ? 'configured' : 'not_configured',
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/server/src/lib/api/controllers/ApiFinancialController.ts
+++ b/server/src/lib/api/controllers/ApiFinancialController.ts
@@ -434,6 +434,43 @@ export class ApiFinancialController extends ApiBaseController {
     };
   }
 
+  /**
+   * GET /api/v1/financial/payment-methods - List payment methods
+   */
+  listPaymentMethods() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, 'read');
+
+          const url = new URL(apiRequest.url);
+          const query: Record<string, any> = {};
+          url.searchParams.forEach((value, key) => {
+            query[key] = value;
+          });
+
+          const validatedQuery = paymentMethodListQuerySchema.parse(query);
+          const result = await this.financialService.listPaymentMethods(validatedQuery, apiRequest.context!);
+
+          return createPaginatedResponse(
+            result.data,
+            result.total,
+            validatedQuery.page || 1,
+            validatedQuery.limit || 25,
+            {
+              filters: validatedQuery,
+              resource: 'financial/payment-methods'
+            }
+          );
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
   // ============================================================================
   // CONTRACT LINE ENDPOINTS
   // ============================================================================
@@ -754,6 +791,43 @@ export class ApiFinancialController extends ApiBaseController {
                 credits: '/api/v1/financial/credits',
                 invoices: '/api/v1/financial/invoices'
               }
+            }
+          );
+        });
+      } catch (error) {
+        return handleApiError(error);
+      }
+    };
+  }
+
+  /**
+   * GET /api/v1/financial/invoices - List invoices for financial operations
+   */
+  listInvoices() {
+    return async (req: NextRequest): Promise<NextResponse> => {
+      try {
+        const apiRequest = await this.authenticate(req);
+
+        return await runWithTenant(apiRequest.context!.tenant, async () => {
+          await this.checkPermission(apiRequest, 'read');
+
+          const url = new URL(apiRequest.url);
+          const query: Record<string, any> = {};
+          url.searchParams.forEach((value, key) => {
+            query[key] = value;
+          });
+
+          const validatedQuery = invoiceListQuerySchema.parse(query);
+          const result = await this.financialService.listInvoices(validatedQuery, apiRequest.context!);
+
+          return createPaginatedResponse(
+            result.data,
+            result.total,
+            validatedQuery.page || 1,
+            validatedQuery.limit || 25,
+            {
+              filters: validatedQuery,
+              resource: 'financial/invoices'
             }
           );
         });

--- a/server/src/lib/api/controllers/ApiInvoiceController.ts
+++ b/server/src/lib/api/controllers/ApiInvoiceController.ts
@@ -451,14 +451,21 @@ export class ApiInvoiceController extends ApiBaseController {
         
         // Run within tenant context
         return await runWithTenant(apiRequest.context.tenant, async () => {
-          // Check permissions
-          await this.checkPermission(apiRequest, 'pdf');
+          // A PDF is a representation of the invoice. Requiring read keeps
+          // machine API access aligned with invoice detail access.
+          await this.checkPermission(apiRequest, 'read');
 
           const id = await this.extractIdFromPath(apiRequest);
           
           const result = await this.invoiceService.generatePDF(id, apiRequest.context);
-          
-          return createSuccessResponse(result);
+
+          return new NextResponse(result.buffer, {
+            headers: {
+              'Content-Type': result.contentType,
+              'Content-Disposition': `attachment; filename="${result.filename}"`,
+              'Cache-Control': 'no-store',
+            },
+          });
         });
       } catch (error) {
         return handleApiError(error);
@@ -477,18 +484,21 @@ export class ApiInvoiceController extends ApiBaseController {
         
         // Run within tenant context
         return await runWithTenant(apiRequest.context.tenant, async () => {
-          // Check permissions
-          await this.checkPermission(apiRequest, 'pdf');
+          // A PDF is a representation of the invoice. Requiring read keeps
+          // machine API access aligned with invoice detail access.
+          await this.checkPermission(apiRequest, 'read');
 
           const id = await this.extractIdFromPath(apiRequest);
           
           const result = await this.invoiceService.generatePDF(id, apiRequest.context);
-          
-          if (result.download_url) {
-            return NextResponse.redirect(result.download_url);
-          }
-          
-          throw new NotFoundError('PDF download URL not available');
+
+          return new NextResponse(result.buffer, {
+            headers: {
+              'Content-Type': result.contentType,
+              'Content-Disposition': `attachment; filename="${result.filename}"`,
+              'Cache-Control': 'no-store',
+            },
+          });
         });
       } catch (error) {
         return handleApiError(error);
@@ -873,13 +883,8 @@ export class ApiInvoiceController extends ApiBaseController {
 
           const id = await this.extractIdFromPath(apiRequest);
           
-          const invoice = await this.invoiceService.getById(id, apiRequest.context, { include_items: true });
-          
-          if (!invoice) {
-            throw new NotFoundError('Invoice not found');
-          }
-          
-          return createSuccessResponse((invoice as any).invoice_charges || []);
+          const items = await this.invoiceService.getInvoiceLineItems(id, apiRequest.context);
+          return createSuccessResponse(items);
         });
       } catch (error) {
         return handleApiError(error);
@@ -903,13 +908,8 @@ export class ApiInvoiceController extends ApiBaseController {
 
           const id = await this.extractIdFromPath(apiRequest);
           
-          const invoice = await this.invoiceService.getById(id, apiRequest.context, { include_transactions: true });
-          
-          if (!invoice) {
-            throw new NotFoundError('Invoice not found');
-          }
-          
-          return createSuccessResponse((invoice as any).transactions || []);
+          const transactions = await this.invoiceService.getInvoiceTransactions(id, apiRequest.context);
+          return createSuccessResponse(transactions);
         });
       } catch (error) {
         return handleApiError(error);

--- a/server/src/lib/api/openapi/routes/financialInvoices.ts
+++ b/server/src/lib/api/openapi/routes/financialInvoices.ts
@@ -98,6 +98,67 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
     }).catchall(zOpenApi.string()),
   );
 
+  const FinancialInvoiceListQuery = registry.registerSchema(
+    'FinancialInvoiceListQuery',
+    zOpenApi.object({
+      page: zOpenApi.string().optional(),
+      limit: zOpenApi.string().optional(),
+      sort: zOpenApi
+        .string()
+        .optional()
+        .describe('Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).'),
+      order: zOpenApi.enum(['asc', 'desc']).optional(),
+      search: zOpenApi.string().optional().describe('Matches invoice_number or client name.'),
+      created_from: zOpenApi.string().optional(),
+      created_to: zOpenApi.string().optional(),
+      updated_from: zOpenApi.string().optional(),
+      updated_to: zOpenApi.string().optional(),
+      is_active: zOpenApi.enum(['true', 'false']).optional(),
+      client_id: zOpenApi.string().uuid().optional(),
+      status: zOpenApi
+        .enum(['draft', 'sent', 'paid', 'overdue', 'cancelled', 'pending', 'prepayment', 'partially_applied'])
+        .optional(),
+      billing_cycle_id: zOpenApi.string().uuid().optional(),
+      due_date_from: zOpenApi.string().optional(),
+      due_date_to: zOpenApi.string().optional(),
+      amount_min: zOpenApi.string().optional(),
+      amount_max: zOpenApi.string().optional(),
+      is_manual: zOpenApi.enum(['true', 'false']).optional(),
+      has_credit_applied: zOpenApi.enum(['true', 'false']).optional(),
+    }),
+  );
+
+  const FinancialPaymentMethodListQuery = registry.registerSchema(
+    'FinancialPaymentMethodListQuery',
+    zOpenApi.object({
+      page: zOpenApi.string().optional(),
+      limit: zOpenApi.string().optional(),
+      sort: zOpenApi
+        .string()
+        .optional()
+        .describe('Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).'),
+      order: zOpenApi.enum(['asc', 'desc']).optional(),
+      search: zOpenApi.string().optional().describe('Matches client name or card last4.'),
+      created_from: zOpenApi.string().optional(),
+      created_to: zOpenApi.string().optional(),
+      updated_from: zOpenApi.string().optional(),
+      updated_to: zOpenApi.string().optional(),
+      is_active: zOpenApi.enum(['true', 'false']).optional(),
+      client_id: zOpenApi.string().uuid().optional(),
+      type: zOpenApi.enum(['credit_card', 'bank_account']).optional(),
+      is_default: zOpenApi.enum(['true', 'false']).optional(),
+      exclude_deleted: zOpenApi
+        .enum(['true', 'false'])
+        .optional()
+        .describe('Exclude soft-deleted payment methods. Defaults to true.'),
+    }),
+  );
+
+  const InvoicePdfBinary = registry.registerSchema(
+    'InvoicePdfBinary',
+    zOpenApi.string().openapi({ format: 'binary' }).describe('Raw PDF file bytes (application/pdf).'),
+  );
+
   const ExecutionIdQuery = registry.registerSchema(
     'InvoiceExecutionIdQuery',
     zOpenApi.object({
@@ -523,14 +584,14 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
   registry.registerRoute({
     method: 'get',
     path: '/api/v1/financial/invoices',
-    summary: 'List financial invoices (transaction list wiring)',
+    summary: 'List invoices',
     description:
-      'Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.',
+      'Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.',
     tags: [financialTag],
     security: [{ ApiKeyAuth: [] }],
-    request: { query: FinancialListQuery },
+    request: { query: FinancialInvoiceListQuery },
     responses: {
-      200: { description: 'Paginated financial list returned.', schema: ApiPaginated },
+      200: { description: 'Paginated invoice list returned.', schema: ApiPaginated },
       400: { description: 'Invalid query parameters.', schema: ApiError },
       401: { description: 'API key missing/invalid.', schema: ApiError },
       403: { description: 'financial:read permission denied.', schema: ApiError },
@@ -540,8 +601,7 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
       ...commonExtensions,
       'x-rbac-resource': 'financial',
       'x-rbac-action': 'read',
-      'x-route-to-controller-mismatch': true,
-      'x-controller-method': 'ApiFinancialController.list()',
+      'x-controller-method': 'ApiFinancialController.listInvoices()',
     },
     edition: 'both',
   });
@@ -609,14 +669,14 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
   registry.registerRoute({
     method: 'get',
     path: '/api/v1/financial/payment-methods',
-    summary: 'List payment methods (transaction list wiring)',
+    summary: 'List payment methods',
     description:
-      'Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.',
+      'Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.',
     tags: [financialTag],
     security: [{ ApiKeyAuth: [] }],
-    request: { query: FinancialListQuery },
+    request: { query: FinancialPaymentMethodListQuery },
     responses: {
-      200: { description: 'Paginated list returned.', schema: ApiPaginated },
+      200: { description: 'Paginated payment method list returned.', schema: ApiPaginated },
       400: { description: 'Invalid query parameters.', schema: ApiError },
       401: { description: 'API key missing/invalid.', schema: ApiError },
       403: { description: 'financial:read permission denied.', schema: ApiError },
@@ -626,8 +686,7 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
       ...commonExtensions,
       'x-rbac-resource': 'financial',
       'x-rbac-action': 'read',
-      'x-route-to-controller-mismatch': true,
-      'x-controller-method': 'ApiFinancialController.list()',
+      'x-controller-method': 'ApiFinancialController.listPaymentMethods()',
     },
     edition: 'both',
   });
@@ -1311,44 +1370,51 @@ export function registerFinancialInvoiceRoutes(registry: ApiOpenApiRegistry) {
   registry.registerRoute({
     method: 'post',
     path: '/api/v1/invoices/{id}/pdf',
-    summary: 'Generate invoice PDF asset',
-    description: 'Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.',
+    summary: 'Generate and download invoice PDF',
+    description: 'Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.',
     tags: [invoiceTag],
     security: [{ ApiKeyAuth: [] }],
     request: { params: UuidIdParam },
     responses: {
-      200: { description: 'PDF generation metadata returned.', schema: ApiSuccess },
+      200: {
+        description: 'PDF file returned as an application/pdf attachment.',
+        contentType: 'application/pdf',
+        schema: InvoicePdfBinary,
+      },
       400: { description: 'Invalid invoice id.', schema: ApiError },
       401: { description: 'API key missing/invalid.', schema: ApiError },
-      403: { description: 'invoice:pdf permission denied.', schema: ApiError },
+      403: { description: 'invoice:read permission denied.', schema: ApiError },
       404: { description: 'Invoice not found.', schema: ApiError },
       500: { description: 'Unexpected PDF generation failure.', schema: ApiError },
     },
-    extensions: { ...commonExtensions, 'x-rbac-resource': 'invoice', 'x-rbac-action': 'pdf' },
+    extensions: { ...commonExtensions, 'x-rbac-resource': 'invoice', 'x-rbac-action': 'read' },
     edition: 'both',
   });
 
   registry.registerRoute({
     method: 'get',
     path: '/api/v1/invoices/{id}/pdf',
-    summary: 'Redirect to invoice PDF download',
-    description: 'Attempts to generate/load PDF metadata and redirects to download_url when present.',
+    summary: 'Download invoice PDF',
+    description: 'Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.',
     tags: [invoiceTag],
     security: [{ ApiKeyAuth: [] }],
     request: { params: UuidIdParam },
     responses: {
-      307: { description: 'Redirect to generated PDF URL.', emptyBody: true },
+      200: {
+        description: 'PDF file returned as an application/pdf attachment.',
+        contentType: 'application/pdf',
+        schema: InvoicePdfBinary,
+      },
       400: { description: 'Invalid invoice id.', schema: ApiError },
       401: { description: 'API key missing/invalid.', schema: ApiError },
-      403: { description: 'invoice:pdf permission denied.', schema: ApiError },
-      404: { description: 'PDF URL unavailable or invoice not found.', schema: ApiError },
+      403: { description: 'invoice:read permission denied.', schema: ApiError },
+      404: { description: 'Invoice not found.', schema: ApiError },
       500: { description: 'Unexpected PDF download failure.', schema: ApiError },
     },
     extensions: {
       ...commonExtensions,
       'x-rbac-resource': 'invoice',
-      'x-rbac-action': 'pdf',
-      'x-redirect-response': true,
+      'x-rbac-action': 'read',
     },
     edition: 'both',
   });

--- a/server/src/lib/api/schemas/financialSchemas.ts
+++ b/server/src/lib/api/schemas/financialSchemas.ts
@@ -1026,6 +1026,7 @@ export type InvoiceListQuery = z.infer<typeof invoiceListQuerySchema>;
 export type CreatePaymentMethodRequest = z.infer<typeof createPaymentMethodSchema>;
 export type UpdatePaymentMethodRequest = z.infer<typeof updatePaymentMethodSchema>;
 export type PaymentMethodResponse = z.infer<typeof paymentMethodResponseSchema>;
+export type PaymentMethodListQuery = z.infer<typeof paymentMethodListQuerySchema>;
 
 export type CreateContractLineRequest = z.infer<typeof createContractLineSchema>;
 export type UpdateContractLineRequest = z.infer<typeof updateContractLineSchema>;

--- a/server/src/lib/api/services/FinancialService.ts
+++ b/server/src/lib/api/services/FinancialService.ts
@@ -54,6 +54,7 @@ import {
   CreatePaymentMethodRequest,
   UpdatePaymentMethodRequest,
   PaymentMethodResponse,
+  PaymentMethodListQuery,
   
   // Contract Line types
   CreateContractLineRequest,
@@ -464,6 +465,132 @@ export class FinancialService extends BaseService<ITransaction> {
     return {
       data: transactionsWithLinks,
       total: parseInt(count as string)
+    };
+  }
+
+  /**
+   * List invoices for financial operations.
+   */
+  async listInvoices(
+    query: InvoiceListQuery,
+    context: ServiceContext
+  ): Promise<ListResult<FinancialResponse<InvoiceResponse>>> {
+    const { knex } = await this.getKnex();
+
+    const {
+      page = 1,
+      limit = 25,
+      client_id,
+      status,
+      billing_cycle_id,
+      due_date_from,
+      due_date_to,
+      amount_min,
+      amount_max,
+      is_manual,
+      has_credit_applied,
+      search,
+      sort = 'created_at',
+      order = 'desc',
+    } = query;
+
+    const sortableFields = new Set([
+      'created_at',
+      'updated_at',
+      'invoice_number',
+      'invoice_date',
+      'due_date',
+      'total_amount',
+      'status',
+    ]);
+    const sortField = sortableFields.has(String(sort)) ? String(sort) : 'created_at';
+
+    let dataQuery = knex('invoices as i')
+      .leftJoin('clients as c', function() {
+        this.on('i.client_id', '=', 'c.client_id')
+          .andOn('i.tenant', '=', 'c.tenant');
+      })
+      .where('i.tenant', context.tenant);
+
+    let countQuery = knex('invoices as i').where('i.tenant', context.tenant);
+
+    if (client_id) {
+      dataQuery = dataQuery.where('i.client_id', client_id);
+      countQuery = countQuery.where('i.client_id', client_id);
+    }
+
+    if (status) {
+      dataQuery = dataQuery.where('i.status', status);
+      countQuery = countQuery.where('i.status', status);
+    }
+
+    if (billing_cycle_id) {
+      dataQuery = dataQuery.where('i.billing_cycle_id', billing_cycle_id);
+      countQuery = countQuery.where('i.billing_cycle_id', billing_cycle_id);
+    }
+
+    if (due_date_from) {
+      dataQuery = dataQuery.where('i.due_date', '>=', due_date_from);
+      countQuery = countQuery.where('i.due_date', '>=', due_date_from);
+    }
+
+    if (due_date_to) {
+      dataQuery = dataQuery.where('i.due_date', '<=', due_date_to);
+      countQuery = countQuery.where('i.due_date', '<=', due_date_to);
+    }
+
+    if (amount_min !== undefined) {
+      dataQuery = dataQuery.where('i.total_amount', '>=', amount_min);
+      countQuery = countQuery.where('i.total_amount', '>=', amount_min);
+    }
+
+    if (amount_max !== undefined) {
+      dataQuery = dataQuery.where('i.total_amount', '<=', amount_max);
+      countQuery = countQuery.where('i.total_amount', '<=', amount_max);
+    }
+
+    if (is_manual !== undefined) {
+      dataQuery = dataQuery.where('i.is_manual', is_manual);
+      countQuery = countQuery.where('i.is_manual', is_manual);
+    }
+
+    if (has_credit_applied !== undefined) {
+      if (has_credit_applied) {
+        dataQuery = dataQuery.where('i.credit_applied', '>', 0);
+        countQuery = countQuery.where('i.credit_applied', '>', 0);
+      } else {
+        dataQuery = dataQuery.where(builder => {
+          builder.whereNull('i.credit_applied').orWhere('i.credit_applied', 0);
+        });
+        countQuery = countQuery.where(builder => {
+          builder.whereNull('i.credit_applied').orWhere('i.credit_applied', 0);
+        });
+      }
+    }
+
+    if (search) {
+      dataQuery = dataQuery.where(builder => {
+        builder.whereILike('i.invoice_number', `%${search}%`)
+          .orWhereILike('c.client_name', `%${search}%`);
+      });
+      countQuery = countQuery.whereILike('i.invoice_number', `%${search}%`);
+    }
+
+    const [invoices, [{ count }]] = await Promise.all([
+      dataQuery
+        .select('i.*', 'c.client_name')
+        .orderBy(`i.${sortField}`, order)
+        .limit(limit)
+        .offset((page - 1) * limit),
+      countQuery.count('* as count'),
+    ]);
+
+    return {
+      data: invoices.map(invoice => ({
+        data: invoice,
+        links: this.generateHATEOASLinks('invoices', invoice.invoice_id, context),
+      })),
+      total: parseInt(count as string, 10),
     };
   }
 
@@ -1141,6 +1268,98 @@ export class FinancialService extends BaseService<ITransaction> {
         ]
       };
     });
+  }
+
+  /**
+   * List payment methods.
+   */
+  async listPaymentMethods(
+    query: PaymentMethodListQuery,
+    context: ServiceContext
+  ): Promise<ListResult<FinancialResponse<PaymentMethodResponse>>> {
+    const { knex } = await this.getKnex();
+
+    const {
+      page = 1,
+      limit = 25,
+      client_id,
+      type,
+      is_default,
+      exclude_deleted = true,
+      search,
+      sort = 'created_at',
+      order = 'desc',
+    } = query;
+
+    const sortableFields = new Set(['created_at', 'updated_at', 'type', 'is_default']);
+    const sortField = sortableFields.has(String(sort)) ? String(sort) : 'created_at';
+
+    let dataQuery = knex('payment_methods as pm')
+      .leftJoin('clients as c', function() {
+        this.on('pm.client_id', '=', 'c.client_id')
+          .andOn('pm.tenant', '=', 'c.tenant');
+      })
+      .where('pm.tenant', context.tenant);
+
+    let countQuery = knex('payment_methods as pm').where('pm.tenant', context.tenant);
+
+    if (client_id) {
+      dataQuery = dataQuery.where('pm.client_id', client_id);
+      countQuery = countQuery.where('pm.client_id', client_id);
+    }
+
+    if (type) {
+      dataQuery = dataQuery.where('pm.type', type);
+      countQuery = countQuery.where('pm.type', type);
+    }
+
+    if (is_default !== undefined) {
+      dataQuery = dataQuery.where('pm.is_default', is_default);
+      countQuery = countQuery.where('pm.is_default', is_default);
+    }
+
+    if (exclude_deleted) {
+      dataQuery = dataQuery.where('pm.is_deleted', false);
+      countQuery = countQuery.where('pm.is_deleted', false);
+    }
+
+    if (search) {
+      dataQuery = dataQuery.where(builder => {
+        builder.whereILike('c.client_name', `%${search}%`)
+          .orWhereILike('pm.last4', `%${search}%`);
+      });
+      countQuery = countQuery.whereILike('pm.last4', `%${search}%`);
+    }
+
+    const [paymentMethods, [{ count }]] = await Promise.all([
+      dataQuery
+        .select('pm.*', 'c.client_name')
+        .orderBy(`pm.${sortField}`, order)
+        .limit(limit)
+        .offset((page - 1) * limit),
+      countQuery.count('* as count'),
+    ]);
+
+    return {
+      data: paymentMethods.map(paymentMethod => ({
+        data: paymentMethod,
+        links: [
+          {
+            rel: 'self',
+            href: `/api/v1/financial/payment-methods/${paymentMethod.payment_method_id}`,
+            method: 'GET',
+            description: 'Get payment method details',
+          },
+          {
+            rel: 'client',
+            href: `/api/v1/clients/${paymentMethod.client_id}`,
+            method: 'GET',
+            description: 'View client details',
+          },
+        ],
+      })),
+      total: parseInt(count as string, 10),
+    };
   }
 
   // ============================================================================
@@ -2071,6 +2290,18 @@ export class FinancialService extends BaseService<ITransaction> {
    */
   async getPaymentTerms(context?: ServiceContext): Promise<FinancialResponse<Array<{ id: string; name: string }>>> {
     const { knex } = await this.getKnex();
+
+    const hasPaymentTermsTable = await knex.schema.hasTable('payment_terms');
+    if (!hasPaymentTermsTable) {
+      return {
+        data: [
+          { id: 'due_on_receipt', name: 'Due on receipt' },
+          { id: 'net_15', name: 'Net 15' },
+          { id: 'net_30', name: 'Net 30' },
+        ],
+        links: []
+      };
+    }
 
     const terms = await knex('payment_terms')
       .select('term_code as id', 'term_name as name')

--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -32,7 +32,6 @@ import {
   generateInvoiceNumber,
   previewInvoiceForSelectionInput,
 } from '@alga-psa/billing/actions/invoiceGeneration';
-import { getDueDate } from '@alga-psa/billing/actions/billingAndTax';
 import { BillingEngine } from '@alga-psa/billing/services';
 import { TaxService } from '@alga-psa/billing/services/taxService';
 import { NumberingService } from '@shared/services/numberingService';
@@ -125,6 +124,12 @@ export interface InvoiceAnalytics {
   };
 }
 
+export interface InvoicePDFResult {
+  buffer: Buffer;
+  filename: string;
+  contentType: 'application/pdf';
+}
+
 export interface InvoiceHATEOASLinks {
   self: string;
   items?: string;
@@ -185,6 +190,30 @@ export class InvoiceService extends BaseService<IInvoice> {
   private async getInvoiceRecurringProvenance(trx: Knex.Transaction, tenant: string, invoiceId: string) {
     const charges = await InvoiceModel.getInvoiceCharges(trx, tenant, invoiceId);
     return summarizeInvoiceRecurringProvenance(charges);
+  }
+
+  private getPaymentTermDays(paymentTerms?: string | null): number {
+    switch (paymentTerms) {
+      case 'net_15':
+        return 15;
+      case 'due_on_receipt':
+        return 0;
+      case 'net_30':
+      default:
+        return 30;
+    }
+  }
+
+  private async computeDueDate(trx: Knex.Transaction, tenant: string, clientId: string, invoiceDate: string): Promise<string> {
+    const client = await trx('clients')
+      .where({ client_id: clientId, tenant })
+      .select('payment_terms')
+      .first();
+
+    const plainInvoiceDate = Temporal.PlainDate.from(invoiceDate);
+    return plainInvoiceDate
+      .add({ days: this.getPaymentTermDays(client?.payment_terms) })
+      .toString();
   }
 
   private buildRecurringInvoiceSummaryQuery(trx: Knex.Transaction, context: ServiceContext) {
@@ -805,30 +834,38 @@ export class InvoiceService extends BaseService<IInvoice> {
       }
 
       // Validate invoice has required data
-      const lineItems = await trx('invoice_line_items')
-        .where({ invoice_id: data.invoice_id, tenant: context.tenant });
+      const hasInvoiceChargesTable = await trx.schema.hasTable('invoice_charges');
+      const lineItems = hasInvoiceChargesTable
+        ? await InvoiceModel.getInvoiceCharges(trx, context.tenant, data.invoice_id)
+        : await trx('invoice_line_items')
+          .where({ invoice_id: data.invoice_id, tenant: context.tenant });
 
       if (!lineItems.length) {
         throw new Error('Invoice must have line items to be finalized');
       }
 
       // Calculate final amounts
-      const subtotal = lineItems.reduce((sum: number, item: any) => sum + item.total_price, 0);
-      const taxAmount = lineItems.reduce((sum: number, item: any) => sum + (item.tax_amount || 0), 0);
+      const subtotal = lineItems.reduce((sum: number, item: any) => sum + Number(item.total_price || 0), 0);
+      const taxAmount = lineItems.reduce((sum: number, item: any) => sum + Number(item.tax_amount || 0), 0);
       const totalAmount = subtotal + taxAmount;
+
+      const invoiceUpdate: Record<string, any> = {
+        status: 'sent', // Change to sent instead of finalized
+        subtotal,
+        tax: taxAmount,
+        total_amount: totalAmount,
+        finalized_at: data.finalized_at || new Date().toISOString().split('T')[0],
+        updated_at: new Date()
+      };
+
+      if (await trx.schema.hasColumn('invoices', 'updated_by')) {
+        invoiceUpdate.updated_by = context.userId;
+      }
 
       // Update invoice status and amounts
       await trx('invoices')
         .where({ invoice_id: data.invoice_id, tenant: context.tenant })
-        .update({
-          status: 'sent', // Change to sent instead of finalized
-          subtotal,
-          tax: taxAmount,
-          total_amount: totalAmount,
-          finalized_at: data.finalized_at || new Date().toISOString().split('T')[0],
-          updated_by: context.userId,
-          updated_at: new Date()
-        });
+        .update(invoiceUpdate);
 
       const recurringProvenance = await this.getInvoiceRecurringProvenance(trx, context.tenant, data.invoice_id);
 
@@ -1748,13 +1785,13 @@ export class InvoiceService extends BaseService<IInvoice> {
     const numberingService = new NumberingService({ knex, tenant });
     const invoiceNumber = await numberingService.getNextNumber('INVOICE');
     const currentDate = Temporal.Now.plainDateISO().toString();
-    const computedDueDate = await getDueDate(data.clientId, currentDate);
     const sessionLike = { user: { id: context.userId } } as { user: { id: string } };
 
     let createdInvoice: InvoiceViewModel | null = null;
 
     await withTransaction(knex, async (trx) => {
       const client = await getClientDetails(trx, tenant, data.clientId);
+      const computedDueDate = await this.computeDueDate(trx, tenant, data.clientId, currentDate);
 
       await trx('invoices').insert({
         invoice_id: invoiceId,
@@ -1881,7 +1918,31 @@ export class InvoiceService extends BaseService<IInvoice> {
   }
 
   async generatePDF(id: string, context: InvoiceServiceContext): Promise<any> {
-    throw new Error('generatePDF not yet implemented');
+    await this.validatePermissions(context, 'invoice', 'read');
+
+    const { knex } = await this.getKnex();
+    const invoice = await knex('invoices')
+      .where({ invoice_id: id, tenant: context.tenant })
+      .select('invoice_id', 'invoice_number')
+      .first();
+
+    if (!invoice) {
+      throw new Error('Invoice not found');
+    }
+
+    const buffer = await this.getPdfService(context.tenant).generatePDF({
+      invoiceId: id,
+      userId: context.userId,
+    });
+
+    const safeInvoiceNumber = String(invoice.invoice_number || invoice.invoice_id)
+      .replace(/[^a-zA-Z0-9._-]/g, '_');
+
+    return {
+      buffer,
+      filename: `Invoice_${safeInvoiceNumber}.pdf`,
+      contentType: 'application/pdf' as const,
+    };
   }
 
   async search(query: any, context: InvoiceServiceContext, options?: any): Promise<{ data: IInvoice[]; total: number }> {
@@ -2062,18 +2123,51 @@ export class InvoiceService extends BaseService<IInvoice> {
   }
 
   // Additional helper methods...
-  private async getInvoiceLineItems(
+  async getInvoiceLineItems(
     invoiceId: string,
-    trx: Knex.Transaction,
-    context: ServiceContext
+    trxOrContext: Knex.Transaction | ServiceContext,
+    maybeContext?: ServiceContext
   ): Promise<IInvoiceCharge[]> {
-    return InvoiceModel.getInvoiceCharges(trx, context.tenant, invoiceId);
+    if (maybeContext) {
+      return InvoiceModel.getInvoiceCharges(trxOrContext as Knex.Transaction, maybeContext.tenant, invoiceId);
+    }
+
+    const context = trxOrContext as ServiceContext;
+    await this.validatePermissions(context, 'invoice', 'read');
+    const { knex } = await this.getKnex();
+    return withTransaction(knex, async (trx) => {
+      const exists = await trx('invoices')
+        .where({ invoice_id: invoiceId, tenant: context.tenant })
+        .select('invoice_id')
+        .first();
+
+      if (!exists) {
+        throw new Error('Invoice not found');
+      }
+
+      return InvoiceModel.getInvoiceCharges(trx, context.tenant, invoiceId);
+    });
   }
 
   private async getInvoiceClient(clientId: string, trx: Knex.Transaction, context: ServiceContext): Promise<any> {
-    return trx('clients')
-      .where({ client_id: clientId, tenant: context.tenant })
-      .select('client_id', 'client_name', 'billing_address', 'email', 'phone_no')
+    return trx('clients as c')
+      .leftJoin('client_locations as cl', function() {
+        this.on('c.client_id', '=', 'cl.client_id')
+          .andOn('c.tenant', '=', 'cl.tenant')
+          .andOn(function() {
+            this.on('cl.is_billing_address', '=', trx.raw('true'))
+              .orOn('cl.is_default', '=', trx.raw('true'));
+          });
+      })
+      .where({ 'c.client_id': clientId, 'c.tenant': context.tenant })
+      .select(
+        'c.client_id',
+        'c.client_name',
+        'c.billing_email as email',
+        trx.raw(`CONCAT_WS(', ', cl.address_line1, cl.address_line2, cl.city, cl.state_province, cl.postal_code, cl.country_name) as billing_address`),
+        'cl.phone as phone_no'
+      )
+      .orderByRaw('cl.is_billing_address DESC, cl.is_default DESC')
       .first();
   }
 
@@ -2089,13 +2183,50 @@ export class InvoiceService extends BaseService<IInvoice> {
       .first();
   }
 
+  async getInvoiceTransactions(invoiceId: string, context: ServiceContext): Promise<any[]> {
+    await this.validatePermissions(context, 'invoice', 'read');
+    const { knex } = await this.getKnex();
+
+    return withTransaction(knex, async (trx) => {
+      const exists = await trx('invoices')
+        .where({ invoice_id: invoiceId, tenant: context.tenant })
+        .select('invoice_id')
+        .first();
+
+      if (!exists) {
+        throw new Error('Invoice not found');
+      }
+
+      const [payments, credits] = await Promise.all([
+        this.getInvoicePayments(invoiceId, trx, context),
+        this.getInvoiceCredits(invoiceId, trx, context),
+      ]);
+
+      return [...payments, ...credits].sort((a, b) => {
+        const aDate = new Date(a.payment_date || a.applied_date || a.created_at || 0).getTime();
+        const bDate = new Date(b.payment_date || b.applied_date || b.created_at || 0).getTime();
+        return bDate - aDate;
+      });
+    });
+  }
+
   private async getInvoicePayments(invoiceId: string, trx: Knex.Transaction, context: ServiceContext): Promise<any[]> {
+    const hasTable = await trx.schema.hasTable('invoice_payments');
+    if (!hasTable) {
+      return [];
+    }
+
     return trx('invoice_payments')
       .where({ invoice_id: invoiceId, tenant: context.tenant })
       .orderBy('payment_date', 'desc');
   }
 
   private async getInvoiceCredits(invoiceId: string, trx: Knex.Transaction, context: ServiceContext): Promise<any[]> {
+    const hasTable = await trx.schema.hasTable('invoice_credits');
+    if (!hasTable) {
+      return [];
+    }
+
     return trx('invoice_credits')
       .where({ invoice_id: invoiceId, tenant: context.tenant })
       .orderBy('applied_date', 'desc');

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -99,6 +99,7 @@ const apiKeySkipPaths = [
   '/api/accounting/csv/',
   '/api/accounting/exports/',
   '/api/webhooks/stripe',
+  '/api/webhooks/alternative-payments',
   '/api/webhooks/ninjaone',
   '/api/webhooks/tacticalrmm',
   // Server-to-server webhooks from nm-store. Authenticated via HMAC


### PR DESCRIPTION
  Replace the placeholder financial endpoints with their intended logic:
  - GET /financial/invoices and /payment-methods now call dedicated listInvoices()/listPaymentMethods() instead of the generic list() that returned transactions
  - Invoice PDF endpoints implement generatePDF() (was a thrown "not yet implemented") and stream application/pdf under invoice:read instead of returning download_url metadata / a 307 redirect
  - PDFGenerationService renders via tenant-scoped knex + Invoice model
  - Add HMAC-verified /api/webhooks/alternative-payments to record external payments (allowlisted in middleware apiKeySkipPaths)
  - Update the OpenAPI registry to describe the fixed behavior and regenerate the CE/EE specs (portal sync handled separately)

  "Curiouser and curiouser!" cried the invoice, who had spent so long
  whispering 'not yet implemented' that it quite forgot it could become
  a PDF; meanwhile the payment-methods removed their transaction disguise,
  and a stranger's webhook slipped a coin under the door. 📄💸🐇