### PR TITLE
Tighten authorization checks across RBAC, client portal, and runner/webhook endpoints

### DIFF
--- a/ee/server/src/app/api/internal/ext-runner/install-config/route.ts
+++ b/ee/server/src/app/api/internal/ext-runner/install-config/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getInstallConfig } from '@ee/lib/extensions/installConfig';
+import { assertRunnerAuth } from '@ee/lib/extensions/runnerAuth';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,16 +12,11 @@ const requestSchema = z.object({
 });
 
 function ensureRunnerAuth(req: NextRequest) {
-  const token = process.env.RUNNER_CONFIG_API_TOKEN || process.env.RUNNER_STORAGE_API_TOKEN;
-  if (!token) {
-    throw new Error('runner auth token not configured');
-  }
-  const provided = req.headers.get('x-runner-auth');
-  if (!provided || provided !== token) {
-    const err = new Error('unauthorized');
-    (err as any).status = 401;
-    throw err;
-  }
+  assertRunnerAuth(
+    req.headers.get('x-runner-auth'),
+    process.env.RUNNER_CONFIG_API_TOKEN,
+    process.env.RUNNER_STORAGE_API_TOKEN,
+  );
 }
 
 export async function POST(req: NextRequest) {

--- a/ee/server/src/app/api/internal/ext-scheduler/install/[installId]/route.ts
+++ b/ee/server/src/app/api/internal/ext-scheduler/install/[installId]/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@ee/lib/extensions/schedulerHostApi';
 import { getInstallConfigByInstallId } from '@ee/lib/extensions/installConfig';
 import { resolveInstallIdFromParamsOrUrl } from '@ee/lib/next/routeParams';
+import { isValidRunnerToken } from '@ee/lib/extensions/runnerAuth';
 
 export const dynamic = 'force-dynamic';
 
@@ -141,12 +142,11 @@ function mapError(error: unknown): NextResponse {
 }
 
 function ensureRunnerAuth(req: NextRequest): void {
-  const expected = process.env.RUNNER_STORAGE_API_TOKEN || process.env.RUNNER_SERVICE_TOKEN;
-  if (!expected) {
-    throw new SchedulerApiError('UNAUTHORIZED', 'Runner token not configured');
-  }
-  const provided = req.headers.get('x-runner-auth');
-  if (!provided || provided !== expected) {
+  if (!isValidRunnerToken(
+    req.headers.get('x-runner-auth'),
+    process.env.RUNNER_STORAGE_API_TOKEN,
+    process.env.RUNNER_SERVICE_TOKEN,
+  )) {
     throw new SchedulerApiError('UNAUTHORIZED', 'Invalid runner token');
   }
 }

--- a/ee/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
+++ b/ee/server/src/app/api/internal/ext-storage/install/[installId]/route.ts
@@ -7,6 +7,7 @@ import {
   StorageValidationError,
 } from '@ee/lib/extensions/storage/v2/errors';
 import { resolveInstallIdFromParamsOrUrl } from '@ee/lib/next/routeParams';
+import { isValidRunnerToken } from '@ee/lib/extensions/runnerAuth';
 
 export const dynamic = 'force-dynamic';
 
@@ -99,12 +100,11 @@ function mapError(error: unknown): NextResponse {
 }
 
 function ensureRunnerAuth(req: NextRequest): void {
-  const expected = process.env.RUNNER_STORAGE_API_TOKEN || process.env.RUNNER_SERVICE_TOKEN;
-  if (!expected) {
-    throw new StorageServiceError('UNAUTHORIZED', 'Runner token not configured');
-  }
-  const provided = req.headers.get('x-runner-auth');
-  if (!provided || provided !== expected) {
+  if (!isValidRunnerToken(
+    req.headers.get('x-runner-auth'),
+    process.env.RUNNER_STORAGE_API_TOKEN,
+    process.env.RUNNER_SERVICE_TOKEN,
+  )) {
     throw new StorageServiceError('UNAUTHORIZED', 'Invalid runner token');
   }
 }

--- a/ee/server/src/lib/extensions/clientsInternalApi.ts
+++ b/ee/server/src/lib/extensions/clientsInternalApi.ts
@@ -4,6 +4,7 @@ import { hasPermission } from '@alga-psa/auth/rbac'
 import { getInstallConfigByInstallId } from '@ee/lib/extensions/installConfig'
 import { CAP_CLIENT_READ, normalizeCapability } from '@ee/lib/extensions/providers'
 import { getClientSummaryById, listClientSummaries } from '@ee/lib/extensions/clientReadService'
+import { isValidRunnerToken } from '@ee/lib/extensions/runnerAuth'
 
 export type ClientsInternalResponse = { status: number; body: any }
 
@@ -40,12 +41,11 @@ const userSchema = z.object({
 }).optional()
 
 function ensureRunnerAuth(headers: Headers): void {
-  const expected = process.env.RUNNER_STORAGE_API_TOKEN || process.env.RUNNER_SERVICE_TOKEN
-  if (!expected) {
-    throw new ClientsInternalError('UNAUTHORIZED', 401, 'Runner token not configured')
-  }
-  const provided = headers.get('x-runner-auth')
-  if (!provided || provided !== expected) {
+  if (!isValidRunnerToken(
+    headers.get('x-runner-auth'),
+    process.env.RUNNER_STORAGE_API_TOKEN,
+    process.env.RUNNER_SERVICE_TOKEN,
+  )) {
     throw new ClientsInternalError('UNAUTHORIZED', 401, 'Invalid runner token')
   }
 }

--- a/ee/server/src/lib/extensions/invoicingInternalApi.ts
+++ b/ee/server/src/lib/extensions/invoicingInternalApi.ts
@@ -2,6 +2,7 @@ import { CAP_INVOICE_MANUAL_CREATE, normalizeCapability } from '@ee/lib/extensio
 import { getInstallConfigByInstallId } from '@ee/lib/extensions/installConfig'
 import { createManualInvoice } from '@ee/lib/extensions/invoicingHostApi'
 import { validateCreateManualInvoiceInput } from '@ee/lib/extensions/invoicingValidation'
+import { isValidRunnerToken } from '@ee/lib/extensions/runnerAuth'
 import { runWithTenant } from 'server/src/lib/db'
 
 export type InvoicingInternalResponse = { status: number; body: any }
@@ -19,12 +20,11 @@ class InvoicingInternalError extends Error {
 }
 
 function ensureRunnerAuth(headers: Headers): void {
-  const expected = process.env.RUNNER_STORAGE_API_TOKEN || process.env.RUNNER_SERVICE_TOKEN
-  if (!expected) {
-    throw new InvoicingInternalError('UNAUTHORIZED', 401, 'Runner token not configured')
-  }
-  const provided = headers.get('x-runner-auth')
-  if (!provided || provided !== expected) {
+  if (!isValidRunnerToken(
+    headers.get('x-runner-auth'),
+    process.env.RUNNER_STORAGE_API_TOKEN,
+    process.env.RUNNER_SERVICE_TOKEN,
+  )) {
     throw new InvoicingInternalError('UNAUTHORIZED', 401, 'Invalid runner token')
   }
 }

--- a/ee/server/src/lib/extensions/runnerAuth.ts
+++ b/ee/server/src/lib/extensions/runnerAuth.ts
@@ -1,0 +1,91 @@
+import crypto from 'crypto';
+
+/**
+ * Shared verification for the internal extension-runner host APIs
+ * (`/api/internal/ext-*`).
+ *
+ * These endpoints are reachable without an API key (they are in the middleware
+ * skip-list) and are authenticated solely by a shared `x-runner-auth` token.
+ * Verification is centralized here so that every host API:
+ *   1. compares the token in constant time (no timing side-channel), and
+ *   2. refuses to accept a well-known development default in production
+ *      (so a deployment that forgot to rotate the secret fails closed instead
+ *      of running with a publicly documented token).
+ */
+
+export class RunnerAuthError extends Error {
+  readonly status = 401;
+  constructor(message = 'unauthorized') {
+    super(message);
+    this.name = 'RunnerAuthError';
+  }
+}
+
+// Tokens that ship in example/compose files for local development. They must
+// never be accepted in production.
+const INSECURE_DEFAULT_TOKENS = new Set([
+  'local-runner-key',
+  'changeme',
+  'change-me',
+  'secret',
+]);
+
+function timingSafeEqual(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Resolve the configured runner token from the supplied env values (in
+ * precedence order). Throws if none is set, or if a known-insecure default is
+ * configured while running in production.
+ */
+export function resolveRunnerToken(...candidates: Array<string | undefined | null>): string {
+  const expected = candidates.find(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0,
+  );
+  if (!expected) {
+    throw new RunnerAuthError('runner auth token not configured');
+  }
+  if (process.env.NODE_ENV === 'production' && INSECURE_DEFAULT_TOKENS.has(expected)) {
+    throw new RunnerAuthError('runner auth token is set to an insecure default value');
+  }
+  return expected;
+}
+
+/**
+ * Assert that the request-provided `x-runner-auth` value matches the configured
+ * token, using a constant-time comparison. Throws {@link RunnerAuthError}
+ * (status 401) on any mismatch or misconfiguration.
+ */
+export function assertRunnerAuth(
+  provided: string | null | undefined,
+  ...candidates: Array<string | undefined | null>
+): void {
+  const expected = resolveRunnerToken(...candidates);
+  if (!provided || !timingSafeEqual(provided, expected)) {
+    throw new RunnerAuthError('unauthorized');
+  }
+}
+
+/**
+ * Boolean variant for call sites that need to throw their own error type.
+ * Returns false when the token is missing/mismatched, or when the token is
+ * unset / left at a known-insecure default in production.
+ */
+export function isValidRunnerToken(
+  provided: string | null | undefined,
+  ...candidates: Array<string | undefined | null>
+): boolean {
+  let expected: string;
+  try {
+    expected = resolveRunnerToken(...candidates);
+  } catch {
+    return false;
+  }
+  return !!provided && timingSafeEqual(provided, expected);
+}

--- a/ee/server/src/lib/extensions/servicesInternalApi.ts
+++ b/ee/server/src/lib/extensions/servicesInternalApi.ts
@@ -4,6 +4,7 @@ import { hasPermission } from '@alga-psa/auth/rbac'
 import { getInstallConfigByInstallId } from '@ee/lib/extensions/installConfig'
 import { CAP_SERVICE_READ, normalizeCapability } from '@ee/lib/extensions/providers'
 import { getServiceSummaryById, listServiceSummaries } from '@ee/lib/extensions/serviceReadService'
+import { isValidRunnerToken } from '@ee/lib/extensions/runnerAuth'
 
 export type ServicesInternalResponse = { status: number; body: any }
 
@@ -42,12 +43,11 @@ const userSchema = z.object({
 }).optional()
 
 function ensureRunnerAuth(headers: Headers): void {
-  const expected = process.env.RUNNER_STORAGE_API_TOKEN || process.env.RUNNER_SERVICE_TOKEN
-  if (!expected) {
-    throw new ServicesInternalError('UNAUTHORIZED', 401, 'Runner token not configured')
-  }
-  const provided = headers.get('x-runner-auth')
-  if (!provided || provided !== expected) {
+  if (!isValidRunnerToken(
+    headers.get('x-runner-auth'),
+    process.env.RUNNER_STORAGE_API_TOKEN,
+    process.env.RUNNER_SERVICE_TOKEN,
+  )) {
     throw new ServicesInternalError('UNAUTHORIZED', 401, 'Invalid runner token')
   }
 }

--- a/ee/server/src/lib/mcp/adminAuth.ts
+++ b/ee/server/src/lib/mcp/adminAuth.ts
@@ -2,7 +2,13 @@ import { NextRequest } from 'next/server';
 import { ApiKeyServiceForApi } from '@/lib/services/apiKeyServiceForApi';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { getUserRoles } from '@alga-psa/auth/actions';
+import { createTenantKnex } from '@alga-psa/db';
+import User from '@alga-psa/db/models/user';
 import type { IRole } from '@alga-psa/types';
+
+function rolesIncludeAdmin(roles: IRole[]): boolean {
+  return roles.some((r) => (r.role_name ?? '').toLowerCase() === 'admin');
+}
 
 export interface McpAdminContext {
   tenant: string;
@@ -22,7 +28,16 @@ export async function authenticateMcpAdmin(req: NextRequest): Promise<McpAdminCo
   const key = req.headers.get('x-api-key') ?? bearer;
   if (key) {
     const record = await ApiKeyServiceForApi.validateApiKeyAnyTenant(key);
-    return record ? { tenant: record.tenant, userId: record.user_id ?? null } : null;
+    if (!record || !record.user_id) {
+      return null;
+    }
+    // Enforce the same Admin requirement as the session path. Previously ANY
+    // valid API key was accepted here, letting a non-admin key holder call the
+    // MCP provisioning endpoints (create agents / register IdP providers) and
+    // self-escalate by minting an internal user bound to the Admin role.
+    const { knex } = await createTenantKnex(record.tenant);
+    const roles = await User.getUserRoles(knex, record.user_id, record.tenant);
+    return rolesIncludeAdmin(roles) ? { tenant: record.tenant, userId: record.user_id } : null;
   }
 
   // 2. Session (admin UI) — internal Admin users only.
@@ -30,8 +45,7 @@ export async function authenticateMcpAdmin(req: NextRequest): Promise<McpAdminCo
     const user = await getCurrentUser();
     if (user && user.user_type === 'internal' && user.tenant) {
       const roles: IRole[] = await getUserRoles(user.user_id);
-      const isAdmin = roles.some((r) => (r.role_name ?? '').toLowerCase() === 'admin');
-      if (isAdmin) return { tenant: user.tenant, userId: user.user_id };
+      if (rolesIncludeAdmin(roles)) return { tenant: user.tenant, userId: user.user_id };
     }
   } catch {
     // not authenticated

--- a/packages/auth/src/actions/policyActions.ts
+++ b/packages/auth/src/actions/policyActions.ts
@@ -13,10 +13,30 @@ import { deleteEntityWithValidation } from '@alga-psa/core';
 
 const policyEngine = new PolicyEngine();
 
+/**
+ * Roles, permissions and policies are governed by the `security_settings`
+ * resource (see preCheckDeletion.ts, which maps the `role` entity to
+ * `security_settings`). Every RBAC/ABAC mutation must be gated on the
+ * corresponding security_settings permission; without this an authenticated
+ * but unprivileged user could create/rename/delete roles or attach arbitrary
+ * permissions to a role they already hold and self-escalate to admin.
+ */
+async function assertSecuritySettingsPermission(
+  user: IUserWithRoles,
+  action: 'create' | 'read' | 'update' | 'delete',
+  knexConnection?: Knex | Knex.Transaction,
+): Promise<void> {
+  const allowed = await hasPermission(user, 'security_settings', action, knexConnection);
+  if (!allowed) {
+    throw new Error('Permission denied: You do not have permission to manage roles and permissions.');
+  }
+}
+
 // Role actions
-export const createRole = withAuth(async (_user, { tenant }, roleName: string, description: string, msp: boolean = true, client: boolean = false): Promise<IRole> => {
+export const createRole = withAuth(async (user, { tenant }, roleName: string, description: string, msp: boolean = true, client: boolean = false): Promise<IRole> => {
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'create', trx);
         const [role] = await trx('roles').insert({
             role_name: roleName,
             description,
@@ -28,9 +48,10 @@ export const createRole = withAuth(async (_user, { tenant }, roleName: string, d
     });
 });
 
-export const updateRole = withAuth(async (_user, { tenant }, roleId: string, roleName: string): Promise<IRole> => {
+export const updateRole = withAuth(async (user, { tenant }, roleId: string, roleName: string): Promise<IRole> => {
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'update', trx);
         const [updatedRole] = await trx('roles')
             .where({ role_id: roleId, tenant })
             .update({ role_name: roleName })
@@ -40,12 +61,14 @@ export const updateRole = withAuth(async (_user, { tenant }, roleId: string, rol
 });
 
 export const deleteRole = withAuth(async (
-  _user,
+  user,
   { tenant },
   roleId: string
 ): Promise<DeletionValidationResult & { success: boolean; deleted?: boolean }> => {
   try {
     const { knex: db } = await createTenantKnex();
+
+    await assertSecuritySettingsPermission(user, 'delete', db);
 
     const role = await db('roles')
       .where({ role_id: roleId, tenant })
@@ -108,10 +131,12 @@ export const getRoles = withAuth(async (_user, { tenant }): Promise<IRole[]> => 
 });
 
 // Role-Permission actions
-export const assignPermissionToRole = withAuth(async (_user, { tenant }, roleId: string, permissionId: string): Promise<void> => {
+export const assignPermissionToRole = withAuth(async (user, { tenant }, roleId: string, permissionId: string): Promise<void> => {
     try {
         const { knex: db } = await createTenantKnex();
         return withTransaction(db, async (trx: Knex.Transaction) => {
+
+        await assertSecuritySettingsPermission(user, 'update', trx);
 
         // First, verify both the role and permission exist for this tenant
         const [role, permission] = await Promise.all([
@@ -139,10 +164,11 @@ export const assignPermissionToRole = withAuth(async (_user, { tenant }, roleId:
     }
 });
 
-export const removePermissionFromRole = withAuth(async (_user, { tenant }, roleId: string, permissionId: string): Promise<void> => {
+export const removePermissionFromRole = withAuth(async (user, { tenant }, roleId: string, permissionId: string): Promise<void> => {
     try {
         const { knex: db } = await createTenantKnex();
         return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'update', trx);
         await trx('role_permissions')
             .where({
                 role_id: roleId,
@@ -309,9 +335,10 @@ export const getTicketAttributes = withAuth(async (_user, { tenant }, ticketId: 
 });
 
 // Policy actions
-export const createPolicy = withAuth(async (_user, { tenant }, policyName: string, resource: string, action: string, conditions: ICondition[]): Promise<IPolicy> => {
+export const createPolicy = withAuth(async (user, { tenant }, policyName: string, resource: string, action: string, conditions: ICondition[]): Promise<IPolicy> => {
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'create', trx);
         const [policy] = await trx('policies').insert({
             tenant,
             policy_name: policyName,
@@ -324,9 +351,10 @@ export const createPolicy = withAuth(async (_user, { tenant }, policyName: strin
     });
 });
 
-export const updatePolicy = withAuth(async (_user, { tenant }, policyId: string, policyName: string, resource: string, action: string, conditions: ICondition[]): Promise<IPolicy> => {
+export const updatePolicy = withAuth(async (user, { tenant }, policyId: string, policyName: string, resource: string, action: string, conditions: ICondition[]): Promise<IPolicy> => {
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'update', trx);
         const [updatedPolicy] = await trx('policies')
             .where({ policy_id: policyId, tenant })
             .update({
@@ -342,9 +370,10 @@ export const updatePolicy = withAuth(async (_user, { tenant }, policyId: string,
     });
 });
 
-export const deletePolicy = withAuth(async (_user, { tenant }, policyId: string): Promise<void> => {
+export const deletePolicy = withAuth(async (user, { tenant }, policyId: string): Promise<void> => {
     const { knex: db } = await createTenantKnex();
     return withTransaction(db, async (trx: Knex.Transaction) => {
+        await assertSecuritySettingsPermission(user, 'delete', trx);
         const [deletedPolicy] = await trx('policies').where({ policy_id: policyId, tenant }).returning('*');
         await trx('policies').where({ policy_id: policyId, tenant }).del();
         policyEngine.removePolicy(deletedPolicy);

--- a/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/clientUserActions.ts
@@ -67,10 +67,73 @@ export async function getClientUserRoles(userId: string): Promise<IRole[]> {
 }
 
 /**
+ * Authorize management of a client-portal user and confirm the target is a
+ * `client` user inside the caller's scope. Returns nothing on success, throws
+ * otherwise.
+ *
+ * - MSP (internal) staff need the standard `user:update` permission.
+ * - Client-portal callers must be a client admin (`is_client_admin`) acting on
+ *   a user that belongs to their own client company.
+ *
+ * The `user_type: 'client'` lookup is critical: without it these flows could be
+ * pointed at MSP staff accounts (cross-portal account takeover).
+ */
+async function assertCanManageClientUser(
+  user: IUserWithRoles,
+  tenant: string,
+  knex: Knex | Knex.Transaction,
+  targetUserId: string
+): Promise<void> {
+  const targetUser = await knex('users')
+    .where({ user_id: targetUserId, tenant, user_type: 'client' })
+    .select('contact_id')
+    .first();
+
+  if (!targetUser) {
+    throw new Error('User not found');
+  }
+
+  // MSP staff: gate on the standard user-management permission.
+  if (user.user_type !== 'client') {
+    const canUpdate = await hasPermission(user, 'user', 'update', knex);
+    if (!canUpdate) {
+      throw new Error('Permission denied: Cannot manage client users');
+    }
+    return;
+  }
+
+  // Client-portal caller: must be a client admin managing a user in their own company.
+  if (!user.contact_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  const [actorContact, targetContact] = await Promise.all([
+    knex('contacts')
+      .where({ tenant, contact_name_id: user.contact_id })
+      .select('client_id', 'is_client_admin')
+      .first(),
+    targetUser.contact_id
+      ? knex('contacts')
+          .where({ tenant, contact_name_id: targetUser.contact_id })
+          .select('client_id')
+          .first()
+      : Promise.resolve(undefined),
+  ]);
+
+  if (!actorContact?.is_client_admin || !actorContact.client_id) {
+    throw new Error('Permission denied: Client portal admin access is required');
+  }
+
+  if (!targetContact?.client_id || targetContact.client_id !== actorContact.client_id) {
+    throw new Error('Permission denied: Cannot manage users for another client');
+  }
+}
+
+/**
  * Update a client user
  */
 export const updateClientUser = withAuth(async (
-  _user: IUserWithRoles,
+  user: IUserWithRoles,
   { tenant }: AuthContext,
   userId: string,
   userData: Partial<IUser>
@@ -79,13 +142,24 @@ export const updateClientUser = withAuth(async (
     const { knex } = await createTenantKnex();
 
     const [updatedUser] = await withTransaction(knex, async (trx: Knex.Transaction) => {
+      await assertCanManageClientUser(user, tenant, trx, userId);
+
+      // Allowlist of self-service profile fields. Never allow privileged columns
+      // (user_type, tenant, hashed_password, roles, username, ...) via this path.
+      const allowedUpdates: Partial<IUser> = {};
+      for (const field of ['first_name', 'last_name', 'email', 'is_inactive'] as const) {
+        if (Object.prototype.hasOwnProperty.call(userData, field)) {
+          (allowedUpdates as Record<string, unknown>)[field] = (userData as Record<string, unknown>)[field];
+        }
+      }
+
       return await trx('users')
-      .where({ user_id: userId, tenant })
-      .update({
-        ...userData,
-        updated_at: new Date().toISOString()
-      })
-      .returning('*');
+        .where({ user_id: userId, tenant, user_type: 'client' })
+        .update({
+          ...allowedUpdates,
+          updated_at: new Date().toISOString()
+        })
+        .returning('*');
     });
 
     return updatedUser || null;
@@ -99,7 +173,7 @@ export const updateClientUser = withAuth(async (
  * Reset client user password
  */
 export const resetClientUserPassword = withAuth(async (
-  _user: IUserWithRoles,
+  user: IUserWithRoles,
   { tenant }: AuthContext,
   userId: string,
   newPassword: string
@@ -107,19 +181,17 @@ export const resetClientUserPassword = withAuth(async (
   try {
     const { knex } = await createTenantKnex();
 
-    const passwordField = 'hashed_password';
-
     const hashedPassword = await hashPassword(newPassword);
 
-    const updateData: any = {
-      updated_at: new Date().toISOString()
-    };
-    updateData[passwordField] = hashedPassword;
-
     await withTransaction(knex, async (trx: Knex.Transaction) => {
+      await assertCanManageClientUser(user, tenant, trx, userId);
+
       await trx('users')
-      .where({ user_id: userId, tenant })
-      .update(updateData);
+        .where({ user_id: userId, tenant, user_type: 'client' })
+        .update({
+          hashed_password: hashedPassword,
+          updated_at: new Date().toISOString()
+        });
     });
 
     return { success: true };

--- a/packages/users/src/actions/user-actions/userActions.ts
+++ b/packages/users/src/actions/user-actions/userActions.ts
@@ -599,6 +599,20 @@ export const updateUser = withAuth(async (
         throwPermissionError('update user');
       }
 
+      // Defense-in-depth against mass-assignment: this generic profile-update
+      // path must never set privileged identity/credential columns. Dedicated
+      // flows exist for password, 2FA, and role/type/tenant changes. Without
+      // this, a user updating their own profile (isOwnProfile, no permission
+      // gate) could escalate by setting e.g. user_type or disabling their 2FA.
+      const PROTECTED_USER_FIELDS: ReadonlyArray<keyof IUser> = [
+        'tenant', 'user_type', 'hashed_password', 'two_factor_secret', 'two_factor_enabled',
+      ];
+      for (const field of PROTECTED_USER_FIELDS) {
+        if (field in userData) {
+          delete (userData as Record<string, unknown>)[field as string];
+        }
+      }
+
       // If user is being deactivated, clear default_assigned_to on boards
       if (userData.is_inactive === true) {
         await trx('boards')

--- a/server/src/app/api/webhooks/alternative-payments/route.ts
+++ b/server/src/app/api/webhooks/alternative-payments/route.ts
@@ -147,7 +147,13 @@ function timingSafeEqualHex(left: string, right: string): boolean {
 function verifySignature(body: string, signature: string | null): boolean {
   const secret = process.env.ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET;
   if (!secret) {
-    return true;
+    // Fail closed: without a configured secret the request cannot be
+    // authenticated. This endpoint records payments against an
+    // attacker-supplied tenant/invoice, so an unsigned request must never be
+    // trusted (previously this returned true, allowing unauthenticated
+    // cross-tenant payment fraud).
+    console.error('[alternative-payments webhook] ALTERNATIVE_PAYMENTS_WEBHOOK_SECRET is not configured; rejecting webhook');
+    return false;
   }
 
   if (!signature) {

--- a/server/src/lib/api/controllers/ApiUserController.ts
+++ b/server/src/lib/api/controllers/ApiUserController.ts
@@ -622,6 +622,19 @@ export class ApiUserController extends ApiBaseController {
             
             // Then assign new roles if any
             if (role_ids.length > 0) {
+              // Validate that every role_id belongs to the caller's tenant before
+              // inserting. Without this, the raw insert would attach any UUID the
+              // caller supplies (e.g. a privileged role) and bypass the tenant
+              // checks enforced by UserService.assignRoles().
+              const validRoleIds: string[] = await trx('roles')
+                .where('tenant', apiRequest.context!.tenant)
+                .whereIn('role_id', role_ids)
+                .pluck('role_id');
+              const invalidRoleIds = role_ids.filter((roleId: string) => !validRoleIds.includes(roleId));
+              if (invalidRoleIds.length > 0) {
+                throw new ValidationError(`Invalid role_ids for this tenant: ${invalidRoleIds.join(', ')}`);
+              }
+
               const userRoles = role_ids.map(roleId => ({
                 tenant: apiRequest.context!.tenant,
                 user_id: targetUserId,

--- a/server/src/middleware/express/authMiddleware.ts
+++ b/server/src/middleware/express/authMiddleware.ts
@@ -1,8 +1,22 @@
 import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import { getToken, decode } from 'next-auth/jwt';
 import { ApiKeyServiceForApi } from '../../lib/services/apiKeyServiceForApi';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { getSessionCookieName } from 'server/src/lib/auth/sessionCookies';
+
+/**
+ * Constant-time comparison for privileged bypass keys. Using `===` leaks the
+ * secret one byte at a time via response-timing differences; these keys grant a
+ * full API-auth bypass, so they must be compared in constant time.
+ */
+function secureKeyEqual(provided: string | undefined | null, expected: string | undefined | null): boolean {
+  if (!provided || !expected) return false;
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
 
 // Cache NM Store key to avoid fetching every request
 let NM_STORE_KEY_CACHE: string | null = null;
@@ -233,7 +247,7 @@ export async function apiKeyAuthMiddleware(
 
     if (isNmAllowedPath) {
       const nmKey = await getNmStoreKeyCached();
-      if (nmKey && apiKey === nmKey) {
+      if (secureKeyEqual(apiKey, nmKey)) {
         // For user search we require tenant header
         if (normalizedPath === '/api/v1/users/search') {
           const tenantId = (req.headers['x-tenant-id'] as string) || '';
@@ -279,7 +293,7 @@ export async function apiKeyAuthMiddleware(
           );
         } catch (_) {}
 
-        if (allowKey && apiKey === allowKey) {
+        if (secureKeyEqual(apiKey, allowKey)) {
           return next();
         }
       } catch {
@@ -298,7 +312,7 @@ export async function apiKeyAuthMiddleware(
           );
         } catch (_) {}
 
-        if (allowKey && apiKey === allowKey) {
+        if (secureKeyEqual(apiKey, allowKey)) {
           return next();
         }
       }

--- a/server/src/services/email/webhooks/resendWebhookEvents.ts
+++ b/server/src/services/email/webhooks/resendWebhookEvents.ts
@@ -106,7 +106,10 @@ export function verifyResendWebhookSignature(params: {
 }): { verified: boolean; reason?: string } {
   const webhookSecret = params.webhookSecret?.trim();
   if (!webhookSecret) {
-    return { verified: true, reason: 'no_secret_configured' };
+    // Fail closed: an unconfigured secret means we cannot authenticate the
+    // webhook. The tenant is derived from the (otherwise attacker-controlled)
+    // payload, so process nothing until a secret is configured.
+    return { verified: false, reason: 'no_secret_configured' };
   }
 
   const svixId = getFirstHeader(params.headers, 'svix-id');

--- a/server/src/test/unit/resendWebhookEvents.test.ts
+++ b/server/src/test/unit/resendWebhookEvents.test.ts
@@ -11,20 +11,20 @@ function signSvix(secret: string, timestamp: string, payload: string): string {
 }
 
 describe('verifyResendWebhookSignature', () => {
-  it('accepts when secret is not configured', () => {
+  it('rejects (fails closed) when secret is not configured', () => {
     const headers = new Headers({
       'svix-id': 'msg_123',
       'svix-timestamp': String(Math.floor(Date.now() / 1000)),
       'svix-signature': 'v1,abc',
     });
 
-    expect(
-      verifyResendWebhookSignature({
-        payload: '{"ok":true}',
-        headers,
-        webhookSecret: undefined,
-      }).verified
-    ).toBe(true);
+    const result = verifyResendWebhookSignature({
+      payload: '{"ok":true}',
+      headers,
+      webhookSecret: undefined,
+    });
+    expect(result.verified).toBe(false);
+    expect(result.reason).toBe('no_secret_configured');
   });
 
   it('verifies a valid svix signature with whsec_ secret', () => {


### PR DESCRIPTION
## Summary

A cleanup pass over a few authorization paths to make permission checks more consistent and add some defense-in-depth. Most of these simply bring existing endpoints in line with patterns already used elsewhere in the codebase (e.g. `security_settings` for role management, the client-admin/company scoping used in `visibilityGroupActions`, constant-time secret comparison, fail-closed webhook verification).

## What's included

**RBAC / role management** (`packages/auth/.../policyActions.ts`)
- Add `security_settings` permission checks to the role, permission, and policy *mutation* actions so they match the gating already used across the rest of the RBAC surface (`preCheckDeletion` already maps `role → security_settings`). Read actions are left as-is to avoid affecting existing role-assignment UIs.

**Client portal user management** (`packages/client-portal/.../clientUserActions.ts`)
- `updateClientUser` / `resetClientUserPassword` now scope to `user_type: 'client'`, require client-admin + same-company access, and apply a field allowlist on profile updates — mirroring the existing `visibilityGroupActions` / `portalInvitationActions` helpers.

**User profile updates** (`packages/users/.../userActions.ts`)
- `updateUser` no longer lets privileged columns (`user_type`, `tenant`, `hashed_password`, `two_factor_*`) flow through the generic profile-update path; those have dedicated flows.

**REST API** (`server/.../ApiUserController.ts`)
- `replaceRoles` now validates that supplied `role_ids` belong to the caller's tenant before writing `user_roles` (the sibling `assignRoles` already did this).

**Extension runner host APIs** (new `ee/.../runnerAuth.ts`)
- Centralize `x-runner-auth` verification: constant-time token comparison and refuse the local-dev default token when `NODE_ENV=production`. Wired into install-config, ext-storage, ext-scheduler, clients, services, and invoicing.

**MCP admin auth** (`ee/.../adminAuth.ts`)
- The API-key path now checks for the Admin role, matching what the session path already required.

**Webhooks**
- `alternative-payments` and `resend` signature checks fail closed when their signing secret isn't configured (previously they accepted unsigned requests). Updated the matching unit test.

**Misc**
- Constant-time comparison for the internal bypass keys in the Express `authMiddleware`.

## Testing notes

These changes follow existing in-repo conventions and reuse established helpers/permissions. I couldn't run the full typecheck/test suite locally (incomplete `node_modules` in my environment), so please let CI run `npm run typecheck` and the unit tests before merging. The one unit test touched (`resendWebhookEvents.test.ts`) was updated to match the new fail-closed behavior.

## Follow-ups (intentionally not in this PR)

A few related items are left out pending a product decision — the cross-tenant extension debug stream, Keycloak SSO claim handling, and workflow execution identity — plus some smaller clean-ups (workflow read-action auth, EE payment-action gating, MCP agent role validation, removing an unused legacy header-auth helper). Happy to follow up in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014xWqpwc2XwgMASqTjE7NmQ)_