### PR TITLE
fix(jobs): break @alga-psa/jobs self-barrel cycle that crashed the EE build

### DIFF
--- a/packages/jobs/src/actions/job-actions.ts
+++ b/packages/jobs/src/actions/job-actions.ts
@@ -2,9 +2,14 @@
 
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
-import { JobStatus } from '@alga-psa/jobs';
+// Import from the concrete modules rather than the '@alga-psa/jobs' barrel: this
+// file is itself reached via the barrel's `export * from './actions'`, so a
+// self-import would read these before the barrel finishes initializing. The
+// top-level TERMINAL_JOB_STATUSES below evaluates JobStatus at module load, so
+// that cycle would leave it undefined. See sibling files (jobService, schedulers).
+import { JobStatus } from '../types/job';
 import { createTenantKnex } from '@alga-psa/db';
-import { JobService } from '@alga-psa/jobs';
+import { JobService } from '../lib/jobService';
 import { withAuth, hasPermission } from '@alga-psa/auth';
 
 export interface JobMetrics {

--- a/packages/jobs/src/actions/job-actions/getJobProgressAction.ts
+++ b/packages/jobs/src/actions/job-actions/getJobProgressAction.ts
@@ -4,7 +4,10 @@ import { withAdminTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
 
-import { JobStatus } from '@alga-psa/jobs';
+// Concrete module, not the '@alga-psa/jobs' barrel — this file is reached via the
+// barrel's `export * from './actions'`, so importing the JobStatus runtime enum
+// back through the barrel risks an undefined value under a load-order cycle.
+import { JobStatus } from '../../types/job';
 import type { JobHeader, JobDetail } from '@alga-psa/jobs';
 import { JobMetrics } from '@alga-psa/jobs/actions';
 


### PR DESCRIPTION
## Problem

`main`'s **EE Workflows Build Guard** CI job is red. It broke exactly at commit `23dd5d35be` (#2781, "Add tenant job-history clearing…"); the prior commit was green.

The EE webpack build fails while collecting page data:

```
TypeError: Cannot read properties of undefined (reading 'A')
> Build error occurred
Error: Failed to collect page data for /api/import/approve
```

## Root cause

#2781 added a **top-level** statement to `packages/jobs/src/actions/job-actions.ts`:

```ts
const TERMINAL_JOB_STATUSES = [JobStatus.Completed, JobStatus.Failed];
```

`JobStatus` was imported from the package's own barrel `@alga-psa/jobs`. The barrel (`src/index.ts`) does `export * from './actions'` **before** `export * from './types/job'`. So when `job-actions.ts` — reached via `./actions` — reads `JobStatus` back through the barrel **at module-evaluation time**, `./types/job` hasn't initialized yet → `JobStatus` is `undefined` → the new top-level array access crashes during page-data collection.

Before #2781, every `JobStatus` use sat inside a function body (deferred), so the self-cycle was harmless.

## Fix

Import `JobStatus`/`JobService` from their concrete modules (`../types/job`, `../lib/jobService`) instead of the self-barrel — the exact idiom the package's other source files (`jobService`, `jobScheduler`, runners) already use. Also fixes the identical self-barrel `JobStatus` import in `getJobProgressAction.ts` (same latent footgun).

The two pre-existing build *warnings* (scheduling star-export conflict, `inboundEmailRuleAiClassifier` not found) are unrelated and were tolerated in the prior green build — left out of scope.

## Verification

Ran the same command CI runs — `EDITION=ee NEXT_PUBLIC_EDITION=enterprise next build --webpack`. It now completes with **exit 0** and a full route table; `/api/import/approve` collects cleanly. No `Failed to collect page data` / `Build error occurred` / `Cannot read properties of undefined` in the output.

https://claude.ai/code/session_011JPsXM5q5r7S11msFM7gBM