### PR TITLE
feat(api): add CE stubs for appliance-installs routes

### DIFF
--- a/packages/ee/src/app/api/v1/appliance-installs/[tenantId]/route.ts
+++ b/packages/ee/src/app/api/v1/appliance-installs/[tenantId]/route.ts
@@ -1,0 +1,17 @@
+// Community Edition stub for appliance installs [tenantId] API
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const eeUnavailable = () => NextResponse.json(
+  { success: false, error: 'Appliance console is only available in Enterprise Edition.' },
+  { status: 501 }
+);
+
+type RouteContext = { params: Promise<{ tenantId: string }> };
+
+export async function GET(_request: NextRequest, _context: RouteContext): Promise<NextResponse> {
+  return eeUnavailable();
+}

--- a/packages/ee/src/app/api/v1/appliance-installs/access/route.ts
+++ b/packages/ee/src/app/api/v1/appliance-installs/access/route.ts
@@ -1,0 +1,15 @@
+// Community Edition stub for appliance installs access logging API
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const eeUnavailable = () => NextResponse.json(
+  { success: false, error: 'Appliance console is only available in Enterprise Edition.' },
+  { status: 501 }
+);
+
+export async function POST(_request: NextRequest): Promise<NextResponse> {
+  return eeUnavailable();
+}

--- a/packages/ee/src/app/api/v1/appliance-installs/route.ts
+++ b/packages/ee/src/app/api/v1/appliance-installs/route.ts
@@ -1,0 +1,15 @@
+// Community Edition stub for appliance installs API
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const eeUnavailable = () => NextResponse.json(
+  { success: false, error: 'Appliance console is only available in Enterprise Edition.' },
+  { status: 501 }
+);
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  return eeUnavailable();
+}

--- a/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
+++ b/server/src/app/api/v1/appliance-installs/[tenantId]/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Appliance Console API — appliance install detail CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const isEnterpriseEdition =
+  (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+  (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
+
+type RouteContext = {
+  params: Promise<{ tenantId: string }>;
+};
+
+type EeRouteModule = {
+  GET: (req: Request, context: RouteContext) => Promise<Response>;
+  OPTIONS?: (req: Request) => Promise<Response>;
+};
+
+let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
+
+async function loadEeRoute(): Promise<EeRouteModule | null> {
+  if (!isEnterpriseEdition) {
+    return null;
+  }
+
+  if (!eeRouteModulePromise) {
+    eeRouteModulePromise = import('@enterprise/app/api/v1/appliance-installs/[tenantId]/route')
+      .then((module) => module as unknown as EeRouteModule)
+      .catch((error) => {
+        console.error('[v1/appliance-installs/:tenantId] Failed to load EE route', error);
+        return null;
+      });
+  }
+
+  return eeRouteModulePromise;
+}
+
+function eeUnavailable(): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: 'Appliance console is only available in Enterprise Edition.',
+    }),
+    {
+      status: 501,
+      headers: { 'content-type': 'application/json' },
+    }
+  );
+}
+
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.GET) {
+    return eeUnavailable();
+  }
+  return eeRoute.GET(request, context);
+}
+
+export async function OPTIONS(request: Request): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.OPTIONS) {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    });
+  }
+  return eeRoute.OPTIONS(request);
+}

--- a/server/src/app/api/v1/appliance-installs/access/route.ts
+++ b/server/src/app/api/v1/appliance-installs/access/route.ts
@@ -1,0 +1,70 @@
+/**
+ * Appliance Console API — access logging CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const isEnterpriseEdition =
+  (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+  (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
+
+type EeRouteModule = {
+  POST: (req: Request) => Promise<Response>;
+  OPTIONS?: (req: Request) => Promise<Response>;
+};
+
+let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
+
+async function loadEeRoute(): Promise<EeRouteModule | null> {
+  if (!isEnterpriseEdition) {
+    return null;
+  }
+
+  if (!eeRouteModulePromise) {
+    eeRouteModulePromise = import('@enterprise/app/api/v1/appliance-installs/access/route')
+      .then((module) => module as unknown as EeRouteModule)
+      .catch((error) => {
+        console.error('[v1/appliance-installs/access] Failed to load EE route', error);
+        return null;
+      });
+  }
+
+  return eeRouteModulePromise;
+}
+
+function eeUnavailable(): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: 'Appliance console is only available in Enterprise Edition.',
+    }),
+    {
+      status: 501,
+      headers: { 'content-type': 'application/json' },
+    }
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.POST) {
+    return eeUnavailable();
+  }
+  return eeRoute.POST(request);
+}
+
+export async function OPTIONS(request: Request): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.OPTIONS) {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    });
+  }
+  return eeRoute.OPTIONS(request);
+}

--- a/server/src/app/api/v1/appliance-installs/route.ts
+++ b/server/src/app/api/v1/appliance-installs/route.ts
@@ -1,0 +1,70 @@
+/**
+ * Appliance Console API — CE stub. Lazy-loads the EE route, or returns 501 for CE builds.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const isEnterpriseEdition =
+  (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
+  (process.env.NEXT_PUBLIC_EDITION ?? '').toLowerCase() === 'enterprise';
+
+type EeRouteModule = {
+  GET: (req: Request) => Promise<Response>;
+  OPTIONS?: (req: Request) => Promise<Response>;
+};
+
+let eeRouteModulePromise: Promise<EeRouteModule | null> | null = null;
+
+async function loadEeRoute(): Promise<EeRouteModule | null> {
+  if (!isEnterpriseEdition) {
+    return null;
+  }
+
+  if (!eeRouteModulePromise) {
+    eeRouteModulePromise = import('@enterprise/app/api/v1/appliance-installs/route')
+      .then((module) => module as unknown as EeRouteModule)
+      .catch((error) => {
+        console.error('[v1/appliance-installs] Failed to load EE route', error);
+        return null;
+      });
+  }
+
+  return eeRouteModulePromise;
+}
+
+function eeUnavailable(): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: 'Appliance console is only available in Enterprise Edition.',
+    }),
+    {
+      status: 501,
+      headers: { 'content-type': 'application/json' },
+    }
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.GET) {
+    return eeUnavailable();
+  }
+  return eeRoute.GET(request);
+}
+
+export async function OPTIONS(request: Request): Promise<Response> {
+  const eeRoute = await loadEeRoute();
+  if (!eeRoute?.OPTIONS) {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    });
+  }
+  return eeRoute.OPTIONS(request);
+}


### PR DESCRIPTION
  Add Community Edition stub routes for the appliance console API:
  /v1/appliance-installs (list), /[tenantId] (detail), and /access (logging).
  Each lazy-loads its @enterprise counterpart when EDITION is enterprise/ee,
  caching the import promise, and otherwise returns 501 with an
  "only available in Enterprise Edition" message. OPTIONS falls back to a plain
  CORS 204 preflight when no EE handler is present.

  Three little route stubs stood at the Enterprise gate, each clutching a lazy
  import like a golden ticket: "Edition ee? Step right in." But for plain CE
  travelers there was only the velvet rope of a 501 and a polite preflight bow —
  "this console is only available in Enterprise Edition," said the doorman, and
  not a tenant slipped past. 🎩🚪🎟️