### PR TITLE
fix(rbac): Admins can't delete interaction types (deletion pre-check maps to a non-existent permission)

### DIFF
--- a/packages/auth/src/lib/preCheckDeletion.test.ts
+++ b/packages/auth/src/lib/preCheckDeletion.test.ts
@@ -70,4 +70,34 @@ describe('preCheckDeletion permission mapping', () => {
     const [, resource] = hasPermissionMock.mock.calls[0];
     expect(resource).toBe('project');
   });
+
+  it('checks settings:delete (not interaction_type:delete) when validating interaction_type deletion', async () => {
+    getDeletionConfigMock.mockReturnValueOnce({ entityType: 'interaction_type', dependencies: [] });
+
+    await preCheckDeletion('interaction_type', 'it-1');
+
+    const [, resource, action] = hasPermissionMock.mock.calls[0];
+    expect(resource).toBe('settings');
+    expect(action).toBe('delete');
+  });
+
+  it('checks billing:delete (not quote:delete) when validating quote deletion', async () => {
+    getDeletionConfigMock.mockReturnValueOnce({ entityType: 'quote', dependencies: [] });
+
+    await preCheckDeletion('quote', 'q-1');
+
+    const [, resource, action] = hasPermissionMock.mock.calls[0];
+    expect(resource).toBe('billing');
+    expect(action).toBe('delete');
+  });
+
+  it('checks timeentry:delete (not time_entry:delete) when validating time_entry deletion', async () => {
+    getDeletionConfigMock.mockReturnValueOnce({ entityType: 'time_entry', dependencies: [] });
+
+    await preCheckDeletion('time_entry', 'te-1');
+
+    const [, resource, action] = hasPermissionMock.mock.calls[0];
+    expect(resource).toBe('timeentry');
+    expect(action).toBe('delete');
+  });
 });

--- a/packages/auth/src/lib/preCheckDeletion.ts
+++ b/packages/auth/src/lib/preCheckDeletion.ts
@@ -28,6 +28,15 @@ function permissionEntityFor(entityType: string): string {
   if (entityType === 'board') return 'ticket_settings';
   if (entityType === 'contract_line') return 'billing';
   if (entityType === 'team') return 'settings';
+  // Interaction types are managed as portal settings; deleteInteractionType gates
+  // on settings:update. Without this mapping the check falls through to a
+  // non-existent 'interaction_type' resource and denies everyone (incl. Admin).
+  if (entityType === 'interaction_type') return 'settings';
+  // Quote deletion is a billing operation (deleteQuote requires billing:delete).
+  if (entityType === 'quote') return 'billing';
+  // The permission resource is 'timeentry' (no underscore); the deletion-config
+  // key is 'time_entry'. Map it so the check resolves to the real resource.
+  if (entityType === 'time_entry') return 'timeentry';
   return entityType;
 }
 


### PR DESCRIPTION
## Symptom

Deleting a tenant **interaction type** fails for everyone — including Admins — with:

> You don't have permission to delete interaction_type records.

Reported by Robert (logged in as an Admin). Same *class* as #2752 (interaction RBAC), but a different root cause: this one is a **code mapping bug**, not missing data, so there's **no migration** — it's fixed purely in code and ships on the next deploy.

## Root cause

`preCheckDeletion()` (the UI deletion pre-flight in `@alga-psa/auth`) maps each entity type to the RBAC permission it requires via `permissionEntityFor()`. Entity types with no explicit case fall through to `return entityType` — i.e. they demand a permission resource named after the entity itself.

Three entries in the deletion config have **no matching permission resource**, so the check resolves to a permission that exists for nobody and denies every user *before the server action runs*:

| entity type | demanded permission | reality |
|---|---|---|
| `interaction_type` | `interaction_type:delete` | no such resource |
| `quote` | `quote:delete` | gated via `billing` |
| `time_entry` | `time_entry:delete` | resource is `timeentry` (no underscore) |

`interaction_type` is the one reachable today: `InteractionTypeSettings.tsx` calls `useDeletionValidation('interaction_type')` → `preCheckDeletion('interaction_type', …)`, which always returns `PERMISSION_DENIED`. (Create/update interaction types still work — they go through the server action's `settings:update` gate, which Admins hold. Only **delete** is blocked.)

Confirmed live: the deployed green release (`a0a82782`) has the buggy fallthrough and the `useDeletionValidation('interaction_type')` wiring, so this is **fleet-wide in prod**.

## Fix

Map each entity to the resource its **server delete action actually enforces**, consistent with existing sibling mappings:

- `interaction_type → settings` — `deleteInteractionType` gates on `settings:update`; consistent with `status`/`team`/`survey_template → settings`
- `quote → billing` — `deleteQuote` requires `billing:delete`; consistent with `contract_line`/`tax_rate → billing`
- `time_entry → timeentry` — `deleteTimeEntry` requires `timeentry:delete`

`quote`/`time_entry` are currently latent (no `preCheckDeletion` caller) but fixed defensively to remove the same landmine.

## Verification

- Verified against **prod** RBAC data: in all 92 tenants the Admin role holds `settings:delete`, `billing:delete`, and `timeentry:delete` (and `settings:update`), so the pre-check now passes for Admins exactly as the server gate does.
- Unit tests added for the three mappings; full `preCheckDeletion` suite passes (6/6).

https://claude.ai/code/session_01UBnms8SFvUd2q2HPcvUvJU