### PR TITLE
fix(workflows): authorize Huntress workflow actions

### DIFF
--- a/ee/packages/workflows/src/runtime/actions/__tests__/huntressWorkflowActions.handlers.test.ts
+++ b/ee/packages/workflows/src/runtime/actions/__tests__/huntressWorkflowActions.handlers.test.ts
@@ -23,11 +23,30 @@ const activeIntegrationBuilder = () => ({
   first: vi.fn().mockResolvedValue({ integration_id: 'int-h', instance_url: 'https://api.huntress.io' })
 });
 
-const integrationOnlyKnex = (): any =>
-  vi.fn((table: string) => {
+const workflowRunActorBuilder = () => ({
+  leftJoin: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  first: vi.fn().mockResolvedValue({ matched_workflow_id: 'wf-1', published_by: 'user-1', created_by: null })
+});
+
+const permissionBuilder = (allowed = true) => ({
+  join: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  first: vi.fn().mockResolvedValue(allowed ? { permission_id: 'perm-1' } : undefined)
+});
+
+const integrationOnlyKnex = (allowed = true): any => {
+  const trx: any = vi.fn((table: string) => {
+    if (table === 'workflow_runs as wr') return workflowRunActorBuilder();
+    if (table === 'user_roles as ur') return permissionBuilder(allowed);
     if (table === 'rmm_integrations') return activeIntegrationBuilder();
     throw new Error(`Unexpected table ${table}`);
   });
+  trx.raw = vi.fn().mockResolvedValue(undefined);
+  trx.transaction = vi.fn(async (callback) => callback(trx));
+  return trx;
+};
 
 const loadActionById = async (actionId: string) => {
   vi.resetModules();
@@ -143,6 +162,23 @@ describe('Huntress workflow action handlers (T010)', () => {
       code: 'CONFLICT',
       message: expect.stringContaining('remediations must be approved')
     });
+  });
+
+  it('denies Huntress API access when the workflow actor cannot manage integrations', async () => {
+    const action = await loadActionById('huntress.incidents.get');
+    const getIncidentReport = vi.fn().mockResolvedValue({ id: 421, status: 'sent', severity: 'high', body: 'secret' });
+    await mockClient({ getIncidentReport });
+
+    await expect(
+      action.handler(
+        { incident_id: 421 },
+        { ...baseCtx, tenantId: 'tenant-1', knex: integrationOnlyKnex(false) } as any
+      )
+    ).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+      message: 'Permission denied: settings:update'
+    });
+    expect(getIncidentReport).not.toHaveBeenCalled();
   });
 
   it('organizations.list and agents.get normalize reference data', async () => {

--- a/ee/packages/workflows/src/runtime/actions/registerHuntressWorkflowActions.ts
+++ b/ee/packages/workflows/src/runtime/actions/registerHuntressWorkflowActions.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { getActionRegistryV2 } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
-import { throwActionError } from '../../../../../../shared/workflow/runtime/actions/businessOperations/shared';
+import {
+  requirePermission,
+  throwActionError,
+  withTenantTransaction
+} from '../../../../../../shared/workflow/runtime/actions/businessOperations/shared';
 import type { ActionContext } from '../../../../../../shared/workflow/runtime/registries/actionRegistry';
 import { registerIntegrationWorkflowModule, rmmIntegrationAvailability } from '../integrationModules';
 
@@ -61,28 +65,32 @@ async function requireHuntressIntegration(ctx: ActionContext): Promise<{
   if (!tenantId) {
     throwActionError(ctx, { category: 'ValidationError', code: 'VALIDATION_ERROR', message: 'tenantId is required' });
   }
-  const knex = ctx.knex;
-  if (!knex) {
-    throwActionError(ctx, { category: 'ActionError', code: 'INTERNAL_ERROR', message: 'Database connection unavailable' });
-  }
+  const { integrationId, instanceUrl } = await withTenantTransaction(ctx, async (tx) => {
+    await requirePermission(ctx, tx, { resource: 'settings', action: 'update' });
 
-  const integration = await knex('rmm_integrations')
-    .where({ tenant: tenantId, provider: PROVIDER, is_active: true })
-    .whereNotNull('connected_at')
-    .first();
-  if (!integration) {
-    throwActionError(ctx, {
-      category: 'ActionError',
-      code: 'INTEGRATION_INACTIVE',
-      message: 'Huntress integration is not active for this tenant. Connect it under Settings > Integrations > RMM.'
-    });
-  }
+    const integration = await tx.trx('rmm_integrations')
+      .where({ tenant: tenantId, provider: PROVIDER, is_active: true })
+      .whereNotNull('connected_at')
+      .first();
+    if (!integration) {
+      throwActionError(ctx, {
+        category: 'ActionError',
+        code: 'INTEGRATION_INACTIVE',
+        message: 'Huntress integration is not active for this tenant. Connect it under Settings > Integrations > RMM.'
+      });
+    }
+
+    return {
+      integrationId: String(integration.integration_id),
+      instanceUrl: integration.instance_url ? String(integration.instance_url) : undefined
+    };
+  });
 
   return {
     tenantId,
-    knex,
-    integrationId: String(integration.integration_id),
-    instanceUrl: integration.instance_url ? String(integration.instance_url) : undefined
+    knex: ctx.knex,
+    integrationId,
+    instanceUrl
   };
 }
 


### PR DESCRIPTION
### Motivation

- Close an authorization bypass where Huntress workflow actions used tenant Huntress credentials after only an integration existence check, allowing workflow authors to read SOC report bodies or resolve incidents without actor RBAC.
- Ensure Huntress actions require an appropriate actor permission (integration/settings management) before loading tenant secrets or calling external Huntress APIs.

### Description

- Require the workflow actor to have `settings:update` for all Huntress workflow actions by invoking `withTenantTransaction(...)` and `requirePermission(...)` before reading the `rmm_integrations` row and using tenant credentials (changes in `registerHuntressWorkflowActions.ts`).
- Move the integration lookup inside the tenant transaction / actor resolution path so the actor is resolved and permission checked before the integration is used (returns `integrationId` and `instanceUrl` to callers).
- Update imports to include `requirePermission` and `withTenantTransaction` from the shared workflow helpers and adjust the returned `knex`/integration context accordingly.
- Extend the Huntress action handler tests to mock workflow actor resolution and permission lookups (test helpers simulate `workflow_runs` and `user_roles` queries) and add an assertion that an actor without `settings:update` receives `PERMISSION_DENIED` and that the Huntress client is not invoked (`__tests__/huntressWorkflowActions.handlers.test.ts`).

### Testing

- Ran `git diff --check` successfully to validate formatting and whitespace.
- Attempted unit tests with `vitest` for the updated Huntress handlers, but test runs in this environment were blocked by unrelated test/runtime environment issues including a missing `@testing-library/jest-dom` import and unresolved workspace package entries (`@alga-psa/core/secrets`, `@alga-psa/storage`), so the suite could not be completed here.
- Ran `npm run typecheck` for the workflows package and observed unrelated workspace-wide type/dependency gaps (missing Next/React types and other dev dependencies) that prevented a clean typecheck in this environment; the change itself is limited and type-compatible with the workflow helpers used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ed9d74e48330b3fad2f1deb92534)