### PR TITLE
docs: reflect RMM default notification contact (#2769)

### DIFF
--- a/docs/integrations/tactical-rmm.md
+++ b/docs/integrations/tactical-rmm.md
@@ -49,6 +49,16 @@ each Tactical Client to an AlgaPSA client and use the **Auto-sync** toggle to
 control whether that organization's devices import. Map a Tactical Client to an
 AlgaPSA client before you sync devices, so its agents land on the right client.
 
+Each mapping also supports a **Default Notification Contact**. Choose a contact from
+the mapped client using the picker that appears alongside the client selector. When
+an alert for that organization creates a ticket, AlgaPSA sets the ticket's contact
+to the person you chose and fires the tenant's configured "Ticket Created"
+client-facing email, notifying the right person at the client the moment an alert
+becomes a ticket. If no default is set, AlgaPSA falls back to the client's primary
+contact. If no valid contact can be resolved in either case, the ticket is still
+created — just without a contact or client notification. Use **Add new contact** in
+the picker to create a contact inline without leaving the mapping screen.
+
 ## Sync devices into assets
 
 Click **Sync Devices** to import agents from the organizations you mapped with


### PR DESCRIPTION
## Source PR

- **Nine-Minds/alga-psa #2769 — "Contact mapping ability"** — https://github.com/Nine-Minds/alga-psa/pull/2769  
  Merged 2026-06-24. Adds a `default_contact_id` field to `rmm_organization_mappings`, exposes a Default Notification Contact picker in the org-mapping UI of all five RMM providers (Huntress, NinjaOne, Tactical, Level, Tanium), and publishes `TICKET_CREATED` from all RMM ticket-create paths. Previously, RMM-created tickets set no contact and fired no client-facing notifications.

## Files edited

| File | Rationale |
| --- | --- |
| `docs/integrations/tactical-rmm.md` | The "Sync clients and map them to AlgaPSA" section described org mapping as assigning a client and toggling Auto-sync, with no mention of the new Default Notification Contact picker or the fact that RMM-created tickets now fire the "Ticket Created" client-facing email. Added a paragraph explaining the picker, the contact resolution fallback chain (mapping default → client primary → none), the resulting email notification, and the inline Add new contact option. |

## Needs human review

- **Other RMM provider docs in alga-psa** — only `docs/integrations/tactical-rmm.md` exists under `docs/integrations/` for RMM providers. If NinjaOne, Huntress, Level, or Tanium admin guides are added in future, they will need a similar Default Notification Contact section in their org-mapping descriptions.
- **`docs/api/api-rate-limiting-and-webhooks.md`** — the existing `ticket.created` webhook event documentation is accurate as-is (it does not exclude RMM-sourced tickets). No update was made. Confirm this is the intended interpretation: `ticket.created` now fires for all five RMM providers' create paths in addition to manual ticket creation.
- **PR #2768 (`fix(billing): drop phantom tenant filter from tax child tables`)** — internal bug fix that corrects a SQL error when saving quotes with threshold-based or composite tax rates. No user-visible behavior change beyond "it now works." No doc updates were made; verify this assessment is correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8iN6T6qUeWzUGoCZLYfUs)_