### PR TITLE
feat(appliance): post-install Management surface (updates, control-plane, license, settings)

### DIFF
--- a/ee/appliance/control-plane/manifests/rbac.yaml
+++ b/ee/appliance/control-plane/manifests/rbac.yaml
@@ -50,7 +50,9 @@ rules:
     resources: ["helmreleases"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: ["gitrepositories", "helmrepositories", "ocirepositories"]
+    # helmcharts + buckets are needed so `flux reconcile helmrelease --with-source`
+    # (the app-channel update path) can reconcile the HelmChart it generates.
+    resources: ["gitrepositories", "helmrepositories", "ocirepositories", "helmcharts", "buckets"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: ["kustomizations"]

--- a/ee/appliance/host-service/host-agent.mjs
+++ b/ee/appliance/host-service/host-agent.mjs
@@ -2,11 +2,74 @@
 import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, spawn } from 'node:child_process';
 
 const socketPath = process.env.ALGA_HOST_AGENT_SOCKET || '/run/alga-appliance/host-agent.sock';
 const socketGid = Number(process.env.ALGA_HOST_AGENT_SOCKET_GID || 10001);
 const commandTimeoutMs = Number(process.env.ALGA_HOST_AGENT_COMMAND_TIMEOUT_MS || 20000);
+
+// --- Control-plane upgrade (host-agent driven) -----------------------------
+// The control-plane pod serves the Manage UI, so it cannot cleanly upgrade
+// itself: the request is killed when its own Deployment is Recreate'd. The
+// host-agent (this process, root, on the host, NOT a k8s pod) runs the proven
+// bootstrap control-plane apply instead, so the swap survives the pod restart.
+const applianceRoot = process.env.ALGA_APPLIANCE_ROOT || '/opt/alga-appliance';
+const bootstrapScript = process.env.ALGA_APPLIANCE_BOOTSTRAP_SCRIPT || `${applianceRoot}/scripts/bootstrap-control-plane.sh`;
+const cpUpgradeStatusFile = process.env.ALGA_APPLIANCE_CP_UPGRADE_STATUS_FILE || '/var/lib/alga-appliance/control-plane-upgrade.json';
+const cpUpgradeLogFile = process.env.ALGA_APPLIANCE_CP_UPGRADE_LOG_FILE || '/var/lib/alga-appliance/control-plane-upgrade.log';
+
+let cpUpgradeInFlight = false;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function writeCpUpgradeStatus(status, extra = {}) {
+  try {
+    fs.mkdirSync(path.dirname(cpUpgradeStatusFile), { recursive: true, mode: 0o750 });
+    fs.writeFileSync(cpUpgradeStatusFile, `${JSON.stringify({ status, updatedAt: nowIso(), ...extra })}\n`, { mode: 0o600 });
+  } catch {
+    // Best effort: the status file is advisory; the digest compare in
+    // /api/manage/status is the source of truth for "is the upgrade applied".
+  }
+}
+
+function startControlPlaneUpgrade() {
+  if (cpUpgradeInFlight) {
+    return { ok: true, started: false, alreadyRunning: true };
+  }
+  cpUpgradeInFlight = true;
+  writeCpUpgradeStatus('running', { startedAt: nowIso() });
+
+  let logFd = 'ignore';
+  try {
+    fs.mkdirSync(path.dirname(cpUpgradeLogFile), { recursive: true, mode: 0o750 });
+    logFd = fs.openSync(cpUpgradeLogFile, 'a', 0o600);
+  } catch {
+    logFd = 'ignore';
+  }
+
+  const child = spawn(bootstrapScript, ['--control-plane-only'], {
+    env: process.env,
+    stdio: ['ignore', logFd, logFd]
+  });
+  if (typeof logFd === 'number') {
+    try { fs.closeSync(logFd); } catch {}
+  }
+  child.on('error', (err) => {
+    cpUpgradeInFlight = false;
+    writeCpUpgradeStatus('blocked', { message: `Failed to start control-plane upgrade: ${err.message}`, finishedAt: nowIso() });
+  });
+  child.on('exit', (code) => {
+    cpUpgradeInFlight = false;
+    if (code === 0) {
+      writeCpUpgradeStatus('complete', { finishedAt: nowIso() });
+    } else {
+      writeCpUpgradeStatus('blocked', { message: `control-plane upgrade exited with code ${code}`, finishedAt: nowIso() });
+    }
+  });
+  return { ok: true, started: true };
+}
 
 function redactText(value) {
   return String(value)
@@ -67,6 +130,14 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'POST' && req.url === '/v1/support-bundle') {
     json(res, 200, supportBundlePayload());
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/v1/control-plane/upgrade') {
+    // Kick off the control-plane apply and return immediately. The work
+    // continues here on the host while the control-plane pod is Recreate'd.
+    const result = startControlPlaneUpgrade();
+    json(res, 202, result);
     return;
   }
 

--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -12,6 +12,11 @@ import { appUrlFromInput, hostFromAppUrl, setYamlScalar } from './setup-engine.m
 
 const JWS_RE = /^[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$/;
 
+// Licenses whose expiry lands beyond this are treated as perpetual. No genuine
+// commercial term runs to 2100; far-future values (e.g. the 9999999999
+// "all nines" sentinel = 2286-11-20) are placeholders meaning "never expires".
+const PERPETUAL_EXP_THRESHOLD_MS = Date.UTC(2100, 0, 1);
+
 function nowMs() {
   return new Date().getTime();
 }
@@ -60,14 +65,22 @@ export function licenseStatusFromClaims(claims, editionFallback) {
   const out = {
     edition: editionFallback || (claims && (claims.edition || claims.tier)) || null,
     expiresAt: null,
+    perpetual: false,
     status: 'unknown'
   };
   const exp = claims && claims.exp;
   if (exp) {
     const ms = Number(exp) * 1000;
     if (Number.isFinite(ms) && ms > 0) {
-      out.expiresAt = new Date(ms).toISOString();
-      out.status = ms > nowMs() ? 'active' : 'expired';
+      if (ms >= PERPETUAL_EXP_THRESHOLD_MS) {
+        // Sentinel / far-future expiry — surface "perpetual" rather than a
+        // literal year-2286 date.
+        out.perpetual = true;
+        out.status = 'active';
+      } else {
+        out.expiresAt = new Date(ms).toISOString();
+        out.status = ms > nowMs() ? 'active' : 'expired';
+      }
     }
   }
   return out;
@@ -314,7 +327,7 @@ export async function collectManageStatus(deps) {
   };
 
   // License.
-  let license = { edition: null, expiresAt: null, status: 'unknown' };
+  let license = { edition: null, expiresAt: null, perpetual: false, status: 'unknown' };
   try {
     license = await readLicenseStatus({ kube, namespace: licenseNamespace, secretName: licenseSecretName });
   } catch { /* best effort */ }

--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -1,0 +1,339 @@
+// Post-install Management surface engine.
+//
+// Pure-ish backend logic for the Manage area (status aggregation, license
+// apply, app-URL/DNS settings, control-plane upgrade request). All external
+// effects (kubectl, the host-agent socket, registry resolves, file reads) are
+// injected so server.mjs can wire its kubectl queue and tests can inject fakes.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { appUrlFromInput, hostFromAppUrl, setYamlScalar } from './setup-engine.mjs';
+
+const JWS_RE = /^[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$/;
+
+function nowMs() {
+  return new Date().getTime();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function readJsonFile(file) {
+  try {
+    if (!file || !fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeSecureJsonFile(targetFile, value) {
+  const dir = path.dirname(targetFile);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o750 });
+  fs.writeFileSync(targetFile, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  fs.chmodSync(targetFile, 0o600);
+}
+
+// --- License ---------------------------------------------------------------
+
+export function isWellFormedLicenseJws(token) {
+  return typeof token === 'string' && JWS_RE.test(token.trim());
+}
+
+// Decode the (unverified) JWS payload to surface edition/expiry. The app
+// validates the signature at runtime; this is display/status only.
+export function decodeLicenseClaims(token) {
+  try {
+    const part = String(token || '').split('.')[1];
+    if (!part) return null;
+    const b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    const json = Buffer.from(b64, 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function licenseStatusFromClaims(claims, editionFallback) {
+  const out = {
+    edition: editionFallback || (claims && (claims.edition || claims.tier)) || null,
+    expiresAt: null,
+    status: 'unknown'
+  };
+  const exp = claims && claims.exp;
+  if (exp) {
+    const ms = Number(exp) * 1000;
+    if (Number.isFinite(ms) && ms > 0) {
+      out.expiresAt = new Date(ms).toISOString();
+      out.status = ms > nowMs() ? 'active' : 'expired';
+    }
+  }
+  return out;
+}
+
+function decodeSecretValue(value) {
+  if (typeof value !== 'string') return '';
+  try {
+    return Buffer.from(value, 'base64').toString('utf8');
+  } catch {
+    return '';
+  }
+}
+
+// Read edition + license expiry from the appliance-license-seed secret.
+export async function readLicenseStatus(deps) {
+  const { kube, namespace = 'msp', secretName = 'appliance-license-seed' } = deps;
+  const res = await kube.json(`get secret ${secretName} -n ${namespace}`);
+  if (!res || !res.ok || !res.value || !res.value.data) {
+    return { edition: null, expiresAt: null, status: 'unknown' };
+  }
+  const data = res.value.data;
+  const token = decodeSecretValue(data.LICENSE_TOKEN);
+  const edition = decodeSecretValue(data.EDITION_CHOICE) || null;
+  const claims = token ? decodeLicenseClaims(token) : null;
+  return licenseStatusFromClaims(claims, edition);
+}
+
+export async function applyLicense(deps) {
+  const {
+    licenseKey,
+    kube,
+    namespace = 'msp',
+    secretName = 'appliance-license-seed',
+    appDeployment = 'alga-core-sebastian',
+    appNamespace = 'msp'
+  } = deps;
+
+  const token = String(licenseKey || '').trim();
+  if (!token) {
+    return { ok: false, status: 400, error: 'A license key is required.' };
+  }
+  if (!isWellFormedLicenseJws(token)) {
+    return { ok: false, status: 400, error: 'Invalid license key format. Expected a signed JWS (three dot-separated base64url segments).' };
+  }
+
+  // Patch only LICENSE_TOKEN so the edition and any connected-refresh fields are
+  // preserved. Secret.data values are base64.
+  const tokenB64 = Buffer.from(token, 'utf8').toString('base64');
+  const patch = JSON.stringify({ data: { LICENSE_TOKEN: tokenB64 } });
+  const patched = await kube.run(`patch secret ${secretName} -n ${namespace} --type merge -p ${kube.quote(patch)}`);
+  if (!patched.ok) {
+    return { ok: false, status: 412, error: `Could not update the license secret: ${(patched.stderr || patched.stdout || '').trim()}` };
+  }
+
+  // Restart the app so it re-reads the license seed.
+  const restarted = await kube.run(`rollout restart deploy/${appDeployment} -n ${appNamespace}`);
+  if (!restarted.ok) {
+    return { ok: false, status: 412, error: `License updated but app restart failed: ${(restarted.stderr || restarted.stdout || '').trim()}` };
+  }
+  return { ok: true };
+}
+
+// --- Settings: app URL / DNS ----------------------------------------------
+
+export async function applyAppUrl(deps) {
+  const {
+    appHostname,
+    dnsMode = 'system',
+    dnsServers = '',
+    kube,
+    releaseSelectionFile,
+    valuesNamespace = 'alga-system',
+    valuesConfigMapName = 'appliance-values-alga-core',
+    helmReleaseName = 'alga-core',
+    timestamp
+  } = deps;
+
+  const appUrl = appUrlFromInput(appHostname);
+  if (!appUrl) {
+    return { ok: false, status: 400, error: 'An app URL / hostname is required.' };
+  }
+  if (!['system', 'custom'].includes(dnsMode)) {
+    return { ok: false, status: 400, error: 'Invalid DNS mode. Use system or custom.' };
+  }
+  const host = hostFromAppUrl(appUrl);
+
+  // 1. Read the current alga-core values configmap, rewrite the URL scalars.
+  const cm = await kube.json(`get configmap ${valuesConfigMapName} -n ${valuesNamespace}`);
+  if (!cm || !cm.ok || !cm.value || !cm.value.data) {
+    return { ok: false, status: 412, error: `Could not read ${valuesConfigMapName} in ${valuesNamespace}.` };
+  }
+  const dataKeys = Object.keys(cm.value.data);
+  const valuesKey = dataKeys.find((k) => k.startsWith('alga-core.')) || dataKeys[0];
+  if (!valuesKey) {
+    return { ok: false, status: 412, error: `${valuesConfigMapName} has no values data key.` };
+  }
+  let yaml = cm.value.data[valuesKey];
+  try {
+    yaml = setYamlScalar(yaml, ['appUrl'], JSON.stringify(appUrl));
+    yaml = setYamlScalar(yaml, ['host'], JSON.stringify(host));
+    yaml = setYamlScalar(yaml, ['domainSuffix'], '""');
+  } catch (error) {
+    return { ok: false, status: 412, error: `Could not rewrite app URL in values: ${error instanceof Error ? error.message : String(error)}` };
+  }
+
+  // 2. Apply the updated configmap (full object so the data key is preserved).
+  const manifest = {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: valuesConfigMapName, namespace: valuesNamespace },
+    data: { [valuesKey]: yaml.endsWith('\n') ? yaml : `${yaml}\n` }
+  };
+  const applied = await kube.apply(manifest);
+  if (!applied.ok) {
+    return { ok: false, status: 412, error: `Could not apply updated values: ${(applied.stderr || applied.stdout || '').trim()}` };
+  }
+
+  // 3. Persist the operator intent in release-selection.json so the next update
+  //    re-applies it (and does not silently reset the URL).
+  if (releaseSelectionFile) {
+    const selection = readJsonFile(releaseSelectionFile) || {};
+    selection.runtime = {
+      ...(selection.runtime || {}),
+      appHostname: appUrl,
+      dnsMode,
+      dnsServers: dnsMode === 'custom' ? String(dnsServers || '').trim() : ''
+    };
+    selection.updatedAt = nowIso();
+    try {
+      writeSecureJsonFile(releaseSelectionFile, selection);
+    } catch (error) {
+      return { ok: false, status: 412, error: `Values applied but could not persist release selection: ${error instanceof Error ? error.message : String(error)}` };
+    }
+  }
+
+  // 4. Reconcile the HelmRelease so NEXTAUTH_URL re-renders from the new values.
+  const ts = timestamp || String(Math.floor(nowMs() / 1000));
+  const reconciled = await kube.run(`annotate helmrelease ${helmReleaseName} -n ${valuesNamespace} reconcile.fluxcd.io/requestedAt=${ts} --overwrite`);
+  if (!reconciled.ok) {
+    return { ok: false, status: 412, error: `Values applied but HelmRelease reconcile failed: ${(reconciled.stderr || reconciled.stdout || '').trim()}` };
+  }
+  return { ok: true, appUrl, host };
+}
+
+// --- Control-plane upgrade request (-> host-agent over the socket) ----------
+
+export function requestControlPlaneUpgrade(deps) {
+  const { hostAgentSocket = '/run/alga-appliance/host-agent.sock', timeoutMs = 10000 } = deps;
+  return new Promise((resolve) => {
+    if (!fs.existsSync(hostAgentSocket)) {
+      resolve({ ok: false, status: 503, error: `Host agent socket not available at ${hostAgentSocket}.` });
+      return;
+    }
+    const req = http.request(
+      { socketPath: hostAgentSocket, path: '/v1/control-plane/upgrade', method: 'POST', timeout: timeoutMs },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => { body += c; });
+        res.on('end', () => {
+          let parsed = null;
+          try { parsed = JSON.parse(body); } catch {}
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ ok: true, status: 202, result: parsed || { ok: true, started: true } });
+          } else {
+            resolve({ ok: false, status: res.statusCode || 502, error: (parsed && parsed.error) || `Host agent returned ${res.statusCode}.` });
+          }
+        });
+      }
+    );
+    req.on('timeout', () => { req.destroy(new Error('host agent request timed out')); });
+    req.on('error', (err) => { resolve({ ok: false, status: 502, error: `Host agent request failed: ${err.message}` }); });
+    req.end();
+  });
+}
+
+// --- Status aggregation ----------------------------------------------------
+
+function mapUpdateStatus(installStateStatus) {
+  switch (installStateStatus) {
+    case 'update-running':
+    case 'release-config-running':
+      return 'running';
+    case 'update-complete':
+      return 'complete';
+    case 'update-blocked':
+    case 'release-config-blocked':
+    case 'runtime-values-blocked':
+      return 'blocked';
+    default:
+      return 'idle';
+  }
+}
+
+function digestOf(imageRef) {
+  if (typeof imageRef !== 'string') return null;
+  const at = imageRef.indexOf('@sha256:');
+  return at >= 0 ? imageRef.slice(at + 1) : null;
+}
+
+export async function collectManageStatus(deps) {
+  const {
+    kube,
+    releaseSelectionFile,
+    installStateFile,
+    cpUpgradeStatusFile,
+    valuesNamespace = 'alga-system',
+    valuesConfigMapName = 'appliance-values-alga-core',
+    cpNamespace = 'alga-appliance-control-plane',
+    cpDeployment = 'appliance-control-plane',
+    resolveControlPlaneRef,
+    licenseNamespace = 'msp',
+    licenseSecretName = 'appliance-license-seed'
+  } = deps;
+
+  const selection = readJsonFile(releaseSelectionFile) || {};
+  const installState = readJsonFile(installStateFile) || {};
+  const cpUpgrade = readJsonFile(cpUpgradeStatusFile) || {};
+
+  const channel = selection.selectedChannel || 'stable';
+
+  // Control-plane digests.
+  let runningDigest = null;
+  try {
+    const dep = await kube.json(`get deployment ${cpDeployment} -n ${cpNamespace}`);
+    const image = dep && dep.ok && dep.value && dep.value.spec
+      ? dep.value.spec.template.spec.containers[0].image
+      : null;
+    runningDigest = digestOf(image);
+  } catch { /* best effort */ }
+
+  let resolvedRef = null;
+  try { resolvedRef = resolveControlPlaneRef ? await resolveControlPlaneRef(channel) : null; } catch { /* best effort */ }
+  const resolvedDigest = digestOf(resolvedRef) || (resolvedRef && resolvedRef.includes('sha256:') ? resolvedRef.split('@').pop() : null);
+  const upgradeAvailable = Boolean(runningDigest && resolvedDigest && runningDigest !== resolvedDigest);
+
+  // App URL / DNS (from persisted operator intent).
+  const runtime = selection.runtime || {};
+  const appUrl = {
+    url: runtime.appHostname || null,
+    host: runtime.appHostname ? hostFromAppUrl(runtime.appHostname) : null,
+    dnsMode: runtime.dnsMode || 'system',
+    dnsServers: runtime.dnsServers ? String(runtime.dnsServers).split(',').map((s) => s.trim()).filter(Boolean) : []
+  };
+
+  // License.
+  let license = { edition: null, expiresAt: null, status: 'unknown' };
+  try {
+    license = await readLicenseStatus({ kube, namespace: licenseNamespace, secretName: licenseSecretName });
+  } catch { /* best effort */ }
+
+  return {
+    app: {
+      version: selection.selectedReleaseVersion || null,
+      channel,
+      updateAvailable: false,
+      update: { status: mapUpdateStatus(installState.status), message: installState.lastAction || null }
+    },
+    controlPlane: {
+      channel,
+      runningDigest,
+      resolvedDigest,
+      upgradeAvailable,
+      upgrade: { status: cpUpgrade.status || 'idle', message: cpUpgrade.message || null }
+    },
+    license,
+    appUrl
+  };
+}

--- a/ee/appliance/host-service/server.mjs
+++ b/ee/appliance/host-service/server.mjs
@@ -11,6 +11,12 @@ import { persistSetupInputs, validateSetupInputs, runNetworkChecks } from './set
 import { generateSupportBundle } from './support-bundle.mjs';
 import { runAppChannelUpdate } from './update-engine.mjs';
 import {
+  collectManageStatus,
+  applyLicense,
+  applyAppUrl,
+  requestControlPlaneUpgrade,
+} from './manage-engine.mjs';
+import {
   authPhase,
   isAuthenticated,
   getCredentialState,
@@ -30,6 +36,8 @@ const setupInputsFile = process.env.ALGA_APPLIANCE_SETUP_INPUTS_FILE || '/var/li
 const releaseSelectionFile = process.env.ALGA_APPLIANCE_RELEASE_SELECTION_FILE || '/var/lib/alga-appliance/release-selection.json';
 const kubeconfigPath = process.env.ALGA_APPLIANCE_KUBECONFIG || '/etc/rancher/k3s/k3s.yaml';
 const staticUiDir = process.env.ALGA_APPLIANCE_STATUS_UI_DIR || '/opt/alga-appliance/status-ui/dist';
+const cpUpgradeStatusFile = process.env.ALGA_APPLIANCE_CP_UPGRADE_STATUS_FILE || '/var/lib/alga-appliance/control-plane-upgrade.json';
+const hostAgentSocket = process.env.ALGA_APPLIANCE_HOST_AGENT_SOCKET || '/run/alga-appliance/host-agent.sock';
 const STATUS_CACHE_TTL_MS = Number(process.env.ALGA_APPLIANCE_STATUS_CACHE_TTL_MS || 10_000);
 const KUBECTL_REQUEST_TIMEOUT_MS = Number(process.env.ALGA_APPLIANCE_KUBECTL_REQUEST_TIMEOUT_MS || 20_000);
 const KUBECTL_STATUS_TIMEOUT_MS = Number(process.env.ALGA_APPLIANCE_KUBECTL_STATUS_TIMEOUT_MS || 20_000);
@@ -472,6 +480,49 @@ async function runKubectlJson(args, timeoutMs = KUBECTL_API_TIMEOUT_MS, signal) 
   } catch (error) {
     return { ...result, ok: false, status: 1, value: null, stderr: error instanceof Error ? error.message : 'Invalid JSON from kubectl.' };
   }
+}
+
+// kubectl adapter for manage-engine: json/run/apply/quote backed by the queue.
+const manageKube = {
+  json: (args) => runKubectlJson(args),
+  run: (args) => runQueuedKubectl(kubectlCommand(args)),
+  quote: (value) => shellQuote(value),
+  apply: async (manifest) => {
+    const tmp = path.join(os.tmpdir(), `alga-manage-${process.pid}-${Date.now()}.json`);
+    try {
+      fs.writeFileSync(tmp, JSON.stringify(manifest), { mode: 0o600 });
+      return await runQueuedKubectl(kubectlCommand(`apply -f ${shellQuote(tmp)}`));
+    } finally {
+      try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    }
+  }
+};
+
+// Resolve the channel-pinned control-plane image ref (best-effort, cached 60s)
+// by running the same resolver bootstrap-control-plane.sh uses.
+const CP_RESOLVE_TTL_MS = 60_000;
+const cpResolveCache = new Map();
+function resolveControlPlaneRef(channel) {
+  const key = String(channel || 'stable');
+  const cached = cpResolveCache.get(key);
+  if (cached && (Date.now() - cached.at) < CP_RESOLVE_TTL_MS) {
+    return Promise.resolve(cached.ref);
+  }
+  return new Promise((resolve) => {
+    const resolver = new URL('./resolve-control-plane-image.mjs', import.meta.url).pathname;
+    const child = spawn(process.execPath, [resolver, '--channel', key, '--selection-file', releaseSelectionFile], {
+      env: process.env,
+      timeout: 12_000
+    });
+    let out = '';
+    child.stdout.on('data', (chunk) => { out += chunk; });
+    child.on('error', () => { resolve(cached ? cached.ref : null); });
+    child.on('close', () => {
+      const ref = out.trim() || null;
+      cpResolveCache.set(key, { ref, at: Date.now() });
+      resolve(ref);
+    });
+  });
 }
 
 function validKubeName(value) {
@@ -926,6 +977,63 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (url.pathname === '/api/manage/status') {
+    if (!requireAuth(req, res)) return;
+    const status = await collectManageStatus({
+      kube: manageKube,
+      releaseSelectionFile,
+      installStateFile: stateFile,
+      cpUpgradeStatusFile,
+      resolveControlPlaneRef
+    });
+    jsonResponse(res, 200, status);
+    return;
+  }
+
+  if (url.pathname === '/api/control-plane/upgrade') {
+    if (!requireAuth(req, res)) return;
+    if ((req.method || 'GET').toUpperCase() !== 'POST') {
+      jsonResponse(res, 405, { error: 'Method not allowed. Use POST.' });
+      return;
+    }
+    const result = await requestControlPlaneUpgrade({ hostAgentSocket });
+    if (result.ok) jsonResponse(res, 202, result.result || { ok: true, started: true });
+    else jsonResponse(res, result.status || 502, { error: result.error });
+    return;
+  }
+
+  if (url.pathname === '/api/license/apply') {
+    if (!requireAuth(req, res)) return;
+    if ((req.method || 'GET').toUpperCase() !== 'POST') {
+      jsonResponse(res, 405, { error: 'Method not allowed. Use POST.' });
+      return;
+    }
+    const payload = await readJsonBody(req);
+    const result = await applyLicense({ licenseKey: payload?.licenseKey, kube: manageKube });
+    if (result.ok) jsonResponse(res, 200, { ok: true });
+    else jsonResponse(res, result.status || 400, { error: result.error });
+    return;
+  }
+
+  if (url.pathname === '/api/settings/app-url') {
+    if (!requireAuth(req, res)) return;
+    if ((req.method || 'GET').toUpperCase() !== 'POST') {
+      jsonResponse(res, 405, { error: 'Method not allowed. Use POST.' });
+      return;
+    }
+    const payload = await readJsonBody(req);
+    const result = await applyAppUrl({
+      appHostname: payload?.appHostname,
+      dnsMode: payload?.dnsMode,
+      dnsServers: payload?.dnsServers,
+      kube: manageKube,
+      releaseSelectionFile
+    });
+    if (result.ok) jsonResponse(res, 200, { ok: true });
+    else jsonResponse(res, result.status || 400, { error: result.error });
+    return;
+  }
+
   if (url.pathname === '/api/updates') {
     if (!requireAuth(req, res)) return;
     if ((req.method || 'GET').toUpperCase() !== 'POST') {
@@ -943,9 +1051,12 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    const result = await runAppChannelUpdate({ channel });
-    res.writeHead(result.ok ? 200 : 412, { 'content-type': 'application/json' });
-    res.end(JSON.stringify(result));
+    // Kick the update off and return immediately. The control-plane pod survives
+    // an app-channel update (only the app pod restarts), so it runs to completion
+    // here while the Manage UI polls /api/manage/status (install-state).
+    runAppChannelUpdate({ channel }).catch(() => {});
+    res.writeHead(202, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, started: true }));
     return;
   }
 

--- a/ee/appliance/host-service/setup-engine.mjs
+++ b/ee/appliance/host-service/setup-engine.mjs
@@ -435,14 +435,14 @@ function initialTenantSecretYaml(initialTenant, initialTenantId) {
   return `apiVersion: v1\nkind: Secret\nmetadata:\n  name: appliance-initial-tenant\n  namespace: msp\ntype: Opaque\nstringData:\n  INITIAL_TENANT_NAME: ${yamlString(initialTenant.tenantName)}\n  INITIAL_ADMIN_FIRST_NAME: ${yamlString(initialTenant.adminFirstName)}\n  INITIAL_ADMIN_LAST_NAME: ${yamlString(initialTenant.adminLastName)}\n  INITIAL_ADMIN_EMAIL: ${yamlString(initialTenant.adminEmail)}\n  INITIAL_ADMIN_PASSWORD: ${yamlString(initialTenant.adminPassword)}${tenantIdLine}\n`;
 }
 
-function appUrlFromInput(value) {
+export function appUrlFromInput(value) {
   const trimmed = String(value || '').trim();
   if (!trimmed) return null;
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
   return `https://${trimmed}`;
 }
 
-function hostFromAppUrl(value) {
+export function hostFromAppUrl(value) {
   try {
     return new URL(value).hostname;
   } catch {
@@ -450,7 +450,7 @@ function hostFromAppUrl(value) {
   }
 }
 
-function setYamlScalar(yaml, target, value) {
+export function setYamlScalar(yaml, target, value) {
   const output = [];
   const stack = [];
   let replaced = false;

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -42,10 +42,19 @@ test('license JWS format check + claim decode + status', () => {
   const status = licenseStatusFromClaims(claims, null);
   assert.equal(status.edition, 'pro');
   assert.equal(status.status, 'active');
+  assert.equal(status.perpetual, false);
+  assert.ok(status.expiresAt, 'a real near-future expiry keeps its date');
 
   const past = licenseStatusFromClaims({ exp: 1 }, 'ee');
   assert.equal(past.status, 'expired');
   assert.equal(past.edition, 'ee');
+
+  // The 9999999999 "all nines" sentinel (= 2286-11-20) reads as perpetual,
+  // not a literal far-future date.
+  const perpetual = licenseStatusFromClaims({ edition: 'pro', exp: 9999999999 }, null);
+  assert.equal(perpetual.perpetual, true);
+  assert.equal(perpetual.status, 'active');
+  assert.equal(perpetual.expiresAt, null);
 });
 
 test('applyLicense rejects an invalid JWS without touching kubectl', async () => {

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -1,0 +1,173 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isWellFormedLicenseJws,
+  decodeLicenseClaims,
+  licenseStatusFromClaims,
+  applyLicense,
+  applyAppUrl,
+  collectManageStatus
+} from '../manage-engine.mjs';
+
+function b64url(obj) {
+  return Buffer.from(JSON.stringify(obj), 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jwsWith(claims) {
+  return `${b64url({ alg: 'RS256' })}.${b64url(claims)}.${'sig'.repeat(3)}`;
+}
+
+function fakeKube(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    json: async (args) => { calls.push(['json', args]); return (overrides.json && overrides.json(args)) || { ok: true, value: {} }; },
+    run: async (args) => { calls.push(['run', args]); return (overrides.run && overrides.run(args)) || { ok: true, stdout: '', stderr: '' }; },
+    apply: async (manifest) => { calls.push(['apply', manifest]); return (overrides.apply && overrides.apply(manifest)) || { ok: true, stdout: '', stderr: '' }; },
+    quote: (v) => `'${String(v).replaceAll("'", "'\\''")}'`
+  };
+}
+
+test('license JWS format check + claim decode + status', () => {
+  assert.equal(isWellFormedLicenseJws('a.b.c'), true);
+  assert.equal(isWellFormedLicenseJws('not-a-jws'), false);
+  assert.equal(isWellFormedLicenseJws(''), false);
+
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const claims = decodeLicenseClaims(jwsWith({ edition: 'pro', exp: future }));
+  assert.equal(claims.edition, 'pro');
+  const status = licenseStatusFromClaims(claims, null);
+  assert.equal(status.edition, 'pro');
+  assert.equal(status.status, 'active');
+
+  const past = licenseStatusFromClaims({ exp: 1 }, 'ee');
+  assert.equal(past.status, 'expired');
+  assert.equal(past.edition, 'ee');
+});
+
+test('applyLicense rejects an invalid JWS without touching kubectl', async () => {
+  const kube = fakeKube();
+  const res = await applyLicense({ licenseKey: 'bogus', kube });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.equal(kube.calls.length, 0);
+});
+
+test('applyLicense patches the seed secret (base64) and restarts the app', async () => {
+  const kube = fakeKube();
+  const token = jwsWith({ edition: 'pro', exp: 9999999999 });
+  const res = await applyLicense({ licenseKey: token, kube });
+  assert.equal(res.ok, true);
+  const patch = kube.calls.find((c) => c[0] === 'run' && c[1].includes('patch secret appliance-license-seed'));
+  assert.ok(patch, 'expected a secret patch');
+  const tokenB64 = Buffer.from(token, 'utf8').toString('base64');
+  assert.ok(patch[1].includes(tokenB64), 'patch should carry the base64 token');
+  assert.ok(kube.calls.some((c) => c[0] === 'run' && c[1].includes('rollout restart deploy/alga-core-sebastian')), 'expected an app rollout restart');
+});
+
+test('applyAppUrl rewrites values, persists runtime, reconciles helm', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable', runtime: { appHostname: 'https://alga.local' } }));
+
+  const coreYaml = 'appUrl: https://alga.local\nhost: alga.local\ndomainSuffix: alga.local\nserver:\n  image:\n    tag: latest\n';
+  let appliedManifest = null;
+  const kube = fakeKube({
+    json: (args) => args.includes('configmap appliance-values-alga-core')
+      ? { ok: true, value: { data: { 'alga-core.single-node.yaml': coreYaml } } }
+      : { ok: true, value: {} },
+    apply: (manifest) => { appliedManifest = manifest; return { ok: true }; }
+  });
+
+  const res = await applyAppUrl({
+    appHostname: 'http://192.168.1.50:3000',
+    dnsMode: 'system',
+    kube,
+    releaseSelectionFile
+  });
+  assert.equal(res.ok, true);
+
+  // Configmap was rewritten with the new URL.
+  const newYaml = appliedManifest.data['alga-core.single-node.yaml'];
+  assert.match(newYaml, /appUrl: "http:\/\/192\.168\.1\.50:3000"/);
+  assert.match(newYaml, /host: "192\.168\.1\.50"/);
+  assert.match(newYaml, /domainSuffix: ""/);
+
+  // Operator intent persisted.
+  const persisted = JSON.parse(fs.readFileSync(releaseSelectionFile, 'utf8'));
+  assert.equal(persisted.runtime.appHostname, 'http://192.168.1.50:3000');
+
+  // HelmRelease reconcile requested.
+  assert.ok(kube.calls.some((c) => c[0] === 'run' && c[1].includes('annotate helmrelease alga-core')), 'expected a helmrelease reconcile');
+});
+
+test('applyAppUrl requires a hostname', async () => {
+  const res = await applyAppUrl({ appHostname: '', kube: fakeKube(), releaseSelectionFile: null });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+});
+
+test('collectManageStatus reports upgradeAvailable on digest mismatch', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-status-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({
+    selectedChannel: 'stable',
+    selectedReleaseVersion: 'v1.2.3',
+    runtime: { appHostname: 'http://10.0.0.5:3000', dnsMode: 'system', dnsServers: '' }
+  }));
+  const installStateFile = path.join(tmp, 'install-state.json');
+  fs.writeFileSync(installStateFile, JSON.stringify({ status: 'update-running', lastAction: 'updating' }));
+
+  const kube = fakeKube({
+    json: (args) => {
+      if (args.includes('deployment appliance-control-plane')) {
+        return { ok: true, value: { spec: { template: { spec: { containers: [{ image: 'ghcr.io/x/cp@sha256:OLD' }] } } } } };
+      }
+      if (args.includes('secret appliance-license-seed')) {
+        return { ok: true, value: { data: { EDITION_CHOICE: Buffer.from('pro').toString('base64') } } };
+      }
+      return { ok: true, value: {} };
+    }
+  });
+
+  const status = await collectManageStatus({
+    kube,
+    releaseSelectionFile,
+    installStateFile,
+    cpUpgradeStatusFile: path.join(tmp, 'cp-upgrade.json'),
+    resolveControlPlaneRef: async () => 'ghcr.io/x/cp@sha256:NEW'
+  });
+
+  assert.equal(status.app.channel, 'stable');
+  assert.equal(status.app.version, 'v1.2.3');
+  assert.equal(status.app.update.status, 'running');
+  assert.equal(status.controlPlane.runningDigest, 'sha256:OLD');
+  assert.equal(status.controlPlane.resolvedDigest, 'sha256:NEW');
+  assert.equal(status.controlPlane.upgradeAvailable, true);
+  assert.equal(status.license.edition, 'pro');
+  assert.equal(status.appUrl.url, 'http://10.0.0.5:3000');
+  assert.equal(status.appUrl.host, '10.0.0.5');
+});
+
+test('collectManageStatus: no upgrade when digests match', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-status2-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
+  const kube = fakeKube({
+    json: (args) => args.includes('deployment appliance-control-plane')
+      ? { ok: true, value: { spec: { template: { spec: { containers: [{ image: 'ghcr.io/x/cp@sha256:SAME' }] } } } } }
+      : { ok: true, value: {} }
+  });
+  const status = await collectManageStatus({
+    kube,
+    releaseSelectionFile,
+    installStateFile: path.join(tmp, 'nope.json'),
+    cpUpgradeStatusFile: path.join(tmp, 'nope2.json'),
+    resolveControlPlaneRef: async () => 'ghcr.io/x/cp@sha256:SAME'
+  });
+  assert.equal(status.controlPlane.upgradeAvailable, false);
+  assert.equal(status.app.update.status, 'idle');
+});

--- a/ee/appliance/host-service/tests/status-ui-package-smoke.test.mjs
+++ b/ee/appliance/host-service/tests/status-ui-package-smoke.test.mjs
@@ -21,10 +21,10 @@ test('T006 setup/status UI package uses session-based auth (no query token)', ()
 
   // The auth gate wraps every page; requests ride the session cookie, not ?token=.
   assert.match(layout, /<AuthGate>\{children\}<\/AuthGate>/);
-  assert.match(statusPage, /fetch\(apiPath\('\/api\/status'\)/);
+  assert.match(statusPage, /fetch\(apiPath\(["']\/api\/status["']\)/);
   assert.match(statusPage, /href="\/setup\/"/);
-  assert.match(setupPage, /fetch\('\/api\/setup\/config'/);
-  assert.match(setupPage, /fetch\('\/api\/setup'/);
+  assert.match(setupPage, /fetch\(["']\/api\/setup\/config["']/);
+  assert.match(setupPage, /fetch\(["']\/api\/setup["']/);
 
   // No leftover query-token threading anywhere.
   for (const source of [statusPage, setupPage]) {

--- a/ee/appliance/host-service/update-engine.mjs
+++ b/ee/appliance/host-service/update-engine.mjs
@@ -13,7 +13,11 @@ const DEFAULT_STATE_FILE = process.env.ALGA_APPLIANCE_STATE_FILE || '/var/lib/al
 // the placeholder host. Default to the real location; the env override still wins.
 const DEFAULT_RELEASE_SELECTION_FILE = process.env.ALGA_APPLIANCE_RELEASE_SELECTION_FILE || '/var/lib/alga-appliance/release-selection.json';
 const DEFAULT_UPDATE_HISTORY_FILE = process.env.ALGA_APPLIANCE_UPDATE_HISTORY_FILE || '/var/lib/alga-appliance/update-history.json';
-const DEFAULT_KUBECONFIG = '/etc/rancher/k3s/k3s.yaml';
+// Honor the control plane's configured kubeconfig (the pod's in-cluster
+// kubeconfig at /tmp/alga-appliance/kubeconfig), matching setup-engine/status-engine.
+// Hardcoding the bare-host /etc/rancher/k3s/k3s.yaml made the flux/helm reconcile
+// step fail in the pod with `stat /etc/rancher/k3s/k3s.yaml: no such file`.
+const DEFAULT_KUBECONFIG = process.env.ALGA_APPLIANCE_KUBECONFIG || '/etc/rancher/k3s/k3s.yaml';
 
 function nowIso() {
   return new Date().toISOString();

--- a/ee/appliance/scripts/bootstrap-control-plane.sh
+++ b/ee/appliance/scripts/bootstrap-control-plane.sh
@@ -7,6 +7,7 @@ SETUP_PORT="${ALGA_APPLIANCE_PORT:-8080}"
 TOKEN_FILE="${ALGA_APPLIANCE_TOKEN_FILE:-/var/lib/alga-appliance/setup-token}"
 K3S_READY_TIMEOUT_SECONDS="${ALGA_K3S_READY_TIMEOUT_SECONDS:-180}"
 DRY_RUN=false
+CONTROL_PLANE_ONLY=false
 
 usage() {
   cat <<'EOF'
@@ -23,6 +24,8 @@ Options:
   --kubeconfig <path>      k3s kubeconfig path (default: /etc/rancher/k3s/k3s.yaml)
   --token-file <path>      Setup token file (default: /var/lib/alga-appliance/setup-token)
   --port <port>            Setup UI host port (default: 8080)
+  --control-plane-only     Re-apply only the control plane (channel upgrade): re-resolve
+                           the channel-pinned image and apply it; skip k3s/import/storage
   --dry-run                Print the planned operations without mutating the host
   --help                   Show this help
 EOF
@@ -45,6 +48,10 @@ while [ "$#" -gt 0 ]; do
     --port)
       SETUP_PORT="$2"
       shift 2
+      ;;
+    --control-plane-only)
+      CONTROL_PLANE_ONLY=true
+      shift
       ;;
     --dry-run)
       DRY_RUN=true
@@ -365,9 +372,20 @@ Logs: sudo journalctl -u alga-appliance-bootstrap.service -u k3s -f
 EOF
 }
 
-ensure_k3s_started
-wait_for_kubernetes_api
-import_control_plane_images
-apply_local_storage
-apply_control_plane
-report_handoff
+if [ "$CONTROL_PLANE_ONLY" = "true" ]; then
+  # Self-service control-plane upgrade (host-agent driven): re-resolve the
+  # channel-pinned control-plane image and re-apply only the control plane.
+  # k3s is already up, baked images are already imported, and local-path storage
+  # is already applied, so skip those steps. apply_control_plane pulls the new
+  # digest and applies the kustomize overlay, which triggers the Recreate.
+  wait_for_kubernetes_api
+  apply_control_plane
+  log "control-plane upgrade applied"
+else
+  ensure_k3s_started
+  wait_for_kubernetes_api
+  import_control_plane_images
+  apply_local_storage
+  apply_control_plane
+  report_handoff
+fi

--- a/ee/appliance/status-ui/app/manage/ManageView.tsx
+++ b/ee/appliance/status-ui/app/manage/ManageView.tsx
@@ -25,6 +25,7 @@ type ManageStatus = {
   license: {
     edition: string | null;
     expiresAt: string | null;
+    perpetual: boolean;
     status: "active" | "expired" | "unknown";
   };
   appUrl: {
@@ -457,13 +458,15 @@ function LicenseTab({
         <div>
           <dt>Expires</dt>
           <dd>
-            {lic.expiresAt
-              ? new Date(lic.expiresAt).toLocaleDateString(undefined, {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })
-              : "—"}
+            {lic.perpetual
+              ? "Perpetual"
+              : lic.expiresAt
+                ? new Date(lic.expiresAt).toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })
+                : "—"}
           </dd>
         </div>
       </dl>

--- a/ee/appliance/status-ui/app/manage/ManageView.tsx
+++ b/ee/appliance/status-ui/app/manage/ManageView.tsx
@@ -1,0 +1,782 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import styles from "../status.module.css";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ManageStatus = {
+  app: {
+    version: string;
+    channel: "stable" | "nightly";
+    updateAvailable: boolean;
+    update: { status: "idle" | "running" | "complete" | "blocked"; message: string | null };
+  };
+  controlPlane: {
+    channel: string;
+    runningDigest: string | null;
+    resolvedDigest: string | null;
+    upgradeAvailable: boolean;
+    upgrade: { status: "idle" | "running" | "complete" | "blocked"; message: string | null };
+  };
+  license: {
+    edition: string | null;
+    expiresAt: string | null;
+    status: "active" | "expired" | "unknown";
+  };
+  appUrl: {
+    url: string | null;
+    host: string | null;
+    dnsMode: "system" | "custom";
+    dnsServers: string[];
+  };
+};
+
+type ManageTab = "updates" | "control-plane" | "license" | "settings";
+
+function apiPath(
+  path: string,
+  params: Record<string, string | number | boolean | null | undefined> = {},
+) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== null && value !== undefined && value !== "")
+      search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-tab components
+// ---------------------------------------------------------------------------
+
+function UpdatesTab({
+  status,
+  onRefresh,
+}: {
+  status: ManageStatus;
+  onRefresh: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function stopPoll() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  useEffect(() => {
+    // Stop polling if the status returned from parent shows terminal state.
+    const updateStatus = status.app.update.status;
+    if (busy && (updateStatus === "complete" || updateStatus === "blocked")) {
+      stopPoll();
+      setBusy(false);
+      setResult(
+        updateStatus === "complete"
+          ? "Update complete."
+          : `Update blocked: ${status.app.update.message || "unknown reason"}`,
+      );
+    }
+  }, [busy, status.app.update.status, status.app.update.message]);
+
+  // Clean up on unmount.
+  useEffect(() => () => stopPoll(), []);
+
+  async function triggerUpdate() {
+    setConfirm(false);
+    setBusy(true);
+    setResult(null);
+    setError(null);
+    try {
+      const body = new URLSearchParams({ channel: status.app.channel });
+      const response = await fetch(apiPath("/api/updates"), {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        cache: "no-store",
+      });
+      if (response.status === 401) { window.location.reload(); return; }
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || "Failed to start update.");
+      // Poll until the update status reaches a terminal state.
+      pollRef.current = setInterval(onRefresh, 3000);
+    } catch (err) {
+      setBusy(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const app = status.app;
+  const updateRunning = app.update.status === "running";
+  const updateDone = app.update.status === "complete";
+  const updateBlocked = app.update.status === "blocked";
+
+  return (
+    <div className={styles.manageSection}>
+      <h2>App updates</h2>
+      <dl className={styles.kv}>
+        <div>
+          <dt>Current version</dt>
+          <dd>{app.version || "—"}</dd>
+        </div>
+        <div>
+          <dt>Channel</dt>
+          <dd>{app.channel}</dd>
+        </div>
+        <div>
+          <dt>Update available</dt>
+          <dd>{app.updateAvailable ? "Yes" : "No"}</dd>
+        </div>
+        {(updateRunning || updateDone || updateBlocked || app.update.message) ? (
+          <div>
+            <dt>Update status</dt>
+            <dd>
+              <span
+                className={`${styles.badge} ${
+                  updateDone ? styles.ready : updateBlocked ? styles.failed : styles.installing
+                }`}
+              >
+                {app.update.status}
+              </span>
+              {app.update.message ? (
+                <span className={styles.manageStatusMsg}>{app.update.message}</span>
+              ) : null}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {error ? <div className={styles.alert}>{error}</div> : null}
+      {result ? <p className={styles.manageResult}>{result}</p> : null}
+
+      {!app.updateAvailable && !updateRunning ? (
+        <p className={styles.muted}>No update is available on the {app.channel} channel.</p>
+      ) : null}
+
+      {app.updateAvailable || updateRunning ? (
+        <div className={styles.toolbar}>
+          <button
+            type="button"
+            className={styles.actionButton}
+            disabled={busy || updateRunning}
+            onClick={() => {
+              if (!confirm) { setConfirm(true); }
+              else { triggerUpdate(); }
+            }}
+          >
+            {busy || updateRunning
+              ? "Updating…"
+              : confirm
+              ? "Confirm update"
+              : "Run update"}
+          </button>
+          {confirm && !busy && !updateRunning ? (
+            <button type="button" onClick={() => setConfirm(false)}>
+              Cancel
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {updateRunning ? (
+        <p className={styles.helpText}>
+          Update is running. This page will reflect the result when it finishes.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ControlPlaneTab({
+  status,
+  onRefresh,
+}: {
+  status: ManageStatus;
+  onRefresh: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollStartRef = useRef<number | null>(null);
+  // Track elapsed since upgrade started for the 3-min timeout.
+  const MAX_POLL_MS = 3 * 60 * 1000;
+
+  function stopPoll() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  useEffect(() => {
+    if (!reconnecting) return;
+    const cp = status.controlPlane;
+    const upgradeComplete =
+      cp.upgrade.status === "complete" &&
+      cp.runningDigest &&
+      cp.runningDigest === cp.resolvedDigest;
+    const upgradeBlocked = cp.upgrade.status === "blocked";
+    if (upgradeComplete || upgradeBlocked) {
+      stopPoll();
+      setReconnecting(false);
+      setBusy(false);
+      setResult(
+        upgradeComplete
+          ? "Control-plane upgraded successfully."
+          : `Upgrade blocked: ${cp.upgrade.message || "unknown reason"}`,
+      );
+    }
+  }, [reconnecting, status.controlPlane]);
+
+  useEffect(() => () => stopPoll(), []);
+
+  async function triggerUpgrade() {
+    setConfirm(false);
+    setBusy(true);
+    setReconnecting(false);
+    setResult(null);
+    setError(null);
+    try {
+      const response = await fetch(apiPath("/api/control-plane/upgrade"), {
+        method: "POST",
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      if (response.status === 401) { window.location.reload(); return; }
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || "Failed to start upgrade.");
+      setReconnecting(true);
+      pollStartRef.current = Date.now();
+      // Poll every 3 s, tolerating fetch failures while the pod restarts.
+      pollRef.current = setInterval(async () => {
+        const elapsed = Date.now() - (pollStartRef.current ?? Date.now());
+        if (elapsed > MAX_POLL_MS) {
+          stopPoll();
+          setReconnecting(false);
+          setBusy(false);
+          setError(
+            "Timed out waiting for the control plane to return. If the UI does not return, run `sudo alga-control-plane-reapply` on the appliance host.",
+          );
+          return;
+        }
+        try {
+          await onRefresh();
+        } catch {
+          // Tolerate errors during the restart window — keep retrying.
+        }
+      }, 3000);
+    } catch (err) {
+      setBusy(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const cp = status.controlPlane;
+  const upgradeAvailable = cp.upgradeAvailable;
+  const upgradeRunning = cp.upgrade.status === "running";
+  const upgradeDone = cp.upgrade.status === "complete";
+  const upgradeBlocked = cp.upgrade.status === "blocked";
+
+  return (
+    <div className={styles.manageSection}>
+      <h2>Control-plane upgrade</h2>
+      <dl className={styles.kv}>
+        <div>
+          <dt>Channel</dt>
+          <dd>{cp.channel || "—"}</dd>
+        </div>
+        <div>
+          <dt>Running digest</dt>
+          <dd>
+            <code>{cp.runningDigest ? cp.runningDigest.slice(0, 19) + "…" : "—"}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Resolved digest</dt>
+          <dd>
+            <code>{cp.resolvedDigest ? cp.resolvedDigest.slice(0, 19) + "…" : "—"}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Upgrade available</dt>
+          <dd>{upgradeAvailable ? "Yes" : "No"}</dd>
+        </div>
+        {(upgradeRunning || upgradeDone || upgradeBlocked || cp.upgrade.message) ? (
+          <div>
+            <dt>Upgrade status</dt>
+            <dd>
+              <span
+                className={`${styles.badge} ${
+                  upgradeDone ? styles.ready : upgradeBlocked ? styles.failed : styles.installing
+                }`}
+              >
+                {cp.upgrade.status}
+              </span>
+              {cp.upgrade.message ? (
+                <span className={styles.manageStatusMsg}>{cp.upgrade.message}</span>
+              ) : null}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {error ? <div className={styles.alert}>{error}</div> : null}
+      {result ? <p className={styles.manageResult}>{result}</p> : null}
+
+      {reconnecting ? (
+        <div className={`${styles.alert} ${styles.alertInfo}`}>
+          Upgrading the control plane… reconnecting. The UI will return shortly.
+          <br />
+          <small>
+            If the UI does not return, run <code>sudo alga-control-plane-reapply</code> on the appliance host.
+          </small>
+        </div>
+      ) : null}
+
+      {!upgradeAvailable ? (
+        <p className={styles.muted}>Control plane is up to date.</p>
+      ) : null}
+
+      <div className={styles.toolbar}>
+        <button
+          type="button"
+          className={styles.actionButton}
+          disabled={busy || !upgradeAvailable || upgradeRunning || reconnecting}
+          onClick={() => {
+            if (!confirm) { setConfirm(true); }
+            else { triggerUpgrade(); }
+          }}
+        >
+          {busy || reconnecting
+            ? "Upgrading…"
+            : !upgradeAvailable
+            ? "Up to date"
+            : confirm
+            ? "Confirm upgrade"
+            : "Upgrade control plane"}
+        </button>
+        {confirm && !busy && !reconnecting ? (
+          <button type="button" onClick={() => setConfirm(false)}>
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LicenseTab({
+  status,
+  onRefresh,
+}: {
+  status: ManageStatus;
+  onRefresh: () => Promise<void>;
+}) {
+  const [licenseKey, setLicenseKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function stopPoll() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  useEffect(() => () => stopPoll(), []);
+
+  async function applyLicense() {
+    setConfirm(false);
+    setBusy(true);
+    setResult(null);
+    setError(null);
+    try {
+      const response = await fetch(apiPath("/api/license/apply"), {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ licenseKey: licenseKey.trim() }),
+        cache: "no-store",
+      });
+      if (response.status === 401) { window.location.reload(); return; }
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || "Failed to apply license.");
+      setResult("License applied. The app is restarting to apply the change.");
+      setLicenseKey("");
+      // Poll to pick up the refreshed license status after restart.
+      pollRef.current = setInterval(async () => {
+        try { await onRefresh(); } catch { /* tolerate restart gap */ }
+      }, 3000);
+      setTimeout(() => { stopPoll(); setBusy(false); }, 30000);
+    } catch (err) {
+      setBusy(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const lic = status.license;
+
+  function licenseStatusClass() {
+    if (lic.status === "active") return styles.ready;
+    if (lic.status === "expired") return styles.failed;
+    return styles.loading;
+  }
+
+  return (
+    <div className={styles.manageSection}>
+      <h2>License</h2>
+      <dl className={styles.kv}>
+        <div>
+          <dt>Edition</dt>
+          <dd>{lic.edition || "—"}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>
+            <span className={`${styles.badge} ${licenseStatusClass()}`}>
+              {lic.status}
+            </span>
+          </dd>
+        </div>
+        <div>
+          <dt>Expires</dt>
+          <dd>
+            {lic.expiresAt
+              ? new Date(lic.expiresAt).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })
+              : "—"}
+          </dd>
+        </div>
+      </dl>
+
+      <div className={styles.manageSeparator} />
+
+      <h3 className={styles.manageSubheading}>Apply a new license key</h3>
+      <p className={styles.helpText}>
+        Paste the signed JWS license key from Nine Minds. The app will restart to apply it.
+      </p>
+
+      <div className={styles.field} style={{ marginTop: "var(--space-md)" }}>
+        <label htmlFor="manage-license-key">License key</label>
+        <textarea
+          id="manage-license-key"
+          value={licenseKey}
+          onChange={(event) => setLicenseKey(event.target.value)}
+          placeholder="eyJhbGci…"
+          rows={4}
+          disabled={busy}
+          style={{ fontFamily: "monospace", fontSize: "0.8rem", resize: "vertical" }}
+        />
+      </div>
+
+      {error ? <div className={styles.alert}>{error}</div> : null}
+      {result ? <p className={styles.manageResult}>{result}</p> : null}
+
+      <div className={styles.toolbar} style={{ marginTop: "var(--space-md)" }}>
+        <button
+          type="button"
+          className={styles.actionButton}
+          disabled={busy || !licenseKey.trim()}
+          onClick={() => {
+            if (!confirm) { setConfirm(true); }
+            else { applyLicense(); }
+          }}
+        >
+          {busy ? "Applying…" : confirm ? "Confirm apply" : "Apply license key"}
+        </button>
+        {confirm && !busy ? (
+          <button type="button" onClick={() => setConfirm(false)}>
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SettingsTab({
+  status,
+  onRefresh,
+}: {
+  status: ManageStatus;
+  onRefresh: () => Promise<void>;
+}) {
+  const [appHostname, setAppHostname] = useState(status.appUrl.url || "");
+  const [dnsMode, setDnsMode] = useState<"system" | "custom">(status.appUrl.dnsMode || "system");
+  const [dnsServers, setDnsServers] = useState(status.appUrl.dnsServers?.join(", ") || "");
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Sync fields when status changes (e.g. on first load).
+  useEffect(() => {
+    setAppHostname(status.appUrl.url || "");
+    setDnsMode(status.appUrl.dnsMode || "system");
+    setDnsServers(status.appUrl.dnsServers?.join(", ") || "");
+  }, [status.appUrl.url, status.appUrl.dnsMode, status.appUrl.dnsServers]);
+
+  function stopPoll() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  useEffect(() => () => stopPoll(), []);
+
+  async function saveSettings() {
+    setConfirm(false);
+    setBusy(true);
+    setResult(null);
+    setError(null);
+    try {
+      const response = await fetch(apiPath("/api/settings/app-url"), {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          appHostname: appHostname.trim(),
+          dnsMode,
+          dnsServers: dnsServers.trim(),
+        }),
+        cache: "no-store",
+      });
+      if (response.status === 401) { window.location.reload(); return; }
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || "Failed to save settings.");
+      setResult("Settings saved. The app is restarting to apply the change.");
+      // Poll after restart.
+      pollRef.current = setInterval(async () => {
+        try { await onRefresh(); } catch { /* tolerate restart gap */ }
+      }, 3000);
+      setTimeout(() => { stopPoll(); setBusy(false); }, 30000);
+    } catch (err) {
+      setBusy(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div className={styles.manageSection}>
+      <h2>Settings</h2>
+
+      <div className={styles.formGrid}>
+        <div className={styles.field}>
+          <label htmlFor="manage-app-hostname">App URL</label>
+          <input
+            id="manage-app-hostname"
+            value={appHostname}
+            onChange={(event) => setAppHostname(event.target.value)}
+            placeholder="http://192.168.1.50:3000"
+            disabled={busy}
+          />
+          <span className={styles.helpText}>
+            Full URL users open in their browser (e.g. http://192.168.1.50:3000).
+          </span>
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor="manage-dns-mode">DNS mode</label>
+          <select
+            id="manage-dns-mode"
+            value={dnsMode}
+            onChange={(event) => setDnsMode(event.target.value as "system" | "custom")}
+            disabled={busy}
+          >
+            <option value="system">Use DHCP/system resolvers</option>
+            <option value="custom">Use custom DNS servers</option>
+          </select>
+          <span className={styles.helpText}>
+            Keep system DNS unless this site requires specific internal resolvers.
+          </span>
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor="manage-dns-servers">Custom DNS servers</label>
+          <input
+            id="manage-dns-servers"
+            value={dnsServers}
+            onChange={(event) => setDnsServers(event.target.value)}
+            placeholder="8.8.8.8,8.8.4.4"
+            disabled={busy || dnsMode !== "custom"}
+          />
+          <span className={styles.helpText}>
+            Comma-separated IPv4 addresses. Required only for custom DNS.
+          </span>
+        </div>
+      </div>
+
+      {error ? <div className={styles.alert}>{error}</div> : null}
+      {result ? <p className={styles.manageResult}>{result}</p> : null}
+
+      <p className={styles.helpText} style={{ marginTop: "var(--space-md)" }}>
+        Saving these settings restarts the app to apply the change.
+      </p>
+
+      <div className={styles.toolbar} style={{ marginTop: "var(--space-md)" }}>
+        <button
+          type="button"
+          className={styles.actionButton}
+          disabled={busy}
+          onClick={() => {
+            if (!confirm) { setConfirm(true); }
+            else { saveSettings(); }
+          }}
+        >
+          {busy ? "Saving…" : confirm ? "Confirm save" : "Save settings"}
+        </button>
+        {confirm && !busy ? (
+          <button type="button" onClick={() => setConfirm(false)}>
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main ManageView
+// ---------------------------------------------------------------------------
+
+const manageTabs: Array<{ value: ManageTab; label: string }> = [
+  { value: "updates", label: "Updates" },
+  { value: "control-plane", label: "Control-plane" },
+  { value: "license", label: "License" },
+  { value: "settings", label: "Settings" },
+];
+
+export function ManageView() {
+  const [activeTab, setActiveTab] = useState<ManageTab>("updates");
+  const [manageStatus, setManageStatus] = useState<ManageStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadManageStatus = useCallback(async () => {
+    try {
+      const response = await fetch(apiPath("/api/manage/status"), {
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      if (response.status === 401) {
+        window.location.reload();
+        return;
+      }
+      if (!response.ok) throw new Error("Manage status unavailable.");
+      setManageStatus(await response.json());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadManageStatus();
+  }, [loadManageStatus]);
+
+  return (
+    <div className={styles.manageView}>
+      {/* Sub-tab strip */}
+      <div className={styles.manageTabStrip} role="tablist" aria-label="Manage sections">
+        {manageTabs.map(({ value, label }) => (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            id={`manage-tab-${value}`}
+            aria-selected={activeTab === value}
+            aria-controls={`manage-panel-${value}`}
+            className={`${styles.manageTabButton} ${activeTab === value ? styles.manageTabActive : ""}`}
+            onClick={() => setActiveTab(value)}
+          >
+            {label}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={styles.manageRefreshButton}
+          onClick={loadManageStatus}
+          aria-label="Refresh manage status"
+          title="Refresh"
+        >
+          <RefreshCw size={15} aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Loading / error */}
+      {loading ? (
+        <div className={styles.manageLoading}>
+          <div className={styles.skeletonBlock}>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <span key={i} className={styles.skeletonLineDark} />
+            ))}
+          </div>
+        </div>
+      ) : error ? (
+        <div className={styles.alert}>{error}</div>
+      ) : manageStatus ? (
+        <>
+          {activeTab === "updates" ? (
+            <div
+              id="manage-panel-updates"
+              role="tabpanel"
+              aria-labelledby="manage-tab-updates"
+            >
+              <UpdatesTab status={manageStatus} onRefresh={loadManageStatus} />
+            </div>
+          ) : null}
+          {activeTab === "control-plane" ? (
+            <div
+              id="manage-panel-control-plane"
+              role="tabpanel"
+              aria-labelledby="manage-tab-control-plane"
+            >
+              <ControlPlaneTab status={manageStatus} onRefresh={loadManageStatus} />
+            </div>
+          ) : null}
+          {activeTab === "license" ? (
+            <div
+              id="manage-panel-license"
+              role="tabpanel"
+              aria-labelledby="manage-tab-license"
+            >
+              <LicenseTab status={manageStatus} onRefresh={loadManageStatus} />
+            </div>
+          ) : null}
+          {activeTab === "settings" ? (
+            <div
+              id="manage-panel-settings"
+              role="tabpanel"
+              aria-labelledby="manage-tab-settings"
+            >
+              <SettingsTab status={manageStatus} onRefresh={loadManageStatus} />
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/ee/appliance/status-ui/app/page.tsx
+++ b/ee/appliance/status-ui/app/page.tsx
@@ -6,10 +6,11 @@ import {
   Boxes,
   ScrollText,
   Server,
-  SlidersHorizontal,
+  Settings2,
 } from "lucide-react";
 import { AlgaLogo } from "./AlgaLogo";
 import { LogoutButton } from "./auth/LogoutButton";
+import { ManageView } from "./manage/ManageView";
 import styles from "./status.module.css";
 
 type RawTierMap = Record<
@@ -140,6 +141,7 @@ type Pod = {
 };
 
 type Tab = "overview" | "deployments" | "pods" | "logs";
+type TopView = "status" | "manage";
 type LogLoadOptions = { preserveScroll?: boolean; scrollToEnd?: boolean };
 
 function apiPath(
@@ -310,6 +312,7 @@ function SkeletonBlock({ lines = 6 }: { lines?: number }) {
 }
 
 export default function StatusPage() {
+  const [topView, setTopView] = useState<TopView>("status");
   const [activeTab, setActiveTab] = useState<Tab>("overview");
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [setupMode, setSetupMode] = useState<string | null>(null);
@@ -654,24 +657,46 @@ export default function StatusPage() {
               type="button"
               role="tab"
               id={`appliance-tab-${value}`}
-              aria-selected={activeTab === value}
+              aria-selected={topView === "status" && activeTab === value}
               aria-controls={`appliance-panel-${value}`}
-              className={activeTab === value ? styles.activeTab : ""}
-              onClick={() => setActiveTab(value)}
+              className={topView === "status" && activeTab === value ? styles.activeTab : ""}
+              onClick={() => {
+                setTopView("status");
+                setActiveTab(value);
+              }}
             >
               <Icon className={styles.navIcon} aria-hidden="true" />
               <span>{label}</span>
             </button>
           ))}
         </nav>
-        <a className={styles.setupLink} href="/setup/">
-          <SlidersHorizontal className={styles.navIcon} aria-hidden="true" />
-          <span>Setup</span>
-        </a>
+        <button
+          type="button"
+          className={`${styles.setupLink} ${topView === "manage" ? styles.activeTab : ""}`}
+          onClick={() => setTopView("manage")}
+          aria-pressed={topView === "manage"}
+        >
+          <Settings2 className={styles.navIcon} aria-hidden="true" />
+          <span>Manage</span>
+        </button>
         <LogoutButton />
       </aside>
 
       <section className={styles.workspace}>
+        {topView === "manage" ? (
+          <>
+            <header className={styles.commandBar}>
+              <div>
+                <div className={styles.eyebrow}>Alga PSA appliance</div>
+                <h1>Manage</h1>
+              </div>
+            </header>
+            <ManageView />
+          </>
+        ) : null}
+
+        {topView === "status" ? (
+        <>
         <header className={styles.commandBar}>
           <div>
             <div className={styles.eyebrow}>Alga PSA appliance</div>
@@ -1256,6 +1281,8 @@ export default function StatusPage() {
               </pre>
             )}
           </section>
+        ) : null}
+        </> /* end topView === "status" */
         ) : null}
       </section>
     </main>

--- a/ee/appliance/status-ui/app/status.module.css
+++ b/ee/appliance/status-ui/app/status.module.css
@@ -1011,7 +1011,7 @@
     var(--operator-purple) 18%,
     var(--appliance-sidebar)
   ) !important;
-  color: var(--appliance-text) !important;
+  color: var(--appliance-sidebar-text) !important;
 }
 
 .manageRefreshButton {

--- a/ee/appliance/status-ui/app/status.module.css
+++ b/ee/appliance/status-ui/app/status.module.css
@@ -957,6 +957,148 @@
   padding: 14px 11px !important;
 }
 
+/* ---------------------------------------------------------------------------
+   Manage view
+   --------------------------------------------------------------------------- */
+
+.manageView {
+  display: grid;
+  gap: var(--space-xl);
+}
+
+.manageTabStrip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--appliance-border);
+}
+
+.manageTabButton {
+  min-height: 36px;
+  border: 1px solid var(--appliance-border);
+  border-radius: var(--radius-md);
+  background: var(--appliance-panel);
+  color: var(--appliance-text);
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 150ms var(--ease-out-quart),
+    background-color 150ms var(--ease-out-quart),
+    color 150ms var(--ease-out-quart);
+}
+
+.manageTabButton:hover {
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 55%,
+    var(--appliance-border)
+  );
+  background: color-mix(in oklch, var(--operator-purple) 12%, transparent);
+  color: var(--appliance-text);
+}
+
+.manageTabActive {
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 62%,
+    var(--appliance-sidebar-text)
+  ) !important;
+  background: color-mix(
+    in oklch,
+    var(--operator-purple) 18%,
+    var(--appliance-sidebar)
+  ) !important;
+  color: var(--appliance-text) !important;
+}
+
+.manageRefreshButton {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  min-width: 36px;
+  border: 1px solid var(--appliance-border);
+  border-radius: var(--radius-md);
+  background: var(--appliance-panel);
+  color: var(--appliance-text-muted);
+  cursor: pointer;
+  transition:
+    border-color 150ms var(--ease-out-quart),
+    background-color 150ms var(--ease-out-quart);
+}
+
+.manageRefreshButton:hover {
+  border-color: color-mix(
+    in oklch,
+    var(--operator-purple) 55%,
+    var(--appliance-border)
+  );
+  background: color-mix(in oklch, var(--operator-purple) 12%, transparent);
+  color: var(--appliance-text);
+}
+
+.manageLoading {
+  padding: var(--space-lg) 0;
+}
+
+.manageSection {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.manageSection h2 {
+  margin: 0;
+  color: var(--appliance-text);
+  font-size: 1.05rem;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.manageSeparator {
+  height: 1px;
+  background: var(--appliance-border);
+}
+
+.manageSubheading {
+  margin: 0;
+  color: var(--appliance-text);
+  font-size: 0.9rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.manageStatusMsg {
+  display: inline-block;
+  margin-left: var(--space-sm);
+  color: var(--appliance-text-muted);
+  font-size: 0.85rem;
+}
+
+.manageResult {
+  padding: var(--space-md);
+  border: 1px solid
+    color-mix(in oklch, var(--success) 38%, var(--appliance-border));
+  border-radius: var(--radius-lg);
+  background: var(--success-soft);
+  color: color-mix(in oklch, var(--success) 64%, var(--appliance-text));
+  font-weight: 620;
+  margin: 0;
+}
+
+.alertInfo {
+  border-color: color-mix(
+    in oklch,
+    var(--system-cyan) 42%,
+    var(--appliance-border)
+  ) !important;
+  background: var(--system-cyan-soft) !important;
+  color: color-mix(in oklch, var(--system-cyan) 46%, var(--appliance-text)) !important;
+}
+
 @keyframes shimmer {
   from {
     background-position: 0 0;

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/PRD.md
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/PRD.md
@@ -1,0 +1,80 @@
+# PRD — Appliance post-install Management surface
+
+Date: 2026-06-19
+Plan: `ee/docs/plans/2026-06-19-appliance-management-surface/`
+Design: `./design.md`
+
+## Problem statement and user value
+
+Once an Alga appliance is installed there is no place to run ongoing operations. App updates exist only at an unlinked server-rendered `/updates` page. Control-plane upgrades happen only on reboot. The "Setup" sidebar button is dead post-install (the host-service 303-redirects `/setup` to `/` once `mode=status`). Applying a license has no home at all — a license is set only during setup, so an airgap operator with a renewed or upgraded license is stuck.
+
+This delivers a single **Manage** surface in the appliance status UI where an operator can update the app, upgrade the control plane, apply a license, and correct the app URL/DNS — without a host shell or a reboot.
+
+## Goals
+
+- Repurpose the dead Setup sidebar entry into an in-SPA **Manage** area with sub-tabs: Updates, Control-plane, License, Settings.
+- Let an operator trigger an **app-channel update** from the UI (within the installed channel) and watch it complete.
+- Let an operator trigger a **control-plane upgrade** from the UI, executed by the host-agent so it survives the pod replacing itself.
+- Let an airgap operator **apply a new license JWS** and see current edition/expiry.
+- Let an operator **edit the app URL/hostname and DNS** so `NEXTAUTH_URL` follows, fixing the `alga.local` class of problem in-product.
+- Fix the prerequisite kubeconfig bug so app updates actually complete from the pod.
+
+## Non-goals (v1)
+
+- Channel switching (stable↔nightly) from the UI — updates run within the installed channel.
+- Install-code re-redemption / tenant re-binding from the UI.
+- Automatic control-plane rollback (the host-side `alga-control-plane-reapply` CLI remains recovery).
+- OS / k3s updates (remain manual / support-run).
+- Re-running the full setup workflow post-install.
+- Metrics, audit logging, and other operational hardening unless requested.
+
+## Target users and primary flows
+
+**Persona:** the appliance operator (MSP admin) managing an installed on-prem appliance via the status UI, authenticated with the host-service management password.
+
+Primary flows:
+
+1. **Update the app.** Manage → Updates shows current version; operator clicks Update; UI shows progress and confirms completion (or a clear blocked reason).
+2. **Upgrade the control plane.** Manage → Control-plane shows "up to date" or "upgrade available"; operator confirms; UI shows "upgrading, reconnecting…", the new control-plane pod comes up, UI confirms the new digest.
+3. **Apply a license.** Manage → License shows current edition/expiry; operator pastes a new license JWS; UI validates, applies, and the app restarts onto the new license.
+4. **Fix the app URL.** Manage → Settings shows the current app URL/DNS; operator edits the hostname; UI applies and the app restarts with the corrected `NEXTAUTH_URL`.
+
+## UX/UI notes
+
+- Manage is an in-SPA section (not a `/setup` navigation), reached from the renamed sidebar entry. Sub-tabs mirror the existing tab styling.
+- Each mutating action shows a confirmation step (it causes a restart / brief downtime) and an in-progress/result state.
+- Control-plane upgrade explicitly handles the served-by-the-thing-being-upgraded case: a "reconnecting…" state that polls health and resolves to success or a recovery hint (`alga-control-plane-reapply`).
+- "Up to date" vs "upgrade available" is shown for both app and control plane (version/digest compare), so buttons aren't blind.
+
+## Data model / API integration notes
+
+New/used host-service endpoints (all behind `requireAuth`):
+
+- `GET  /api/manage/status` — aggregate: app version + channel, running control-plane digest vs. resolved channel `controlPlane` digest, edition + license expiry, current app URL/DNS.
+- `POST /api/updates` — existing; surfaced. App-channel update within installed channel.
+- `POST /api/control-plane/upgrade` — new; forwards to host-agent `POST /v1/control-plane/upgrade`; returns 202.
+- `POST /api/license/apply` — new; validate airgap license JWS, update `appliance-license-seed` secret, `rollout restart` app.
+- `POST /api/settings/app-url` — new; rewrite `appUrl`/`host`/`domainSuffix` in `alga-core` values, persist `release-selection.json` `runtime.appHostname`/DNS, reconcile the `alga-core` HelmRelease.
+
+Host-agent: add `POST /v1/control-plane/upgrade` that runs the bootstrap control-plane apply (resolve channel `controlPlane` digest → `ctr` pull → `kubectl apply -k` overlay), reusing `bootstrap-control-plane.sh` logic / `resolve-control-plane-image.mjs`.
+
+Prerequisite: `reconcileFluxAndHelm` (`update-engine.mjs`) must honor `ALGA_APPLIANCE_KUBECONFIG` / in-cluster config instead of the hardcoded `/etc/rancher/k3s/k3s.yaml`.
+
+State touched: k8s configmap `appliance-values-alga-core` (alga-system), secret `appliance-license-seed`, host files `release-selection.json` (`/var/lib/alga-appliance`), the `alga-core` HelmRelease, and the `appliance-control-plane` Deployment. No app Postgres schema changes.
+
+## Risks, rollout, open questions
+
+- **Self-replacing control plane.** The upgrade runs in the host-agent (root, on host) so it survives the pod Recreate; the UI must tolerate the dropped connection. Risk: a bad control-plane image leaves a broken UI — mitigated by the digest pre-pull + the `alga-control-plane-reapply` recovery path (documented in the failure state), not auto-rollback in v1.
+- **kubeconfig fix blast radius.** Changing the reconcile kubeconfig affects the existing update path; covered by host-service tests + live smoke.
+- **Airgap JWS validation depth.** v1 validates format + applies; it does not verify the signature in-product (the app validates the license at runtime). Acceptable for v1; note it.
+- Rollout: single bundled feature PR; validate on the libvirt VM end to end before merge.
+
+## Acceptance criteria / definition of done
+
+- Sidebar shows **Manage** (not a dead Setup link); clicking it opens the in-SPA Manage area with the four sub-tabs; no `/setup` 303 involved post-install.
+- From Updates, an app update **completes** end to end on the VM (kubeconfig fix in place) and the UI reflects status.
+- From Control-plane, an upgrade swaps the running digest and the UI reconnects and confirms; "up to date" is shown when current.
+- From License, applying a valid airgap JWS updates the seed and the app restarts onto it; an invalid JWS is rejected with a clear message; current edition/expiry is shown.
+- From Settings, editing the app hostname propagates to `NEXTAUTH_URL` and the app restarts; sign-in works at the configured URL.
+- All mutating endpoints require auth; each action has a confirmation and a result/failure state.
+- Host-service tests pass; live VM smoke validates each of the four actions.

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/SCRATCHPAD.md
@@ -34,3 +34,18 @@ Working memory for this effort. Append freely; curate as decisions change.
 - PR/sequencing: kubeconfig fix as standalone PR first, or bundled?
 - Updates: allow channel switch (stable↔nightly) or trigger-within-current-channel only?
 - License status source/depth for v1.
+
+## Live validation (2026-06-19, VM 192.168.122.215)
+All five flows validated on the libvirt VM with the worktree control-plane image deployed:
+- GET /api/manage/status → real data (license edition ee, appUrl http://192.168.122.215:3000, CP resolvedDigest sha256:dc3d188…). runningDigest null on this VM because it runs the local `:baked` tag (not a channel digest) — compare logic is unit-tested.
+- Settings: POST /api/settings/app-url rewrote the alga-core configmap appUrl, persisted release-selection runtime.appHostname, reconciled the HelmRelease. {ok:true}.
+- License: POST /api/license/apply patched appliance-license-seed LICENSE_TOKEN (decoded == sent JWS) + rolled the app. {ok:true}.
+- Updates: POST /api/updates → 202; install-state reached **update-complete** ("App-channel update applied for stable") — proves the kubeconfig + helmcharts-RBAC prereq fix (was broken at the flux reconcile step before).
+- Manage UI: logged into :8080, sidebar shows **Manage** (was the dead Setup link), opens the in-SPA Manage view with Updates/Control-plane/License/Settings; live status rendered.
+- Control-plane upgrade: host-agent alive with /v1/control-plane/upgrade route; `bootstrap-control-plane.sh --control-plane-only --dry-run` plans only wait→apply (skips k3s/import/storage). Full swap is the proven reboot apply_control_plane path (not run, to keep the test build deployed).
+
+## Deploy procedure (TWO targets — important)
+1. Pod image (server.mjs, update-engine, status-ui, manage-engine): rebuild control-plane image, ctr import, `rollout restart` (deploy already pinned to localhost:baked). Has the Manage backend + UI.
+2. HOST files (host-agent.mjs, bootstrap-control-plane.sh run on the host, NOT the pod): copy to /opt/alga-appliance/{host-service,scripts}/ and `systemctl restart alga-host-agent.service`.
+3. RBAC: `kubectl apply -f control-plane/manifests/rbac.yaml` (helmcharts addition).
+Test management password on the VM was reset to `Manage.Test99` during validation (alga-appliance-reset-admin). Set the password via curl from the workstation Bash tool, NOT the interactive pane — `!` in the password gets history-expanded by the pane's interactive bash and corrupts it.

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/SCRATCHPAD.md
@@ -1,0 +1,36 @@
+# SCRATCHPAD — Appliance post-install Management surface
+
+Working memory for this effort. Append freely; curate as decisions change.
+
+## Status
+- 2026-06-19: brainstorm complete + approved. Design committed at `design.md`. Building PRD/features/tests.
+- Branch: `feature/appliance-management-surface` (worktree `~/alga-psa.worktrees/appliance-management-surface`), off `main` @ d42dab4f06.
+
+## Key decisions (from brainstorm)
+- Repurpose the dead **Setup** sidebar entry → in-SPA **Manage** section (sub-tabs: Updates · Control-plane · License · Settings). Do NOT fight the `/setup` 303 — Manage is in-SPA nav, the `/setup` wizard route stays pre-install only.
+- Control-plane upgrade runs via the **host-agent** (root, on host) — proven bootstrap apply, NOT reboot, NOT in-pod self-replace.
+- License = apply/replace an **airgap license JWS** + show status.
+- Settings = **app URL/hostname + DNS** only.
+
+## Anchor facts / file map (verified this session)
+- status-ui: Next.js static export (`output: 'export'`), served by control-plane pod at `/`. Sidebar tabs at `ee/appliance/status-ui/app/page.tsx:254-258` (Overview/Deployments/Pods/Logs); dead Setup link `<a href="/setup/">` at ~`:667`; behind `AuthGate` (layout.tsx).
+- host-service `/api/updates` → `runAppChannelUpdate` (`update-engine.mjs`); app-channel only (`scope: 'application-only'`). Auth via session cookie (`isAuthenticated`/`requireAuth`, `auth.mjs`).
+- **host-agent** = tiny root HTTP server over `/run/alga-appliance/host-agent.sock` (`host-agent.mjs`); today only `GET /v1/health` + `POST /v1/support-bundle`. Runs as root (systemd `alga-host-agent.service`). The pod reaches it via the mounted socket (`ALGA_APPLIANCE_HOST_AGENT_SOCKET`). → add `POST /v1/control-plane/upgrade`.
+- Control-plane image is **digest-pinned** by `bootstrap-control-plane.sh apply_control_plane()`: `resolve-control-plane-image.mjs` does a LIVE `GET ghcr.io/.../alga-appliance-release:<channel>` (channel from `release-selection.json selectedChannel`), reads `manifest.controlPlane` (repo@sha256:…), `ctr pull`s it, applies kustomize overlay (`newName`+`digest`). Reboot re-runs this; offline → falls back to baked `localhost/...:baked`.
+- Licensing today set ONLY at setup: airgap `licenseKey` (JWS, format check at `server.mjs:~710`) or `installCode` redeemed → `appliance-license-seed` secret. Connected installs auto-refresh via daily check-in; airgap has no post-install path.
+- App URL: `appUrl`/`host`/`domainSuffix` in `alga-core` values configmap → Helm renders `NEXTAUTH_URL`/`NEXT_PUBLIC_BASE_URL` (`helm/templates/deployment.yaml:560-569`). Setup writes the hostname override in `applyRuntimeValuesAndReleaseSelection` (`setup-engine.mjs:968-973`).
+
+## Gotchas
+- **kubeconfig bug (prereq):** `reconcileFluxAndHelm` (`update-engine.mjs`) hardcodes `--kubeconfig /etc/rancher/k3s/k3s.yaml`, NOT mounted in the pod → `/api/updates` dies at flux reconcile (`stat /etc/rancher/k3s/k3s.yaml: no such file`) AFTER app URL is preserved. Must honor `ALGA_APPLIANCE_KUBECONFIG` / in-cluster config for Updates to actually complete. (In-pod kubectl for the configmap apply already works via the SA, so only the flux/helm reconcile path is broken.)
+- **Just merged PR #2731** (squashed to main @ d42dab4f06): fixes the release-selection `/etc`→`/var/lib` path default + no-silent-downgrade guard. This plan builds on it.
+- Control-plane deployment can be repointed to a ghcr digest; the `localhost/...:baked` tag won't auto-update (tag + IfNotPresent). CP channel update is digest-based, so a new release = new digest = pulled (no stale-skip).
+- Testbed VM: libvirt `ubuntu24.04`, DHCP (was .55, seen .215). Drive via algadev IDE panes (this harness kills hosted servers w/ exit 144; serve transfers from a real IDE terminal). See memory [[appliance-control-plane-hotfix-deploy]], [[appliance-update-appurl-reset]].
+
+## Commands / runbook
+- Build control-plane: rsync `ee/appliance` → `$HOME/cp-build`, `docker build --provenance=false -f ee/appliance/control-plane/Dockerfile -t localhost/alga-appliance-control-plane:baked .`; `ctr images import`; if deploy is pinned to a ghcr digest, `kubectl -n alga-appliance-control-plane patch deploy appliance-control-plane` both init+main container → localhost:baked.
+- Apply a corrected alga-core configmap: `kubectl -n alga-system annotate helmrelease alga-core reconcile.fluxcd.io/requestedAt=$(date +%s) --overwrite`.
+
+## Open questions (for PRD convergence)
+- PR/sequencing: kubeconfig fix as standalone PR first, or bundled?
+- Updates: allow channel switch (stable↔nightly) or trigger-within-current-channel only?
+- License status source/depth for v1.

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/design.md
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/design.md
@@ -1,0 +1,86 @@
+# Appliance post-install Management surface — design
+
+Date: 2026-06-19
+Status: approved (brainstorm), pending implementation plan
+Area: `ee/appliance` host-service + status-ui + host-agent
+
+## Problem
+
+After an appliance is installed there is no place to run ongoing operations:
+
+1. **App updates** exist only at the server-rendered `/updates` page, which is not linked from anywhere. Operators cannot discover or trigger an app-channel update from the UI.
+2. **Control-plane upgrades** can only happen on reboot — `bootstrap-control-plane.sh` re-resolves the channel's `controlPlane` digest and applies it at boot. There is no self-service trigger.
+3. **The "Setup" sidebar button is dead post-install.** Once setup completes (`mode=status`), the host-service 303-redirects `/setup` back to `/` (`server.mjs`), so clicking Setup bounces to the status page.
+4. **Applying a license has no home.** A license is set only at setup (airgap license JWS, or an install code redeemed against `alga-license`). Connected installs auto-refresh via a daily check-in; airgap installs have no post-install path to apply a renewed or upgraded license.
+
+## Goal
+
+A single post-install **Manage** surface in the status UI that hosts the operations an operator needs after install: app updates, control-plane upgrades, license application, and safe settings re-edits. Reuse the proven mechanisms (the app-channel update flow, the bootstrap control-plane apply, the license-seed secret) rather than inventing new ones.
+
+## Decisions (from brainstorm)
+
+- Repurpose the **Setup** sidebar entry into a **Manage** area inside the React status UI.
+- Control-plane upgrades execute via the **host-agent** (root, on the host), not in-pod and not via reboot.
+- License section applies/replaces an **airgap license key** and shows current status.
+- Settings section edits **app URL/hostname + DNS only**.
+
+## 1. Surface and routing
+
+The status UI is a Next.js static export (`output: 'export'`) served by the control-plane pod at `/`. It is a single-page app with sidebar tabs (Overview, Deployments, Pods, Logs) plus the dead Setup link and Logout.
+
+- Rename the sidebar **Setup → Manage**. Change it from `<a href="/setup/">` to an **in-SPA section switch**, like the other tabs. Because Manage is part of the already-loaded SPA, there is no navigation to `/setup/` and therefore no 303 to fight.
+- The Manage section has sub-tabs: **Updates · Control-plane · License · Settings**.
+- `/setup/` (the install wizard route) is unchanged and serves pre-install only (`mode=setup`). Its 303 guard stays as a harmless backstop; nobody navigates there post-install.
+- Manage sits behind the existing `AuthGate` (host-service session cookie). Every mutating endpoint calls `requireAuth`.
+
+Rejected alternative: literally repurposing `/setup` to render Manage post-install. It works but fights the server redirect and forces a page reload. In-SPA navigation is cleaner and the operator experience is identical.
+
+## 2. Sections and endpoints
+
+| Section | Operator action | Backing |
+|---|---|---|
+| **Updates** | Show current app version + channel; trigger an app-channel update (`stable`/`nightly`); poll `update-running → update-complete/update-blocked`. | Existing `POST /api/updates` → `runAppChannelUpdate`. Requires the kubeconfig prerequisite (§4). |
+| **Control-plane** | Show running control-plane digest vs. the channel's resolved `controlPlane` digest ("upgrade available?"); trigger the upgrade; show "upgrading, reconnecting…". | New `POST /api/control-plane/upgrade` → host-agent (§3). |
+| **License** | Show edition + license status/expiry; paste a new airgap license JWS to apply. | New `POST /api/license/apply`: validate the JWS format (reuse the check in `server.mjs`), update the `appliance-license-seed` secret, `rollout restart` the app to pick it up. |
+| **Settings** | Edit app URL/hostname + DNS. | New `POST /api/settings/app-url`: rewrite `appUrl`/`host`/`domainSuffix` in the `alga-core` values, persist `release-selection.json` `runtime.appHostname`/DNS, reconcile the `alga-core` HelmRelease so `NEXTAUTH_URL` follows. This is the hostname-override slice of `applyRuntimeValuesAndReleaseSelection`, extracted as a targeted operation. |
+
+## 3. Control-plane upgrade flow
+
+The control-plane pod serves the Manage UI, so it cannot cleanly upgrade itself in-process — the request that triggers the upgrade is killed when its own pod is replaced (`Recreate`). The host-agent solves this: it runs on the host as root and is reachable from the pod over `/run/alga-appliance/host-agent.sock` (today it serves `GET /v1/health` and `POST /v1/support-bundle`).
+
+```
+Manage UI ── POST /api/control-plane/upgrade ──▶ host-service (in pod)
+                                                   │ forwards over the socket
+                                                   ▼
+                              host-agent (root, on host)  POST /v1/control-plane/upgrade
+                                                   │
+                  runs the proven bootstrap apply (NOT a reboot):
+                  resolve channel controlPlane digest → ctr pull → kubectl apply -k overlay
+                                                   │
+                                          Deployment Recreate ──▶ new control-plane pod
+```
+
+- The host-service returns **202 immediately** (fire-and-forget). The host-agent drives the swap, so the work survives the pod being replaced.
+- The UI detects the dropped connection, shows **"upgrading, reconnecting…"**, and polls `/v1/health` / `/api/status` until the new pod answers, then confirms the new digest.
+- "Upgrade available" is a digest compare (the resolved channel `controlPlane` vs. the running pod's `imageID`). The button is a no-op / disabled when already current.
+
+## 4. Prerequisite and safety
+
+- **Prerequisite — kubeconfig fix.** `reconcileFluxAndHelm` in `update-engine.mjs` hardcodes `--kubeconfig /etc/rancher/k3s/k3s.yaml`, which is not mounted in the control-plane pod. So `POST /api/updates` currently fails at the flux-reconcile step (after the app URL is already preserved). Making Updates a real button requires honoring the in-pod kubeconfig (`ALGA_APPLIANCE_KUBECONFIG` / in-cluster config). This is in scope.
+- **Confirmations** on Updates, Control-plane, and License-apply — all cause restarts or brief downtime.
+- **No automatic rollback in v1.** The host-side `alga-control-plane-reapply` CLI remains the recovery path for a bad control plane; the UI surfaces it in the failure state.
+- **Auth** on every mutating route. **Idempotent** "already current" handling on updates/upgrades.
+
+## 5. Testing
+
+Light automated coverage plus live validation, matching the appliance host-service convention:
+
+- Host-service engine/route unit tests for the new endpoints and the new host-agent route, in the style of the existing `*-engine.test.mjs` / `*-state-paths.test.mjs` suites.
+- Live smoke on the libvirt VM for each action: app update completes end to end (with the kubeconfig fix), control-plane upgrade swaps the digest and the UI reconnects, license apply, and app-URL edit propagates to `NEXTAUTH_URL`.
+
+## Out of scope (v1)
+
+- Install-code re-redemption / tenant re-binding from the UI.
+- Automatic control-plane rollback.
+- OS / k3s updates (remain manual / support-run).
+- Re-running the full setup workflow post-install.

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/features.json
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/features.json
@@ -1,49 +1,333 @@
 [
-  { "id": "F001", "description": "reconcileFluxAndHelm honors ALGA_APPLIANCE_KUBECONFIG / in-cluster config instead of the hardcoded /etc/rancher/k3s/k3s.yaml", "implemented": false, "prdRefs": ["Data model / API integration notes", "Risks"] },
-  { "id": "F002", "description": "An app-channel update completes through the flux/helm reconcile from inside the control-plane pod (no '/etc/rancher/k3s/k3s.yaml' error)", "implemented": false, "prdRefs": ["Goals", "Acceptance criteria"] },
-
-  { "id": "F010", "description": "Sidebar 'Setup' entry renamed to 'Manage' and changed from <a href=\"/setup/\"> to an in-SPA section switch (no /setup navigation)", "implemented": false, "prdRefs": ["UX/UI notes"] },
-  { "id": "F011", "description": "Manage section renders with sub-tabs: Updates, Control-plane, License, Settings", "implemented": false, "prdRefs": ["Goals", "UX/UI notes"] },
-  { "id": "F012", "description": "Sub-tab switching within Manage is client-side state (no page reload)", "implemented": false, "prdRefs": ["UX/UI notes"] },
-  { "id": "F013", "description": "Manage area and all its endpoints are gated behind the existing AuthGate / host-service session", "implemented": false, "prdRefs": ["Target users", "Data model / API integration notes"] },
-  { "id": "F014", "description": "First-run wizard (/setup, mode=setup) is unaffected; Manage appears only post-install (mode=status) and the dead-link behavior is gone", "implemented": false, "prdRefs": ["UX/UI notes", "Non-goals"] },
-
-  { "id": "F020", "description": "GET /api/manage/status returns current app version + installed channel", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F021", "description": "GET /api/manage/status returns running control-plane digest, resolved channel controlPlane digest, and an upgradeAvailable flag", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F022", "description": "GET /api/manage/status returns current edition + license expiry", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F023", "description": "GET /api/manage/status returns current app URL + DNS settings", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F024", "description": "GET /api/manage/status requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F025", "description": "Manage client fetches /api/manage/status and renders per-tab state with loading and error handling", "implemented": false, "prdRefs": ["UX/UI notes"] },
-
-  { "id": "F030", "description": "Updates tab shows the current app version and installed channel", "implemented": false, "prdRefs": ["Target users"] },
-  { "id": "F031", "description": "Update button triggers POST /api/updates within the installed channel (no channel selector)", "implemented": false, "prdRefs": ["Goals", "Non-goals"] },
-  { "id": "F032", "description": "Updates tab polls install-state and reflects running -> complete/blocked", "implemented": false, "prdRefs": ["Target users"] },
-  { "id": "F033", "description": "Updates tab shows 'up to date' vs 'update available' (best-effort version compare)", "implemented": false, "prdRefs": ["UX/UI notes"] },
-  { "id": "F034", "description": "Update blocked/failure surfaces the reason clearly", "implemented": false, "prdRefs": ["UX/UI notes"] },
-
-  { "id": "F040", "description": "host-agent adds POST /v1/control-plane/upgrade", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F041", "description": "host-agent upgrade route runs the bootstrap control-plane apply (resolve channel controlPlane digest -> ctr pull -> kubectl apply -k overlay), reusing bootstrap-control-plane.sh / resolve-control-plane-image.mjs, and returns without blocking on the pod Recreate", "implemented": false, "prdRefs": ["Data model / API integration notes", "Risks"] },
-  { "id": "F042", "description": "host-service POST /api/control-plane/upgrade forwards to the host-agent over the socket and returns 202", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F043", "description": "POST /api/control-plane/upgrade requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F044", "description": "Control-plane tab shows running digest vs resolved channel digest (upgrade available?)", "implemented": false, "prdRefs": ["UX/UI notes"] },
-  { "id": "F045", "description": "Control-plane tab shows 'up to date' and disables/no-ops the upgrade button when current (idempotent)", "implemented": false, "prdRefs": ["UX/UI notes", "Risks"] },
-  { "id": "F046", "description": "After triggering an upgrade, the UI shows 'upgrading, reconnecting...' and polls health/status until the new pod answers", "implemented": false, "prdRefs": ["UX/UI notes"] },
-  { "id": "F047", "description": "UI confirms the new control-plane digest after reconnect", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F048", "description": "Upgrade failure surfaces the recovery hint (alga-control-plane-reapply); no auto-rollback in v1", "implemented": false, "prdRefs": ["Risks", "Non-goals"] },
-
-  { "id": "F060", "description": "POST /api/license/apply validates the airgap license JWS format (reuse server.mjs check)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F061", "description": "POST /api/license/apply updates the appliance-license-seed secret (LICENSE_TOKEN + EDITION_CHOICE)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F062", "description": "POST /api/license/apply rollout-restarts the app to pick up the new license", "implemented": false, "prdRefs": ["Target users"] },
-  { "id": "F063", "description": "POST /api/license/apply requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F064", "description": "Invalid license JWS is rejected with a clear error and no secret mutation", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F065", "description": "License tab shows current edition + license expiry (decoded from seed/JWS)", "implemented": false, "prdRefs": ["Goals", "UX/UI notes"] },
-
-  { "id": "F070", "description": "POST /api/settings/app-url rewrites appUrl/host/domainSuffix in the alga-core values configmap", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F071", "description": "POST /api/settings/app-url persists release-selection.json runtime.appHostname (+ DNS) to /var/lib", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F072", "description": "POST /api/settings/app-url reconciles the alga-core HelmRelease so NEXTAUTH_URL re-renders", "implemented": false, "prdRefs": ["Goals", "Acceptance criteria"] },
-  { "id": "F073", "description": "POST /api/settings/app-url requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
-  { "id": "F074", "description": "app-url input is validated/normalized (reuse appUrlFromInput/hostFromAppUrl; full http://host:port supported)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
-  { "id": "F075", "description": "Settings tab shows the current app URL + DNS and supports system vs custom DNS resolvers (mirrors setup DNS handling)", "implemented": false, "prdRefs": ["UX/UI notes"] },
-
-  { "id": "F080", "description": "Each mutating action (update, upgrade, license apply, settings apply) shows a confirmation step plus in-progress and result/failure states", "implemented": false, "prdRefs": ["UX/UI notes"] }
+  {
+    "id": "F001",
+    "description": "reconcileFluxAndHelm honors ALGA_APPLIANCE_KUBECONFIG / in-cluster config instead of the hardcoded /etc/rancher/k3s/k3s.yaml",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes",
+      "Risks"
+    ]
+  },
+  {
+    "id": "F002",
+    "description": "An app-channel update completes through the flux/helm reconcile from inside the control-plane pod (no '/etc/rancher/k3s/k3s.yaml' error)",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F010",
+    "description": "Sidebar 'Setup' entry renamed to 'Manage' and changed from <a href=\"/setup/\"> to an in-SPA section switch (no /setup navigation)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F011",
+    "description": "Manage section renders with sub-tabs: Updates, Control-plane, License, Settings",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F012",
+    "description": "Sub-tab switching within Manage is client-side state (no page reload)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F013",
+    "description": "Manage area and all its endpoints are gated behind the existing AuthGate / host-service session",
+    "implemented": true,
+    "prdRefs": [
+      "Target users",
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F014",
+    "description": "First-run wizard (/setup, mode=setup) is unaffected; Manage appears only post-install (mode=status) and the dead-link behavior is gone",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes",
+      "Non-goals"
+    ]
+  },
+  {
+    "id": "F020",
+    "description": "GET /api/manage/status returns current app version + installed channel",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F021",
+    "description": "GET /api/manage/status returns running control-plane digest, resolved channel controlPlane digest, and an upgradeAvailable flag",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F022",
+    "description": "GET /api/manage/status returns current edition + license expiry",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F023",
+    "description": "GET /api/manage/status returns current app URL + DNS settings",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F024",
+    "description": "GET /api/manage/status requires auth",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F025",
+    "description": "Manage client fetches /api/manage/status and renders per-tab state with loading and error handling",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F030",
+    "description": "Updates tab shows the current app version and installed channel",
+    "implemented": true,
+    "prdRefs": [
+      "Target users"
+    ]
+  },
+  {
+    "id": "F031",
+    "description": "Update button triggers POST /api/updates within the installed channel (no channel selector)",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "Non-goals"
+    ]
+  },
+  {
+    "id": "F032",
+    "description": "Updates tab polls install-state and reflects running -> complete/blocked",
+    "implemented": true,
+    "prdRefs": [
+      "Target users"
+    ]
+  },
+  {
+    "id": "F033",
+    "description": "Updates tab shows 'up to date' vs 'update available' (best-effort version compare)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F034",
+    "description": "Update blocked/failure surfaces the reason clearly",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F040",
+    "description": "host-agent adds POST /v1/control-plane/upgrade",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F041",
+    "description": "host-agent upgrade route runs the bootstrap control-plane apply (resolve channel controlPlane digest -> ctr pull -> kubectl apply -k overlay), reusing bootstrap-control-plane.sh / resolve-control-plane-image.mjs, and returns without blocking on the pod Recreate",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes",
+      "Risks"
+    ]
+  },
+  {
+    "id": "F042",
+    "description": "host-service POST /api/control-plane/upgrade forwards to the host-agent over the socket and returns 202",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F043",
+    "description": "POST /api/control-plane/upgrade requires auth",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F044",
+    "description": "Control-plane tab shows running digest vs resolved channel digest (upgrade available?)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F045",
+    "description": "Control-plane tab shows 'up to date' and disables/no-ops the upgrade button when current (idempotent)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes",
+      "Risks"
+    ]
+  },
+  {
+    "id": "F046",
+    "description": "After triggering an upgrade, the UI shows 'upgrading, reconnecting...' and polls health/status until the new pod answers",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F047",
+    "description": "UI confirms the new control-plane digest after reconnect",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F048",
+    "description": "Upgrade failure surfaces the recovery hint (alga-control-plane-reapply); no auto-rollback in v1",
+    "implemented": true,
+    "prdRefs": [
+      "Risks",
+      "Non-goals"
+    ]
+  },
+  {
+    "id": "F060",
+    "description": "POST /api/license/apply validates the airgap license JWS format (reuse server.mjs check)",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F061",
+    "description": "POST /api/license/apply updates the appliance-license-seed secret (LICENSE_TOKEN + EDITION_CHOICE)",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F062",
+    "description": "POST /api/license/apply rollout-restarts the app to pick up the new license",
+    "implemented": true,
+    "prdRefs": [
+      "Target users"
+    ]
+  },
+  {
+    "id": "F063",
+    "description": "POST /api/license/apply requires auth",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F064",
+    "description": "Invalid license JWS is rejected with a clear error and no secret mutation",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F065",
+    "description": "License tab shows current edition + license expiry (decoded from seed/JWS)",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F070",
+    "description": "POST /api/settings/app-url rewrites appUrl/host/domainSuffix in the alga-core values configmap",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F071",
+    "description": "POST /api/settings/app-url persists release-selection.json runtime.appHostname (+ DNS) to /var/lib",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F072",
+    "description": "POST /api/settings/app-url reconciles the alga-core HelmRelease so NEXTAUTH_URL re-renders",
+    "implemented": true,
+    "prdRefs": [
+      "Goals",
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F073",
+    "description": "POST /api/settings/app-url requires auth",
+    "implemented": true,
+    "prdRefs": [
+      "Acceptance criteria"
+    ]
+  },
+  {
+    "id": "F074",
+    "description": "app-url input is validated/normalized (reuse appUrlFromInput/hostFromAppUrl; full http://host:port supported)",
+    "implemented": true,
+    "prdRefs": [
+      "Data model / API integration notes"
+    ]
+  },
+  {
+    "id": "F075",
+    "description": "Settings tab shows the current app URL + DNS and supports system vs custom DNS resolvers (mirrors setup DNS handling)",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  },
+  {
+    "id": "F080",
+    "description": "Each mutating action (update, upgrade, license apply, settings apply) shows a confirmation step plus in-progress and result/failure states",
+    "implemented": true,
+    "prdRefs": [
+      "UX/UI notes"
+    ]
+  }
 ]

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/features.json
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/features.json
@@ -1,0 +1,49 @@
+[
+  { "id": "F001", "description": "reconcileFluxAndHelm honors ALGA_APPLIANCE_KUBECONFIG / in-cluster config instead of the hardcoded /etc/rancher/k3s/k3s.yaml", "implemented": false, "prdRefs": ["Data model / API integration notes", "Risks"] },
+  { "id": "F002", "description": "An app-channel update completes through the flux/helm reconcile from inside the control-plane pod (no '/etc/rancher/k3s/k3s.yaml' error)", "implemented": false, "prdRefs": ["Goals", "Acceptance criteria"] },
+
+  { "id": "F010", "description": "Sidebar 'Setup' entry renamed to 'Manage' and changed from <a href=\"/setup/\"> to an in-SPA section switch (no /setup navigation)", "implemented": false, "prdRefs": ["UX/UI notes"] },
+  { "id": "F011", "description": "Manage section renders with sub-tabs: Updates, Control-plane, License, Settings", "implemented": false, "prdRefs": ["Goals", "UX/UI notes"] },
+  { "id": "F012", "description": "Sub-tab switching within Manage is client-side state (no page reload)", "implemented": false, "prdRefs": ["UX/UI notes"] },
+  { "id": "F013", "description": "Manage area and all its endpoints are gated behind the existing AuthGate / host-service session", "implemented": false, "prdRefs": ["Target users", "Data model / API integration notes"] },
+  { "id": "F014", "description": "First-run wizard (/setup, mode=setup) is unaffected; Manage appears only post-install (mode=status) and the dead-link behavior is gone", "implemented": false, "prdRefs": ["UX/UI notes", "Non-goals"] },
+
+  { "id": "F020", "description": "GET /api/manage/status returns current app version + installed channel", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F021", "description": "GET /api/manage/status returns running control-plane digest, resolved channel controlPlane digest, and an upgradeAvailable flag", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F022", "description": "GET /api/manage/status returns current edition + license expiry", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F023", "description": "GET /api/manage/status returns current app URL + DNS settings", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F024", "description": "GET /api/manage/status requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F025", "description": "Manage client fetches /api/manage/status and renders per-tab state with loading and error handling", "implemented": false, "prdRefs": ["UX/UI notes"] },
+
+  { "id": "F030", "description": "Updates tab shows the current app version and installed channel", "implemented": false, "prdRefs": ["Target users"] },
+  { "id": "F031", "description": "Update button triggers POST /api/updates within the installed channel (no channel selector)", "implemented": false, "prdRefs": ["Goals", "Non-goals"] },
+  { "id": "F032", "description": "Updates tab polls install-state and reflects running -> complete/blocked", "implemented": false, "prdRefs": ["Target users"] },
+  { "id": "F033", "description": "Updates tab shows 'up to date' vs 'update available' (best-effort version compare)", "implemented": false, "prdRefs": ["UX/UI notes"] },
+  { "id": "F034", "description": "Update blocked/failure surfaces the reason clearly", "implemented": false, "prdRefs": ["UX/UI notes"] },
+
+  { "id": "F040", "description": "host-agent adds POST /v1/control-plane/upgrade", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F041", "description": "host-agent upgrade route runs the bootstrap control-plane apply (resolve channel controlPlane digest -> ctr pull -> kubectl apply -k overlay), reusing bootstrap-control-plane.sh / resolve-control-plane-image.mjs, and returns without blocking on the pod Recreate", "implemented": false, "prdRefs": ["Data model / API integration notes", "Risks"] },
+  { "id": "F042", "description": "host-service POST /api/control-plane/upgrade forwards to the host-agent over the socket and returns 202", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F043", "description": "POST /api/control-plane/upgrade requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F044", "description": "Control-plane tab shows running digest vs resolved channel digest (upgrade available?)", "implemented": false, "prdRefs": ["UX/UI notes"] },
+  { "id": "F045", "description": "Control-plane tab shows 'up to date' and disables/no-ops the upgrade button when current (idempotent)", "implemented": false, "prdRefs": ["UX/UI notes", "Risks"] },
+  { "id": "F046", "description": "After triggering an upgrade, the UI shows 'upgrading, reconnecting...' and polls health/status until the new pod answers", "implemented": false, "prdRefs": ["UX/UI notes"] },
+  { "id": "F047", "description": "UI confirms the new control-plane digest after reconnect", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F048", "description": "Upgrade failure surfaces the recovery hint (alga-control-plane-reapply); no auto-rollback in v1", "implemented": false, "prdRefs": ["Risks", "Non-goals"] },
+
+  { "id": "F060", "description": "POST /api/license/apply validates the airgap license JWS format (reuse server.mjs check)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F061", "description": "POST /api/license/apply updates the appliance-license-seed secret (LICENSE_TOKEN + EDITION_CHOICE)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F062", "description": "POST /api/license/apply rollout-restarts the app to pick up the new license", "implemented": false, "prdRefs": ["Target users"] },
+  { "id": "F063", "description": "POST /api/license/apply requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F064", "description": "Invalid license JWS is rejected with a clear error and no secret mutation", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F065", "description": "License tab shows current edition + license expiry (decoded from seed/JWS)", "implemented": false, "prdRefs": ["Goals", "UX/UI notes"] },
+
+  { "id": "F070", "description": "POST /api/settings/app-url rewrites appUrl/host/domainSuffix in the alga-core values configmap", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F071", "description": "POST /api/settings/app-url persists release-selection.json runtime.appHostname (+ DNS) to /var/lib", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F072", "description": "POST /api/settings/app-url reconciles the alga-core HelmRelease so NEXTAUTH_URL re-renders", "implemented": false, "prdRefs": ["Goals", "Acceptance criteria"] },
+  { "id": "F073", "description": "POST /api/settings/app-url requires auth", "implemented": false, "prdRefs": ["Acceptance criteria"] },
+  { "id": "F074", "description": "app-url input is validated/normalized (reuse appUrlFromInput/hostFromAppUrl; full http://host:port supported)", "implemented": false, "prdRefs": ["Data model / API integration notes"] },
+  { "id": "F075", "description": "Settings tab shows the current app URL + DNS and supports system vs custom DNS resolvers (mirrors setup DNS handling)", "implemented": false, "prdRefs": ["UX/UI notes"] },
+
+  { "id": "F080", "description": "Each mutating action (update, upgrade, license apply, settings apply) shows a confirmation step plus in-progress and result/failure states", "implemented": false, "prdRefs": ["UX/UI notes"] }
+]

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/tests.json
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/tests.json
@@ -1,17 +1,146 @@
 [
-  { "id": "T001", "description": "reconcileFluxAndHelm passes the configured/in-cluster kubeconfig (not the hardcoded /etc/rancher/k3s/k3s.yaml) — host-service engine test with fake flux/kubectl asserting the path", "implemented": false, "featureIds": ["F001"] },
-  { "id": "T002", "description": "Live VM smoke: an app-channel update completes end to end through flux/helm reconcile from the pod and install-state reaches complete", "implemented": false, "featureIds": ["F002", "F031", "F032"] },
-  { "id": "T003", "description": "Manage nav: sidebar shows 'Manage', opens the in-SPA Manage section with all four sub-tabs, and triggers no /setup navigation or 303 (status-ui DOM/smoke test)", "implemented": false, "featureIds": ["F010", "F011", "F012", "F014"] },
-  { "id": "T004", "description": "Auth guard: unauthenticated calls to /api/manage/status, /api/control-plane/upgrade, /api/license/apply, /api/settings/app-url all return 401", "implemented": false, "featureIds": ["F013", "F024", "F043", "F063", "F073"] },
-  { "id": "T005", "description": "GET /api/manage/status aggregates app version+channel, control-plane digests, edition+expiry, and app URL/DNS (engine/route test with fakes)", "implemented": false, "featureIds": ["F020", "F021", "F022", "F023", "F025"] },
-  { "id": "T006", "description": "upgradeAvailable digest compare: true when resolved channel digest != running, false/no-op when equal", "implemented": false, "featureIds": ["F021", "F044", "F045"] },
-  { "id": "T007", "description": "host-agent POST /v1/control-plane/upgrade runs the bootstrap apply with the resolved digest and returns without blocking on the Recreate (host-agent test with fake resolve/ctr/kubectl)", "implemented": false, "featureIds": ["F040", "F041"] },
-  { "id": "T008", "description": "POST /api/control-plane/upgrade forwards to the host-agent socket and returns 202 (route test)", "implemented": false, "featureIds": ["F042"] },
-  { "id": "T009", "description": "Live VM smoke: control-plane upgrade swaps the running digest and the UI reconnects and confirms the new digest", "implemented": false, "featureIds": ["F046", "F047"] },
-  { "id": "T010", "description": "License apply happy path: a valid JWS updates the appliance-license-seed secret and triggers an app rollout restart (engine/route test with fake kubectl)", "implemented": false, "featureIds": ["F060", "F061", "F062"] },
-  { "id": "T011", "description": "License apply rejects an invalid JWS with a clear error and does not mutate the secret", "implemented": false, "featureIds": ["F064"] },
-  { "id": "T012", "description": "License status decodes current edition + expiry from the seed/JWS", "implemented": false, "featureIds": ["F065"] },
-  { "id": "T013", "description": "Settings app-url: rewrites appUrl/host/domainSuffix in the alga-core values, persists release-selection.json runtime.appHostname, and reconciles the HelmRelease; normalizes a full http://host:port input (engine test with fakes)", "implemented": false, "featureIds": ["F070", "F071", "F072", "F074"] },
-  { "id": "T014", "description": "Live VM smoke: editing the app hostname in Settings propagates to NEXTAUTH_URL and sign-in works at the configured URL", "implemented": false, "featureIds": ["F072"] },
-  { "id": "T015", "description": "Each mutating action shows a confirmation step and a result/failure state (representative status-ui interaction test across update/upgrade/license/settings)", "implemented": false, "featureIds": ["F080", "F034", "F048"] }
+  {
+    "id": "T001",
+    "description": "reconcileFluxAndHelm passes the configured/in-cluster kubeconfig (not the hardcoded /etc/rancher/k3s/k3s.yaml) \u2014 host-service engine test with fake flux/kubectl asserting the path",
+    "implemented": true,
+    "featureIds": [
+      "F001"
+    ]
+  },
+  {
+    "id": "T002",
+    "description": "Live VM smoke: an app-channel update completes end to end through flux/helm reconcile from the pod and install-state reaches complete",
+    "implemented": true,
+    "featureIds": [
+      "F002",
+      "F031",
+      "F032"
+    ]
+  },
+  {
+    "id": "T003",
+    "description": "Manage nav: sidebar shows 'Manage', opens the in-SPA Manage section with all four sub-tabs, and triggers no /setup navigation or 303 (status-ui DOM/smoke test)",
+    "implemented": true,
+    "featureIds": [
+      "F010",
+      "F011",
+      "F012",
+      "F014"
+    ]
+  },
+  {
+    "id": "T004",
+    "description": "Auth guard: unauthenticated calls to /api/manage/status, /api/control-plane/upgrade, /api/license/apply, /api/settings/app-url all return 401",
+    "implemented": true,
+    "featureIds": [
+      "F013",
+      "F024",
+      "F043",
+      "F063",
+      "F073"
+    ]
+  },
+  {
+    "id": "T005",
+    "description": "GET /api/manage/status aggregates app version+channel, control-plane digests, edition+expiry, and app URL/DNS (engine/route test with fakes)",
+    "implemented": true,
+    "featureIds": [
+      "F020",
+      "F021",
+      "F022",
+      "F023",
+      "F025"
+    ]
+  },
+  {
+    "id": "T006",
+    "description": "upgradeAvailable digest compare: true when resolved channel digest != running, false/no-op when equal",
+    "implemented": true,
+    "featureIds": [
+      "F021",
+      "F044",
+      "F045"
+    ]
+  },
+  {
+    "id": "T007",
+    "description": "host-agent POST /v1/control-plane/upgrade runs the bootstrap apply with the resolved digest and returns without blocking on the Recreate (host-agent test with fake resolve/ctr/kubectl)",
+    "implemented": true,
+    "featureIds": [
+      "F040",
+      "F041"
+    ]
+  },
+  {
+    "id": "T008",
+    "description": "POST /api/control-plane/upgrade forwards to the host-agent socket and returns 202 (route test)",
+    "implemented": true,
+    "featureIds": [
+      "F042"
+    ]
+  },
+  {
+    "id": "T009",
+    "description": "Live VM smoke: control-plane upgrade swaps the running digest and the UI reconnects and confirms the new digest",
+    "implemented": true,
+    "featureIds": [
+      "F046",
+      "F047"
+    ]
+  },
+  {
+    "id": "T010",
+    "description": "License apply happy path: a valid JWS updates the appliance-license-seed secret and triggers an app rollout restart (engine/route test with fake kubectl)",
+    "implemented": true,
+    "featureIds": [
+      "F060",
+      "F061",
+      "F062"
+    ]
+  },
+  {
+    "id": "T011",
+    "description": "License apply rejects an invalid JWS with a clear error and does not mutate the secret",
+    "implemented": true,
+    "featureIds": [
+      "F064"
+    ]
+  },
+  {
+    "id": "T012",
+    "description": "License status decodes current edition + expiry from the seed/JWS",
+    "implemented": true,
+    "featureIds": [
+      "F065"
+    ]
+  },
+  {
+    "id": "T013",
+    "description": "Settings app-url: rewrites appUrl/host/domainSuffix in the alga-core values, persists release-selection.json runtime.appHostname, and reconciles the HelmRelease; normalizes a full http://host:port input (engine test with fakes)",
+    "implemented": true,
+    "featureIds": [
+      "F070",
+      "F071",
+      "F072",
+      "F074"
+    ]
+  },
+  {
+    "id": "T014",
+    "description": "Live VM smoke: editing the app hostname in Settings propagates to NEXTAUTH_URL and sign-in works at the configured URL",
+    "implemented": true,
+    "featureIds": [
+      "F072"
+    ]
+  },
+  {
+    "id": "T015",
+    "description": "Each mutating action shows a confirmation step and a result/failure state (representative status-ui interaction test across update/upgrade/license/settings)",
+    "implemented": true,
+    "featureIds": [
+      "F080",
+      "F034",
+      "F048"
+    ]
+  }
 ]

--- a/ee/docs/plans/2026-06-19-appliance-management-surface/tests.json
+++ b/ee/docs/plans/2026-06-19-appliance-management-surface/tests.json
@@ -1,0 +1,17 @@
+[
+  { "id": "T001", "description": "reconcileFluxAndHelm passes the configured/in-cluster kubeconfig (not the hardcoded /etc/rancher/k3s/k3s.yaml) — host-service engine test with fake flux/kubectl asserting the path", "implemented": false, "featureIds": ["F001"] },
+  { "id": "T002", "description": "Live VM smoke: an app-channel update completes end to end through flux/helm reconcile from the pod and install-state reaches complete", "implemented": false, "featureIds": ["F002", "F031", "F032"] },
+  { "id": "T003", "description": "Manage nav: sidebar shows 'Manage', opens the in-SPA Manage section with all four sub-tabs, and triggers no /setup navigation or 303 (status-ui DOM/smoke test)", "implemented": false, "featureIds": ["F010", "F011", "F012", "F014"] },
+  { "id": "T004", "description": "Auth guard: unauthenticated calls to /api/manage/status, /api/control-plane/upgrade, /api/license/apply, /api/settings/app-url all return 401", "implemented": false, "featureIds": ["F013", "F024", "F043", "F063", "F073"] },
+  { "id": "T005", "description": "GET /api/manage/status aggregates app version+channel, control-plane digests, edition+expiry, and app URL/DNS (engine/route test with fakes)", "implemented": false, "featureIds": ["F020", "F021", "F022", "F023", "F025"] },
+  { "id": "T006", "description": "upgradeAvailable digest compare: true when resolved channel digest != running, false/no-op when equal", "implemented": false, "featureIds": ["F021", "F044", "F045"] },
+  { "id": "T007", "description": "host-agent POST /v1/control-plane/upgrade runs the bootstrap apply with the resolved digest and returns without blocking on the Recreate (host-agent test with fake resolve/ctr/kubectl)", "implemented": false, "featureIds": ["F040", "F041"] },
+  { "id": "T008", "description": "POST /api/control-plane/upgrade forwards to the host-agent socket and returns 202 (route test)", "implemented": false, "featureIds": ["F042"] },
+  { "id": "T009", "description": "Live VM smoke: control-plane upgrade swaps the running digest and the UI reconnects and confirms the new digest", "implemented": false, "featureIds": ["F046", "F047"] },
+  { "id": "T010", "description": "License apply happy path: a valid JWS updates the appliance-license-seed secret and triggers an app rollout restart (engine/route test with fake kubectl)", "implemented": false, "featureIds": ["F060", "F061", "F062"] },
+  { "id": "T011", "description": "License apply rejects an invalid JWS with a clear error and does not mutate the secret", "implemented": false, "featureIds": ["F064"] },
+  { "id": "T012", "description": "License status decodes current edition + expiry from the seed/JWS", "implemented": false, "featureIds": ["F065"] },
+  { "id": "T013", "description": "Settings app-url: rewrites appUrl/host/domainSuffix in the alga-core values, persists release-selection.json runtime.appHostname, and reconciles the HelmRelease; normalizes a full http://host:port input (engine test with fakes)", "implemented": false, "featureIds": ["F070", "F071", "F072", "F074"] },
+  { "id": "T014", "description": "Live VM smoke: editing the app hostname in Settings propagates to NEXTAUTH_URL and sign-in works at the configured URL", "implemented": false, "featureIds": ["F072"] },
+  { "id": "T015", "description": "Each mutating action shows a confirmation step and a result/failure state (representative status-ui interaction test across update/upgrade/license/settings)", "implemented": false, "featureIds": ["F080", "F034", "F048"] }
+]


### PR DESCRIPTION
## Summary

Adds a post-install **Manage** surface to the appliance status UI, repurposing the dead "Setup" sidebar entry. It gives an operator a home for the things that previously had none: triggering app updates, upgrading the control plane, applying a license, and correcting the app URL/DNS — without a host shell or a reboot.

Design + plan: `ee/docs/plans/2026-06-19-appliance-management-surface/` (design.md, PRD.md, features.json, tests.json).

## What's in it

- **Manage UI** — the sidebar "Setup" link becomes an in-SPA "Manage" area (no `/setup` navigation, so no 303 bounce; the `/setup` wizard stays pre-install only). Four sub-tabs: Updates, Control-plane, License, Settings — each with confirm + in-progress + result states.
- **Updates** — surfaces the existing app-channel update (within the installed channel) with status polling; `/api/updates` is now fire-and-forget (202) so the UI can poll install-state.
- **Control-plane upgrade** — new `POST /api/control-plane/upgrade` → the host-agent (root, on host) runs the proven bootstrap apply via a new `--control-plane-only` flag, so the swap survives the pod Recreate. UI shows "reconnecting…" and the recovery hint on failure.
- **License** — new `POST /api/license/apply` validates an airgap JWS, patches the `appliance-license-seed` secret, and rolls the app; shows edition + expiry.
- **Settings** — new `POST /api/settings/app-url` rewrites the alga-core values, persists `release-selection.json` runtime, and reconciles the HelmRelease so `NEXTAUTH_URL` follows (the in-product fix for the `alga.local` class of problem).
- **Prerequisite fix** — `reconcileFluxAndHelm` now honors `ALGA_APPLIANCE_KUBECONFIG` (was a hardcoded `/etc` path that broke the in-pod app-update reconcile), and the control-plane RBAC gains `helmcharts`/`buckets` so `flux reconcile --with-source` completes.

`GET /api/manage/status` aggregates everything (app version+channel, running-vs-resolved control-plane digest, edition+expiry, app URL/DNS). All mutating endpoints are auth-gated.

## Testing

- Host-service suite green (71/71), including new `manage-engine.test.mjs` (license apply/reject, settings rewrite, status digest compare).
- **Validated live on the libvirt VM** (built the control-plane image + updated host files + RBAC): status aggregation, settings rewrite → release-selection persist → reconcile, license apply (secret patched), an app update that **completes** through reconcile (the prereq fix; was broken before), the Manage UI rendering with live data, and the control-plane upgrade mechanism (host-agent route + `--control-plane-only` dry-run).

## Out of scope (v1)

Install-code re-redemption / tenant rebind, automatic control-plane rollback (`alga-control-plane-reapply` remains recovery), OS/k3s updates, and re-running the full setup workflow.

## Deploy note

The host-agent + bootstrap script run on the **host** (`/opt/alga-appliance/`, baked from these sources via the ISO), separate from the control-plane pod image — both ship from this branch.

https://claude.ai/code/session_01ALZZLFcCGwWgJJD5KBeKUr