### PR TITLE
fix(time-entry): show date picker when editing a saved time entry (alga0002002)

### DIFF
--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/SingleTimeEntryForm.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/SingleTimeEntryForm.tsx
@@ -3,7 +3,7 @@
 import { memo } from 'react';
 import TimeEntryEditForm from './TimeEntryEditForm';
 import { ITimeEntryWithNew, TimeInputs, Service } from './types';
-import { TaxRegion } from '@alga-psa/types';
+import { ITimePeriodView, TaxRegion } from '@alga-psa/types';
 
 interface SingleTimeEntryFormProps {
   id: string;
@@ -18,6 +18,7 @@ interface SingleTimeEntryFormProps {
   onDelete: (index: number) => Promise<void>;
   onUpdateEntry: (index: number, entry: ITimeEntryWithNew) => void;
   onUpdateTimeInputs: (inputs: TimeInputs) => void;
+  timePeriod?: ITimePeriodView;
   date?: Date;
   isNewEntry?: boolean;
 }
@@ -35,6 +36,7 @@ const SingleTimeEntryForm = memo(function SingleTimeEntryForm({
   onDelete,
   onUpdateEntry,
   onUpdateTimeInputs,
+  timePeriod,
   date,
   isNewEntry = false
 }: SingleTimeEntryFormProps) {
@@ -54,6 +56,7 @@ const SingleTimeEntryForm = memo(function SingleTimeEntryForm({
         onUpdateEntry={onUpdateEntry}
         onUpdateTimeInputs={onUpdateTimeInputs}
         lastNoteInputRef={lastNoteInputRef}
+        timePeriod={timePeriod}
         date={date}
         isNewEntry={isNewEntry}
       />

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryDialog.tsx
@@ -50,6 +50,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
     workItem,
     date,
     existingEntries,
+    timePeriod,
     isEditable,
     defaultStartTime,
     defaultEndTime,
@@ -308,6 +309,7 @@ const TimeEntryDialogContent = memo(function TimeEntryDialogContent(props: TimeE
             onDelete={handleDeleteEntry}
             onUpdateEntry={updateEntry}
             onUpdateTimeInputs={updateTimeInputs}
+            timePeriod={timePeriod}
             date={date}
             isNewEntry={!hasExistingEntry}
           />

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/TimeEntryEditForm.tsx
@@ -34,6 +34,15 @@ interface EligiblePlanUI {
   has_bucket_overlay: boolean;
 }
 
+// Parse a 'YYYY-MM-DD' (or ISO) date string into a local midnight Date, avoiding the UTC shift
+// that `new Date(str)`/`parseISO` introduce for date-only values.
+// LEVERAGE: pattern date-only-local-parse — 4th site (also TimeSheet.tsx, IntervalSection.tsx,
+// timeSheetOperations.ts). Candidate for a shared scheduling date util.
+const parseDateOnlyLocal = (value: string): Date => {
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
 const TimeEntryEditForm = memo(function TimeEntryEditForm({
   id,
   entry,
@@ -48,6 +57,7 @@ const TimeEntryEditForm = memo(function TimeEntryEditForm({
   onUpdateEntry,
   onUpdateTimeInputs,
   lastNoteInputRef,
+  timePeriod,
   date,
   isNewEntry = false,
   isSaving = false,
@@ -112,6 +122,18 @@ const TimeEntryEditForm = memo(function TimeEntryEditForm({
     }
     return date || new Date();
   });
+
+  // Keep the entry inside its time sheet's period. The period is a half-open interval
+  // [start_date, end_date), so the last selectable day is end_date - 1. This mirrors the
+  // backend guard in saveTimeEntry (work_date >= start && work_date < end), so any date the
+  // picker allows will also pass server-side validation.
+  const periodBounds = useMemo(() => {
+    if (!timePeriod?.start_date || !timePeriod?.end_date) return undefined;
+    const minDate = parseDateOnlyLocal(timePeriod.start_date);
+    const maxDate = parseDateOnlyLocal(timePeriod.end_date);
+    maxDate.setDate(maxDate.getDate() - 1);
+    return { minDate, maxDate };
+  }, [timePeriod?.start_date, timePeriod?.end_date]);
 
   const validateTimes = useCallback(() => {
     if (!entry?.start_time || !entry?.end_time) return false;
@@ -516,62 +538,67 @@ const updateBillableDuration = useCallback((updatedEntry: typeof entry, newDurat
         />
       )}
 
-      {isNewEntry && (
-        <div className="space-y-1.5">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            {t('timeEntryForm.labels.date', { defaultValue: 'Date' })} <span className="text-red-500">*</span>
-          </label>
-          <DatePicker
-            value={selectedDate}
-            onChange={(newDate) => {
-              if (!newDate || !entry) return;
+      {/*
+        Date field — shown for both new and existing entries so a saved entry can be moved to a
+        different day. Bounded to the current time period (when known) so the entry stays in the
+        same time sheet; see periodBounds above.
+      */}
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {t('timeEntryForm.labels.date', { defaultValue: 'Date' })} <span className="text-red-500">*</span>
+        </label>
+        <DatePicker
+          value={selectedDate}
+          minDate={periodBounds?.minDate}
+          maxDate={periodBounds?.maxDate}
+          onChange={(newDate) => {
+            if (!newDate || !entry) return;
 
-              setSelectedDate(newDate);
+            setSelectedDate(newDate);
 
-              // Update the entry's start time to the new date and preserve duration when it still fits the same day.
-              const startTime = parseISO(entry.start_time);
-              const endTime = parseISO(entry.end_time);
+            // Update the entry's start time to the new date and preserve duration when it still fits the same day.
+            const startTime = parseISO(entry.start_time);
+            const endTime = parseISO(entry.end_time);
 
-              const newStartTime = setSeconds(
-                setMinutes(
-                  setHours(newDate, startTime.getHours()),
-                  startTime.getMinutes()
-                ),
-                startTime.getSeconds()
-              );
+            const newStartTime = setSeconds(
+              setMinutes(
+                setHours(newDate, startTime.getHours()),
+                startTime.getMinutes()
+              ),
+              startTime.getSeconds()
+            );
 
-              const originalDuration = calculateDuration(startTime, endTime);
-              const {
-                durationMinutes,
-                endTime: newEndTime,
-                wasClampedToSameDay,
-              } = clampDurationToSameDay(newStartTime, originalDuration);
+            const originalDuration = calculateDuration(startTime, endTime);
+            const {
+              durationMinutes,
+              endTime: newEndTime,
+              wasClampedToSameDay,
+            } = clampDurationToSameDay(newStartTime, originalDuration);
 
-              onUpdateEntry(index, markEntryAsDirty({
-                ...entry,
-                start_time: formatISO(newStartTime),
-                end_time: formatISO(newEndTime),
-                billable_duration: entry.billable_duration === 0 ? 0 : durationMinutes,
-              }));
-              onUpdateTimeInputs({
-                [`start-${index}`]: formatTimeForInput(newStartTime),
-                [`end-${index}`]: formatTimeForInput(newEndTime),
-              });
-              setValidationErrors(prev => ({
-                ...prev,
-                duration: wasClampedToSameDay
-                  ? t('timeEntryForm.validation.durationSameDay', {
-                    defaultValue: 'Duration must end on the same day'
-                  })
-                  : undefined,
-              }));
-            }}
-            placeholder={t('timeEntryForm.placeholders.selectDate', { defaultValue: 'Select date' })}
-            disabled={!isEditable}
-            clearable={false}
-          />
-        </div>
-      )}
+            onUpdateEntry(index, markEntryAsDirty({
+              ...entry,
+              start_time: formatISO(newStartTime),
+              end_time: formatISO(newEndTime),
+              billable_duration: entry.billable_duration === 0 ? 0 : durationMinutes,
+            }));
+            onUpdateTimeInputs({
+              [`start-${index}`]: formatTimeForInput(newStartTime),
+              [`end-${index}`]: formatTimeForInput(newEndTime),
+            });
+            setValidationErrors(prev => ({
+              ...prev,
+              duration: wasClampedToSameDay
+                ? t('timeEntryForm.validation.durationSameDay', {
+                  defaultValue: 'Duration must end on the same day'
+                })
+                : undefined,
+            }));
+          }}
+          placeholder={t('timeEntryForm.placeholders.selectDate', { defaultValue: 'Select date' })}
+          disabled={!isEditable}
+          clearable={false}
+        />
+      </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-1.5">

--- a/packages/ui/src/components/DatePicker.tsx
+++ b/packages/ui/src/components/DatePicker.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { format } from 'date-fns';
 import { Calendar as CalendarIcon, X } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
+import type { Matcher } from 'react-day-picker';
 import { useAutomationIdAndRegister } from '../ui-reflection/useAutomationIdAndRegister';
 import { DatePickerComponent } from '../ui-reflection/types';
 import { Calendar } from './Calendar';
@@ -25,6 +26,10 @@ interface DatePickerBaseProps {
   required?: boolean;
   /** Fixed date-fns display pattern; overrides the locale-derived format */
   displayFormat?: string;
+  /** Earliest selectable date (inclusive). Days before this are disabled and navigation starts here. */
+  minDate?: Date;
+  /** Latest selectable date (inclusive). Days after this are disabled, including the "Today" shortcut. */
+  maxDate?: Date;
   /** Ref for the component */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -54,9 +59,20 @@ export function DatePicker({
   required,
   clearable = false,
   displayFormat,
+  minDate,
+  maxDate,
   ref
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
+
+  // Constrain selection to [minDate, maxDate] (both inclusive) when bounds are provided.
+  // `before`/`after` matchers are exclusive of the boundary date itself, so the bounds stay selectable.
+  const disabledMatchers = React.useMemo<Matcher[] | undefined>(() => {
+    const matchers: Matcher[] = [];
+    if (minDate) matchers.push({ before: minDate });
+    if (maxDate) matchers.push({ after: maxDate });
+    return matchers.length > 0 ? matchers : undefined;
+  }, [minDate, maxDate]);
   const i18n = useOptionalI18n();
   const locale = i18n?.locale ?? LOCALE_CONFIG.defaultLocale;
   const dateFnsLocale = getDateFnsLocale(locale);
@@ -170,7 +186,9 @@ export function DatePicker({
                 }}
                 onClear={clearValue ? handleClear : undefined}
                 defaultMonth={value}
-                fromDate={new Date(new Date().getFullYear(), new Date().getMonth(), 1)}
+                fromDate={minDate ?? new Date(new Date().getFullYear(), new Date().getMonth(), 1)}
+                toDate={maxDate}
+                disabled={disabledMatchers}
               />
             </div>
           </Popover.Content>

--- a/server/src/test/unit/timeEntryEditFormDateField.test.tsx
+++ b/server/src/test/unit/timeEntryEditFormDateField.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression coverage for alga0002002: editing a saved time entry must expose a Date
+ * field so the entry can be moved to another day, bounded to the entry's time period so
+ * it stays in the same time sheet.
+ *
+ * The DatePicker is stubbed to capture the bounds the form computes — this keeps the test
+ * focused on the form's logic (un-gating + the exclusive-end off-by-one) without depending
+ * on react-day-picker's calendar DOM.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { WorkItemType } from '../../interfaces/workItem.interfaces';
+import { TimeSheetStatus } from '../../interfaces/timeEntry.interfaces';
+import TimeEntryEditForm from '@alga-psa/scheduling/components/time-management/time-entry/time-sheet/TimeEntryEditForm';
+
+// Capture every set of props the (stubbed) DatePicker receives.
+const datePickerSpy = vi.hoisted(() => ({ calls: [] as Array<Record<string, unknown>> }));
+
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  DatePicker: (props: Record<string, unknown>) => {
+    datePickerSpy.calls.push(props);
+    return <div data-testid="time-entry-date-picker" />;
+  }
+}));
+
+// The form resolves a client and loads eligible contract lines on mount; stub both so the
+// effects stay inert and never touch a real DB.
+vi.mock('@alga-psa/scheduling/lib/contractLineDisambiguation', () => ({
+  getClientIdForWorkItem: vi.fn().mockResolvedValue(null),
+  getEligibleContractLinesForUI: vi.fn().mockResolvedValue([])
+}));
+
+vi.mock('@alga-psa/scheduling/actions/clientInteractionLookupActions', () => ({
+  getSchedulingClientById: vi.fn().mockResolvedValue(null)
+}));
+
+describe('TimeEntryEditForm date field (alga0002002)', () => {
+  const baseEntry = {
+    entry_id: 'entry-1',
+    work_item_id: 'work-item-1',
+    work_item_type: 'project_task' as WorkItemType,
+    start_time: '2026-02-10T12:00:00.000Z',
+    end_time: '2026-02-10T13:00:00.000Z',
+    billable_duration: 60,
+    notes: '',
+    user_id: 'user-1',
+    time_sheet_id: 'timesheet-1',
+    approval_status: 'DRAFT' as TimeSheetStatus,
+    service_id: 'service-1',
+    created_at: '2026-02-10T12:00:00.000Z',
+    updated_at: '2026-02-10T12:00:00.000Z',
+    isNew: false,
+    isDirty: false
+  };
+
+  // Half-open period [start, end): Feb 1 through Feb 15 inclusive; Feb 16 is the exclusive end.
+  const timePeriod = {
+    period_id: 'period-1',
+    start_date: '2026-02-01',
+    end_date: '2026-02-16'
+  } as never;
+
+  const services = [
+    { id: 'service-1', name: 'Test Service', type: 'Time', tax_rate_id: null, tax_percentage: null }
+  ];
+
+  const noop = vi.fn();
+
+  const renderForm = (overrides: Record<string, unknown> = {}) =>
+    render(
+      <TimeEntryEditForm
+        id="form"
+        entry={baseEntry}
+        index={0}
+        isEditable={true}
+        services={services}
+        taxRegions={[]}
+        timeInputs={{}}
+        totalDuration={60}
+        onSave={noop}
+        onDelete={noop}
+        onUpdateEntry={noop}
+        onUpdateTimeInputs={noop}
+        isNewEntry={false}
+        {...overrides}
+      />
+    );
+
+  const lastDatePickerProps = () => datePickerSpy.calls[datePickerSpy.calls.length - 1];
+
+  beforeEach(() => {
+    datePickerSpy.calls.length = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders the Date field when editing a saved entry (not just new entries)', () => {
+    renderForm({ isNewEntry: false, timePeriod });
+
+    // The bug was that the date control was gated behind isNewEntry; on edit it must show.
+    expect(screen.getByTestId('time-entry-date-picker')).toBeTruthy();
+  });
+
+  test('bounds the picker to the period, treating end_date as exclusive (maxDate = end_date - 1)', () => {
+    renderForm({ isNewEntry: false, timePeriod });
+
+    const { minDate, maxDate } = lastDatePickerProps() as { minDate: Date; maxDate: Date };
+
+    // minDate is the inclusive period start (Feb 1, 2026), built as a local date.
+    expect(minDate.getFullYear()).toBe(2026);
+    expect(minDate.getMonth()).toBe(1); // February (0-indexed)
+    expect(minDate.getDate()).toBe(1);
+
+    // maxDate is the last day *inside* the half-open period: end_date (Feb 16) minus one day.
+    expect(maxDate.getFullYear()).toBe(2026);
+    expect(maxDate.getMonth()).toBe(1);
+    expect(maxDate.getDate()).toBe(15);
+  });
+
+  test('leaves the picker unbounded when no time period is supplied', () => {
+    renderForm({ isNewEntry: false, timePeriod: undefined });
+
+    const { minDate, maxDate } = lastDatePickerProps() as { minDate?: Date; maxDate?: Date };
+    expect(minDate).toBeUndefined();
+    expect(maxDate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **alga0002002** — editing a saved time entry showed only Service / Start / End / Duration / Notes with **no date control**, so an entry couldn't be moved to a different day within its time sheet.

The `DatePicker` already existed in `TimeEntryEditForm` but was gated behind `{isNewEntry && (...)}`. Its `onChange` already recomputed start/end, preserved duration, clamped to the same day, and marked the entry dirty — it simply wasn't rendered on edit.

## Changes

- **`TimeEntryEditForm.tsx`** — render the Date field for **edits (and view)** too, not just new entries, bounded to the entry's time period.
- **`TimeEntryDialog.tsx` / `SingleTimeEntryForm.tsx`** — thread the already-available `timePeriod` down to the form (the dialog received the prop but never passed it on).
- **`DatePicker.tsx`** (shared) — add optional `minDate`/`maxDate`. The underlying `Calendar`/react-day-picker already supports the constraint; the wrapper just didn't expose it. **Purely additive — existing callers are unchanged** (`fromDate` falls back to the previous default, `toDate`/`disabled` stay `undefined`).

## Correctness: exclusive period end

Time periods are half-open `[start_date, end_date)` (verified via period generation, the `TimeSheet` day loop, and the backend guard in `saveTimeEntry`: `work_date >= start && work_date < end`). So the picker's `maxDate = end_date - 1 day`. This makes the UI match the server rule exactly — every date the picker allows also passes server-side validation, so users can't pick a date the save then rejects with an opaque error.

## Tests

- New regression test `server/src/test/unit/timeEntryEditFormDateField.test.tsx` (3 cases): date field renders on edit, `maxDate = end_date - 1` (exclusive-end off-by-one), and unbounded when no period is supplied.
- Typecheck clean: `packages/ui`, `packages/scheduling`.
- Existing suites green: DatePicker/Calendar (9), the form's billing unit test that renders it directly (4), dialog + timesheet contract tests (6).

## Notes

- Added a `// LEVERAGE:` marker on a `parseDateOnlyLocal` helper — that date-only-local-parse shape now recurs in 4 places (`TimeSheet`, `IntervalSection`, `timeSheetOperations`, here); flagged as a candidate for a shared scheduling date util rather than detouring now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)