### PR TITLE
Prevent ticket read bypass via self-added co-assignee rows

### DIFF
--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -64,7 +64,7 @@ import {
   type RelationshipSqlCompileResult,
 } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
-import { createTicketRelationshipSqlAdapter, fetchTicketAdditionalUserIds } from '../lib/ticketAuthorizationSql';
+import { createTicketRelationshipSqlAdapter } from '../lib/ticketAuthorizationSql';
 import { getClientContactVisibilityContext } from '../lib/clientPortalVisibility';
 import { buildTicketTransitionWorkflowEvents } from '../lib/workflowTicketTransitionEvents';
 import { buildTicketCommunicationWorkflowEvents } from '../lib/workflowTicketCommunicationEvents';
@@ -140,16 +140,13 @@ async function resolveAuthorizationSubjectForUser(
 }
 
 function toTicketAuthorizationRecord(
-  ticket: Partial<ITicket>,
-  additionalUserIds: string[] = []
+  ticket: Partial<ITicket>
 ): AuthorizationRecord {
-  // `tickets.assigned_to` is the primary assignee; `ticket_resources.additional_user_id`
-  // holds co-assignees ("additional agents"). Both should authorize via own_or_assigned.
+  // Only the primary assignee grants ticket read authorization. Do not trust
+  // `ticket_resources.additional_user_id` as an authorization assignment because
+  // time-entry workflows can create those rows without ticket row-level access.
   const assignees = new Set<string>();
   if (ticket.assigned_to) assignees.add(ticket.assigned_to);
-  for (const id of additionalUserIds) {
-    if (id) assignees.add(id);
-  }
   return {
     id: ticket.ticket_id ?? null,
     ownerUserId: ticket.entered_by ?? null,
@@ -244,14 +241,6 @@ async function filterAuthorizedTickets<T extends Partial<ITicket> & { ticket_id?
   context: Awaited<ReturnType<typeof createTicketAuthorizationContext>>,
   tickets: T[]
 ): Promise<T[]> {
-  const ticketIds = tickets
-    .map((ticket) => ticket.ticket_id)
-    .filter((id): id is string => typeof id === 'string' && id.length > 0);
-  const additionalUserIdsByTicket = await fetchTicketAdditionalUserIds(
-    trx,
-    context.authorizationSubject.tenant,
-    ticketIds
-  );
 
   const decisions = await Promise.all(
     tickets.map((ticket) => {
@@ -266,10 +255,7 @@ async function filterAuthorizedTickets<T extends Partial<ITicket> & { ticket_id?
           action: 'read',
           id: ticket.ticket_id,
         },
-        record: toTicketAuthorizationRecord(
-          ticket,
-          additionalUserIdsByTicket.get(ticket.ticket_id) ?? []
-        ),
+        record: toTicketAuthorizationRecord(ticket),
         selectedBoardIds: context.selectedBoardIds,
         requestCache: context.requestCache,
         knex: trx,

--- a/packages/tickets/src/actions/ticketActions.ts
+++ b/packages/tickets/src/actions/ticketActions.ts
@@ -163,16 +163,13 @@ async function resolveAuthorizationSubjectForUser(
 }
 
 function toTicketAuthorizationRecord(
-  ticket: Partial<ITicket>,
-  additionalUserIds: string[] = []
+  ticket: Partial<ITicket>
 ): AuthorizationRecord {
-  // `tickets.assigned_to` is the primary assignee; `ticket_resources.additional_user_id`
-  // holds co-assignees ("additional agents"). Both should authorize via own_or_assigned.
+  // Only the primary assignee grants ticket read authorization. Do not trust
+  // `ticket_resources.additional_user_id` as an authorization assignment because
+  // time-entry workflows can create those rows without ticket row-level access.
   const assignees = new Set<string>();
   if (ticket.assigned_to) assignees.add(ticket.assigned_to);
-  for (const id of additionalUserIds) {
-    if (id) assignees.add(id);
-  }
   return {
     id: ticket.ticket_id ?? null,
     ownerUserId: ticket.entered_by ?? null,
@@ -181,28 +178,6 @@ function toTicketAuthorizationRecord(
     boardId: ticket.board_id ?? null,
     teamIds: ticket.assigned_team_id ? [ticket.assigned_team_id] : [],
   };
-}
-
-async function fetchTicketAdditionalUserIds(
-  trx: Knex.Transaction | Knex,
-  tenant: string,
-  ticketIds: string[]
-): Promise<Map<string, string[]>> {
-  const map = new Map<string, string[]>();
-  if (ticketIds.length === 0) {
-    return map;
-  }
-  const rows = await trx('ticket_resources')
-    .where({ tenant })
-    .whereIn('ticket_id', ticketIds)
-    .whereNotNull('additional_user_id')
-    .select<{ ticket_id: string; additional_user_id: string }[]>('ticket_id', 'additional_user_id');
-  for (const row of rows) {
-    const ids = map.get(row.ticket_id) ?? [];
-    ids.push(row.additional_user_id);
-    map.set(row.ticket_id, ids);
-  }
-  return map;
 }
 
 async function resolveClientSelectedBoardIds(
@@ -1402,13 +1377,6 @@ export const getTicketsForList = withAuth(async (user, { tenant }, filters: ITic
         })
         .orderBy('t.ticket_id', 'desc');
 
-      const additionalUserIdsByTicket = await fetchTicketAdditionalUserIds(
-        trx,
-        tenant,
-        tickets
-          .map((ticket: any) => ticket.ticket_id)
-          .filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)
-      );
 
       const decisions = await Promise.all(
         tickets.map((ticket: any) =>
@@ -1419,10 +1387,7 @@ export const getTicketsForList = withAuth(async (user, { tenant }, filters: ITic
               action: 'read',
               id: ticket.ticket_id,
             },
-            record: toTicketAuthorizationRecord(
-              ticket,
-              additionalUserIdsByTicket.get(ticket.ticket_id) ?? []
-            ),
+            record: toTicketAuthorizationRecord(ticket),
             selectedBoardIds,
             requestCache,
             knex: trx,
@@ -2275,7 +2240,6 @@ export const getTicketById = withAuth(async (user, { tenant }, id: string): Prom
         }
       }
 
-      const additionalUserIdsByTicket = await fetchTicketAdditionalUserIds(trx, tenant, [id]);
       const authorizationDecision = await authorizationKernel.authorizeResource({
         subject: authorizationSubject,
         resource: {
@@ -2283,10 +2247,7 @@ export const getTicketById = withAuth(async (user, { tenant }, id: string): Prom
           action: 'read',
           id,
         },
-        record: toTicketAuthorizationRecord(
-          ticket,
-          additionalUserIdsByTicket.get(id) ?? []
-        ),
+        record: toTicketAuthorizationRecord(ticket),
         selectedBoardIds,
         requestCache,
         knex: trx,

--- a/packages/tickets/src/lib/ticketAuthorizationSql.ts
+++ b/packages/tickets/src/lib/ticketAuthorizationSql.ts
@@ -6,15 +6,14 @@ type TicketDbConnection = Knex | Knex.Transaction;
 /**
  * Physical mapping the shared read-authorization SQL compiler needs for the
  * `tickets` table. Mirrors `toTicketAuthorizationRecord`: a ticket is
- * "assigned" to its primary `assigned_to` OR any `ticket_resources`
- * `additional_user_id` co-assignee.
+ * "assigned" only to its primary `assigned_to`.
  *
  * Shared by the web server-action list and the public API list so both paths
  * authorize identically — a single source of truth for the ticket adapter.
  */
 export function createTicketRelationshipSqlAdapter(
-  conn: TicketDbConnection,
-  tenant: string
+  _conn: TicketDbConnection,
+  _tenant: string
 ): RelationshipSqlAdapter {
   return {
     ownerColumn: 't.entered_by',
@@ -37,29 +36,15 @@ export function createTicketRelationshipSqlAdapter(
       } else {
         query.whereIn('t.assigned_to', normalizedUserIds);
       }
-
-      query.orWhereExists(function () {
-        this.select(conn.raw('1'))
-          .from('ticket_resources as tr_auth')
-          .whereRaw('tr_auth.tenant = t.tenant')
-          .whereRaw('tr_auth.ticket_id = t.ticket_id')
-          .andWhere('tr_auth.tenant', tenant)
-          .whereNotNull('tr_auth.additional_user_id');
-
-        if (normalizedUserIds.length === 1) {
-          this.andWhere('tr_auth.additional_user_id', normalizedUserIds[0]);
-        } else {
-          this.whereIn('tr_auth.additional_user_id', normalizedUserIds);
-        }
-      });
     },
   };
 }
 
 /**
  * Batch-fetch `ticket_resources.additional_user_id` (co-assignees) keyed by
- * ticket_id. Used to build JS authorization records that count co-assignees the
- * same way `createTicketRelationshipSqlAdapter` does in SQL.
+ * ticket_id. Used by non-authorization ticket features that need additional
+ * agent metadata. These rows are intentionally not used as read grants because
+ * some workflows can create them without ticket row-level authorization.
  */
 export async function fetchTicketAdditionalUserIds(
   conn: TicketDbConnection,

--- a/server/src/lib/api/controllers/ApiTicketController.ts
+++ b/server/src/lib/api/controllers/ApiTicketController.ts
@@ -37,10 +37,7 @@ import { authorizeApiResourceRead, buildAuthorizationPrincipalSubject } from './
 import { buildAuthorizationAwarePage } from '@alga-psa/authorization/pagination';
 import { compileResourceReadAuthorizationSql } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
-import {
-  createTicketRelationshipSqlAdapter,
-  fetchTicketAdditionalUserIds,
-} from '@alga-psa/tickets/lib/ticketAuthorizationSql';
+import { createTicketRelationshipSqlAdapter } from '@alga-psa/tickets/lib/ticketAuthorizationSql';
 import type { Knex } from 'knex';
 import { fetchTimeEntriesForTicketCore } from '@alga-psa/scheduling/actions/timeEntryTicketActions';
 import {
@@ -123,16 +120,12 @@ export class ApiTicketController extends ApiBaseController {
     this.ticketService = ticketService;
   }
 
-  // A ticket is "assigned" to its primary `assigned_to` OR any
-  // `ticket_resources` co-assignee — matching the web server-action and the SQL
-  // adapter (createTicketRelationshipSqlAdapter). Callers batch-fetch the
-  // co-assignees via fetchTicketAdditionalUserIds and pass them in.
-  private buildTicketRecordContext(ticket: Record<string, any>, additionalUserIds: string[] = []) {
+  // A ticket is "assigned" only to its primary `assigned_to` for read authorization.
+  // Do not trust `ticket_resources.additional_user_id` as a read grant because
+  // time-entry workflows can create those rows without ticket row-level authorization.
+  private buildTicketRecordContext(ticket: Record<string, any>) {
     const assignedUserIds = new Set<string>();
     if (typeof ticket.assigned_to === 'string') assignedUserIds.add(ticket.assigned_to);
-    for (const id of additionalUserIds) {
-      if (typeof id === 'string' && id.length > 0) assignedUserIds.add(id);
-    }
     return {
       id: ticket.ticket_id,
       ownerUserId: typeof ticket.entered_by === 'string' ? ticket.entered_by : undefined,
@@ -156,21 +149,13 @@ export class ApiTicketController extends ApiBaseController {
     }
 
     const ticketRow = ticket as Record<string, any>;
-    const additionalByTicket = await fetchTicketAdditionalUserIds(
-      resolvedKnex,
-      apiRequest.context.tenant,
-      typeof ticketRow.ticket_id === 'string' ? [ticketRow.ticket_id] : []
-    );
     const allowed = await authorizeApiResourceRead({
       knex: resolvedKnex,
       tenant: apiRequest.context.tenant,
       user: apiRequest.context.user,
       apiKeyId: apiRequest.context.apiKeyId,
       resource: 'ticket',
-      recordContext: this.buildTicketRecordContext(
-        ticketRow,
-        additionalByTicket.get(ticketRow.ticket_id) ?? []
-      ),
+      recordContext: this.buildTicketRecordContext(ticketRow),
     });
 
     if (!allowed) {
@@ -190,14 +175,6 @@ export class ApiTicketController extends ApiBaseController {
     }
 
     const resolvedKnex = knex ?? await getConnection(apiRequest.context.tenant);
-    const ticketIds = tickets
-      .map((ticket) => ticket.ticket_id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
-    const additionalByTicket = await fetchTicketAdditionalUserIds(
-      resolvedKnex,
-      apiRequest.context.tenant,
-      ticketIds
-    );
     const allowedByRow = await Promise.all(
       tickets.map((ticket) =>
         authorizeApiResourceRead({
@@ -206,7 +183,7 @@ export class ApiTicketController extends ApiBaseController {
           user: apiRequest.context.user,
           apiKeyId: apiRequest.context.apiKeyId,
           resource: 'ticket',
-          recordContext: this.buildTicketRecordContext(ticket, additionalByTicket.get(ticket.ticket_id) ?? []),
+          recordContext: this.buildTicketRecordContext(ticket),
         })
       )
     );
@@ -368,21 +345,13 @@ export class ApiTicketController extends ApiBaseController {
                 apiRequest.context
               ),
             authorizeRecord: async (ticket) => {
-              const additionalByTicket = await fetchTicketAdditionalUserIds(
-                knex,
-                apiRequest.context.tenant,
-                typeof ticket.ticket_id === 'string' ? [ticket.ticket_id] : []
-              );
               return authorizeApiResourceRead({
                 knex,
                 tenant: apiRequest.context.tenant,
                 user: apiRequest.context.user,
                 apiKeyId: apiRequest.context.apiKeyId,
                 resource: 'ticket',
-                recordContext: this.buildTicketRecordContext(
-                  ticket,
-                  additionalByTicket.get(ticket.ticket_id) ?? []
-                ),
+                recordContext: this.buildTicketRecordContext(ticket),
               });
             },
             scanLimit: 100,


### PR DESCRIPTION
### Motivation
- A recent change treated `ticket_resources.additional_user_id` rows as assignment grants for ticket read authorization, which is unsafe because `timeentry:create` workflows can insert those rows without performing ticket row-level authorization and thus allow a low-privileged same-tenant user to gain read access to otherwise restricted tickets. 
- The goal is to remove trust in self-populatable co-assignee rows for read authorization while preserving existing ticket functionality and metadata access to those rows.

### Description
- Stop treating co-assignee rows as read grants by removing the `ticket_resources.additional_user_id` predicate from the shared SQL adapter `createTicketRelationshipSqlAdapter` in `packages/tickets/src/lib/ticketAuthorizationSql.ts` so only `tickets.assigned_to` is considered for assignment-based authorization. 
- Document `fetchTicketAdditionalUserIds` as a non-authorization metadata helper in `packages/tickets/src/lib/ticketAuthorizationSql.ts` so these rows remain available for UI/metadata use but are not trusted as read grants. 
- Update API-side authorization to build record contexts from the primary assignee only by removing co-assignee merging and batched co-assignee fetches from `server/src/lib/api/controllers/ApiTicketController.ts`. 
- Align server-action and ticket-action authorization code to the same model by removing uses of `fetchTicketAdditionalUserIds` for authorization and changing `toTicketAuthorizationRecord` implementations to include only `ticket.assigned_to` in `packages/tickets/src/actions/optimizedTicketActions.ts` and `packages/tickets/src/actions/ticketActions.ts`.

### Testing
- Ran `git diff --check` which completed with no whitespace errors. 
- Attempted `npm run lint -- --quiet` but it was blocked by the local environment missing the `globals` package required by ESLint. 
- Attempted the targeted unit test run with `npm run test:local -- packages/tickets/src/actions/ticketActions.authorizationNarrowing.test.ts --run` but it was blocked by the local environment missing the `dotenv` executable; therefore no test suite was executed to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c33e76b08330825f4da0132611e6)