### PR TITLE
fix(jobs): stop baked .env from forcing pgboss; guard EE runner selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,10 +101,15 @@ ALGA_WEBHOOK_SECRET=your-shared-secret-here  # Shared secret for webhook authent
 REQUIRE_HOCUSPOCUS=false  # Optional: Set to "true" to require hocuspocus
 
 # Job Runner Configuration
-# The job runner type: 'pgboss' (default for CE) or 'temporal' (EE only)
-JOB_RUNNER_TYPE=pgboss
-# Whether to fall back to PG Boss if Temporal is unavailable (EE only, default: true)
-JOB_RUNNER_FALLBACK_TO_PGBOSS=true
+# The job runner backend is selected by edition automatically: CE -> pgboss,
+# EE -> temporal. Do NOT pin JOB_RUNNER_TYPE here: this file is baked into the
+# image as /app/server/.env, and @next/env would backfill the value for any
+# deployment that leaves it unset, silently overriding the edition default
+# (this is exactly what made EE run on pg-boss in production). Only set
+# JOB_RUNNER_TYPE explicitly in an environment that genuinely needs to override
+# the default (e.g. a CE-on-pgboss local dev box). It is ignored for pgboss
+# under EE regardless. JOB_RUNNER_FALLBACK_TO_PGBOSS is removed — EE never
+# silently falls back to pg-boss.
 
 # App-wide Search
 # Default false for rollout safety. Set true after the search backfill has completed

--- a/server/src/lib/jobs/JobRunnerFactory.ts
+++ b/server/src/lib/jobs/JobRunnerFactory.ts
@@ -131,7 +131,15 @@ export class JobRunnerFactory implements IJobRunnerFactory {
     const runnerType = this.determineRunnerType(config);
     const enterprise = isEnterpriseEdition();
 
-    logger.info(`Initializing job runner`, { type: runnerType, isEnterprise: enterprise });
+    logger.info(`Initializing job runner`, {
+      type: runnerType,
+      isEnterprise: enterprise,
+      // Surface the raw env (which @next/env may have backfilled from a baked
+      // .env) and the explicit config so a silent dotenv override is visible
+      // instead of looking like a paradox.
+      jobRunnerTypeEnv: process.env.JOB_RUNNER_TYPE ?? null,
+      configType: config?.type ?? null,
+    });
 
     // No silent fallback. In EE, Temporal is the durable scheduling/execution
     // authority; failing to bring it up must surface loudly rather than quietly
@@ -163,9 +171,24 @@ export class JobRunnerFactory implements IJobRunnerFactory {
       return config.type;
     }
 
-    // Check environment variable
+    // Check environment variable.
+    // NOTE: process.env.JOB_RUNNER_TYPE is not only the operator-supplied k8s
+    // env — @next/env also backfills it from a baked /app/server/.env (the
+    // image ships .env.example, whose CE default is `pgboss`). So an unset
+    // orchestration var silently surfaces here as `pgboss`. In EE that is never
+    // what we want: Temporal is the durable scheduling authority, so we refuse
+    // an explicit/implicit `pgboss` request rather than honoring a stray dotenv.
+    const enterprise = isEnterpriseEdition();
     const envType = process.env.JOB_RUNNER_TYPE?.toLowerCase();
     if (envType === 'temporal' || envType === 'pgboss') {
+      if (envType === 'pgboss' && enterprise) {
+        logger.warn(
+          'JOB_RUNNER_TYPE=pgboss ignored in Enterprise Edition; Temporal is the durable ' +
+            'scheduling authority. This usually comes from a baked .env default rather than ' +
+            'an explicit operator setting.',
+        );
+        return 'temporal';
+      }
       return envType;
     }
 
@@ -173,7 +196,7 @@ export class JobRunnerFactory implements IJobRunnerFactory {
     // EE should use Temporal as the durable scheduling/execution authority by default.
     // Call isEnterpriseEdition() (reads process.env) instead of the module-level
     // `isEnterprise` const to stay immune to module-initialization ordering.
-    return isEnterpriseEdition() ? 'temporal' : 'pgboss';
+    return enterprise ? 'temporal' : 'pgboss';
   }
 
   /**

--- a/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
+++ b/server/src/lib/jobs/tests/renewalQueueScheduling.wiring.test.ts
@@ -297,12 +297,22 @@ describe('renewal queue scheduling wiring', () => {
   });
 
   it('resolves edition via isEnterpriseEdition() so selection is immune to module init ordering', () => {
-    // The default and the EE gate must re-read the edition via the function
-    // rather than the module-level `isEnterprise` const (which can be read
-    // before the features module finishes initializing, silently selecting pgboss).
-    expect(jobRunnerFactorySource).toContain("return isEnterpriseEdition() ? 'temporal' : 'pgboss';");
+    // Edition is re-read via the function rather than the module-level
+    // `isEnterprise` const (which can be read before the features module
+    // finishes initializing).
     expect(jobRunnerFactorySource).toContain('const enterprise = isEnterpriseEdition();');
+    expect(jobRunnerFactorySource).toContain("return enterprise ? 'temporal' : 'pgboss';");
     expect(jobRunnerFactorySource).toContain("if (runnerType === 'temporal' && enterprise) {");
+  });
+
+  it('refuses a baked/explicit JOB_RUNNER_TYPE=pgboss under Enterprise Edition', () => {
+    // The image bakes .env.example (JOB_RUNNER_TYPE=pgboss) into /app/server/.env
+    // and @next/env backfills the unset var; EE must ignore that stray default
+    // and use Temporal rather than silently downgrading to pg-boss.
+    expect(jobRunnerFactorySource).toContain("if (envType === 'pgboss' && enterprise) {");
+    expect(jobRunnerFactorySource).toContain('JOB_RUNNER_TYPE=pgboss ignored in Enterprise Edition');
+    // And the init log surfaces the raw env so a baked override is visible.
+    expect(jobRunnerFactorySource).toContain('jobRunnerTypeEnv: process.env.JOB_RUNNER_TYPE ?? null,');
   });
 
   it('does NOT silently fall back to pg-boss when temporal bootstrap fails (EE must fail loudly)', () => {


### PR DESCRIPTION
## Real root cause (supersedes the theory behind #2753)

EE was running on PG Boss because the **image bakes `.env.example` into `/app/server/.env`** (`Dockerfile`/`Dockerfile.build` `COPY .env.example …`), and `.env.example` pinned `JOB_RUNNER_TYPE=pgboss` (the CE default). At boot `next start` → `@next/env` **backfills the unset `JOB_RUNNER_TYPE` with `pgboss`** inside the node process (invisible to a shell `echo`). So `determineRunnerType()` returns via the **env branch** and never reaches the edition default — which is why #2753's `const`→`isEnterpriseEdition()` change had no runtime effect. The logged `isEnterprise: true` is a *separate* `isEnterpriseEdition()` call, so there was never a real contradiction.

(Verified empirically in the running pod: `JOB_RUNNER_TYPE` unset → `temporal`; baked `=pgboss` → `pgboss` while `isEnterpriseEdition()` is `true`.)

## Changes
1. **`.env.example`** — remove `JOB_RUNNER_TYPE` and the now-dead `JOB_RUNNER_FALLBACK_TO_PGBOSS` so they aren't baked into the image and can't silently override the edition default. Backend is edition-selected (CE→pgboss, EE→temporal).
2. **`determineRunnerType`** — under EE, **ignore `JOB_RUNNER_TYPE=pgboss`** (warn + return `temporal`). Robust against any stray dotenv/env value. Explicit `temporal`, and CE `pgboss`, are still honored.
3. **Observability** — init log now includes `jobRunnerTypeEnv` + `configType` so a baked-dotenv override is visible instead of looking paradoxical.
4. Wiring test updated for the guard + edition resolution.

## Notes
- Edition keys (`NEXT_PUBLIC_EDITION`/`APP_EDITION`) intentionally left in `.env.example`: they're build-time-inlined and already overridden by k8s env at runtime — not the bug, and stripping them risks the EE build.
- This makes the `JOB_RUNNER_TYPE=temporal` helm override (nm-kube-config #67) belt-and-suspenders rather than load-bearing, and removes the silent CE-default foot-gun for the whole image.
- **EE without Temporal now fails loudly** (consistent with #2753 removing the fallback) — local EE dev must run Temporal.

https://claude.ai/code/session_01KiSzbhMyC6KMtkRsbX4Lkm