### PR TITLE
feat(tickets): Refined List ticket dashboard + active-filter chips

### DIFF
--- a/docs/plans/leverage-ledger.md
+++ b/docs/plans/leverage-ledger.md
@@ -60,6 +60,7 @@ Inline markers are the per-site ledger; `grep -rn "LEVERAGE:"` is the count.
   filter state, a 300ms debounce on text search, "reset page to 1" on every filter/size/sort
   change, and either a client-side `filteredX` `useMemo` or a server fetch state machine.
 - **Where (strong instances, marked):**
+  - `packages/tickets/src/components/TicketingDashboard.tsx` (**largest instance** — full server list-query: filter state + 500ms search debounce + reset-page + manual fetch + URL sync; added 2026-06-19 during the ticket-list redesign)
   - `server/src/components/settings/profile/ApiKeysSetup.tsx` (client filter + debounce + reset)
   - `server/src/components/settings/security/AdminApiKeysSetup.tsx` (near-identical to ApiKeysSetup — the two files are ~95% duplicate components, a separate candidate)
   - `server/src/app/msp/email-logs/EmailLogsClient.tsx` (server variant: fetch + debounce + reset + manual sort)
@@ -77,6 +78,25 @@ Inline markers are the per-site ledger; `grep -rn "LEVERAGE:"` is the count.
 - **Status:** watching.
 
 ---
+
+## filter-descriptor-table — pattern
+
+- **What:** Within a single filtered list, each filter dimension's three facts — *is it active*,
+  *its human label*, and *how to clear it* — get written once per consumer of that knowledge. In
+  `TicketingDashboard` that's now three copies: the toolbar control's `onValueChange`, the
+  `activeFilterCount` memo, and the `activeFilterChips` memo. Adding the chips this session was the
+  third hand-written copy across ~12 dimensions (board, client, assignee, team, unassigned, status,
+  response, priority, due, sla, category, tags).
+- **Where:** `packages/tickets/src/components/TicketingDashboard.tsx` (marked at `activeFilterChips`).
+- **Gate:** frequency 3 copies × ~12 dimensions; cost medium (every new filter or chip must touch
+  all three in sync — drift = a chip that doesn't clear, or a miscount); stability good (filter set
+  is stable); leverage real but **local to one component** so far.
+- **Shape if extracted:** one `FILTER_DESCRIPTORS` list of `{ key, isActive(filters), label(filters,
+  lookups), clear() }`; the count, the chips, and (eventually) the controls all derive from it.
+- **Axis-2:** in-pass/bounded-now — self-contained to this component, no API ripple. Worth doing if
+  a 4th consumer of the per-dimension knowledge appears (e.g. a saved-views feature).
+- **Status:** watching (1 component; revisit if it recurs in another filtered list, at which point
+  it converges with `datatable-filter-paging`).
 
 ## Notes
 

--- a/packages/tickets/src/actions/ticketDisplaySettings.ts
+++ b/packages/tickets/src/actions/ticketDisplaySettings.ts
@@ -45,22 +45,25 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
       dateTimeFormat: display.dateTimeFormat || DEFAULT_TICKETING_DATETIME_FORMAT,
       responseStateTrackingEnabled: display.responseStateTrackingEnabled ?? true,
       list: {
+        // Default on-screen column set mirrors the "Refined List" design: ticket
+        // number and category fold under the title, created/created-by are off by
+        // default. All remain enableable in ticket display settings.
         columnVisibility: {
-          ticket_number: display?.list?.columnVisibility?.ticket_number ?? true,
+          ticket_number: display?.list?.columnVisibility?.ticket_number ?? false,
           title: display?.list?.columnVisibility?.title ?? true,
           status: display?.list?.columnVisibility?.status ?? true,
           priority: display?.list?.columnVisibility?.priority ?? true,
           sla: display?.list?.columnVisibility?.sla ?? false,
           board: display?.list?.columnVisibility?.board ?? true,
-          category: display?.list?.columnVisibility?.category ?? true,
+          category: display?.list?.columnVisibility?.category ?? false,
           client: display?.list?.columnVisibility?.client ?? true,
           assigned_to: display?.list?.columnVisibility?.assigned_to ?? true,
           due_date: display?.list?.columnVisibility?.due_date ?? true,
-          created: display?.list?.columnVisibility?.created ?? true,
-          created_by: display?.list?.columnVisibility?.created_by ?? true,
+          created: display?.list?.columnVisibility?.created ?? false,
+          created_by: display?.list?.columnVisibility?.created_by ?? false,
           tags: display?.list?.columnVisibility?.tags ?? true,
         },
-        tagsInlineUnderTitle: display?.list?.tagsInlineUnderTitle ?? false,
+        tagsInlineUnderTitle: display?.list?.tagsInlineUnderTitle ?? true,
       },
     };
   } catch (e) {
@@ -70,21 +73,21 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
       responseStateTrackingEnabled: true,
       list: {
         columnVisibility: {
-          ticket_number: true,
+          ticket_number: false,
           title: true,
           status: true,
           priority: true,
           sla: false,
           board: true,
-          category: true,
+          category: false,
           client: true,
           assigned_to: true,
           due_date: true,
-          created: true,
-          created_by: true,
+          created: false,
+          created_by: false,
           tags: true,
         },
-        tagsInlineUnderTitle: false,
+        tagsInlineUnderTitle: true,
       },
     };
   }

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -41,7 +41,7 @@ import {
 import { getBoardTicketStatuses } from '../actions/board-actions/boardTicketStatusActions';
 import { bundleTicketsAction, getBundleMasterStatusAction } from '../actions/ticketBundleActions';
 import { fetchBundleChildrenForMaster, fetchTicketsWithPagination, getAllMatchingTicketIds, getTicketBoardIds } from '../actions/optimizedTicketActions';
-import { XCircle, Clock, Download, Upload, ChevronDown, Printer, Settings2 } from 'lucide-react';
+import { XCircle, Clock, Download, Upload, ChevronDown, Printer, Settings2, SlidersHorizontal } from 'lucide-react';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@alga-psa/ui/components/DropdownMenu';
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
 import { withDataAutomationId } from '@alga-psa/ui/ui-reflection/withDataAutomationId';
@@ -376,6 +376,26 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       selectedResponseState !== 'all' ||
       (allowSlaStatusFilter && selectedSlaStatus !== 'all');
   }, [selectedBoards, excludedBoards, selectedClient, selectedStatus, selectedPriority, selectedCategories, excludedCategories, searchQuery, selectedTags, selectedAssignees, selectedTeams, includeUnassigned, selectedDueDateFilter, selectedResponseState, allowSlaStatusFilter, selectedSlaStatus]);
+
+  // Count of active filter groups (excludes the always-visible search box) — drives
+  // the "Filters" button badge in the candidate #1 collapsed toolbar.
+  const activeFilterCount = useMemo(() => {
+    let n = 0;
+    if (selectedBoards.length > 0 || excludedBoards.length > 0) n++;
+    if (selectedClient !== null) n++;
+    if (selectedAssignees.length > 0 || selectedTeams.length > 0 || includeUnassigned) n++;
+    if (selectedStatus !== TICKET_STATUS_FILTER_OPEN) n++;
+    if (selectedResponseState !== 'all') n++;
+    if (selectedPriority !== 'all') n++;
+    if (selectedDueDateFilter !== 'all') n++;
+    if (allowSlaStatusFilter && selectedSlaStatus !== 'all') n++;
+    if (selectedCategories.length > 0 || excludedCategories.length > 0) n++;
+    if (selectedTags.length > 0) n++;
+    return n;
+  }, [selectedBoards, excludedBoards, selectedClient, selectedAssignees, selectedTeams, includeUnassigned, selectedStatus, selectedResponseState, selectedPriority, selectedDueDateFilter, allowSlaStatusFilter, selectedSlaStatus, selectedCategories, excludedCategories, selectedTags]);
+
+  // Candidate #1 toolbar: the picker controls collapse behind a "Filters" button.
+  const [showFilters, setShowFilters] = useState(false);
 
   const handleTableSortChange = useCallback((columnId: string, direction: 'asc' | 'desc') => {
     if (columnId === sortBy && direction === sortDirection) {
@@ -1741,8 +1761,74 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         <div className={`sticky top-0 z-40 bg-white dark:bg-[rgb(var(--color-card))] rounded-t-lg border-b border-gray-100 dark:border-[rgb(var(--color-border-200))] ${densityClasses.filterPadding}`}>
           <ReflectionContainer id={`${id}-filters`} label="Ticket DashboardFilters">
             <div className={`space-y-3`}>
+              {/* Candidate #1: always-visible search + Filters toggle + density */}
+              <div className="flex items-center gap-2 flex-wrap">
+                <Input
+                  id={`${id}-search-tickets-input`}
+                  placeholder={t('filters.search', 'Search tickets and comments...')}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="h-[38px] w-full text-sm"
+                  containerClassName="flex-1 min-w-[260px] max-w-[460px]"
+                />
+                <Button
+                  id={`${id}-toggle-filters`}
+                  variant={showFilters ? 'soft' : 'outline'}
+                  onClick={() => setShowFilters((v) => !v)}
+                  className="shrink-0 flex items-center gap-1.5 h-[38px]"
+                >
+                  <SlidersHorizontal className="h-4 w-4" />
+                  {t('filters.button', 'Filters')}
+                  {activeFilterCount > 0 && (
+                    <span className="ml-0.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[rgb(var(--color-primary-100))] px-1.5 text-[11px] font-semibold text-[rgb(var(--color-primary-700))]">
+                      {activeFilterCount}
+                    </span>
+                  )}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleResetFilters}
+                  className={`shrink-0 flex items-center gap-1 ${isFiltered ? 'text-gray-500 hover:text-gray-700' : 'invisible'}`}
+                  id='reset-filters'
+                  disabled={!isFiltered}
+                >
+                  <XCircle className="h-4 w-4" />
+                  {t('resetFilters', 'Reset')}
+                </Button>
+                <div className="ml-auto flex items-center gap-2 shrink-0">
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Label htmlFor={`${id}-bundle-view-toggle`} className={`${densityClasses.tagSize === 'sm' ? 'text-xs' : 'text-sm'} text-gray-600`}>
+                      {t('dashboard.bundledToggle', 'Bundled')}
+                    </Label>
+                    <Switch
+                      id={`${id}-bundle-view-toggle`}
+                      checked={bundleView === 'bundled'}
+                      onCheckedChange={(checked) => onFilterChange({ bundleView: checked ? 'bundled' : 'individual' })}
+                      size={densityClasses.tagSize}
+                    />
+                  </div>
+                  <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />
+                  <div className="shrink-0">
+                    <ViewDensityControl
+                      idPrefix={`${id}-list-density`}
+                      value={ticketListDensityLevel}
+                      onChange={handleTicketListDensityChange}
+                      step={TICKET_LIST_DENSITY_STEP}
+                      compactLabel={t('dashboard.spacing.compact', 'Compact')}
+                      spaciousLabel={t('dashboard.spacing.spacious', 'Spacious')}
+                      decreaseTitle={t('dashboard.spacing.decrease', 'Decrease ticket list spacing')}
+                      increaseTitle={t('dashboard.spacing.increase', 'Increase ticket list spacing')}
+                      resetTitle={t('dashboard.spacing.reset', 'Reset ticket list spacing')}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {showFilters && (
+              <div className="space-y-3 pt-1 border-t border-gray-100 dark:border-[rgb(var(--color-border-200))]">
               {/* Row 1: Primary filters */}
-              <div className={`flex items-center ${densityClasses.filterGap} ${densityClasses.filterControlClass}`}>
+              <div className={`flex items-center flex-wrap ${densityClasses.filterGap} ${densityClasses.filterControlClass}`}>
                 <BoardFilterPicker
                   id={`${id}-board-picker`}
                   boards={boards}
@@ -1877,8 +1963,8 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                 )}
               </div>
 
-              {/* Row 2: Category, search, tags, reset, bundled, density */}
-              <div className={`flex items-center ${densityClasses.filterGap}`}>
+              {/* Row 2: Category, tags */}
+              <div className={`flex items-center flex-wrap ${densityClasses.filterGap}`}>
                 <div className={`contents ${densityClasses.filterControlClass}`}>
                 <CategoryPicker
                   id={`${id}-category-picker`}
@@ -1918,14 +2004,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                   categories={categories}
                   boards={boards}
                 />
-                <Input
-                  id={`${id}-search-tickets-input`}
-                  placeholder={t('filters.search', 'Search tickets and comments...')}
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="h-[38px] min-w-[350px] text-sm"
-                  containerClassName=""
-                />
                 <TagFilter
                   tags={allUniqueTags}
                   selectedTags={selectedTags}
@@ -1938,44 +2016,9 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                   onClearTags={() => onFilterChange({ tags: undefined })}
                 />
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleResetFilters}
-                  className={`shrink-0 flex items-center gap-1 ${isFiltered ? 'text-gray-500 hover:text-gray-700' : 'invisible'}`}
-                  id='reset-filters'
-                  disabled={!isFiltered}
-                >
-                  <XCircle className="h-4 w-4" />
-                  {t('resetFilters', 'Reset')}
-                </Button>
-                <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />
-                <div className="flex items-center gap-2 shrink-0">
-                  <Label htmlFor={`${id}-bundle-view-toggle`} className={`${densityClasses.tagSize === 'sm' ? 'text-xs' : 'text-sm'} text-gray-600`}>
-                    {t('dashboard.bundledToggle', 'Bundled')}
-                  </Label>
-                  <Switch
-                    id={`${id}-bundle-view-toggle`}
-                    checked={bundleView === 'bundled'}
-                    onCheckedChange={(checked) => onFilterChange({ bundleView: checked ? 'bundled' : 'individual' })}
-                    size={densityClasses.tagSize}
-                  />
-                </div>
-                <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />
-                <div className="shrink-0">
-                  <ViewDensityControl
-                    idPrefix={`${id}-list-density`}
-                    value={ticketListDensityLevel}
-                    onChange={handleTicketListDensityChange}
-                    step={TICKET_LIST_DENSITY_STEP}
-                    compactLabel={t('dashboard.spacing.compact', 'Compact')}
-                    spaciousLabel={t('dashboard.spacing.spacious', 'Spacious')}
-                    decreaseTitle={t('dashboard.spacing.decrease', 'Decrease ticket list spacing')}
-                    increaseTitle={t('dashboard.spacing.increase', 'Increase ticket list spacing')}
-                    resetTitle={t('dashboard.spacing.reset', 'Reset ticket list spacing')}
-                  />
-                </div>
               </div>
+              </div>
+              )}
             </div>
           </ReflectionContainer>
         </div>

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -283,6 +283,8 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [rawStatusOptions] = useState<TicketStatusFilterOption[]>(initialStatuses);
   const [priorityOptions] = useState<SelectOption[]>(initialPriorities);
   
+  // LEVERAGE: pattern datatable-filter-paging — largest instance of the list-query state machine
+  // (filter state + debounced search + reset-page + manual fetch); see docs/plans/leverage-ledger.md
   // Filter values derived from props (single source of truth is Container's activeFilters)
   const selectedBoards = useMemo(() => {
     if (filterValues.boardIds && filterValues.boardIds.length > 0) {
@@ -1700,6 +1702,133 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     });
   }, [onFilterChange, clearSelection]);
 
+  // LEVERAGE: pattern filter-descriptor-table — per-dimension "is-active / label / clear" logic is
+  // now duplicated three ways (toolbar controls, activeFilterCount, activeFilterChips). One
+  // descriptor list { key, isActive, label, clear } per filter would collapse all three.
+  // Active-filter chips (candidate #1): one removable chip per applied filter,
+  // shown above the table so what's filtering is always visible. Labels reuse the
+  // already-localized field/value strings; removal clears just that dimension.
+  const activeFilterChips = useMemo(() => {
+    const chips: Array<{ key: string; label: string; onRemove: () => void }> = [];
+    const boardLabel = t('fields.board', 'Board');
+    const categoryLabel = t('fields.category', 'Category');
+
+    selectedBoards.forEach((boardId) => {
+      const name = boardId === NO_BOARD_VALUE
+        ? 'No board'
+        : boards.find((b) => b.board_id === boardId)?.board_name ?? boardLabel;
+      chips.push({
+        key: `board:${boardId}`,
+        label: `${boardLabel}: ${name}`,
+        onRemove: () => handleBoardSelect(selectedBoards.filter((id) => id !== boardId), excludedBoards),
+      });
+    });
+    excludedBoards.forEach((boardId) => {
+      const name = boards.find((b) => b.board_id === boardId)?.board_name ?? boardLabel;
+      chips.push({
+        key: `board-ex:${boardId}`,
+        label: `${boardLabel} ≠ ${name}`,
+        onRemove: () => handleBoardSelect(selectedBoards, excludedBoards.filter((id) => id !== boardId)),
+      });
+    });
+
+    if (selectedClient) {
+      const name = clients.find((c) => c.client_id === selectedClient)?.client_name ?? t('fields.client', 'Client');
+      chips.push({ key: `client:${selectedClient}`, label: `${t('fields.client', 'Client')}: ${name}`, onRemove: () => handleClientSelect(null) });
+    }
+
+    selectedAssignees.forEach((userId) => {
+      const u = initialUsers.find((x) => x.user_id === userId);
+      const name = u ? `${u.first_name ?? ''} ${u.last_name ?? ''}`.trim() || t('fields.assignedTo', 'Assignee') : t('fields.assignedTo', 'Assignee');
+      chips.push({
+        key: `assignee:${userId}`,
+        label: name,
+        onRemove: () => { const rest = selectedAssignees.filter((id) => id !== userId); onFilterChange({ assignedToIds: rest.length > 0 ? rest : undefined }); },
+      });
+    });
+    selectedTeams.forEach((teamId) => {
+      const name = teams.find((x) => x.team_id === teamId)?.team_name ?? t('fields.team', 'Team');
+      chips.push({
+        key: `team:${teamId}`,
+        label: name,
+        onRemove: () => { const rest = selectedTeams.filter((id) => id !== teamId); onFilterChange({ assignedTeamIds: rest.length > 0 ? rest : undefined }); },
+      });
+    });
+    if (includeUnassigned) {
+      chips.push({ key: 'unassigned', label: t('filters.unassigned', 'Unassigned'), onRemove: () => onFilterChange({ includeUnassigned: false }) });
+    }
+
+    if (selectedStatus !== TICKET_STATUS_FILTER_OPEN) {
+      const label = statusOptions.find((o) => o.value === selectedStatus)?.label ?? selectedStatus;
+      chips.push({ key: 'status', label: `${t('fields.status', 'Status')}: ${label}`, onRemove: () => onFilterChange({ statusId: TICKET_STATUS_FILTER_OPEN, showOpenOnly: true }) });
+    }
+
+    if (selectedResponseState !== 'all') {
+      const map: Record<string, string> = {
+        awaiting_client: t('responseState.awaitingClient', 'Awaiting Client'),
+        awaiting_internal: t('responseState.awaitingInternal', 'Awaiting Internal'),
+        none: t('dashboard.filters.noResponseState', 'No Response State'),
+      };
+      chips.push({ key: 'response', label: `${t('fields.responseState', 'Response State')}: ${map[selectedResponseState] ?? selectedResponseState}`, onRemove: () => onFilterChange({ responseState: undefined }) });
+    }
+
+    if (selectedPriority !== 'all') {
+      const label = priorityOptions.find((o) => o.value === selectedPriority)?.label ?? selectedPriority;
+      chips.push({ key: 'priority', label: `${t('fields.priority', 'Priority')}: ${label}`, onRemove: () => onFilterChange({ priorityId: 'all' }) });
+    }
+
+    if (selectedDueDateFilter !== 'all') {
+      const dateStr = dueDateFilterValue ? dueDateFilterValue.toLocaleDateString() : '';
+      const map: Record<string, string> = {
+        overdue: t('dashboard.filters.overdue', 'Overdue'),
+        today: t('dashboard.filters.dueToday', 'Due Today'),
+        upcoming: t('dashboard.filters.dueNext7Days', 'Due Next 7 Days'),
+        before: dueDateFilterValue ? t('dashboard.filters.beforeDateSelected', 'Before {{date}}', { date: dateStr }) : t('dashboard.filters.beforeDate', 'Before Date...'),
+        after: dueDateFilterValue ? t('dashboard.filters.afterDateSelected', 'After {{date}}', { date: dateStr }) : t('dashboard.filters.afterDate', 'After Date...'),
+        no_due_date: t('dashboard.filters.noDueDate', 'No Due Date'),
+      };
+      chips.push({ key: 'due', label: `${t('fields.dueDate', 'Due Date')}: ${map[selectedDueDateFilter] ?? selectedDueDateFilter}`, onRemove: () => onFilterChange({ dueDateFilter: undefined, dueDateFrom: undefined, dueDateTo: undefined }) });
+    }
+
+    if (allowSlaStatusFilter && selectedSlaStatus !== 'all') {
+      const map: Record<string, string> = {
+        has_sla: t('dashboard.filters.hasSla', 'Has SLA'),
+        no_sla: t('dashboard.filters.noSla', 'No SLA'),
+        on_track: t('dashboard.filters.onTrack', 'On Track'),
+        breached: t('dashboard.filters.breached', 'Breached'),
+        paused: t('dashboard.filters.paused', 'Paused'),
+      };
+      chips.push({ key: 'sla', label: `${t('fields.slaStatus', 'SLA Status')}: ${map[selectedSlaStatus] ?? selectedSlaStatus}`, onRemove: () => onFilterChange({ slaStatusFilter: undefined }) });
+    }
+
+    selectedCategories.forEach((categoryId) => {
+      const name = categories.find((c) => c.category_id === categoryId)?.category_name ?? categoryLabel;
+      chips.push({
+        key: `cat:${categoryId}`,
+        label: `${categoryLabel}: ${name}`,
+        onRemove: () => handleCategorySelect(selectedCategories.filter((id) => id !== categoryId), excludedCategories),
+      });
+    });
+    excludedCategories.forEach((categoryId) => {
+      const name = categories.find((c) => c.category_id === categoryId)?.category_name ?? categoryLabel;
+      chips.push({
+        key: `cat-ex:${categoryId}`,
+        label: `${categoryLabel} ≠ ${name}`,
+        onRemove: () => handleCategorySelect(selectedCategories, excludedCategories.filter((id) => id !== categoryId)),
+      });
+    });
+
+    selectedTags.forEach((tag) => {
+      chips.push({
+        key: `tag:${tag}`,
+        label: `#${tag}`,
+        onRemove: () => { const rest = selectedTags.filter((x) => x !== tag); onFilterChange({ tags: rest.length > 0 ? rest : undefined }); },
+      });
+    });
+
+    return chips;
+  }, [selectedBoards, excludedBoards, boards, selectedClient, clients, selectedAssignees, initialUsers, selectedTeams, teams, includeUnassigned, selectedStatus, statusOptions, selectedResponseState, selectedPriority, priorityOptions, selectedDueDateFilter, dueDateFilterValue, allowSlaStatusFilter, selectedSlaStatus, selectedCategories, excludedCategories, categories, selectedTags, handleBoardSelect, handleClientSelect, handleCategorySelect, onFilterChange, t]);
+
   return (
     <>
     <ReflectionContainer id={id} label="Ticketing Dashboard">
@@ -1824,6 +1953,34 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                   </div>
                 </div>
               </div>
+
+              {activeFilterChips.length > 0 && (
+                <div className="flex items-center flex-wrap gap-2">
+                  {activeFilterChips.map((chip) => (
+                    <span
+                      key={chip.key}
+                      className="inline-flex items-center gap-1.5 rounded-full border border-[rgb(var(--color-primary-100))] bg-[rgb(var(--color-primary-50))] py-1 pl-2.5 pr-1.5 text-xs font-medium text-[rgb(var(--color-primary-700))]"
+                    >
+                      <span className="max-w-[220px] truncate">{chip.label}</span>
+                      <button
+                        type="button"
+                        onClick={chip.onRemove}
+                        aria-label={`Remove ${chip.label}`}
+                        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-[rgb(var(--color-primary-500))] hover:bg-[rgb(var(--color-primary-100))] hover:text-[rgb(var(--color-primary-700))]"
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={handleResetFilters}
+                    className="ml-1 text-xs font-medium text-[rgb(var(--color-text-500))] underline-offset-2 hover:text-[rgb(var(--color-text-700))] hover:underline"
+                  >
+                    {t('filters.clearFilters', 'Clear filters')}
+                  </button>
+                </div>
+              )}
 
               {showFilters && (
               <div className="space-y-3 pt-1 border-t border-gray-100 dark:border-[rgb(var(--color-border-200))]">

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -80,6 +80,89 @@ function calculateSlaStatus(ticket: ITicketListItem): {
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Presentation helpers — "Refined List" look (redesign candidate #1):
+// hero title + mono id/category subtitle, semantic status pills, priority
+// bars, initials avatars, and a relative Due column.
+// ---------------------------------------------------------------------------
+
+// Deterministic avatar palette so the same client/agent always gets the same hue.
+const AVATAR_PALETTE = [
+  '#8a4dea', '#0ea5e9', '#10b981', '#f59e0b', '#ef4444',
+  '#6366f1', '#ec4899', '#14b8a6', '#f97316', '#3b82f6',
+];
+
+function hashString(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function avatarColor(seed: string | null | undefined): string {
+  if (!seed) return '#94a3b8';
+  return AVATAR_PALETTE[hashString(seed) % AVATAR_PALETTE.length];
+}
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+// Soft status-pill themes. Open statuses get a stable color by name (Alga
+// statuses are per-board and custom, so there's no fixed semantic set); closed
+// statuses always read as muted green.
+const STATUS_PILL_THEMES: Array<{ bg: string; text: string; dot: string }> = [
+  { bg: 'rgb(var(--color-primary-50))', text: 'rgb(var(--color-primary-700))', dot: 'rgb(var(--color-primary-500))' },
+  { bg: 'rgb(var(--color-secondary-50))', text: 'rgb(var(--color-secondary-800))', dot: 'rgb(var(--color-secondary-600))' },
+  { bg: 'rgb(var(--color-accent-50))', text: 'rgb(var(--color-accent-700))', dot: 'rgb(var(--color-accent-600))' },
+  { bg: '#eef2ff', text: '#4338ca', dot: '#6366f1' },
+  { bg: '#fdf2f8', text: '#be185d', dot: '#ec4899' },
+  { bg: '#ecfeff', text: '#0e7490', dot: '#06b6d4' },
+];
+const STATUS_PILL_CLOSED = { bg: '#ecfdf3', text: '#15803d', dot: '#22c55e' };
+
+function statusPillTheme(statusName: string, closed: boolean): { bg: string; text: string; dot: string } {
+  if (closed) return STATUS_PILL_CLOSED;
+  return STATUS_PILL_THEMES[hashString(statusName || 'status') % STATUS_PILL_THEMES.length];
+}
+
+// Compact relative due label, e.g. "Overdue 2d", "in 5h", "in 3 days".
+function relativeDueLabel(due: Date, now: Date): string {
+  const ms = due.getTime() - now.getTime();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const overdue = ms < 0;
+  const absMs = Math.abs(ms);
+  const days = Math.floor(absMs / dayMs);
+  const hours = Math.floor(absMs / (60 * 60 * 1000));
+  let magnitude: string;
+  if (days >= 1) magnitude = `${days}d`;
+  else if (hours >= 1) magnitude = `${hours}h`;
+  else magnitude = `${Math.max(1, Math.round(absMs / 60000))}m`;
+  if (overdue) return `Overdue ${magnitude}`;
+  return days >= 1 ? `in ${days} days` : `in ${magnitude}`;
+}
+
+// Shared category label resolver, used by both the category column and the
+// category subtitle folded under the title cell.
+function formatCategoryLabel(record: ITicketListItem, categories: ITicketCategory[]): string {
+  const categoryId = record.category_id || null;
+  if (!categoryId && !record.subcategory_id) return 'No Category';
+  if (record.subcategory_id) {
+    const subcategory = categories.find(c => c.category_id === record.subcategory_id);
+    if (!subcategory) return 'Unknown Category';
+    const parent = categories.find(c => c.category_id === subcategory.parent_category);
+    return parent ? `${parent.category_name} → ${subcategory.category_name}` : subcategory.category_name;
+  }
+  const category = categories.find(c => c.category_id === categoryId);
+  if (!category) return 'Unknown Category';
+  return category.category_name;
+}
+
 type TicketListColumnKey =
   | 'ticket_number'
   | 'title'
@@ -165,25 +248,35 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
 
   const t = _t ?? ((_key: string, fallback: string) => fallback);
 
+  // Default on-screen column set mirrors redesign candidate #1: ticket number
+  // and category fold under the title, created/created-by and the standalone SLA
+  // column are off by default (still enableable via display settings / print).
   const columnVisibility = showAllAvailableColumns ? ALL_TICKET_LIST_COLUMN_VISIBILITY : (displaySettings?.list?.columnVisibility || {
-    ticket_number: true,
+    ticket_number: false,
     title: true,
     status: true,
     priority: true,
     sla: false,
     board: true,
-    category: true,
+    category: false,
     client: true,
     assigned_to: true,
     due_date: true,
-    created: true,
-    created_by: true,
+    created: false,
+    created_by: false,
     tags: true,
   });
 
   const tagsInlineUnderTitle = displaySettings?.list?.tagsInlineUnderTitle ?? true;
   const showInlineTagsInTitle = columnVisibility.tags && showTags && !showAllAvailableColumns;
   const dateTimeFormat = displaySettings?.dateTimeFormat || 'MMM d, yyyy h:mm a';
+
+  // When a dedicated ticket-number / category column isn't shown, fold those
+  // values under the title (the candidate #1 "Ticket" cell). Never fold in the
+  // print/export path, which renders every column separately.
+  const foldIntoTitle = !showAllAvailableColumns;
+  const showTicketNumberSubtitle = foldIntoTitle && !columnVisibility.ticket_number;
+  const showCategorySubtitle = foldIntoTitle && !columnVisibility.category;
 
   const columns: Array<{ key: string; col: ColumnDefinition<ITicketListItem> }> = [];
 
@@ -216,19 +309,17 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
                   )}
                 </button>
               ) : null}
-              <Link
-                href={`/msp/tickets/${record.ticket_id}`}
-                prefetch={false}
+              <button
+                type="button"
                 onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey) return;
                   e.preventDefault();
                   e.stopPropagation();
                   onTicketClick(record.ticket_id as string);
                 }}
-                className="text-blue-600 hover:text-blue-800 whitespace-normal text-left"
+                className="text-blue-600 hover:text-blue-800 whitespace-normal text-left bg-transparent border-none p-0 cursor-pointer"
               >
                 {value}
-              </Link>
+              </button>
             </span>
             {(record.master_ticket_id || (!record.master_ticket_id && (record.bundle_child_count ?? 0) > 0)) && (
               <div className="flex items-center gap-1">
@@ -262,41 +353,106 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     });
   }
 
-  // Title (with optional inline tags)
+  // Title — the "Ticket" hero cell: bold title with the mono ticket number and
+  // category folded underneath when those columns aren't shown separately.
   columns.push({
     key: 'title',
     col: {
       title: t('fields.title', 'Title'),
       dataIndex: 'title',
-      width: showInlineTagsInTitle ? '20%' : '16%',
-      render: (value: string, record: ITicketListItem) => (
-        <div className="flex flex-col gap-1 overflow-hidden">
-          <Link
-            href={`/msp/tickets/${record.ticket_id}`}
-            prefetch={false}
-            onClick={(e) => {
-              if (e.metaKey || e.ctrlKey) return;
-              e.preventDefault();
-              e.stopPropagation();
-              onTicketClick(record.ticket_id as string);
-            }}
-            className="text-blue-600 hover:text-blue-800 block whitespace-normal break-words"
-          >
-            {value}
-          </Link>
-          {showInlineTagsInTitle && ticketTagsRef && onTagsChange && record.ticket_id && (ticketTagsRef.current[record.ticket_id]?.length ?? 0) > 0 && (
-            <div onClick={(e) => e.stopPropagation()}>
-              <TagManager
-                entityId={record.ticket_id}
-                entityType="ticket"
-                initialTags={ticketTagsRef.current[record.ticket_id] || []}
-                onTagsChange={(tags) => onTagsChange(record.ticket_id!, tags)}
-                size={tagSize}
-              />
+      width: showInlineTagsInTitle ? '26%' : '24%',
+      render: (value: string, record: ITicketListItem) => {
+        const isBundleMaster = !record.master_ticket_id && (record.bundle_child_count ?? 0) > 0;
+        const showBundleToggle = showTicketNumberSubtitle && isBundleMaster && !!onToggleBundleExpanded;
+        const categoryLabel = formatCategoryLabel(record, categories);
+        return (
+          <div className="flex items-start gap-2 overflow-hidden">
+            {showBundleToggle && (
+              <button
+                type="button"
+                className="mt-0.5 inline-flex items-center justify-center rounded hover:bg-gray-100 dark:hover:bg-gray-800 relative z-10"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggleBundleExpanded!(record.ticket_id as string);
+                }}
+                aria-label="Toggle bundle children"
+              >
+                {isBundleExpanded && isBundleExpanded(record.ticket_id as string) ? (
+                  <ChevronDown className="h-4 w-4 text-gray-600" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 text-gray-600" />
+                )}
+              </button>
+            )}
+            <div className="flex flex-col gap-0.5 overflow-hidden">
+              <Link
+                href={`/msp/tickets/${record.ticket_id}`}
+                prefetch={false}
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onTicketClick(record.ticket_id as string);
+                }}
+                className="block truncate font-semibold text-[rgb(var(--color-text-900))] hover:text-[rgb(var(--color-primary-700))]"
+              >
+                {value}
+              </Link>
+              {(showTicketNumberSubtitle || showCategorySubtitle) && (
+                <div className="flex items-center gap-1.5 overflow-hidden text-[11px] leading-tight text-[rgb(var(--color-text-500))]">
+                  {showTicketNumberSubtitle && (
+                    <Link
+                      href={`/msp/tickets/${record.ticket_id}`}
+                      prefetch={false}
+                      onClick={(e) => {
+                        if (e.metaKey || e.ctrlKey) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onTicketClick(record.ticket_id as string);
+                      }}
+                      className="shrink-0 font-mono text-[11px] text-[rgb(var(--color-text-400))] hover:text-[rgb(var(--color-primary-600))]"
+                    >
+                      {record.ticket_number}
+                    </Link>
+                  )}
+                  {showTicketNumberSubtitle && showCategorySubtitle && (
+                    <span className="text-[rgb(var(--color-text-300))]">·</span>
+                  )}
+                  {showCategorySubtitle && <span className="truncate">{categoryLabel}</span>}
+                </div>
+              )}
+              {showTicketNumberSubtitle && record.master_ticket_id && (
+                <span
+                  className="w-fit rounded px-2 py-0.5 text-[11px] font-medium"
+                  style={{ color: 'rgb(var(--color-primary-700))', backgroundColor: 'rgb(var(--color-primary-100))' }}
+                >
+                  Bundled → {record.bundle_master_ticket_number || 'Master'}
+                </span>
+              )}
+              {showTicketNumberSubtitle && isBundleMaster && (
+                <span
+                  className="w-fit rounded px-2 py-0.5 text-[11px] font-medium"
+                  style={{ color: 'rgb(var(--color-secondary-700))', backgroundColor: 'rgb(var(--color-secondary-100))' }}
+                >
+                  Bundle · {record.bundle_child_count}
+                </span>
+              )}
+              {showInlineTagsInTitle && ticketTagsRef && onTagsChange && record.ticket_id && (ticketTagsRef.current[record.ticket_id]?.length ?? 0) > 0 && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <TagManager
+                    entityId={record.ticket_id}
+                    entityType="ticket"
+                    initialTags={ticketTagsRef.current[record.ticket_id] || []}
+                    onTagsChange={(tags) => onTagsChange(record.ticket_id!, tags)}
+                    size={tagSize}
+                  />
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      ),
+          </div>
+        );
+      },
     }
   });
 
@@ -312,9 +468,17 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
           // Get response_state from the record - it may be on the record if fetched
           const responseState = (record as any).response_state as TicketResponseState | undefined;
           const showResponseState = displaySettings?.responseStateTrackingEnabled !== false;
+          const closed = !!(record as { is_closed?: boolean }).is_closed;
+          const theme = statusPillTheme(value || '', closed);
           return (
             <div className="flex items-center gap-1.5 overflow-hidden whitespace-nowrap">
-              <span className="overflow-hidden text-ellipsis">{value || 'No Status'}</span>
+              <span
+                className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+                style={{ backgroundColor: theme.bg, color: theme.text }}
+              >
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: theme.dot }} />
+                <span className="overflow-hidden text-ellipsis">{value || 'No Status'}</span>
+              </span>
               {showResponseState && responseState && (
                 <ResponseStateBadge
                   responseState={responseState}
@@ -339,14 +503,15 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
         dataIndex: 'priority_name',
         width: '7%',
         render: (value: string, record: ITicketListItem) => {
-          // All tickets now use the unified priority system with priority_name and priority_color
+          // All tickets now use the unified priority system with priority_name and priority_color.
+          // Candidate #1 renders priority as a colored bar + label for at-a-glance scanning.
           return (
             <div className="flex items-center gap-2">
-              <div
-                className="w-3 h-3 rounded-full border border-gray-300"
-                style={{ backgroundColor: record.priority_color || '#6B7280' }}
+              <span
+                className="h-3.5 w-[3px] shrink-0 rounded-full"
+                style={{ backgroundColor: record.priority_color || '#94a3b8' }}
               />
-              <span>{value || 'No Priority'}</span>
+              <span className="font-medium text-[rgb(var(--color-text-700))]">{value || 'No Priority'}</span>
             </div>
           );
         },
@@ -389,7 +554,12 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
       col: {
         title: t('fields.board', 'Board'),
         dataIndex: 'board_name',
-        width: '7%',
+        width: '8%',
+        render: (value: string) => value ? (
+          <span className="inline-block rounded-md bg-[rgb(var(--color-border-100))] px-2 py-0.5 text-[11px] font-medium text-[rgb(var(--color-text-600))]">
+            {value}
+          </span>
+        ) : <span className="text-[rgb(var(--color-text-400))]">-</span>,
       }
     });
   }
@@ -402,26 +572,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
         title: t('fields.category', 'Category'),
         dataIndex: 'category_name',
         width: '7%',
-        render: (_value: string, record: ITicketListItem) => {
-          const categoryId = record.category_id || null;
-
-          // Use unified category display for all boards (ITIL and custom)
-          if (!categoryId && !record.subcategory_id) return 'No Category';
-
-          // If there's a subcategory, use that for display
-          if (record.subcategory_id) {
-            const subcategory = categories.find(c => c.category_id === record.subcategory_id);
-            if (!subcategory) return 'Unknown Category';
-
-            const parent = categories.find(c => c.category_id === subcategory.parent_category);
-            return parent ? `${parent.category_name} → ${subcategory.category_name}` : subcategory.category_name;
-          }
-
-          // Otherwise use the main category
-          const category = categories.find(c => c.category_id === categoryId);
-          if (!category) return 'Unknown Category';
-          return category.category_name;
-        },
+        render: (_value: string, record: ITicketListItem) => formatCategoryLabel(record, categories),
       }
     });
   }
@@ -434,30 +585,45 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
         title: t('fields.client', 'Client'),
         dataIndex: 'client_name',
         width: '9%',
-        render: onClientClick ? (value: string, record: ITicketListItem) => (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              if (record.client_id) onClientClick(record.client_id);
-            }}
-            className="text-blue-500 hover:underline text-left whitespace-normal break-words bg-transparent border-none p-0"
-          >
-            <div className="flex flex-col gap-1">
-              <span>{value || 'No Client'}</span>
-              {!record.master_ticket_id && (record.bundle_child_count ?? 0) > 0 && (record.bundle_distinct_client_count ?? 0) > 1 ? (
-                <span 
-                  className="rounded px-2 py-0.5 text-[11px] font-medium"
-                  style={{
-                    color: 'rgb(var(--color-accent-700))',
-                    backgroundColor: 'rgb(var(--color-accent-100))'
-                  }}
-                >
-                  Multiple clients
-                </span>
-              ) : null}
-            </div>
-          </button>
-        ) : undefined,
+        render: (value: string, record: ITicketListItem) => {
+          const hasClient = !!value;
+          const multiClient = !record.master_ticket_id && (record.bundle_child_count ?? 0) > 0 && (record.bundle_distinct_client_count ?? 0) > 1;
+          const body = (
+            <span className="flex items-center gap-2 overflow-hidden">
+              <span
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[10px] font-bold text-white"
+                style={{ backgroundColor: hasClient ? avatarColor(record.client_id || value) : '#cbd5e1' }}
+              >
+                {hasClient ? getInitials(value) : '—'}
+              </span>
+              <span className="flex flex-col gap-0.5 overflow-hidden">
+                <span className="truncate">{value || 'No Client'}</span>
+                {multiClient ? (
+                  <span
+                    className="w-fit rounded px-2 py-0.5 text-[11px] font-medium"
+                    style={{ color: 'rgb(var(--color-accent-700))', backgroundColor: 'rgb(var(--color-accent-100))' }}
+                  >
+                    Multiple clients
+                  </span>
+                ) : null}
+              </span>
+            </span>
+          );
+          if (!onClientClick) {
+            return <span className="text-[rgb(var(--color-text-700))]">{body}</span>;
+          }
+          return (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (record.client_id) onClientClick(record.client_id);
+              }}
+              className="bg-transparent border-none p-0 text-left text-[rgb(var(--color-text-700))] hover:[&_.truncate]:text-[rgb(var(--color-primary-700))]"
+            >
+              {body}
+            </button>
+          );
+        },
       }
     });
   }
@@ -474,8 +640,20 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
           const additionalCount = record.additional_agent_count || 0;
           const additionalAgents = record.additional_agents || [];
           return (
-            <span className="text-gray-700 flex items-center gap-1.5">
-              {value || 'Unassigned'}
+            <span className="text-gray-700 flex items-center gap-2">
+              {value ? (
+                <span
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+                  style={{ backgroundColor: avatarColor(value) }}
+                >
+                  {getInitials(value)}
+                </span>
+              ) : (
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-dashed border-[rgb(var(--color-border-400))] text-xs text-[rgb(var(--color-text-400))]">
+                  +
+                </span>
+              )}
+              <span className="truncate">{value || 'Unassigned'}</span>
               {record.assigned_team_id && record.assigned_team_name && (
                 <Tooltip content={record.assigned_team_name}>
                   <span className="inline-flex items-center cursor-help">
@@ -535,35 +713,27 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
         width: '9%',
         render: (value: string | null) => {
           if (!value) {
-            return <div className="text-sm text-[rgb(var(--color-text-500))]">-</div>;
+            return <div className="text-sm text-[rgb(var(--color-text-400))]">No due date</div>;
           }
 
           const dueDate = new Date(value);
           const now = new Date();
           const hoursUntilDue = (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60);
 
-          // Check if time is midnight (00:00) - show date only
+          // Midnight (00:00) means a date-only due date — drop the time portion.
           const isMidnight = dueDate.getHours() === 0 && dueDate.getMinutes() === 0;
           const displayFormat = isMidnight ? 'MMM d, yyyy' : dateTimeFormat;
 
-          // Determine styling based on due date status
-          let textColorClass = 'text-[rgb(var(--color-text-500))]';
-          let bgColorClass = '';
-
-          if (hoursUntilDue < 0) {
-            // Overdue - red/warning style
-            textColorClass = 'text-red-600 dark:text-red-400';
-            bgColorClass = 'bg-red-500/10';
-          } else if (hoursUntilDue <= 24) {
-            // Approaching due date (within 24 hours) - orange/caution style
-            textColorClass = 'text-orange-600 dark:text-orange-400';
-            bgColorClass = 'bg-orange-500/10';
-          }
+          // Candidate #1: primary date colored by urgency + a relative secondary line.
+          let primaryClass = 'text-[rgb(var(--color-text-700))]';
+          if (hoursUntilDue < 0) primaryClass = 'text-red-600 dark:text-red-400';
+          else if (hoursUntilDue <= 24) primaryClass = 'text-orange-600 dark:text-orange-400';
 
           return (
-            <span className={`text-sm inline-block ${textColorClass} ${bgColorClass ? `${bgColorClass} px-2 py-0.5 rounded-full` : ''}`}>
-              {format(dueDate, displayFormat)}
-            </span>
+            <div className="flex flex-col leading-tight">
+              <span className={`text-sm font-medium ${primaryClass}`}>{format(dueDate, displayFormat)}</span>
+              <span className="text-[11px] text-[rgb(var(--color-text-400))]">{relativeDueLabel(dueDate, now)}</span>
+            </div>
           );
         },
       }

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "Alle Prioritäten",
     "search": "Tickets und Kommentare suchen...",
     "button": "Filter",
+    "unassigned": "Nicht zugewiesen",
     "category": "Nach Kategorie filtern",
     "clearFilters": "Filter löschen",
     "assignee": "Zuständiger",

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "Alle geschlossenen Tickets",
     "allPriorities": "Alle Prioritäten",
     "search": "Tickets und Kommentare suchen...",
+    "button": "Filter",
     "category": "Nach Kategorie filtern",
     "clearFilters": "Filter löschen",
     "assignee": "Zuständiger",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "All Closed Tickets",
     "allPriorities": "All Priorities",
     "search": "Search tickets and comments...",
+    "button": "Filters",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "All Priorities",
     "search": "Search tickets and comments...",
     "button": "Filters",
+    "unassigned": "Unassigned",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "Todos los tickets cerrados",
     "allPriorities": "Todas las prioridades",
     "search": "Buscar tickets y comentarios...",
+    "button": "Filtros",
     "category": "Filtrar por categoría",
     "clearFilters": "Limpiar filtros",
     "assignee": "Asignado",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "Todas las prioridades",
     "search": "Buscar tickets y comentarios...",
     "button": "Filtros",
+    "unassigned": "Sin asignar",
     "category": "Filtrar por categoría",
     "clearFilters": "Limpiar filtros",
     "assignee": "Asignado",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "Tous les tickets fermés",
     "allPriorities": "Toutes les priorités",
     "search": "Rechercher des tickets et commentaires...",
+    "button": "Filtres",
     "category": "Filtrer par catégorie",
     "clearFilters": "Effacer les filtres",
     "assignee": "Destinataire",

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "Toutes les priorités",
     "search": "Rechercher des tickets et commentaires...",
     "button": "Filtres",
+    "unassigned": "Non attribué",
     "category": "Filtrer par catégorie",
     "clearFilters": "Effacer les filtres",
     "assignee": "Destinataire",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "Tutte le priorità",
     "search": "Cerca ticket e commenti...",
     "button": "Filtri",
+    "unassigned": "Non assegnato",
     "category": "Filtra per categoria",
     "clearFilters": "Pulisci filtri",
     "assignee": "Assegnatario",

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "Tutti i ticket chiusi",
     "allPriorities": "Tutte le priorità",
     "search": "Cerca ticket e commenti...",
+    "button": "Filtri",
     "category": "Filtra per categoria",
     "clearFilters": "Pulisci filtri",
     "assignee": "Assegnatario",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "Alle prioriteiten",
     "search": "Tickets en opmerkingen zoeken...",
     "button": "Filters",
+    "unassigned": "Niet toegewezen",
     "category": "Filter op categorie",
     "clearFilters": "Filters wissen",
     "assignee": "Toegewezene",

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "Alle gesloten tickets",
     "allPriorities": "Alle prioriteiten",
     "search": "Tickets en opmerkingen zoeken...",
+    "button": "Filters",
     "category": "Filter op categorie",
     "clearFilters": "Filters wissen",
     "assignee": "Toegewezene",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -79,6 +79,7 @@
     "allClosed": "Wszystkie zamknięte zgłoszenia",
     "allPriorities": "Wszystkie priorytety",
     "search": "Szukaj zgłoszeń i komentarzy...",
+    "button": "Filtry",
     "category": "Filtruj według kategorii",
     "clearFilters": "Wyczyść filtry",
     "assignee": "Przypisany do",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -80,6 +80,7 @@
     "allPriorities": "Wszystkie priorytety",
     "search": "Szukaj zgłoszeń i komentarzy...",
     "button": "Filtry",
+    "unassigned": "Nieprzypisane",
     "category": "Filtruj według kategorii",
     "clearFilters": "Wyczyść filtry",
     "assignee": "Przypisany do",

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "All Closed Tickets",
     "allPriorities": "All Priorities",
     "search": "Search tickets and comments...",
+    "button": "Filtros",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "All Priorities",
     "search": "Search tickets and comments...",
     "button": "Filtros",
+    "unassigned": "Não atribuído",
     "category": "Filter by category",
     "clearFilters": "Clear filters",
     "assignee": "Assignee",

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "11111",
     "search": "11111",
     "button": "11111",
+    "unassigned": "11111",
     "category": "11111",
     "clearFilters": "11111",
     "assignee": "11111",

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "11111",
     "allPriorities": "11111",
     "search": "11111",
+    "button": "11111",
     "category": "11111",
     "clearFilters": "11111",
     "assignee": "11111",

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -47,6 +47,7 @@
     "allClosed": "55555",
     "allPriorities": "55555",
     "search": "55555",
+    "button": "11111",
     "category": "55555",
     "clearFilters": "55555",
     "assignee": "55555",

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -48,6 +48,7 @@
     "allPriorities": "55555",
     "search": "55555",
     "button": "11111",
+    "unassigned": "11111",
     "category": "55555",
     "clearFilters": "55555",
     "assignee": "55555",


### PR DESCRIPTION
## What

Redesigns the **Ticketing Dashboard** list view to the "Refined List" direction (mockup candidate #1) and brings the filter UI to parity. Two commits:

1. `feat(tickets): refine ticket list view` — the rows + column set + collapsed toolbar
2. `feat(tickets): active-filter chips + leverage markers` — removable filter chips + detection markers

## Rows (`packages/tickets/src/lib/ticket-columns.tsx`)
- **Hero "Ticket" cell**: bold title with the mono ticket number + category folded underneath (ticket#/category drop as standalone default columns; still available in display settings + print/export).
- **Status → soft colored pill** with a dot (stable color per status name; closed = green).
- **Priority → colored bar + label** (uses `priority_color`).
- **Board → soft tag pill.**
- **Client / Assignee → initials avatars** (dashed circle = unassigned).
- **Due → two-line**: date + relative/urgency ("Overdue 1d", "in 5h").

## Column set (`ticketDisplaySettings.ts`)
Default on-screen columns now match #1 (Title, Status, Priority, Board, Client, Assignee, Due). `ticket_number`/`category` fold under the title; `created`/`created_by` off by default. **Behavior note:** this only changes the out-of-the-box default — tenants who've customized their ticket columns keep their settings, and every column is re-enableable in ticket display settings.

## Toolbar + filters (`TicketingDashboard.tsx`)
- The nine always-on dropdowns collapse behind a **Filters** button with an active-count badge, beside a prominent search box; density stays visible.
- **Removable active-filter chips** above the table — one pill per applied filter (boards incl. excluded, client, assignees/teams/unassigned, status, response state, priority, due, SLA, categories incl. excluded, tags) + a "Clear filters" link.
- All filter wiring is unchanged; removal clears just that dimension. Adds `filters.button` / `filters.unassigned` locale keys across all 10 locales.

## Leverage (detection only — no extraction)
- `pattern datatable-filter-paging` — TicketingDashboard marked as the largest instance of the list-query state-machine candidate.
- `pattern filter-descriptor-table` — per-dimension is-active/label/clear logic duplicated across toolbar controls, count, and chips.
- Both recorded in `docs/plans/leverage-ledger.md`.

## Verification
Typecheck clean; `ticketColumns.prefetch` / category / i18n contract assertions hold; no new console errors. Verified live against the dev stack: rows, collapsed/expanded toolbar, chip render + count badge + removal + clear-all.

https://claude.ai/code/session_014MJ2hBFXRDu86ChdshQ8iy