### PR TITLE
chore: mark PostHog tenant-targeting friction (LEVERAGE)

### DIFF
--- a/packages/ui/src/components/analytics/PostHogUserIdentifier.tsx
+++ b/packages/ui/src/components/analytics/PostHogUserIdentifier.tsx
@@ -88,6 +88,7 @@ export function PostHogUserIdentifier() {
           });
         }
 
+        // LEVERAGE: friction posthog-tenant-group — client sets `tenant` as a person property only; server-side evals (featureFlagRuntime.ts) send groups:{tenant}. Same flag needs different PostHog targeting depending on where it's read (client→person-property, server→group). A posthog.group('tenant', user.tenant) here would let group-targeted flags resolve client-side too, so tenant flags target uniformly.
         if (!shouldAnonymize) {
           posthog.identify(user.id, {
             email: user.email,


### PR DESCRIPTION
## What

Drops a single `// LEVERAGE: friction posthog-tenant-group` marker at the client `identify()` site in `PostHogUserIdentifier.tsx`. Comment-only — no behavior change.

## Why

Tenant feature-flag targeting is inconsistent depending on where a flag is read:

- **Client-side** (`useFeatureFlag` → `posthog.isFeatureEnabled`): the browser only ever sets `tenant` as a **person property** via `identify()`. It never calls `posthog.group('tenant', …)`.
- **Server-side** (`featureFlagRuntime.ts`): evaluations send `groups: { tenant }` (and person properties).

Consequence: the *same* flag needs *different* PostHog targeting depending on the read site. A flag targeted by a **tenant group** silently evaluates `false` in the browser, so client-gated UI stays hidden even when the flag is "on". This is what hid the MCP Server settings tab (`mcp-server`), and it affects every client-read flag (`billing-enabled`, the `entra-integration-*` UI flags, the RMM integration flags, `delegated-time-entry`, `live-ticket-updates`, etc.), plus the client side of dual-checked flags (`hudu-integration`, `entra-integration-ui`).

## The fix shape (not done here)

Add `posthog.group('tenant', user.tenant)` alongside the `identify()` calls (followed by `reloadFeatureFlags()`) so group-targeted flags resolve client-side too — collapsing the per-flag "which targeting style?" decision. The marker records the hypothesis; actually extracting/closing it is a follow-up (the `leverage` skill's job).

https://claude.ai/code/session_01La5GjFbpDzFkakvHDwbtHe