### PR TITLE
Add a read-only window for the appliance console

### DIFF
--- a/ee/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
+++ b/ee/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Appliance Console API — appliance install detail.
+ *
+ * GET /api/v1/appliance-installs/:tenantId — registry tenant detail (entitlement,
+ * install codes, appliances) for one appliance.
+ *
+ * Access restricted to MASTER_BILLING_TENANT_ID. Thin read-proxy to alga-license
+ * (C4) GET /tenants/:tenant_id.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { PlatformReportAuditService as ExtensionAuditService, extractClientInfo } from '@ee/lib/platformReports';
+import { assertMasterTenantAccess, isAuthError } from '@ee/lib/applianceConsole/auth';
+import { getApplianceTenant } from '@ee/lib/applianceConsole/algaLicenseAdminClient';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface RouteContext {
+  params: Promise<{ tenantId: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  try {
+    const { tenantId: masterTenantId, userId, userEmail } = await assertMasterTenantAccess(request);
+    const { tenantId } = await context.params;
+    const audit = new ExtensionAuditService(masterTenantId);
+
+    const detail = await getApplianceTenant(tenantId);
+    if (!detail) {
+      return NextResponse.json({ success: false, error: 'Appliance tenant not found' }, { status: 404 });
+    }
+
+    const clientInfo = extractClientInfo(request);
+    await audit.logEvent({
+      eventType: 'appliance.view',
+      userId,
+      userEmail,
+      resourceType: 'appliance',
+      resourceId: tenantId,
+      resourceName: detail.tenant.company_name,
+      ...clientInfo,
+    });
+
+    return NextResponse.json({ success: true, data: detail });
+  } catch (error) {
+    console.error('[appliance-installs/:tenantId] GET error:', error);
+    if (isAuthError(error)) {
+      return NextResponse.json({ success: false, error: (error as Error).message }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/ee/server/src/app/api/v1/appliance-installs/access/route.ts
+++ b/ee/server/src/app/api/v1/appliance-installs/access/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Appliance Console API — access logging.
+ *
+ * POST /api/v1/appliance-installs/access — record that an operator opened the
+ * Appliance Console (called on iframe load), for the audit trail.
+ *
+ * Static segment; takes precedence over the sibling [tenantId] dynamic route.
+ * Access restricted to MASTER_BILLING_TENANT_ID.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { PlatformReportAuditService as ExtensionAuditService, extractClientInfo } from '@ee/lib/platformReports';
+import { assertMasterTenantAccess, isAuthError } from '@ee/lib/applianceConsole/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { tenantId, userId, userEmail } = await assertMasterTenantAccess(request);
+    const audit = new ExtensionAuditService(tenantId);
+
+    let details: Record<string, unknown> = {};
+    try {
+      const body = await request.json();
+      if (body && typeof body === 'object' && body.details && typeof body.details === 'object') {
+        details = body.details as Record<string, unknown>;
+      }
+    } catch {
+      /* no body or invalid JSON */
+    }
+
+    const clientInfo = extractClientInfo(request);
+    await audit.logEvent({
+      eventType: 'appliance.access',
+      userId,
+      userEmail,
+      details: { ...details, accessedAt: new Date().toISOString() },
+      ...clientInfo,
+    });
+
+    return NextResponse.json({ success: true, message: 'Access logged' });
+  } catch (error) {
+    console.error('[appliance-installs/access] POST error:', error);
+    if (isAuthError(error)) {
+      return NextResponse.json({ success: false, error: (error as Error).message }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/ee/server/src/app/api/v1/appliance-installs/route.ts
+++ b/ee/server/src/app/api/v1/appliance-installs/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Appliance Console API — list appliance installs.
+ *
+ * GET /api/v1/appliance-installs — list registry tenants (deployment_type=appliance).
+ *
+ * Access restricted to MASTER_BILLING_TENANT_ID. Thin read-proxy: forwards to the
+ * alga-license service (C4) GET /tenants with the server-held service secret and
+ * audits the access. No license data or credentials reach the extension/browser.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { PlatformReportAuditService as ExtensionAuditService, extractClientInfo } from '@ee/lib/platformReports';
+import { assertMasterTenantAccess, isAuthError } from '@ee/lib/applianceConsole/auth';
+import { listApplianceTenants } from '@ee/lib/applianceConsole/algaLicenseAdminClient';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { tenantId, userId, userEmail } = await assertMasterTenantAccess(request);
+    const audit = new ExtensionAuditService(tenantId);
+
+    const { searchParams } = new URL(request.url);
+    const limitRaw = searchParams.get('limit');
+    const limit = limitRaw ? Math.min(Math.max(parseInt(limitRaw, 10) || 0, 1), 200) : undefined;
+
+    const result = await listApplianceTenants({
+      query: searchParams.get('query') || undefined,
+      edition: searchParams.get('edition') || undefined,
+      product_code: searchParams.get('product_code') || undefined,
+      status: searchParams.get('status') || undefined,
+      limit,
+      cursor: searchParams.get('cursor') || undefined,
+    });
+
+    const clientInfo = extractClientInfo(request);
+    await audit.logEvent({
+      eventType: 'appliance.list',
+      userId,
+      userEmail,
+      details: { count: result.items.length },
+      ...clientInfo,
+    });
+
+    return NextResponse.json({ success: true, data: result.items, next_cursor: result.next_cursor });
+  } catch (error) {
+    console.error('[appliance-installs] GET error:', error);
+    if (isAuthError(error)) {
+      return NextResponse.json({ success: false, error: (error as Error).message }, { status: 403 });
+    }
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/ee/server/src/lib/applianceConsole/algaLicenseAdminClient.ts
+++ b/ee/server/src/lib/applianceConsole/algaLicenseAdminClient.ts
@@ -1,0 +1,183 @@
+/**
+ * Read-only admin client for the alga-license service ("C4").
+ *
+ * Backs the Appliance Console read-proxy: lists/inspects appliance tenants in the
+ * separate `alga_license` DB via C4's service-authed endpoints. The service secret
+ * stays on the server and is never exposed to the extension/browser. Mutating
+ * actions (reissue/resend/revoke/resign) go through Temporal, not this client.
+ *
+ * Contract mirrors `Nine-Minds/alga-license` src/api-types.ts + the planned
+ * `GET /tenants` and `GET /tenants/:tenant_id` endpoints (see
+ * .ai/nineminds-appliance-console-plan.md §7.1).
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export type ApplianceEdition = 'essentials' | 'pro' | 'premium';
+export type ApplianceProduct = 'psa' | 'algadesk';
+export type ApplianceStatus = 'registered' | 'installed' | 'active' | 'suspended' | 'cancelled';
+export type InstallCodeState = 'live' | 'consumed' | 'revoked' | 'expired' | 'none';
+
+export interface ApplianceListRow {
+  tenant_id: string;
+  company_name: string;
+  contact_email: string;
+  edition: ApplianceEdition;
+  product_code: ApplianceProduct;
+  status: ApplianceStatus;
+  registered_at: string;
+  installed_at: string | null;
+  /** Entitlement (paid only; null for essentials). */
+  stripe_sub_id: string | null;
+  tier: 'pro' | 'premium' | null;
+  seats: number | null;
+  entitlement_active: boolean | null;
+  /** max(appliances.last_checkin_at) across the tenant's entitlement. */
+  last_checkin_at: string | null;
+  appliance_count: number;
+  connected: boolean;
+  install_code_state: InstallCodeState;
+}
+
+export interface ApplianceListResult {
+  items: ApplianceListRow[];
+  next_cursor: string | null;
+}
+
+export interface ApplianceInstallCode {
+  /** Last 4 chars only — full code is never returned by the read API. */
+  code_masked: string;
+  expires_at: number; // unix seconds
+  consumed: boolean;
+  revoked: boolean;
+  created_at: string;
+}
+
+export interface ApplianceRecord {
+  appliance_id: string;
+  last_checkin_at: string | null;
+  revoked: boolean;
+}
+
+export interface ApplianceEntitlement {
+  stripe_sub_id: string;
+  tier: 'pro' | 'premium';
+  seats: number | null;
+  active: boolean;
+  license_sub: string | null;
+  /** Presence only — the raw token is not returned on detail reads. */
+  has_current_token: boolean;
+}
+
+export interface ApplianceTenantDetail {
+  tenant: {
+    tenant_id: string;
+    edition: ApplianceEdition;
+    product_code: ApplianceProduct;
+    deployment_type: 'appliance' | 'hosted';
+    region: string | null;
+    status: ApplianceStatus;
+    company_name: string;
+    contact_name: string | null;
+    contact_email: string;
+    stripe_customer_id: string | null;
+    registered_at: string;
+    installed_at: string | null;
+    created_at: string;
+    updated_at: string;
+  };
+  entitlement: ApplianceEntitlement | null;
+  install_codes: ApplianceInstallCode[];
+  appliances: ApplianceRecord[];
+}
+
+export interface ListApplianceTenantsParams {
+  query?: string;
+  edition?: string;
+  product_code?: string;
+  status?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+interface AlgaLicenseConfig {
+  serviceUrl: string;
+  serviceSecret: string;
+}
+
+/**
+ * Read the service secret from inline env or a Vault-rendered file, matching the
+ * loader in nm-store/alga-license (ALGA_LICENSE_SERVICE_SECRET[_FILE]).
+ */
+function loadServiceSecret(): string {
+  const inline = process.env.ALGA_LICENSE_SERVICE_SECRET;
+  if (inline) return inline.trim();
+
+  const file = process.env.ALGA_LICENSE_SERVICE_SECRET_FILE;
+  if (file) {
+    const resolved = resolve(file);
+    if (!existsSync(resolved)) {
+      throw new Error(`ALGA_LICENSE_SERVICE_SECRET_FILE not found: ${resolved}`);
+    }
+    return readFileSync(resolved, 'utf8').trim();
+  }
+
+  throw new Error('ALGA_LICENSE_SERVICE_SECRET (or ALGA_LICENSE_SERVICE_SECRET_FILE) is not configured');
+}
+
+function configFromEnv(): AlgaLicenseConfig {
+  const serviceUrl = process.env.ALGA_LICENSE_SERVICE_URL;
+  if (!serviceUrl) throw new Error('ALGA_LICENSE_SERVICE_URL is not configured');
+  return { serviceUrl: serviceUrl.replace(/\/$/, ''), serviceSecret: loadServiceSecret() };
+}
+
+async function get<T>(path: string): Promise<{ status: number; data: T | null }> {
+  const config = configFromEnv();
+  let res: Response;
+  try {
+    res = await fetch(`${config.serviceUrl}${path}`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${config.serviceSecret}`, accept: 'application/json' },
+    });
+  } catch (err) {
+    throw new Error(`alga-license GET ${path} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (res.status === 404) return { status: 404, data: null };
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const body = (await res.json()) as { error?: string; code?: string };
+      detail = body.error ? ` — ${body.error}${body.code ? ` (${body.code})` : ''}` : '';
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(`alga-license GET ${path} returned HTTP ${res.status}${detail}`);
+  }
+
+  return { status: res.status, data: (await res.json()) as T };
+}
+
+/** List appliance registry tenants (forces deployment_type=appliance). */
+export async function listApplianceTenants(
+  params: ListApplianceTenantsParams = {},
+): Promise<ApplianceListResult> {
+  const qs = new URLSearchParams();
+  qs.set('deployment_type', 'appliance');
+  if (params.query) qs.set('query', params.query);
+  if (params.edition) qs.set('edition', params.edition);
+  if (params.product_code) qs.set('product_code', params.product_code);
+  if (params.status) qs.set('status', params.status);
+  if (params.limit) qs.set('limit', String(params.limit));
+  if (params.cursor) qs.set('cursor', params.cursor);
+
+  const { data } = await get<ApplianceListResult>(`/tenants?${qs.toString()}`);
+  return data ?? { items: [], next_cursor: null };
+}
+
+/** Fetch one appliance tenant's detail; null if the registry has no such tenant. */
+export async function getApplianceTenant(tenantId: string): Promise<ApplianceTenantDetail | null> {
+  const { data } = await get<ApplianceTenantDetail>(`/tenants/${encodeURIComponent(tenantId)}`);
+  return data;
+}

--- a/ee/server/src/lib/applianceConsole/auth.ts
+++ b/ee/server/src/lib/applianceConsole/auth.ts
@@ -1,0 +1,66 @@
+/**
+ * Master-tenant authorization gate for the Appliance Console API.
+ *
+ * Mirrors the platform-reports gate: the caller MUST belong to
+ * MASTER_BILLING_TENANT_ID, via either API-key auth (extension uiProxy) or
+ * session auth (direct browser). Operator identity is forwarded by the runner as
+ * x-user-id / x-user-email for auditing.
+ */
+
+import { NextRequest } from 'next/server';
+import { getCurrentUser } from '@alga-psa/user-composition/actions';
+import { ApiKeyServiceForApi } from '@/lib/services/apiKeyServiceForApi';
+
+const MASTER_BILLING_TENANT_ID = process.env.MASTER_BILLING_TENANT_ID;
+
+export interface MasterTenantCaller {
+  tenantId: string;
+  userId?: string;
+  userEmail?: string;
+}
+
+export async function assertMasterTenantAccess(request: NextRequest): Promise<MasterTenantCaller> {
+  if (!MASTER_BILLING_TENANT_ID) {
+    throw new Error('MASTER_BILLING_TENANT_ID not configured on server');
+  }
+
+  const extensionId = request.headers.get('x-alga-extension');
+
+  // API KEY AUTH (extension uiProxy → ext-proxy → here)
+  const apiKey = request.headers.get('x-api-key');
+  if (apiKey) {
+    const keyRecord = await ApiKeyServiceForApi.validateApiKeyAnyTenant(apiKey);
+    if (keyRecord) {
+      if (keyRecord.tenant === MASTER_BILLING_TENANT_ID) {
+        const headerUserId = request.headers.get('x-user-id');
+        const headerUserEmail = request.headers.get('x-user-email');
+        return {
+          tenantId: MASTER_BILLING_TENANT_ID,
+          userId: headerUserId || (extensionId ? `extension:${extensionId}` : keyRecord.user_id),
+          userEmail: headerUserEmail || undefined,
+        };
+      }
+      throw new Error('Access denied: API key not authorized for the appliance console');
+    }
+    console.warn('[appliance-installs] Invalid API key');
+  }
+
+  // SESSION AUTH (direct browser)
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error('Authentication required');
+  }
+  if (user.tenant !== MASTER_BILLING_TENANT_ID) {
+    throw new Error('Access denied: appliance console requires master tenant access');
+  }
+
+  return { tenantId: MASTER_BILLING_TENANT_ID, userId: user.user_id, userEmail: user.email };
+}
+
+/** True for auth/authorization failures from assertMasterTenantAccess → map to 403. */
+export function isAuthError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes('Access denied') || error.message.includes('Authentication'))
+  );
+}

--- a/ee/server/src/lib/platformReports/auditService.ts
+++ b/ee/server/src/lib/platformReports/auditService.ts
@@ -41,12 +41,23 @@ export type NotificationEventType =
   | 'notification.stats'
   | 'notification.resolve_recipients';
 
+// Appliance console events (NineMinds Appliance Console extension)
+export type ApplianceEventType =
+  | 'appliance.list'
+  | 'appliance.view'
+  | 'appliance.access'
+  | 'appliance.reissue'
+  | 'appliance.resend'
+  | 'appliance.revoke'
+  | 'appliance.suspend'
+  | 'appliance.resign';
+
 // General events
 export type GeneralEventType = 'extension.access';
 
-export type AuditEventType = ReportEventType | TenantEventType | NotificationEventType | GeneralEventType;
+export type AuditEventType = ReportEventType | TenantEventType | NotificationEventType | ApplianceEventType | GeneralEventType;
 
-export type ResourceType = 'report' | 'tenant' | 'user' | 'subscription' | 'notification';
+export type ResourceType = 'report' | 'tenant' | 'user' | 'subscription' | 'notification' | 'appliance';
 export type AuditStatus = 'pending' | 'completed' | 'failed' | 'running';
 
 export interface AuditLogEntry {

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -836,6 +836,21 @@ spec:
                 key: APPLE_SIGN_IN_ENCRYPTION_KEY
           {{- end }}
 
+          # Appliance license service (alga-license / C4) — Appliance Console read-proxy.
+          # URL is non-secret config; the service secret is generated into the chart
+          # secret from .Values.secrets.ALGA_LICENSE_SERVICE_SECRET (see secret.yaml).
+          {{- if and .Values.licenseService .Values.licenseService.url }}
+          - name: ALGA_LICENSE_SERVICE_URL
+            value: "{{ .Values.licenseService.url }}"
+          {{- end }}
+          {{- if and .Values.secrets .Values.secrets.ALGA_LICENSE_SERVICE_SECRET }}
+          - name: ALGA_LICENSE_SERVICE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{include "sebastian.fullname" .}}-secrets"
+                key: ALGA_LICENSE_SERVICE_SECRET
+          {{- end }}
+
           # Non-sensitive Stripe configuration
           {{- if .Values.stripe }}
           {{- if .Values.stripe.master_billing_tenant_id_secret }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -118,6 +118,11 @@ data:
   {{- else if index $existing.data "TEAMS_BOT_APP_PASSWORD" }}
   TEAMS_BOT_APP_PASSWORD: {{ index $existing.data "TEAMS_BOT_APP_PASSWORD" }}
   {{- end }}
+  {{- if and .Values.secrets .Values.secrets.ALGA_LICENSE_SERVICE_SECRET }}
+  ALGA_LICENSE_SERVICE_SECRET: {{ .Values.secrets.ALGA_LICENSE_SERVICE_SECRET | b64enc | quote }}
+  {{- else if index $existing.data "ALGA_LICENSE_SERVICE_SECRET" }}
+  ALGA_LICENSE_SERVICE_SECRET: {{ index $existing.data "ALGA_LICENSE_SERVICE_SECRET" }}
+  {{- end }}
 {{- else }}
   {{- /* First install — generate or use explicit values */}}
   {{- if .Values.secrets }}
@@ -178,6 +183,9 @@ data:
   {{- end }}
   {{- if .Values.secrets.TEAMS_BOT_APP_PASSWORD }}
   TEAMS_BOT_APP_PASSWORD: {{ .Values.secrets.TEAMS_BOT_APP_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.ALGA_LICENSE_SERVICE_SECRET }}
+  ALGA_LICENSE_SERVICE_SECRET: {{ .Values.secrets.ALGA_LICENSE_SERVICE_SECRET | b64enc | quote }}
   {{- end }}
   {{- else }}
   NEXTAUTH_SECRET: {{ randAlphaNum 32 | b64enc | quote }}


### PR DESCRIPTION
  A one-way pane onto the fleet of self-hosted appliances: the console
  may look but never reach through. Only the bearer of the master key is
  admitted to the glass, every glance is noted in the margins, and the
  chart now tucks away the sealed letter that lets the watcher hail the
  faraway registry.

  What is seen cannot be touched, and what is whispered stays under seal. 🔭🗝️