### PR TITLE
fix(jobs): make EE select Temporal reliably; remove silent pgboss fallback

### DIFF
--- a/ee/docs/runbooks/2026-06-22-jobrunner-pgboss-to-temporal-cutover.md
+++ b/ee/docs/runbooks/2026-06-22-jobrunner-pgboss-to-temporal-cutover.md
@@ -1,0 +1,123 @@
+# Runbook — Cut the job runner over from PG Boss to Temporal
+
+**Why:** In production the EE job-runner abstraction silently resolved to PG Boss
+(`isEnterprise` module-init race + silent `fallbackToPgBoss`). Recurring polls
+(Huntress, RMM, extension schedules) run as pg-boss cron jobs whose consumers are
+**in-process `boss.work()` subscriptions** — a redeploy (2026-06-19 17:53) orphaned
+them and polls stopped. Fix: PR alga-psa#2753 (edition-race fix + remove fallback +
+`JOB_RUNNER_TYPE` chart env) and PR nm-kube-config#67 (`temporal.jobRunnerType: temporal`).
+
+Switching the runner is **not** enough on its own: the reconciler treats the existing
+pg-boss `jobs` rows as "converged" and won't recreate them on Temporal, and the old
+`pgboss.schedule` cron rows keep enqueuing forever with no consumer. This runbook does
+the cutover cleanly.
+
+Scope of this runbook: **`huntress-incident-poll:*` and `rmm-alert-reconciliation:*`**,
+both managed by `reconcileRmmPollingSchedules()` (verified). `extsched:*` is handled by a
+separate extension-schedule reconciler — see the **EXTSCHED** caveat at the bottom; do
+**not** delete its schedules until that path is verified.
+
+All DB statements use the admin role. From a sebastian pod:
+`kubectl -n msp exec -i <sebastian-pod> -c sebastian -- node` with a `pg` client built
+from `DB_HOST/DB_PORT/DB_NAME_SERVER` + `DB_USER_ADMIN/DB_PASSWORD_ADMIN`.
+
+---
+
+## 0. Preconditions
+
+- [ ] alga-psa#2753 merged and a new sebastian image built.
+- [ ] nm-kube-config#67 merged.
+- [ ] sebastian (blue+green) redeployed with the new image **and** chart values.
+
+## 1. Verify sebastian now selects Temporal
+
+```
+kubectl -n msp logs <sebastian-pod> -c sebastian --since=15m | grep -i "Initializing job runner"
+# expect:  Initializing job runner { type: 'temporal', isEnterprise: true }
+#          (and NO "Falling back to PG Boss")
+```
+
+Confirm the env landed:
+
+```
+kubectl -n msp exec <sebastian-pod> -c sebastian -- sh -lc 'echo "$JOB_RUNNER_TYPE"'   # -> temporal
+```
+
+## 2. Verify the Temporal worker polls `alga-jobs`
+
+The `temporal-worker` already force-appends `alga-jobs` (workerConfig). Confirm pollers
+exist (Temporal UI task-queue view, or a temporal CLI pod):
+`temporal task-queue describe --task-queue alga-jobs` → expect ≥1 workflow poller.
+
+## 3. Stop the pg-boss bleed (delete cron schedules)
+
+```sql
+DELETE FROM pgboss.schedule
+WHERE name LIKE 'huntress-incident-poll:%'
+   OR name LIKE 'rmm-alert-reconciliation:%';
+```
+
+## 4. Drain remaining pg-boss backlog for these queues
+
+```sql
+DELETE FROM pgboss.job
+WHERE state IN ('created','retry','active')
+  AND ( name LIKE 'huntress-incident-poll:%'
+     OR name LIKE 'rmm-alert-reconciliation:%' );
+```
+
+## 5. Clear the Alga recurring job rows so the reconciler recreates on Temporal
+
+`findExistingRecurringJob()` only skips when a matching recurring row with a non-null
+`external_id` exists. Deleting the recurring **marker** rows (not execution history)
+forces re-creation through the now-Temporal runner.
+
+```sql
+DELETE FROM jobs
+WHERE metadata->>'recurring' = 'true'
+  AND ( metadata->>'singletonKey' LIKE 'huntress-incident-poll:%'
+     OR metadata->>'singletonKey' LIKE 'rmm-alert-reconciliation:%' );
+```
+
+## 6. Let the reconciler recreate on Temporal
+
+It runs every 5 min from `initializeApp` (or trigger immediately by toggling an
+integration, or for Huntress call the `runHuntressPollNow()` action). Then verify the new
+rows are Temporal-backed:
+
+```sql
+SELECT metadata->>'singletonKey' AS sk, runner_type, status, external_id IS NOT NULL AS has_sched
+FROM jobs
+WHERE metadata->>'recurring' = 'true'
+  AND ( metadata->>'singletonKey' LIKE 'huntress-incident-poll:%'
+     OR metadata->>'singletonKey' LIKE 'rmm-alert-reconciliation:%' )
+ORDER BY created_at DESC;
+-- expect runner_type = 'temporal', has_sched = true
+```
+
+And confirm `pgboss.schedule` has **no** rows for these names (step 3 held).
+
+## 7. Verify end-to-end (Huntress)
+
+- A new Temporal Schedule fires `genericJobWorkflow` on `alga-jobs`.
+- `rmm_integrations.last_incremental_sync_at` for tenant
+  `a42aa793-9aa8-4db1-b771-247badcf2f6a` (Shift Left Security) advances to ~now.
+- New `status='sent'` incidents create tickets (`source='huntress'`).
+
+---
+
+## Rollback
+
+The code fix makes EE **default** to Temporal, so to revert you must force pg-boss
+explicitly: set `temporal.jobRunnerType: pgboss` (nm-kube-config) and redeploy. NOTE:
+pg-boss still has the in-process worker re-subscription gap that started this incident —
+rolling back reintroduces that exposure. Prefer fixing forward.
+
+## EXTSCHED caveat (do NOT run blindly)
+
+`extsched:*` queues (extension schedules) are **not** managed by
+`reconcileRmmPollingSchedules()`. They had ~9,932 orphaned jobs and will regrow on
+pg-boss until migrated. Before deleting their `pgboss.schedule` rows, confirm the
+extension-schedule reconciler (`extRegistryV2Actions` / `extensionScheduleActions`)
+recreates them on the Temporal runner — otherwise those extension schedules would stop
+entirely. Migrate extsched as a separate, verified step.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -267,6 +267,10 @@ spec:
             value: "{{ .Values.temporal.namespace }}"
           - name: TEMPORAL_PORTAL_DOMAIN_TASK_QUEUE
             value: "{{ .Values.temporal.portalDomainTaskQueue }}"
+          {{- if .Values.temporal.jobRunnerType }}
+          - name: JOB_RUNNER_TYPE
+            value: "{{ .Values.temporal.jobRunnerType }}"
+          {{- end }}
 
           # ----------- REDIS ----------------
           {{- if .Values.redis.enabled }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -119,6 +119,10 @@ temporal:
   address: "temporal-frontend.temporal.svc.cluster.local:7233"
   namespace: "default"
   portalDomainTaskQueue: "portal-domain-workflows"
+  # Job-runner backend override. Leave empty to let the app pick by edition
+  # (EE -> temporal, CE -> pgboss). Set to "temporal" on EE deployments as a
+  # belt-and-suspenders override of the edition default.
+  jobRunnerType: ""
 
 # Development Pod Configuration
 devPod:

--- a/packages/jobs/src/lib/jobs/interfaces/IJobRunnerFactory.ts
+++ b/packages/jobs/src/lib/jobs/interfaces/IJobRunnerFactory.ts
@@ -44,9 +44,6 @@ export interface JobRunnerConfig {
 
   /** Temporal specific configuration (used when type is 'temporal') */
   temporal?: TemporalConfig;
-
-  /** Whether to fall back to PG Boss if Temporal is unavailable (EE only) */
-  fallbackToPgBoss?: boolean;
 }
 
 /**

--- a/server/src/lib/jobs/JobRunnerFactory.ts
+++ b/server/src/lib/jobs/JobRunnerFactory.ts
@@ -1,65 +1,11 @@
 import logger from '@alga-psa/core/logger';
-import { isEnterprise } from '../features';
+import { isEnterprise, isEnterpriseEdition } from '../features';
 import {
   IJobRunner,
   IJobRunnerFactory,
   JobRunnerConfig,
 } from './interfaces';
 import { PgBossJobRunner } from './runners/PgBossJobRunner';
-
-/**
- * Dummy job runner that logs operations but doesn't execute jobs
- * Used as a fallback when no job runner can be initialized
- */
-class DummyJobRunner implements IJobRunner {
-  constructor() {
-    logger.warn('Using DummyJobRunner - job processing will be disabled');
-  }
-
-  getRunnerType(): 'pgboss' | 'temporal' {
-    return 'pgboss';
-  }
-
-  registerHandler(): void {
-    logger.warn('DummyJobRunner: Attempted to register handler');
-  }
-
-  async scheduleJob(): Promise<{ jobId: string; externalId: null }> {
-    logger.warn('DummyJobRunner: Attempted to schedule job');
-    return { jobId: 'dummy', externalId: null };
-  }
-
-  async scheduleJobAt(): Promise<{ jobId: string; externalId: null }> {
-    logger.warn('DummyJobRunner: Attempted to schedule job at time');
-    return { jobId: 'dummy', externalId: null };
-  }
-
-  async scheduleRecurringJob(): Promise<{ jobId: string; externalId: null }> {
-    logger.warn('DummyJobRunner: Attempted to schedule recurring job');
-    return { jobId: 'dummy', externalId: null };
-  }
-
-  async cancelJob(): Promise<boolean> {
-    logger.warn('DummyJobRunner: Attempted to cancel job');
-    return false;
-  }
-
-  async getJobStatus(): Promise<null> {
-    return null;
-  }
-
-  async start(): Promise<void> {
-    logger.warn('DummyJobRunner: start() called');
-  }
-
-  async stop(): Promise<void> {
-    logger.warn('DummyJobRunner: stop() called');
-  }
-
-  async isHealthy(): Promise<boolean> {
-    return false;
-  }
-}
 
 /**
  * Factory for creating job runner instances
@@ -177,36 +123,32 @@ export class JobRunnerFactory implements IJobRunnerFactory {
   private async initializeJobRunner(
     config?: Partial<JobRunnerConfig>
   ): Promise<IJobRunner> {
-    // Determine runner type based on config, environment, and edition
+    // Determine runner type based on config, environment, and edition.
+    // Re-evaluate the edition via isEnterpriseEdition() (reads process.env)
+    // rather than the module-level `isEnterprise` const: the const can be read
+    // before the features module finishes initializing, which previously made
+    // EE silently resolve to PG Boss.
     const runnerType = this.determineRunnerType(config);
+    const enterprise = isEnterpriseEdition();
 
-    logger.info(`Initializing job runner`, { type: runnerType, isEnterprise });
+    logger.info(`Initializing job runner`, { type: runnerType, isEnterprise: enterprise });
 
+    // No silent fallback. In EE, Temporal is the durable scheduling/execution
+    // authority; failing to bring it up must surface loudly rather than quietly
+    // degrading to PG Boss (which strands recurring schedules on a backend with
+    // no durable consumer). Let the error propagate to the caller.
     try {
-      if (runnerType === 'temporal' && isEnterprise) {
+      if (runnerType === 'temporal' && enterprise) {
         return await this.createTemporalRunner(config);
-      } else {
-        return await this.createPgBossRunner(config);
       }
+      return await this.createPgBossRunner(config);
     } catch (error) {
-      logger.error('Failed to initialize job runner:', error);
-
-      // If Temporal fails and fallback is enabled, try PG Boss
-      if (
-        runnerType === 'temporal' &&
-        config?.fallbackToPgBoss !== false
-      ) {
-        logger.warn('Falling back to PG Boss job runner');
-        try {
-          return await this.createPgBossRunner(config);
-        } catch (fallbackError) {
-          logger.error('Fallback to PG Boss also failed:', fallbackError);
-        }
-      }
-
-      // Return dummy runner as last resort
-      logger.warn('Using DummyJobRunner as fallback');
-      return new DummyJobRunner();
+      logger.error('Failed to initialize job runner; refusing to fall back', {
+        runnerType,
+        isEnterprise: enterprise,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
   }
 
@@ -229,7 +171,9 @@ export class JobRunnerFactory implements IJobRunnerFactory {
 
     // Default based on edition.
     // EE should use Temporal as the durable scheduling/execution authority by default.
-    return isEnterprise ? 'temporal' : 'pgboss';
+    // Call isEnterpriseEdition() (reads process.env) instead of the module-level
+    // `isEnterprise` const to stay immune to module-initialization ordering.
+    return isEnterpriseEdition() ? 'temporal' : 'pgboss';
   }
 
   /**
@@ -247,7 +191,7 @@ export class JobRunnerFactory implements IJobRunnerFactory {
   private async createTemporalRunner(
     config?: Partial<JobRunnerConfig>
   ): Promise<IJobRunner> {
-    if (!isEnterprise) {
+    if (!isEnterpriseEdition()) {
       throw new Error('Temporal job runner is only available in Enterprise Edition');
     }
 

--- a/server/src/lib/jobs/interfaces/IJobRunnerFactory.ts
+++ b/server/src/lib/jobs/interfaces/IJobRunnerFactory.ts
@@ -44,9 +44,6 @@ export interface JobRunnerConfig {
 
   /** Temporal specific configuration (used when type is 'temporal') */
   temporal?: TemporalConfig;
-
-  /** Whether to fall back to PG Boss if Temporal is unavailable (EE only) */
-  fallbackToPgBoss?: boolean;
 }
 
 /**

--- a/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
+++ b/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
@@ -291,19 +291,30 @@ describe('renewal queue scheduling wiring', () => {
     expect(jobRunnerFactorySource).toContain('private determineRunnerType(');
     expect(jobRunnerFactorySource).toContain('const envType = process.env.JOB_RUNNER_TYPE?.toLowerCase();');
     expect(jobRunnerFactorySource).toContain("if (envType === 'temporal' || envType === 'pgboss') {");
-    expect(jobRunnerFactorySource).toContain('if (runnerType === \'temporal\' && isEnterprise) {');
+    expect(jobRunnerFactorySource).toContain("if (runnerType === 'temporal' && enterprise) {");
     expect(renewalHandlerSource).not.toContain('process.env.EDITION');
     expect(renewalHandlerSource).not.toContain('JOB_RUNNER_TYPE');
   });
 
-  it('falls back gracefully to pg-boss when temporal bootstrap is unavailable', () => {
-    expect(jobRunnerFactorySource).toContain("if (runnerType === 'temporal' && isEnterprise) {");
+  it('resolves edition via isEnterpriseEdition() so selection is immune to module init ordering', () => {
+    // The default and the EE gate must re-read the edition via the function
+    // rather than the module-level `isEnterprise` const (which can be read
+    // before the features module finishes initializing, silently selecting pgboss).
+    expect(jobRunnerFactorySource).toContain("return isEnterpriseEdition() ? 'temporal' : 'pgboss';");
+    expect(jobRunnerFactorySource).toContain('const enterprise = isEnterpriseEdition();');
+    expect(jobRunnerFactorySource).toContain("if (runnerType === 'temporal' && enterprise) {");
+  });
+
+  it('does NOT silently fall back to pg-boss when temporal bootstrap fails (EE must fail loudly)', () => {
+    expect(jobRunnerFactorySource).toContain("if (runnerType === 'temporal' && enterprise) {");
     expect(jobRunnerFactorySource).toContain('return await this.createTemporalRunner(config);');
-    expect(jobRunnerFactorySource).toContain('if (');
-    expect(jobRunnerFactorySource).toContain("runnerType === 'temporal' &&");
-    expect(jobRunnerFactorySource).toContain('config?.fallbackToPgBoss !== false');
-    expect(jobRunnerFactorySource).toContain("logger.warn('Falling back to PG Boss job runner');");
-    expect(jobRunnerFactorySource).toContain('return await this.createPgBossRunner(config);');
+    // The silent fallback path and the dummy no-op runner are gone: a failed
+    // Temporal bootstrap must propagate, not quietly degrade to PG Boss.
+    expect(jobRunnerFactorySource).not.toContain('fallbackToPgBoss');
+    expect(jobRunnerFactorySource).not.toContain('Falling back to PG Boss job runner');
+    expect(jobRunnerFactorySource).not.toContain('DummyJobRunner');
+    expect(jobRunnerFactorySource).toContain('refusing to fall back');
+    expect(jobRunnerFactorySource).toContain('throw error;');
     expect(jobRunnerFactorySource).toContain("logger.error('Failed to load TemporalJobRunner:', error);");
     expect(jobRunnerFactorySource).toContain(
       "'TemporalJobRunner not available. Ensure EE modules are properly installed.'"


### PR DESCRIPTION
## Problem

In production (EE), the job-runner abstraction was silently resolving to **PG Boss** instead of **Temporal**. Evidence: every job in the `jobs` table (52k+, since Feb 2025) is `runner_type=pgboss`, the boot log shows `Initializing job runner { type: 'pgboss', isEnterprise: true }`, and the Temporal worker polls `alga-jobs` with nothing ever scheduled onto it.

### Root cause
`JobRunnerFactory.determineRunnerType()` read the module-level `isEnterprise` **const**. In the compiled bundle that const is read before the `features` module finishes initializing, so the EE default (`isEnterprise ? 'temporal' : 'pgboss'`) evaluated `isEnterprise` as falsy and returned `pgboss`. The `fallbackToPgBoss` path then masked the failure permanently. (One statement later the same value logged `true` — classic init-order race.)

This is also why Huntress/RMM/extension recurring polls were exposed to pg-boss's in-process worker re-subscription gap: a redeploy orphaned the consumers and cron-enqueued polls piled up.

## Changes
- `determineRunnerType()` and the EE creation gate now call **`isEnterpriseEdition()`** (reads `process.env`) instead of the possibly-uninitialized const → selection is immune to module-init ordering.
- **Remove the silent fallback to PG Boss** and the `DummyJobRunner` no-op last resort. In EE, Temporal is the durable scheduling authority; a failed bootstrap now **rethrows** (fails loudly) instead of quietly degrading.
- Drop the now-dead `fallbackToPgBoss` field from both `IJobRunnerFactory` interface copies.
- Update `renewalQueueScheduling.wiring.test.ts` to assert the new behavior.

## Deploy / cutover notes
- Pair with setting **`JOB_RUNNER_TYPE=temporal`** in the sebastian deployment (nm-kube-config) as belt-and-suspenders.
- Existing pg-boss schedules for `huntress-incident-poll:*`, `rmm-alert-reconciliation:*`, `extsched:*` must be cleaned up at cutover (delete `pgboss.schedule` rows + clear the corresponding Alga `jobs` rows) so the reconciler recreates them as Temporal Schedules. See the cutover runbook.
- CI should run typecheck + the renewal wiring test (worktree had no node_modules locally).

https://claude.ai/code/session_01KiSzbhMyC6KMtkRsbX4Lkm