### PR TITLE
chore: mark duplicated settings-tab definitions (LEVERAGE)

### DIFF
--- a/server/src/components/settings/SettingsPage.tsx
+++ b/server/src/components/settings/SettingsPage.tsx
@@ -348,6 +348,7 @@ const SettingsPageContent = ({ initialTabParam }: SettingsPageProps): React.JSX.
   };
 
   // Create a map of tab content by label for easy lookup
+  // LEVERAGE: pattern settings-tabs-twice — this tab set is duplicated by settingsNavigationSections in menuConfig.ts (the sidebar's settings menu); they drift. The EE+flag gate below adds 'mcp-server' here, but there's no matching entry/gate over there, so the tab has no side-menu link. Both should derive from one gated registry.
   const allTabs = useMemo(() => {
     const tabs = [...baseTabContent, extensionsTab];
     if (isEEAvailable && mcpServerUiEnabled) {

--- a/server/src/config/menuConfig.ts
+++ b/server/src/config/menuConfig.ts
@@ -226,6 +226,7 @@ export const bottomMenuItems: MenuItem[] = [
 
 // Settings navigation sections - used when sidebar is in 'settings' mode
 // These correspond to the settings tabs in SettingsPage
+// LEVERAGE: pattern settings-tabs-twice — the settings tab set is defined twice (here, and in SettingsPage.tsx's allTabs builder); the two lists drift. The EE+flag-gated 'mcp-server' tab exists there but is missing here, so it never appears in the side menu. This nav config also has no EE/feature-flag gating primitive (only product + tier), so a gated tab can't be expressed as data. Both lists should derive from one gated registry (cf. providerRegistry.ts requiresEnterprise + featureFlagKey).
 export const settingsNavigationSections: NavigationSection[] = [
   {
     title: 'Organization & Access',


### PR DESCRIPTION
## What

Drops a `// LEVERAGE: pattern settings-tabs-twice` marker at the two sites where the settings tab set is defined. Comment-only — no behavior change.

## Why

The MSP settings tabs are defined in **two unsynchronized places**:

1. `server/src/components/settings/SettingsPage.tsx` — the `allTabs` builder, which is *dynamic* and appends the `MCP Server` tab when `NEXT_PUBLIC_EDITION === 'enterprise'` **and** the `mcp-server` PostHog flag is on.
2. `server/src/config/menuConfig.ts` — `settingsNavigationSections`, the *static* list that renders the sidebar's settings sub-menu.

These have drifted. `mcp-server` exists in (1) but not (2), so the screen is reachable via `/msp/settings?tab=mcp-server` but **has no entry in the side menu** — regardless of the flag. Worse, the nav config has no EE/feature-flag gating primitive at all (only product + tier filtering in `SidebarWithFeatureFlags.tsx`), so a flag-gated tab cannot currently be expressed there as data without a naive static add that would dead-link for non-EE / flag-off tenants.

## The fix shape (not done here)

Drive both lists from a single gated registry — extend the menu-item schema with `requiresEnterprise` + `requiredFeatureFlag` and honor them in the settings-section filter, exactly as `packages/integrations/src/lib/rmm/providerRegistry.ts` already does for RMM providers (`requiresEnterprise` + `featureFlagKey`). The marker records the hypothesis; extracting the layer is a follow-up (the `leverage` skill's job).

## Related

Pairs with the `posthog-tenant-group` friction marker in #2774 — both are facets of how feature-flag-gated surfaces are wired in this codebase.

https://claude.ai/code/session_01La5GjFbpDzFkakvHDwbtHe