### PR TITLE
fix(email): stop auto-reply reopen loops (RFC 3834/5230)

### DIFF
--- a/server/src/lib/notifications/sendEventEmail.ts
+++ b/server/src/lib/notifications/sendEventEmail.ts
@@ -9,6 +9,7 @@ import { getUserInfoForEmail, resolveEmailLocale } from '@alga-psa/notifications
 import { SupportedLocale } from '@alga-psa/core/i18n/config';
 import Handlebars from 'handlebars';
 import { EmailAddress, EmailAttachment } from '../../types/email.types';
+import { AUTO_GENERATED_MAIL_HEADERS } from '@shared/lib/email/automatedMessage';
 
 const REPLY_BANNER_TEXT = '--- Please reply above this line ---';
 const EMAIL_SERVICE_DISABLED_MESSAGE = 'Email service is disabled or not configured';
@@ -432,7 +433,9 @@ export async function sendEventEmail(params: SendEmailParams): Promise<void> {
       notificationSubtypeId: params.notificationSubtypeId,
       replyContext: effectiveReplyContext,
       templateProcessor: processor,
-      headers: params.headers,
+      // RFC 3834: mark event-driven notifications as auto-generated so compliant
+      // recipient systems do not auto-reply (caller-supplied headers win on conflict).
+      headers: { ...AUTO_GENERATED_MAIL_HEADERS, ...params.headers },
       attachments: params.attachments,
       providerId: params.providerId,
       from: params.from,

--- a/server/src/services/surveyService.ts
+++ b/server/src/services/surveyService.ts
@@ -9,6 +9,7 @@ import logger from '@alga-psa/core/logger';
 import { createTenantKnex, runWithTenant } from '../lib/db';
 import { issueSurveyToken } from '@alga-psa/surveys/actions/surveyTokenService';
 import { TenantEmailService } from '@alga-psa/email';
+import { AUTO_GENERATED_MAIL_HEADERS } from '@shared/lib/email/automatedMessage';
 import { isValidEmail } from '@alga-psa/core';
 import { DatabaseTemplateProcessor } from '@alga-psa/email';
 import { resolveEmailLocale } from '@alga-psa/notifications/notifications/emailLocaleResolver';
@@ -283,6 +284,8 @@ export async function sendSurveyInvitation(params: SendSurveyInvitationParams): 
         templateProcessor: processor,
         templateData,
         locale,
+        // RFC 3834: survey invitations are auto-generated; suppress recipient auto-replies.
+        headers: { ...AUTO_GENERATED_MAIL_HEADERS },
       });
 
       if (!sendResult.success) {

--- a/shared/lib/email/__tests__/automatedMessage.test.ts
+++ b/shared/lib/email/__tests__/automatedMessage.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTO_GENERATED_MAIL_HEADERS,
+  detectAutomatedInboundMessage,
+  extractRelevantInboundHeaders,
+} from '../automatedMessage';
+
+function withHeaders(headers: Record<string, string>) {
+  return { headers };
+}
+
+describe('detectAutomatedInboundMessage', () => {
+  it('treats a genuine human reply as not automated', () => {
+    const result = detectAutomatedInboundMessage(
+      withHeaders({
+        'From': 'person@example.com',
+        'Subject': 'Re: Ticket Closed',
+        'Auto-Submitted': 'no',
+      })
+    );
+    expect(result.isAutomated).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  it('returns not automated when no headers are present', () => {
+    expect(detectAutomatedInboundMessage({ headers: undefined }).isAutomated).toBe(false);
+    expect(detectAutomatedInboundMessage({}).isAutomated).toBe(false);
+  });
+
+  it('flags RFC 3834 Auto-Submitted: auto-replied (case-insensitive, with comment)', () => {
+    const result = detectAutomatedInboundMessage(withHeaders({ 'auto-submitted': 'Auto-Replied (vacation)' }));
+    expect(result.isAutomated).toBe(true);
+    expect(result.reason).toBe('auto-submitted');
+  });
+
+  it('flags Auto-Submitted: auto-generated', () => {
+    expect(detectAutomatedInboundMessage(withHeaders({ 'Auto-Submitted': 'auto-generated' })).reason).toBe(
+      'auto-submitted'
+    );
+  });
+
+  it('flags a null reverse-path (RFC 5321 bounce)', () => {
+    expect(detectAutomatedInboundMessage(withHeaders({ 'Return-Path': '<>' })).reason).toBe('null-return-path');
+    expect(detectAutomatedInboundMessage(withHeaders({ 'Return-Path': '< >' })).reason).toBe('null-return-path');
+  });
+
+  it('does not flag a normal return-path', () => {
+    expect(
+      detectAutomatedInboundMessage(withHeaders({ 'Return-Path': '<sender@example.com>' })).isAutomated
+    ).toBe(false);
+  });
+
+  it('flags a delivery-status report (DSN)', () => {
+    expect(
+      detectAutomatedInboundMessage(
+        withHeaders({ 'Content-Type': 'multipart/report; report-type=delivery-status; boundary="x"' })
+      ).reason
+    ).toBe('delivery-status-report');
+  });
+
+  it('flags list mail via any List-* header (RFC 2919/2369)', () => {
+    expect(detectAutomatedInboundMessage(withHeaders({ 'List-Id': '<list.example.com>' })).reason).toBe(
+      'list-header'
+    );
+    expect(
+      detectAutomatedInboundMessage(withHeaders({ 'List-Unsubscribe': '<mailto:x@example.com>' })).reason
+    ).toBe('list-header');
+  });
+
+  it('flags Precedence bulk/junk/auto-reply', () => {
+    expect(detectAutomatedInboundMessage(withHeaders({ Precedence: 'bulk' })).reason).toBe('precedence-bulk');
+    expect(detectAutomatedInboundMessage(withHeaders({ Precedence: 'auto_reply' })).reason).toBe('precedence-bulk');
+  });
+
+  it('does not flag Precedence: list-less normal mail', () => {
+    expect(detectAutomatedInboundMessage(withHeaders({ Precedence: 'normal' })).isAutomated).toBe(false);
+  });
+
+  it('flags Microsoft X-Auto-Response-Suppress and X-Autoreply', () => {
+    expect(
+      detectAutomatedInboundMessage(withHeaders({ 'X-Auto-Response-Suppress': 'All' })).reason
+    ).toBe('x-auto-response-suppress');
+    expect(detectAutomatedInboundMessage(withHeaders({ 'X-Autoreply': 'yes' })).reason).toBe('x-autoreply');
+  });
+});
+
+describe('extractRelevantInboundHeaders', () => {
+  it('projects only standards-relevant headers with lower-cased keys', () => {
+    const out = extractRelevantInboundHeaders(
+      withHeaders({
+        'Auto-Submitted': 'auto-replied',
+        'Subject': 'irrelevant',
+        'X-Mailer': 'irrelevant',
+        'List-Id': '<l.example.com>',
+      })
+    );
+    expect(out).toEqual({ 'auto-submitted': 'auto-replied', 'list-id': '<l.example.com>' });
+  });
+
+  it('returns an empty object when no relevant headers exist', () => {
+    expect(extractRelevantInboundHeaders(withHeaders({ Subject: 'hi' }))).toEqual({});
+    expect(extractRelevantInboundHeaders({ headers: undefined })).toEqual({});
+  });
+});
+
+describe('AUTO_GENERATED_MAIL_HEADERS', () => {
+  it('marks outbound mail as auto-generated per RFC 3834', () => {
+    expect(AUTO_GENERATED_MAIL_HEADERS['Auto-Submitted']).toBe('auto-generated');
+    expect(AUTO_GENERATED_MAIL_HEADERS['X-Auto-Response-Suppress']).toContain('AutoReply');
+  });
+});

--- a/shared/lib/email/automatedMessage.ts
+++ b/shared/lib/email/automatedMessage.ts
@@ -1,0 +1,197 @@
+/**
+ * RFC 3834 / RFC 5230 automated-message handling for inbound and outbound mail.
+ *
+ * Inbound  - `detectAutomatedInboundMessage()` recognizes auto-replies, vacation/OOO
+ *            responses, delivery-status bounces, and bulk/list mail so callers can avoid
+ *            acting on them (e.g. reopening a closed ticket on an auto-acknowledgement,
+ *            which produces a notification -> auto-reply -> reopen email loop). Detection
+ *            is header-based on purpose: body heuristics risk suppressing genuine human
+ *            replies. To also stop non-compliant responders, layer a per-sender rate
+ *            limit (RFC 5230 vacation semantics) on top of this.
+ *
+ * Outbound - `AUTO_GENERATED_MAIL_HEADERS` marks our own system notifications so that
+ *            well-behaved recipient systems do not auto-respond to them (RFC 3834 sec 5;
+ *            `X-Auto-Response-Suppress` for Microsoft Exchange). These headers do NOT
+ *            stop a human from replying.
+ *
+ * Relevant standards: RFC 3834 (Auto-Submitted), RFC 5230 (Sieve vacation), RFC 5321
+ * (null reverse-path), RFC 3462/3464 (delivery-status reports), RFC 2919/2369 (List-*),
+ * plus the de-facto `Precedence`, `X-Auto-Response-Suppress`, `X-Autoreply` headers.
+ */
+
+import type { EmailMessageDetails } from '../../interfaces/inbound-email.interfaces';
+
+/** Header names consulted when classifying inbound mail (lower-cased for matching). */
+const RELEVANT_INBOUND_HEADER_NAMES = [
+  'auto-submitted',
+  'precedence',
+  'return-path',
+  'content-type',
+  'x-auto-response-suppress',
+  'x-autoreply',
+  'x-autorespond',
+  'x-loop',
+  'list-id',
+  'list-unsubscribe',
+  'list-help',
+  'list-post',
+  'list-subscribe',
+  'list-archive',
+  'list-owner',
+] as const;
+
+export type AutomatedMessageReason =
+  | 'auto-submitted'
+  | 'null-return-path'
+  | 'delivery-status-report'
+  | 'list-header'
+  | 'precedence-bulk'
+  | 'x-auto-response-suppress'
+  | 'x-autoreply'
+  | 'x-loop';
+
+export interface AutomatedMessageSignal {
+  /** True when the message looks machine-generated (auto-reply, vacation, bounce, bulk/list). */
+  isAutomated: boolean;
+  /** Stable machine-readable reason code, or null when not automated. */
+  reason: AutomatedMessageReason | null;
+  /** Human-readable detail (e.g. the offending header value) for diagnostics. */
+  detail: string | null;
+}
+
+function buildHeaderLookup(
+  headers: Record<string, string> | undefined
+): (name: string) => string | null {
+  const normalized = new Map<string, string>();
+  if (headers) {
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        normalized.set(key.trim().toLowerCase(), value);
+      }
+    }
+  }
+  return (name: string) => {
+    const found = normalized.get(name.toLowerCase());
+    return typeof found === 'string' ? found.trim() : null;
+  };
+}
+
+/**
+ * Project the standards-relevant headers from an inbound message for persistence and
+ * forensics. (The previous metadata snapshot dropped these, which made auto-reply loops
+ * hard to diagnose after the fact.) Returns a lower-cased-key map of only present headers.
+ */
+export function extractRelevantInboundHeaders(
+  emailData: Pick<EmailMessageDetails, 'headers'>
+): Record<string, string> {
+  const get = buildHeaderLookup(emailData.headers);
+  const out: Record<string, string> = {};
+  for (const name of RELEVANT_INBOUND_HEADER_NAMES) {
+    const value = get(name);
+    if (value) {
+      out[name] = value;
+    }
+  }
+  return out;
+}
+
+/** Reduce a header value to its leading token, dropping params/comments ("auto-replied (vacation)" -> "auto-replied"). */
+function headerToken(value: string): string {
+  return value.split(';')[0]?.split('(')[0]?.trim().toLowerCase() ?? '';
+}
+
+/**
+ * Detect machine-generated inbound mail. Returns the first matching signal so the reason
+ * is deterministic. Header-only by design (see file header).
+ */
+export function detectAutomatedInboundMessage(
+  emailData: Pick<EmailMessageDetails, 'headers'>
+): AutomatedMessageSignal {
+  const get = buildHeaderLookup(emailData.headers);
+  const automated = (reason: AutomatedMessageReason, detail: string | null): AutomatedMessageSignal => ({
+    isAutomated: true,
+    reason,
+    detail,
+  });
+
+  // RFC 3834 sec 5: any Auto-Submitted value other than "no" marks automatic submission.
+  const autoSubmitted = get('auto-submitted');
+  if (autoSubmitted && headerToken(autoSubmitted) !== 'no') {
+    return automated('auto-submitted', autoSubmitted);
+  }
+
+  // RFC 5321: a null reverse-path (<>) is used by bounces and most auto-responses.
+  const returnPath = get('return-path');
+  if (returnPath && returnPath.replace(/\s/g, '') === '<>') {
+    return automated('null-return-path', returnPath);
+  }
+
+  // RFC 3462/3464: delivery-status / disposition-notification reports are bounces/MDNs.
+  const contentType = get('content-type');
+  if (contentType) {
+    const ct = contentType.toLowerCase();
+    if (
+      ct.includes('multipart/report') &&
+      (ct.includes('report-type=delivery-status') || ct.includes('report-type=disposition-notification'))
+    ) {
+      return automated('delivery-status-report', contentType);
+    }
+  }
+
+  // RFC 2919 / RFC 2369: presence of any List-* header indicates list/bulk mail.
+  for (const name of [
+    'list-id',
+    'list-unsubscribe',
+    'list-post',
+    'list-help',
+    'list-subscribe',
+    'list-archive',
+    'list-owner',
+  ]) {
+    const value = get(name);
+    if (value) {
+      return automated('list-header', `${name}: ${value}`);
+    }
+  }
+
+  // De-facto: Precedence bulk/list/junk/auto-reply marks non-personal mail.
+  const precedence = get('precedence');
+  if (precedence) {
+    const token = headerToken(precedence).replace(/[\s_]+/g, '-');
+    if (['bulk', 'list', 'junk', 'auto-reply', 'auto-replied', 'auto-notified'].includes(token)) {
+      return automated('precedence-bulk', precedence);
+    }
+  }
+
+  // Microsoft Exchange: presence of X-Auto-Response-Suppress on inbound mail signals an automated sender.
+  const suppress = get('x-auto-response-suppress');
+  if (suppress) {
+    return automated('x-auto-response-suppress', suppress);
+  }
+
+  // De-facto auto-responder markers.
+  const xAutoreply = get('x-autoreply');
+  if (xAutoreply && xAutoreply.toLowerCase() !== 'no') {
+    return automated('x-autoreply', xAutoreply);
+  }
+  const xAutorespond = get('x-autorespond');
+  if (xAutorespond) {
+    return automated('x-autoreply', xAutorespond);
+  }
+  const xLoop = get('x-loop');
+  if (xLoop) {
+    return automated('x-loop', xLoop);
+  }
+
+  return { isAutomated: false, reason: null, detail: null };
+}
+
+/**
+ * Headers to attach to OUTBOUND system-generated notifications so that compliant
+ * recipient systems do not auto-reply to them (RFC 3834 sec 5; `X-Auto-Response-Suppress`
+ * for Exchange). These do NOT prevent humans from replying.
+ */
+export const AUTO_GENERATED_MAIL_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  'Auto-Submitted': 'auto-generated',
+  'X-Auto-Response-Suppress': 'OOF, AutoReply, AutoForward',
+});

--- a/shared/services/email/inboundReopenRateLimiter.test.ts
+++ b/shared/services/email/inboundReopenRateLimiter.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  checkInboundReopenRateLimit,
+  type InboundReopenRedisClient,
+} from './inboundReopenRateLimiter';
+
+/** In-memory stand-in for the node-redis client (INCR/EXPIRE/TTL). */
+function fakeRedis() {
+  const counts = new Map<string, number>();
+  const ttls = new Map<string, number>();
+  const client: InboundReopenRedisClient & { expireCalls: number } = {
+    expireCalls: 0,
+    async incr(key: string) {
+      const next = (counts.get(key) ?? 0) + 1;
+      counts.set(key, next);
+      return next;
+    },
+    async expire(key: string, seconds: number) {
+      client.expireCalls += 1;
+      ttls.set(key, seconds);
+      return true;
+    },
+    async ttl(key: string) {
+      return ttls.has(key) ? (ttls.get(key) as number) : -1;
+    },
+  };
+  return client;
+}
+
+describe('checkInboundReopenRateLimit', () => {
+  const ORIGINAL = { ...process.env };
+
+  beforeEach(() => {
+    process.env.INBOUND_REOPEN_RATELIMIT_MAX = '3';
+    process.env.INBOUND_REOPEN_RATELIMIT_WINDOW_SECONDS = '3600';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('allows up to the configured limit then denies', async () => {
+    const redis = fakeRedis();
+    const getter = async () => redis;
+    const results = [];
+    for (let i = 0; i < 5; i += 1) {
+      results.push(await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter }));
+    }
+    expect(results.map((r) => r.allowed)).toEqual([true, true, true, false, false]);
+    expect(results.map((r) => r.count)).toEqual([1, 2, 3, 4, 5]);
+    expect(results[0]).toMatchObject({ limit: 3, windowSeconds: 3600 });
+  });
+
+  it('sets the window TTL once on the first reopen', async () => {
+    const redis = fakeRedis();
+    const getter = async () => redis;
+    await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    expect(redis.expireCalls).toBe(1);
+  });
+
+  it('counts each ticket independently', async () => {
+    const redis = fakeRedis();
+    const getter = async () => redis;
+    await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    const other = await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k2', redisClientGetter: getter });
+    expect(other).toMatchObject({ allowed: true, count: 1 });
+  });
+
+  it('repairs a missing TTL defensively so a key cannot become permanent', async () => {
+    const redis = fakeRedis();
+    // Simulate a key that exists with no TTL (e.g. a lost EXPIRE).
+    await redis.incr('alga:inbound-reopen-rl:t1:k1');
+    const getter = async () => redis;
+    await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    expect(redis.expireCalls).toBe(1);
+  });
+
+  it('fails open when Redis errors (never blocks a legitimate reopen)', async () => {
+    const getter = async (): Promise<InboundReopenRedisClient> => ({
+      async incr() {
+        throw new Error('redis down');
+      },
+      async expire() {
+        return true;
+      },
+      async ttl() {
+        return -1;
+      },
+    });
+    const result = await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    expect(result.allowed).toBe(true);
+    expect(result.count).toBe(-1);
+  });
+
+  it('honors configured limit/window overrides', async () => {
+    process.env.INBOUND_REOPEN_RATELIMIT_MAX = '1';
+    const redis = fakeRedis();
+    const getter = async () => redis;
+    const first = await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    const second = await checkInboundReopenRateLimit({ tenantId: 't1', ticketId: 'k1', redisClientGetter: getter });
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(false);
+  });
+});

--- a/shared/services/email/inboundReopenRateLimiter.ts
+++ b/shared/services/email/inboundReopenRateLimiter.ts
@@ -1,0 +1,98 @@
+/**
+ * Redis-backed backstop that caps how often a single ticket can be reopened by inbound
+ * mail within a rolling window. This is the RFC 5230 (Sieve vacation) "do not respond to
+ * the same correspondent repeatedly" idea applied to ticket reopens: it bounds runaway
+ * notification -> auto-reply -> reopen loops driven by auto-responders that do NOT carry
+ * the standard auto-reply markers (which `detectAutomatedInboundMessage` relies on).
+ *
+ * Design notes:
+ * - Fixed-window counter via INCR + EXPIRE keyed per (tenant, ticket). Simple, atomic
+ *   enough for a backstop, and identical behavior in the server and the email-service
+ *   worker (no dependency on a process-specific rate-limiter singleton).
+ * - Reuses the inbound-email Redis connection the worker already opens.
+ * - Fails OPEN: a Redis hiccup must never block a legitimate reopen. The primary defenses
+ *   (RFC 3834 auto-reply detection + outbound Auto-Submitted marking) remain in force.
+ * - Only consult this when a reopen would otherwise happen, so ordinary comment-only
+ *   replies are not counted against the limit.
+ */
+
+import { getInboundEmailRedisClient } from './unifiedInboundEmailQueue';
+
+/** Minimal Redis surface needed for the fixed-window counter (satisfied by node-redis v4). */
+export interface InboundReopenRedisClient {
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<unknown>;
+  ttl(key: string): Promise<number>;
+}
+
+const KEY_PREFIX = 'alga:inbound-reopen-rl:';
+const DEFAULT_MAX_REOPENS = 3;
+const DEFAULT_WINDOW_SECONDS = 3600; // 1 hour
+
+export interface InboundReopenRateLimitResult {
+  /** True when the reopen is within the configured limit and should proceed. */
+  allowed: boolean;
+  /** Reopen attempts counted in the current window (including this one); -1 when unknown (fail-open). */
+  count: number;
+  /** Configured maximum reopens per window. */
+  limit: number;
+  /** Window length in seconds. */
+  windowSeconds: number;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number((value ?? '').trim());
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function getRateLimitConfig(): { limit: number; windowSeconds: number } {
+  return {
+    limit: parsePositiveInteger(process.env.INBOUND_REOPEN_RATELIMIT_MAX, DEFAULT_MAX_REOPENS),
+    windowSeconds: parsePositiveInteger(
+      process.env.INBOUND_REOPEN_RATELIMIT_WINDOW_SECONDS,
+      DEFAULT_WINDOW_SECONDS
+    ),
+  };
+}
+
+/**
+ * Record a reopen attempt for the ticket and report whether it is within the limit.
+ * Call this only when a reopen would otherwise be applied.
+ */
+export async function checkInboundReopenRateLimit(params: {
+  tenantId: string;
+  ticketId: string;
+  /** Override for tests; defaults to the shared inbound-email Redis connection. */
+  redisClientGetter?: () => Promise<InboundReopenRedisClient>;
+}): Promise<InboundReopenRateLimitResult> {
+  const { limit, windowSeconds } = getRateLimitConfig();
+  const key = `${KEY_PREFIX}${params.tenantId}:${params.ticketId}`;
+
+  try {
+    const getClient = params.redisClientGetter ?? getInboundEmailRedisClient;
+    const client = await getClient();
+    const count = await client.incr(key);
+
+    if (count === 1) {
+      // First reopen in this window — start the TTL.
+      await client.expire(key, windowSeconds);
+    } else {
+      // Defensive: ensure a TTL exists even if a prior EXPIRE was lost, so the key
+      // cannot become permanent and wedge the ticket in a suppressed state forever.
+      const ttl = await client.ttl(key);
+      if (ttl < 0) {
+        await client.expire(key, windowSeconds);
+      }
+    }
+
+    return { allowed: count <= limit, count, limit, windowSeconds };
+  } catch (error) {
+    // Fail open: never block a legitimate reopen on a Redis failure.
+    console.warn('[inboundReopenRateLimiter] check failed; allowing reopen (fail-open)', {
+      tenantId: params.tenantId,
+      ticketId: params.ticketId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { allowed: true, count: -1, limit, windowSeconds };
+  }
+}

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -3,6 +3,15 @@ import { createHash } from 'node:crypto';
 import { convertHtmlToBlockNote, convertMarkdownToBlocks } from '../../lib/utils/contentConversion';
 import { extractEmailDomain, normalizeEmailAddress } from '../../lib/email/addressUtils';
 import {
+  detectAutomatedInboundMessage,
+  extractRelevantInboundHeaders,
+  type AutomatedMessageSignal,
+} from '../../lib/email/automatedMessage';
+import {
+  checkInboundReopenRateLimit,
+  type InboundReopenRateLimitResult,
+} from './inboundReopenRateLimiter';
+import {
   processInboundEmailArtifactsBestEffort,
   type ProcessInboundEmailArtifactsResult,
 } from './processInboundEmailArtifacts';
@@ -47,6 +56,8 @@ export interface ProcessInboundEmailInAppDiagnostics extends Record<string, unkn
     from: string | null;
     to: string[];
     subject: string | null;
+    /** Standards-relevant headers (Auto-Submitted, Precedence, List-*, etc.) for loop diagnostics. */
+    relevantHeaders?: Record<string, string>;
   };
   threading: {
     tokenLookupAttempted: boolean;
@@ -156,6 +167,10 @@ type InboundReplyDecisionMetadata = {
   action: 'reopen' | 'comment_only' | 'new_ticket';
   reopenTargetSource?: 'explicit' | 'board_default' | null;
   reopenTargetStatusId?: string | null;
+  /** RFC 3834/5230 automated-message classification used to suppress reopen. */
+  automated: AutomatedMessageSignal;
+  /** Redis reopen rate-limit outcome; set only when a reopen was otherwise going to apply. */
+  reopenRateLimit?: InboundReopenRateLimitResult | null;
   aiSuppression: {
     enabled: boolean;
     attempted: boolean;
@@ -202,6 +217,7 @@ function buildDiagnostics(params: {
       from: params.senderEmail,
       to: (params.emailData.to ?? []).map((recipient) => recipient.email),
       subject: params.emailData.subject ?? null,
+      relevantHeaders: extractRelevantInboundHeaders(params.emailData),
     },
     threading: {
       tokenLookupAttempted: Boolean(params.conversationToken),
@@ -1126,6 +1142,10 @@ export async function processInboundEmailInApp(
       rawOutput: null,
     };
 
+    // RFC 3834/5230: classify the message once so the reopen decision (and the persisted
+    // decision metadata) can suppress reopen for auto-replies, bounces, and bulk/list mail.
+    const automatedSignal = detectAutomatedInboundMessage(emailData);
+
     let decisionMetadata: InboundReplyDecisionMetadata = {
       policyEnabled: Boolean(policyContext?.inboundReplyReopenEnabled),
       wasClosedTicketMatch: Boolean(policyContext?.ticketIsClosed),
@@ -1135,6 +1155,7 @@ export async function processInboundEmailInApp(
       action: 'comment_only',
       reopenTargetSource: null,
       reopenTargetStatusId: null,
+      automated: automatedSignal,
       aiSuppression: aiSuppressionDefault,
     };
 
@@ -1165,7 +1186,22 @@ export async function processInboundEmailInApp(
           return null;
         }
 
-        if (matchedSenderIsInternalUser) {
+        if (automatedSignal.isAutomated) {
+          // RFC 3834/5230: never reopen a closed ticket on an automated message
+          // (auto-reply, vacation/OOO, delivery-status bounce, or bulk/list mail).
+          // This breaks the notification -> auto-reply -> reopen email loop. The reply
+          // is still recorded as a comment; only the reopen transition is suppressed.
+          decisionMetadata.action = 'comment_only';
+          console.info('processInboundEmailInApp: suppressing reopen for automated inbound message (RFC 3834)', {
+            tenantId,
+            providerId,
+            emailId: emailData.id,
+            ticketId: params.ticketId,
+            matchedBy: params.matchedBy,
+            reason: automatedSignal.reason,
+            detail: automatedSignal.detail,
+          });
+        } else if (matchedSenderIsInternalUser) {
           shouldReopen = true;
         } else {
           const aiSuppressionEnabled = policyContext.inboundReplyAiAckSuppressionEnabled;
@@ -1199,20 +1235,44 @@ export async function processInboundEmailInApp(
     }
 
     if (shouldReopen && policyContext?.ticketIsClosed) {
-      const reopenTarget = await resolveBoardReopenStatusTarget({
-        tenantId,
-        boardId: policyContext.boardId,
-        explicitStatusId: policyContext.inboundReplyReopenStatusId,
-      });
-      await applyInboundReplyReopenTransition({
+      // RFC 5230 backstop: cap inbound-triggered reopens per ticket per window so that an
+      // auto-responder which slips past the auto-reply header detection cannot drive a
+      // runaway reopen loop. Only consulted on the reopen path so ordinary comment-only
+      // replies are not counted. Fails open (see inboundReopenRateLimiter).
+      const reopenRateLimit = await checkInboundReopenRateLimit({
         tenantId,
         ticketId: params.ticketId,
-        statusId: reopenTarget.statusId,
-        updatedByUserId: matchedSenderIsInternalUser ? matchedSenderContact?.user_id : undefined,
       });
-      decisionMetadata.action = 'reopen';
-      decisionMetadata.reopenTargetSource = reopenTarget.source;
-      decisionMetadata.reopenTargetStatusId = reopenTarget.statusId;
+      decisionMetadata.reopenRateLimit = reopenRateLimit;
+
+      if (!reopenRateLimit.allowed) {
+        decisionMetadata.action = 'comment_only';
+        console.warn('processInboundEmailInApp: suppressing reopen; inbound reopen rate limit exceeded', {
+          tenantId,
+          providerId,
+          emailId: emailData.id,
+          ticketId: params.ticketId,
+          matchedBy: params.matchedBy,
+          count: reopenRateLimit.count,
+          limit: reopenRateLimit.limit,
+          windowSeconds: reopenRateLimit.windowSeconds,
+        });
+      } else {
+        const reopenTarget = await resolveBoardReopenStatusTarget({
+          tenantId,
+          boardId: policyContext.boardId,
+          explicitStatusId: policyContext.inboundReplyReopenStatusId,
+        });
+        await applyInboundReplyReopenTransition({
+          tenantId,
+          ticketId: params.ticketId,
+          statusId: reopenTarget.statusId,
+          updatedByUserId: matchedSenderIsInternalUser ? matchedSenderContact?.user_id : undefined,
+        });
+        decisionMetadata.action = 'reopen';
+        decisionMetadata.reopenTargetSource = reopenTarget.source;
+        decisionMetadata.reopenTargetStatusId = reopenTarget.statusId;
+      }
     }
 
     const watchListRecipients = mergeTicketWatchListRecipients(

--- a/shared/services/email/unifiedInboundEmailQueue.ts
+++ b/shared/services/email/unifiedInboundEmailQueue.ts
@@ -150,6 +150,16 @@ async function getRedisClient(): Promise<RedisClientType> {
   return redisClientPromise;
 }
 
+/**
+ * Shared accessor for the inbound-email Redis connection. Reused by the inbound
+ * reopen rate limiter so the limiter rides the same connection the email-service
+ * worker already establishes (instead of opening a second one or depending on a
+ * server-only singleton).
+ */
+export async function getInboundEmailRedisClient(): Promise<RedisClientType> {
+  return getRedisClient();
+}
+
 export type UnifiedInboundEmailQueueJobInput =
   | {
       tenantId: string;

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -15,6 +15,7 @@ import {
 import { GmailAdapter } from '@alga-psa/shared/services/email/providers/GmailAdapter';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { resolveListRewriteSender } from '@alga-psa/shared/lib/email/listRewriteSender';
+import { extractRelevantInboundHeaders } from '@alga-psa/shared/lib/email/automatedMessage';
 
 export class SourceMessageUnavailableError extends Error {
   public readonly reason: string;
@@ -850,6 +851,7 @@ function buildProcessingMetadata(params: {
             from: params.emailData.from?.email ?? null,
             to: (params.emailData.to ?? []).map((recipient) => recipient.email),
             subject: params.emailData.subject ?? null,
+            relevantHeaders: extractRelevantInboundHeaders(params.emailData),
           },
         }
       : {}),


### PR DESCRIPTION
## Summary

Closed tickets (auto-created from Huntress/automated alert emails) were being **reopened seconds after every close** by auto-acknowledgements that bounced our own "Ticket Closed" notifications back to us. Each reopen re-ran the close→notify cycle, fanning **duplicate notifications** out to every watcher — the email-loop behavior seen in production for tenant Cross Industries (e.g. TK-4570 / TK-4657).

### Root cause
The inbound reply path had **no auto-responder detection**. A `reply_token` match reopened a closed ticket *unconditionally* for external senders (`processInboundEmailInApp.ts`); the only content-aware gate (the EE AI ACK decider) is **off by default**. So an automated `Re: Ticket Closed …` ack reopened the ticket, which a human then re-closed, which produced another notification, which got auto-acked again…

## Fix — three standards-based layers

1. **Outbound marking (RFC 3834 §5).** Tag system notifications and survey invitations with `Auto-Submitted: auto-generated` + `X-Auto-Response-Suppress` so compliant recipient systems don't auto-reply. Humans can still reply.
   - `server/src/lib/notifications/sendEventEmail.ts`, `server/src/services/surveyService.ts`
2. **Inbound detection.** New `detectAutomatedInboundMessage()` recognizes auto-replies / vacation / bounces / bulk-list mail via `Auto-Submitted` (RFC 3834), null reverse-path (RFC 5321), `multipart/report` DSNs (RFC 3462/3464), `List-*` (RFC 2919/2369), and de-facto `Precedence` / `X-Auto-Response-Suppress` / `X-Autoreply`. Automated matches are recorded as a comment but **do not reopen**. Header-only by design, so genuine human replies are never suppressed. The standards-relevant headers (previously dropped from processing metadata) are now captured for diagnostics.
   - `shared/lib/email/automatedMessage.ts`, `shared/services/email/processInboundEmailInApp.ts`, `unifiedInboundEmailQueueJobProcessor.ts`
3. **Redis rate-limit backstop (RFC 5230 spirit).** `checkInboundReopenRateLimit()` caps inbound-triggered reopens per ticket per window (**default 3/hour**, env-configurable) to bound loops from non-compliant responders that carry no markers. Fixed-window `INCR`/`EXPIRE` on the inbound-email Redis connection the worker already uses; consulted only on the reopen path; **fails open** so a Redis hiccup never blocks a legitimate reopen.
   - `shared/services/email/inboundReopenRateLimiter.ts`, `shared/services/email/unifiedInboundEmailQueue.ts`

A dedicated limiter is used instead of the existing `TokenBucketRateLimiter` because that singleton is only initialized in the **server** process, not the **email-service worker** where inbound mail is processed (it would silently fail open there).

## Config
- `INBOUND_REOPEN_RATELIMIT_MAX` (default `3`)
- `INBOUND_REOPEN_RATELIMIT_WINDOW_SECONDS` (default `3600`)

## Testing
- **20 new unit tests** pass via the configured vitest runner: header detection (14) + rate limiter incl. fail-open (6).
- `shared` package `tsc --noEmit`: **0 errors**.

## Notes / follow-ups (not in this PR)
- We still don't know whether the specific Gnosis/SES auto-ack sets `Auto-Submitted` (past headers were dropped — now captured). Layer 1 stops compliant responders; layer 3 covers the rest.
- Optional next step: suppress "New Comment" notifications for automated inbound so auto-acks generate no outbound mail at all.
- Separately observed: a single close emits the closed-notice **twice** (event-bus redelivery after a post-send throw) — tracked separately; not addressed here.

https://claude.ai/code/session_011Qe959nUTFigwEWZAJyjde
