### PR TITLE
fix(appliance): persist tenant secrets on-prem (and enable inbound IMAP email)

### DIFF
--- a/ee/appliance/flux/profiles/single-node/values/alga-core.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/alga-core.single-node.yaml
@@ -79,6 +79,12 @@ pgbouncer:
     name: pgbouncer
     port: 6432
 
+# Share the tenant-secret store with email-service via a host directory so the
+# IMAP passwords written here by the filesystem secret provider are readable by
+# the email-service pod.
+sharedTenantSecrets:
+  enabled: true
+
 config:
   storage:
     default_provider: local

--- a/ee/appliance/flux/profiles/single-node/values/email-service.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/email-service.single-node.yaml
@@ -33,3 +33,32 @@ db:
   adminPasswordSecret:
     name: db-credentials
     key: DB_PASSWORD_SUPERUSER
+
+# Point inbound IMAP webhooks at the in-cluster alga-core server (alga-core runs
+# hostNetwork, so http://server:3000 is unresolvable in k3s) and source the
+# webhook secret from the alga-core server secret so the HMAC matches.
+webhook:
+  url: "http://alga-core-sebastian.msp.svc.cluster.local:3000/api/email/webhooks/imap"
+  secretKeyRef:
+    name: alga-core-sebastian-secrets
+    key: IMAP_WEBHOOK_SECRET
+
+# Source the application secrets from the alga-core server secret so the crypto
+# key (used to decrypt tenant IMAP credentials) and auth secrets match.
+appSecrets:
+  existingSecret: alga-core-sebastian-secrets
+  keys:
+    cryptoKey: CRYPTR_KEY        # NOTE: alga-core stores the crypto key under CRYPTR_KEY
+    nextauthSecret: NEXTAUTH_SECRET
+    tokenSecretKey: TOKEN_SECRET_KEY
+
+# Share the tenant-secret store with alga-core via a host directory so this
+# service can read the IMAP passwords alga-core writes via the filesystem
+# secret provider.
+sharedTenantSecrets:
+  enabled: true
+
+# Block startup until the server database has been bootstrapped (email_providers
+# table exists) so the service does not crashloop during first-run migrations.
+waitForBootstrap:
+  enabled: true

--- a/ee/helm/email-service/templates/deployment.yaml
+++ b/ee/helm/email-service/templates/deployment.yaml
@@ -64,7 +64,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.waitForBootstrap.enabled }}
-      {{- $useAdmin := and .Values.db.adminPasswordSecret.name .Values.db.adminPasswordSecret.key }}
       initContainers:
         - name: wait-for-bootstrap
           {{- with .Values.securityContext }}
@@ -87,15 +86,9 @@ spec:
               value: "{{ .Values.db.port }}"
             - name: DB_NAME_SERVER
               value: "{{ .Values.db.serverDatabase }}"
-            {{- if $useAdmin }}
-            - name: WAIT_DB_USER
-              value: "{{ .Values.db.adminUser | default "postgres" }}"
-            - name: WAIT_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.db.adminPasswordSecret.name }}
-                  key: {{ .Values.db.adminPasswordSecret.key }}
-            {{- else }}
+            # Use the server (pgbouncer) credentials for the readiness poll: the
+            # superuser may not be authenticated through pgbouncer, and reading
+            # information_schema only needs the app role.
             - name: WAIT_DB_USER
               value: "{{ .Values.db.user }}"
             - name: WAIT_DB_PASSWORD
@@ -103,7 +96,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.db.serverPasswordSecret.name }}
                   key: {{ .Values.db.serverPasswordSecret.key }}
-            {{- end }}
       {{- end }}
       containers:
         - name: email-service

--- a/ee/helm/email-service/templates/deployment.yaml
+++ b/ee/helm/email-service/templates/deployment.yaml
@@ -63,6 +63,48 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.waitForBootstrap.enabled }}
+      {{- $useAdmin := and .Values.db.adminPasswordSecret.name .Values.db.adminPasswordSecret.key }}
+      initContainers:
+        - name: wait-for-bootstrap
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.waitForBootstrap.image.name }}:{{ .Values.waitForBootstrap.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForBootstrap.pullPolicy }}
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              echo "Waiting for the email_providers table to exist..."
+              until PGPASSWORD="${WAIT_DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${WAIT_DB_USER}" -d "${DB_NAME_SERVER}" -Atqc "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'email_providers');" 2>/dev/null | grep -q '^t$'; do
+                sleep 2
+              done
+          env:
+            - name: DB_HOST
+              value: "{{ .Values.db.host }}"
+            - name: DB_PORT
+              value: "{{ .Values.db.port }}"
+            - name: DB_NAME_SERVER
+              value: "{{ .Values.db.serverDatabase }}"
+            {{- if $useAdmin }}
+            - name: WAIT_DB_USER
+              value: "{{ .Values.db.adminUser | default "postgres" }}"
+            - name: WAIT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.adminPasswordSecret.name }}
+                  key: {{ .Values.db.adminPasswordSecret.key }}
+            {{- else }}
+            - name: WAIT_DB_USER
+              value: "{{ .Values.db.user }}"
+            - name: WAIT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.serverPasswordSecret.name }}
+                  key: {{ .Values.db.serverPasswordSecret.key }}
+            {{- end }}
+      {{- end }}
       containers:
         - name: email-service
           {{- with .Values.securityContext }}
@@ -137,6 +179,10 @@ spec:
               value: "{{ .Values.secretsProvider.readChain }}"
             - name: SECRET_WRITE_PROVIDER
               value: "{{ .Values.secretsProvider.writeProvider }}"
+            {{- if .Values.sharedTenantSecrets.enabled }}
+            - name: SECRET_FS_BASE_PATH
+              value: "{{ .Values.sharedTenantSecrets.mountPath }}"
+            {{- end }}
             {{- if .Values.secretsProvider.vault.addr }}
             - name: VAULT_ADDR
               value: "{{ .Values.secretsProvider.vault.addr }}"
@@ -195,21 +241,22 @@ spec:
                   key: {{ default "IMAP_WEBHOOK_SECRET" .Values.webhook.secretKeyRef.key | quote }}
 
             {{- if not .Values.vaultAgent.enabled }}
+            {{- $appSecretName := .Values.appSecrets.existingSecret | default (printf "%s-secrets" (include "email-service.fullname" .)) }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "email-service.fullname" . }}-secrets
-                  key: NEXTAUTH_SECRET
+                  name: {{ $appSecretName | quote }}
+                  key: {{ if .Values.appSecrets.existingSecret }}{{ .Values.appSecrets.keys.nextauthSecret | quote }}{{ else }}NEXTAUTH_SECRET{{ end }}
             - name: TOKEN_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "email-service.fullname" . }}-secrets
-                  key: TOKEN_SECRET_KEY
+                  name: {{ $appSecretName | quote }}
+                  key: {{ if .Values.appSecrets.existingSecret }}{{ .Values.appSecrets.keys.tokenSecretKey | quote }}{{ else }}TOKEN_SECRET_KEY{{ end }}
             - name: CRYPTO_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "email-service.fullname" . }}-secrets
-                  key: CRYPTO_KEY
+                  name: {{ $appSecretName | quote }}
+                  key: {{ if .Values.appSecrets.existingSecret }}{{ .Values.appSecrets.keys.cryptoKey | quote }}{{ else }}CRYPTO_KEY{{ end }}
             {{- end }}
 
             {{- range .Values.extraEnv }}
@@ -251,11 +298,21 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
 
           volumeMounts:
+            {{- if .Values.sharedTenantSecrets.enabled }}
+            - name: shared-tenant-secrets
+              mountPath: {{ .Values.sharedTenantSecrets.mountPath }}
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
       volumes:
+        {{- if .Values.sharedTenantSecrets.enabled }}
+        - name: shared-tenant-secrets
+          hostPath:
+            path: {{ .Values.sharedTenantSecrets.hostPath }}
+            type: DirectoryOrCreate
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/ee/helm/email-service/values.yaml
+++ b/ee/helm/email-service/values.yaml
@@ -87,6 +87,18 @@ secrets:
   cryptoKey: "change-me-in-prod"
   imapWebhookSecret: "change-me-in-prod"
 
+# Source the application secrets (crypto/nextauth/token) from an existing
+# Kubernetes secret instead of this chart's own "<fullname>-secrets". When
+# existingSecret is empty (default) the chart-managed secret is used, so
+# cloud/hosted rendering is unchanged. The on-prem appliance points these at
+# the alga-core server secret so both services share identical keys.
+appSecrets:
+  existingSecret: ""        # when set, source app secrets from this k8s secret
+  keys:
+    cryptoKey: CRYPTO_KEY
+    nextauthSecret: NEXTAUTH_SECRET
+    tokenSecretKey: TOKEN_SECRET_KEY
+
 vaultAgent:
   enabled: false
   role: email-service
@@ -137,6 +149,26 @@ affinity: {}
 extraEnv: []
 extraVolumes: []
 extraVolumeMounts: []
+
+# Shared tenant-secret store on the single-node appliance. When enabled, mounts
+# a hostPath into the pod and points the filesystem secret provider at it via
+# SECRET_FS_BASE_PATH so this service reads the same tenant secrets alga-core
+# writes. Disabled by default → cloud/hosted rendering is unchanged.
+sharedTenantSecrets:
+  enabled: false
+  hostPath: /var/lib/alga-appliance/tenant-secrets
+  mountPath: /shared-tenant-secrets
+
+# Wait-for-bootstrap init container. When enabled, polls the server database
+# until the email_providers table exists so the service does not crashloop on
+# Postgres undefined_table errors while migrations are still running. Disabled
+# by default → cloud/hosted rendering is unchanged.
+waitForBootstrap:
+  enabled: false
+  image:
+    name: ankane/pgvector
+    tag: latest
+  pullPolicy: IfNotPresent
 
 namespace: ""
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -100,7 +100,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "sebastian.fullname" . }}-storage
           {{- end }}
-        {{- end }}        
+        {{- end }}
+        {{- if .Values.sharedTenantSecrets.enabled }}
+        - name: shared-tenant-secrets
+          hostPath:
+            path: {{ .Values.sharedTenantSecrets.hostPath }}
+            type: DirectoryOrCreate
+        {{- end }}
       {{- if or .Values.setup.runMigrations .Values.setup.runSeeds }}
       initContainers:
         - name: wait-for-bootstrap
@@ -943,6 +949,10 @@ spec:
             value: "{{ .Values.secrets_provider.readChain | default "env,filesystem" }}"
           - name: SECRET_WRITE_PROVIDER
             value: "{{ .Values.secrets_provider.writeProvider | default "filesystem" }}"
+          {{- if .Values.sharedTenantSecrets.enabled }}
+          - name: SECRET_FS_BASE_PATH
+            value: "{{ .Values.sharedTenantSecrets.mountPath }}"
+          {{- end }}
           {{- if .Values.secrets_provider.envPrefix }}
           - name: SECRET_ENV_PREFIX
             value: "{{ .Values.secrets_provider.envPrefix }}"
@@ -974,10 +984,16 @@ spec:
             value: "{{ .Values.secrets_provider.vault.tenantSecretPathTemplate }}"
           {{- end }}
           {{- end }}
-         {{- if and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled) }}
+          {{- if or (and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled)) .Values.sharedTenantSecrets.enabled }}
           volumeMounts:
+            {{- if and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled) }}
             - name: storage-volume
               mountPath: {{ .Values.server.persistence.mountPath }}
+            {{- end }}
+            {{- if .Values.sharedTenantSecrets.enabled }}
+            - name: shared-tenant-secrets
+              mountPath: {{ .Values.sharedTenantSecrets.mountPath }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -490,6 +490,16 @@ secrets_provider:
     # Path template for tenant secrets
     tenantSecretPathTemplate: "kv/data/tenants/{tenantId}/secrets"
 
+# Shared tenant-secret store on the single-node appliance. When enabled, mounts
+# a hostPath into the server pod and points the filesystem secret provider at it
+# via SECRET_FS_BASE_PATH, so tenant secrets the server writes are visible to
+# other appliance services (e.g. email-service) that mount the same hostPath.
+# Disabled by default → cloud/hosted rendering is unchanged.
+sharedTenantSecrets:
+  enabled: false
+  hostPath: /var/lib/alga-appliance/tenant-secrets
+  mountPath: /shared-tenant-secrets
+
 # Development environment configuration
 devEnv:
   enabled: false


### PR DESCRIPTION
## Summary

On the on-prem appliance, tenant-scoped secrets were written to ephemeral container storage and lost on every restart. This change makes them durable and shared across pods. That also unblocks inbound IMAP email. All new behavior is gated behind values that default to off or empty, so cloud and hosted rendering is unchanged (verified with `helm template`).

## The main bug: tenant secrets do not survive a restart

The appliance secret provider chain is `env,filesystem` with `writeProvider: filesystem`. With no `SECRET_FS_BASE_PATH` set, `FileSystemSecretProvider` resolves its base path to `/run/secrets` inside the pod. On the appliance that path is the container's ephemeral writable layer, not persistent storage.

So `setTenantSecret(...)` succeeds with no error, then the value disappears on the next container or pod restart (reschedule, node reboot, OOM, eviction, or any Helm upgrade). Nothing is logged at save time, so the integration stops working later with no obvious cause.

This affects any tenant-scoped credential written through the secret provider:
- OAuth email providers: Microsoft 365 and Gmail client secrets and refresh tokens
- IMAP passwords
- any other integration credential stored via `setTenantSecret`

It is also why secrets never crossed pods. `alga-core` wrote to its own `/run/secrets` and `email-service` read from a different pod's empty `/run/secrets`, so the value was invisible to the reader even within a single boot.

## Fix

Add a gated `sharedTenantSecrets` option that mounts a host directory (`/var/lib/alga-appliance/tenant-secrets`) into both `alga-core` and `email-service` at `/shared-tenant-secrets`, and sets `SECRET_FS_BASE_PATH` to it. The directory lives on the host disk, so secrets persist across container restarts, pod restarts, and OS reboots, and both pods share one store.

## Also fixed: inbound IMAP email on-prem

With the shared store in place, three more gaps blocked inbound IMAP:

1. Webhook URL was unset, so email-service fell back to `http://server:3000`, which does not resolve in k3s (alga-core runs `hostNetwork`). It now points at `http://alga-core-sebastian.msp.svc.cluster.local:3000/api/email/webhooks/imap`.
2. Webhook secret and crypto key did not match. email-service generated its own `IMAP_WEBHOOK_SECRET` and `CRYPTO_KEY` (`change-me-in-prod`), so the webhook returned 401 and credential decryption failed. New `appSecrets.existingSecret` sources `CRYPTO_KEY`, `NEXTAUTH_SECRET`, and `TOKEN_SECRET_KEY` from the alga-core secret (`alga-core-sebastian-secrets`, crypto key under `CRYPTR_KEY`). `webhook.secretKeyRef` points `IMAP_WEBHOOK_SECRET` there too.
3. email-service crashlooped on first boot because it started before migrations created the email tables (Postgres `42P01`). A new gated `waitForBootstrap` init container waits for the `email_providers` table.

## Changes

- `ee/helm/email-service/` (chart and values): `appSecrets`, `sharedTenantSecrets`, `waitForBootstrap`. All default off or empty.
- `helm/` (sebastian chart and values): `sharedTenantSecrets`. Default off.
- `ee/appliance/flux/profiles/single-node/values/{alga-core,email-service}.single-node.yaml`: enable the above for the appliance.

## Impact on existing on-prem installs

- Secrets stored before this upgrade are not migrated. After upgrading, re-enter integration secrets once (OAuth email connections, IMAP passwords). They then persist. Installs were already losing these on every reboot, so this is a one-time, net-positive step rather than new data loss.
- The upgrade restarts the application pods. `alga-core` is `hostNetwork` and uses the `Recreate` strategy, so expect a brief outage during the rollout.
- Cloud and hosted are unaffected. Everything is gated default-off, and `helm template` with default values is byte-unchanged.

## Validation

- `helm template` with default values renders cloud and hosted unchanged. With the appliance profile values it renders the full fixed config.
- On the libvirt test appliance, confirmed that `/run/secrets` writes succeed but are ephemeral (the bug), and that the shared host path persists and is read by both pods. An inbound GreenMail email became a ticket through a clean Flux reconcile of the published charts, with no manual hotfixes.

## Follow-ups (not in this PR)

- Onboarding's `createBoardTicketStatus` returns a raw 500 on a validation rejection (manual status add). It is non-blocking; onboarding completes through the import path. Harden separately with a confirmed repro.
- The appliance publish workflow re-versions all charts, so an upgrade restarts the whole stack. It could be narrowed to changed charts.

https://claude.ai/code/session_011CU91Ymbvuq427p1ar7F3F
