### PR TITLE
Cancel and reduce trial/past_due subscriptions

### DIFF
--- a/ee/server/src/__tests__/unit/stripeService.tierPricing.test.ts
+++ b/ee/server/src/__tests__/unit/stripeService.tierPricing.test.ts
@@ -12,6 +12,7 @@ function createTenantKnex(planByTenant: Record<string, string>) {
     if (table === 'stripe_subscriptions') {
       return {
         where: () => ({
+          whereIn: () => ({ first: async () => null }),
           first: async () => null,
         }),
       };
@@ -848,23 +849,27 @@ describe('StripeService tier pricing', () => {
       }
 
       if (table === 'stripe_subscriptions') {
+        const subscriptionRow = {
+          tenant: 'tenant-pro',
+          stripe_subscription_id: 'sub_db_pro',
+          stripe_subscription_external_id: 'sub_ext_pro',
+          stripe_subscription_item_id: 'si_pro_seat',
+          stripe_customer_id: 'cust_db_pro',
+          stripe_price_id: 'price_record_pro_seat',
+          status: 'active',
+          quantity: 5,
+          stripe_base_item_id: null,
+          stripe_base_price_id: null,
+          billing_interval: 'month',
+          metadata: {},
+          current_period_end: new Date('2026-04-26T00:00:00.000Z'),
+        };
         return {
           where: (criteria: Record<string, any>) => ({
-            first: async () => ({
-              tenant: 'tenant-pro',
-              stripe_subscription_id: 'sub_db_pro',
-              stripe_subscription_external_id: 'sub_ext_pro',
-              stripe_subscription_item_id: 'si_pro_seat',
-              stripe_customer_id: 'cust_db_pro',
-              stripe_price_id: 'price_record_pro_seat',
-              status: 'active',
-              quantity: 5,
-              stripe_base_item_id: null,
-              stripe_base_price_id: null,
-              billing_interval: 'month',
-              metadata: {},
-              current_period_end: new Date('2026-04-26T00:00:00.000Z'),
+            whereIn: (_column: string, _values: string[]) => ({
+              first: async () => subscriptionRow,
             }),
+            first: async () => subscriptionRow,
             update: async (values: Record<string, any>) => {
               subscriptionUpdates.push({ criteria, values });
               return 1;

--- a/ee/server/src/lib/actions/license-actions.ts
+++ b/ee/server/src/lib/actions/license-actions.ts
@@ -352,18 +352,16 @@ export async function getSubscriptionInfoAction(): Promise<IGetSubscriptionInfoR
 
     const knex = await getConnection(session.user.tenant);
 
-    // Get active subscription with related price info
+    // Get active, trialing, or past_due subscription with related price info
     const subscription = await knex<IStripeSubscription>('stripe_subscriptions')
-      .where({
-        tenant: session.user.tenant,
-        status: 'active',
-      })
+      .where({ tenant: session.user.tenant })
+      .whereIn('status', ['active', 'trialing', 'past_due'])
       .first();
 
     if (!subscription) {
       return {
         success: false,
-        error: 'No active subscription found',
+        error: 'No active, trialing, or past due subscription found',
       };
     }
 
@@ -646,15 +644,16 @@ export async function sendCancellationFeedbackAction(
 
     const knex = await getConnection(session.user.tenant);
 
-    // Get subscription details
+    // Get subscription details (active, trialing, or past_due — all are cancelable)
     const subscription = await knex<IStripeSubscription>('stripe_subscriptions')
-      .where({ tenant: session.user.tenant, status: 'active' })
+      .where({ tenant: session.user.tenant })
+      .whereIn('status', ['active', 'trialing', 'past_due'])
       .first();
 
     if (!subscription) {
       return {
         success: false,
-        error: 'No active subscription found',
+        error: 'No active, trialing, or past due subscription found',
       };
     }
 
@@ -729,18 +728,19 @@ export async function cancelSubscriptionAction(): Promise<ICancelSubscriptionRes
       };
     }
 
-    // Get active subscription
+    // Get active, trialing, or past_due subscription. Trialing subs cancel just like
+    // active ones via cancel_at_period_end: Stripe treats the trial as the current
+    // period, so the subscription cancels at trial_end and the customer is never
+    // charged. past_due subs cancel at period end too, stopping further dunning.
     const subscription = await knex<IStripeSubscription>('stripe_subscriptions')
-      .where({
-        tenant: session.user.tenant,
-        status: 'active',
-      })
+      .where({ tenant: session.user.tenant })
+      .whereIn('status', ['active', 'trialing', 'past_due'])
       .first();
 
     if (!subscription) {
       return {
         success: false,
-        error: 'No active subscription found',
+        error: 'No active, trialing, or past due subscription found',
       };
     }
 
@@ -946,12 +946,10 @@ export async function reduceLicenseCount(
       };
     }
 
-    // Get subscription details for effective date
+    // Get subscription details for effective date (active or trialing)
     const subscription = await knex<IStripeSubscription>('stripe_subscriptions')
-      .where({
-        tenant: tenantId,
-        status: 'active',
-      })
+      .where({ tenant: tenantId })
+      .whereIn('status', ['active', 'trialing'])
       .first();
 
     if (!subscription || !subscription.current_period_end) {

--- a/ee/server/src/lib/stripe/StripeService.ts
+++ b/ee/server/src/lib/stripe/StripeService.ts
@@ -762,16 +762,26 @@ export class StripeService {
     // Get or import customer
     const customer = await this.getOrImportCustomer(tenantId);
 
-    // Check for existing active subscription for the license price
+    // Check for an existing active or trialing subscription for the license price.
     const existingSubscription = await knex<StripeSubscription>('stripe_subscriptions')
       .where({
         tenant: tenantId,
         stripe_customer_id: customer.stripe_customer_id,
-        status: 'active',
       })
+      .whereIn('status', ['active', 'trialing'])
       .first();
 
-    if (existingSubscription && existingSubscription.stripe_subscription_item_id) {
+    // Trials can only be DECREASED here (scheduled at trial end, no charge). A trial
+    // increase falls through to checkout so we never bill mid-trial.
+    const isTrialingIncrease =
+      existingSubscription?.status === 'trialing' &&
+      quantity > existingSubscription.quantity;
+
+    if (
+      existingSubscription &&
+      existingSubscription.stripe_subscription_item_id &&
+      !isTrialingIncrease
+    ) {
       const currentQuantity = existingSubscription.quantity;
       const isIncrease = quantity > currentQuantity;
 
@@ -1621,17 +1631,17 @@ export class StripeService {
     const knex = await getConnection(tenantId);
     const customer = await this.getOrImportCustomer(tenantId);
 
-    // Get existing subscription
+    // Get existing subscription (active, trialing, or past_due)
     const existingSubscription = await knex<StripeSubscription>('stripe_subscriptions')
       .where({
         tenant: tenantId,
         stripe_customer_id: customer.stripe_customer_id,
-        status: 'active',
       })
+      .whereIn('status', ['active', 'trialing', 'past_due'])
       .first();
 
     if (!existingSubscription) {
-      logger.info(`[StripeService] No active subscription found for tenant ${tenantId}`);
+      logger.info(`[StripeService] No active, trialing, or past_due subscription found for tenant ${tenantId}`);
       return null;
     }
 


### PR DESCRIPTION
  The cancel, display, and license-reduce queries only matched
  status='active', so trialing and past_due subscriptions—though
  shown in the billing UI—silently failed to cancel or reduce
  ("No active subscription found", with no log line).

  Widen the status filters: sendCancellationFeedbackAction,
  cancelSubscriptionAction, and getSubscriptionInfoAction now accept
  active/trialing/past_due; reduceLicenseCount, getScheduledLicense
  changes, and updateOrCreateLicenseSubscription accept trials. Trial
  cancellation rides cancel_at_period_end (Stripe cancels at trial_end,
  no charge), and an isTrialingIncrease guard keeps trial *increases*
  on the checkout path so no one is billed mid-trial. Mock updates add
  the .whereIn().first() chain for the affected tests.

  The Cheshire Cat grinned: a subscription needn't be 'active' to take
  its leave—'trialing' fades just as politely at period's end, no coin
  exchanged, leaving only a cancel_at and a smile. 🐱🎩✨