### PR TITLE
docs: documentation drift update 2026-06-19

### DIFF
--- a/docs/api/api-rate-limiting-and-webhooks.md
+++ b/docs/api/api-rate-limiting-and-webhooks.md
@@ -659,3 +659,82 @@ Webhook delivery also has an outbound cap per webhook. The default is
 
 Test deliveries sent through `POST /api/v1/webhooks/{id}/test` do not consume
 that outbound bucket.
+
+## Alternative Payments Inbound Webhook
+
+The alternative payments inbound webhook is a **fixed, pre-wired endpoint** that
+payment processors call to push payment lifecycle events into Alga PSA. Unlike
+the configurable inbound webhook system (`POST /api/v1/inbound-webhooks`), this
+endpoint is not tenant-configurable and does not use slugged receiver paths.
+
+### Endpoint
+
+```
+POST /api/webhooks/alternative-payments
+GET  /api/webhooks/alternative-payments   ← health check
+```
+
+### Authentication
+
+Alga verifies incoming requests using HMAC-SHA256. The payment processor must
+sign the raw request body and send the digest in **one** of the following headers
+(checked in order):
+
+1. `X-Alternative-Payments-Signature`
+2. `X-Ap-Signature`
+3. `X-Webhook-Signature`
+
+The value is a raw hex-encoded HMAC-SHA256 digest — no prefix, no `t=…` timestamp
+envelope. This differs from the outbound `X-Alga-Signature` format described
+above.
+
+Configure the shared secret on the Alga side by setting:
+
+```
+ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET=<secret-provided-by-processor>
+```
+
+### Tenant Identification
+
+Alga resolves the target tenant from:
+
+1. The `X-Tenant-Id` request header (preferred), or
+2. A `tenant_id` field in the JSON body.
+
+At least one must be present; requests that cannot be resolved to a tenant are
+rejected with `400 Bad Request`.
+
+### Idempotency
+
+Processed events are recorded in the `payment_webhook_events` table. Alga uses
+the processor-supplied event identifier as an idempotency key. Duplicate
+deliveries are acknowledged with `200 OK` but not re-processed.
+
+### Response Shape
+
+**Success (`200 OK`)**
+
+```json
+{ "received": true }
+```
+
+**Signature mismatch (`401 Unauthorized`)**
+
+```json
+{ "error": "Invalid signature" }
+```
+
+**Missing or unresolvable tenant (`400 Bad Request`)**
+
+```json
+{ "error": "Missing tenant_id" }
+```
+
+### Health Check
+
+```
+GET /api/webhooks/alternative-payments
+```
+
+Returns `200 OK` with `{ "status": "ok" }` when the service is reachable. Payment
+processors may poll this endpoint to confirm connectivity before going live.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -194,7 +194,7 @@ This document provides a high-level architectural overview of the open-source MS
     - Configurable notification thresholds with duplicate prevention
     - Full audit log for SLA compliance reporting
 
-* **Security:** Implements security measures. RBAC and ABAC logic is under `server/src/lib/auth/`. Authentication is handled through NextAuth.js with multi-portal support:
+* **Security:** Implements security measures. RBAC and ABAC logic is primarily under `server/src/lib/auth/`; a shared ABAC relationship-template registry lives in `packages/authorization/src/kernel/` — each template defines both a JavaScript `matches()` predicate and a SQL `compileSql()` predicate to keep in-memory and query-level enforcement consistent. Authentication is handled through NextAuth.js with multi-portal support:
   * Authentication Routes:
     - **MSP Portal**: `/auth/msp/signin` (purple theme, internal users)
     - **Client Portal**: `/auth/client-portal/signin` (blue theme, client users)
@@ -445,7 +445,7 @@ No code has been merged yet – this section serves as an architectural note so 
 * **Scalability:** Addressed through caching (`server/src/lib/cache`) and database optimization strategies.
 
 * **Security:**
-  * Implemented through RBAC/ABAC (`server/src/lib/auth`) and secure authentication (`server/src/pages/api/auth/[...nextauth]/options.ts`).
+  * Implemented through RBAC/ABAC (`server/src/lib/auth`, `packages/authorization/src/kernel/`) and secure authentication (`server/src/pages/api/auth/[...nextauth]/options.ts`).
   * The workflows feature incorporates security measures to ensure that only authorized users can create or modify workflows.
 
   RBAC Roles (Client Portal)


### PR DESCRIPTION
## Summary\n\nAutomated documentation-drift audit for PRs merged to main by @NatalliaBukhtsik on 2026-06-18.\n\n### Source PRs covered\n\n| PR | Title |\n|---|---|\n| #2726 | Wire real financial list/PDF handlers + alternative-payments webhook |\n| #2727 | Push ticket read authorization into SQL |\n\n### Files edited\n\n#### `docs/api/api-rate-limiting-and-webhooks.md` (source: #2726)\n\nAdded a new **Alternative Payments Inbound Webhook** section documenting the fixed, pre-wired `POST /api/webhooks/alternative-payments` endpoint introduced in #2726. The existing doc only covered outbound (ticket/project) webhooks and the configurable inbound webhook system; it was silent on this new payment-processor receiver. The new section covers:\n- Endpoint (`POST` + `GET` health check)\n- HMAC-SHA256 authentication: which headers are accepted (`X-Alternative-Payments-Signature`, `X-Ap-Signature`, `X-Webhook-Signature`) and how the format differs from outbound `X-Alga-Signature`\n- `ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET` environment variable\n- Tenant resolution from `X-Tenant-Id` header or `tenant_id` body field\n- Idempotency via the `payment_webhook_events` table\n- Success/error response shapes\n- Health-check (`GET`) behavior\n\n#### `docs/architecture/overview.md` (source: #2727)\n\nUpdated two Security references that pointed only to `server/src/lib/auth/` for ABAC logic. PR #2727 introduced a shared ABAC relationship-template registry in `packages/authorization/src/kernel/` where each template defines both a JavaScript `matches()` predicate and a SQL `compileSql()` predicate to guarantee consistency between in-memory checks and database-pushed authorization. Updated both the Security module description (Section I) and the Key Design Considerations Security bullet (Section III) to reference this new package.\n\n---\n\n## Needs human review\n\nThe following items were identified as potentially stale but require human judgment before any doc change is made:\n\n1. **OpenAPI artifacts** — PR #2726 regenerated `sdk/docs/openapi/alga-openapi*.{json,yaml}`. The nm-store public OpenAPI file (`public/openapi/alga.json`) is likely out of sync. Regenerate via `cd sdk && npm run openapi:generate` and sync the result to nm-store. This audit never touches generated artifacts.\n\n2. **Invoice PDF permission change** — PR #2726 renamed the required permission from `invoice:pdf` to `invoice:read` for the `GET /api/v1/invoices/{id}/pdf` endpoint. This is a breaking API change for any consumer who checked permissions by name. The nm-store invoices reference page (`/developers/reference/invoices`) does not explicitly list required permissions, so it is not explicitly wrong — but adding a permissions note (and a breaking-change callout) would help API consumers.\n\n3. **Password policy changes** (PR #2725) — #2725 tightened password validation: sequence runs of 6+ characters are rejected, a fuzzy common-word blocklist is applied, the UK postcode `AA9A` format is now accepted, and annual-revenue validation was broadened. No in-scope customer-facing doc was found that explicitly describes password requirements. If such a doc exists outside the audited paths, it should be updated.\n\n4. **Co-assignee ticket authorization** (PR #2727) — #2727 added co-assignee authorization via the `ticket_resources` table so that technicians assigned as co-assignees can read tickets through the API. No dedicated tickets API reference page was found in the audited paths. If one exists or is planned, it should note that the `assigned_to` and co-assignee (`ticket_resources`) fields both grant read access.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF77McDM8WK3TQfWAx2BvL)_