### PR TITLE
fix(workflows): prevent Teams service URL token leak

### DIFF
--- a/ee/packages/workflows/src/runtime/actions/__tests__/teamsWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/teamsWorkflowActions.handlers.test.ts
@@ -205,7 +205,11 @@ describe('Teams workflow action handlers (T011)', () => {
     mocks.createChannelConversation.mockResolvedValue({ conversationId: '19:abc;messageid=1', activityId: 'act-9' });
 
     const result = await action.handler(
-      { channel_id: '19:abc@thread.tacv2', message: 'New critical alert' },
+      {
+        channel_id: '19:abc@thread.tacv2',
+        message: 'New critical alert',
+        service_url: 'https://attacker-profile.trafficmanager.net/'
+      } as any,
       { ...baseCtx, tenantId: 'tenant-1', knex: buildKnex() } as any
     );
     expect(mocks.createChannelConversation).toHaveBeenCalledWith({
@@ -229,6 +233,22 @@ describe('Teams workflow action handlers (T011)', () => {
     ).rejects.toMatchObject({
       code: 'APP_NOT_IN_TEAM',
       message: expect.stringContaining('not installed in that team')
+    });
+  });
+
+  it('post_to_channel does not expose service_url in its input schema', async () => {
+    const action = await loadActionById('teams.post_to_channel');
+
+    const parsed = action.inputSchema.safeParse({
+      channel_id: '19:abc@thread.tacv2',
+      message: 'New critical alert',
+      service_url: 'https://attacker-profile.trafficmanager.net/'
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success ? parsed.data : null).toEqual({
+      channel_id: '19:abc@thread.tacv2',
+      message: 'New critical alert'
     });
   });
 
@@ -256,6 +276,15 @@ describe('Teams workflow action handlers (T011)', () => {
         action.handler(input as any, { ...baseCtx, tenantId: 'tenant-1', knex: buildKnex({ installStatus: 'install_pending' }) } as any)
       ).rejects.toMatchObject({ code: 'INTEGRATION_INACTIVE' });
     }
+  });
+});
+
+describe('Teams service URL trust checks', () => {
+  it('rejects attacker-controlled trafficmanager subdomains while preserving known Teams hosts', async () => {
+    const { isTrustedServiceUrl } = await import('../teamsWorkflowRuntimeSupport');
+
+    expect(isTrustedServiceUrl('https://smba.trafficmanager.net/amer/')).toBe(true);
+    expect(isTrustedServiceUrl('https://attacker-profile.trafficmanager.net/')).toBe(false);
   });
 });
 

--- a/ee/packages/workflows/src/runtime/actions/registerTeamsWorkflowActions.ts
+++ b/ee/packages/workflows/src/runtime/actions/registerTeamsWorkflowActions.ts
@@ -295,8 +295,7 @@ export function registerTeamsWorkflowActionsV2(): void {
     idempotency: { mode: 'engineProvided' },
     inputSchema: z.object({
       channel_id: z.string().trim().min(1),
-      message: z.string().trim().min(1),
-      service_url: z.string().url().optional()
+      message: z.string().trim().min(1)
     }),
     outputSchema: z.object({
       posted: z.boolean(),
@@ -312,13 +311,13 @@ export function registerTeamsWorkflowActionsV2(): void {
     handler: async (input, ctx) => {
       const { tenantId, knex } = await requireTeamsIntegration(ctx);
 
-      const serviceUrl = input.service_url ?? (await getAnyTenantServiceUrl(knex, tenantId));
+      const serviceUrl = await getAnyTenantServiceUrl(knex, tenantId);
       if (!serviceUrl) {
         throwActionError(ctx, {
           category: 'ActionError',
           code: 'NO_SERVICE_URL',
           message:
-            'No Teams service URL is known for this tenant yet. Install the Alga app in a team (or have a user open the bot) so Teams sends one, or pass service_url explicitly.'
+            'No Teams service URL is known for this tenant yet. Install the Alga app in a team (or have a user open the bot) so Teams sends one.'
         });
       }
 

--- a/ee/packages/workflows/src/runtime/actions/teamsWorkflowRuntimeSupport.ts
+++ b/ee/packages/workflows/src/runtime/actions/teamsWorkflowRuntimeSupport.ts
@@ -25,9 +25,10 @@ export type TeamsIntegrationContext = {
 
 const TEAMS_PERSONAL_TAB_ENTITY_ID = 'alga-psa-personal-tab';
 
-// Bot Framework service URLs all live under trusted Microsoft suffixes;
-// never send a bot token anywhere else.
-const TRUSTED_SERVICE_URL_SUFFIXES = ['.botframework.com', '.trafficmanager.net', '.botplatform.cloudes.microsoft.com'];
+// Bot Framework service URLs use known Microsoft-operated hosts; never send a
+// bot token to broad cloud-hosting suffixes that non-Microsoft tenants can own.
+const TRUSTED_SERVICE_URL_HOSTS = new Set(['smba.trafficmanager.net']);
+const TRUSTED_SERVICE_URL_SUFFIXES = ['.botframework.com', '.botplatform.cloudes.microsoft.com'];
 const TOKEN_EXPIRY_BUFFER_MS = 60_000;
 
 let cachedBotToken: { accessToken: string; expiresAt: number } | null = null;
@@ -39,7 +40,10 @@ export function isTrustedServiceUrl(serviceUrl: string): boolean {
     const url = new URL(serviceUrl);
     if (url.protocol !== 'https:') return false;
     const host = url.hostname.toLowerCase();
-    return TRUSTED_SERVICE_URL_SUFFIXES.some((suffix) => host.endsWith(suffix));
+    return (
+      TRUSTED_SERVICE_URL_HOSTS.has(host) ||
+      TRUSTED_SERVICE_URL_SUFFIXES.some((suffix) => host.endsWith(suffix))
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
### Motivation
- Prevent exfiltration of the global Teams bot bearer token by removing workflow-controlled `service_url` input and ensuring channel posts use tenant-captured, verified service URLs. 
- Narrow the trust boundary for Bot Framework service URLs so the runtime does not accept attacker-controlled hosts that merely share broad Microsoft-looking suffixes.

### Description
- Removed `service_url` from the `teams.post_to_channel` `inputSchema` and changed the handler to always resolve the service URL via `getAnyTenantServiceUrl(knex, tenantId)` so workflow input cannot override it. 
- Tightened the service URL trust check by introducing `TRUSTED_SERVICE_URL_HOSTS = new Set(['smba.trafficmanager.net'])` and removing the broad `.trafficmanager.net` suffix from the allowlist, and updated `isTrustedServiceUrl` to require either an exact known host or one of the previously trusted Bot Framework suffixes. 
- Adjusted tests in `__tests__/teamsWorkflowActions.handlers.test.ts` to assert that `service_url` is not part of the input schema and added a test that `isTrustedServiceUrl` rejects attacker-controlled Traffic Manager subdomains while accepting the known Teams host. 
- Minor message tweak to `NO_SERVICE_URL` error text to remove the suggestion that callers may pass a `service_url` explicitly.

### Testing
- Ran `git diff --check` which passed with no whitespace / diff errors. 
- Attempted to run the action unit tests with `npx vitest run --root ee/packages/workflows src/runtime/actions/__tests__/teamsWorkflowActions.handlers.test.ts`, but the test runner failed due to a missing environment dependency (`@testing-library/jest-dom`) so the suite could not be executed to completion. 
- Ran type checks with `npm -w @alga-psa/workflows run typecheck` and `tsc --noEmit`, which failed due to missing type/declaration packages in the current environment (for example `next/cache`, `@types/react`, and other repo-wide typings), so a full typecheck could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ee478b0c8330a51e7048404deea3)