### PR TITLE
Push ticket read authorization into SQL

### DIFF
--- a/packages/authorization/src/kernel/index.ts
+++ b/packages/authorization/src/kernel/index.ts
@@ -3,5 +3,6 @@ export * from './engine';
 export * from './providers/builtinProvider';
 export * from './providers/bundleProvider';
 export * from './relationships';
+export * from './relationshipTemplates';
 export * from './requestCache';
 export * from './scope';

--- a/packages/authorization/src/kernel/providers/bundleProvider.ts
+++ b/packages/authorization/src/kernel/providers/bundleProvider.ts
@@ -7,7 +7,7 @@ import type {
   ScopeConstraint,
 } from '../contracts';
 import { ALLOW_ALL_SCOPE } from '../scope';
-import { evaluateRelationshipTemplate } from '../relationships';
+import { evaluateRelationshipTemplate } from '../relationshipTemplates';
 
 export interface BundleNarrowingRule {
   id: string;

--- a/packages/authorization/src/kernel/relationshipTemplates.ts
+++ b/packages/authorization/src/kernel/relationshipTemplates.ts
@@ -1,0 +1,320 @@
+import type { Knex } from 'knex';
+import type {
+  AuthorizationEvaluationInput,
+  AuthorizationSubject,
+  RelationshipRule,
+  RelationshipTemplateKey,
+} from './contracts';
+import type { BundleNarrowingRule } from './providers/bundleProvider';
+
+// ---------------------------------------------------------------------------
+// Shared relationship-template definitions.
+//
+// Each template is defined ONCE with two facets:
+//   - matches(): per-record JS evaluation (used by the kernel to filter
+//     already-fetched rows)
+//   - compileSql(): emits the equivalent SQL predicate onto a query builder
+//     (used to push read-authorization into the database so pagination/count
+//     run server-side instead of fetch-all-then-filter-in-JS)
+//
+// Keeping both facets in a single registry keyed by RelationshipTemplateKey
+// makes the two paths impossible to drift: adding a template is a compile error
+// until both facets are supplied. The kernel owns template *semantics*; a
+// resource supplies its physical columns via RelationshipSqlAdapter.
+// ---------------------------------------------------------------------------
+
+function hasIntersection(left: string[] = [], right: string[] = []): boolean {
+  if (left.length === 0 || right.length === 0) {
+    return false;
+  }
+  const rightSet = new Set(right);
+  return left.some((item) => rightSet.has(item));
+}
+
+function uniqueNonEmpty(values: Array<string | null | undefined> | undefined): string[] {
+  return Array.from(
+    new Set(
+      (values ?? []).filter((value): value is string => typeof value === 'string' && value.length > 0)
+    )
+  );
+}
+
+/**
+ * Resource-specific physical mapping the SQL compiler needs. The kernel owns the
+ * template semantics; the resource supplies the columns/relations they map to.
+ */
+export interface RelationshipSqlAdapter {
+  ownerColumn: string;
+  clientColumn: string;
+  boardColumn: string;
+  teamColumn: string;
+  /**
+   * Column holding a boolean client-visibility flag. When omitted, the
+   * `client_visible_only` bundle constraint denies all rows — matching the JS
+   * kernel, which denies when `record.is_client_visible !== true` and the
+   * resource never exposes that field.
+   */
+  clientVisibleColumn?: string;
+  /**
+   * Narrow `builder` to rows assigned to any of `userIds` (the primary assignee
+   * column and/or a resource-specific co-assignee relation). Must deny (no rows)
+   * when `userIds` is empty.
+   */
+  applyAssignedUsers(builder: Knex.QueryBuilder, userIds: string[]): void;
+}
+
+export interface RelationshipSqlContext {
+  subject: AuthorizationSubject;
+  selectedClientIds?: string[];
+  selectedBoardIds?: string[];
+  adapter: RelationshipSqlAdapter;
+}
+
+export type RelationshipSqlCompileResult =
+  | { supported: true }
+  | { supported: false; reason: string };
+
+function deny(builder: Knex.QueryBuilder): void {
+  builder.whereRaw('1 = 0');
+}
+
+function whereInOrDeny(
+  builder: Knex.QueryBuilder,
+  column: string,
+  values: Array<string | null | undefined> | undefined
+): void {
+  const normalized = uniqueNonEmpty(values);
+  if (normalized.length === 0) {
+    deny(builder);
+    return;
+  }
+  builder.whereIn(column, normalized);
+}
+
+interface RelationshipTemplateDef {
+  matches(input: AuthorizationEvaluationInput): boolean;
+  compileSql(builder: Knex.QueryBuilder, ctx: RelationshipSqlContext): void;
+}
+
+const RELATIONSHIP_TEMPLATES: Record<RelationshipTemplateKey, RelationshipTemplateDef> = {
+  own: {
+    matches: (input) =>
+      typeof input.record?.ownerUserId === 'string' && input.record.ownerUserId === input.subject.userId,
+    compileSql: (builder, ctx) => {
+      builder.where(ctx.adapter.ownerColumn, ctx.subject.userId);
+    },
+  },
+  assigned: {
+    matches: (input) =>
+      Array.isArray(input.record?.assignedUserIds) &&
+      input.record.assignedUserIds.includes(input.subject.userId),
+    compileSql: (builder, ctx) => {
+      ctx.adapter.applyAssignedUsers(builder, [ctx.subject.userId]);
+    },
+  },
+  managed: {
+    matches: (input) =>
+      Array.isArray(input.record?.assignedUserIds) &&
+      hasIntersection(input.record.assignedUserIds, input.subject.managedUserIds),
+    compileSql: (builder, ctx) => {
+      ctx.adapter.applyAssignedUsers(builder, ctx.subject.managedUserIds ?? []);
+    },
+  },
+  own_or_assigned: {
+    matches: (input) =>
+      RELATIONSHIP_TEMPLATES.own.matches(input) || RELATIONSHIP_TEMPLATES.assigned.matches(input),
+    compileSql: (builder, ctx) => {
+      builder
+        .where(ctx.adapter.ownerColumn, ctx.subject.userId)
+        .orWhere(function orAssigned(this: Knex.QueryBuilder) {
+          ctx.adapter.applyAssignedUsers(this, [ctx.subject.userId]);
+        });
+    },
+  },
+  own_or_managed: {
+    matches: (input) =>
+      RELATIONSHIP_TEMPLATES.own.matches(input) || RELATIONSHIP_TEMPLATES.managed.matches(input),
+    compileSql: (builder, ctx) => {
+      builder
+        .where(ctx.adapter.ownerColumn, ctx.subject.userId)
+        .orWhere(function orManaged(this: Knex.QueryBuilder) {
+          ctx.adapter.applyAssignedUsers(this, ctx.subject.managedUserIds ?? []);
+        });
+    },
+  },
+  same_client: {
+    matches: (input) =>
+      Boolean(
+        input.record?.clientId &&
+          input.subject.clientId &&
+          input.record.clientId === input.subject.clientId
+      ),
+    compileSql: (builder, ctx) => {
+      if (!ctx.subject.clientId) {
+        deny(builder);
+        return;
+      }
+      builder.where(ctx.adapter.clientColumn, ctx.subject.clientId);
+    },
+  },
+  client_portfolio: {
+    matches: (input) =>
+      Boolean(input.record?.clientId && input.subject.portfolioClientIds?.includes(input.record.clientId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.clientColumn, ctx.subject.portfolioClientIds);
+    },
+  },
+  selected_clients: {
+    matches: (input) =>
+      Boolean(input.record?.clientId && input.selectedClientIds?.includes(input.record.clientId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.clientColumn, ctx.selectedClientIds);
+    },
+  },
+  same_team: {
+    matches: (input) => hasIntersection(input.record?.teamIds, input.subject.teamIds),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.teamColumn, ctx.subject.teamIds);
+    },
+  },
+  selected_boards: {
+    matches: (input) =>
+      Boolean(input.record?.boardId && input.selectedBoardIds?.includes(input.record.boardId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.boardColumn, ctx.selectedBoardIds);
+    },
+  },
+};
+
+export function evaluateRelationshipTemplate(
+  template: RelationshipTemplateKey,
+  input: AuthorizationEvaluationInput
+): boolean {
+  if (!input.record) {
+    return false;
+  }
+  return RELATIONSHIP_TEMPLATES[template].matches(input);
+}
+
+export function compileRelationshipTemplateSql(
+  builder: Knex.QueryBuilder,
+  template: RelationshipTemplateKey,
+  ctx: RelationshipSqlContext
+): void {
+  RELATIONSHIP_TEMPLATES[template].compileSql(builder, ctx);
+}
+
+/**
+ * Built-in relationship rules narrow with OR semantics (a row is allowed if ANY
+ * rule's template matches); an empty rule set allows all. Mirrors
+ * `evaluateRelationshipRules`.
+ */
+export function compileRelationshipRulesSql(
+  builder: Knex.QueryBuilder,
+  rules: RelationshipRule[],
+  ctx: RelationshipSqlContext
+): void {
+  if (rules.length === 0) {
+    return;
+  }
+  builder.andWhere(function relationshipGroup(this: Knex.QueryBuilder) {
+    rules.forEach((rule, index) => {
+      const apply = function templatePredicate(this: Knex.QueryBuilder) {
+        compileRelationshipTemplateSql(this, rule.template, ctx);
+      };
+      if (index === 0) {
+        this.where(apply);
+      } else {
+        this.orWhere(apply);
+      }
+    });
+  });
+}
+
+function compileBundleRuleSql(
+  builder: Knex.QueryBuilder,
+  rule: BundleNarrowingRule,
+  ctx: RelationshipSqlContext
+): RelationshipSqlCompileResult {
+  if (rule.constraintKey === 'client_visible_only') {
+    if (ctx.adapter.clientVisibleColumn) {
+      builder.where(ctx.adapter.clientVisibleColumn, true);
+    } else {
+      deny(builder);
+    }
+    return { supported: true };
+  }
+
+  // `not_self_approver` only constrains mutations; it never denies a read.
+  if (rule.constraintKey && rule.constraintKey !== 'not_self_approver') {
+    return { supported: false, reason: `unsupported bundle constraint ${rule.constraintKey}` };
+  }
+
+  if (!rule.templateKey) {
+    return { supported: true };
+  }
+
+  const ruleCtx: RelationshipSqlContext = {
+    ...ctx,
+    selectedClientIds:
+      rule.templateKey === 'selected_clients' ? (rule.selectedClientIds ?? []) : ctx.selectedClientIds,
+    selectedBoardIds:
+      rule.templateKey === 'selected_boards' ? (rule.selectedBoardIds ?? []) : ctx.selectedBoardIds,
+  };
+
+  builder.andWhere(function bundleTemplate(this: Knex.QueryBuilder) {
+    compileRelationshipTemplateSql(this, rule.templateKey as RelationshipTemplateKey, ruleCtx);
+  });
+  return { supported: true };
+}
+
+/**
+ * Bundle narrowing rules intersect with AND semantics (every matching rule's
+ * template must hold). Mirrors `BundleAuthorizationKernelProvider.evaluateNarrowing`
+ * for the read path. Returns `{ supported: false }` for any constraint not yet
+ * representable in SQL so the caller can fall back to the JS kernel.
+ */
+export function compileBundleReadNarrowingSql(
+  builder: Knex.QueryBuilder,
+  bundleRules: BundleNarrowingRule[],
+  resourceType: string,
+  action: string,
+  ctx: RelationshipSqlContext
+): RelationshipSqlCompileResult {
+  const matching = bundleRules.filter((rule) => rule.resource === resourceType && rule.action === action);
+  for (const rule of matching) {
+    const result = compileBundleRuleSql(builder, rule, ctx);
+    if (!result.supported) {
+      return result;
+    }
+  }
+  return { supported: true };
+}
+
+export interface ResourceReadAuthorizationSqlParams {
+  resourceType: string;
+  action: string;
+  builtinRules: RelationshipRule[];
+  bundleRules: BundleNarrowingRule[];
+  ctx: RelationshipSqlContext;
+}
+
+/**
+ * Compile a complete read-authorization predicate onto `builder`: the built-in
+ * relationship rules (OR-group) ANDed with every matching bundle rule. Returns
+ * `{ supported: false }` when a rule cannot be represented in SQL — callers
+ * MUST then fall back to the JS kernel rather than run the partial query.
+ */
+export function compileResourceReadAuthorizationSql(
+  builder: Knex.QueryBuilder,
+  params: ResourceReadAuthorizationSqlParams
+): RelationshipSqlCompileResult {
+  compileRelationshipRulesSql(builder, params.builtinRules, params.ctx);
+  return compileBundleReadNarrowingSql(
+    builder,
+    params.bundleRules,
+    params.resourceType,
+    params.action,
+    params.ctx
+  );
+}

--- a/packages/authorization/src/kernel/relationships.ts
+++ b/packages/authorization/src/kernel/relationships.ts
@@ -3,58 +3,9 @@ import type {
   AuthorizationReason,
   AuthorizationScope,
   RelationshipRule,
-  RelationshipTemplateKey,
 } from './contracts';
 import { DENY_ALL_SCOPE } from './scope';
-
-function hasIntersection(left: string[] = [], right: string[] = []): boolean {
-  if (left.length === 0 || right.length === 0) {
-    return false;
-  }
-  const rightSet = new Set(right);
-  return left.some((item) => rightSet.has(item));
-}
-
-export function evaluateRelationshipTemplate(
-  template: RelationshipTemplateKey,
-  input: AuthorizationEvaluationInput
-): boolean {
-  const record = input.record;
-  if (!record) {
-    return false;
-  }
-
-  switch (template) {
-    case 'own':
-      return typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId;
-    case 'assigned':
-      return Array.isArray(record.assignedUserIds) && record.assignedUserIds.includes(input.subject.userId);
-    case 'managed':
-      return Array.isArray(record.assignedUserIds) && hasIntersection(record.assignedUserIds, input.subject.managedUserIds);
-    case 'own_or_assigned':
-      return (
-        (typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId) ||
-        (Array.isArray(record.assignedUserIds) && record.assignedUserIds.includes(input.subject.userId))
-      );
-    case 'own_or_managed':
-      return (
-        (typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId) ||
-        (Array.isArray(record.assignedUserIds) && hasIntersection(record.assignedUserIds, input.subject.managedUserIds))
-      );
-    case 'same_client':
-      return Boolean(record.clientId && input.subject.clientId && record.clientId === input.subject.clientId);
-    case 'client_portfolio':
-      return Boolean(record.clientId && input.subject.portfolioClientIds?.includes(record.clientId));
-    case 'selected_clients':
-      return Boolean(record.clientId && input.selectedClientIds?.includes(record.clientId));
-    case 'same_team':
-      return hasIntersection(record.teamIds, input.subject.teamIds);
-    case 'selected_boards':
-      return Boolean(record.boardId && input.selectedBoardIds?.includes(record.boardId));
-    default:
-      return false;
-  }
-}
+import { evaluateRelationshipTemplate } from './relationshipTemplates';
 
 export function evaluateRelationshipRules(
   rules: RelationshipRule[],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alga-psa/core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/msp-composition/src/clients/MspClientQuickViewProvider.tsx
+++ b/packages/msp-composition/src/clients/MspClientQuickViewProvider.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { ClientCrossFeatureProvider } from '@alga-psa/clients/context/ClientCrossFeatureContext';
+import type {
+  ClientCrossFeatureCallbacks,
+  QuickAddTicketRenderProps,
+  TicketFormOptions,
+} from '@alga-psa/clients/context/ClientCrossFeatureContext';
+import { getSlaPolicies } from '@alga-psa/sla/actions';
+import { buildCreateTicketHref } from '@alga-psa/tickets/lib/createTicketRoute';
+
+// Lightweight cross-feature provider for the read-only client quick-view drawer
+// (ClientQuickView), the only client surface the tickets list mounts. The full
+// MspClientCrossFeatureProvider statically pulls the rich-text editor, billing
+// contract wizard, assets, contact/client ticket lists, and scheduling actions into
+// the first-load of every host page. This variant wires only the quick-view
+// behavior the tickets route needs and stubs the rest, keeping the heavy
+// implementations out of the host bundle through the existing render-prop layer
+// (no dynamic imports). The survey summary is intentionally omitted here because
+// ClientQuickView currently passes a null summary; the full client detail
+// provider keeps the real survey card.
+// "Add ticket" routes through the shared create-ticket route, exactly like every
+// other create surface, instead of mounting the editor inline.
+
+function QuickAddTicketRouteBridge({
+  open,
+  onOpenChange,
+  prefilledClient,
+  prefilledContact,
+}: QuickAddTicketRenderProps) {
+  const router = useRouter();
+  const navigatedRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      navigatedRef.current = false;
+      return;
+    }
+    if (navigatedRef.current) return;
+    navigatedRef.current = true;
+    router.push(
+      buildCreateTicketHref({
+        client: prefilledClient ? { id: prefilledClient.id, name: prefilledClient.name } : undefined,
+        contact: prefilledContact ? { id: prefilledContact.id, name: prefilledContact.name } : undefined,
+      }),
+    );
+    onOpenChange(false);
+  }, [open, prefilledClient, prefilledContact, router, onOpenChange]);
+
+  return null;
+}
+
+const noopRender = (): ReactNode => null;
+const emptyTicketFormOptions = async (): Promise<TicketFormOptions> => ({
+  statusOptions: [],
+  priorityOptions: [],
+  boardOptions: [],
+  categories: [],
+  tags: [],
+  users: [],
+});
+
+export function MspClientQuickViewProvider({ children }: { children: ReactNode }) {
+  const renderQuickAddTicket = useCallback(
+    (props: QuickAddTicketRenderProps) => <QuickAddTicketRouteBridge {...props} />,
+    [],
+  );
+
+  const value = useMemo<ClientCrossFeatureCallbacks>(
+    () => ({
+      renderQuickAddTicket,
+      renderSurveySummaryCard: noopRender,
+      getSlaPolicies,
+      // The quick-view never invokes these — stubbed so the editor form options,
+      // assets, and ticket-list implementations stay out of the host page's bundle.
+      getTicketFormOptions: emptyTicketFormOptions,
+      renderClientAssets: noopRender,
+      renderClientTickets: noopRender,
+      renderContactTickets: noopRender,
+    }),
+    [renderQuickAddTicket],
+  );
+
+  return <ClientCrossFeatureProvider value={value}>{children}</ClientCrossFeatureProvider>;
+}

--- a/packages/msp-composition/src/tickets/MspTicketsPageClient.tsx
+++ b/packages/msp-composition/src/tickets/MspTicketsPageClient.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react';
 import TicketingDashboardContainer from '@alga-psa/tickets/components/TicketingDashboardContainer';
 import ClientQuickView from '@alga-psa/clients/components/clients/ClientQuickView';
 import type { IClient } from '@alga-psa/types';
-import { MspClientCrossFeatureProvider } from '../clients/MspClientCrossFeatureProvider';
+import { MspClientQuickViewProvider } from '../clients/MspClientQuickViewProvider';
 
 type MspTicketsPageClientProps = Omit<
   React.ComponentProps<typeof TicketingDashboardContainer>,
@@ -14,9 +14,9 @@ type MspTicketsPageClientProps = Omit<
 export default function MspTicketsPageClient(props: MspTicketsPageClientProps) {
   const renderClientDetails = useCallback(({ id, client }: { id: string; client: IClient }) => {
     return (
-      <MspClientCrossFeatureProvider>
+      <MspClientQuickViewProvider>
         <ClientQuickView id={id} client={client} isInDrawer={true} quickView={true} />
-      </MspClientCrossFeatureProvider>
+      </MspClientQuickViewProvider>
     );
   }, []);
 

--- a/packages/projects/src/components/TaskCommentThread.tsx
+++ b/packages/projects/src/components/TaskCommentThread.tsx
@@ -13,7 +13,8 @@ import { getCurrentUser, getCurrentUserAvatarUrl } from '@alga-psa/user-composit
 import UserAvatar from '@alga-psa/ui/components/UserAvatar';
 import { Button } from '@alga-psa/ui/components/Button';
 import { useTranslation } from 'react-i18next';
-import { CommentThreadDrawer, CommentThreadList, HybridThreadNode, buildCommentThreadGroups } from '@alga-psa/ui/components';
+import CommentThreadDrawer from '@alga-psa/ui/components/CommentThreadDrawer';
+import { CommentThreadList, HybridThreadNode, buildCommentThreadGroups } from '@alga-psa/ui/components';
 import { usePageCreateShortcut } from '@alga-psa/ui/keyboard-shortcuts';
 
 interface TaskCommentThreadProps {

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -57,10 +57,14 @@ import {
   BundleAuthorizationKernelProvider,
   RequestLocalAuthorizationCache,
   createAuthorizationKernel,
+  compileResourceReadAuthorizationSql,
   type AuthorizationRecord,
   type AuthorizationSubject,
+  type RelationshipRule,
+  type RelationshipSqlCompileResult,
 } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
+import { createTicketRelationshipSqlAdapter, fetchTicketAdditionalUserIds } from '../lib/ticketAuthorizationSql';
 import { getClientContactVisibilityContext } from '../lib/clientPortalVisibility';
 import { buildTicketTransitionWorkflowEvents } from '../lib/workflowTicketTransitionEvents';
 import { buildTicketCommunicationWorkflowEvents } from '../lib/workflowTicketCommunicationEvents';
@@ -156,28 +160,6 @@ function toTicketAuthorizationRecord(
   };
 }
 
-async function fetchTicketAdditionalUserIds(
-  trx: Knex.Transaction | Knex,
-  tenant: string,
-  ticketIds: string[]
-): Promise<Map<string, string[]>> {
-  const map = new Map<string, string[]>();
-  if (ticketIds.length === 0) {
-    return map;
-  }
-  const rows = await trx('ticket_resources')
-    .where({ tenant })
-    .whereIn('ticket_id', ticketIds)
-    .whereNotNull('additional_user_id')
-    .select<{ ticket_id: string; additional_user_id: string }[]>('ticket_id', 'additional_user_id');
-  for (const row of rows) {
-    const ids = map.get(row.ticket_id) ?? [];
-    ids.push(row.additional_user_id);
-    map.set(row.ticket_id, ids);
-  }
-  return map;
-}
-
 async function resolveClientSelectedBoardIds(
   trx: Knex.Transaction,
   tenant: string,
@@ -208,11 +190,23 @@ async function createTicketAuthorizationContext(
   authorizationKernel: ReturnType<typeof createAuthorizationKernel>;
   selectedBoardIds: string[] | undefined;
   requestCache: RequestLocalAuthorizationCache;
+  ticketReadBundleNarrowingRules: Awaited<ReturnType<typeof resolveBundleNarrowingRulesForEvaluation>>;
 }> {
   const authorizationSubject = await resolveAuthorizationSubjectForUser(trx, tenant, user);
   const selectedBoardIds = await resolveClientSelectedBoardIds(trx, tenant, user);
   const relationshipRules =
     selectedBoardIds === undefined ? [] : [{ template: 'selected_boards' as const }];
+  const requestCache = new RequestLocalAuthorizationCache();
+  const ticketReadBundleNarrowingRules = await resolveBundleNarrowingRulesForEvaluation(trx, {
+    subject: authorizationSubject,
+    resource: {
+      type: 'ticket',
+      action: 'read',
+    },
+    selectedBoardIds,
+    requestCache,
+    knex: trx,
+  });
 
   return {
     authorizationSubject,
@@ -222,8 +216,16 @@ async function createTicketAuthorizationContext(
       }),
       bundleProvider: new BundleAuthorizationKernelProvider({
         resolveRules: async (input) => {
+          if (input.resource.type === 'ticket' && input.resource.action === 'read') {
+            return ticketReadBundleNarrowingRules;
+          }
+
           try {
-            return await resolveBundleNarrowingRulesForEvaluation(trx, input);
+            return await resolveBundleNarrowingRulesForEvaluation(trx, {
+              ...input,
+              requestCache,
+              knex: trx,
+            });
           } catch {
             return [];
           }
@@ -232,7 +234,8 @@ async function createTicketAuthorizationContext(
       rbacEvaluator: async () => true,
     }),
     selectedBoardIds,
-    requestCache: new RequestLocalAuthorizationCache(),
+    requestCache,
+    ticketReadBundleNarrowingRules,
   };
 }
 
@@ -275,6 +278,31 @@ async function filterAuthorizedTickets<T extends Partial<ITicket> & { ticket_id?
   );
 
   return tickets.filter((_, index) => decisions[index]?.allowed);
+}
+
+type TicketAuthorizationContext = Awaited<ReturnType<typeof createTicketAuthorizationContext>>;
+
+function applyTicketReadAuthorizationSql(
+  query: Knex.QueryBuilder,
+  trx: Knex.Transaction,
+  tenant: string,
+  context: TicketAuthorizationContext
+): RelationshipSqlCompileResult {
+  // Built-in narrowing for client-portal users mirrors createTicketAuthorizationContext.
+  const builtinRules: RelationshipRule[] =
+    context.selectedBoardIds === undefined ? [] : [{ template: 'selected_boards' }];
+
+  return compileResourceReadAuthorizationSql(query, {
+    resourceType: 'ticket',
+    action: 'read',
+    builtinRules,
+    bundleRules: context.ticketReadBundleNarrowingRules,
+    ctx: {
+      subject: context.authorizationSubject,
+      selectedBoardIds: context.selectedBoardIds,
+      adapter: createTicketRelationshipSqlAdapter(trx, tenant),
+    },
+  });
 }
 
 async function updateTicketResponseStateFromComment(
@@ -647,20 +675,19 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       board.enable_live_ticket_timer = true;
     }
 
-    // Process user data for userMap, including avatar URLs
-    const usersWithAvatars = await Promise.all(users.map(async (user: any) => {
-      let avatarUrl: string | null = null;
-      try {
-        avatarUrl = await getUserAvatarUrl(user.user_id, tenant);
-      } catch (imgError) {
-        console.error(`Error fetching avatar URL for user ${user.user_id}:`, imgError);
-        avatarUrl = null;
-      }
-
-      return {
-        ...user,
-        avatarUrl,
-      };
+    // Resolve avatar URLs in one batch (2 queries) instead of a DB transaction per
+    // tenant user — the per-user path scaled O(users) and dominated ticket-open latency.
+    const userAvatarUrls = await getEntityImageUrlsBatch(
+      'user',
+      users.map((user: any) => user.user_id),
+      tenant,
+    ).catch((imgError) => {
+      console.error('Error batch-fetching user avatar URLs:', imgError);
+      return new Map<string, string | null>();
+    });
+    const usersWithAvatars = users.map((user: any) => ({
+      ...user,
+      avatarUrl: userAvatarUrls.get(user.user_id) ?? null,
     }));
 
     const userMap = usersWithAvatars.reduce((acc, user) => {
@@ -1570,6 +1597,39 @@ function applyTicketListSort(
 }
 
 /**
+ * Get the ORDER BY clause as a raw SQL string for use in window functions.
+ * Mirrors applyTicketListSort but returns a string instead of modifying a query.
+ */
+function getTicketListSortOrderByClause(validatedFilters: ITicketListFilters): string {
+    const sortBy = validatedFilters.sortBy ?? 'entered_at';
+    const sortDirection: 'asc' | 'desc' = validatedFilters.sortDirection ?? 'desc';
+    const sortColumnMap: Record<string, { column?: string; rawExpression?: string }> = {
+      ticket_number: { column: 't.ticket_number' },
+      title: { column: 't.title' },
+      status_name: { column: 's.name' },
+      priority_name: { column: 'p.priority_name' },
+      board_name: { column: 'c.board_name' },
+      category_name: { column: 'cat.category_name' },
+      client_name: { column: 'comp.client_name' },
+      entered_at: { column: 't.entered_at' },
+      entered_by_name: { rawExpression: "COALESCE(CONCAT(u.first_name, ' ', u.last_name), '')" },
+      due_date: { column: 't.due_date' }
+    };
+    const selectedSort = sortColumnMap[sortBy] || sortColumnMap.entered_at;
+
+    let primarySort: string;
+    if (selectedSort.rawExpression) {
+      primarySort = `${selectedSort.rawExpression} ${sortDirection}`;
+    } else if (selectedSort.column) {
+      primarySort = `${selectedSort.column} ${sortDirection}`;
+    } else {
+      primarySort = `t.entered_at ${sortDirection}`;
+    }
+
+    return `${primarySort}, t.ticket_id DESC`;
+}
+
+/**
  * Validate and clean filter values, clearing "$undefined" string sentinel values.
  */
 function cleanFilterValues(validatedFilters: ITicketListFilters): ITicketListFilters {
@@ -1586,6 +1646,145 @@ function cleanFilterValues(validatedFilters: ITicketListFilters): ITicketListFil
       validatedFilters.contactId = undefined;
     }
     return validatedFilters;
+}
+
+function buildTicketListItemsQuery(
+  trx: Knex.Transaction,
+  tenant: string,
+  baseQuery: Knex.QueryBuilder
+): Knex.QueryBuilder {
+  return baseQuery
+    .clone()
+    .joinRaw(`LEFT JOIN (
+      SELECT
+        tc.master_ticket_id,
+        tc.tenant,
+        COUNT(*)::int as bundle_child_count,
+        array_agg(DISTINCT tc.client_id) FILTER (WHERE tc.client_id IS NOT NULL) as child_client_ids
+      FROM tickets tc
+      WHERE tc.master_ticket_id IS NOT NULL AND tc.tenant = ?
+      GROUP BY tc.master_ticket_id, tc.tenant
+    ) as bs ON bs.master_ticket_id = t.ticket_id AND bs.tenant = t.tenant`, [tenant])
+    .joinRaw(`LEFT JOIN (
+      SELECT
+        tr.ticket_id,
+        tr.tenant,
+        COUNT(*) FILTER (WHERE tr.additional_user_id IS NOT NULL)::int as additional_agent_count,
+        COALESCE(
+          json_agg(
+            json_build_object('user_id', uu.user_id, 'name', CONCAT(uu.first_name, ' ', uu.last_name))
+          ) FILTER (WHERE uu.user_id IS NOT NULL),
+          '[]'::json
+        ) as additional_agents
+      FROM ticket_resources tr
+      LEFT JOIN users uu ON tr.additional_user_id = uu.user_id AND tr.tenant = uu.tenant
+      WHERE tr.tenant = ?
+      GROUP BY tr.ticket_id, tr.tenant
+    ) as ags ON ags.ticket_id = t.ticket_id AND ags.tenant = t.tenant`, [tenant])
+    .select(
+      // Ticket columns (explicit list avoids fetching large unused columns)
+      't.ticket_id', 't.ticket_number', 't.title', 't.url',
+      't.board_id', 't.client_id', 't.location_id', 't.contact_name_id',
+      't.status_id', 't.category_id', 't.subcategory_id', 't.priority_id',
+      't.entered_by', 't.updated_by', 't.closed_by',
+      't.assigned_to', 't.assigned_team_id',
+      't.entered_at', 't.updated_at', 't.closed_at', 't.due_date',
+      't.is_closed', 't.attributes',
+      't.master_ticket_id', 't.tenant',
+      't.itil_impact', 't.itil_urgency', 't.itil_priority_level',
+      't.response_state', 't.ticket_origin',
+      't.sla_policy_id', 't.sla_started_at',
+      't.sla_response_due_at', 't.sla_response_at', 't.sla_response_met',
+      't.sla_resolution_due_at', 't.sla_resolution_at', 't.sla_resolution_met',
+      't.sla_paused_at', 't.sla_total_pause_minutes',
+      // Bundle stats from pre-aggregated JOIN
+      trx.raw('COALESCE(bs.bundle_child_count, 0) as bundle_child_count'),
+      trx.raw(`COALESCE(
+        (SELECT COUNT(DISTINCT cid) FROM unnest(
+          array_append(COALESCE(bs.child_client_ids, ARRAY[]::uuid[]), t.client_id)
+        ) AS cid WHERE cid IS NOT NULL),
+        0
+      )::int as bundle_distinct_client_count`),
+      // Joined display columns
+      'mt.ticket_number as bundle_master_ticket_number',
+      's.name as status_name',
+      'p.priority_name',
+      'p.color as priority_color',
+      'c.board_name',
+      'cat.category_name',
+      'comp.client_name',
+      trx.raw("CONCAT(u.first_name, ' ', u.last_name) as entered_by_name"),
+      trx.raw("CONCAT(au.first_name, ' ', au.last_name) as assigned_to_name"),
+      'tm.team_name as assigned_team_name',
+      // Additional agents from pre-aggregated JOIN
+      trx.raw('COALESCE(ags.additional_agent_count, 0)::int as additional_agent_count'),
+      trx.raw("COALESCE(ags.additional_agents, '[]'::json) as additional_agents"),
+    );
+}
+
+function mapTicketListItems(tickets: any[]): ITicketListItem[] {
+  return tickets.map((ticket: any): ITicketListItem => {
+    const {
+      status_id,
+      priority_id,
+      board_id,
+      category_id,
+      entered_by,
+      status_name,
+      priority_name,
+      priority_color,
+      board_name,
+      category_name,
+      client_name,
+      entered_by_name,
+      assigned_to_name,
+      assigned_team_name,
+      additional_agent_count,
+      additional_agents,
+      bundle_child_count,
+      bundle_distinct_client_count,
+      bundle_master_ticket_number,
+      // NOTE: Legacy ITIL fields removed - now using unified system
+      ...rest
+    } = ticket;
+
+    const convertedRest = convertDates(rest);
+    // Clean up null optional fields to undefined for type compatibility
+    if (convertedRest.itil_impact === null) {
+      convertedRest.itil_impact = undefined;
+    }
+    if (convertedRest.itil_urgency === null) {
+      convertedRest.itil_urgency = undefined;
+    }
+    if (convertedRest.itil_priority_level === null) {
+      convertedRest.itil_priority_level = undefined;
+    }
+    if (convertedRest.due_date === null) {
+      convertedRest.due_date = undefined;
+    }
+    return {
+      ...convertedRest,
+      status_id: status_id || null,
+      priority_id: priority_id || null,
+      board_id: board_id || null,
+      category_id: category_id || null,
+      entered_by: entered_by || null,
+      status_name: status_name || 'Unknown',
+      priority_name: priority_name || 'Unknown',
+      priority_color: priority_color || '#6B7280',
+      board_name: board_name || 'Unknown',
+      category_name: category_name || 'Unknown',
+      client_name: client_name || 'Unknown',
+      entered_by_name: entered_by_name || 'Unknown',
+      assigned_to_name: assigned_to_name || null,
+      assigned_team_name: assigned_team_name || null,
+      additional_agent_count: additional_agent_count || 0,
+      additional_agents: additional_agents || [],
+      bundle_child_count: typeof bundle_child_count === 'number' ? bundle_child_count : Number.parseInt(String(bundle_child_count ?? '0'), 10) || 0,
+      bundle_distinct_client_count: typeof bundle_distinct_client_count === 'number' ? bundle_distinct_client_count : Number.parseInt(String(bundle_distinct_client_count ?? '0'), 10) || 0,
+      bundle_master_ticket_number: bundle_master_ticket_number ?? null
+    };
+  });
 }
 
 /**
@@ -1619,148 +1818,47 @@ export const getTicketsForList = withAuth(async (
       user as IUserWithRoles
     );
 
-    // Build query for results before pagination so authorization can narrow rows first.
-    // R2: Select explicit columns instead of t.* to reduce response size
-    // R3: Use pre-aggregated LEFT JOINs instead of correlated subqueries
-    const paginatedQuery = baseQuery
-      .clone()
-      .joinRaw(`LEFT JOIN (
-        SELECT
-          tc.master_ticket_id,
-          tc.tenant,
-          COUNT(*)::int as bundle_child_count,
-          array_agg(DISTINCT tc.client_id) FILTER (WHERE tc.client_id IS NOT NULL) as child_client_ids
-        FROM tickets tc
-        WHERE tc.master_ticket_id IS NOT NULL AND tc.tenant = ?
-        GROUP BY tc.master_ticket_id, tc.tenant
-      ) as bs ON bs.master_ticket_id = t.ticket_id AND bs.tenant = t.tenant`, [tenant])
-      .joinRaw(`LEFT JOIN (
-        SELECT
-          tr.ticket_id,
-          tr.tenant,
-          COUNT(*) FILTER (WHERE tr.additional_user_id IS NOT NULL)::int as additional_agent_count,
-          COALESCE(
-            json_agg(
-              json_build_object('user_id', uu.user_id, 'name', CONCAT(uu.first_name, ' ', uu.last_name))
-            ) FILTER (WHERE uu.user_id IS NOT NULL),
-            '[]'::json
-          ) as additional_agents
-        FROM ticket_resources tr
-        LEFT JOIN users uu ON tr.additional_user_id = uu.user_id AND tr.tenant = uu.tenant
-        WHERE tr.tenant = ?
-        GROUP BY tr.ticket_id, tr.tenant
-      ) as ags ON ags.ticket_id = t.ticket_id AND ags.tenant = t.tenant`, [tenant])
-      .select(
-        // Ticket columns (explicit list avoids fetching large unused columns)
-        't.ticket_id', 't.ticket_number', 't.title', 't.url',
-        't.board_id', 't.client_id', 't.location_id', 't.contact_name_id',
-        't.status_id', 't.category_id', 't.subcategory_id', 't.priority_id',
-        't.entered_by', 't.updated_by', 't.closed_by',
-        't.assigned_to', 't.assigned_team_id',
-        't.entered_at', 't.updated_at', 't.closed_at', 't.due_date',
-        't.is_closed', 't.attributes',
-        't.master_ticket_id', 't.tenant',
-        't.itil_impact', 't.itil_urgency', 't.itil_priority_level',
-        't.response_state', 't.ticket_origin',
-        't.sla_policy_id', 't.sla_started_at',
-        't.sla_response_due_at', 't.sla_response_at', 't.sla_response_met',
-        't.sla_resolution_due_at', 't.sla_resolution_at', 't.sla_resolution_met',
-        't.sla_paused_at', 't.sla_total_pause_minutes',
-        // Bundle stats from pre-aggregated JOIN
-        trx.raw('COALESCE(bs.bundle_child_count, 0) as bundle_child_count'),
-        trx.raw(`COALESCE(
-          (SELECT COUNT(DISTINCT cid) FROM unnest(
-            array_append(COALESCE(bs.child_client_ids, ARRAY[]::uuid[]), t.client_id)
-          ) AS cid WHERE cid IS NOT NULL),
-          0
-        )::int as bundle_distinct_client_count`),
-        // Joined display columns
-        'mt.ticket_number as bundle_master_ticket_number',
-        's.name as status_name',
-        'p.priority_name',
-        'p.color as priority_color',
-        'c.board_name',
-        'cat.category_name',
-        'comp.client_name',
-        trx.raw("CONCAT(u.first_name, ' ', u.last_name) as entered_by_name"),
-        trx.raw("CONCAT(au.first_name, ' ', au.last_name) as assigned_to_name"),
-        'tm.team_name as assigned_team_name',
-        // Additional agents from pre-aggregated JOIN
-        trx.raw('COALESCE(ags.additional_agent_count, 0)::int as additional_agent_count'),
-        trx.raw("COALESCE(ags.additional_agents, '[]'::json) as additional_agents"),
+    let totalCount = 0;
+    let ticketListItems: ITicketListItem[] = [];
+    const normalizedPage = Math.max(1, Number.isFinite(page) ? Math.floor(page) : 1);
+    const normalizedPageSize = Math.max(1, Number.isFinite(pageSize) ? Math.floor(pageSize) : 10);
+    const offset = (normalizedPage - 1) * normalizedPageSize;
+    const scopedBaseQuery = baseQuery.clone();
+    const authSqlResult = applyTicketReadAuthorizationSql(scopedBaseQuery, trx, tenant, authorizationContext);
+
+    if (authSqlResult.supported) {
+      const countQuery = scopedBaseQuery
+        .clone()
+        .clearSelect()
+        .clearOrder()
+        .countDistinct<{ count: string | number }[]>({ count: 't.ticket_id' })
+        .first();
+
+      const pageQuery = applyTicketListSort(
+        buildTicketListItemsQuery(trx, tenant, scopedBaseQuery),
+        validatedFilters
+      )
+        .limit(normalizedPageSize)
+        .offset(offset);
+
+      const [countRow, pageTickets] = await Promise.all([countQuery, pageQuery]);
+      totalCount = Number((countRow as { count?: string | number } | undefined)?.count ?? 0);
+      ticketListItems = mapTicketListItems(pageTickets);
+    } else {
+      // Future ABAC templates/constraints may not be representable in SQL yet.
+      // Fall back to the exact JS kernel path instead of risking overexposure.
+      const tickets = await applyTicketListSort(
+        buildTicketListItemsQuery(trx, tenant, baseQuery),
+        validatedFilters
       );
-
-    const tickets = await applyTicketListSort(paginatedQuery, validatedFilters);
-    const authorizedTickets = await filterAuthorizedTickets(trx, authorizationContext, tickets);
-    const totalCount = authorizedTickets.length;
-    const paginatedAuthorizedTickets = authorizedTickets.slice(
-      (page - 1) * pageSize,
-      (page - 1) * pageSize + pageSize
-    );
-
-    // Transform and validate the data
-    const ticketListItems = paginatedAuthorizedTickets.map((ticket: any): ITicketListItem => {
-      const {
-        status_id,
-        priority_id,
-        board_id,
-        category_id,
-        entered_by,
-        status_name,
-        priority_name,
-        priority_color,
-        board_name,
-        category_name,
-        client_name,
-        entered_by_name,
-        assigned_to_name,
-        assigned_team_name,
-        additional_agent_count,
-        additional_agents,
-        bundle_child_count,
-        bundle_distinct_client_count,
-        bundle_master_ticket_number,
-        // NOTE: Legacy ITIL fields removed - now using unified system
-        ...rest
-      } = ticket;
-
-      const convertedRest = convertDates(rest);
-      // Clean up null optional fields to undefined for type compatibility
-      if (convertedRest.itil_impact === null) {
-        convertedRest.itil_impact = undefined;
-      }
-      if (convertedRest.itil_urgency === null) {
-        convertedRest.itil_urgency = undefined;
-      }
-      if (convertedRest.itil_priority_level === null) {
-        convertedRest.itil_priority_level = undefined;
-      }
-      if (convertedRest.due_date === null) {
-        convertedRest.due_date = undefined;
-      }
-      return {
-        ...convertedRest,
-        status_id: status_id || null,
-        priority_id: priority_id || null,
-        board_id: board_id || null,
-        category_id: category_id || null,
-        entered_by: entered_by || null,
-        status_name: status_name || 'Unknown',
-        priority_name: priority_name || 'Unknown',
-        priority_color: priority_color || '#6B7280',
-        board_name: board_name || 'Unknown',
-        category_name: category_name || 'Unknown',
-        client_name: client_name || 'Unknown',
-        entered_by_name: entered_by_name || 'Unknown',
-        assigned_to_name: assigned_to_name || null,
-        assigned_team_name: assigned_team_name || null,
-        additional_agent_count: additional_agent_count || 0,
-        additional_agents: additional_agents || [],
-        bundle_child_count: typeof bundle_child_count === 'number' ? bundle_child_count : Number.parseInt(String(bundle_child_count ?? '0'), 10) || 0,
-        bundle_distinct_client_count: typeof bundle_distinct_client_count === 'number' ? bundle_distinct_client_count : Number.parseInt(String(bundle_distinct_client_count ?? '0'), 10) || 0,
-        bundle_master_ticket_number: bundle_master_ticket_number ?? null
-      };
-    });
+      const authorizedTickets = await filterAuthorizedTickets(trx, authorizationContext, tickets);
+      totalCount = authorizedTickets.length;
+      const paginatedAuthorizedTickets = authorizedTickets.slice(
+        (page - 1) * pageSize,
+        (page - 1) * pageSize + pageSize
+      );
+      ticketListItems = mapTicketListItems(paginatedAuthorizedTickets);
+    }
 
     // Fetch metadata in parallel: avatar URLs, team avatar URLs, ticket tags
     const ticketIds = ticketListItems
@@ -1878,15 +1976,25 @@ export const getAllMatchingTicketIds = withAuth(async (
       user as IUserWithRoles
     );
 
-    const rows = await baseQuery
-      .clone()
-      .clearSelect()
-      .clearOrder()
-      .select('t.ticket_id', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id');
-    const authorizedRows = await filterAuthorizedTickets(trx, authorizationContext, rows);
-    return authorizedRows
-      .map((row: { ticket_id?: string | null }) => row.ticket_id)
-      .filter((ticketId): ticketId is string => typeof ticketId === 'string' && ticketId.length > 0);
+    const scopedBaseQuery = baseQuery.clone();
+    const authSqlResult = applyTicketReadAuthorizationSql(scopedBaseQuery, trx, tenant, authorizationContext);
+    const rows = authSqlResult.supported
+      ? await scopedBaseQuery
+          .clearSelect()
+          .clearOrder()
+          .select('t.ticket_id')
+      : await filterAuthorizedTickets(
+          trx,
+          authorizationContext,
+          await baseQuery
+            .clone()
+            .clearSelect()
+            .clearOrder()
+            .select('t.ticket_id', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id')
+        );
+
+    const ticketIds: Array<string | null | undefined> = rows.map((row: { ticket_id?: string | null }) => row.ticket_id);
+    return ticketIds.filter((ticketId): ticketId is string => typeof ticketId === 'string' && ticketId.length > 0);
   });
 });
 
@@ -1922,13 +2030,24 @@ export const getTicketBoardIds = withAuth(async (
       user as IUserWithRoles
     );
 
-    const rows = await trx('tickets as t')
+    const boardQuery = trx('tickets as t')
       .where('t.tenant', tenant)
       .whereIn('t.ticket_id', uniqueIds)
-      .select('t.ticket_id', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id');
+      .select('t.ticket_id', 't.board_id');
+    const authSqlResult = applyTicketReadAuthorizationSql(boardQuery, trx, tenant, authorizationContext);
 
-    const authorizedRows = await filterAuthorizedTickets(trx, authorizationContext, rows);
-    return authorizedRows
+    const rows = authSqlResult.supported
+      ? await boardQuery
+      : await filterAuthorizedTickets(
+          trx,
+          authorizationContext,
+          await trx('tickets as t')
+            .where('t.tenant', tenant)
+            .whereIn('t.ticket_id', uniqueIds)
+            .select('t.ticket_id', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id')
+        );
+
+    return rows
       .filter((row: { ticket_id?: string | null }): row is { ticket_id: string; board_id?: string | null } =>
         typeof row.ticket_id === 'string' && row.ticket_id.length > 0)
       .map((row) => ({
@@ -3339,6 +3458,59 @@ export const getAdjacentTicketIds = withAuth(async (
       tenant,
       user as IUserWithRoles
     );
+    const scopedBaseQuery = baseQuery.clone();
+    const authSqlResult = applyTicketReadAuthorizationSql(scopedBaseQuery, trx, tenant, authorizationContext);
+
+    if (authSqlResult.supported) {
+      const sortOrderBy = getTicketListSortOrderByClause(validatedFilters);
+      const innerQuery = scopedBaseQuery
+        .clone()
+        .clearSelect()
+        .clearOrder()
+        .select(
+          't.ticket_id',
+          't.ticket_number',
+          trx.raw(`LAG(t.ticket_id) OVER (ORDER BY ${sortOrderBy}) as prev_ticket_id`),
+          trx.raw(`LAG(t.ticket_number) OVER (ORDER BY ${sortOrderBy}) as prev_ticket_number`),
+          trx.raw(`LEAD(t.ticket_id) OVER (ORDER BY ${sortOrderBy}) as next_ticket_id`),
+          trx.raw(`LEAD(t.ticket_number) OVER (ORDER BY ${sortOrderBy}) as next_ticket_number`),
+          trx.raw(`ROW_NUMBER() OVER (ORDER BY ${sortOrderBy}) as rn`),
+          trx.raw('COUNT(*) OVER () as total_count')
+        );
+
+      const results = await trx
+        .select('*')
+        .from(innerQuery.as('windowed'))
+        .where('ticket_id', currentTicketId);
+
+      if (results.length === 0) {
+        const countRow = await scopedBaseQuery
+          .clone()
+          .clearSelect()
+          .clearOrder()
+          .countDistinct<{ count: string | number }[]>({ count: 't.ticket_id' })
+          .first();
+
+        return {
+          prevTicketId: null,
+          nextTicketId: null,
+          prevTicketNumber: null,
+          nextTicketNumber: null,
+          currentPosition: 0,
+          totalCount: Number((countRow as { count?: string | number } | undefined)?.count ?? 0),
+        };
+      }
+
+      const row = results[0];
+      return {
+        prevTicketId: row.prev_ticket_id ?? null,
+        nextTicketId: row.next_ticket_id ?? null,
+        prevTicketNumber: row.prev_ticket_number ?? null,
+        nextTicketNumber: row.next_ticket_number ?? null,
+        currentPosition: Number.parseInt(String(row.rn), 10),
+        totalCount: Number.parseInt(String(row.total_count), 10),
+      };
+    }
 
     const orderedRows = await applyTicketListSort(
       baseQuery.clone().clearSelect().select('t.ticket_id', 't.ticket_number', 't.entered_by', 't.assigned_to', 't.client_id', 't.board_id', 't.assigned_team_id'),

--- a/packages/tickets/src/components/BulkChangePriorityDialog.tsx
+++ b/packages/tickets/src/components/BulkChangePriorityDialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
-import { PrioritySelect } from '@alga-psa/ui/components';
+import { PrioritySelect } from '@alga-psa/ui/components/tickets/PrioritySelect';
 import type { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { useTranslation } from 'react-i18next';
 

--- a/packages/tickets/src/components/ResponseStateSelect.tsx
+++ b/packages/tickets/src/components/ResponseStateSelect.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { TicketResponseState } from '@alga-psa/types';
-import { ResponseStateBadge } from '@alga-psa/ui/components';
+import { ResponseStateBadge } from '@alga-psa/ui/components/tickets/ResponseStateBadge';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 interface ResponseStateSelectProps {

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -10,7 +10,7 @@ import { CategoryPicker } from './CategoryPicker';
 import { BoardFilterPicker, NO_BOARD_VALUE } from './BoardFilterPicker';
 import BulkTicketActionBar from './BulkTicketActionBar';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
-import { PrioritySelect } from '@alga-psa/ui/components';
+import { PrioritySelect } from '@alga-psa/ui/components/tickets/PrioritySelect';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Input } from '@alga-psa/ui/components/Input';
@@ -18,7 +18,7 @@ import { Switch } from '@alga-psa/ui/components/Switch';
 import { Label } from '@alga-psa/ui/components/Label';
 import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
-import { TagFilter } from '@alga-psa/ui/components';
+import { TagFilter } from '@alga-psa/ui/components/tags/TagFilter';
 import type { TagSize } from '@alga-psa/ui/components/tags';
 import { usePrintAction } from '@alga-psa/ui/components/PrintButton';
 import {

--- a/packages/tickets/src/components/ticket/TicketConversation.tsx
+++ b/packages/tickets/src/components/ticket/TicketConversation.tsx
@@ -11,7 +11,9 @@ import { IDocument } from '@alga-psa/types';
 import { PartialBlock } from '@blocknote/core';
 import RichTextEditorSkeleton from '@alga-psa/ui/components/skeletons/RichTextEditorSkeleton';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
-import { CommentThreadDrawer, CommentThreadList, HybridThreadNode, InlineReplyComposer, buildCommentThreadGroups } from '@alga-psa/ui/components';
+import CommentThreadDrawer from '@alga-psa/ui/components/CommentThreadDrawer';
+import InlineReplyComposer from '@alga-psa/ui/components/InlineReplyComposer';
+import { CommentThreadList, HybridThreadNode, buildCommentThreadGroups } from '@alga-psa/ui/components';
 
 // Dynamic import for TextEditor
 const TextEditor = dynamic(() => import('@alga-psa/ui/editor').then((mod) => mod.TextEditor), {

--- a/packages/tickets/src/components/ticket/TicketInfo.tsx
+++ b/packages/tickets/src/components/ticket/TicketInfo.tsx
@@ -11,7 +11,7 @@ import { ITag } from '@alga-psa/types';
 import { TicketResponseState } from '@alga-psa/types';
 import { Button } from '@alga-psa/ui/components/Button';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
-import { PrioritySelect } from '@alga-psa/ui/components';
+import { PrioritySelect } from '@alga-psa/ui/components/tickets/PrioritySelect';
 import UserAndTeamPicker from '@alga-psa/ui/components/UserAndTeamPicker';
 import { getUserAvatarUrlsBatchAction, searchUsersForMentions } from '@alga-psa/user-composition/actions';
 import { getTeamAvatarUrlsBatchAction } from '@alga-psa/teams/actions';

--- a/packages/tickets/src/components/ticket/__tests__/TicketInfo.boardChangeStatusReselection.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketInfo.boardChangeStatusReselection.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
   ),
 }));
 
-vi.mock('@alga-psa/ui/components', () => ({
+vi.mock('@alga-psa/ui/components/tickets/PrioritySelect', () => ({
   PrioritySelect: () => <div data-testid="priority-select" />,
 }));
 

--- a/packages/tickets/src/components/ticket/__tests__/TicketInfo.liveEditing.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketInfo.liveEditing.test.tsx
@@ -68,7 +68,7 @@ vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
   ),
 }));
 
-vi.mock('@alga-psa/ui/components', () => ({
+vi.mock('@alga-psa/ui/components/tickets/PrioritySelect', () => ({
   PrioritySelect: ({
     value,
     options,

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -8,7 +8,7 @@ import UserAvatar from '@alga-psa/ui/components/UserAvatar';
 import TeamAvatar from '@alga-psa/ui/components/TeamAvatar';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { format } from 'date-fns';
-import { ResponseStateBadge } from '@alga-psa/ui/components';
+import { ResponseStateBadge } from '@alga-psa/ui/components/tickets/ResponseStateBadge';
 import { SlaIndicator } from '@alga-psa/ui/components/sla';
 import type { SlaTimerStatus } from '@alga-psa/types';
 

--- a/packages/tickets/src/lib/ticketAuthorizationSql.ts
+++ b/packages/tickets/src/lib/ticketAuthorizationSql.ts
@@ -1,0 +1,84 @@
+import type { Knex } from 'knex';
+import type { RelationshipSqlAdapter } from '@alga-psa/authorization/kernel';
+
+type TicketDbConnection = Knex | Knex.Transaction;
+
+/**
+ * Physical mapping the shared read-authorization SQL compiler needs for the
+ * `tickets` table. Mirrors `toTicketAuthorizationRecord`: a ticket is
+ * "assigned" to its primary `assigned_to` OR any `ticket_resources`
+ * `additional_user_id` co-assignee.
+ *
+ * Shared by the web server-action list and the public API list so both paths
+ * authorize identically — a single source of truth for the ticket adapter.
+ */
+export function createTicketRelationshipSqlAdapter(
+  conn: TicketDbConnection,
+  tenant: string
+): RelationshipSqlAdapter {
+  return {
+    ownerColumn: 't.entered_by',
+    clientColumn: 't.client_id',
+    boardColumn: 't.board_id',
+    teamColumn: 't.assigned_team_id',
+    // Tickets expose no client-visibility column ⇒ `client_visible_only` denies,
+    // matching the JS kernel (record.is_client_visible is absent).
+    applyAssignedUsers(query, userIds) {
+      const normalizedUserIds = Array.from(
+        new Set(userIds.filter((value): value is string => typeof value === 'string' && value.length > 0))
+      );
+      if (normalizedUserIds.length === 0) {
+        query.whereRaw('1 = 0');
+        return;
+      }
+
+      if (normalizedUserIds.length === 1) {
+        query.where('t.assigned_to', normalizedUserIds[0]);
+      } else {
+        query.whereIn('t.assigned_to', normalizedUserIds);
+      }
+
+      query.orWhereExists(function () {
+        this.select(conn.raw('1'))
+          .from('ticket_resources as tr_auth')
+          .whereRaw('tr_auth.tenant = t.tenant')
+          .whereRaw('tr_auth.ticket_id = t.ticket_id')
+          .andWhere('tr_auth.tenant', tenant)
+          .whereNotNull('tr_auth.additional_user_id');
+
+        if (normalizedUserIds.length === 1) {
+          this.andWhere('tr_auth.additional_user_id', normalizedUserIds[0]);
+        } else {
+          this.whereIn('tr_auth.additional_user_id', normalizedUserIds);
+        }
+      });
+    },
+  };
+}
+
+/**
+ * Batch-fetch `ticket_resources.additional_user_id` (co-assignees) keyed by
+ * ticket_id. Used to build JS authorization records that count co-assignees the
+ * same way `createTicketRelationshipSqlAdapter` does in SQL.
+ */
+export async function fetchTicketAdditionalUserIds(
+  conn: TicketDbConnection,
+  tenant: string,
+  ticketIds: string[]
+): Promise<Map<string, string[]>> {
+  const map = new Map<string, string[]>();
+  if (ticketIds.length === 0) {
+    return map;
+  }
+  const rows = await conn('ticket_resources')
+    .where({ tenant })
+    .whereIn('ticket_id', ticketIds)
+    .whereNotNull('additional_user_id')
+    .select<{ ticket_id: string; additional_user_id: string }[]>('ticket_id', 'additional_user_id');
+  for (const row of rows) {
+    const ids = map.get(row.ticket_id) ?? [];
+    ids.push(row.additional_user_id);
+    map.set(row.ticket_id, ids);
+  }
+  return map;
+}

--- a/packages/tickets/src/lib/ticketRichText.ts
+++ b/packages/tickets/src/lib/ticketRichText.ts
@@ -1,4 +1,4 @@
-import { PartialBlock } from '@blocknote/core';
+import type { PartialBlock } from '@blocknote/core';
 
 const EMPTY_TICKET_RICH_TEXT_BLOCK: PartialBlock[] = [
   {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss",
+    "*.css",
+    "*.scss"
+  ],
   "main": "./dist/index.mjs",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -20,8 +20,8 @@ export { default as ClientAvatar } from './ClientAvatar';
 export * from './ClientPicker';
 export * from './ColorPicker';
 export { default as ColorPicker } from './ColorPicker';
-export * from './CommentThreadDrawer';
-export { default as CommentThreadDrawer } from './CommentThreadDrawer';
+// CommentThreadDrawer pulls the BlockNote editor (via InlineReplyComposer). Not re-exported
+// from the barrel — import directly from '@alga-psa/ui/components/CommentThreadDrawer'.
 export * from './CommentThreadList';
 export { default as CommentThreadList } from './CommentThreadList';
 export * from './CollapseToggleButton';
@@ -72,8 +72,8 @@ export * from './IconPicker';
 export * from './Input';
 export * from './InteractionIcon';
 export { default as InteractionIcon } from './InteractionIcon';
-export * from './InlineReplyComposer';
-export { default as InlineReplyComposer } from './InlineReplyComposer';
+// InlineReplyComposer pulls the BlockNote editor. Not re-exported from the barrel —
+// import directly from '@alga-psa/ui/components/InlineReplyComposer'.
 export * from './Label';
 export * from './LanguagePreference';
 export * from './LoadingIndicator';
@@ -161,8 +161,8 @@ export * from './widgets/ButtonLinkWidget';
 export { default as ButtonLinkWidget } from './widgets/ButtonLinkWidget';
 export * from './widgets/HighlightWidget';
 export { default as HighlightWidget } from './widgets/HighlightWidget';
-export * from './widgets/RichTextViewerWidget';
-export { default as RichTextViewerWidget } from './widgets/RichTextViewerWidget';
+// RichTextViewerWidget pulls the BlockNote editor. Not re-exported from the barrel —
+// import directly from '@alga-psa/ui/components/widgets/RichTextViewerWidget'.
 export * from './tags';
 export * from './dashboard';
 export * from './common';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -25,6 +25,8 @@ export const getUniqueTagTexts = (tags: ITag[]): string[] => {
 
 export * from './ui-reflection';
 export * from './context';
-export * from './editor';
+// editor (BlockNote) is intentionally NOT re-exported from the barrel — it would pull
+// the ~1MB rich-text bundle into every @alga-psa/ui consumer (incl. signin / tickets
+// list). Import it directly from '@alga-psa/ui/editor'.
 export * from './services';
 export { DeleteEntityDialog } from './components/DeleteEntityDialog';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/src/app/msp/service-requests/ServiceRequestDefinitionEditorPage.tsx
+++ b/server/src/app/msp/service-requests/ServiceRequestDefinitionEditorPage.tsx
@@ -33,7 +33,7 @@ import BackNav from '@alga-psa/ui/components/BackNav';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Checkbox } from '@alga-psa/ui/components/Checkbox';
 import { Input } from '@alga-psa/ui/components/Input';
-import { MspTicketDetailsContainerClient } from '@alga-psa/msp-composition/tickets';
+import MspTicketDetailsContainerClient from '@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';

--- a/server/src/app/msp/tickets/[id]/page.tsx
+++ b/server/src/app/msp/tickets/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Suspense } from 'react';
 import { TicketDetailsSkeleton } from '@alga-psa/tickets/components/ticket/TicketDetailsSkeleton';
 import { getSurveyTicketSummary } from '@alga-psa/surveys/actions/survey-actions/surveyDashboardActions';
 import AssociatedAssets from '@alga-psa/assets/components/AssociatedAssets';
-import { MspTicketDetailsContainerClient } from '@alga-psa/msp-composition/tickets';
+import MspTicketDetailsContainerClient from '@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient';
 
 import { getTicketById } from '@alga-psa/tickets/actions/ticketActions';
 import { AIChatContextBoundary } from '@product/chat/context';

--- a/server/src/app/msp/tickets/page.tsx
+++ b/server/src/app/msp/tickets/page.tsx
@@ -3,7 +3,7 @@ import { getCurrentUser, getCurrentUserPermissions, getUserPreference } from '@a
 import { getTicketingDisplaySettings } from '@alga-psa/tickets/actions/ticketDisplaySettings';
 import { getTeams } from '@alga-psa/teams/actions';
 import type { ITicketListFilters } from '@alga-psa/types';
-import { MspTicketsPageClient } from '@alga-psa/msp-composition/tickets';
+import MspTicketsPageClient from '@alga-psa/msp-composition/tickets/MspTicketsPageClient';
 import {
   isTicketStatusOpenFilter,
   TICKET_STATUS_FILTER_OPEN,

--- a/server/src/app/msp/tickets/ticketsModalRoutes.contract.test.ts
+++ b/server/src/app/msp/tickets/ticketsModalRoutes.contract.test.ts
@@ -6,6 +6,21 @@ const repoRoot = path.resolve(__dirname, '../../../../..');
 const read = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 
 describe('tickets modal route infrastructure', () => {
+  it('keeps list and detail composition clients on separate import entrypoints', () => {
+    const listPage = read('server/src/app/msp/tickets/page.tsx');
+    const detailPage = read('server/src/app/msp/tickets/[id]/page.tsx');
+
+    expect(listPage).toContain(
+      "import MspTicketsPageClient from '@alga-psa/msp-composition/tickets/MspTicketsPageClient'",
+    );
+    expect(listPage).not.toContain("from '@alga-psa/msp-composition/tickets'");
+    expect(listPage).not.toContain('MspTicketDetailsContainerClient');
+
+    expect(detailPage).toContain(
+      "import MspTicketDetailsContainerClient from '@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient'",
+    );
+  });
+
   it('renders the tickets page and modal slot inside the shared tickets provider', () => {
     const layout = read('server/src/app/msp/tickets/layout.tsx');
 

--- a/server/src/lib/api/controllers/ApiTicketController.ts
+++ b/server/src/lib/api/controllers/ApiTicketController.ts
@@ -33,8 +33,15 @@ import {
 import { 
   hasPermission 
 } from '../../auth/rbac';
-import { authorizeApiResourceRead } from './authorizationKernel';
+import { authorizeApiResourceRead, buildAuthorizationPrincipalSubject } from './authorizationKernel';
 import { buildAuthorizationAwarePage } from '@alga-psa/authorization/pagination';
+import { compileResourceReadAuthorizationSql } from '@alga-psa/authorization/kernel';
+import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
+import {
+  createTicketRelationshipSqlAdapter,
+  fetchTicketAdditionalUserIds,
+} from '@alga-psa/tickets/lib/ticketAuthorizationSql';
+import type { Knex } from 'knex';
 import { fetchTimeEntriesForTicketCore } from '@alga-psa/scheduling/actions/timeEntryTicketActions';
 import {
   ApiRequest,
@@ -53,6 +60,45 @@ import {
   updateBundleSettingsSchema
 } from '../schemas/ticketBundle';
 import { ZodError } from 'zod';
+
+// Resolve a read-authorization predicate that mirrors the global authorization
+// kernel for ticket:read (no built-in relationship rules; bundle narrowing only —
+// empty in CE, populated in EE). Returns null when a rule isn't representable in
+// SQL so the caller falls back to the per-row JS kernel. RBAC is gated upstream
+// by checkPermission('read'), exactly as the per-row path relies on.
+async function resolveTicketReadAuthorizationApplier(
+  apiRequest: AuthenticatedApiRequest,
+  knex: Knex
+): Promise<((query: Knex.QueryBuilder) => void) | null> {
+  const subject = buildAuthorizationPrincipalSubject(
+    apiRequest.context.user,
+    apiRequest.context.apiKeyId
+  );
+  subject.tenant = apiRequest.context.tenant;
+
+  const bundleRules = await resolveBundleNarrowingRulesForEvaluation(knex, {
+    subject,
+    resource: { type: 'ticket', action: 'read' },
+    knex,
+  });
+  const adapter = createTicketRelationshipSqlAdapter(knex, subject.tenant);
+  const compile = (query: Knex.QueryBuilder) =>
+    compileResourceReadAuthorizationSql(query, {
+      resourceType: 'ticket',
+      action: 'read',
+      builtinRules: [],
+      bundleRules,
+      ctx: { subject, adapter },
+    });
+
+  // Probe representability on a throwaway builder before committing to SQL.
+  if (!compile(knex('tickets as t').where('t.tenant', subject.tenant)).supported) {
+    return null;
+  }
+  return (query: Knex.QueryBuilder) => {
+    compile(query);
+  };
+}
 
 export class ApiTicketController extends ApiBaseController {
   private ticketService: TicketService;
@@ -77,11 +123,20 @@ export class ApiTicketController extends ApiBaseController {
     this.ticketService = ticketService;
   }
 
-  private buildTicketRecordContext(ticket: Record<string, any>) {
+  // A ticket is "assigned" to its primary `assigned_to` OR any
+  // `ticket_resources` co-assignee — matching the web server-action and the SQL
+  // adapter (createTicketRelationshipSqlAdapter). Callers batch-fetch the
+  // co-assignees via fetchTicketAdditionalUserIds and pass them in.
+  private buildTicketRecordContext(ticket: Record<string, any>, additionalUserIds: string[] = []) {
+    const assignedUserIds = new Set<string>();
+    if (typeof ticket.assigned_to === 'string') assignedUserIds.add(ticket.assigned_to);
+    for (const id of additionalUserIds) {
+      if (typeof id === 'string' && id.length > 0) assignedUserIds.add(id);
+    }
     return {
       id: ticket.ticket_id,
       ownerUserId: typeof ticket.entered_by === 'string' ? ticket.entered_by : undefined,
-      assignedUserIds: typeof ticket.assigned_to === 'string' ? [ticket.assigned_to] : [],
+      assignedUserIds: Array.from(assignedUserIds),
       clientId: typeof ticket.client_id === 'string' ? ticket.client_id : undefined,
       boardId: typeof ticket.board_id === 'string' ? ticket.board_id : undefined,
       teamIds: typeof ticket.assigned_team_id === 'string' ? [ticket.assigned_team_id] : [],
@@ -100,13 +155,22 @@ export class ApiTicketController extends ApiBaseController {
       throw new NotFoundError('ticket not found');
     }
 
+    const ticketRow = ticket as Record<string, any>;
+    const additionalByTicket = await fetchTicketAdditionalUserIds(
+      resolvedKnex,
+      apiRequest.context.tenant,
+      typeof ticketRow.ticket_id === 'string' ? [ticketRow.ticket_id] : []
+    );
     const allowed = await authorizeApiResourceRead({
       knex: resolvedKnex,
       tenant: apiRequest.context.tenant,
       user: apiRequest.context.user,
       apiKeyId: apiRequest.context.apiKeyId,
       resource: 'ticket',
-      recordContext: this.buildTicketRecordContext(ticket as Record<string, any>),
+      recordContext: this.buildTicketRecordContext(
+        ticketRow,
+        additionalByTicket.get(ticketRow.ticket_id) ?? []
+      ),
     });
 
     if (!allowed) {
@@ -126,6 +190,14 @@ export class ApiTicketController extends ApiBaseController {
     }
 
     const resolvedKnex = knex ?? await getConnection(apiRequest.context.tenant);
+    const ticketIds = tickets
+      .map((ticket) => ticket.ticket_id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    const additionalByTicket = await fetchTicketAdditionalUserIds(
+      resolvedKnex,
+      apiRequest.context.tenant,
+      ticketIds
+    );
     const allowedByRow = await Promise.all(
       tickets.map((ticket) =>
         authorizeApiResourceRead({
@@ -134,7 +206,7 @@ export class ApiTicketController extends ApiBaseController {
           user: apiRequest.context.user,
           apiKeyId: apiRequest.context.apiKeyId,
           resource: 'ticket',
-          recordContext: this.buildTicketRecordContext(ticket),
+          recordContext: this.buildTicketRecordContext(ticket, additionalByTicket.get(ticket.ticket_id) ?? []),
         })
       )
     );
@@ -256,6 +328,37 @@ export class ApiTicketController extends ApiBaseController {
           delete filters.fields;
 
           const knex = await getConnection(apiRequest.context.tenant);
+
+          // Preferred path: push read-authorization into SQL so the database
+          // paginates and counts only the authorized set (one data + one count
+          // query, accurate total). RBAC was already enforced by checkPermission
+          // above. Falls back to the per-row JS kernel when a narrowing rule
+          // isn't representable in SQL.
+          const applyAuthorization = await resolveTicketReadAuthorizationApplier(apiRequest, knex);
+          if (applyAuthorization) {
+            const authorizedResult = await this.ticketService.list(
+              {
+                page,
+                limit,
+                filters,
+                sort,
+                order,
+                fields: fields.length > 0 ? fields : undefined,
+                applyAuthorization,
+              },
+              apiRequest.context
+            );
+
+            return createPaginatedResponse(
+              authorizedResult.data,
+              authorizedResult.total,
+              page,
+              limit,
+              { sort, order, filters },
+              apiRequest
+            );
+          }
+
           const authorizedPage = await buildAuthorizationAwarePage<Record<string, any>>({
             page,
             limit,
@@ -264,15 +367,24 @@ export class ApiTicketController extends ApiBaseController {
                 { page: sourcePage, limit: sourceLimit, filters, sort, order, fields: fields.length > 0 ? fields : undefined },
                 apiRequest.context
               ),
-            authorizeRecord: (ticket) =>
-              authorizeApiResourceRead({
+            authorizeRecord: async (ticket) => {
+              const additionalByTicket = await fetchTicketAdditionalUserIds(
+                knex,
+                apiRequest.context.tenant,
+                typeof ticket.ticket_id === 'string' ? [ticket.ticket_id] : []
+              );
+              return authorizeApiResourceRead({
                 knex,
                 tenant: apiRequest.context.tenant,
                 user: apiRequest.context.user,
                 apiKeyId: apiRequest.context.apiKeyId,
                 resource: 'ticket',
-                recordContext: this.buildTicketRecordContext(ticket),
-              }),
+                recordContext: this.buildTicketRecordContext(
+                  ticket,
+                  additionalByTicket.get(ticket.ticket_id) ?? []
+                ),
+              });
+            },
             scanLimit: 100,
           });
 

--- a/server/src/lib/api/controllers/types.ts
+++ b/server/src/lib/api/controllers/types.ts
@@ -27,6 +27,12 @@ export interface ListOptions {
    * Services may ignore this if not supported.
    */
   fields?: string[];
+  /**
+   * Optional row-level authorization predicate (e.g. compiled read-narrowing)
+   * applied to both the data and count queries, so the service paginates and
+   * counts only the authorized set in SQL. Services may ignore this if unsupported.
+   */
+  applyAuthorization?: (query: import('knex').Knex.QueryBuilder) => void;
 }
 
 export interface BaseService {

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -202,6 +202,13 @@ export class TicketService extends BaseService<ITicket> {
     dataQuery = this.applyTicketFilters(dataQuery, filters);
     countQuery = this.applyTicketFilters(countQuery, filters);
 
+    // Push row-level read authorization into SQL (when the caller provides it)
+    // so both the page and the total count reflect only authorized rows.
+    if (options.applyAuthorization) {
+      options.applyAuthorization(dataQuery);
+      options.applyAuthorization(countQuery);
+    }
+
     // Apply sorting
     const sortField = sort || this.defaultSort;
     const sortOrder = order || this.defaultOrder;

--- a/server/src/lib/authorization/kernel/providers/bundleProvider.ts
+++ b/server/src/lib/authorization/kernel/providers/bundleProvider.ts
@@ -7,7 +7,7 @@ import type {
   ScopeConstraint,
 } from '../contracts';
 import { ALLOW_ALL_SCOPE } from '../scope';
-import { evaluateRelationshipTemplate } from '../relationships';
+import { evaluateRelationshipTemplate } from '../relationshipTemplates';
 
 export interface BundleNarrowingRule {
   id: string;

--- a/server/src/lib/authorization/kernel/relationshipTemplates.ts
+++ b/server/src/lib/authorization/kernel/relationshipTemplates.ts
@@ -1,0 +1,320 @@
+import type { Knex } from 'knex';
+import type {
+  AuthorizationEvaluationInput,
+  AuthorizationSubject,
+  RelationshipRule,
+  RelationshipTemplateKey,
+} from './contracts';
+import type { BundleNarrowingRule } from './providers/bundleProvider';
+
+// ---------------------------------------------------------------------------
+// Shared relationship-template definitions.
+//
+// Each template is defined ONCE with two facets:
+//   - matches(): per-record JS evaluation (used by the kernel to filter
+//     already-fetched rows)
+//   - compileSql(): emits the equivalent SQL predicate onto a query builder
+//     (used to push read-authorization into the database so pagination/count
+//     run server-side instead of fetch-all-then-filter-in-JS)
+//
+// Keeping both facets in a single registry keyed by RelationshipTemplateKey
+// makes the two paths impossible to drift: adding a template is a compile error
+// until both facets are supplied. The kernel owns template *semantics*; a
+// resource supplies its physical columns via RelationshipSqlAdapter.
+// ---------------------------------------------------------------------------
+
+function hasIntersection(left: string[] = [], right: string[] = []): boolean {
+  if (left.length === 0 || right.length === 0) {
+    return false;
+  }
+  const rightSet = new Set(right);
+  return left.some((item) => rightSet.has(item));
+}
+
+function uniqueNonEmpty(values: Array<string | null | undefined> | undefined): string[] {
+  return Array.from(
+    new Set(
+      (values ?? []).filter((value): value is string => typeof value === 'string' && value.length > 0)
+    )
+  );
+}
+
+/**
+ * Resource-specific physical mapping the SQL compiler needs. The kernel owns the
+ * template semantics; the resource supplies the columns/relations they map to.
+ */
+export interface RelationshipSqlAdapter {
+  ownerColumn: string;
+  clientColumn: string;
+  boardColumn: string;
+  teamColumn: string;
+  /**
+   * Column holding a boolean client-visibility flag. When omitted, the
+   * `client_visible_only` bundle constraint denies all rows — matching the JS
+   * kernel, which denies when `record.is_client_visible !== true` and the
+   * resource never exposes that field.
+   */
+  clientVisibleColumn?: string;
+  /**
+   * Narrow `builder` to rows assigned to any of `userIds` (the primary assignee
+   * column and/or a resource-specific co-assignee relation). Must deny (no rows)
+   * when `userIds` is empty.
+   */
+  applyAssignedUsers(builder: Knex.QueryBuilder, userIds: string[]): void;
+}
+
+export interface RelationshipSqlContext {
+  subject: AuthorizationSubject;
+  selectedClientIds?: string[];
+  selectedBoardIds?: string[];
+  adapter: RelationshipSqlAdapter;
+}
+
+export type RelationshipSqlCompileResult =
+  | { supported: true }
+  | { supported: false; reason: string };
+
+function deny(builder: Knex.QueryBuilder): void {
+  builder.whereRaw('1 = 0');
+}
+
+function whereInOrDeny(
+  builder: Knex.QueryBuilder,
+  column: string,
+  values: Array<string | null | undefined> | undefined
+): void {
+  const normalized = uniqueNonEmpty(values);
+  if (normalized.length === 0) {
+    deny(builder);
+    return;
+  }
+  builder.whereIn(column, normalized);
+}
+
+interface RelationshipTemplateDef {
+  matches(input: AuthorizationEvaluationInput): boolean;
+  compileSql(builder: Knex.QueryBuilder, ctx: RelationshipSqlContext): void;
+}
+
+const RELATIONSHIP_TEMPLATES: Record<RelationshipTemplateKey, RelationshipTemplateDef> = {
+  own: {
+    matches: (input) =>
+      typeof input.record?.ownerUserId === 'string' && input.record.ownerUserId === input.subject.userId,
+    compileSql: (builder, ctx) => {
+      builder.where(ctx.adapter.ownerColumn, ctx.subject.userId);
+    },
+  },
+  assigned: {
+    matches: (input) =>
+      Array.isArray(input.record?.assignedUserIds) &&
+      input.record.assignedUserIds.includes(input.subject.userId),
+    compileSql: (builder, ctx) => {
+      ctx.adapter.applyAssignedUsers(builder, [ctx.subject.userId]);
+    },
+  },
+  managed: {
+    matches: (input) =>
+      Array.isArray(input.record?.assignedUserIds) &&
+      hasIntersection(input.record.assignedUserIds, input.subject.managedUserIds),
+    compileSql: (builder, ctx) => {
+      ctx.adapter.applyAssignedUsers(builder, ctx.subject.managedUserIds ?? []);
+    },
+  },
+  own_or_assigned: {
+    matches: (input) =>
+      RELATIONSHIP_TEMPLATES.own.matches(input) || RELATIONSHIP_TEMPLATES.assigned.matches(input),
+    compileSql: (builder, ctx) => {
+      builder
+        .where(ctx.adapter.ownerColumn, ctx.subject.userId)
+        .orWhere(function orAssigned(this: Knex.QueryBuilder) {
+          ctx.adapter.applyAssignedUsers(this, [ctx.subject.userId]);
+        });
+    },
+  },
+  own_or_managed: {
+    matches: (input) =>
+      RELATIONSHIP_TEMPLATES.own.matches(input) || RELATIONSHIP_TEMPLATES.managed.matches(input),
+    compileSql: (builder, ctx) => {
+      builder
+        .where(ctx.adapter.ownerColumn, ctx.subject.userId)
+        .orWhere(function orManaged(this: Knex.QueryBuilder) {
+          ctx.adapter.applyAssignedUsers(this, ctx.subject.managedUserIds ?? []);
+        });
+    },
+  },
+  same_client: {
+    matches: (input) =>
+      Boolean(
+        input.record?.clientId &&
+          input.subject.clientId &&
+          input.record.clientId === input.subject.clientId
+      ),
+    compileSql: (builder, ctx) => {
+      if (!ctx.subject.clientId) {
+        deny(builder);
+        return;
+      }
+      builder.where(ctx.adapter.clientColumn, ctx.subject.clientId);
+    },
+  },
+  client_portfolio: {
+    matches: (input) =>
+      Boolean(input.record?.clientId && input.subject.portfolioClientIds?.includes(input.record.clientId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.clientColumn, ctx.subject.portfolioClientIds);
+    },
+  },
+  selected_clients: {
+    matches: (input) =>
+      Boolean(input.record?.clientId && input.selectedClientIds?.includes(input.record.clientId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.clientColumn, ctx.selectedClientIds);
+    },
+  },
+  same_team: {
+    matches: (input) => hasIntersection(input.record?.teamIds, input.subject.teamIds),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.teamColumn, ctx.subject.teamIds);
+    },
+  },
+  selected_boards: {
+    matches: (input) =>
+      Boolean(input.record?.boardId && input.selectedBoardIds?.includes(input.record.boardId)),
+    compileSql: (builder, ctx) => {
+      whereInOrDeny(builder, ctx.adapter.boardColumn, ctx.selectedBoardIds);
+    },
+  },
+};
+
+export function evaluateRelationshipTemplate(
+  template: RelationshipTemplateKey,
+  input: AuthorizationEvaluationInput
+): boolean {
+  if (!input.record) {
+    return false;
+  }
+  return RELATIONSHIP_TEMPLATES[template].matches(input);
+}
+
+export function compileRelationshipTemplateSql(
+  builder: Knex.QueryBuilder,
+  template: RelationshipTemplateKey,
+  ctx: RelationshipSqlContext
+): void {
+  RELATIONSHIP_TEMPLATES[template].compileSql(builder, ctx);
+}
+
+/**
+ * Built-in relationship rules narrow with OR semantics (a row is allowed if ANY
+ * rule's template matches); an empty rule set allows all. Mirrors
+ * `evaluateRelationshipRules`.
+ */
+export function compileRelationshipRulesSql(
+  builder: Knex.QueryBuilder,
+  rules: RelationshipRule[],
+  ctx: RelationshipSqlContext
+): void {
+  if (rules.length === 0) {
+    return;
+  }
+  builder.andWhere(function relationshipGroup(this: Knex.QueryBuilder) {
+    rules.forEach((rule, index) => {
+      const apply = function templatePredicate(this: Knex.QueryBuilder) {
+        compileRelationshipTemplateSql(this, rule.template, ctx);
+      };
+      if (index === 0) {
+        this.where(apply);
+      } else {
+        this.orWhere(apply);
+      }
+    });
+  });
+}
+
+function compileBundleRuleSql(
+  builder: Knex.QueryBuilder,
+  rule: BundleNarrowingRule,
+  ctx: RelationshipSqlContext
+): RelationshipSqlCompileResult {
+  if (rule.constraintKey === 'client_visible_only') {
+    if (ctx.adapter.clientVisibleColumn) {
+      builder.where(ctx.adapter.clientVisibleColumn, true);
+    } else {
+      deny(builder);
+    }
+    return { supported: true };
+  }
+
+  // `not_self_approver` only constrains mutations; it never denies a read.
+  if (rule.constraintKey && rule.constraintKey !== 'not_self_approver') {
+    return { supported: false, reason: `unsupported bundle constraint ${rule.constraintKey}` };
+  }
+
+  if (!rule.templateKey) {
+    return { supported: true };
+  }
+
+  const ruleCtx: RelationshipSqlContext = {
+    ...ctx,
+    selectedClientIds:
+      rule.templateKey === 'selected_clients' ? (rule.selectedClientIds ?? []) : ctx.selectedClientIds,
+    selectedBoardIds:
+      rule.templateKey === 'selected_boards' ? (rule.selectedBoardIds ?? []) : ctx.selectedBoardIds,
+  };
+
+  builder.andWhere(function bundleTemplate(this: Knex.QueryBuilder) {
+    compileRelationshipTemplateSql(this, rule.templateKey as RelationshipTemplateKey, ruleCtx);
+  });
+  return { supported: true };
+}
+
+/**
+ * Bundle narrowing rules intersect with AND semantics (every matching rule's
+ * template must hold). Mirrors `BundleAuthorizationKernelProvider.evaluateNarrowing`
+ * for the read path. Returns `{ supported: false }` for any constraint not yet
+ * representable in SQL so the caller can fall back to the JS kernel.
+ */
+export function compileBundleReadNarrowingSql(
+  builder: Knex.QueryBuilder,
+  bundleRules: BundleNarrowingRule[],
+  resourceType: string,
+  action: string,
+  ctx: RelationshipSqlContext
+): RelationshipSqlCompileResult {
+  const matching = bundleRules.filter((rule) => rule.resource === resourceType && rule.action === action);
+  for (const rule of matching) {
+    const result = compileBundleRuleSql(builder, rule, ctx);
+    if (!result.supported) {
+      return result;
+    }
+  }
+  return { supported: true };
+}
+
+export interface ResourceReadAuthorizationSqlParams {
+  resourceType: string;
+  action: string;
+  builtinRules: RelationshipRule[];
+  bundleRules: BundleNarrowingRule[];
+  ctx: RelationshipSqlContext;
+}
+
+/**
+ * Compile a complete read-authorization predicate onto `builder`: the built-in
+ * relationship rules (OR-group) ANDed with every matching bundle rule. Returns
+ * `{ supported: false }` when a rule cannot be represented in SQL — callers
+ * MUST then fall back to the JS kernel rather than run the partial query.
+ */
+export function compileResourceReadAuthorizationSql(
+  builder: Knex.QueryBuilder,
+  params: ResourceReadAuthorizationSqlParams
+): RelationshipSqlCompileResult {
+  compileRelationshipRulesSql(builder, params.builtinRules, params.ctx);
+  return compileBundleReadNarrowingSql(
+    builder,
+    params.bundleRules,
+    params.resourceType,
+    params.action,
+    params.ctx
+  );
+}

--- a/server/src/lib/authorization/kernel/relationships.ts
+++ b/server/src/lib/authorization/kernel/relationships.ts
@@ -3,58 +3,9 @@ import type {
   AuthorizationReason,
   AuthorizationScope,
   RelationshipRule,
-  RelationshipTemplateKey,
 } from './contracts';
 import { DENY_ALL_SCOPE } from './scope';
-
-function hasIntersection(left: string[] = [], right: string[] = []): boolean {
-  if (left.length === 0 || right.length === 0) {
-    return false;
-  }
-  const rightSet = new Set(right);
-  return left.some((item) => rightSet.has(item));
-}
-
-export function evaluateRelationshipTemplate(
-  template: RelationshipTemplateKey,
-  input: AuthorizationEvaluationInput
-): boolean {
-  const record = input.record;
-  if (!record) {
-    return false;
-  }
-
-  switch (template) {
-    case 'own':
-      return typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId;
-    case 'assigned':
-      return Array.isArray(record.assignedUserIds) && record.assignedUserIds.includes(input.subject.userId);
-    case 'managed':
-      return Array.isArray(record.assignedUserIds) && hasIntersection(record.assignedUserIds, input.subject.managedUserIds);
-    case 'own_or_assigned':
-      return (
-        (typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId) ||
-        (Array.isArray(record.assignedUserIds) && record.assignedUserIds.includes(input.subject.userId))
-      );
-    case 'own_or_managed':
-      return (
-        (typeof record.ownerUserId === 'string' && record.ownerUserId === input.subject.userId) ||
-        (Array.isArray(record.assignedUserIds) && hasIntersection(record.assignedUserIds, input.subject.managedUserIds))
-      );
-    case 'same_client':
-      return Boolean(record.clientId && input.subject.clientId && record.clientId === input.subject.clientId);
-    case 'client_portfolio':
-      return Boolean(record.clientId && input.subject.portfolioClientIds?.includes(record.clientId));
-    case 'selected_clients':
-      return Boolean(record.clientId && input.selectedClientIds?.includes(record.clientId));
-    case 'same_team':
-      return hasIntersection(record.teamIds, input.subject.teamIds);
-    case 'selected_boards':
-      return Boolean(record.boardId && input.selectedBoardIds?.includes(record.boardId));
-    default:
-      return false;
-  }
-}
+import { evaluateRelationshipTemplate } from './relationshipTemplates';
 
 export function evaluateRelationshipRules(
   rules: RelationshipRule[],

--- a/server/src/test/integration/authorization/relationshipSqlParity.integration.test.ts
+++ b/server/src/test/integration/authorization/relationshipSqlParity.integration.test.ts
@@ -1,0 +1,314 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import knexFactory, { type Knex } from 'knex';
+import {
+  BuiltinAuthorizationKernelProvider,
+  BundleAuthorizationKernelProvider,
+  RequestLocalAuthorizationCache,
+  createAuthorizationKernel,
+  compileResourceReadAuthorizationSql,
+  type AuthorizationRecord,
+  type AuthorizationSubject,
+  type BundleNarrowingRule,
+  type RelationshipRule,
+  type RelationshipSqlAdapter,
+} from '@alga-psa/authorization/kernel';
+
+// Differential parity: the SQL compiler must select EXACTLY the rows the JS
+// kernel allows, across a fixture matrix. The JS side runs the real kernel
+// (the same providers the ticket server-action wires); the SQL side runs the
+// shared compiler. They share one template registry, so this proves the two
+// facets stay in lock-step against real Postgres semantics (OR/AND grouping,
+// EXISTS, IN, NULL handling).
+//
+// Uses session-local TEMP tables on the local dev DB — never touches real data.
+
+function readPassword(): string {
+  const candidates = [
+    path.resolve(process.cwd(), '../secrets/postgres_password'),
+    path.resolve(process.cwd(), 'secrets/postgres_password'),
+    '/run/secrets/postgres_password',
+  ];
+  for (const file of candidates) {
+    try {
+      const value = fs.readFileSync(file, 'utf8').trim();
+      if (value) return value;
+    } catch {
+      /* try next */
+    }
+  }
+  return 'postpass123';
+}
+
+const TENANT = '11111111-1111-4111-8111-111111111111';
+const U1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1';
+const U9 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa9';
+const MANAGED = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaab2';
+const TEAM1 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1';
+const TEAMX = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbx'.replace('x', '9');
+const C1 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1';
+const C2 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2';
+const CX = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc9';
+const B1 = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1';
+const BX = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd9';
+const OTHER_TENANT = '22222222-2222-4222-8222-222222222222';
+
+interface TicketRow {
+  ticket_id: string;
+  entered_by: string;
+  assigned_to: string | null;
+  client_id: string | null;
+  board_id: string | null;
+  assigned_team_id: string | null;
+}
+
+// id -> additional (co-assignee) user ids
+const ADDITIONAL: Record<string, string[]> = {
+  'ticket-6': [U1],
+};
+
+const TICKETS: TicketRow[] = [
+  { ticket_id: 'ticket-1', entered_by: U1, assigned_to: U9, client_id: CX, board_id: BX, assigned_team_id: TEAMX },
+  { ticket_id: 'ticket-2', entered_by: U9, assigned_to: U1, client_id: CX, board_id: BX, assigned_team_id: TEAMX },
+  { ticket_id: 'ticket-3', entered_by: U9, assigned_to: U9, client_id: CX, board_id: BX, assigned_team_id: TEAM1 },
+  { ticket_id: 'ticket-4', entered_by: U9, assigned_to: U9, client_id: C1, board_id: B1, assigned_team_id: TEAMX },
+  { ticket_id: 'ticket-5', entered_by: U9, assigned_to: U9, client_id: C2, board_id: BX, assigned_team_id: TEAMX },
+  // ticket-6: U1 reaches this ONLY as a ticket_resources co-assignee (entered/assigned = U9).
+  { ticket_id: 'ticket-6', entered_by: U9, assigned_to: U9, client_id: CX, board_id: BX, assigned_team_id: TEAMX },
+  { ticket_id: 'ticket-7', entered_by: U1, assigned_to: U1, client_id: C1, board_id: B1, assigned_team_id: TEAM1 },
+  { ticket_id: 'ticket-8', entered_by: U9, assigned_to: null, client_id: null, board_id: null, assigned_team_id: null },
+  // ticket-9: U1 is a co-assignee ONLY under a different tenant (see beforeAll). The
+  // tenant-scoped EXISTS must ignore it — this guards the adapter's tenant filter.
+  { ticket_id: 'ticket-9', entered_by: U9, assigned_to: U9, client_id: CX, board_id: BX, assigned_team_id: TEAMX },
+];
+
+const internalSubject: AuthorizationSubject = {
+  tenant: TENANT,
+  userId: U1,
+  userType: 'internal',
+  teamIds: [TEAM1],
+  managedUserIds: [MANAGED],
+  portfolioClientIds: [C1, C2],
+  clientId: null,
+};
+
+const clientSubject: AuthorizationSubject = {
+  tenant: TENANT,
+  userId: U1,
+  userType: 'client',
+  teamIds: [TEAM1],
+  managedUserIds: [],
+  portfolioClientIds: [C1, C2],
+  clientId: C1,
+};
+
+interface Scenario {
+  name: string;
+  subject: AuthorizationSubject;
+  selectedBoardIds?: string[];
+  bundleRules: BundleNarrowingRule[];
+}
+
+const rule = (overrides: Partial<BundleNarrowingRule> & { id: string }): BundleNarrowingRule => ({
+  resource: 'ticket',
+  action: 'read',
+  ...overrides,
+});
+
+const SCENARIOS: Scenario[] = [
+  { name: 'own', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'own' })] },
+  { name: 'assigned (primary + co-assignee)', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'assigned' })] },
+  { name: 'managed', subject: { ...internalSubject, managedUserIds: [U9] }, bundleRules: [rule({ id: 'r', templateKey: 'managed' })] },
+  { name: 'own_or_assigned', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'own_or_assigned' })] },
+  { name: 'same_team', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'same_team' })] },
+  { name: 'client_portfolio', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'client_portfolio' })] },
+  { name: 'selected_clients (rule-scoped)', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'selected_clients', selectedClientIds: [C2] })] },
+  { name: 'two rules ANDed (own + same_team)', subject: internalSubject, bundleRules: [rule({ id: 'r1', templateKey: 'own' }), rule({ id: 'r2', templateKey: 'same_team' })] },
+  { name: 'client_visible_only denies all', subject: internalSubject, bundleRules: [rule({ id: 'r', constraintKey: 'client_visible_only' })] },
+  { name: 'no rules ⇒ allow all', subject: internalSubject, bundleRules: [] },
+  {
+    name: 'client portal: selected_boards builtin + same_client bundle',
+    subject: clientSubject,
+    selectedBoardIds: [B1],
+    bundleRules: [rule({ id: 'r', templateKey: 'same_client' })],
+  },
+  {
+    name: 'client portal: selected_boards builtin only',
+    subject: clientSubject,
+    selectedBoardIds: [B1],
+    bundleRules: [],
+  },
+];
+
+let db: Knex | undefined;
+try {
+  db = knexFactory({
+    client: 'pg',
+    connection: {
+      host: process.env.RELSQL_DB_HOST || 'localhost',
+      port: Number(process.env.RELSQL_DB_PORT || 5432),
+      user: 'postgres',
+      password: readPassword(),
+      database: process.env.RELSQL_DB_NAME || 'server',
+    },
+    // TEMP tables are connection-local; pin to a single connection so every
+    // query in the suite sees them.
+    pool: { min: 1, max: 1 },
+  });
+  await db.raw('select 1');
+} catch {
+  if (db) await db.destroy().catch(() => undefined);
+  db = undefined;
+}
+
+const parityIt = db ? it : it.skip;
+if (!db) {
+  // eslint-disable-next-line no-console
+  console.warn('[relationshipSqlParity] no local Postgres on :5432 — parity tests skipped');
+}
+
+function toRecord(row: TicketRow): AuthorizationRecord {
+  const assignees = new Set<string>();
+  if (row.assigned_to) assignees.add(row.assigned_to);
+  for (const id of ADDITIONAL[row.ticket_id] ?? []) assignees.add(id);
+  return {
+    id: row.ticket_id,
+    ownerUserId: row.entered_by,
+    assignedUserIds: Array.from(assignees),
+    clientId: row.client_id,
+    boardId: row.board_id,
+    teamIds: row.assigned_team_id ? [row.assigned_team_id] : [],
+  };
+}
+
+async function jsKernelAllowedIds(scenario: Scenario): Promise<Set<string>> {
+  const builtinRules: RelationshipRule[] =
+    scenario.selectedBoardIds === undefined ? [] : [{ template: 'selected_boards' }];
+  const kernel = createAuthorizationKernel({
+    builtinProvider: new BuiltinAuthorizationKernelProvider({ relationshipRules: builtinRules }),
+    bundleProvider: new BundleAuthorizationKernelProvider({ resolveRules: async () => scenario.bundleRules }),
+    rbacEvaluator: async () => true,
+  });
+  const requestCache = new RequestLocalAuthorizationCache();
+  const allowed = new Set<string>();
+  for (const row of TICKETS) {
+    const decision = await kernel.authorizeResource({
+      subject: scenario.subject,
+      resource: { type: 'ticket', action: 'read', id: row.ticket_id },
+      record: toRecord(row),
+      selectedBoardIds: scenario.selectedBoardIds,
+      requestCache,
+    });
+    if (decision.allowed) allowed.add(row.ticket_id);
+  }
+  return allowed;
+}
+
+function sqlAdapter(connection: Knex): RelationshipSqlAdapter {
+  return {
+    ownerColumn: 't.entered_by',
+    clientColumn: 't.client_id',
+    boardColumn: 't.board_id',
+    teamColumn: 't.assigned_team_id',
+    applyAssignedUsers(builder, userIds) {
+      const ids = Array.from(new Set(userIds.filter((v): v is string => typeof v === 'string' && v.length > 0)));
+      if (ids.length === 0) {
+        builder.whereRaw('1 = 0');
+        return;
+      }
+      builder.whereIn('t.assigned_to', ids).orWhereExists(function exists(this: Knex.QueryBuilder) {
+        this.select(connection.raw('1'))
+          .from('relsql_ticket_resources as tr')
+          .whereRaw('tr.tenant = t.tenant')
+          .whereRaw('tr.ticket_id = t.ticket_id')
+          .whereNotNull('tr.additional_user_id')
+          .whereIn('tr.additional_user_id', ids);
+      });
+    },
+  };
+}
+
+async function sqlAllowedIds(connection: Knex, scenario: Scenario): Promise<Set<string> | null> {
+  const builtinRules: RelationshipRule[] =
+    scenario.selectedBoardIds === undefined ? [] : [{ template: 'selected_boards' }];
+  const query = connection('relsql_tickets as t').where('t.tenant', TENANT);
+  const result = compileResourceReadAuthorizationSql(query, {
+    resourceType: 'ticket',
+    action: 'read',
+    builtinRules,
+    bundleRules: scenario.bundleRules,
+    ctx: { subject: scenario.subject, selectedBoardIds: scenario.selectedBoardIds, adapter: sqlAdapter(connection) },
+  });
+  if (!result.supported) return null;
+  const rows = await query.clearSelect().select('t.ticket_id');
+  return new Set(rows.map((r: { ticket_id: string }) => r.ticket_id));
+}
+
+describe('relationship SQL ↔ JS kernel parity', () => {
+  beforeAll(async () => {
+    if (!db) return;
+    await db.raw('CREATE TEMP TABLE relsql_tickets (tenant uuid, ticket_id text, entered_by uuid, assigned_to uuid, client_id uuid, board_id uuid, assigned_team_id uuid) ON COMMIT PRESERVE ROWS');
+    await db.raw('CREATE TEMP TABLE relsql_ticket_resources (tenant uuid, ticket_id text, additional_user_id uuid) ON COMMIT PRESERVE ROWS');
+    await db('relsql_tickets').insert(TICKETS.map((t) => ({ ...t, tenant: TENANT })));
+    const resources = Object.entries(ADDITIONAL).flatMap(([ticketId, userIds]) =>
+      userIds.map((additional_user_id) => ({ tenant: TENANT, ticket_id: ticketId, additional_user_id }))
+    );
+    if (resources.length > 0) await db('relsql_ticket_resources').insert(resources);
+
+    // Cross-tenant co-assignee: U1 is an additional agent on ticket-9 but under
+    // OTHER_TENANT. The tenant-scoped EXISTS must ignore it. Intentionally NOT
+    // mirrored into ADDITIONAL, so the JS record context excludes it too — if the
+    // SQL adapter dropped its tenant filter, the two paths would diverge here.
+    await db('relsql_ticket_resources').insert({
+      tenant: OTHER_TENANT,
+      ticket_id: 'ticket-9',
+      additional_user_id: U1,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    if (db) await db.destroy();
+  });
+
+  parityIt('every scenario selects identical rows in SQL and the JS kernel', async () => {
+    const connection = db as Knex;
+    const mismatches: string[] = [];
+    for (const scenario of SCENARIOS) {
+      const jsIds = await jsKernelAllowedIds(scenario);
+      const sqlIds = await sqlAllowedIds(connection, scenario);
+      expect(sqlIds, `${scenario.name}: SQL path should be supported`).not.toBeNull();
+      const js = [...jsIds].sort();
+      const sql = [...(sqlIds as Set<string>)].sort();
+      if (JSON.stringify(js) !== JSON.stringify(sql)) {
+        mismatches.push(`${scenario.name}\n  js : ${js.join(', ') || '∅'}\n  sql: ${sql.join(', ') || '∅'}`);
+      }
+    }
+    expect(mismatches, `parity mismatches:\n${mismatches.join('\n')}`).toHaveLength(0);
+  });
+
+  parityIt('discriminates (own selects only u1-entered tickets, not everything/nothing)', async () => {
+    const ids = await sqlAllowedIds(db as Knex, { name: 'own', subject: internalSubject, bundleRules: [rule({ id: 'r', templateKey: 'own' })] });
+    expect(ids).not.toBeNull();
+    expect([...(ids as Set<string>)].sort()).toEqual(['ticket-1', 'ticket-7']);
+  });
+
+  parityIt('co-assignee path: includes a pure co-assignee, excludes a cross-tenant one', async () => {
+    const scenario: Scenario = {
+      name: 'assigned',
+      subject: internalSubject,
+      bundleRules: [rule({ id: 'r', templateKey: 'assigned' })],
+    };
+    const sqlIds = await sqlAllowedIds(db as Knex, scenario);
+    expect(sqlIds).not.toBeNull();
+    const set = sqlIds as Set<string>;
+    // ticket-2 / ticket-7: U1 is the primary assignee. ticket-6: U1 only via a
+    // same-tenant ticket_resources co-assignee. ticket-9: U1 co-assignee under a
+    // different tenant ⇒ must NOT appear.
+    expect(set.has('ticket-6')).toBe(true);
+    expect(set.has('ticket-9')).toBe(false);
+    expect([...set].sort()).toEqual(['ticket-2', 'ticket-6', 'ticket-7']);
+    // And the JS kernel agrees exactly.
+    expect([...(await jsKernelAllowedIds(scenario))].sort()).toEqual(['ticket-2', 'ticket-6', 'ticket-7']);
+  });
+});

--- a/server/src/test/unit/app/msp/tickets/[id]/page.productComposition.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/[id]/page.productComposition.test.tsx
@@ -37,8 +37,8 @@ vi.mock('@alga-psa/assets/components/AssociatedAssets', () => ({
   default: () => null,
 }));
 
-vi.mock('@alga-psa/msp-composition/tickets', () => ({
-  MspTicketDetailsContainerClient: MspTicketDetailsContainerClientMock,
+vi.mock('@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient', () => ({
+  default: MspTicketDetailsContainerClientMock,
 }));
 
 const { default: TicketDetailsPage } = await import('server/src/app/msp/tickets/[id]/page');

--- a/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
@@ -191,12 +191,12 @@ vi.mock('@alga-psa/assets/components/AssociatedAssets', () => ({
   default: () => null,
 }));
 
-vi.mock('@alga-psa/msp-composition/tickets', async () => {
+vi.mock('@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient', async () => {
   const ReactModule = await import('react');
   const { useTranslation } = await import('@alga-psa/ui/lib/i18n/client');
 
   return {
-    MspTicketDetailsContainerClient: () => {
+    default: () => {
       const { t } = useTranslation('features/tickets');
 
       return (

--- a/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/detail.page.i18n.test.tsx
@@ -196,7 +196,7 @@ vi.mock('@alga-psa/msp-composition/tickets/MspTicketDetailsContainerClient', asy
   const { useTranslation } = await import('@alga-psa/ui/lib/i18n/client');
 
   return {
-    default: () => {
+    default: function MockTicketDetailsContainer() {
       const { t } = useTranslation('features/tickets');
 
       return (

--- a/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
@@ -276,7 +276,7 @@ vi.mock('@alga-psa/msp-composition/tickets/MspTicketsPageClient', async () => {
   const { useTranslation } = await import('@alga-psa/ui/lib/i18n/client');
 
   return {
-    default: () => {
+    default: function MockTicketsPageClient() {
       const { t } = useTranslation('features/tickets');
 
       return (

--- a/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/page.i18n.test.tsx
@@ -271,12 +271,12 @@ vi.mock('@alga-psa/teams/actions', () => ({
   getTeams: (...args: unknown[]) => getTeamsMock(...args),
 }));
 
-vi.mock('@alga-psa/msp-composition/tickets', async () => {
+vi.mock('@alga-psa/msp-composition/tickets/MspTicketsPageClient', async () => {
   const ReactModule = await import('react');
   const { useTranslation } = await import('@alga-psa/ui/lib/i18n/client');
 
   return {
-    MspTicketsPageClient: () => {
+    default: () => {
       const { t } = useTranslation('features/tickets');
 
       return (

--- a/server/src/test/unit/app/msp/tickets/page.productComposition.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/page.productComposition.test.tsx
@@ -37,8 +37,8 @@ vi.mock('@alga-psa/teams/actions', () => ({
   getTeams: getTeamsMock,
 }));
 
-vi.mock('@alga-psa/msp-composition/tickets', () => ({
-  MspTicketsPageClient: MspTicketsPageClientMock,
+vi.mock('@alga-psa/msp-composition/tickets/MspTicketsPageClient', () => ({
+  default: MspTicketsPageClientMock,
 }));
 
 const { default: TicketsPage } = await import('server/src/app/msp/tickets/page');

--- a/server/src/test/unit/authorization/kernel.relationshipSql.test.ts
+++ b/server/src/test/unit/authorization/kernel.relationshipSql.test.ts
@@ -1,0 +1,233 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import knexFactory, { type Knex } from 'knex';
+import {
+  compileRelationshipTemplateSql,
+  compileResourceReadAuthorizationSql,
+  type AuthorizationSubject,
+  type RelationshipSqlAdapter,
+  type RelationshipSqlContext,
+  type RelationshipTemplateKey,
+} from '@alga-psa/authorization/kernel';
+
+// Build SQL offline (no DB connection) and assert the generated predicate text.
+const db = knexFactory({ client: 'pg' });
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+const ALL_TEMPLATES: RelationshipTemplateKey[] = [
+  'own',
+  'assigned',
+  'managed',
+  'own_or_assigned',
+  'own_or_managed',
+  'same_client',
+  'client_portfolio',
+  'selected_clients',
+  'same_team',
+  'selected_boards',
+];
+
+const subject: AuthorizationSubject = {
+  tenant: 'tenant-1',
+  userId: 'user-1',
+  userType: 'internal',
+  teamIds: ['team-1'],
+  managedUserIds: ['managed-1'],
+  portfolioClientIds: ['client-1', 'client-2'],
+  clientId: 'client-1',
+};
+
+const adapter: RelationshipSqlAdapter = {
+  ownerColumn: 't.entered_by',
+  clientColumn: 't.client_id',
+  boardColumn: 't.board_id',
+  teamColumn: 't.assigned_team_id',
+  applyAssignedUsers(builder, userIds) {
+    if (userIds.length === 0) {
+      builder.whereRaw('1 = 0');
+      return;
+    }
+    builder.whereIn('t.assigned_to', userIds).orWhereExists(function exists(this: Knex.QueryBuilder) {
+      this.select(db.raw('1'))
+        .from('ticket_resources as tr')
+        .whereRaw('tr.ticket_id = t.ticket_id')
+        .whereIn('tr.additional_user_id', userIds);
+    });
+  },
+};
+
+function ctx(overrides: Partial<RelationshipSqlContext> = {}): RelationshipSqlContext {
+  return { subject, adapter, ...overrides };
+}
+
+function sql(build: (builder: Knex.QueryBuilder) => void): string {
+  const builder = db('tickets as t').where('t.tenant', subject.tenant);
+  build(builder);
+  return builder.toString().toLowerCase();
+}
+
+describe('relationship template SQL compiler', () => {
+  it('compiles every relationship template without throwing', () => {
+    for (const template of ALL_TEMPLATES) {
+      const text = sql((b) => compileRelationshipTemplateSql(b, template, ctx({ selectedBoardIds: ['board-1'], selectedClientIds: ['client-9'] })));
+      expect(text.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('maps scalar-column templates to equality / IN predicates', () => {
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'own', ctx()))).toContain('"t"."entered_by" = \'user-1\'');
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'same_client', ctx()))).toContain('"t"."client_id" = \'client-1\'');
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'client_portfolio', ctx()))).toContain(
+      '"t"."client_id" in (\'client-1\', \'client-2\')'
+    );
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'same_team', ctx()))).toContain('"t"."assigned_team_id" in (\'team-1\')');
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'selected_boards', ctx({ selectedBoardIds: ['board-1'] })))).toContain(
+      '"t"."board_id" in (\'board-1\')'
+    );
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'selected_clients', ctx({ selectedClientIds: ['client-9'] })))).toContain(
+      '"t"."client_id" in (\'client-9\')'
+    );
+  });
+
+  it('denies (1 = 0) when a template has nothing to match', () => {
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'same_client', ctx({ subject: { ...subject, clientId: null } })))).toContain('1 = 0');
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'selected_boards', ctx({ selectedBoardIds: [] })))).toContain('1 = 0');
+    expect(sql((b) => compileRelationshipTemplateSql(b, 'managed', ctx({ subject: { ...subject, managedUserIds: [] } })))).toContain('1 = 0');
+  });
+
+  it('routes assignment templates through the adapter (primary + co-assignee)', () => {
+    const assigned = sql((b) => compileRelationshipTemplateSql(b, 'assigned', ctx()));
+    expect(assigned).toContain('"t"."assigned_to" in (\'user-1\')');
+    expect(assigned).toContain('exists');
+    expect(assigned).toContain('additional_user_id');
+
+    const ownOrAssigned = sql((b) => compileRelationshipTemplateSql(b, 'own_or_assigned', ctx()));
+    expect(ownOrAssigned).toContain('"t"."entered_by" = \'user-1\'');
+    expect(ownOrAssigned).toContain('"t"."assigned_to" in (\'user-1\')');
+    expect(ownOrAssigned).toContain(' or ');
+  });
+});
+
+describe('resource read authorization SQL compiler', () => {
+  it('applies builtin relationship rules as an OR group', () => {
+    const result: { supported: boolean } = { supported: true };
+    const text = sql((b) => {
+      const r = compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [{ template: 'own' }, { template: 'same_client' }],
+        bundleRules: [],
+        ctx: ctx(),
+      });
+      result.supported = r.supported;
+    });
+    expect(result.supported).toBe(true);
+    expect(text).toContain('"t"."entered_by" = \'user-1\'');
+    expect(text).toContain('"t"."client_id" = \'client-1\'');
+    expect(text).toContain(' or ');
+  });
+
+  it('intersects bundle rules with AND semantics and respects rule-scoped ids', () => {
+    const text = sql((b) =>
+      compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [],
+        bundleRules: [
+          { id: 'r1', resource: 'ticket', action: 'read', templateKey: 'own' },
+          { id: 'r2', resource: 'ticket', action: 'read', templateKey: 'selected_clients', selectedClientIds: ['client-9'] },
+        ],
+        ctx: ctx(),
+      })
+    );
+    expect(text).toContain('"t"."entered_by" = \'user-1\'');
+    expect(text).toContain('"t"."client_id" in (\'client-9\')');
+  });
+
+  it('ignores bundle rules for other resources/actions', () => {
+    const text = sql((b) =>
+      compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [],
+        bundleRules: [
+          { id: 'r1', resource: 'project', action: 'read', templateKey: 'own' },
+          { id: 'r2', resource: 'ticket', action: 'update', templateKey: 'same_team' },
+        ],
+        ctx: ctx(),
+      })
+    );
+    // Only the tenant filter survives; no narrowing predicate was added.
+    expect(text).not.toContain('"t"."entered_by"');
+    expect(text).not.toContain('"t"."assigned_team_id"');
+  });
+
+  it('denies tickets for client_visible_only when no visibility column exists', () => {
+    let supported = false;
+    const text = sql((b) => {
+      const r = compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [],
+        bundleRules: [{ id: 'r1', resource: 'ticket', action: 'read', constraintKey: 'client_visible_only' }],
+        ctx: ctx(),
+      });
+      supported = r.supported;
+    });
+    expect(supported).toBe(true);
+    expect(text).toContain('1 = 0');
+  });
+
+  it('honours a clientVisibleColumn when the adapter provides one', () => {
+    const text = sql((b) =>
+      compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [],
+        bundleRules: [{ id: 'r1', resource: 'ticket', action: 'read', constraintKey: 'client_visible_only' }],
+        ctx: ctx({ adapter: { ...adapter, clientVisibleColumn: 't.is_client_visible' } }),
+      })
+    );
+    expect(text).toContain('"t"."is_client_visible" = true');
+  });
+
+  it('treats not_self_approver as supported on the read path (mutation-only)', () => {
+    const r = compileResourceReadAuthorizationSql(db('tickets as t'), {
+      resourceType: 'ticket',
+      action: 'read',
+      builtinRules: [],
+      bundleRules: [{ id: 'r1', resource: 'ticket', action: 'read', constraintKey: 'not_self_approver', templateKey: 'own' }],
+      ctx: ctx(),
+    });
+    expect(r.supported).toBe(true);
+  });
+
+  it('reports unsupported for constraints not representable in SQL', () => {
+    const r = compileResourceReadAuthorizationSql(db('tickets as t'), {
+      resourceType: 'ticket',
+      action: 'read',
+      builtinRules: [],
+      bundleRules: [{ id: 'r1', resource: 'ticket', action: 'read', constraintKey: 'some_future_constraint' }],
+      ctx: ctx(),
+    });
+    expect(r.supported).toBe(false);
+    if (!r.supported) {
+      expect(r.reason).toContain('some_future_constraint');
+    }
+  });
+
+  it('adds no narrowing when there are no builtin or bundle rules', () => {
+    const text = sql((b) =>
+      compileResourceReadAuthorizationSql(b, {
+        resourceType: 'ticket',
+        action: 'read',
+        builtinRules: [],
+        bundleRules: [],
+        ctx: ctx(),
+      })
+    );
+    expect(text).toBe('select * from "tickets" as "t" where "t"."tenant" = \'tenant-1\'');
+  });
+});


### PR DESCRIPTION
  Add a shared relationship-template registry to the authorization kernel
  where each ABAC template is defined once with two facets: a JS matches()
  (per-row filtering) and a compileSql() (database predicate). A single
  registry keyed by template makes the two paths impossible to drift —
  adding a template won't compile until both facets exist.

  - Ticket list and public API now push read-narrowing into SQL so the database paginates and counts only the authorized set (one data + one count query, accurate totals), falling back to the per-row JS kernel when a rule isn't representable in SQL.
  - Share one ticket SQL adapter between the web server-action and API lists; both now count ticket_resources co-assignees as "assigned".
  - Batch ticket-open avatar URLs in two queries instead of a transaction per tenant user.
  - Slim the tickets-page bundle: stop re-exporting the BlockNote editor from the @alga-psa/ui barrel, mark CSS sideEffects, and add a lightweight MspClientQuickViewProvider that stubs the heavy cross-feature surfaces the quick-view drawer never uses.
  - Add SQL/JS parity tests covering every relationship template.

  And so the tickets sorted themselves before the Queen could even shout
  "Off with their rows!" — for the looking-glass kernel now wears two
  faces, one of JS and one of SQL, that may never disagree, lest a stern
  `1 = 0` send the unauthorized tumbling down the rabbit hole. 🐇🪞 🎫