### PR TITLE
fix(assets): require settings permission for asset type management

### DIFF
--- a/packages/assets/src/actions/assetTypeRegistryActions.rbac.test.ts
+++ b/packages/assets/src/actions/assetTypeRegistryActions.rbac.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 type Row = Record<string, any>;
 
 const h = vi.hoisted(() => {
-  const permissionState = { read: true, update: true };
+  const permissionState = { read: true, update: true, systemUpdate: true };
   const mockUser = { user_id: 'user-1', tenant: 'tenant_a' };
   const dbState: { asset_type_registry: Row[]; assets: Row[] } = {
     asset_type_registry: [],
@@ -99,9 +99,9 @@ const h = vi.hoisted(() => {
 
 const hasPermissionMock = vi.hoisted(() =>
   vi.fn(async (_user: unknown, resource: string, action: string) => {
-    if (resource !== 'asset') return false;
-    if (action === 'read') return h.permissionState.read;
-    if (action === 'update') return h.permissionState.update;
+    if (resource === 'asset' && action === 'read') return h.permissionState.read;
+    if (resource === 'asset' && action === 'update') return h.permissionState.update;
+    if (resource === 'system_settings' && action === 'update') return h.permissionState.systemUpdate;
     return false;
   })
 );
@@ -127,6 +127,7 @@ import {
 beforeEach(() => {
   h.permissionState.read = true;
   h.permissionState.update = true;
+  h.permissionState.systemUpdate = true;
   h.dbState.asset_type_registry.length = 0;
   h.dbState.assets.length = 0;
   hasPermissionMock.mockClear();
@@ -167,24 +168,24 @@ describe('asset type registry action RBAC (T307)', () => {
     expect(single?.slug).toBe('workstation');
   });
 
-  it('createAssetTypeAction requires asset.update (asset.read alone is not enough)', async () => {
-    h.permissionState.update = false;
+  it('createAssetTypeAction requires system settings update (asset permissions alone are not enough)', async () => {
+    h.permissionState.systemUpdate = false;
     await expect(createAssetTypeAction({ name: 'Door Access' })).rejects.toThrow(
       'Permission denied: Cannot manage asset types'
     );
-    expect(hasPermissionMock).toHaveBeenCalledWith(h.mockUser, 'asset', 'update');
+    expect(hasPermissionMock).toHaveBeenCalledWith(h.mockUser, 'system_settings', 'update');
     expect(h.dbState.asset_type_registry).toHaveLength(0);
   });
 
-  it('updateAssetTypeAction requires asset.update', async () => {
-    h.permissionState.update = false;
+  it('updateAssetTypeAction requires system settings update', async () => {
+    h.permissionState.systemUpdate = false;
     await expect(updateAssetTypeAction('door_access', { name: 'Doors' })).rejects.toThrow(
       'Permission denied: Cannot manage asset types'
     );
   });
 
-  it('deleteAssetTypeAction requires asset.update', async () => {
-    h.permissionState.update = false;
+  it('deleteAssetTypeAction requires system settings update', async () => {
+    h.permissionState.systemUpdate = false;
     await expect(deleteAssetTypeAction('door_access')).rejects.toThrow(
       'Permission denied: Cannot manage asset types'
     );

--- a/packages/assets/src/actions/assetTypeRegistryActions.ts
+++ b/packages/assets/src/actions/assetTypeRegistryActions.ts
@@ -22,6 +22,10 @@ export type AssetTypeRegistryActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: AssetTypeRegistryError };
 
+async function canManageAssetTypeRegistry(user: Parameters<typeof hasPermission>[0]): Promise<boolean> {
+  return hasPermission(user, 'system_settings', 'update');
+}
+
 function toActionResult<T>(result: AssetTypeRegistryResult<T>): AssetTypeRegistryActionResult<T> {
   if (result.ok) {
     return { success: true, data: result.value };
@@ -59,7 +63,7 @@ export const createAssetTypeAction = withAuth(async (
 ): Promise<AssetTypeRegistryActionResult<AssetTypeRegistryEntry>> => {
   const { knex } = await createTenantKnex();
 
-  if (!await hasPermission(user, 'asset', 'update')) {
+  if (!await canManageAssetTypeRegistry(user)) {
     throw new Error('Permission denied: Cannot manage asset types');
   }
 
@@ -76,7 +80,7 @@ export const updateAssetTypeAction = withAuth(async (
 ): Promise<AssetTypeRegistryActionResult<AssetTypeRegistryEntry>> => {
   const { knex } = await createTenantKnex();
 
-  if (!await hasPermission(user, 'asset', 'update')) {
+  if (!await canManageAssetTypeRegistry(user)) {
     throw new Error('Permission denied: Cannot manage asset types');
   }
 
@@ -92,7 +96,7 @@ export const deleteAssetTypeAction = withAuth(async (
 ): Promise<AssetTypeRegistryActionResult<{ slug: string }>> => {
   const { knex } = await createTenantKnex();
 
-  if (!await hasPermission(user, 'asset', 'update')) {
+  if (!await canManageAssetTypeRegistry(user)) {
     throw new Error('Permission denied: Cannot manage asset types');
   }
 


### PR DESCRIPTION
### Motivation

- Prevent scoped asset operators with only `asset:update` from mutating tenant-wide asset type registry settings via the new Settings UI.

### Description

- Require a `system_settings:update` permission check inside the asset type registry write actions by adding `canManageAssetTypeRegistry` and using it for `createAssetTypeAction`, `updateAssetTypeAction`, and `deleteAssetTypeAction` in `packages/assets/src/actions/assetTypeRegistryActions.ts`.
- Preserve read access guarded by `asset:read` for `getAssetTypes` and `getAssetType` so clients can still list and view types without settings rights.
- Update the RBAC unit test to mock and assert `system_settings:update` for registry writes in `packages/assets/src/actions/assetTypeRegistryActions.rbac.test.ts`.

### Testing

- Updated RBAC tests in `packages/assets/src/actions/assetTypeRegistryActions.rbac.test.ts` to validate that asset permissions alone cannot manage registry entries, but the test run was blocked by the local environment missing `@testing-library/jest-dom` and could not be executed to completion via `cd server && npx vitest run ../packages/assets/src/actions/assetTypeRegistryActions.rbac.test.ts`.
- Ran `npm -w @alga-psa/assets run typecheck`, which failed in the current environment due to missing ambient/dev dependencies such as `next/cache` and `@types/react` and thus could not complete.
- The change is minimal and limited to permission gating for tenant-wide registry writes and corresponding test updates, and the modified tests pass conceptually when the test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39e1373dd4833082e0d7f4257cbb5c)