### PR TITLE
fix(billing): show arrears periods as "Not yet due" instead of blocked

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -919,6 +919,15 @@ function buildRecurringDueWorkInvoiceCandidates(
                 .slice(-1)[0] as ISO8601String;
             const cadenceSources = Array.from(new Set(members.map((member) => member.cadenceSource))).sort();
             const canGenerate = members.every((member) => member.canGenerate);
+            // A candidate is "not yet due" (rather than blocked) when the only
+            // reason it cannot generate is that its invoice window has not opened
+            // yet — every member is early, and none has a real data problem.
+            const everyMemberEarly = members.length > 0 && members.every((member) => member.isEarly === true);
+            const anyAttributionIncomplete = members.some((member) => member.attribution?.isComplete === false);
+            const notYetDue = !canGenerate && everyMemberEarly && !anyAttributionIncomplete;
+            const availableOnDate = notYetDue
+                ? (members.map((member) => member.invoiceWindowStart).sort()[0] ?? null)
+                : null;
             const explicitContractCount = members.filter(
                 (member) => member.attribution?.source === 'explicit_contract',
             ).length;
@@ -960,7 +969,11 @@ function buildRecurringDueWorkInvoiceCandidates(
                 splitReasons: [...candidate.splitReasons],
                 memberCount: members.length,
                 canGenerate,
-                blockedReason: canGenerate ? null : 'One or more included obligations are not eligible for generation.',
+                notYetDue,
+                availableOnDate,
+                blockedReason: canGenerate || notYetDue
+                    ? null
+                    : 'One or more included obligations are not eligible for generation.',
                 attributionSummary: {
                     explicitContractCount,
                     systemManagedDefaultContractCount,
@@ -1046,6 +1059,8 @@ function applyClientCadenceMaterializationGapBlocks(
         return {
             ...candidate,
             canGenerate: false,
+            notYetDue: false,
+            availableOnDate: null,
             blockedReason:
                 'Recurring service periods are partially materialized for this window. Repair service periods before generation.',
         };
@@ -1105,6 +1120,8 @@ function applyRecurringApprovalBlocksToInvoiceCandidates(
             ...candidate,
             members,
             canGenerate: false,
+            notYetDue: false,
+            availableOnDate: null,
             blockedReason: formatApprovalBlockedReason(approvalBlockedEntryCount),
             approvalBlockedEntryCount,
             hasApprovalBlockers: true,

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -54,7 +54,7 @@ interface AutomaticInvoicesProps {
   refreshTrigger?: number;
 }
 
-type AutomaticInvoiceGroupLabelKey = 'ready' | 'canCombine' | 'separate' | 'blocked' | 'notReady';
+type AutomaticInvoiceGroupLabelKey = 'ready' | 'canCombine' | 'separate' | 'blocked' | 'notReady' | 'upcoming';
 type AutomaticInvoiceIncompatibilityReasonKey =
   | 'invoiceWindowDiffers'
   | 'clientDiffers'
@@ -82,6 +82,8 @@ interface RecurringInvoiceParentGroup {
     incompatibilityReasons: AutomaticInvoiceIncompatibilityReasonKey[];
     canGenerate: boolean;
     blockedReason: string | null;
+    notYetDue: boolean;
+    availableOnDate: string | null;
   };
   childExecutionRows: ReadyPeriod['members'];
   candidate: ReadyPeriod;
@@ -99,16 +101,19 @@ const AUTOMATIC_INVOICE_GROUP_LABELS: Record<AutomaticInvoiceGroupLabelKey, stri
   separate: 'Must invoice separately',
   blocked: 'Contains blocked items',
   notReady: 'Not ready to invoice',
+  upcoming: 'Not yet due',
 };
 
 const getParentGroupSummary = ({
   isCombinable,
   canGenerate,
+  notYetDue,
   incompatibilityReasons,
   childCount,
 }: {
   isCombinable: boolean;
   canGenerate: boolean;
+  notYetDue: boolean;
   incompatibilityReasons: AutomaticInvoiceIncompatibilityReasonKey[];
   childCount: number;
 }): {
@@ -119,6 +124,15 @@ const getParentGroupSummary = ({
     return {
       labelKey: childCount > 1 ? 'canCombine' : 'ready',
       className: 'border-border/70 text-foreground',
+    };
+  }
+
+  // A period that simply hasn't reached its invoice window yet is "upcoming",
+  // not blocked — keep it visually neutral so it doesn't read like an error.
+  if (notYetDue) {
+    return {
+      labelKey: 'upcoming',
+      className: 'border-border/60 text-muted-foreground',
     };
   }
 
@@ -153,9 +167,11 @@ const buildRecurringInvoiceParentGroups = (candidates: ReadyPeriod[]): Recurring
         : null;
     const incompatibilityReasons = resolveIncompatibilityReasons(candidate);
     const isCombinable = candidate.canGenerate && incompatibilityReasons.length === 0;
+    const notYetDue = candidate.notYetDue === true;
     const parentGroupSummary = getParentGroupSummary({
       isCombinable,
       canGenerate: candidate.canGenerate,
+      notYetDue,
       incompatibilityReasons,
       childCount: candidate.memberCount,
     });
@@ -175,6 +191,8 @@ const buildRecurringInvoiceParentGroups = (candidates: ReadyPeriod[]): Recurring
       incompatibilityReasons,
       canGenerate: candidate.canGenerate,
       blockedReason: candidate.blockedReason ?? null,
+      notYetDue,
+      availableOnDate: candidate.availableOnDate ?? null,
     },
     childExecutionRows: candidate.members,
     candidate,
@@ -1714,6 +1732,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
                                   className={`inline-flex whitespace-nowrap rounded-full border px-2 py-0.5 font-medium ${getParentGroupSummary({
                                     isCombinable: record.parentSummary.isCombinable,
                                     canGenerate: record.parentSummary.canGenerate,
+                                    notYetDue: record.parentSummary.notYetDue,
                                     incompatibilityReasons: record.parentSummary.incompatibilityReasons,
                                     childCount: record.parentSummary.childCount,
                                   }).className}`}
@@ -1740,6 +1759,21 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
                             {!record.parentSummary.canGenerate && record.parentSummary.blockedReason ? (
                               <div className="text-xs text-muted-foreground">
                                 {formatBlockedReason(record.parentSummary.blockedReason)}
+                              </div>
+                            ) : null}
+                            {record.parentSummary.notYetDue ? (
+                              <div
+                                className="text-xs text-muted-foreground"
+                                data-testid={`not-yet-due-${record.parentSummary.parentGroupKey}`}
+                              >
+                                {record.parentSummary.availableOnDate
+                                  ? t('automaticInvoices.groups.upcomingDetailWithDate', {
+                                    date: formatDate(record.parentSummary.availableOnDate, { timeZone: 'UTC', year: 'numeric', month: 'short', day: 'numeric' }),
+                                    defaultValue: `This period bills in arrears, so it becomes available to invoice on ${formatDate(record.parentSummary.availableOnDate, { timeZone: 'UTC', year: 'numeric', month: 'short', day: 'numeric' })}, after the service period ends.`,
+                                  })
+                                  : t('automaticInvoices.groups.upcomingDetail', {
+                                    defaultValue: 'This period bills in arrears, so it becomes available to invoice after the service period ends.',
+                                  })}
                               </div>
                             ) : null}
                             {shouldShowAssignmentContexts ? assignmentLabels.map((contextValue) => (
@@ -1909,6 +1943,16 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
                                   {!member.canGenerate && (member as { blockedReason?: string | null }).blockedReason ? (
                                     <div className="text-xs text-muted-foreground">
                                       {formatBlockedReason((member as { blockedReason?: string | null }).blockedReason)}
+                                    </div>
+                                  ) : !member.canGenerate && member.isEarly ? (
+                                    <div
+                                      className="text-xs text-muted-foreground"
+                                      data-testid={`child-not-yet-due-${member.executionIdentityKey}`}
+                                    >
+                                      {t('automaticInvoices.executionRows.billableOn', {
+                                        date: formatDate(member.invoiceWindowStart, { timeZone: 'UTC', year: 'numeric', month: 'short', day: 'numeric' }),
+                                        defaultValue: `Billable on ${formatDate(member.invoiceWindowStart, { timeZone: 'UTC', year: 'numeric', month: 'short', day: 'numeric' })}`,
+                                      })}
                                     </div>
                                   ) : null}
                                 </div>

--- a/packages/types/src/interfaces/recurringTiming.interfaces.ts
+++ b/packages/types/src/interfaces/recurringTiming.interfaces.ts
@@ -565,6 +565,16 @@ export interface IRecurringDueWorkInvoiceCandidate {
   memberCount: number;
   canGenerate: boolean;
   blockedReason?: string | null;
+  /**
+   * True when the candidate is not generatable solely because its invoice
+   * window has not opened yet (an arrears period still in progress) — i.e. it
+   * is "not yet due" rather than blocked by a data problem. The UI surfaces
+   * this as a neutral "upcoming" state instead of the alarming "blocked"
+   * treatment used for genuine failures.
+   */
+  notYetDue?: boolean;
+  /** Date the invoice window opens for a notYetDue candidate (earliest member window start). */
+  availableOnDate?: ISO8601String | null;
   approvalBlockedEntryCount?: number;
   hasApprovalBlockers?: boolean;
   attributionSummary?: IRecurringDueWorkCandidateAttributionSummary;

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Kann zu einer Rechnung zusammengefasst werden",
       "separate": "Muss separat in Rechnung gestellt werden",
       "blocked": "Enthält blockierte Elemente",
-      "notReady": "Nicht bereit zur Rechnungsstellung"
+      "notReady": "Nicht bereit zur Rechnungsstellung",
+      "upcoming": "Noch nicht fällig",
+      "upcomingDetail": "Dieser Zeitraum wird nachträglich abgerechnet und kann daher erst nach Ende des Leistungszeitraums in Rechnung gestellt werden.",
+      "upcomingDetailWithDate": "Dieser Zeitraum wird nachträglich abgerechnet und kann daher ab dem {{date}}, nach Ende des Leistungszeitraums, in Rechnung gestellt werden."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "Das Rechnungsfenster ist unterschiedlich",
@@ -75,6 +78,7 @@
         "servicePeriod": "Servicezeitraum"
       },
       "pendingAmount": "Ausstehender Betrag",
+      "billableOn": "Abrechenbar am {{date}}",
       "attributionWarning": "Metadaten zur Zuweisungszuordnung fehlen",
       "blockedUntilApproval": "Bis zur Genehmigung blockiert: {{count}} nicht genehmigter Eintrag.",
       "blockedUntilApproval_one": "Bis zur Genehmigung blockiert: {{count}} nicht genehmigter Eintrag.",

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Can combine into 1 invoice",
       "separate": "Must invoice separately",
       "blocked": "Contains blocked items",
-      "notReady": "Not ready to invoice"
+      "notReady": "Not ready to invoice",
+      "upcoming": "Not yet due",
+      "upcomingDetail": "This period bills in arrears, so it becomes available to invoice after the service period ends.",
+      "upcomingDetailWithDate": "This period bills in arrears, so it becomes available to invoice on {{date}}, after the service period ends."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "Invoice window differs",
@@ -75,6 +78,7 @@
         "servicePeriod": "Service period"
       },
       "pendingAmount": "Pending amount",
+      "billableOn": "Billable on {{date}}",
       "attributionWarning": "Assignment attribution metadata missing",
       "blockedUntilApproval": "Blocked until approval: {{count}} unapproved entry.",
       "blockedUntilApproval_one": "Blocked until approval: {{count}} unapproved entry.",

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Se puede combinar en 1 factura",
       "separate": "Debe facturar por separado",
       "blocked": "Contiene elementos bloqueados",
-      "notReady": "No listo para facturar"
+      "notReady": "No listo para facturar",
+      "upcoming": "Aún no vence",
+      "upcomingDetail": "Este período se factura por vencido, por lo que queda disponible para facturar una vez finalizado el período de servicio.",
+      "upcomingDetailWithDate": "Este período se factura por vencido, por lo que queda disponible para facturar el {{date}}, una vez finalizado el período de servicio."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "La ventana de factura es diferente",
@@ -75,6 +78,7 @@
         "servicePeriod": "Período de servicio"
       },
       "pendingAmount": "Monto pendiente",
+      "billableOn": "Facturable el {{date}}",
       "attributionWarning": "Faltan metadatos de atribución de tareas",
       "blockedUntilApproval": "Bloqueado hasta aprobación: {{count}} entrada no aprobada.",
       "blockedUntilApproval_one": "Bloqueado hasta aprobación: {{count}} entrada no aprobada.",

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Peut être combiné en une seule facture",
       "separate": "Doit facturer séparément",
       "blocked": "Contient des éléments bloqués",
-      "notReady": "Pas prêt à facturer"
+      "notReady": "Pas prêt à facturer",
+      "upcoming": "Pas encore exigible",
+      "upcomingDetail": "Cette période est facturée à terme échu, elle ne peut donc être facturée qu’une fois la période de service terminée.",
+      "upcomingDetailWithDate": "Cette période est facturée à terme échu, elle peut donc être facturée à partir du {{date}}, une fois la période de service terminée."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "La fenêtre de facturation diffère",
@@ -75,6 +78,7 @@
         "servicePeriod": "Période de service"
       },
       "pendingAmount": "Montant en attente",
+      "billableOn": "Facturable le {{date}}",
       "attributionWarning": "Métadonnées d'attribution d'attribution manquantes",
       "blockedUntilApproval": "Bloqué jusqu'à approbation : {{count}} entrée non approuvée.",
       "blockedUntilApproval_one": "Bloqué jusqu'à approbation : {{count}} entrée non approuvée.",

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Può essere combinato in 1 fattura",
       "separate": "Deve fatturare separatamente",
       "blocked": "Contiene elementi bloccati",
-      "notReady": "Non pronto per la fatturazione"
+      "notReady": "Non pronto per la fatturazione",
+      "upcoming": "Non ancora dovuto",
+      "upcomingDetail": "Questo periodo viene fatturato a consuntivo, quindi diventa disponibile per la fatturazione al termine del periodo di servizio.",
+      "upcomingDetailWithDate": "Questo periodo viene fatturato a consuntivo, quindi diventa disponibile per la fatturazione il {{date}}, al termine del periodo di servizio."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "La finestra della fattura è diversa",
@@ -75,6 +78,7 @@
         "servicePeriod": "Periodo di servizio"
       },
       "pendingAmount": "Importo in sospeso",
+      "billableOn": "Fatturabile il {{date}}",
       "attributionWarning": "Metadati di attribuzione dell'assegnazione mancanti",
       "blockedUntilApproval": "Bloccato fino all'approvazione: {{count}} voce non approvata.",
       "blockedUntilApproval_one": "Bloccato fino all'approvazione: {{count}} voce non approvata.",

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Combineerbaar tot 1 factuur",
       "separate": "Moet apart factureren",
       "blocked": "Bevat geblokkeerde items",
-      "notReady": "Niet klaar om te factureren"
+      "notReady": "Niet klaar om te factureren",
+      "upcoming": "Nog niet verschuldigd",
+      "upcomingDetail": "Deze periode wordt achteraf gefactureerd en is daarom pas beschikbaar om te factureren nadat de serviceperiode is afgelopen.",
+      "upcomingDetailWithDate": "Deze periode wordt achteraf gefactureerd en is daarom beschikbaar om te factureren op {{date}}, nadat de serviceperiode is afgelopen."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "Factuurvenster verschilt",
@@ -75,6 +78,7 @@
         "servicePeriod": "Serviceperiode"
       },
       "pendingAmount": "Bedrag in behandeling",
+      "billableOn": "Factureerbaar op {{date}}",
       "attributionWarning": "Metagegevens van toewijzingsattributie ontbreken",
       "blockedUntilApproval": "Geblokkeerd tot goedkeuring: {{count}} niet-goedgekeurde invoer.",
       "blockedUntilApproval_one": "Geblokkeerd tot goedkeuring: {{count}} niet-goedgekeurde invoer.",

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -61,6 +61,9 @@
       "separate": "Należy wystawić osobną fakturę",
       "blocked": "Zawiera zablokowane elementy",
       "notReady": "Brak gotowości do wystawienia faktury",
+      "upcoming": "Jeszcze nie wymagalne",
+      "upcomingDetail": "Ten okres jest rozliczany z dołu, więc staje się dostępny do zafakturowania po zakończeniu okresu świadczenia usługi.",
+      "upcomingDetailWithDate": "Ten okres jest rozliczany z dołu, więc staje się dostępny do zafakturowania w dniu {{date}}, po zakończeniu okresu świadczenia usługi.",
       "attributionMetadataMissing_few": "Brak metadanych przypisania przypisania ({{count}} obowiązki)",
       "attributionMetadataMissing_many": "Brak metadanych przypisania przypisania ({{count}} obowiązków)",
       "contract_few": "{{count}} kontrakty",
@@ -89,6 +92,7 @@
         "servicePeriod": "Okres świadczenia usług"
       },
       "pendingAmount": "Oczekująca kwota",
+      "billableOn": "Możliwe do zafakturowania dnia {{date}}",
       "attributionWarning": "Brak metadanych przypisania przypisania",
       "blockedUntilApproval": "Zablokowany do czasu zatwierdzenia: wpis niezatwierdzony {{count}}.",
       "blockedUntilApproval_one": "Zablokowany do czasu zatwierdzenia: wpis niezatwierdzony {{count}}.",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "Pode combinar em 1 fatura",
       "separate": "Deve faturar separadamente",
       "blocked": "Contém itens bloqueados",
-      "notReady": "Não estou pronto para faturar"
+      "notReady": "Não estou pronto para faturar",
+      "upcoming": "Ainda não vencido",
+      "upcomingDetail": "Este período é faturado no vencimento, portanto fica disponível para faturamento após o término do período de serviço.",
+      "upcomingDetailWithDate": "Este período é faturado no vencimento, portanto fica disponível para faturamento em {{date}}, após o término do período de serviço."
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "A janela da fatura é diferente",
@@ -75,6 +78,7 @@
         "servicePeriod": "Período de serviço"
       },
       "pendingAmount": "Valor pendente",
+      "billableOn": "Faturável em {{date}}",
       "attributionWarning": "Faltam metadados de atribuição de atribuição",
       "blockedUntilApproval": "Bloqueado até aprovação: {{count}} entrada não aprovada.",
       "blockedUntilApproval_one": "Bloqueado até aprovação: {{count}} entrada não aprovada.",

--- a/server/public/locales/xx/msp/invoicing.json
+++ b/server/public/locales/xx/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "11111",
       "separate": "11111",
       "blocked": "11111",
-      "notReady": "11111"
+      "notReady": "11111",
+      "upcoming": "11111",
+      "upcomingDetail": "11111",
+      "upcomingDetailWithDate": "11111 {{date}} 11111"
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "11111",
@@ -75,6 +78,7 @@
         "servicePeriod": "11111"
       },
       "pendingAmount": "11111",
+      "billableOn": "11111 {{date}} 11111",
       "attributionWarning": "11111",
       "blockedUntilApproval": "11111 {{count}} 11111",
       "blockedUntilApproval_one": "11111 {{count}} 11111",

--- a/server/public/locales/yy/msp/invoicing.json
+++ b/server/public/locales/yy/msp/invoicing.json
@@ -58,7 +58,10 @@
       "canCombine": "55555",
       "separate": "55555",
       "blocked": "55555",
-      "notReady": "55555"
+      "notReady": "55555",
+      "upcoming": "55555",
+      "upcomingDetail": "55555",
+      "upcomingDetailWithDate": "55555 {{date}} 55555"
     },
     "incompatibilityReasons": {
       "invoiceWindowDiffers": "55555",
@@ -75,6 +78,7 @@
         "servicePeriod": "55555"
       },
       "pendingAmount": "55555",
+      "billableOn": "55555 {{date}} 55555",
       "attributionWarning": "55555",
       "blockedUntilApproval": "55555 {{count}} 55555",
       "blockedUntilApproval_one": "55555 {{count}} 55555",

--- a/server/src/test/unit/billing/recurringDueWorkReader.integration.test.ts
+++ b/server/src/test/unit/billing/recurringDueWorkReader.integration.test.ts
@@ -508,7 +508,7 @@ describe('recurring due-work reader', () => {
     expect(result.invoiceCandidates).toEqual([]);
   });
 
-  it('T117: client-arrears rows stay visible by service-period filter but remain blocked until the selected to-date reaches the invoice window start', async () => {
+  it('T117: client-arrears rows stay visible by service-period filter but surface as not-yet-due until the selected to-date reaches the invoice window start', async () => {
     const beforeWindowStarts = await getAvailableRecurringDueWork({
       page: 1,
       pageSize: 10,
@@ -521,11 +521,17 @@ describe('recurring due-work reader', () => {
       (candidate) => candidate.clientId === 'client-3',
     );
 
+    // The invoice window has not opened yet, so the candidate is "not yet due"
+    // (an arrears period still in progress) rather than blocked by a data
+    // problem. It carries no alarming blockedReason and exposes the date the
+    // window opens so the UI can say "Billable on <date>".
     expect(blockedCandidate).toMatchObject({
       servicePeriodStart: '2025-03-01',
       windowStart: '2025-04-01',
       canGenerate: false,
-      blockedReason: 'One or more included obligations are not eligible for generation.',
+      notYetDue: true,
+      availableOnDate: '2025-04-01',
+      blockedReason: null,
     });
 
     const afterWindowStarts = await getAvailableRecurringDueWork({
@@ -544,6 +550,7 @@ describe('recurring due-work reader', () => {
       servicePeriodStart: '2025-03-01',
       windowStart: '2025-04-01',
       canGenerate: true,
+      notYetDue: false,
       blockedReason: null,
     });
   });


### PR DESCRIPTION
## Problem

On the **Automatic Invoices** screen, recurring obligations that bill in **arrears** can't be invoiced until their service period ends and the invoice window opens. The screen marked those rows as **"Contains blocked items" / "One or more included obligations are not eligible for generation"** with a disabled checkbox and **no explanation** — so a period that is simply *not due yet* looked identical to a genuine data error.

Reported by the **Maloughney Cloud** tenant: their June rows (service period Jun 1 – Jul 1, arrears window opening Jul 1) were grayed out while past months were fine. The cause is purely timing — `isEarly = invoiceWindowStart > today` ⇒ `canGenerate = false` (`shared/billingClients/recurringDueWork.ts`). Nothing was broken; the UI just couldn't say so.

## Change

Distinguish "not your turn yet" from "something is broken":

- **Builder (`billingAndTax.ts`)** — a candidate is flagged `notYetDue` (with `availableOnDate` = window-open date) when its *only* obstacle is an unopened invoice window: every member is early, and there's no attribution/approval/materialization problem. The generic `blockedReason` is suppressed for that case. Real blockers (materialization gap, approval) still override `notYetDue` back to blocked.
- **UI (`AutomaticInvoices.tsx`)** — neutral **"Not yet due"** badge instead of "Contains blocked items"; a group note *"This period bills in arrears, so it becomes available to invoice on Jul 1, 2026, after the service period ends."*; and a per-line *"Billable on Jul 1, 2026."*
- **Type** — added `notYetDue?` / `availableOnDate?` to `IRecurringDueWorkInvoiceCandidate`.
- **Locale** — `groups.upcoming`, `groups.upcomingDetail`, `groups.upcomingDetailWithDate`, `executionRows.billableOn`.

`notYetDue` rows keep `canGenerate = false`, so they remain correctly excluded from generation until their window opens — this is a presentation fix, not a behavior change to what can be billed.

## Tests

- Updated reader integration test **T117** (it asserted the old "remain blocked" behavior) to assert the new contract: `notYetDue: true`, `availableOnDate: '2025-04-01'`, `blockedReason: null`. **14/14 pass.**
- No regressions: `recurringBillingRunActions` 13/13, `cadenceResyncWiring` 8/8.
- `packages/types` + `packages/billing` typecheck clean.
- The `.tsx` component tests don't run on this host (pre-existing `React.act` / `createRequire` tooling breakage, unrelated to this change), so the badge/notes rely on typecheck + the integration test for the data contract.

https://claude.ai/code/session_0133y87FyMNeR6cvKGZ5i7Yz