### PR TITLE
fix(mcp): improve API registry discoverability + ranking (alga0001973)

### DIFF
--- a/ee/docs/api-registry/lookups.json
+++ b/ee/docs/api-registry/lookups.json
@@ -405,6 +405,60 @@
     {
       "match": {
         "method": "get",
+        "path": "/api/v1/priorities"
+      },
+      "metadata": {
+        "displayName": "List Priorities",
+        "summary": "Fetch ticket priorities",
+        "description": "Returns the priority catalog for the tenant. This is the canonical way to resolve a valid priority_id before creating or updating a ticket — do not infer one from a board's default_priority_id, which is frequently null. Priorities are tenant-wide (not board-scoped), but each row has an item_type (ticket, project_task, ...); when creating a ticket, use a priority whose item_type is \"ticket\". Each row includes priority_id, priority_name, order_number (sort ascending to list by urgency), color, and item_type.",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Sort column, e.g. order_number to order by urgency.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": { "type": "string", "enum": ["asc", "desc"] }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of records per page (default 25, max 100).",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Pagination page number starting at 1.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "examples": [
+          {
+            "name": "Resolve a priority_id before creating a ticket",
+            "request": {
+              "query": {
+                "sort": "order_number",
+                "order": "asc",
+                "limit": 100
+              }
+            },
+            "notes": "Call this before POST /api/v1/tickets to obtain a valid priority_id. Keep only rows where item_type is \"ticket\", then map the user's intent (e.g. priority_name \"Medium\") to its priority_id. Do not read priority_id from a board record — boards often have a null default_priority_id."
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "method": "get",
         "path": "/api/v1/categories/ticket"
       },
       "metadata": {

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -5222,14 +5222,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "description": "Asset type stored in assets.asset_type.",
         "schema": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type stored in assets.asset_type."
         }
       },
@@ -5403,14 +5395,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         },
         "asset_type": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type. Determines the optional extension data table."
         },
         "asset_tag": {
@@ -5690,14 +5674,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ]
+            "description": "Asset type slug from the tenant asset type registry."
           },
           "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
         }
@@ -5975,14 +5952,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ]
+            "description": "Asset type slug from the tenant asset type registry."
           },
           "description": "Optional asset type filters."
         }
@@ -6185,14 +6155,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         },
         "asset_type": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type to store in assets.asset_type."
         },
         "asset_tag": {
@@ -10064,6 +10026,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
                 "type": [
                   "string",
                   "null"
+                ],
+                "enum": [
+                  "company",
+                  "individual"
                 ]
               },
               "tax_id_number": {
@@ -10365,7 +10331,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "string"
         },
         "client_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "company",
+            "individual"
+          ]
         },
         "tax_id_number": {
           "type": "string"
@@ -10507,6 +10477,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -10805,6 +10779,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -11071,7 +11049,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "string"
         },
         "client_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "company",
+            "individual"
+          ]
         },
         "tax_id_number": {
           "type": "string"
@@ -11213,6 +11195,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -17183,9 +17169,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_financial_invoices",
     "method": "get",
     "path": "/api/v1/financial/invoices",
-    "displayName": "List financial invoices (transaction list wiring)",
-    "summary": "List financial invoices (transaction list wiring)",
-    "description": "Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.",
+    "displayName": "List invoices",
+    "summary": "List invoices",
+    "description": "Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.",
     "tags": [
       "Financial"
     ],
@@ -17211,8 +17197,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
         }
       },
       {
@@ -17231,8 +17219,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "search",
         "in": "query",
         "required": false,
+        "description": "Matches invoice_number or client name.",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Matches invoice_number or client name."
         }
       },
       {
@@ -17268,6 +17258,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
+        "name": "is_active",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      },
+      {
         "name": "client_id",
         "in": "query",
         "required": false,
@@ -17277,7 +17279,25 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "invoice_id",
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "sent",
+            "paid",
+            "overdue",
+            "cancelled",
+            "pending",
+            "prepayment",
+            "partially_applied"
+          ]
+        }
+      },
+      {
+        "name": "billing_cycle_id",
         "in": "query",
         "required": false,
         "schema": {
@@ -17286,7 +17306,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "type",
+        "name": "due_date_from",
         "in": "query",
         "required": false,
         "schema": {
@@ -17294,7 +17314,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "status",
+        "name": "due_date_to",
         "in": "query",
         "required": false,
         "schema": {
@@ -17318,7 +17338,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "include_expired",
+        "name": "is_manual",
         "in": "query",
         "required": false,
         "schema": {
@@ -17330,7 +17350,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "expiring_soon",
+        "name": "has_credit_applied",
         "in": "query",
         "required": false,
         "schema": {
@@ -17339,79 +17359,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "true",
             "false"
           ]
-        }
-      },
-      {
-        "name": "has_remaining",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "has_expiration",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "date_from",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "date_to",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "group_by",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "day",
-            "week",
-            "month"
-          ]
-        }
-      },
-      {
-        "name": "include_projections",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "as_of_date",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
         }
       }
     ],
@@ -17673,9 +17620,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_financial_paymentmethods",
     "method": "get",
     "path": "/api/v1/financial/payment-methods",
-    "displayName": "List payment methods (transaction list wiring)",
-    "summary": "List payment methods (transaction list wiring)",
-    "description": "Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.",
+    "displayName": "List payment methods",
+    "summary": "List payment methods",
+    "description": "Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.",
     "tags": [
       "Financial"
     ],
@@ -17701,8 +17648,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
         }
       },
       {
@@ -17721,8 +17670,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "search",
         "in": "query",
         "required": false,
+        "description": "Matches client name or card last4.",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Matches client name or card last4."
         }
       },
       {
@@ -17758,16 +17709,19 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "client_id",
+        "name": "is_active",
         "in": "query",
         "required": false,
         "schema": {
           "type": "string",
-          "format": "uuid"
+          "enum": [
+            "true",
+            "false"
+          ]
         }
       },
       {
-        "name": "invoice_id",
+        "name": "client_id",
         "in": "query",
         "required": false,
         "schema": {
@@ -17780,35 +17734,15 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "in": "query",
         "required": false,
         "schema": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "credit_card",
+            "bank_account"
+          ]
         }
       },
       {
-        "name": "status",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "amount_min",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "amount_max",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "include_expired",
+        "name": "is_default",
         "in": "query",
         "required": false,
         "schema": {
@@ -17820,88 +17754,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "expiring_soon",
+        "name": "exclude_deleted",
         "in": "query",
         "required": false,
+        "description": "Exclude soft-deleted payment methods. Defaults to true.",
         "schema": {
           "type": "string",
           "enum": [
             "true",
             "false"
-          ]
-        }
-      },
-      {
-        "name": "has_remaining",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "has_expiration",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "date_from",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "date_to",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "group_by",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "day",
-            "week",
-            "month"
-          ]
-        }
-      },
-      {
-        "name": "include_projections",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "as_of_date",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
+          ],
+          "description": "Exclude soft-deleted payment methods. Defaults to true."
         }
       }
     ],
@@ -22833,9 +22696,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_invoices_id_pdf",
     "method": "get",
     "path": "/api/v1/invoices/{id}/pdf",
-    "displayName": "Redirect to invoice PDF download",
-    "summary": "Redirect to invoice PDF download",
-    "description": "Attempts to generate/load PDF metadata and redirects to download_url when present.",
+    "displayName": "Download invoice PDF",
+    "summary": "Download invoice PDF",
+    "description": "Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.",
     "tags": [
       "Invoices"
     ],
@@ -22858,9 +22721,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "post-_api_v1_invoices_id_pdf",
     "method": "post",
     "path": "/api/v1/invoices/{id}/pdf",
-    "displayName": "Generate invoice PDF asset",
-    "summary": "Generate invoice PDF asset",
-    "description": "Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.",
+    "displayName": "Generate and download invoice PDF",
+    "summary": "Generate and download invoice PDF",
+    "description": "Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.",
     "tags": [
       "Invoices"
     ],
@@ -22877,34 +22740,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "description": "Path UUID parameter resolved by ApiBaseController.extractIdFromPath()."
         }
       }
-    ],
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {}
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": {}
-              }
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "data"
-      ]
-    }
+    ]
   },
   {
     "id": "get-_api_v1_financial",
@@ -23931,37 +23767,19 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_priorities",
     "method": "get",
     "path": "/api/v1/priorities",
-    "displayName": "List priorities",
-    "summary": "List priorities",
-    "description": "Lists ticket priorities for the tenant with pagination and sorting.",
+    "displayName": "List Priorities",
+    "summary": "Fetch ticket priorities",
+    "description": "Returns the priority catalog for the tenant. This is the canonical way to resolve a valid priority_id before creating or updating a ticket — do not infer one from a board's default_priority_id, which is frequently null. Priorities are tenant-wide (not board-scoped), but each row has an item_type (ticket, project_task, ...); when creating a ticket, use a priority whose item_type is \"ticket\". Each row includes priority_id, priority_name, order_number (sort ascending to list by urgency), color, and item_type.",
     "tags": [
       "Priorities"
     ],
     "approvalRequired": false,
     "parameters": [
       {
-        "name": "page",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "integer",
-          "minimum": 1
-        }
-      },
-      {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
-        }
-      },
-      {
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort column, e.g. order_number to order by urgency.",
         "schema": {
           "type": "string"
         }
@@ -23970,12 +23788,34 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "order",
         "in": "query",
         "required": false,
+        "description": "Sort direction.",
         "schema": {
           "type": "string",
           "enum": [
             "asc",
             "desc"
           ]
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Number of records per page (default 25, max 100).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "Pagination page number starting at 1.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     ],
@@ -24005,7 +23845,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "required": [
         "data"
       ]
-    }
+    },
+    "examples": [
+      {
+        "name": "Resolve a priority_id before creating a ticket",
+        "request": {
+          "query": {
+            "sort": "order_number",
+            "order": "asc",
+            "limit": 100
+          }
+        },
+        "notes": "Call this before POST /api/v1/tickets to obtain a valid priority_id. Keep only rows where item_type is \"ticket\", then map the user's intent (e.g. priority_name \"Medium\") to its priority_id. Do not read priority_id from a board record — boards often have a null default_priority_id."
+      }
+    ]
   },
   {
     "id": "get-_api_v1_priorities_id",

--- a/packages/agent-tooling/src/registry/__tests__/search.test.ts
+++ b/packages/agent-tooling/src/registry/__tests__/search.test.ts
@@ -73,3 +73,95 @@ describe('searchRegistryEntries (T002 — relevant over irrelevant)', () => {
     expect(top.entry.id).toBe('alpha');
   });
 });
+
+describe('searchRegistryEntries (T003 — alga0001973 registry gaps)', () => {
+  // Mirrors the real registry: the create-ticket endpoint is tagged "Work
+  // Management v1" (no "ticket" token), while "Create ticket category" is tagged
+  // "Ticket Categories" and its path ends in "ticket" — so it used to win a bare
+  // "create ticket" search on a +2.5 tag match it did not deserve.
+  const TICKET_VS_CATEGORY: ChatApiRegistryEntry[] = [
+    entry({
+      id: 'categories.ticket.create',
+      method: 'post',
+      path: '/api/v1/categories/ticket',
+      displayName: 'Create ticket category',
+      summary: 'Create ticket category',
+      description: 'Creates a ticket category row for one board.',
+      tags: ['Ticket Categories'],
+      requestBodySchema: { type: 'object', properties: { category_name: { type: 'string' } } },
+    }),
+    entry({
+      id: 'tickets.create',
+      method: 'post',
+      path: '/api/v1/tickets',
+      displayName: 'Create Ticket',
+      summary: 'Create a new ticket',
+      description: 'Creates a new ticket on a specified board with the desired status and priority.',
+      tags: ['Work Management v1'],
+      requestBodySchema: { type: 'object', properties: { title: { type: 'string' } } },
+    }),
+  ];
+
+  it('ranks Create Ticket above Create ticket category for "create ticket"', () => {
+    const top = searchRegistryEntries(TICKET_VS_CATEGORY, 'create ticket')[0];
+    expect(top.entry.id).toBe('tickets.create');
+  });
+
+  it('still ranks Create ticket category first when the query names the category', () => {
+    const top = searchRegistryEntries(TICKET_VS_CATEGORY, 'create ticket category')[0];
+    expect(top.entry.id).toBe('categories.ticket.create');
+  });
+
+  // Mirrors the real registry: List Tickets mentions "priority" in its description
+  // and filter params, so it used to outrank the dedicated List priorities endpoint —
+  // whose own name ("priorities") never matched the singularized "priority" token.
+  const PRIORITY_LOOKUP: ChatApiRegistryEntry[] = [
+    entry({
+      id: 'tickets.list',
+      method: 'get',
+      path: '/api/v1/tickets',
+      displayName: 'List Tickets',
+      summary: 'List tickets',
+      description:
+        'Returns a paginated list of tickets. Supports filtering by board, status, priority, client. Use GET /api/v1/priorities for lookup data.',
+      tags: ['Work Management v1'],
+      parameters: [
+        {
+          name: 'priority_id',
+          in: 'query',
+          required: false,
+          description: 'Filter by ticket priority UUID. Call GET /api/v1/priorities to discover priority UUIDs.',
+        },
+        { name: 'priority_name', in: 'query', required: false, description: 'Filter by priority display name.' },
+      ],
+    }),
+    entry({
+      id: 'priorities.list',
+      method: 'get',
+      path: '/api/v1/priorities',
+      displayName: 'List priorities',
+      summary: 'List priorities',
+      description: 'Lists ticket priorities for the tenant with pagination and sorting.',
+      tags: ['Priorities'],
+    }),
+  ];
+
+  it('ranks List priorities first for "list priorities"', () => {
+    const top = searchRegistryEntries(PRIORITY_LOOKUP, 'list priorities')[0];
+    expect(top.entry.id).toBe('priorities.list');
+  });
+
+  it('ranks List priorities first for the bare query "priorities"', () => {
+    const top = searchRegistryEntries(PRIORITY_LOOKUP, 'priorities')[0];
+    expect(top.entry.id).toBe('priorities.list');
+  });
+
+  it('matches a resource endpoint when the query uses the plural form', () => {
+    const registry: ChatApiRegistryEntry[] = [
+      entry({ id: 'tickets.list', method: 'get', path: '/api/v1/tickets', displayName: 'List Tickets', tags: ['Tickets'] }),
+      entry({ id: 'categories.list', method: 'get', path: '/api/v1/categories', displayName: 'List Categories', tags: ['Categories'] }),
+    ];
+    const top = searchRegistryEntries(registry, 'categories')[0];
+    expect(top.entry.id).toBe('categories.list');
+  });
+});

--- a/packages/agent-tooling/src/registry/search.ts
+++ b/packages/agent-tooling/src/registry/search.ts
@@ -71,6 +71,15 @@ function tokenize(text: string) {
   );
 }
 
+// Singularize every word in a block of text while leaving separators intact.
+// Query tokens are singularized (e.g. "priorities" -> "priority"), so matching a
+// singularized view of the field text keeps substring matching symmetric for
+// irregular plurals whose singular is not a substring of the plural — "priorities",
+// "categories", "companies". Input is expected to already be lower-cased.
+function singularizeText(text: string) {
+  return text.replace(/[a-z0-9]+/g, (word) => singularize(word));
+}
+
 function buildSearchContext(query: string): SearchContext {
   const normalizedQuery = query.trim().toLowerCase();
   const intents = new Set<SearchIntent>();
@@ -207,9 +216,13 @@ function scoreTokenMatches(
   ];
 
   let score = 0;
-  for (const token of context.tokens) {
-    for (const [field, value, weight] of fieldTexts) {
-      if (value.includes(token)) {
+  for (const [field, value, weight] of fieldTexts) {
+    // Match against the raw field text and a singularized view of it so a query
+    // token like "priority" (singularized from "priorities") still matches a field
+    // that literally reads "priorities". Computed once per field, not per token.
+    const singularValue = singularizeText(value);
+    for (const token of context.tokens) {
+      if (value.includes(token) || singularValue.includes(token)) {
         score += weight;
         matchedFields.add(field);
       }
@@ -252,6 +265,19 @@ function scoreEntry(
   ) {
     score += 4;
     matchedFields.add('resourceTail');
+  }
+
+  // Exact-resource match: every resource segment of the path is named in the query.
+  // This favors the endpoint whose whole resource the user asked for (POST /tickets
+  // for "create ticket") over one where the noun is only a trailing qualifier
+  // (POST /categories/ticket — a ticket *category*). The bonus applies equally to
+  // all of a resource's endpoints, so it never disturbs intra-resource ordering.
+  if (
+    resourceSegments.length > 0 &&
+    resourceSegments.every((segment) => context.tokens.includes(segment))
+  ) {
+    score += 4;
+    matchedFields.add('resourceExact');
   }
 
   if (

--- a/server/src/lib/mcp/registry.generated.ts
+++ b/server/src/lib/mcp/registry.generated.ts
@@ -5222,14 +5222,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "description": "Asset type stored in assets.asset_type.",
         "schema": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type stored in assets.asset_type."
         }
       },
@@ -5403,14 +5395,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         },
         "asset_type": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type. Determines the optional extension data table."
         },
         "asset_tag": {
@@ -5690,14 +5674,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ]
+            "description": "Asset type slug from the tenant asset type registry."
           },
           "description": "Filter to these asset types. Repeat the param or pass a comma-separated list."
         }
@@ -5975,14 +5952,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "workstation",
-              "network_device",
-              "server",
-              "mobile_device",
-              "printer",
-              "unknown"
-            ]
+            "description": "Asset type slug from the tenant asset type registry."
           },
           "description": "Optional asset type filters."
         }
@@ -6185,14 +6155,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         },
         "asset_type": {
           "type": "string",
-          "enum": [
-            "workstation",
-            "network_device",
-            "server",
-            "mobile_device",
-            "printer",
-            "unknown"
-          ],
           "description": "Asset type to store in assets.asset_type."
         },
         "asset_tag": {
@@ -10064,6 +10026,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
                 "type": [
                   "string",
                   "null"
+                ],
+                "enum": [
+                  "company",
+                  "individual"
                 ]
               },
               "tax_id_number": {
@@ -10365,7 +10331,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "string"
         },
         "client_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "company",
+            "individual"
+          ]
         },
         "tax_id_number": {
           "type": "string"
@@ -10507,6 +10477,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -10805,6 +10779,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -11071,7 +11049,11 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "type": "string"
         },
         "client_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "company",
+            "individual"
+          ]
         },
         "tax_id_number": {
           "type": "string"
@@ -11213,6 +11195,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
               "type": [
                 "string",
                 "null"
+              ],
+              "enum": [
+                "company",
+                "individual"
               ]
             },
             "tax_id_number": {
@@ -17183,9 +17169,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_financial_invoices",
     "method": "get",
     "path": "/api/v1/financial/invoices",
-    "displayName": "List financial invoices (transaction list wiring)",
-    "summary": "List financial invoices (transaction list wiring)",
-    "description": "Route file maps to ApiFinancialController.list(), which is transaction-oriented (resource financial/transactions) rather than invoice-specific list logic. Current response is the generic transaction list envelope with financial report links.",
+    "displayName": "List invoices",
+    "summary": "List invoices",
+    "description": "Returns a paginated list of invoices for the tenant. Maps to ApiFinancialController.listInvoices() → FinancialService.listInvoices(), filtered and sorted by the supplied query parameters. Each item carries the invoice record (including client_name) plus HATEOAS links.",
     "tags": [
       "Financial"
     ],
@@ -17211,8 +17197,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at).",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Sort field. One of created_at, updated_at, invoice_number, invoice_date, due_date, total_amount, status (defaults to created_at)."
         }
       },
       {
@@ -17231,8 +17219,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "search",
         "in": "query",
         "required": false,
+        "description": "Matches invoice_number or client name.",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Matches invoice_number or client name."
         }
       },
       {
@@ -17268,6 +17258,18 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
+        "name": "is_active",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        }
+      },
+      {
         "name": "client_id",
         "in": "query",
         "required": false,
@@ -17277,7 +17279,25 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "invoice_id",
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "sent",
+            "paid",
+            "overdue",
+            "cancelled",
+            "pending",
+            "prepayment",
+            "partially_applied"
+          ]
+        }
+      },
+      {
+        "name": "billing_cycle_id",
         "in": "query",
         "required": false,
         "schema": {
@@ -17286,7 +17306,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "type",
+        "name": "due_date_from",
         "in": "query",
         "required": false,
         "schema": {
@@ -17294,7 +17314,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "status",
+        "name": "due_date_to",
         "in": "query",
         "required": false,
         "schema": {
@@ -17318,7 +17338,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "include_expired",
+        "name": "is_manual",
         "in": "query",
         "required": false,
         "schema": {
@@ -17330,7 +17350,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "expiring_soon",
+        "name": "has_credit_applied",
         "in": "query",
         "required": false,
         "schema": {
@@ -17339,79 +17359,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "true",
             "false"
           ]
-        }
-      },
-      {
-        "name": "has_remaining",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "has_expiration",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "date_from",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "date_to",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "group_by",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "day",
-            "week",
-            "month"
-          ]
-        }
-      },
-      {
-        "name": "include_projections",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "as_of_date",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
         }
       }
     ],
@@ -17673,9 +17620,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_financial_paymentmethods",
     "method": "get",
     "path": "/api/v1/financial/payment-methods",
-    "displayName": "List payment methods (transaction list wiring)",
-    "summary": "List payment methods (transaction list wiring)",
-    "description": "Current route wiring calls ApiFinancialController.list(), which lists transaction records and not payment methods. This discrepancy is documented as implementation behavior.",
+    "displayName": "List payment methods",
+    "summary": "List payment methods",
+    "description": "Returns a paginated list of payment methods for the tenant. Maps to ApiFinancialController.listPaymentMethods() → FinancialService.listPaymentMethods(). Soft-deleted methods are excluded by default. Each item carries the payment method record (including client_name) plus HATEOAS links.",
     "tags": [
       "Financial"
     ],
@@ -17701,8 +17648,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at).",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Sort field. One of created_at, updated_at, type, is_default (defaults to created_at)."
         }
       },
       {
@@ -17721,8 +17670,10 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "search",
         "in": "query",
         "required": false,
+        "description": "Matches client name or card last4.",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Matches client name or card last4."
         }
       },
       {
@@ -17758,16 +17709,19 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "client_id",
+        "name": "is_active",
         "in": "query",
         "required": false,
         "schema": {
           "type": "string",
-          "format": "uuid"
+          "enum": [
+            "true",
+            "false"
+          ]
         }
       },
       {
-        "name": "invoice_id",
+        "name": "client_id",
         "in": "query",
         "required": false,
         "schema": {
@@ -17780,35 +17734,15 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "in": "query",
         "required": false,
         "schema": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "credit_card",
+            "bank_account"
+          ]
         }
       },
       {
-        "name": "status",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "amount_min",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "amount_max",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "include_expired",
+        "name": "is_default",
         "in": "query",
         "required": false,
         "schema": {
@@ -17820,88 +17754,17 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         }
       },
       {
-        "name": "expiring_soon",
+        "name": "exclude_deleted",
         "in": "query",
         "required": false,
+        "description": "Exclude soft-deleted payment methods. Defaults to true.",
         "schema": {
           "type": "string",
           "enum": [
             "true",
             "false"
-          ]
-        }
-      },
-      {
-        "name": "has_remaining",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "has_expiration",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "date_from",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "date_to",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
-        "name": "group_by",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "day",
-            "week",
-            "month"
-          ]
-        }
-      },
-      {
-        "name": "include_projections",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false"
-          ]
-        }
-      },
-      {
-        "name": "as_of_date",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "string"
+          ],
+          "description": "Exclude soft-deleted payment methods. Defaults to true."
         }
       }
     ],
@@ -22833,9 +22696,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_invoices_id_pdf",
     "method": "get",
     "path": "/api/v1/invoices/{id}/pdf",
-    "displayName": "Redirect to invoice PDF download",
-    "summary": "Redirect to invoice PDF download",
-    "description": "Attempts to generate/load PDF metadata and redirects to download_url when present.",
+    "displayName": "Download invoice PDF",
+    "summary": "Download invoice PDF",
+    "description": "Generates (when needed) and returns the invoice PDF as a raw application/pdf attachment.",
     "tags": [
       "Invoices"
     ],
@@ -22858,9 +22721,9 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "post-_api_v1_invoices_id_pdf",
     "method": "post",
     "path": "/api/v1/invoices/{id}/pdf",
-    "displayName": "Generate invoice PDF asset",
-    "summary": "Generate invoice PDF asset",
-    "description": "Generates/refreshes invoice PDF metadata and returns file_id plus optional download_url.",
+    "displayName": "Generate and download invoice PDF",
+    "summary": "Generate and download invoice PDF",
+    "description": "Generates the invoice PDF and returns the raw PDF file as an application/pdf attachment.",
     "tags": [
       "Invoices"
     ],
@@ -22877,34 +22740,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
           "description": "Path UUID parameter resolved by ApiBaseController.extractIdFromPath()."
         }
       }
-    ],
-    "responseBodySchema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": {}
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": {}
-              }
-            }
-          ]
-        },
-        "meta": {
-          "type": "object",
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "data"
-      ]
-    }
+    ]
   },
   {
     "id": "get-_api_v1_financial",
@@ -23931,37 +23767,19 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "id": "get-_api_v1_priorities",
     "method": "get",
     "path": "/api/v1/priorities",
-    "displayName": "List priorities",
-    "summary": "List priorities",
-    "description": "Lists ticket priorities for the tenant with pagination and sorting.",
+    "displayName": "List Priorities",
+    "summary": "Fetch ticket priorities",
+    "description": "Returns the priority catalog for the tenant. This is the canonical way to resolve a valid priority_id before creating or updating a ticket — do not infer one from a board's default_priority_id, which is frequently null. Priorities are tenant-wide (not board-scoped), but each row has an item_type (ticket, project_task, ...); when creating a ticket, use a priority whose item_type is \"ticket\". Each row includes priority_id, priority_name, order_number (sort ascending to list by urgency), color, and item_type.",
     "tags": [
       "Priorities"
     ],
     "approvalRequired": false,
     "parameters": [
       {
-        "name": "page",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "integer",
-          "minimum": 1
-        }
-      },
-      {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "schema": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
-        }
-      },
-      {
         "name": "sort",
         "in": "query",
         "required": false,
+        "description": "Sort column, e.g. order_number to order by urgency.",
         "schema": {
           "type": "string"
         }
@@ -23970,12 +23788,34 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "name": "order",
         "in": "query",
         "required": false,
+        "description": "Sort direction.",
         "schema": {
           "type": "string",
           "enum": [
             "asc",
             "desc"
           ]
+        }
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Number of records per page (default 25, max 100).",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "Pagination page number starting at 1.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     ],
@@ -24005,7 +23845,20 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
       "required": [
         "data"
       ]
-    }
+    },
+    "examples": [
+      {
+        "name": "Resolve a priority_id before creating a ticket",
+        "request": {
+          "query": {
+            "sort": "order_number",
+            "order": "asc",
+            "limit": 100
+          }
+        },
+        "notes": "Call this before POST /api/v1/tickets to obtain a valid priority_id. Keep only rows where item_type is \"ticket\", then map the user's intent (e.g. priority_name \"Medium\") to its priority_id. Do not read priority_id from a board record — boards often have a null default_priority_id."
+      }
+    ]
   },
   {
     "id": "get-_api_v1_priorities_id",


### PR DESCRIPTION
## Ticket
Handles **alga0001973 — "MCP API registry gaps observed during ticket creation via agent."**

Four friction points were reported when an agent created a ticket through the MCP API. Verified each against the branch:

| # | Reported issue | Verdict | Action |
|---|----------------|---------|--------|
| 1 | No priorities endpoint; priority UUIDs had to be inferred from board defaults | Endpoint exists but was **undiscoverable** + thin metadata | Fixed |
| 2 | "Client Communication" board has null `default_priority_id` | Tenant data; real path is listing priorities | Resolved via #1 + guidance |
| 3 | Board↔status coupling, two round trips, under-documented | Documentation already present on the create endpoint | No change |
| 4 | "create ticket" ranks "Create ticket category" first | Still reproduced | Fixed |

## Root causes (both in the shared ranked-search engine)
- **#4** — For `create ticket`, the category endpoint won purely on a **+2.5 tag match**: it's tagged *"Ticket Categories"* (contains "ticket") while the real endpoint is tagged *"Work Management v1"*. Both paths end in "ticket", so the existing resource-tail bonus tied them.
- **#1** — A **singular/plural asymmetry**: the query token `priority` (singularized from "priorities") never substring-matched the field text *"priorities"*, so the priorities endpoint scored **zero on its own name** and lost to "List Tickets", which merely *mentions* priority.

## Changes
- **`packages/agent-tooling/src/registry/search.ts`**
  - Match singularized query tokens against a singularized view of each field (fixes #1; additive — only adds matches).
  - Add an **exact-resource-match** bonus when every path resource segment is named in the query (fixes #4). Symmetric within a resource, so intra-resource ordering is unchanged.
- **`packages/agent-tooling/src/registry/__tests__/search.test.ts`** — 5 regression tests mirroring the real tag/description layout.
- **`ee/docs/api-registry/lookups.json`** — rich `GET /api/v1/priorities` override: canonical source of `priority_id`, filter `item_type=ticket`, don't infer from a board's often-null `default_priority_id`; worked example.
- Regenerated **`server/src/lib/mcp/registry.generated.ts`** (CE) and **`ee/server/src/chat/registry/apiRegistry.generated.ts`** (EE).

## Verification (against the real regenerated registry, not fixtures)
```
create ticket          → POST /api/v1/tickets          43.0  (was behind categories/ticket 41.5)
list priorities        → GET  /api/v1/priorities        32.0  (was behind List Tickets)
priorities             → GET  /api/v1/priorities        18.5
create ticket category → POST /api/v1/categories/ticket 60.0  (no regression)
```
17/17 agent-tooling tests pass; typecheck clean; billing inventory contract test confirmed unaffected (`billing_cycle_alignment` count and service-period field refs unchanged in the CE artifact).

## Notes for reviewers
- Most of the diff in the two `*.generated.ts` files is **pre-existing drift**: the OpenAPI spec changed on 2026-06-18 but the artifacts were last regenerated 2026-06-12 (~344 lines/file). Regenerating to apply the priorities override necessarily syncs it. **No registry entries were added or removed.**
- The deployed MCP server won't reflect this until the registry + `@alga-psa/agent-tooling` are redeployed.
- Follow-up: there is no CI gate verifying the generated artifacts are fresh, which is why the drift went unnoticed.