### PR TITLE
Fail closed on invalid appliance console API key and add unit test

### DIFF
--- a/ee/server/src/__tests__/unit/applianceConsole/auth.test.ts
+++ b/ee/server/src/__tests__/unit/applianceConsole/auth.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  validateApiKeyAnyTenant: vi.fn(),
+  getCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/lib/services/apiKeyServiceForApi', () => ({
+  ApiKeyServiceForApi: {
+    validateApiKeyAnyTenant: mocks.validateApiKeyAnyTenant,
+  },
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+function requestWithHeaders(headers: Record<string, string>) {
+  return {
+    headers: new Headers(headers),
+  } as never;
+}
+
+describe('assertMasterTenantAccess', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv('MASTER_BILLING_TENANT_ID', 'master-tenant');
+  });
+
+  it('rejects an invalid API key without falling back to session authentication', async () => {
+    mocks.validateApiKeyAnyTenant.mockResolvedValue(null);
+    mocks.getCurrentUser.mockResolvedValue({
+      tenant: 'master-tenant',
+      user_id: 'victim-master-user',
+      email: 'victim@example.test',
+    });
+
+    const { assertMasterTenantAccess } = await import('@ee/lib/applianceConsole/auth');
+
+    await expect(assertMasterTenantAccess(requestWithHeaders({ 'x-api-key': 'junk' }))).rejects.toThrow(
+      'Invalid API key',
+    );
+    expect(mocks.getCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it('continues to allow session authentication when no API key is present', async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      tenant: 'master-tenant',
+      user_id: 'master-user',
+      email: 'master@example.test',
+    });
+
+    const { assertMasterTenantAccess } = await import('@ee/lib/applianceConsole/auth');
+
+    await expect(assertMasterTenantAccess(requestWithHeaders({}))).resolves.toEqual({
+      tenantId: 'master-tenant',
+      userId: 'master-user',
+      userEmail: 'master@example.test',
+    });
+  });
+});

--- a/ee/server/src/lib/applianceConsole/auth.ts
+++ b/ee/server/src/lib/applianceConsole/auth.ts
@@ -42,7 +42,7 @@ export async function assertMasterTenantAccess(request: NextRequest): Promise<Ma
       }
       throw new Error('Access denied: API key not authorized for the appliance console');
     }
-    console.warn('[appliance-installs] Invalid API key');
+    throw new Error('Invalid API key');
   }
 
   // SESSION AUTH (direct browser)
@@ -61,6 +61,8 @@ export async function assertMasterTenantAccess(request: NextRequest): Promise<Ma
 export function isAuthError(error: unknown): boolean {
   return (
     error instanceof Error &&
-    (error.message.includes('Access denied') || error.message.includes('Authentication'))
+    (error.message.includes('Access denied') ||
+      error.message.includes('Authentication') ||
+      error.message.includes('Invalid API key'))
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent a present-but-invalid `x-api-key` from falling through to session authentication which, combined with permissive CORS, could allow cross-origin data exfiltration from a victim master-tenant session.

### Description
- Change `assertMasterTenantAccess` to fail closed by throwing `new Error('Invalid API key')` when `x-api-key` is present but validation returns no record instead of merely logging a warning.
- Extend `isAuthError` to treat the `Invalid API key` error string as an authorization failure so route handlers map it to a 403-style response.
- Add unit tests in `ee/server/src/__tests__/unit/applianceConsole/auth.test.ts` that assert an invalid API key is rejected without calling `getCurrentUser` and that requests with no API key still allow session auth.

### Testing
- Added unit tests that exercise the invalid-API-key and no-API-key paths (`ee/server/src/__tests__/unit/applianceConsole/auth.test.ts`).
- Attempted to run the tests with Vitest; the repository-wide EE test harness imports `@testing-library/jest-dom` from the global setup which is not available in this execution environment so the full EE test run could not complete. 
- Focused Vitest runs using a custom config were attempted but import/alias resolution in this environment prevented a clean run; the new tests are present and designed to pass when run in the repository test environment or CI with normal module aliases and dev dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c8a2d7f08330afaa9aaa0346b3f3)