### PR TITLE
Lighter, tighter shared form controls (Input, Select, DatePicker, TextArea)

### DIFF
--- a/packages/ui/src/components/CustomSelect.tsx
+++ b/packages/ui/src/components/CustomSelect.tsx
@@ -32,7 +32,7 @@ type SelectSize = 'sm' | 'md' | 'lg';
 
 const sizeClasses: Record<SelectSize, string> = {
   sm: 'h-8 text-xs px-2',
-  md: 'h-10 text-sm p-2',
+  md: 'h-9 text-sm px-3',
   lg: 'h-12 text-base px-4',
 };
 
@@ -263,8 +263,8 @@ const CustomSelect = ({
             inline-flex items-center justify-between
             rounded-lg ${sizeClasses[size]}
             font-medium transition-colors w-full
-            bg-background cursor-pointer
-            border border-[rgb(var(--color-border-400))] text-[rgb(var(--color-text-700))]
+            bg-white dark:bg-[rgb(var(--color-card))] cursor-pointer
+            border border-border text-[rgb(var(--color-text-700))]
             hover:bg-[rgb(var(--color-primary-50))] hover:text-[rgb(var(--color-primary-700))]
             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
             disabled:pointer-events-none disabled:cursor-not-allowed

--- a/packages/ui/src/components/DatePicker.tsx
+++ b/packages/ui/src/components/DatePicker.tsx
@@ -113,10 +113,10 @@ export function DatePicker({
           aria-label={label || placeholder}
           onKeyDown={handleKeyDown}
           className={`
-            flex h-10 w-full rounded-md border border-[rgb(var(--color-border-300))] bg-[rgb(var(--color-card))] px-3 py-2 text-sm
+            flex h-9 w-full rounded-lg border border-border bg-[rgb(var(--color-card))] px-3 py-1.5 text-sm
             file:border-0 file:bg-transparent file:text-sm file:font-medium
             placeholder:text-[rgb(var(--color-text-500))]
-            hover:border-[rgb(var(--color-border-400))]
+            hover:border-[rgb(var(--color-border-300))]
             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--color-primary-500))] focus-visible:ring-offset-2
             disabled:cursor-not-allowed disabled:opacity-50
             ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -9,7 +9,7 @@ type InputSize = 'sm' | 'md' | 'lg';
 
 const inputSizeClasses: Record<InputSize, string> = {
   sm: 'py-1 px-2 text-xs h-8',
-  md: 'py-2 px-3 h-10',
+  md: 'py-1.5 px-3 text-sm h-9',
   lg: 'py-3 px-4 text-base h-12',
 };
 
@@ -152,10 +152,10 @@ export function Input({
       <input
         {...finalAutomationProps}
         ref={mergedRef}
-        className={`w-full ${inputSizeClasses[size]} border rounded-md shadow-sm focus:outline-none focus:ring-2 bg-white dark:bg-[rgb(var(--color-card))] text-[rgb(var(--color-text-900))] placeholder:text-[rgb(var(--color-text-400))] ${
+        className={`w-full ${inputSizeClasses[size]} border rounded-lg shadow-sm focus:outline-none focus:ring-2 bg-white dark:bg-[rgb(var(--color-card))] text-[rgb(var(--color-text-900))] placeholder:text-[rgb(var(--color-text-400))] ${
           hasErrorState
             ? 'border-destructive focus:ring-destructive focus:border-destructive bg-[rgb(var(--color-destructive)/0.1)]'
-            : 'border-[rgb(var(--color-border-400))] focus:ring-[rgb(var(--color-primary-500))] focus:border-transparent file:mr-3 file:rounded-md file:border-0 file:bg-[rgba(var(--color-primary-500),0.08)] file:px-3 file:py-2 file:text-sm file:font-medium file:text-[rgb(var(--color-primary-700))]'
+            : 'border-border focus:ring-[rgb(var(--color-primary-500))] focus:border-transparent file:mr-3 file:rounded-md file:border-0 file:bg-[rgba(var(--color-primary-500),0.08)] file:px-3 file:py-2 file:text-sm file:font-medium file:text-[rgb(var(--color-primary-700))]'
         } ${className}`}
         value={value}
         disabled={disabled}

--- a/packages/ui/src/components/TextArea.tsx
+++ b/packages/ui/src/components/TextArea.tsx
@@ -145,8 +145,8 @@ export function TextArea({
           w-full max-w-4xl
           ${textAreaSizeClasses[size]}
           border
-          border-[rgb(var(--color-border-400))]
-          rounded-md
+          border-border
+          rounded-lg
           shadow-sm
           focus:outline-none
           focus:ring-2


### PR DESCRIPTION
## Summary

Aligns the shared text/select inputs to one lighter, more compact standard that matches the design mockups. These controls carried heavier chrome than the rest of the UI — slate-400 borders (vs the slate-200 `border` token everything else uses), 40px height, and 6px radius — and `CustomSelect` used `bg-background`, which resolves transparent off a card and showed the page behind the control.

## Changes (global, shared components)

`Input`, `CustomSelect`, `DatePicker`, `TextArea`:
- **Border:** slate-400 → `border-border` (slate-200), the app's default border token
- **Height (md):** h-10 (40px) → h-9 (36px), padding tightened to `py-1.5`
- **Radius:** rounded-md (6px) → rounded-lg (8px) on Input / DatePicker / TextArea
- **CustomSelect background:** `bg-background` → `bg-white dark:bg-card` (matches Input; fixes the transparent-off-card case)

## Scope / follow-up

This is a global change to shared components. `Button`, `PhoneInput`, `TreeSelect`, and `ContactPicker` still use the older slate-400 border and are intentionally left for a follow-up.

## Verification
- `tsc --noEmit` clean for `@alga-psa/ui`.
- Live-verified on the invoicing toolbar (select + client filter), the manual-invoice form (select + text input), and the Filters-popover date pickers.

https://claude.ai/code/session_0133y87FyMNeR6cvKGZ5i7Yz