### PR TITLE
docs: reflect appliance-installs API stubs and new event types (#2776, #2767)

### DIFF
--- a/docs/api/api_overview.md
+++ b/docs/api/api_overview.md
@@ -24,6 +24,7 @@ Our APIs are segmented into two editions:
 - Current EE-only APIs:
   - Tenant Provisioning API (see [tenant_provisioning_api.md](tenant_provisioning_api.md))
   - Hudu Integration Status API (see Section 6)
+  - Appliance Console API (see Section 6)
 
 The edition is controlled by the `EDITION` environment variable:
 - `EDITION=community` for CE deployments
@@ -169,6 +170,15 @@ Assets and tickets can be linked to each other (the same association surfaced in
 ### Enterprise Edition APIs
 - **Tenant Provisioning API:** Enables partner-driven tenant management. See [tenant_provisioning_api.md](tenant_provisioning_api.md) for details.
 - **Hudu Integration Status:** `GET /api/integrations/hudu` returns connection health for the tenant's Hudu integration: `status`, `baseUrl`, `connectedAt`, `lastSyncedAt`, and `passwordAccess` (whether the Hudu API key can reach the password endpoints). Connection setup, company mapping, and asset layout mapping are configured through the Alga PSA UI at **Settings → Integrations → Hudu**, not via REST. Requires the `system_settings` read permission; available on EE deployments with the Hudu feature enabled. See [hudu.md](../integrations/hudu.md) for the full admin guide.
+- **Appliance Console API (EE only):** Manages on-premise appliance installations for Enterprise Edition deployments. Three endpoints are available under `/api/v1/appliance-installs/`:
+
+  | Method | Path | Purpose |
+  |--------|------|--------|
+  | `GET` | `/api/v1/appliance-installs` | List appliance installs visible to the authenticated tenant |
+  | `GET` | `/api/v1/appliance-installs/{tenantId}` | Retrieve details for a specific appliance install by tenant ID |
+  | `POST` | `/api/v1/appliance-installs/access` | Log an access event for an appliance install |
+
+  Community Edition deployments respond to all three endpoints with `501 Not Implemented` and the message `"Appliance console is only available in Enterprise Edition."` CORS preflight (`OPTIONS`) requests return `204 No Content` in both editions.
 
 ## 7. Development Guidelines
 

--- a/docs/architecture/event_system.md
+++ b/docs/architecture/event_system.md
@@ -21,7 +21,9 @@ Events consist of three main components:
    ```
 
 3. **Event Types**
-   The system supports various event types (defined in [events.ts](../server/src/lib/eventBus/events.ts)):
+   Core event types are defined in `server/src/lib/eventBus/events.ts`. Newer domain-specific schemas are defined in `packages/event-schemas/src/schemas/domain/` — prefer this location when adding new event types, as it can be imported from the Temporal worker without pulling in the full Next.js server module graph (see [temporal-worker-job-execution.md](./temporal-worker-job-execution.md)).
+
+   Core event types include:
    ```typescript
    export const EventTypeEnum = z.enum([
      'TICKET_CREATED',
@@ -36,6 +38,14 @@ Events consist of three main components:
      'INVOICE_FINALIZED',
    ]);
    ```
+
+   Additional domain events (defined in `packages/event-schemas/src/schemas/domain/`):
+
+   | Event type | When it fires | Default subscriber behavior |
+   |------------|--------------|-----------------------------|
+   | `TICKET_AUTO_CLOSE_WARNING` | A ticket is approaching its auto-close deadline | Warning email sent to the ticket's assigned user or owner |
+   | `CREDIT_EXPIRING` | A tenant's prepaid credit balance is nearing its expiration date | Credit-expiry notification email sent to the billing contact |
+   | `MAINTENANCE_JOB_REQUESTED` | (EE only) A maintenance job has been dispatched to the Temporal worker via the fan-out workflow | Worker executes the named maintenance handler across all tenants |
 
 ## Channel Management
 
@@ -259,7 +269,8 @@ The event system is implemented using:
 - Knex.js for database operations
 
 Key files:
-- `eventBus/events.ts`: Event type definitions
+- `eventBus/events.ts`: Core event type definitions (original events)
+- `packages/event-schemas/src/schemas/domain/`: Domain event schemas (newer events; importable from Temporal worker)
 - `eventBus/index.ts`: Core event bus implementation
 - `eventBus/initialize.ts`: System initialization
 - `eventBus/subscribers/`: Event handlers


### PR DESCRIPTION
## Documentation drift audit — 2026-06-25

**Automated draft. Human review required before merging.**

---

### Source PRs

| # | Title | Link |
|---|-------|------|
| #2776 | feat(api): add CE stubs for appliance-installs routes | https://github.com/nine-minds/alga-psa/pull/2776 |
| #2767 | Fix/workflow to temporal | https://github.com/nine-minds/alga-psa/pull/2767 |

---

### Files edited

| File | Rationale |
|------|-----------|
| `docs/api/api_overview.md` | Appliance Console API endpoints now exist in the CE codebase (`/api/v1/appliance-installs/`, `/api/v1/appliance-installs/{tenantId}`, `/api/v1/appliance-installs/access`) and return `501 Not Implemented` for CE deployments; EE deployments get full functionality. Added entry to Section 2 EE-only API list and full endpoint table to Section 6. |
| `docs/architecture/event_system.md` | Three new internal event types were introduced via `packages/event-schemas/`: `TICKET_AUTO_CLOSE_WARNING`, `CREDIT_EXPIRING`, and `MAINTENANCE_JOB_REQUESTED`. Updated the event-types section to reference the new schema package location, added a table describing each event's trigger and default subscriber behavior, and noted that new events should be placed in `packages/event-schemas/` for Temporal worker compatibility. |

---

### Needs human review

- **Full EE appliance console feature docs**: PR #2776 adds CE stubs only; the EE implementation in `packages/ee/src/app/api/v1/appliance-installs/` contains the real business logic. A dedicated `docs/integrations/appliance-console.md` (or similar) should be written by someone with access to the full EE feature spec.
- **Stale "Adding a New Job Handler" paths in `docs/architecture/job_scheduler.md`**: The section still references `server/src/lib/jobs/handlers/` and `server/src/lib/jobs/registerAllHandlers.ts`, which appear to have moved to `packages/jobs/src/lib/handlers/` after PR #2767's Temporal migration. Correcting these paths requires verifying the full handler registration flow in the new layout.
- **OpenAPI staleness**: `/sdk/docs/openapi/alga-openapi*.{json,yaml}` and `/packages/nm-store/public/openapi/alga.json` are out of scope for this auditor. A regeneration pass against the new appliance-installs endpoints should be scheduled separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01375h8U5PSroVRtVCeJFCmL)_