### PR TITLE
docs: document the on-premise appliance ISO install

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,33 @@ docker compose -f docker-compose.prebuilt.base.yaml -f docker-compose.prebuilt.c
 
 For Windows-specific setup, see the [Windows Setup Guide](docs/getting-started/setup_guide_windows.md).
 
+## On-premise appliance (ISO)
+
+The Quick start above runs the Community Edition stack with Docker Compose, which suits teams that want to build on the source or manage the containers themselves. If you want a turnkey on-premise install instead, the appliance ISO installs and configures the full platform for you.
+
+The appliance ships as a single bootable image. It installs Ubuntu Server 24.04, brings up a self-contained Kubernetes runtime, and deploys AlgaPSA with its database, cache, and background workers. You boot the image, answer a short setup wizard, and sign in. There are no containers to assemble and no manifests to write.
+
+The free **Essentials** edition runs the open-source feature set and is community-supported. Each appliance includes a 15-day trial of the Enterprise feature set that you can start from inside the app, and paid editions add the integration layer, a support contract, and an SLA.
+
+### How it installs
+
+1. Register for the appliance at [nineminds.com/self-hosted](https://www.nineminds.com/self-hosted). You receive an install code and an ISO download link by email.
+2. Boot the ISO on your hardware or VM. Ubuntu installs unattended, then the machine reboots and prints a setup URL and one-time token on the console.
+3. Open the setup console on port `8080`, enter your install code, and create the first tenant and administrator. The appliance pulls its images and deploys itself.
+4. Sign in to AlgaPSA on port `3000` and complete the guided onboarding.
+
+A first install takes about 30 to 45 minutes, most of it unattended.
+
+### Appliance requirements
+
+- 64-bit x86 machine or VM running the appliance image (Ubuntu Server 24.04)
+- 4 vCPUs and 16 GB RAM recommended
+- At least 60 GB disk; the installer uses the whole disk you select
+- A reachable IPv4 address; reserve the DHCP lease or set a static address so the setup URL stays stable
+- Outbound HTTPS (port 443) to `license.nineminds.com` and `ghcr.io` to redeem the install code and pull images
+
+For the full walkthrough, see the [Appliance Install Guide](docs/getting-started/appliance_install.md).
+
 ## Technical architecture
 
 The following details are for teams evaluating the technical stack. For deployment requirements, see [Quick start](#quick-start).
@@ -181,6 +208,7 @@ Useful technical docs:
 ### Setup and configuration
 
 - [Complete Setup Guide](docs/getting-started/setup_guide.md)
+- [Appliance Install Guide](docs/getting-started/appliance_install.md)
 - [Windows Setup Guide](docs/getting-started/setup_guide_windows.md)
 - [Configuration Guide](docs/getting-started/configuration_guide.md)
 - [Development Guide](docs/getting-started/development_guide.md)

--- a/docs/getting-started/appliance_install.md
+++ b/docs/getting-started/appliance_install.md
@@ -1,0 +1,91 @@
+# Appliance Install Guide (On-Premise ISO)
+
+The appliance is the turnkey way to self-host AlgaPSA on your own hardware or VM. It ships as a single bootable ISO that installs the operating system, a self-contained Kubernetes runtime, and AlgaPSA with its database, cache, and background workers. You boot the image, answer a short setup wizard, and sign in. There are no containers to assemble and no manifests to write.
+
+If you would rather build from source or manage the containers yourself, use the [Complete Setup Guide](setup_guide.md) for the Docker Compose path instead.
+
+## What the appliance installs
+
+| Component | What it does |
+| --- | --- |
+| AlgaPSA application | The web app your team signs in to, on port `3000`. |
+| Setup and status console | A separate console on port `8080` for first-time setup and ongoing health. |
+| In-cluster services | Postgres, Redis, Temporal, and the workflow and email workers, all managed for you. |
+| Kubernetes runtime | A single-node control plane that pulls and reconciles the application during setup. |
+
+You work in the application on port `3000`. You check its health on port `8080` when you need to.
+
+## Editions and the install code
+
+When you register, you receive an **install code** by email. The code binds the appliance to your tenant and applies the correct edition, so you do not pick an edition during setup.
+
+- **Essentials** runs the free, open-source feature set and is community-supported. The application offers a 15-day Enterprise trial you can start at any time from inside the app.
+- **Paid editions** add the integration layer, a support contract, and an SLA.
+
+Install codes are single-use. Keep the registration email handy. You enter the code once, in the setup wizard.
+
+## Requirements
+
+| Requirement | Recommendation |
+| --- | --- |
+| Host | A 64-bit x86 machine or VM. The appliance image is Ubuntu Server 24.04. |
+| CPU and memory | 4 vCPUs and 16 GB RAM is a practical starting point. The appliance runs a database, cache, workers, and the application together. |
+| Disk | At least 60 GB. The installer uses the whole disk you select. |
+| Network address | A reachable IPv4 address. If you use DHCP, reserve the lease so the address does not change after a reboot. |
+| Outbound internet | HTTPS (port 443) to `license.nineminds.com` and `ghcr.io`. |
+| Install code | The code from your AlgaPSA registration email. |
+
+Outbound access matters most. During setup the appliance contacts `license.nineminds.com` to redeem the install code, then pulls its images from GitHub Container Registry (`ghcr.io`). If a firewall blocks either host, setup pauses at that step until you open the access.
+
+## Install steps
+
+### 1. Register and download
+
+Register for the appliance at [nineminds.com/self-hosted](https://www.nineminds.com/self-hosted). You receive an install code and an ISO download link by email. For security, install codes are delivered only by email.
+
+### 2. Prepare the machine and boot the ISO
+
+Create a VM with a fresh disk, or use a bare-metal machine, and attach the ISO. Use networking that lets a workstation browser reach the machine on port `8080`. Power on and boot from the ISO. Ubuntu installs unattended, then the machine reboots into Ubuntu Server 24.04.
+
+### 3. Read the setup banner
+
+After the reboot, the console prints a setup banner with:
+
+- the node IP address
+- the setup URL, for example `http://<node-ip>:8080/setup`
+- a one-time setup token
+- a console fallback command
+
+The setup console is usually reachable within a minute or two of first boot.
+
+### 4. Complete the setup wizard
+
+Open the setup URL from a workstation on the same network and enter the setup token. Then provide:
+
+- your **install code** from the registration email
+- a management password for the setup and status console
+- your company name, which becomes the first tenant
+- the administrator account (name, email, and password) you will sign in with
+
+The wizard runs preflight checks for DNS, GitHub access, and registry reachability. It then deploys the platform unattended: it pulls the application images, runs database migrations, and creates your tenant and administrator. This usually takes several minutes, depending on your download speed.
+
+### 5. Sign in and onboard
+
+When the application is ready, open AlgaPSA on port `3000`, for example `http://<node-ip>:3000/`, and sign in with the administrator email and password from the wizard. Guided onboarding walks you through your team, your first client, a billable service, and ticketing.
+
+A first install takes about 30 to 45 minutes, most of it unattended.
+
+## After install
+
+Use the status console on port `8080` for health and diagnostics. App-channel updates (`stable` or `nightly`) run from the status console at `http://<node-ip>:8080/updates`. In the current release, Ubuntu and Kubernetes updates are run manually.
+
+Install codes are single-use. If you lose your code or need to reinstall, re-issue a fresh one for the same tenant from [nineminds.com/self-hosted](https://www.nineminds.com/self-hosted).
+
+## Related documentation
+
+- [Self-Hosting AlgaPSA: The On-Premise Appliance](https://www.nineminds.com/documentation/181-self-hosting-overview) — full walkthrough with screenshots
+- [Installing the appliance OS](https://www.nineminds.com/documentation/182-installing-the-appliance-os) — the Ubuntu installer questions
+- [Configure the appliance](https://www.nineminds.com/documentation/183-appliance-setup-wizard) — the setup wizard in detail
+- [First sign-in and onboarding](https://www.nineminds.com/documentation/184-first-sign-in-and-onboarding) — team, client, billing, and ticketing
+- [Appliance Quick Start](../../ee/docs/appliance/quick-start.md) — VMware ESXi and cloud VM notes
+- [Appliance Operator's Manual](../../ee/docs/appliance/operators-manual.md) — day-2 operation and updates

--- a/docs/getting-started/setup_guide.md
+++ b/docs/getting-started/setup_guide.md
@@ -2,6 +2,8 @@
 
 This guide provides step-by-step instructions for setting up the PSA system using Docker Compose, supporting both Community Edition (CE) and Enterprise Edition (EE).
 
+If you want a turnkey on-premise install instead of running Docker Compose yourself, see the [Appliance Install Guide](appliance_install.md). It installs and configures AlgaPSA from a single bootable ISO.
+
 > Note: The instructions below focus on the CE prebuilt images. Full EE setup guidance, including any edition-specific overrides, is being prepared and will be added soon.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

GitHub readers had no way to discover that AlgaPSA can be self-hosted from a single bootable **appliance ISO** — the README only documents the Docker Compose path. This PR adds that option to the README and installation docs so it's visible to anyone landing on the repo.

The appliance ships as one bootable image that installs Ubuntu Server 24.04, a self-contained Kubernetes runtime, and AlgaPSA with its database, cache, and workers, then sets itself up via a short setup wizard. The free **Essentials** edition runs the open-source feature set; paid editions and a 15-day Enterprise trial are available.

## Changes

- **`README.md`** — new `## On-premise appliance (ISO)` section after Quick start: what it installs, the register → boot → setup wizard → sign-in flow, and appliance hardware requirements. Added the new guide to the Documentation index.
- **`docs/getting-started/appliance_install.md`** (new) — full GitHub-facing install guide: components and ports (3000/8080), editions and the single-use install code, requirements, the five install steps, and day-2 updates. Links to the nineminds.com walkthrough and the in-repo `ee/docs/appliance/` references.
- **`docs/getting-started/setup_guide.md`** — one-line pointer so Docker Compose readers discover the turnkey appliance path.

Docs-only; no code changes. Facts reconciled across the nineminds.com self-hosting docs and the in-repo `ee/docs/appliance/` quick-start and operator's manual. Where requirements conflicted, used the authoritative self-hosting docs (4 vCPU / 16 GB / 60 GB).

https://claude.ai/code/session_013kek7dMvm85WTisvF2zkrd