### PR TITLE
Harden tenant resolution and prevent cross-tenant access in extension gateway, file downloads, and runner lookups

### DIFF
--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -581,7 +581,7 @@ export const unfinalizeInvoice = withAuth(async (
   await withTransaction(knex, async (trx: Knex.Transaction) => {
     // Check if invoice exists and is finalized
     const invoice = await trx('invoices')
-      .where({ invoice_id: invoiceId })
+      .where({ invoice_id: invoiceId, tenant })
       .first();
 
     if (!invoice) {
@@ -654,7 +654,7 @@ export const updateInvoiceManualItems = withAuth(async (
   // Load and validate invoice
   const invoice = await withTransaction(knex, async (trx: Knex.Transaction) => {
     return await trx('invoices')
-      .where({ invoice_id: invoiceId })
+      .where({ invoice_id: invoiceId, tenant })
       .first();
   });
 
@@ -668,7 +668,7 @@ export const updateInvoiceManualItems = withAuth(async (
 
   const client = await withTransaction(knex, async (trx: Knex.Transaction) => {
     return await trx('clients')
-      .where({ client_id: invoice.client_id })
+      .where({ client_id: invoice.client_id, tenant })
       .first();
   });
 

--- a/packages/product-ext-proxy/ee/gateway/auth.ts
+++ b/packages/product-ext-proxy/ee/gateway/auth.ts
@@ -162,22 +162,24 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
 }
 
 export async function getTenantFromAuth(req: NextRequest): Promise<string> {
-  // Minimal scaffolding:
-  // - Prefer internal header `x-alga-tenant` (e.g., set by edge/auth middleware)
-  // - Fallback to DEV_TENANT_ID for local development
-  // - Otherwise, reject (to avoid running as a fake tenant)
-  const h = req.headers.get('x-alga-tenant');
-  if (h && h.trim()) return h.trim();
-
-  // Accept legacy header used by admin/publishing clients.
-  const legacy = req.headers.get('x-tenant-id');
-  if (legacy && legacy.trim()) return legacy.trim();
-
   const session = await getSession();
   const sessionTenant = (session?.user as any)?.tenant;
+  const h = req.headers.get('x-alga-tenant')?.trim();
+  const legacy = req.headers.get('x-tenant-id')?.trim();
+
   if (sessionTenant && String(sessionTenant).trim()) {
-    return String(sessionTenant).trim();
+    const tenant = String(sessionTenant).trim();
+    if ((h && h !== tenant) || (legacy && legacy !== tenant)) {
+      throw new Error('tenant_mismatch');
+    }
+    return tenant;
   }
+
+  // Header-based tenant selection is only allowed for non-browser/internal callers
+  // that do not already have a session tenant. A browser user must never be able
+  // to switch tenants by supplying x-alga-tenant/x-tenant-id.
+  if (h) return h;
+  if (legacy) return legacy;
 
   const dev = process.env.DEV_TENANT_ID;
   if (dev && dev.trim()) return dev.trim();

--- a/packages/product-ext-proxy/ee/handler.ts
+++ b/packages/product-ext-proxy/ee/handler.ts
@@ -356,6 +356,9 @@ async function handle(
     if (error instanceof AccessError) {
       return applyCorsHeaders(json(error.status, { error: error.message }), corsOrigin);
     }
+    if (error?.message === 'tenant_mismatch') {
+      return applyCorsHeaders(json(403, { error: 'tenant_mismatch' }), corsOrigin);
+    }
     if (error instanceof RunnerConfigError) {
       console.error('[ext-proxy] Runner configuration error:', error.message);
       return applyCorsHeaders(json(500, { error: 'Runner not configured' }), corsOrigin);

--- a/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
+++ b/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
@@ -397,6 +397,12 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ extensionId: st
       );
     }
   } catch (err) {
+    if (err instanceof Error && err.message === 'tenant_mismatch') {
+      return applyCorsHeaders(
+        NextResponse.json({ error: 'tenant_mismatch' }, { status: 403 }),
+        corsOrigin
+      );
+    }
     console.error('[api/ext] unhandled error in gateway', {
       error: err,
       extensionId,

--- a/server/src/app/api/files/[fileId]/download/route.ts
+++ b/server/src/app/api/files/[fileId]/download/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { StorageService } from 'server/src/lib/storage/StorageService';
 import { createTenantKnex } from 'server/src/lib/db';
+import { getCurrentUser } from 'server/src/lib/auth/session';
+import { canAccessDocument } from 'server/src/lib/utils/documentPermissionUtils';
 
 export async function GET(
     request: NextRequest,
@@ -9,8 +11,13 @@ export async function GET(
     const resolvedParams = await params;
     console.log('GET request received for file download with params:', resolvedParams);
     try {
+        const user = await getCurrentUser();
+        if (!user?.tenant) {
+            return new NextResponse('Unauthorized', { status: 401 });
+        }
+
         console.log('Creating tenant knex connection...');
-        const { tenant } = await createTenantKnex();
+        const { knex, tenant } = await createTenantKnex(user.tenant);
         if (!tenant) {
             console.log('Tenant not found');
             return new NextResponse('Tenant not found', { status: 404 });
@@ -18,6 +25,13 @@ export async function GET(
         console.log('Tenant found:', tenant);
 
         const fileId = resolvedParams.fileId;
+        const document = await knex('documents')
+            .where({ tenant, file_id: fileId })
+            .first();
+        if (!document || !(await canAccessDocument(user, document))) {
+            return new NextResponse('Not found', { status: 404 });
+        }
+
         console.log('Attempting to download file with ID:', fileId);
         
         // Use the static downloadFile method with just the fileId

--- a/server/src/lib/extensions/gateway/auth.test.ts
+++ b/server/src/lib/extensions/gateway/auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { getTenantFromAuth } from './auth';
+
+const getSessionMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  getSession: () => getSessionMock(),
+}));
+
+function request(headers: Record<string, string> = {}) {
+  return new NextRequest('https://example.test/api/ext/demo', { headers });
+}
+
+describe('extension gateway tenant resolution', () => {
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    delete process.env.DEV_TENANT_ID;
+  });
+
+  it('uses the authenticated session tenant even when no tenant header is present', async () => {
+    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+    await expect(getTenantFromAuth(request())).resolves.toBe('tenant-a');
+  });
+
+  it('rejects a tenant header that attempts to switch away from the session tenant', async () => {
+    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+    await expect(
+      getTenantFromAuth(request({ 'x-alga-tenant': 'tenant-b' }))
+    ).rejects.toThrow('tenant_mismatch');
+  });
+
+  it('allows matching tenant headers for callers with a session tenant', async () => {
+    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+    await expect(
+      getTenantFromAuth(request({ 'x-tenant-id': 'tenant-a' }))
+    ).resolves.toBe('tenant-a');
+  });
+
+  it('still supports header-only tenant resolution for internal callers without a session', async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    await expect(
+      getTenantFromAuth(request({ 'x-alga-tenant': 'tenant-internal' }))
+    ).resolves.toBe('tenant-internal');
+  });
+});

--- a/server/src/lib/extensions/gateway/auth.ts
+++ b/server/src/lib/extensions/gateway/auth.ts
@@ -109,22 +109,24 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
 }
 
 export async function getTenantFromAuth(req: NextRequest): Promise<string> {
-  // Minimal scaffolding:
-  // - Prefer internal header `x-alga-tenant` (e.g., set by edge/auth middleware)
-  // - Fallback to DEV_TENANT_ID for local development
-  // - Otherwise, reject (to avoid running as a fake tenant)
-  const h = req.headers.get('x-alga-tenant');
-  if (h && h.trim()) return h.trim();
-
-  // Accept legacy header used by admin/publishing clients.
-  const legacy = req.headers.get('x-tenant-id');
-  if (legacy && legacy.trim()) return legacy.trim();
-
   const session = await getSession();
   const sessionTenant = (session?.user as any)?.tenant;
+  const h = req.headers.get('x-alga-tenant')?.trim();
+  const legacy = req.headers.get('x-tenant-id')?.trim();
+
   if (sessionTenant && String(sessionTenant).trim()) {
-    return String(sessionTenant).trim();
+    const tenant = String(sessionTenant).trim();
+    if ((h && h !== tenant) || (legacy && legacy !== tenant)) {
+      throw new Error('tenant_mismatch');
+    }
+    return tenant;
   }
+
+  // Header-based tenant selection is only allowed for non-browser/internal callers
+  // that do not already have a session tenant. A browser user must never be able
+  // to switch tenants by supplying x-alga-tenant/x-tenant-id.
+  if (h) return h;
+  if (legacy) return legacy;
 
   const dev = process.env.DEV_TENANT_ID;
   if (dev && dev.trim()) return dev.trim();

--- a/server/src/middleware/express/authMiddleware.ts
+++ b/server/src/middleware/express/authMiddleware.ts
@@ -316,13 +316,16 @@ export async function apiKeyAuthMiddleware(
           return next();
         }
       }
-      // If we got here, allowlist check failed; log reason context
+      // If we got here, allowlist check failed. These runner endpoints expose
+      // cross-tenant install metadata and must not fall through to ordinary
+      // tenant API-key authentication.
       try {
         console.warn(
-          `[auth] runner allowlist did not match; falling back to DB validation`,
+          `[auth] runner allowlist did not match; rejecting request`,
           JSON.stringify({ path: normalizedPath })
         );
       } catch (_) {}
+      return res.status(401).json({ error: 'Unauthorized: Invalid runner API key' });
     }
   } catch (_) {
     // Continue to standard validation path on any error


### PR DESCRIPTION
### Motivation

- Prevent header-based tenant selection from letting an authenticated session switch to another tenant and thereby enabling cross-tenant extension execution or data access.
- Stop internal runner install/validation endpoints from leaking tenant/extension metadata to arbitrary tenant API keys.
- Prevent unauthenticated/unsafely-scoped file downloads and close several places where reads were performed by object id only (allowing tenant-ID enumeration/leakage).

### Description

- Enforce session-first tenant resolution in extension gateway auth and reject mismatched tenant headers by throwing a `tenant_mismatch` error, while preserving header-only resolution for sessionless internal callers (files: `server/src/lib/extensions/gateway/auth.ts`, `packages/product-ext-proxy/ee/gateway/auth.ts`).
- Surface `tenant_mismatch` as a 403 response in extension proxy handlers to avoid generic 500s (files: `server/src/app/api/ext/[extensionId]/[[...path]]/route.ts`, `packages/product-ext-proxy/ee/handler.ts`).
- Require an authenticated user and document-ACL check before serving the generic file download path, and derive tenant from the authenticated user instead of request headers (file: `server/src/app/api/files/[fileId]/download/route.ts`).
- Prevent runner install lookup/validate endpoints from falling back to ordinary tenant API-key DB validation when the internal runner allowlist key does not match, returning 401 for invalid runner keys instead of proceeding (file: `server/src/middleware/express/authMiddleware.ts`).
- Scope several preflight invoice reads/related client lookups by tenant to avoid leaking existence/status across tenants (file: `packages/billing/src/actions/invoiceModification.ts`).
- Add a targeted unit test covering extension gateway tenant resolution and header mismatch rejection (new file: `server/src/lib/extensions/gateway/auth.test.ts`).

### Testing

- `git diff --check` was run and produced no whitespace/format issues (passed).
- Ran `npx vitest run --root server src/lib/extensions/gateway/auth.test.ts` to exercise the new regression test but the run failed in this environment due to a missing test dependency (`@testing-library/jest-dom`), so the test itself was not executed to completion (blocked).
- Ran a scoped `tsc --noEmit` invocation against the modified files which surfaced repository-wide type-resolution issues (module/type resolution errors from dev environment and unrelated packages), so no clean compile of the whole repo could be reported here (blocked).

If you want, I can split the PR into smaller change-sets, add additional unit / integration tests for the file-download and runner lookup behavior, or change the tenant-header policy to allow a verified internal token path for service-to-service callers and add explicit tests for that flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a376eae233c83309f0299ee93fc6c93)