### PR TITLE
Remove unused timesheets and periods from the Time Entry list

### DIFF
--- a/docs/plans/2026-06-24-remove-unused-timesheets-design.md
+++ b/docs/plans/2026-06-24-remove-unused-timesheets-design.md
@@ -1,0 +1,69 @@
+# Remove unused timesheets & periods — design
+
+Date: 2026-06-24
+Branch: `chore/remove-timesheets`
+
+## Goal
+
+Let users remove unused/unneeded timesheets — and, for managers, the unused pay periods
+themselves — directly from the Time Entry period list, when it is safe to do so. "Safe"
+means nothing of value is ever destroyed (only empty drafts and periods nobody has logged
+against).
+
+Removal is **selection-driven**: row checkboxes + a floating bulk-action bar (mirroring the
+tickets screen). There is no per-row delete button.
+
+## Surface
+
+Screen: `TimePeriodList` (rendered by `TimeTracking.tsx`) — a `DataTable` where every row is a
+pay **period** showing the current user's timesheet status / hours for it.
+
+The list mixes two objects, so "Remove" resolves per row to a single, possibly composite,
+operation `{ deleteTimeSheetId?, deletePeriod }`:
+
+- **Empty draft timesheet** — the user's `DRAFT`/`CHANGES_REQUESTED` timesheet with zero
+  entries → delete the timesheet (user-scoped, safe).
+- **Unused period** — a period with no timesheets for anyone (⇒ no entries) and not the
+  current period → delete the period (tenant-wide; **managers only**).
+- **One action clears the row**: removing the user's empty draft on an otherwise-unused
+  period deletes the draft *and* the period together, so the row disappears in a single
+  action (no two-step). On a *shared* period only the draft is removed (the period stays).
+
+Rows that are submitted/approved, have entries, or (for periods) the current period or other
+users' timesheets, expose no removal.
+
+## Changes
+
+1. **Types** — `ITimePeriodWithStatusView` gains `timeSheetId`, `entryCount`, and
+   `periodTimesheetCount` (lets a row tell "only my draft" = 1 from "shared" > 1 or "unused" = 0).
+2. **`fetchTimePeriods`** (`timeSheetOperations.ts`) — also selects the timesheet `id`, a true
+   per-timesheet entry count, and a per-period timesheet count across all users.
+3. **`deleteTimeSheets(ids)`** (`timeSheetOperations.ts`) — security boundary for timesheet
+   removal: per id, authorize via `assertCanActOnBehalf`, require empty draft, clean up
+   comments, delete. Returns `{ deletedIds, failed[] }`.
+4. **`deleteTimePeriods(ids)`** (`timePeriodsActions.ts`) — manager-gated (direct `teams`
+   manager check), per id re-validates `isEditable` (no timesheets anywhere) and refuses the
+   current period, then deletes. Returns `{ deletedIds, failed[] }`.
+5. **`TimePeriodList`** — checkbox selection keyed by `period_id`, `getRowRemoval` composite,
+   `BulkActionBar`, adaptive confirmation copy. On confirm, deletes timesheets first, then
+   periods (so the period is editable by the time it is removed).
+6. **`TimeTracking`** — passes `canManagePeriods={isManager}`, wires `onDeleteTimeSheets` /
+   `onDeletePeriods` with toasts + reload.
+
+## Authorization
+
+- Timesheet removal: the owner (or valid delegate), mirroring `submitTimeSheet`.
+- Period removal: team managers only (period deletion is tenant-wide), enforced in the UI
+  (`canManagePeriods`) and re-enforced in `deleteTimePeriods`.
+
+## Out of scope
+
+Deleting non-empty / submitted / approved timesheets; soft-delete/restore; changes to the
+REST `/api/v1/time-sheets/[id]` delete endpoint.
+
+## Verification
+
+Static tests in `server/src/test/unit/scheduling/deleteTimeSheetBehavior.test.ts` lock the
+safety invariants. Manually smoke-tested in a live dev environment (browser + DB): per-kind
+gating, single & bulk removal, the one-action composite (draft + unused period together),
+manager gating, and that periods/entries that should be protected are untouched.

--- a/packages/scheduling/src/actions/timeEntryActions.ts
+++ b/packages/scheduling/src/actions/timeEntryActions.ts
@@ -8,7 +8,8 @@ import {
   submitTimeSheet,
   fetchAllTimeSheets,
   fetchTimePeriods,
-  fetchOrCreateTimeSheet
+  fetchOrCreateTimeSheet,
+  deleteTimeSheets
 } from './timeSheetOperations';
 import {
   fetchTimeEntriesForTimeSheet,
@@ -38,6 +39,7 @@ export {
   fetchAllTimeSheets,
   fetchTimePeriods,
   fetchOrCreateTimeSheet,
+  deleteTimeSheets,
   fetchTimeEntriesForTimeSheet,
   saveTimeEntry,
   updateTimeEntryApprovalStatus,

--- a/packages/scheduling/src/actions/timePeriodsActions.ts
+++ b/packages/scheduling/src/actions/timePeriodsActions.ts
@@ -397,6 +397,79 @@ export const deleteTimePeriod = withAuth(async (_user, { tenant }, periodId: str
   }
 });
 
+/**
+ * Remove unused/unneeded time periods directly from the Time Entry list. A period is only
+ * removable when it is completely unused: no timesheets exist for it (for any user, which
+ * also implies no time entries) and it is not the current period. Because deleting a period
+ * is tenant-wide, this is restricted to team managers. Removal is per-id and isolated, so a
+ * blocked period only fails itself (reported in `failed`) without aborting the batch.
+ */
+export const deleteTimePeriods = withAuth(async (
+  user,
+  { tenant },
+  periodIds: string[]
+): Promise<{ deletedIds: string[]; failed: Array<{ periodId: string; message: string }> }> => {
+  const { knex } = await createTenantKnex();
+
+  // Manager gate: mirrors how the Time Entry page derives isManager (manages any team).
+  const managedTeam = await knex('teams')
+    .where({ tenant, manager_id: user.user_id })
+    .first('team_id');
+  const isManager = !!managedTeam;
+
+  const uniqueIds = Array.from(
+    new Set((periodIds ?? []).filter((id) => typeof id === 'string' && id.length > 0))
+  );
+
+  const deletedIds: string[] = [];
+  const failed: Array<{ periodId: string; message: string }> = [];
+
+  if (!isManager) {
+    for (const periodId of uniqueIds) {
+      failed.push({ periodId, message: 'Only managers can remove time periods' });
+    }
+    return { deletedIds, failed };
+  }
+
+  const today = formatISO(new Date(), { representation: 'date' });
+
+  for (const periodId of uniqueIds) {
+    try {
+      const period = await TimePeriod.findById(knex, tenant, periodId);
+      if (!period) {
+        throw new Error('Time period not found');
+      }
+
+      // Tenant-wide guard: refuse if any timesheet exists for the period.
+      const editable = await TimePeriod.isEditable(knex, tenant, periodId);
+      if (!editable) {
+        throw new Error('Cannot remove a period that has timesheets');
+      }
+
+      // Never remove the active period (defense in depth; the UI also hides it).
+      const start = toPlainDate(period.start_date).toString();
+      const end = toPlainDate(period.end_date).toString();
+      if (today >= start && today < end) {
+        throw new Error('Cannot remove the current period');
+      }
+
+      await TimePeriod.delete(knex, tenant, periodId);
+      deletedIds.push(periodId);
+    } catch (error) {
+      failed.push({
+        periodId,
+        message: error instanceof Error ? error.message : 'Failed to remove time period'
+      });
+    }
+  }
+
+  if (deletedIds.length > 0) {
+    revalidatePath('/msp/time-entry');
+  }
+
+  return { deletedIds, failed };
+});
+
 export const updateTimePeriod = withAuth(async (
   _user,
   { tenant },

--- a/packages/scheduling/src/actions/timeSheetOperations.ts
+++ b/packages/scheduling/src/actions/timeSheetOperations.ts
@@ -35,6 +35,7 @@ interface TimePeriodSummaryRow {
   hours_entered: number | string | null;
   days_logged: number | string | null;
   last_entry_date?: string | Date | null;
+  entry_count?: number | string | null;
 }
 
 function parseNumericValue(value: number | string | null | undefined): number {
@@ -245,6 +246,24 @@ export const fetchTimePeriods = withAuth(async (user, { tenant }, userId: string
     )
     .as('tes');
 
+  // True count of time_entries per timesheet (independent of the work_date-filtered
+  // summary above), used to decide whether a timesheet is safe to remove.
+  const entryCounts = db('time_entries')
+    .where('tenant', tenant)
+    .groupBy('time_sheet_id', 'tenant')
+    .select('time_sheet_id', 'tenant')
+    .count('* as entry_count')
+    .as('ec');
+
+  // Number of timesheets attached to each period across ALL users. Zero => the period
+  // itself is unused (no one has logged against it) and is safe to remove entirely.
+  const periodSheetCounts = db('time_sheets')
+    .where('tenant', tenant)
+    .groupBy('period_id', 'tenant')
+    .select('period_id', 'tenant')
+    .count('* as period_sheet_count')
+    .as('psc');
+
   const periods = await db('time_periods as tp')
     .leftJoin('time_sheets as ts', function() {
       this.on('tp.period_id', '=', 'ts.period_id')
@@ -255,15 +274,26 @@ export const fetchTimePeriods = withAuth(async (user, { tenant }, userId: string
       this.on('tp.period_id', '=', 'tes.period_id')
           .andOn('tp.tenant', '=', 'tes.tenant');
     })
+    .leftJoin(entryCounts, function() {
+      this.on('ts.id', '=', 'ec.time_sheet_id')
+          .andOn('tp.tenant', '=', 'ec.tenant');
+    })
+    .leftJoin(periodSheetCounts, function() {
+      this.on('tp.period_id', '=', 'psc.period_id')
+          .andOn('tp.tenant', '=', 'psc.tenant');
+    })
     .where({ 'tp.tenant': tenant })
     .orderBy('tp.start_date', 'desc')
     .select(
       'tp.*',
+      'ts.id as time_sheet_id',
       'ts.approval_status',
       db.raw('COALESCE(ts.approval_status, ?) as timeSheetStatus', ['DRAFT']),
       'tes.hours_entered',
       'tes.days_logged',
-      'tes.last_entry_date'
+      'tes.last_entry_date',
+      'ec.entry_count',
+      'psc.period_sheet_count'
     );
 
   console.log('Fetched periods:', periods);
@@ -278,7 +308,10 @@ export const fetchTimePeriods = withAuth(async (user, { tenant }, userId: string
       timeSheetStatus: (period.approval_status || period.timeSheetStatus || 'DRAFT') as TimeSheetStatus,
       hoursEntered: parseNumericValue(summary.hours_entered),
       daysLogged: parseNumericValue(summary.days_logged),
-      lastEntryDate: toDateOnlyString(summary.last_entry_date)
+      lastEntryDate: toDateOnlyString(summary.last_entry_date),
+      timeSheetId: (period as { time_sheet_id?: string | null }).time_sheet_id ?? null,
+      entryCount: parseNumericValue(summary.entry_count),
+      periodTimesheetCount: parseNumericValue((period as { period_sheet_count?: number | string | null }).period_sheet_count)
     };
   });
 });
@@ -338,4 +371,80 @@ export const fetchOrCreateTimeSheet = withAuth(async (user, { tenant }, userId: 
     },
     comments: comments,
   };
+});
+
+export interface DeleteTimeSheetsResult {
+  deletedIds: string[];
+  failed: Array<{ timeSheetId: string; message: string }>;
+}
+
+/**
+ * Remove unused/unneeded timesheets when it is safe to do so. A timesheet is only
+ * removable when it is an *empty draft*: status DRAFT or CHANGES_REQUESTED with zero
+ * time entries. This action is the security boundary — every rule is re-checked
+ * server-side per id and never trusts the caller. Removal is per-id and isolated, so a
+ * blocked sheet only fails itself (reported in `failed`) without aborting the batch.
+ */
+export const deleteTimeSheets = withAuth(async (
+  user,
+  { tenant },
+  timeSheetIds: string[]
+): Promise<DeleteTimeSheetsResult> => {
+  const { knex: db } = await createTenantKnex();
+
+  const uniqueIds = Array.from(
+    new Set((timeSheetIds ?? []).filter((id): id is string => typeof id === 'string' && id.length > 0))
+  );
+
+  const deletedIds: string[] = [];
+  const failed: Array<{ timeSheetId: string; message: string }> = [];
+
+  for (const timeSheetId of uniqueIds) {
+    try {
+      await db.transaction(async (trx) => {
+        const sheet = await trx('time_sheets')
+          .where({ id: timeSheetId, tenant })
+          .first();
+
+        if (!sheet) {
+          throw new Error('Time sheet not found');
+        }
+
+        // Authorize: caller must own the sheet or have a valid delegation (mirrors submitTimeSheet).
+        await assertCanActOnBehalf(user, tenant, sheet.user_id, trx);
+
+        // Only empty drafts are safe to remove.
+        if (sheet.approval_status !== 'DRAFT' && sheet.approval_status !== 'CHANGES_REQUESTED') {
+          throw new Error('Only draft time sheets can be removed');
+        }
+
+        const existingEntry = await trx('time_entries')
+          .where({ time_sheet_id: timeSheetId, tenant })
+          .first('entry_id');
+
+        if (existingEntry) {
+          throw new Error('Time sheet still has time entries');
+        }
+
+        // CHANGES_REQUESTED sheets can carry approver feedback comments even with no
+        // entries; clear them first so the FK to time_sheets does not block the delete.
+        await trx('time_sheet_comments')
+          .where({ time_sheet_id: timeSheetId, tenant })
+          .del();
+
+        await trx('time_sheets')
+          .where({ id: timeSheetId, tenant })
+          .del();
+      });
+
+      deletedIds.push(timeSheetId);
+    } catch (error) {
+      failed.push({
+        timeSheetId,
+        message: error instanceof Error ? error.message : 'Failed to remove time sheet'
+      });
+    }
+  }
+
+  return { deletedIds, failed };
 });

--- a/packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx
@@ -3,8 +3,11 @@ import { ITimePeriodWithStatusView, TimeSheetStatus } from '@alga-psa/types';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { Badge } from '@alga-psa/ui/components/Badge';
 import { Button } from '@alga-psa/ui/components/Button';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog';
 import { DataTable } from '@alga-psa/ui/components/DataTable';
-import { Settings } from 'lucide-react';
+import { BulkActionBar } from '@alga-psa/ui/components/BulkActionBar';
+import { Settings, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { formatISO, parseISO } from 'date-fns';
 import { Temporal } from '@js-temporal/polyfill';
@@ -17,21 +20,191 @@ function getLastInclusiveDay(exclusiveEndDate: string): string {
   return lastDay.toString();
 }
 
+// Removing a row is a single action that fully clears it when possible. Each removable row
+// resolves to a composite operation:
+//  - deleteTimeSheetId: the user's empty draft (DRAFT/CHANGES_REQUESTED, no entries) to delete.
+//  - deletePeriod:      whether to also delete the (then-unused) period so the row disappears.
+// A manager removing their empty draft on an otherwise-unused period clears both in one go;
+// on a shared period only the timesheet is removed (the period stays for the other users).
+interface RowRemoval {
+  deleteTimeSheetId?: string;
+  deletePeriod: boolean;
+}
+
+const DELETABLE_STATUSES: ReadonlySet<string> = new Set(['DRAFT', 'CHANGES_REQUESTED']);
+
 interface TimePeriodListProps {
   timePeriods: ITimePeriodWithStatusView[];
   onSelectTimePeriod: (timePeriod: ITimePeriodWithStatusView) => void;
+  /** Removes the backing timesheets for the given ids. Omit to hide timesheet removal. */
+  onDeleteTimeSheets?: (timeSheetIds: string[]) => Promise<void>;
+  /** Removes the given unused periods entirely. Omit (or canManagePeriods=false) to hide period removal. */
+  onDeletePeriods?: (periodIds: string[]) => Promise<void>;
+  /** Whether the current user may remove tenant-wide periods (team manager). */
+  canManagePeriods?: boolean;
 }
 
 function formatPeriodRange(startDate: string, endDate: string): string {
   return `${startDate.slice(0, 10)} - ${getLastInclusiveDay(endDate)}`;
 }
 
-export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodListProps) {
+export function TimePeriodList({
+  timePeriods,
+  onSelectTimePeriod,
+  onDeleteTimeSheets,
+  onDeletePeriods,
+  canManagePeriods = false,
+}: TimePeriodListProps) {
   const { t } = useTranslation('msp/time-entry');
   const { formatDate, formatNumber } = useFormatters();
   const router = useRouter();
   const [currentPage, setCurrentPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(10);
+  const [selectedPeriodIds, setSelectedPeriodIds] = React.useState<Set<string>>(new Set());
+  const [pendingRemovalIds, setPendingRemovalIds] = React.useState<string[] | null>(null);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
+  const canRemoveTimeSheets = !!onDeleteTimeSheets;
+  const canRemovePeriods = canManagePeriods && !!onDeletePeriods;
+  const removalEnabled = canRemoveTimeSheets || canRemovePeriods;
+
+  const isCurrentPeriod = React.useCallback((start: string, end: string) => {
+    const today = formatISO(new Date(), { representation: 'date' });
+    const s = start.slice(0, 10);
+    const e = end.slice(0, 10);
+    // Periods are treated as half-open: [start_date, end_date)
+    return today >= s && today < e;
+  }, []);
+
+  // Resolve a row to its single (possibly composite) removal, or null if nothing is removable.
+  const getRowRemoval = React.useCallback((record: ITimePeriodWithStatusView): RowRemoval | null => {
+    const hasUserSheet = !!record.timeSheetId;
+    const userHasEmptyDraft = hasUserSheet
+      && (record.entryCount ?? 1) === 0
+      && DELETABLE_STATUSES.has(record.timeSheetStatus as string);
+
+    // A user timesheet that is not an empty draft (has entries / submitted / approved) blocks the row.
+    if (hasUserSheet && !userHasEmptyDraft) {
+      return null;
+    }
+
+    const deleteTimeSheetId = userHasEmptyDraft && canRemoveTimeSheets ? (record.timeSheetId as string) : undefined;
+    // The user's sheet (if any) must actually be going away for the period to become empty.
+    const userSheetCleared = hasUserSheet ? !!deleteTimeSheetId : true;
+    const sheetsLeftAfter = (record.periodTimesheetCount ?? Infinity) - (hasUserSheet ? 1 : 0);
+    const deletePeriod = canRemovePeriods
+      && userSheetCleared
+      && sheetsLeftAfter <= 0
+      && !isCurrentPeriod(record.start_date, record.end_date);
+
+    if (!deleteTimeSheetId && !deletePeriod) {
+      return null;
+    }
+    return { deleteTimeSheetId, deletePeriod };
+  }, [canRemovePeriods, canRemoveTimeSheets, isCurrentPeriod]);
+
+  const removableIds = React.useMemo(
+    () => timePeriods.filter((record) => getRowRemoval(record) !== null).map((record) => record.period_id),
+    [timePeriods, getRowRemoval],
+  );
+
+  // Drop selections that are no longer removable (e.g. after a refresh changed the row).
+  React.useEffect(() => {
+    const valid = new Set(removableIds);
+    setSelectedPeriodIds((prev) => {
+      const next = new Set([...prev].filter((id) => valid.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [removableIds]);
+
+  const allRemovableSelected = removableIds.length > 0 && removableIds.every((id) => selectedPeriodIds.has(id));
+  const someRemovableSelected = removableIds.some((id) => selectedPeriodIds.has(id));
+
+  // Split a set of row period_ids into the two underlying removal operations.
+  const partitionForRemoval = React.useCallback((periodIds: string[]) => {
+    const timeSheetIds: string[] = [];
+    const periodsToDelete: string[] = [];
+    periodIds.forEach((periodId) => {
+      const record = timePeriods.find((r) => r.period_id === periodId);
+      if (!record) {
+        return;
+      }
+      const removal = getRowRemoval(record);
+      if (!removal) {
+        return;
+      }
+      if (removal.deleteTimeSheetId) {
+        timeSheetIds.push(removal.deleteTimeSheetId);
+      }
+      if (removal.deletePeriod) {
+        periodsToDelete.push(periodId);
+      }
+    });
+    return { timeSheetIds, periodsToDelete };
+  }, [timePeriods, getRowRemoval]);
+
+  const pendingCounts = React.useMemo(() => {
+    if (!pendingRemovalIds) {
+      return { timesheets: 0, periods: 0 };
+    }
+    const { timeSheetIds, periodsToDelete } = partitionForRemoval(pendingRemovalIds);
+    return { timesheets: timeSheetIds.length, periods: periodsToDelete.length };
+  }, [pendingRemovalIds, partitionForRemoval]);
+
+  const toggleSelectAll = (checked: boolean) => {
+    setSelectedPeriodIds(checked ? new Set(removableIds) : new Set());
+  };
+
+  const toggleOne = (periodId: string) => {
+    setSelectedPeriodIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(periodId)) {
+        next.delete(periodId);
+      } else {
+        next.add(periodId);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirmRemoval = async () => {
+    if (!pendingRemovalIds) {
+      return;
+    }
+    const { timeSheetIds, periodsToDelete } = partitionForRemoval(pendingRemovalIds);
+    setIsDeleting(true);
+    try {
+      if (timeSheetIds.length > 0 && onDeleteTimeSheets) {
+        await onDeleteTimeSheets(timeSheetIds);
+      }
+      if (periodsToDelete.length > 0 && onDeletePeriods) {
+        await onDeletePeriods(periodsToDelete);
+      }
+      setSelectedPeriodIds((prev) => {
+        const next = new Set(prev);
+        pendingRemovalIds.forEach((id) => next.delete(id));
+        return next;
+      });
+      setPendingRemovalIds(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const removalMessage = (): string => {
+    const rows = pendingRemovalIds?.length ?? 0;
+    const { periods } = pendingCounts;
+    if (periods > 0) {
+      return t('timePeriodList.remove.message', {
+        defaultValue: 'Remove {{count}} selected period(s)? Unused pay periods are removed for the whole organization, along with any empty draft time logged in them. This cannot be undone.',
+        count: rows,
+      });
+    }
+    return t('timePeriodList.remove.timesheetMessage', {
+      defaultValue: 'Remove {{count}} unused time sheet(s)? Only empty draft time sheets are removed and this cannot be undone.',
+      count: rows,
+    });
+  };
 
   const getStatusBadgeConfig = React.useCallback((status: string) => {
     const statusBadgeConfig: Record<string, { variant: 'outline' | 'secondary' | 'success' | 'warning'; label: string }> = {
@@ -91,13 +264,111 @@ export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodLi
     router.push('/msp/settings?tab=time-entry&subtab=time-periods');
   };
 
-  const isCurrentPeriod = (start: string, end: string) => {
-    const today = formatISO(new Date(), { representation: 'date' });
-    const s = start.slice(0, 10);
-    const e = end.slice(0, 10);
-    // Periods are treated as half-open: [start_date, end_date)
-    return today >= s && today < e;
+  const selectionColumn = {
+    title: (
+      <div className="flex items-center justify-center" onClick={(event: React.MouseEvent) => event.stopPropagation()}>
+        <Checkbox
+          id="time-periods-select-all"
+          checked={allRemovableSelected}
+          indeterminate={someRemovableSelected && !allRemovableSelected}
+          disabled={removableIds.length === 0}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            event.stopPropagation();
+            toggleSelectAll(event.target.checked);
+          }}
+          containerClassName="mb-0"
+          className="m-0"
+          skipRegistration
+        />
+      </div>
+    ),
+    dataIndex: 'selection',
+    width: '4%',
+    sortable: false,
+    render: (_: unknown, record: ITimePeriodWithStatusView) => {
+      if (getRowRemoval(record) === null) {
+        return null;
+      }
+      const isChecked = selectedPeriodIds.has(record.period_id);
+      return (
+        <div className="flex items-center justify-center" onClick={(event: React.MouseEvent) => event.stopPropagation()}>
+          <Checkbox
+            id={`time-period-select-${record.period_id}`}
+            checked={isChecked}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              event.stopPropagation();
+              toggleOne(record.period_id);
+            }}
+            containerClassName="mb-0"
+            className="m-0"
+            skipRegistration
+          />
+        </div>
+      );
+    }
   };
+
+  const baseColumns = [
+    {
+      title: t('timePeriodList.columns.period', { defaultValue: 'Period' }),
+      dataIndex: 'start_date',
+      width: '30%',
+      render: (_: unknown, record: ITimePeriodWithStatusView) => formatPeriodRange(record.start_date, record.end_date)
+    },
+    {
+      title: t('timePeriodList.columns.status', { defaultValue: 'Status' }),
+      dataIndex: 'timeSheetStatus',
+      width: '20%',
+      render: (status: TimeSheetStatus, record: ITimePeriodWithStatusView) => {
+        const config = getStatusBadgeConfig(status);
+        return (
+          <div className="flex items-center gap-2">
+            <Badge variant={config.variant} className="py-1">{config.label}</Badge>
+            {isCurrentPeriod(record.start_date, record.end_date) && (
+              <Badge variant="primary" className="py-1">
+                {t('common.states.current', { defaultValue: 'Current' })}
+              </Badge>
+            )}
+          </div>
+        );
+      }
+    },
+    {
+      title: t('timePeriodList.columns.hoursEntered', { defaultValue: 'Hours Entered' }),
+      dataIndex: 'hoursEntered',
+      width: '12%',
+      render: (hoursEntered: number) => formatHoursEntered(hoursEntered)
+    },
+    {
+      title: t('timePeriodList.columns.daysLogged', { defaultValue: 'Days Logged' }),
+      dataIndex: 'daysLogged',
+      width: '10%',
+      render: (daysLogged: number) => formatDaysLogged(daysLogged)
+    },
+    {
+      title: t('timePeriodList.columns.lastEntry', { defaultValue: 'Last Entry' }),
+      dataIndex: 'lastEntryDate',
+      width: '14%',
+      render: (lastEntryDate?: string) => formatLastEntryDate(lastEntryDate)
+    },
+    {
+      title: t('timePeriodList.columns.actions', { defaultValue: 'Actions' }),
+      dataIndex: 'action',
+      width: '10%',
+      // Removal is selection-driven (checkbox + floating bulk bar); no per-row delete here.
+      render: (_: unknown, record: ITimePeriodWithStatusView) => (
+        <Button
+          id={`view-period-${record.period_id}`}
+          onClick={() => onSelectTimePeriod(record)}
+          variant="soft"
+        >
+          {t('common.actions.view', { defaultValue: 'View' })}
+        </Button>
+      )
+    }
+  ];
+
+  const columns = removalEnabled ? [selectionColumn, ...baseColumns] : baseColumns;
 
   return (
     <div className="space-y-4 w-full">
@@ -118,64 +389,7 @@ export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodLi
       <DataTable
         id="time-periods-list"
         data={timePeriods}
-        columns={[
-          {
-            title: t('timePeriodList.columns.period', { defaultValue: 'Period' }),
-            dataIndex: 'start_date',
-            width: '28%',
-            render: (_, record) => formatPeriodRange(record.start_date, record.end_date)
-          },
-          {
-            title: t('timePeriodList.columns.status', { defaultValue: 'Status' }),
-            dataIndex: 'timeSheetStatus',
-            width: '20%',
-            render: (status: TimeSheetStatus, record) => {
-              const config = getStatusBadgeConfig(status);
-              return (
-                <div className="flex items-center gap-2">
-                  <Badge variant={config.variant} className="py-1">{config.label}</Badge>
-                  {isCurrentPeriod(record.start_date, record.end_date) && (
-                    <Badge variant="primary" className="py-1">
-                      {t('common.states.current', { defaultValue: 'Current' })}
-                    </Badge>
-                  )}
-                </div>
-              );
-            }
-          },
-          {
-            title: t('timePeriodList.columns.hoursEntered', { defaultValue: 'Hours Entered' }),
-            dataIndex: 'hoursEntered',
-            width: '14%',
-            render: (hoursEntered: number) => formatHoursEntered(hoursEntered)
-          },
-          {
-            title: t('timePeriodList.columns.daysLogged', { defaultValue: 'Days Logged' }),
-            dataIndex: 'daysLogged',
-            width: '12%',
-            render: (daysLogged: number) => formatDaysLogged(daysLogged)
-          },
-          {
-            title: t('timePeriodList.columns.lastEntry', { defaultValue: 'Last Entry' }),
-            dataIndex: 'lastEntryDate',
-            width: '16%',
-            render: (lastEntryDate?: string) => formatLastEntryDate(lastEntryDate)
-          },
-          {
-            title: t('timePeriodList.columns.actions', { defaultValue: 'Actions' }),
-            dataIndex: 'action',
-            width: '10%',
-            render: (_, record) => (
-              <Button
-                id={`view-period-${record.period_id}`}
-                onClick={() => onSelectTimePeriod(record)}
-                variant="soft"
-              >
-                {t('common.actions.view', { defaultValue: 'View' })}
-              </Button>
-            )
-          }
-        ]}
+        columns={columns}
         pagination={true}
         currentPage={currentPage}
         onPageChange={setCurrentPage}
@@ -205,6 +419,42 @@ export function TimePeriodList({ timePeriods, onSelectTimePeriod }: TimePeriodLi
           return classes.join(' ');
         }}
       />
+
+      {removalEnabled && selectedPeriodIds.size > 0 && (
+        <BulkActionBar
+          idPrefix="timesheet-bulk-action-bar"
+          count={selectedPeriodIds.size}
+          selectedLabel={t('timePeriodList.bulk.selectedCount', { defaultValue: '{{count}} selected', count: selectedPeriodIds.size })}
+          actions={[
+            {
+              id: 'delete',
+              label: t('common.actions.remove', { defaultValue: 'Remove' }),
+              icon: <Trash2 className="h-4 w-4" />,
+              onClick: () => setPendingRemovalIds([...selectedPeriodIds]),
+              destructive: true,
+            },
+          ]}
+          onClear={() => setSelectedPeriodIds(new Set())}
+          clearLabel={t('common.actions.clear', { defaultValue: 'Clear' })}
+        />
+      )}
+
+      {pendingRemovalIds && (
+        <ConfirmationDialog
+          id="timesheet-delete-confirmation"
+          isOpen={true}
+          isConfirming={isDeleting}
+          onConfirm={handleConfirmRemoval}
+          onClose={() => {
+            if (!isDeleting) {
+              setPendingRemovalIds(null);
+            }
+          }}
+          title={t('timePeriodList.remove.title', { defaultValue: 'Remove unused items' })}
+          message={removalMessage()}
+          confirmLabel={t('common.actions.remove', { defaultValue: 'Remove' })}
+        />
+      )}
     </div>
   );
 }

--- a/packages/scheduling/src/components/time-management/time-entry/TimeTracking.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/TimeTracking.tsx
@@ -3,13 +3,15 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'react-hot-toast';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { TimePeriodList } from './TimePeriodList';
 import { SkeletonTimeSheet } from './SkeletonTimeSheet';
 import { ITimePeriodWithStatusView } from '@alga-psa/types';
 import { IUser } from '@alga-psa/types';
 import { IUserWithRoles } from '@alga-psa/types';
-import { fetchTimePeriods, fetchOrCreateTimeSheet } from '../../../actions/timeEntryActions';
+import { fetchTimePeriods, fetchOrCreateTimeSheet, deleteTimeSheets } from '../../../actions/timeEntryActions';
+import { deleteTimePeriods } from '../../../actions/timePeriodsActions';
 import { fetchEligibleTimeEntrySubjects } from '../../../actions/timeEntryDelegationActions';
 import UserPicker from '@alga-psa/ui/components/UserPicker';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
@@ -21,7 +23,7 @@ interface TimeTrackingProps {
   isManager: boolean;
 }
 
-export default function TimeTracking({ currentUser, isManager: _isManager }: TimeTrackingProps) {
+export default function TimeTracking({ currentUser, isManager }: TimeTrackingProps) {
   const { t } = useTranslation('msp/time-entry');
   const router = useRouter();
   const pathname = usePathname();
@@ -115,6 +117,56 @@ export default function TimeTracking({ currentUser, isManager: _isManager }: Tim
     }
   };
 
+  const handleDeleteTimeSheets = async (timeSheetIds: string[]) => {
+    try {
+      const result = await deleteTimeSheets(timeSheetIds);
+
+      if (result.deletedIds.length > 0) {
+        toast.success(t('timePeriodList.delete.success', {
+          defaultValue: '{{count}} time sheet(s) removed',
+          count: result.deletedIds.length,
+        }));
+      }
+
+      if (result.failed.length > 0) {
+        toast.error(t('timePeriodList.delete.partialFailure', {
+          defaultValue: "{{count}} time sheet(s) couldn't be removed",
+          count: result.failed.length,
+        }));
+      }
+    } catch (error) {
+      console.error('Error removing time sheets:', error);
+      toast.error(t('timePeriodList.delete.error', { defaultValue: 'Failed to remove time sheet(s)' }));
+    } finally {
+      await loadTimePeriods();
+    }
+  };
+
+  const handleDeletePeriods = async (periodIds: string[]) => {
+    try {
+      const result = await deleteTimePeriods(periodIds);
+
+      if (result.deletedIds.length > 0) {
+        toast.success(t('timePeriodList.removePeriod.success', {
+          defaultValue: '{{count}} time period(s) removed',
+          count: result.deletedIds.length,
+        }));
+      }
+
+      if (result.failed.length > 0) {
+        toast.error(t('timePeriodList.removePeriod.partialFailure', {
+          defaultValue: "{{count}} time period(s) couldn't be removed",
+          count: result.failed.length,
+        }));
+      }
+    } catch (error) {
+      console.error('Error removing time periods:', error);
+      toast.error(t('timePeriodList.removePeriod.error', { defaultValue: 'Failed to remove time period(s)' }));
+    } finally {
+      await loadTimePeriods();
+    }
+  };
+
   const handleSelectTimePeriod = async (timePeriod: ITimePeriodWithStatusView) => {
     try {
       const timeSheet = await fetchOrCreateTimeSheet(subjectUserId, timePeriod.period_id);
@@ -160,7 +212,13 @@ export default function TimeTracking({ currentUser, isManager: _isManager }: Tim
         </div>
       )}
 
-      <TimePeriodList timePeriods={timePeriods} onSelectTimePeriod={handleSelectTimePeriod} />
+      <TimePeriodList
+        timePeriods={timePeriods}
+        onSelectTimePeriod={handleSelectTimePeriod}
+        onDeleteTimeSheets={handleDeleteTimeSheets}
+        onDeletePeriods={handleDeletePeriods}
+        canManagePeriods={isManager}
+      />
     </div>
   );
 }

--- a/packages/types/src/interfaces/timeEntry.interfaces.ts
+++ b/packages/types/src/interfaces/timeEntry.interfaces.ts
@@ -138,6 +138,12 @@ export interface ITimePeriodWithStatusView extends Omit<ITimePeriodWithStatus, '
   hoursEntered: number;
   daysLogged: number;
   lastEntryDate?: string;
+  /** Id of the backing time_sheets row, or null when none exists yet (created lazily on view). */
+  timeSheetId?: string | null;
+  /** Total number of time_entries on the backing timesheet. Used to gate safe removal. */
+  entryCount?: number;
+  /** Number of timesheets on this period across all users. Lets a row tell "only my draft" (1) from "shared" (>1) or "unused" (0). */
+  periodTimesheetCount?: number;
 }
 
 export interface ITimeSheetView extends Omit<ITimeSheet, 'time_period'> {

--- a/server/public/locales/de/msp/time-entry.json
+++ b/server/public/locales/de/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Details anzeigen",
       "manageTimePeriods": "Zeiträume verwalten",
       "selectWorkItem": "Wählen Sie Arbeitselement aus",
-      "clearFilter": "Filter löschen"
+      "clearFilter": "Filter löschen",
+      "remove": "Entfernen",
+      "clear": "Leeren"
     },
     "states": {
       "inProgress": "In Arbeit",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "Keine Einträge"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} ausgewählt"
+    },
+    "delete": {
+      "success": "{{count}} Stundenzettel entfernt",
+      "partialFailure": "{{count}} Stundenzettel konnten nicht entfernt werden",
+      "error": "Stundenzettel konnten nicht entfernt werden"
+    },
+    "removePeriod": {
+      "success": "{{count}} Zeiträume entfernt",
+      "partialFailure": "{{count}} Zeiträume konnten nicht entfernt werden",
+      "error": "Zeiträume konnten nicht entfernt werden"
+    },
+    "remove": {
+      "title": "Nicht verwendete Elemente entfernen",
+      "message": "{{count}} ausgewählte(n) Zeitraum/Zeiträume entfernen? Nicht verwendete Abrechnungszeiträume werden für die gesamte Organisation entfernt, zusammen mit allen darin erfassten leeren Entwürfen. Dies kann nicht rückgängig gemacht werden.",
+      "timesheetMessage": "{{count}} nicht verwendete(n) Stundenzettel entfernen? Es werden nur leere Stundenzettel-Entwürfe entfernt und dies kann nicht rückgängig gemacht werden."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/en/msp/time-entry.json
+++ b/server/public/locales/en/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "View details",
       "manageTimePeriods": "Manage Time Periods",
       "selectWorkItem": "Select Work Item",
-      "clearFilter": "Clear filter"
+      "clearFilter": "Clear filter",
+      "remove": "Remove",
+      "clear": "Clear"
     },
     "states": {
       "inProgress": "In Progress",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "No entries"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} selected"
+    },
+    "delete": {
+      "success": "{{count}} time sheet(s) removed",
+      "partialFailure": "{{count}} time sheet(s) couldn't be removed",
+      "error": "Failed to remove time sheet(s)"
+    },
+    "removePeriod": {
+      "success": "{{count}} time period(s) removed",
+      "partialFailure": "{{count}} time period(s) couldn't be removed",
+      "error": "Failed to remove time period(s)"
+    },
+    "remove": {
+      "title": "Remove unused items",
+      "message": "Remove {{count}} selected period(s)? Unused pay periods are removed for the whole organization, along with any empty draft time logged in them. This cannot be undone.",
+      "timesheetMessage": "Remove {{count}} unused time sheet(s)? Only empty draft time sheets are removed and this cannot be undone."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/es/msp/time-entry.json
+++ b/server/public/locales/es/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Ver detalles",
       "manageTimePeriods": "Administrar períodos de tiempo",
       "selectWorkItem": "Seleccionar elemento de trabajo",
-      "clearFilter": "Borrar filtro"
+      "clearFilter": "Borrar filtro",
+      "remove": "Eliminar",
+      "clear": "Limpiar"
     },
     "states": {
       "inProgress": "En progreso",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "No hay entradas"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} seleccionado(s)"
+    },
+    "delete": {
+      "success": "{{count}} hoja(s) de horas eliminada(s)",
+      "partialFailure": "No se pudieron eliminar {{count}} hoja(s) de horas",
+      "error": "No se pudieron eliminar las hojas de horas"
+    },
+    "removePeriod": {
+      "success": "{{count}} período(s) eliminado(s)",
+      "partialFailure": "No se pudieron eliminar {{count}} período(s)",
+      "error": "No se pudieron eliminar los períodos"
+    },
+    "remove": {
+      "title": "Eliminar elementos no utilizados",
+      "message": "¿Eliminar {{count}} período(s) seleccionado(s)? Los períodos de pago no utilizados se eliminan para toda la organización, junto con cualquier borrador vacío registrado en ellos. Esto no se puede deshacer.",
+      "timesheetMessage": "¿Eliminar {{count}} hoja(s) de horas no utilizada(s)? Solo se eliminan los borradores de hojas de horas vacíos y esto no se puede deshacer."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/fr/msp/time-entry.json
+++ b/server/public/locales/fr/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Afficher les détails",
       "manageTimePeriods": "Gérer les périodes",
       "selectWorkItem": "Sélectionner un élément de travail",
-      "clearFilter": "Effacer le filtre"
+      "clearFilter": "Effacer le filtre",
+      "remove": "Supprimer",
+      "clear": "Effacer"
     },
     "states": {
       "inProgress": "En cours",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "Aucune entrée"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} sélectionné(s)"
+    },
+    "delete": {
+      "success": "{{count}} feuille(s) de temps supprimée(s)",
+      "partialFailure": "{{count}} feuille(s) de temps n'ont pas pu être supprimée(s)",
+      "error": "Échec de la suppression des feuilles de temps"
+    },
+    "removePeriod": {
+      "success": "{{count}} période(s) supprimée(s)",
+      "partialFailure": "{{count}} période(s) n'ont pas pu être supprimée(s)",
+      "error": "Échec de la suppression des périodes"
+    },
+    "remove": {
+      "title": "Supprimer les éléments inutilisés",
+      "message": "Supprimer {{count}} période(s) sélectionnée(s) ? Les périodes de paie inutilisées sont supprimées pour toute l'organisation, ainsi que tout brouillon vide qui y est enregistré. Cette action est irréversible.",
+      "timesheetMessage": "Supprimer {{count}} feuille(s) de temps inutilisée(s) ? Seuls les brouillons de feuilles de temps vides sont supprimés et cette action est irréversible."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/it/msp/time-entry.json
+++ b/server/public/locales/it/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Visualizza i dettagli",
       "manageTimePeriods": "Gestisci periodi di tempo",
       "selectWorkItem": "Seleziona elemento di lavoro",
-      "clearFilter": "Cancella filtro"
+      "clearFilter": "Cancella filtro",
+      "remove": "Rimuovi",
+      "clear": "Cancella"
     },
     "states": {
       "inProgress": "In corso",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "Nessuna voce"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} selezionato/i"
+    },
+    "delete": {
+      "success": "{{count}} foglio/i ore rimosso/i",
+      "partialFailure": "Impossibile rimuovere {{count}} foglio/i ore",
+      "error": "Impossibile rimuovere i fogli ore"
+    },
+    "removePeriod": {
+      "success": "{{count}} periodo/i rimosso/i",
+      "partialFailure": "Impossibile rimuovere {{count}} periodo/i",
+      "error": "Impossibile rimuovere i periodi"
+    },
+    "remove": {
+      "title": "Rimuovi elementi non utilizzati",
+      "message": "Rimuovere {{count}} periodo/i selezionato/i? I periodi di paga non utilizzati vengono rimossi per l'intera organizzazione, insieme a eventuali bozze vuote registrate al loro interno. L'operazione non può essere annullata.",
+      "timesheetMessage": "Rimuovere {{count}} foglio/i ore non utilizzato/i? Vengono rimossi solo i fogli ore in bozza vuoti e l'operazione non può essere annullata."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/nl/msp/time-entry.json
+++ b/server/public/locales/nl/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Bekijk details",
       "manageTimePeriods": "Beheer tijdsperioden",
       "selectWorkItem": "Selecteer Werkitem",
-      "clearFilter": "Filter wissen"
+      "clearFilter": "Filter wissen",
+      "remove": "Verwijderen",
+      "clear": "Wissen"
     },
     "states": {
       "inProgress": "Bezig",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "Geen vermeldingen"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} geselecteerd"
+    },
+    "delete": {
+      "success": "{{count}} urenstaat/-staten verwijderd",
+      "partialFailure": "{{count}} urenstaat/-staten konden niet worden verwijderd",
+      "error": "Verwijderen van urenstaten mislukt"
+    },
+    "removePeriod": {
+      "success": "{{count}} periode(n) verwijderd",
+      "partialFailure": "{{count}} periode(n) konden niet worden verwijderd",
+      "error": "Verwijderen van perioden mislukt"
+    },
+    "remove": {
+      "title": "Ongebruikte items verwijderen",
+      "message": "{{count}} geselecteerde periode(n) verwijderen? Ongebruikte loonperioden worden voor de hele organisatie verwijderd, samen met eventuele lege concepten die erin zijn vastgelegd. Dit kan niet ongedaan worden gemaakt.",
+      "timesheetMessage": "{{count}} ongebruikte urenstaat/-staten verwijderen? Alleen lege concept-urenstaten worden verwijderd en dit kan niet ongedaan worden gemaakt."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/pl/msp/time-entry.json
+++ b/server/public/locales/pl/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "Zobacz szczegóły",
       "manageTimePeriods": "Zarządzaj okresami czasu",
       "selectWorkItem": "Wybierz element pracy",
-      "clearFilter": "Wyczyść filtr"
+      "clearFilter": "Wyczyść filtr",
+      "remove": "Usuń",
+      "clear": "Wyczyść"
     },
     "states": {
       "inProgress": "W toku",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "Brak wpisów"
+    },
+    "bulk": {
+      "selectedCount": "Wybrano: {{count}}"
+    },
+    "delete": {
+      "success": "Usunięto karty czasu pracy: {{count}}",
+      "partialFailure": "Nie można usunąć kart czasu pracy: {{count}}",
+      "error": "Nie udało się usunąć kart czasu pracy"
+    },
+    "removePeriod": {
+      "success": "Usunięto okresy: {{count}}",
+      "partialFailure": "Nie można usunąć okresów: {{count}}",
+      "error": "Nie udało się usunąć okresów"
+    },
+    "remove": {
+      "title": "Usuń nieużywane elementy",
+      "message": "Usunąć {{count}} wybrany(ch) okres(ów)? Nieużywane okresy rozliczeniowe zostaną usunięte dla całej organizacji wraz z wszelkimi pustymi wersjami roboczymi w nich zapisanymi. Tej operacji nie można cofnąć.",
+      "timesheetMessage": "Usunąć {{count}} nieużywaną(ych) kartę(kart) czasu pracy? Usuwane są tylko puste robocze karty czasu pracy, a tej operacji nie można cofnąć."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/pt/msp/time-entry.json
+++ b/server/public/locales/pt/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "View details",
       "manageTimePeriods": "Manage Time Periods",
       "selectWorkItem": "Select Work Item",
-      "clearFilter": "Clear filter"
+      "clearFilter": "Clear filter",
+      "remove": "Remover",
+      "clear": "Limpar"
     },
     "states": {
       "inProgress": "In Progress",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "No entries"
+    },
+    "bulk": {
+      "selectedCount": "{{count}} selecionado(s)"
+    },
+    "delete": {
+      "success": "{{count}} folha(s) de horas removida(s)",
+      "partialFailure": "Não foi possível remover {{count}} folha(s) de horas",
+      "error": "Falha ao remover as folhas de horas"
+    },
+    "removePeriod": {
+      "success": "{{count}} período(s) removido(s)",
+      "partialFailure": "Não foi possível remover {{count}} período(s)",
+      "error": "Falha ao remover os períodos"
+    },
+    "remove": {
+      "title": "Remover itens não utilizados",
+      "message": "Remover {{count}} período(s) selecionado(s)? Os períodos de pagamento não utilizados são removidos para toda a organização, juntamente com quaisquer rascunhos vazios registrados neles. Esta ação não pode ser desfeita.",
+      "timesheetMessage": "Remover {{count}} folha(s) de horas não utilizada(s)? Apenas os rascunhos de folhas de horas vazios são removidos e esta ação não pode ser desfeita."
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/xx/msp/time-entry.json
+++ b/server/public/locales/xx/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "11111",
       "manageTimePeriods": "11111",
       "selectWorkItem": "11111",
-      "clearFilter": "11111"
+      "clearFilter": "11111",
+      "remove": "11111",
+      "clear": "11111"
     },
     "states": {
       "inProgress": "11111",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "11111"
+    },
+    "bulk": {
+      "selectedCount": "11111 {{count}} 11111"
+    },
+    "delete": {
+      "success": "11111 {{count}} 11111",
+      "partialFailure": "11111 {{count}} 11111",
+      "error": "11111"
+    },
+    "removePeriod": {
+      "success": "11111 {{count}} 11111",
+      "partialFailure": "11111 {{count}} 11111",
+      "error": "11111"
+    },
+    "remove": {
+      "title": "11111",
+      "message": "11111 {{count}} 11111",
+      "timesheetMessage": "11111 {{count}} 11111"
     }
   },
   "timeEntryForm": {

--- a/server/public/locales/yy/msp/time-entry.json
+++ b/server/public/locales/yy/msp/time-entry.json
@@ -29,7 +29,9 @@
       "viewDetails": "55555",
       "manageTimePeriods": "55555",
       "selectWorkItem": "55555",
-      "clearFilter": "55555"
+      "clearFilter": "55555",
+      "remove": "55555",
+      "clear": "55555"
     },
     "states": {
       "inProgress": "55555",
@@ -95,6 +97,24 @@
     },
     "lastEntry": {
       "none": "55555"
+    },
+    "bulk": {
+      "selectedCount": "55555 {{count}} 55555"
+    },
+    "delete": {
+      "success": "55555 {{count}} 55555",
+      "partialFailure": "55555 {{count}} 55555",
+      "error": "55555"
+    },
+    "removePeriod": {
+      "success": "55555 {{count}} 55555",
+      "partialFailure": "55555 {{count}} 55555",
+      "error": "55555"
+    },
+    "remove": {
+      "title": "55555",
+      "message": "55555 {{count}} 55555",
+      "timesheetMessage": "55555 {{count}} 55555"
     }
   },
   "timeEntryForm": {

--- a/server/src/interfaces/timeEntry.interfaces.ts
+++ b/server/src/interfaces/timeEntry.interfaces.ts
@@ -119,6 +119,9 @@ export interface ITimePeriodView extends Omit<ITimePeriod, 'start_date' | 'end_d
 export interface ITimePeriodWithStatusView extends Omit<ITimePeriodWithStatus, 'start_date' | 'end_date'> {
   start_date: string;
   end_date: string;
+  timeSheetId?: string | null;
+  entryCount?: number;
+  periodTimesheetCount?: number;
 }
 
 export interface ITimeSheetView extends Omit<ITimeSheet, 'time_period'> {

--- a/server/src/test/unit/scheduling/deleteTimeSheetBehavior.test.ts
+++ b/server/src/test/unit/scheduling/deleteTimeSheetBehavior.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePathFromRepoRoot: string): string {
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  return readFileSync(path.join(repoRoot, relativePathFromRepoRoot), 'utf8');
+}
+
+describe('deleteTimeSheets behavior (static)', () => {
+  const actionSrc = readRepoFile('packages/scheduling/src/actions/timeSheetOperations.ts');
+
+  it('exposes a bulk-capable deleteTimeSheets action returning per-id results', () => {
+    expect(actionSrc).toContain('export const deleteTimeSheets');
+    expect(actionSrc).toMatch(/deletedIds:\s*string\[\]/);
+    expect(actionSrc).toMatch(/failed:\s*Array<\{\s*timeSheetId:\s*string;\s*message:\s*string\s*\}>/);
+  });
+
+  it('authorizes the caller via delegation before removing', () => {
+    expect(actionSrc).toMatch(/deleteTimeSheets[\s\S]*assertCanActOnBehalf/);
+  });
+
+  it('only removes empty drafts (DRAFT/CHANGES_REQUESTED with no entries)', () => {
+    expect(actionSrc).toContain("sheet.approval_status !== 'DRAFT'");
+    expect(actionSrc).toContain("sheet.approval_status !== 'CHANGES_REQUESTED'");
+    expect(actionSrc).toContain('Only draft time sheets can be removed');
+    expect(actionSrc).toMatch(/time_entries[\s\S]*Time sheet still has time entries/);
+  });
+
+  it('exposes the timesheet id, entry count, and period-wide timesheet count to gate removal in the UI', () => {
+    expect(actionSrc).toContain("'ts.id as time_sheet_id'");
+    expect(actionSrc).toMatch(/entryCount:\s*parseNumericValue/);
+    expect(actionSrc).toContain("'psc.period_sheet_count'");
+    expect(actionSrc).toMatch(/periodTimesheetCount:\s*parseNumericValue/);
+  });
+});
+
+describe('deleteTimePeriods behavior (static)', () => {
+  const actionSrc = readRepoFile('packages/scheduling/src/actions/timePeriodsActions.ts');
+
+  it('exposes a bulk-capable deleteTimePeriods action returning per-id results', () => {
+    expect(actionSrc).toContain('export const deleteTimePeriods');
+    expect(actionSrc).toMatch(/deletedIds:\s*string\[\]/);
+    expect(actionSrc).toMatch(/failed:\s*Array<\{\s*periodId:\s*string;\s*message:\s*string\s*\}>/);
+  });
+
+  it('restricts period removal to team managers (tenant-wide deletion)', () => {
+    expect(actionSrc).toMatch(/manager_id:\s*user\.user_id/);
+    expect(actionSrc).toContain('Only managers can remove time periods');
+  });
+
+  it('only removes truly-unused, non-current periods', () => {
+    expect(actionSrc).toMatch(/isEditable/);
+    expect(actionSrc).toContain('Cannot remove a period that has timesheets');
+    expect(actionSrc).toContain('Cannot remove the current period');
+  });
+});
+
+describe('TimePeriodList removal gating (static)', () => {
+  const componentSrc = readRepoFile(
+    'packages/scheduling/src/components/time-management/time-entry/TimePeriodList.tsx',
+  );
+
+  it('removes an empty draft timesheet only when it is DRAFT/CHANGES_REQUESTED with no entries', () => {
+    expect(componentSrc).toContain('getRowRemoval');
+    expect(componentSrc).toContain('userHasEmptyDraft');
+    expect(componentSrc).toMatch(/entryCount\s*\?\?\s*1\)\s*===\s*0/);
+    expect(componentSrc).toMatch(/DELETABLE_STATUSES[\s\S]*'DRAFT'[\s\S]*'CHANGES_REQUESTED'/);
+  });
+
+  it('clears an empty row in one action: removes the draft and, when the period is then unused, the period too', () => {
+    // Composite removal: a single row can yield both a timesheet delete and a period delete.
+    expect(componentSrc).toContain('deleteTimeSheetId');
+    expect(componentSrc).toMatch(/deletePeriod\s*=\s*canRemovePeriods/);
+    expect(componentSrc).toContain('sheetsLeftAfter');
+  });
+
+  it('offers period removal only to managers, for unused non-current periods', () => {
+    expect(componentSrc).toContain('canManagePeriods');
+    expect(componentSrc).toMatch(/sheetsLeftAfter\s*<=\s*0/);
+    expect(componentSrc).toMatch(/!isCurrentPeriod\(record\.start_date, record\.end_date\)/);
+  });
+
+  it('drives removal from selection + floating bulk bar (no per-row delete button)', () => {
+    expect(componentSrc).toContain('BulkActionBar');
+    expect(componentSrc).toContain('time-period-select-');
+    expect(componentSrc).toContain('ConfirmationDialog');
+    // The inline per-row delete was removed as it duplicated the bulk bar.
+    expect(componentSrc).not.toContain('remove-time-row-');
+  });
+});


### PR DESCRIPTION
## What

Lets users clean up unused/unneeded rows on the Time Entry **period list** when it's safe to do so. Removal is **selection-driven** (row checkboxes + a floating bulk-action bar, like the tickets screen) — there is no per-row delete button.

Each row is a pay **period**, so "Remove" resolves per row to a single, possibly composite, operation:

| Row state | Remove does | Who |
|---|---|---|
| Your empty draft timesheet (DRAFT/CHANGES_REQUESTED, 0 entries) on a **shared** period | deletes the **timesheet**; period stays | owner |
| Your empty draft on an otherwise-**unused** period | deletes the **timesheet + the period** in one action → row disappears | manager |
| An **unused period** (no timesheets for anyone, not the current period) | deletes the **period** | manager |
| Submitted/approved, has entries, current period, or shared by others | no removal | — |

The single-action composite is the key UX point: clearing an empty row doesn't make you delete the draft and *then* the period — one **Remove** does both.

## Why

There was no UI to remove timesheets at all, and empty draft timesheets / stray pay periods accumulated on the period list with no way to clean them up without going into Settings.

## How

- **Data** — `fetchTimePeriods` now exposes `timeSheetId`, `entryCount`, and `periodTimesheetCount`; `ITimePeriodWithStatusView` gains those fields. The period count lets a row tell "only my draft" (1) from "shared" (>1) from "unused" (0).
- **Server actions** (security boundary, per-id `{ deletedIds, failed[] }`):
  - `deleteTimeSheets` — authorizes via `assertCanActOnBehalf`, requires an empty draft, cleans up comments, deletes.
  - `deleteTimePeriods` — **manager-gated** (direct `teams` manager check), re-validates `isEditable` (no timesheets anywhere) and refuses the current period.
- **UI** — `TimePeriodList` selection keyed by `period_id`, `getRowRemoval` composite, `BulkActionBar`, adaptive confirm copy; on confirm it deletes timesheets first, then periods (so the period is editable by the time it's removed). `TimeTracking` passes `canManagePeriods={isManager}`.

## Safety

- Only empty drafts and periods nobody has logged against are ever removed.
- Period deletion is tenant-wide, so it's restricted to team managers and re-enforced server-side (not just hidden in the UI). The current period is never removable.

## Testing

- Static invariant tests in `server/src/test/unit/scheduling/deleteTimeSheetBehavior.test.ts` (11 tests).
- `tsc --noEmit` clean for `@alga-psa/scheduling` and `@alga-psa/types`.
- Manually smoke-tested in a live dev env (browser + DB): per-kind gating (submitted/approved/has-entries excluded), single & bulk removal, the one-action composite (draft + unused period deleted together, row vanishes), manager gating, and that protected periods/entries are untouched.

## Out of scope

Deleting non-empty/submitted/approved timesheets; soft-delete/restore; the REST `/api/v1/time-sheets/[id]` delete endpoint.

https://claude.ai/code/session_014AZqAZZcghd1wKCifuyQbA
