### PR TITLE
fix(rbac): backfill missing 'interaction' permissions (interactions appear 'vanished' for all tenants)

### DIFF
--- a/server/migrations/20260622120000_add_interaction_permissions.cjs
+++ b/server/migrations/20260622120000_add_interaction_permissions.cjs
@@ -1,0 +1,150 @@
+/**
+ * Add RBAC permissions for the 'interaction' resource.
+ *
+ * The interaction server actions (getRecentInteractions, getInteractionsForEntity,
+ * getInteractionTypes, getInteractionStatuses, addInteraction, updateInteraction,
+ * deleteInteraction in packages/clients/src/actions/interactionActions.ts) authorize
+ * against resource 'interaction' via assertMspPermission(user, 'interaction', <action>).
+ * Those gates were introduced by the server-action RBAC audit (#2743 and related),
+ * but no tenant ever received permission rows for the 'interaction' resource:
+ *   - The comprehensive-permissions migration (20250619120000) that defines them was
+ *     first applied to existing tenants from an image built before the 'interaction'
+ *     defs were committed, so knex marked it complete and never inserted those rows.
+ *   - New-tenant provisioning has no 'interaction' entry in its permission set.
+ * Result: every interaction read/write returned "Permission denied: Cannot read
+ * interactions" for ALL MSP users in ALL tenants — even Admins, with nothing to grant
+ * through the UI. Interactions silently rendered empty (the client feed swallows the
+ * action error), so customers reported that their interactions had "vanished" even
+ * though the underlying rows were intact.
+ *
+ * This migration backfills the 'interaction' permission rows for every tenant and
+ * grants them to MSP roles, mirroring the existing 'contact'/'ticket' (CRM activity)
+ * distribution so prior behaviour — every internal user can at least read interactions
+ * — is restored. Idempotent: safe to re-run and safe for tenants that already have
+ * some/all of the rows. Adjust ROLE_ACTIONS if a tenant uses custom role names.
+ */
+
+const INTERACTION_PERMISSION_DEFS = [
+  { resource: 'interaction', action: 'create', msp: true, client: false, description: 'Create interactions (calls, notes, check-ins, activity)' },
+  { resource: 'interaction', action: 'read', msp: true, client: false, description: 'View interactions' },
+  { resource: 'interaction', action: 'update', msp: true, client: false, description: 'Update interactions' },
+  { resource: 'interaction', action: 'delete', msp: true, client: false, description: 'Delete interactions' },
+];
+
+// Per standard MSP role: which interaction actions to grant. Mirrors the existing
+// contact/ticket CRM-activity model. Every role gets at least 'read' so interactions
+// stop rendering empty; delete is reserved to Admin/Finance.
+const ROLE_ACTIONS = {
+  'Admin': ['create', 'read', 'update', 'delete'],
+  'Finance': ['create', 'read', 'update', 'delete'],
+  'Manager': ['create', 'read', 'update'],
+  'Project Manager': ['create', 'read', 'update'],
+  'Dispatcher': ['create', 'read', 'update'],
+  'Technician': ['create', 'read', 'update'],
+};
+
+async function ensurePermission(knex, tenant, def) {
+  const existing = await knex('permissions')
+    .where({ tenant, resource: def.resource, action: def.action })
+    .first();
+
+  if (existing) {
+    if (existing.msp !== def.msp || existing.client !== def.client || existing.description !== def.description) {
+      await knex('permissions')
+        .where({ tenant, permission_id: existing.permission_id })
+        .update({
+          msp: def.msp,
+          client: def.client,
+          description: def.description,
+          updated_at: knex.fn.now(),
+        });
+    }
+
+    return existing.permission_id;
+  }
+
+  const [inserted] = await knex('permissions')
+    .insert({
+      tenant,
+      resource: def.resource,
+      action: def.action,
+      msp: def.msp,
+      client: def.client,
+      description: def.description,
+      created_at: knex.fn.now(),
+    })
+    .returning('permission_id');
+
+  return inserted.permission_id;
+}
+
+async function assignPermission(knex, tenant, roleId, permissionId) {
+  const existing = await knex('role_permissions')
+    .where({ tenant, role_id: roleId, permission_id: permissionId })
+    .first('tenant');
+
+  if (existing) {
+    return;
+  }
+
+  await knex('role_permissions').insert({
+    tenant,
+    role_id: roleId,
+    permission_id: permissionId,
+    created_at: knex.fn.now(),
+  });
+}
+
+exports.up = async function up(knex) {
+  const tenants = await knex('tenants').select('tenant');
+
+  for (const { tenant } of tenants) {
+    // 1) Ensure all four interaction permission rows exist for this tenant.
+    const permissionIdByAction = {};
+    for (const def of INTERACTION_PERMISSION_DEFS) {
+      permissionIdByAction[def.action] = await ensurePermission(knex, tenant, def);
+    }
+
+    // 2) Grant the per-role action set to each matching MSP role.
+    const roles = await knex('roles')
+      .where({ tenant, msp: true })
+      .whereIn('role_name', Object.keys(ROLE_ACTIONS))
+      .select('role_id', 'role_name');
+
+    for (const role of roles) {
+      const actions = ROLE_ACTIONS[role.role_name] || [];
+      for (const action of actions) {
+        const permissionId = permissionIdByAction[action];
+        if (permissionId) {
+          await assignPermission(knex, tenant, role.role_id, permissionId);
+        }
+      }
+    }
+  }
+};
+
+exports.down = async function down(knex) {
+  const tenants = await knex('tenants').select('tenant');
+  const actions = INTERACTION_PERMISSION_DEFS.map((def) => def.action);
+
+  for (const { tenant } of tenants) {
+    const permissionIds = await knex('permissions')
+      .where({ tenant, resource: 'interaction' })
+      .whereIn('action', actions)
+      .pluck('permission_id');
+
+    if (!permissionIds.length) {
+      continue;
+    }
+
+    await knex('role_permissions')
+      .where({ tenant })
+      .whereIn('permission_id', permissionIds)
+      .del();
+
+    await knex('permissions')
+      .where({ tenant, resource: 'interaction' })
+      .whereIn('action', actions)
+      .del();
+  }
+};

--- a/server/seeds/dev/47_permissions.cjs
+++ b/server/seeds/dev/47_permissions.cjs
@@ -29,7 +29,13 @@ exports.seed = async function(knex) {
         { resource: 'contact', action: 'read', msp: true, client: false, description: 'View contacts' },
         { resource: 'contact', action: 'update', msp: true, client: false, description: 'Update contacts' },
         { resource: 'contact', action: 'delete', msp: true, client: false, description: 'Delete contacts' },
-        
+
+        // Interaction permissions (calls, notes, check-ins, activity — gated by interactionActions)
+        { resource: 'interaction', action: 'create', msp: true, client: false, description: 'Create interactions (calls, notes, check-ins, activity)' },
+        { resource: 'interaction', action: 'read', msp: true, client: false, description: 'View interactions' },
+        { resource: 'interaction', action: 'update', msp: true, client: false, description: 'Update interactions' },
+        { resource: 'interaction', action: 'delete', msp: true, client: false, description: 'Delete interactions' },
+
         // Credit permissions
         { resource: 'credit', action: 'create', msp: true, client: false, description: 'Create credits' },
         { resource: 'credit', action: 'read', msp: true, client: false, description: 'View credits' },

--- a/server/seeds/dev/48_role_permissions.cjs
+++ b/server/seeds/dev/48_role_permissions.cjs
@@ -39,6 +39,7 @@ exports.seed = async function (knex) {
         // MSP Finance - Based on permissions_list.md
         else if (role.role_name === 'Finance' && role.msp === true) {
             const financePermissions = [
+                'interaction:create:msp', 'interaction:read:msp', 'interaction:update:msp', 'interaction:delete:msp',
                 'asset:read:msp',
                 'billing:create:msp', 'billing:read:msp', 'billing:update:msp', 'billing:delete:msp',
                 'client:create:msp', 'client:read:msp', 'client:update:msp', 'client:delete:msp',
@@ -68,6 +69,7 @@ exports.seed = async function (knex) {
         // MSP Manager - parity baseline: technician capabilities plus scoped approvals and user/team visibility
         else if (role.role_name === 'Manager' && role.msp === true) {
             const managerPermissions = [
+                'interaction:create:msp', 'interaction:read:msp', 'interaction:update:msp',
                 'asset:create:msp', 'asset:read:msp', 'asset:update:msp',
                 'client:read:msp', 'client:delete:msp',
                 'contact:read:msp', 'contact:delete:msp',
@@ -96,6 +98,7 @@ exports.seed = async function (knex) {
         // MSP Technician - Based on permissions_list.md
         else if (role.role_name === 'Technician' && role.msp === true) {
             const technicianPermissions = [
+                'interaction:create:msp', 'interaction:read:msp', 'interaction:update:msp',
                 'asset:create:msp', 'asset:read:msp', 'asset:update:msp',
                 'client:read:msp', 'client:delete:msp',
                 'contact:read:msp', 'contact:delete:msp',
@@ -122,6 +125,7 @@ exports.seed = async function (knex) {
         // MSP Project Manager - Based on permissions_list.md
         else if (role.role_name === 'Project Manager' && role.msp === true) {
             const projectManagerPermissions = [
+                'interaction:create:msp', 'interaction:read:msp', 'interaction:update:msp',
                 'asset:read:msp',
                 'billing:read:msp',
                 'client:create:msp', 'client:read:msp', 'client:update:msp',
@@ -152,6 +156,7 @@ exports.seed = async function (knex) {
         // MSP Dispatcher - Based on permissions_list.md
         else if (role.role_name === 'Dispatcher' && role.msp === true) {
             const dispatcherPermissions = [
+                'interaction:create:msp', 'interaction:read:msp', 'interaction:update:msp',
                 'asset:read:msp',
                 'client:read:msp',
                 'contact:read:msp',


### PR DESCRIPTION
## Incident
A customer (AI MED CONSULT LLC) reported that **all their interactions for all clients had vanished**. Investigation found this is a **fleet-wide RBAC regression — not data loss**. Every tenant's interactions are affected; this customer just noticed first because they rely on Interactions heavily (automated weekly lead reports). Their 110 interaction rows are fully intact in the DB.

## Root cause
The interaction server actions (`getRecentInteractions`, `getInteractionsForEntity`, `getInteractionTypes`, `getInteractionStatuses`, `add/update/deleteInteraction`) authorize against resource `interaction` via `assertMspPermission` — gates introduced by the server-action RBAC work (#2743), live in the current release. But **no production tenant has ever had an `interaction` permission row**:

- The comprehensive-permissions migration (`20250619120000`) that defines the `interaction` perms had those lines committed **after** it had already run in prod, so knex marked it complete and never inserted them.
- The canonical permission seed (`47_permissions.cjs`) **omits `interaction` entirely**, so newly provisioned tenants never received it either.

`hasPermission` has no admin bypass, so **every MSP user in every tenant — including Admins — is denied interaction read/write** (`Permission denied: Cannot read interactions`, actively logged in prod). The client feed swallows the action error and renders empty → "vanished," while the underlying rows are untouched.

## Fix
Mirrors the `add_financial_resource_permissions` precedent (same bug class):
- **New migration** `20260622120000_add_interaction_permissions.cjs` — backfills the 4 `interaction` perms for every tenant and grants them to MSP roles (Admin/Finance full; Manager/Technician/Dispatcher/Project Manager get create/read/update). Idempotent + reversible (`down`).
- **Seeds** `47_permissions.cjs` + `48_role_permissions.cjs` — adds `interaction` so new tenants/fresh installs get it going forward (Admin auto-inherits all MSP perms).

## Validation
- Read-only probes against production confirmed: zero tenants hold any `interaction` permission; 110 rows for the reporting tenant are intact and referentially clean.
- Dry-run of the migration's grant logic against the affected tenant's real roles confirms Admin users regain `interaction:read` → incident resolved on next deploy.
- All three files pass `node --check`.

## Rollout
Ships via the normal deploy; the migration backfills all tenants (cloud + appliance) when it runs. No manual prod writes performed.
