### PR TITLE
fix(hudu): prevent stored API key exfiltration by requiring key when base URL changes

### DIFF
--- a/ee/server/src/__tests__/unit/huduClient.test.ts
+++ b/ee/server/src/__tests__/unit/huduClient.test.ts
@@ -89,6 +89,16 @@ describe('T010: header + base URL injection', () => {
     expect(buildHuduApiBaseUrl('https://acme.huducloud.com/api/v1/')).toBe('https://acme.huducloud.com/api/v1');
     expect(buildHuduApiBaseUrl('https://acme.huducloud.com/')).toBe('https://acme.huducloud.com/api/v1');
   });
+
+  it('rejects non-HTTPS and local/private base URLs', async () => {
+    const { buildHuduApiBaseUrl } = await importClient();
+
+    expect(() => buildHuduApiBaseUrl('http://acme.huducloud.com')).toThrow(/HTTPS/);
+    expect(() => buildHuduApiBaseUrl('https://localhost')).toThrow(/private network/);
+    expect(() => buildHuduApiBaseUrl('https://127.0.0.1')).toThrow(/private network/);
+    expect(() => buildHuduApiBaseUrl('https://10.0.0.5')).toThrow(/private network/);
+    expect(() => buildHuduApiBaseUrl('https://192.168.1.5')).toThrow(/private network/);
+  });
 });
 
 describe('T011: credential resolution precedence', () => {

--- a/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
+++ b/ee/server/src/__tests__/unit/huduConnectionActions.test.ts
@@ -68,6 +68,8 @@ vi.mock('@ee/lib/integrations/hudu/huduIntegrationRepository', () => ({
 }));
 
 vi.mock('@ee/lib/integrations/hudu/huduClient', () => ({
+  buildHuduApiBaseUrl: (baseUrl: string) =>
+    baseUrl.trim().replace(/\/+$/, '').replace(/\/api(?:\/v1)?$/, '').concat('/api/v1'),
   HuduClient: class {
     constructor(config: unknown) {
       huduClientConstructorSpy(config);
@@ -163,7 +165,23 @@ describe('T023: connectHudu', () => {
     expect(upsertHuduIntegrationMock).not.toHaveBeenCalled();
   });
 
-  it('F033: reuses the stored api key when the input omits it (keep-existing-key)', async () => {
+  it('reuses the stored api key only when the input keeps the stored base URL', async () => {
+    getTenantSecretMock.mockImplementation(async (_tenant: string, name: string) =>
+      name === 'hudu_api_key' ? API_KEY : BASE_URL
+    );
+    const { connectHudu } = await importActions();
+
+    const result = await connectHudu({ baseUrl: BASE_URL });
+
+    expect(result).toMatchObject({ success: true, data: { connected: true } });
+    expect(huduClientConstructorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ credentials: { apiKey: API_KEY, baseUrl: BASE_URL } })
+    );
+    expect(setTenantSecretMock).toHaveBeenCalledWith(TENANT, 'hudu_api_key', API_KEY);
+    expect(setTenantSecretMock).toHaveBeenCalledWith(TENANT, 'hudu_base_url', BASE_URL);
+  });
+
+  it('requires a fresh api key when changing the base URL', async () => {
     getTenantSecretMock.mockImplementation(async (_tenant: string, name: string) =>
       name === 'hudu_api_key' ? API_KEY : BASE_URL
     );
@@ -171,12 +189,9 @@ describe('T023: connectHudu', () => {
 
     const result = await connectHudu({ baseUrl: 'https://new.example.com' });
 
-    expect(result).toMatchObject({ success: true, data: { connected: true } });
-    expect(huduClientConstructorSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ credentials: { apiKey: API_KEY, baseUrl: 'https://new.example.com' } })
-    );
-    expect(setTenantSecretMock).toHaveBeenCalledWith(TENANT, 'hudu_api_key', API_KEY);
-    expect(setTenantSecretMock).toHaveBeenCalledWith(TENANT, 'hudu_base_url', 'https://new.example.com');
+    expect(result).toEqual({ success: false, error: 'Hudu API key is required when changing the base URL.' });
+    expect(huduClientConstructorSpy).not.toHaveBeenCalled();
+    expect(setTenantSecretMock).not.toHaveBeenCalled();
   });
 
   it('F033: still requires an api key when none is stored', async () => {
@@ -184,7 +199,7 @@ describe('T023: connectHudu', () => {
 
     const result = await connectHudu({ baseUrl: BASE_URL });
 
-    expect(result).toEqual({ success: false, error: 'Hudu base URL and API key are required.' });
+    expect(result).toEqual({ success: false, error: 'Hudu API key is required when changing the base URL.' });
     expect(validateConnectionMock).not.toHaveBeenCalled();
     expect(setTenantSecretMock).not.toHaveBeenCalled();
   });
@@ -254,7 +269,7 @@ describe('T024: testHuduConnection', () => {
     );
   });
 
-  it('F033: merges a base-URL-only candidate with the stored api key', async () => {
+  it('requires a fresh api key when testing a changed base URL', async () => {
     getTenantSecretMock.mockImplementation(async (_tenant: string, name: string) =>
       name === 'hudu_api_key' ? API_KEY : BASE_URL
     );
@@ -262,10 +277,8 @@ describe('T024: testHuduConnection', () => {
 
     const result = await testHuduConnection({ baseUrl: 'https://new.example.com' });
 
-    expect(result).toEqual({ success: true, data: { connected: true, passwordAccess: true } });
-    expect(huduClientConstructorSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ credentials: { apiKey: API_KEY, baseUrl: 'https://new.example.com' } })
-    );
+    expect(result).toEqual({ success: false, error: 'Hudu API key is required when changing the base URL.' });
+    expect(huduClientConstructorSpy).not.toHaveBeenCalled();
     expect(setTenantSecretMock).not.toHaveBeenCalled();
   });
 

--- a/ee/server/src/lib/actions/integrations/huduActions.ts
+++ b/ee/server/src/lib/actions/integrations/huduActions.ts
@@ -23,7 +23,7 @@ import { TIER_FEATURES } from '@alga-psa/types';
 import { featureFlags } from 'server/src/lib/feature-flags/featureFlags';
 import { assertTierAccess } from 'server/src/lib/tier-gating/assertTierAccess';
 import { createTenantKnex } from 'server/src/lib/db';
-import { HuduClient } from '../../integrations/hudu/huduClient';
+import { HuduClient, buildHuduApiBaseUrl } from '../../integrations/hudu/huduClient';
 import type { HuduErrorKind, HuduValidationResult } from '../../integrations/hudu/huduClient';
 import { HUDU_SECRET_KEYS, resolveHuduCredentials } from '../../integrations/hudu/secrets';
 import { clearHuduReferenceCacheForTenant } from '../../integrations/hudu/referenceData';
@@ -59,8 +59,9 @@ export interface HuduCredentialsInput {
 }
 
 /**
- * Connect input. `apiKey` may be omitted to keep using the already-stored key
- * (the UI never round-trips the stored value, so "blank key" means "keep").
+ * Connect input. `apiKey` may be omitted only when revalidating the currently
+ * stored base URL with the already-stored key (the UI never round-trips the
+ * stored value, so "blank key" means "keep" for the same instance).
  */
 export interface HuduConnectInput {
   baseUrl: string;
@@ -106,6 +107,30 @@ function toIso(value: Date | string | null | undefined): string | null {
   return value instanceof Date ? value.toISOString() : String(value);
 }
 
+function sameHuduBaseUrl(left: string, right: string): boolean {
+  return buildHuduApiBaseUrl(left) === buildHuduApiBaseUrl(right);
+}
+
+async function resolveCredentialsForCandidate(
+  tenant: string,
+  baseUrl: string | undefined,
+  apiKey: string | undefined
+): Promise<HuduCredentialsInput | null> {
+  if (baseUrl && apiKey) {
+    return { baseUrl, apiKey };
+  }
+
+  const stored = await resolveHuduCredentials(tenant);
+  const candidateBaseUrl = baseUrl || stored.baseUrl;
+  const candidateApiKey = apiKey || stored.apiKey;
+
+  if (!baseUrl || apiKey || sameHuduBaseUrl(candidateBaseUrl, stored.baseUrl)) {
+    return { baseUrl: candidateBaseUrl, apiKey: candidateApiKey };
+  }
+
+  return null;
+}
+
 function settingsPasswordAccess(settings: Record<string, unknown> | null | undefined): boolean {
   return settings?.password_access === true;
 }
@@ -132,18 +157,17 @@ export const connectHudu = withHuduSettingsAccess(
   async (_user, { tenant }, input: HuduConnectInput): Promise<HuduActionResult<HuduConnectionStatusData>> => {
     try {
       const baseUrl = input?.baseUrl?.trim();
-      let apiKey = input?.apiKey?.trim();
-      if (baseUrl && !apiKey) {
-        // Keep-existing-key: fall back to the stored credential.
-        apiKey = await resolveHuduCredentials(tenant)
-          .then((stored) => stored.apiKey)
-          .catch(() => undefined);
-      }
-      if (!baseUrl || !apiKey) {
+      const apiKey = input?.apiKey?.trim();
+      if (!baseUrl) {
         return { success: false, error: 'Hudu base URL and API key are required.' };
       }
 
-      const validation = await validateCandidate(tenant, { baseUrl, apiKey });
+      const credentials = await resolveCredentialsForCandidate(tenant, baseUrl, apiKey).catch(() => null);
+      if (!credentials) {
+        return { success: false, error: 'Hudu API key is required when changing the base URL.' };
+      }
+
+      const validation = await validateCandidate(tenant, credentials);
       if (!validation.ok || !validation.connected) {
         return {
           success: false,
@@ -153,12 +177,12 @@ export const connectHudu = withHuduSettingsAccess(
       }
 
       const secretProvider = await getSecretProviderInstance();
-      await secretProvider.setTenantSecret(tenant, HUDU_SECRET_KEYS.apiKey, apiKey);
-      await secretProvider.setTenantSecret(tenant, HUDU_SECRET_KEYS.baseUrl, baseUrl);
+      await secretProvider.setTenantSecret(tenant, HUDU_SECRET_KEYS.apiKey, credentials.apiKey);
+      await secretProvider.setTenantSecret(tenant, HUDU_SECRET_KEYS.baseUrl, credentials.baseUrl);
 
       const { knex } = await createTenantKnex(tenant);
       const row = await upsertHuduIntegration(knex, tenant, {
-        base_url: baseUrl,
+        base_url: credentials.baseUrl,
         is_active: true,
         connected_at: new Date().toISOString(),
         settings: { password_access: validation.passwordAccess },
@@ -196,18 +220,12 @@ export const testHuduConnection = withHuduSettingsAccess(
       const baseUrl = input?.baseUrl?.trim();
       const apiKey = input?.apiKey?.trim();
 
-      let validation: HuduValidationResult;
-      if (baseUrl && apiKey) {
-        validation = await validateCandidate(tenant, { baseUrl, apiKey });
-      } else {
-        // Merge partial candidates with the stored credentials so a blank key
-        // (or blank base URL) means "use the stored value".
-        const stored = await resolveHuduCredentials(tenant);
-        validation = await validateCandidate(tenant, {
-          baseUrl: baseUrl || stored.baseUrl,
-          apiKey: apiKey || stored.apiKey,
-        });
+      const credentials = await resolveCredentialsForCandidate(tenant, baseUrl, apiKey);
+      if (!credentials) {
+        return { success: false, error: 'Hudu API key is required when changing the base URL.' };
       }
+
+      const validation: HuduValidationResult = await validateCandidate(tenant, credentials);
 
       if (!validation.ok || !validation.connected) {
         return {

--- a/ee/server/src/lib/integrations/hudu/huduClient.ts
+++ b/ee/server/src/lib/integrations/hudu/huduClient.ts
@@ -12,6 +12,7 @@
  */
 
 import axios, { AxiosInstance, AxiosError } from 'axios';
+import * as net from 'node:net';
 import logger from '@alga-psa/core/logger';
 import { resolveHuduCredentials, HuduCredentials } from './secrets';
 import type {
@@ -420,13 +421,50 @@ export function redactSecret(value: string, secret?: string): string {
   return value.split(secret).join('[REDACTED]');
 }
 
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split('.').map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = parts;
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    a === 0
+  );
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true;
+  if (net.isIP(normalized) === 4) return isPrivateIpv4(normalized);
+  if (net.isIP(normalized) === 6) {
+    return (
+      normalized === '::1' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe80')
+    );
+  }
+  return false;
+}
+
 /** Normalize a base URL to `<instance>/api/v1` (idempotent). */
 export function buildHuduApiBaseUrl(baseUrl: string): string {
-  return baseUrl
+  const normalized = baseUrl
     .trim()
     .replace(/\/+$/, '')
     .replace(/\/api(?:\/v1)?$/, '')
     .concat('/api/v1');
+  const parsed = new URL(normalized);
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Hudu base URL must use HTTPS.');
+  }
+  if (isBlockedHostname(parsed.hostname)) {
+    throw new Error('Hudu base URL must not target localhost or private network addresses.');
+  }
+  return normalized;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- A blank/omitted Hudu API key was previously treated as “keep existing key” while allowing the caller to supply a new `baseUrl`, which could cause the server to send the stored write-only key to an attacker-controlled host.
- The change prevents accidental or malicious exfiltration of the stored API key by only reusing the stored key when the candidate base URL is the same as the stored base URL, and by hardening outbound URL handling.

### Description
- Added `resolveCredentialsForCandidate` and `sameHuduBaseUrl` in `ee/server/src/lib/actions/integrations/huduActions.ts` and updated `connectHudu` and `testHuduConnection` to require an explicit API key when the requested base URL differs from the currently stored base URL.
- Updated `ee/server/src/lib/integrations/hudu/huduClient.ts`'s `buildHuduApiBaseUrl` to normalize the URL, enforce `https:` and reject localhost/private-IP literal targets (SSRF/loopback protections); added `net`-based checks and hostname validation.
- Updated unit tests and mocks to reflect the new security behavior and to add a test that `buildHuduApiBaseUrl` rejects non-HTTPS / local/private targets; tests now mock/export `buildHuduApiBaseUrl` where needed.
- Small changes to tests to assert that stored-key reuse is allowed only when the base URL is unchanged and that attempting to change the base URL without providing a fresh key returns a clear error.

### Testing
- Ran unit tests: `npx vitest run src/__tests__/unit/huduConnectionActions.test.ts src/__tests__/unit/huduClient.test.ts --coverage.enabled=false` (from `ee/server`) and all tests passed (`43 passed`).
- Ran the project typecheck: `npm run typecheck` (from `ee/server`) which failed in this environment due to Node JS heap out-of-memory during `tsc --noEmit -p tsconfig.json` (environment limitation), not a code compilation error observed during test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39d21bc67c8330a110f72dcf792931)