### PR TITLE
chore(leverage): annotate DataTable paging/filter layering (detection only)

### DIFF
--- a/docs/plans/leverage-ledger.md
+++ b/docs/plans/leverage-ledger.md
@@ -1,0 +1,85 @@
+# Leverage ledger
+
+Tracking for cross-cutting leverage candidates (no single home) and decisions.
+Inline markers are the per-site ledger; `grep -rn "LEVERAGE:"` is the count.
+
+---
+
+## datatable-client-paging — friction
+
+- **What:** Every client-side consumer of `@alga-psa/ui/components/DataTable` re-derives the
+  same controlled paging state — `const [currentPage] = useState(1)` / `const [pageSize] =
+  useState(10)` plus a `handlePageSizeChange` that sets size and resets the page to 1 — and threads
+  all four (`currentPage` / `onPageChange` / `pageSize` / `onItemsPerPageChange`) back into the
+  table.
+- **Root cause (wrong layer):** `DataTable` is *half-controlled*. It keeps its own
+  `{pageIndex, pageSize}` state and syncs from the controlled props via effects, and it renders the
+  items-per-page selector but delegates the actual size change back to the parent
+  (`onItemsPerPageChange`, with no internal `setPageSize`). So a consumer that just wants default
+  client paging with a working size selector is forced to hold the state anyway.
+- **Where (~13 sites, all marked):**
+  - `packages/ui/src/components/DataTable.tsx` (engine root-cause marker)
+  - `packages/jobs/src/components/monitoring/RecentJobsDataTable.tsx`
+  - `server/src/app/client-portal/request-services/my-requests/MyRequestsTable.tsx`
+  - `server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx` (no-op variant — dummy `currentPage={1}` / `onPageChange={() => {}}`)
+  - `server/src/components/settings/general/{UserList,BoardsSettings,ChecklistTemplatesSettings,InteractionTypeSettings,InteractionStatusSettings}.tsx`
+  - `server/src/components/settings/profile/ApiKeysSetup.tsx`
+  - `server/src/components/settings/secrets/SecretsManagement.tsx`
+  - `server/src/components/settings/security/{AdminApiKeysSetup,AdminWebhooksSetup}.tsx` (AdminWebhooksSetup has 2 instances — two components)
+- **Variants worth noting (not separately marked):** some consumers opt out of the awkward API by
+  hardcoding — `pageSize={999} // Show all users` (`UserRoleAssignment.tsx`), `pageSize={10}`
+  (`TeamDetails.tsx`). The spread of strategies (thread state / no-op props / hardcode) is itself
+  evidence the paging contract is unclear.
+- **Gate:** frequency saturated (≫3, verbatim); cost low per site but correctness-adjacent (page
+  reset on size change is easy to forget); stable (shape has stopped moving — identical across all
+  sites); leverage high (one fix removes the block everywhere + clarifies the contract).
+- **Axis-2 (how to land):** **promote-to-plan / staged-migration.** Wide blast radius across an
+  exported UI primitive with ~13 callers. Candidate call-site-first shape: let `DataTable` own
+  client paging by default (uncontrolled), exposing the items-per-page selector without requiring
+  the parent to hold `pageSize`; keep the controlled props as an opt-in escape hatch for
+  server-side paging. Migrate callers, then delete the boilerplate.
+- **Status:** watching (markers placed this pass — detection only, no extraction).
+
+---
+
+## datatable-paging-remount — friction
+
+- **What:** `key={`${currentPage}-${pageSize}`}` on `<DataTable>` to remount the entire table and
+  force paging to apply — a sharper symptom of the same half-controlled engine as
+  [[datatable-client-paging]].
+- **Where (2 sites, marked):** `UserList.tsx`, `RecentJobsDataTable.tsx`.
+- **Gate:** friction (weighs heavy — direct evidence the layer is wrong); fixing the root cause
+  above removes the need for the remount hack entirely.
+- **Status:** watching (resolve together with `datatable-client-paging`).
+
+---
+
+## datatable-filter-paging — pattern
+
+- **What:** Tables with filters re-implement the same list-controller shape with no shared layer:
+  filter state, a 300ms debounce on text search, "reset page to 1" on every filter/size/sort
+  change, and either a client-side `filteredX` `useMemo` or a server fetch state machine.
+- **Where (strong instances, marked):**
+  - `server/src/components/settings/profile/ApiKeysSetup.tsx` (client filter + debounce + reset)
+  - `server/src/components/settings/security/AdminApiKeysSetup.tsx` (near-identical to ApiKeysSetup — the two files are ~95% duplicate components, a separate candidate)
+  - `server/src/app/msp/email-logs/EmailLogsClient.tsx` (server variant: fetch + debounce + reset + manual sort)
+- **Lighter / partial instances (not marked — different/smaller shape):**
+  - `SecretsManagement.tsx` (search-only `filteredSecrets`, no debounce, no page reset)
+  - `ServiceRequestsManagementPage.tsx` (`showArchived` toggle → `visibleDefinitions`)
+  - `UserList.tsx` (`selectedClientId` → `visibleUsers`)
+  - `AdminWebhooksSetup.tsx` inbound deliveries (server paging + `inboundDeliveryStatusFilter`)
+- **Gate:** frequency strong; cost medium (debounce + page-reset coordination is easy to get
+  subtly wrong); leverage high. Missing layer, not a wrong one → **extract** a `useListController`
+  / `useFilteredTable` hook (filters + paging + sort + debounce + reset, client or server).
+- **Axis-2 (how to land):** bounded-now to promote-to-plan — a hook is additive (callers migrate
+  incrementally), but coordinating with the `datatable-client-paging` engine revision argues for a
+  single plan.
+- **Status:** watching.
+
+---
+
+## Notes
+
+- `ApiKeysSetup.tsx` and `AdminApiKeysSetup.tsx` are near-duplicate components (profile vs admin
+  API keys). Worth a separate `apikeys-setup-dup` candidate if it recurs / diverges — left
+  unmarked this pass to keep the table-focused ledger clean.

--- a/packages/jobs/src/components/monitoring/RecentJobsDataTable.tsx
+++ b/packages/jobs/src/components/monitoring/RecentJobsDataTable.tsx
@@ -57,6 +57,7 @@ export default function RecentJobsDataTable({ initialData = [] }: RecentJobsData
   const [data, setData] = React.useState<JobRecord[]>(initialData);
   const intervalRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(10);
@@ -338,6 +339,7 @@ export default function RecentJobsDataTable({ initialData = [] }: RecentJobsData
         onPrint={() => triggerPrintJobs()}
         isPrinting={isPreparingJobPrint}
       />
+      {/* LEVERAGE: friction datatable-paging-remount — remounts the whole table via key to force paging to apply (works around DataTable's internal paging state) */}
       <DataTable
         key={`${currentPage}-${pageSize}`}
         data={data}

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -465,6 +465,10 @@ export const DataTable = <T extends object>(props: ExtendedDataTableProps<T>): R
     [columns, visibleColumnIds, columnLayout, fittedSizeOverrides]
   );
 
+  // LEVERAGE: friction datatable-client-paging — half-controlled paging: the table keeps its own
+  // page/size state AND syncs from controlled props, and renders the items-per-page selector but
+  // delegates the size change back to the parent. So every client-side consumer must re-derive
+  // page/size state + a reset-to-page-1 handler just to use built-in pagination (see ~13 sites).
   const [{ pageIndex, pageSize: currentPageSize }, setPagination] = React.useState({
     pageIndex: currentPage - 1,
     pageSize,

--- a/server/src/app/client-portal/request-services/my-requests/MyRequestsTable.tsx
+++ b/server/src/app/client-portal/request-services/my-requests/MyRequestsTable.tsx
@@ -45,6 +45,7 @@ function formatDateTime(value: string, unknownLabel: string): string {
 }
 
 export function MyRequestsTable({ rows, labels }: MyRequestsTableProps) {
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const columns = useMemo<ColumnDefinition<MyRequestsTableRow>[]>(

--- a/server/src/app/msp/email-logs/EmailLogsClient.tsx
+++ b/server/src/app/msp/email-logs/EmailLogsClient.tsx
@@ -85,6 +85,7 @@ export default function EmailLogsClient({ initialMetrics, initialLogs }: EmailLo
   const [sortBy, setSortBy] = useState<NonNullable<EmailLogFilters['sortBy']>>('sent_at');
   const [sortDirection, setSortDirection] = useState<NonNullable<EmailLogFilters['sortDirection']>>('desc');
 
+  // LEVERAGE: pattern datatable-filter-paging — server variant: filter state + debounced text filters + reset-page-to-1 on every filter/sort change + fetch state machine, re-implemented per table; no list-controller layer
   const [status, setStatus] = useState<string>('');
   const [startDate, setStartDate] = useState<string>('');
   const [endDate, setEndDate] = useState<string>('');

--- a/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
+++ b/server/src/app/msp/service-requests/ServiceRequestsManagementPage.tsx
@@ -297,6 +297,7 @@ export default function ServiceRequestsManagementPage() {
         </div>
       </div>
 
+      {/* LEVERAGE: friction datatable-client-paging — no-op variant: passes dummy currentPage/onPageChange because the paging props feel required even for plain client-side data */}
       <DataTable
         id="service-requests-management-table"
         data={visibleDefinitions}

--- a/server/src/components/settings/general/BoardsSettings.tsx
+++ b/server/src/components/settings/general/BoardsSettings.tsx
@@ -272,6 +272,7 @@ const BoardsSettings: React.FC = () => {
     };
   }, [deleteDialog]);
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/server/src/components/settings/general/ChecklistTemplatesSettings.tsx
+++ b/server/src/components/settings/general/ChecklistTemplatesSettings.tsx
@@ -51,6 +51,7 @@ const ChecklistTemplatesSettings: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [dialogError, setDialogError] = useState<string | null>(null);
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/server/src/components/settings/general/InteractionStatusSettings.tsx
+++ b/server/src/components/settings/general/InteractionStatusSettings.tsx
@@ -51,6 +51,7 @@ const InteractionStatusSettings = (): React.JSX.Element => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [statusToDelete, setStatusToDelete] = useState<IStatus | null>(null);
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/server/src/components/settings/general/InteractionTypeSettings.tsx
+++ b/server/src/components/settings/general/InteractionTypeSettings.tsx
@@ -62,6 +62,7 @@ const InteractionTypesSettings: React.FC = () => {
   const [importConflicts, setImportConflicts] = useState<ImportConflict[]>([]);
   const [conflictResolutions, setConflictResolutions] = useState<Record<string, { action: 'skip' | 'rename' | 'reorder', newName?: string, newOrder?: number }>>({});
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/server/src/components/settings/general/UserList.tsx
+++ b/server/src/components/settings/general/UserList.tsx
@@ -40,6 +40,7 @@ const UserList: React.FC<UserListProps> = ({ users, onDeleteSuccess, onUpdate, s
   const [userClients, setUserClients] = useState<Record<string, { client_id: string; client_name: string } | null>>({});
   const { openDrawer } = useDrawer();
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -360,6 +361,7 @@ const UserList: React.FC<UserListProps> = ({ users, onDeleteSuccess, onUpdate, s
 
   return (
     <div>
+      {/* LEVERAGE: friction datatable-paging-remount — remounts the whole table via key to force paging to apply (works around DataTable's internal paging state) */}
       <DataTable
         key={`${currentPage}-${pageSize}`}
         id="users-table"

--- a/server/src/components/settings/profile/ApiKeysSetup.tsx
+++ b/server/src/components/settings/profile/ApiKeysSetup.tsx
@@ -61,10 +61,12 @@ export default function ApiKeysSetup() {
   const [newKeyValue, setNewKeyValue] = useState('');
   const router = useRouter();
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
+  // LEVERAGE: pattern datatable-filter-paging — filter state + debounced search + reset-page-to-1 + client filtering re-implemented per table; no list-controller layer
   // Filter state
   const [searchInput, setSearchInput] = useState('');
   const [searchTerm, setSearchTerm] = useState('');

--- a/server/src/components/settings/secrets/SecretsManagement.tsx
+++ b/server/src/components/settings/secrets/SecretsManagement.tsx
@@ -34,6 +34,7 @@ export default function SecretsManagement() {
   // Search/filter state
   const [searchQuery, setSearchQuery] = useState('');
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/server/src/components/settings/security/AdminApiKeysSetup.tsx
+++ b/server/src/components/settings/security/AdminApiKeysSetup.tsx
@@ -69,10 +69,12 @@ export default function AdminApiKeysSetup() {
   const [savingRateLimitKeyId, setSavingRateLimitKeyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
+  // LEVERAGE: pattern datatable-filter-paging — filter state + debounced search + reset-page-to-1 + client filtering re-implemented per table; no list-controller layer
   // Filter state
   const [searchInput, setSearchInput] = useState('');
   const [searchTerm, setSearchTerm] = useState('');

--- a/server/src/components/settings/security/AdminWebhooksSetup.tsx
+++ b/server/src/components/settings/security/AdminWebhooksSetup.tsx
@@ -527,6 +527,7 @@ function InboundWebhooksListView() {
   const [lastDeliveries, setLastDeliveries] = useState<Record<string, InboundWebhookDelivery | null>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   const [tableCurrentPage, setTableCurrentPage] = useState(1);
   const [tablePageSize, setTablePageSize] = useState(10);
   const [identityDialogOpen, setIdentityDialogOpen] = useState(false);
@@ -2043,6 +2044,7 @@ function OutboundWebhooksSetup() {
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
   const [isFormDialogOpen, setIsFormDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<'list' | 'deliveries'>('list');
+  // LEVERAGE: friction datatable-client-paging — re-derives page/size state + reset handler DataTable already owns internally
   const [tableCurrentPage, setTableCurrentPage] = useState(1);
   const [tablePageSize, setTablePageSize] = useState(10);
 


### PR DESCRIPTION
## What

A **detection-only** leverage pass over the shared `DataTable` (`packages/ui/src/components/DataTable.tsx`) and its consumers. This PR adds `// LEVERAGE:` markers and a ledger — **no logic changes**, no refactor.

## Findings (markers)

| Slug | Type | Sites | Shape |
|------|------|-------|-------|
| `datatable-client-paging` | friction | 14 | Every client-side table re-derives the same `currentPage`/`pageSize` state + reset-to-page-1 handler that `DataTable` already manages internally. Root cause: the engine is *half-controlled* — it keeps internal paging state, syncs from props, and renders the items-per-page selector but delegates the size change back to the parent. |
| `datatable-paging-remount` | friction | 2 | `UserList` and `RecentJobsDataTable` remount the whole table via `key={...}` to force paging to apply — a sharper symptom of the same wrong layer. |
| `datatable-filter-paging` | pattern | 3 | Filtered tables re-implement filter state + 300ms debounce + reset-page-to-1 + client/server filtering with no shared list-controller (`ApiKeysSetup`, `AdminApiKeysSetup`, `EmailLogsClient`). |

Count anytime with `grep -rn "LEVERAGE:"`.

## Ledger

`docs/plans/leverage-ledger.md` records the cross-cutting analysis, the gate read (axis 1 worth-it / axis 2 how-to-land), and the variants deliberately left unmarked (`pageSize={999}` hardcodes, single-toggle filters, the near-duplicate `ApiKeysSetup`/`AdminApiKeysSetup` files).

## Not in scope

No extraction. Both friction candidates point at one engine revision on an exported primitive with ~13 callers — that's **promote-to-plan / staged-migration** (wide blast radius), tracked for a follow-up.

https://claude.ai/code/session_014MJ2hBFXRDu86ChdshQ8iy