### PR TITLE
perf(billing): render invoicing tab without waiting on recurring due-work fetch

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -1465,28 +1465,29 @@ export const getAvailableRecurringDueWork = withAuth(async (
     const asOf = options.dateRange?.to ?? toISODate(Temporal.Now.plainDateISO());
 
     try {
-        const candidateBillingPeriods = await fetchAvailableBillingPeriodsUnpaginated(
-            knex,
-            tenant,
-            options,
-        );
-        const clientMetadataById = await fetchClientBillingMetadataById(
-            knex,
-            tenant,
-            Array.from(
-                new Set(candidateBillingPeriods.map((period) => period.client_id).filter(Boolean)),
+        // candidateBillingPeriods and persistedDbRows both derive straight from
+        // `options`, so fetch them concurrently. clientMetadataById and
+        // rawMaterializationGaps both depend only on candidateBillingPeriods, so they
+        // run concurrently once it resolves. knex is a pooled connection (no shared
+        // transaction here), so these parallel queries are safe.
+        const [candidateBillingPeriods, persistedDbRows] = await Promise.all([
+            fetchAvailableBillingPeriodsUnpaginated(knex, tenant, options),
+            fetchPersistedRecurringDueWorkDbRows(knex, tenant, options),
+        ]);
+        const [clientMetadataById, rawMaterializationGaps] = await Promise.all([
+            fetchClientBillingMetadataById(
+                knex,
+                tenant,
+                Array.from(
+                    new Set(candidateBillingPeriods.map((period) => period.client_id).filter(Boolean)),
+                ),
             ),
-        );
-        const rawMaterializationGaps = await fetchClientCadenceMaterializationGaps(
-            knex,
-            tenant,
-            candidateBillingPeriods,
-        );
-        const persistedDbRows = await fetchPersistedRecurringDueWorkDbRows(
-            knex,
-            tenant,
-            options,
-        );
+            fetchClientCadenceMaterializationGaps(
+                knex,
+                tenant,
+                candidateBillingPeriods,
+            ),
+        ]);
         const groupingMetadataByRecordId = new Map<string, RecurringDueWorkGroupingMetadata>(
             persistedDbRows.map((row) => [
                 row.record_id,

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -49,12 +49,35 @@ import {
 } from "@alga-psa/ui/components/DropdownMenu";
 // Use ConfirmationDialog instead of AlertDialog
 import { ConfirmationDialog } from '@alga-psa/ui/components/ConfirmationDialog'; // Corrected import
-import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
+import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useRangeSelection } from '@alga-psa/ui/hooks';
 
 interface AutomaticInvoicesProps {
   onGenerateSuccess: () => void;
   refreshTrigger?: number;
+}
+
+// Placeholder for a DataTable while its (independent) section data loads, so the
+// rest of the screen can render immediately instead of waiting behind one spinner.
+function BillingTableSkeleton({ rows = 5, columns = 5 }: { rows?: number; columns?: number }) {
+  return (
+    <div className="w-full" data-testid="billing-table-skeleton" aria-hidden="true">
+      <div className="flex items-center gap-4 border-b border-[rgb(var(--color-border-200))] py-3">
+        {Array.from({ length: columns }).map((_, columnIndex) => (
+          <Skeleton key={`billing-skeleton-head-${columnIndex}`} className="h-4 flex-1" />
+        ))}
+      </div>
+      <div className="divide-y divide-[rgb(var(--color-border-100))]">
+        {Array.from({ length: rows }).map((_, rowIndex) => (
+          <div key={`billing-skeleton-row-${rowIndex}`} className="flex items-center gap-4 py-4">
+            {Array.from({ length: columns }).map((_, columnIndex) => (
+              <Skeleton key={`billing-skeleton-cell-${rowIndex}-${columnIndex}`} className="h-4 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 type AutomaticInvoiceGroupLabelKey = 'ready' | 'canCombine' | 'separate' | 'blocked' | 'notReady' | 'upcoming';
@@ -630,8 +653,8 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
   const [invoicedSearchTerm, setInvoicedSearchTerm] = useState('');
   const [debouncedInvoicedSearchTerm, setDebouncedInvoicedSearchTerm] = useState('');
   const [currentReadyPage, setCurrentReadyPage] = useState(1);
-  const [isInvoicedLoading, setIsInvoicedLoading] = useState(false);
-  const [isPeriodsLoading, setIsPeriodsLoading] = useState(false);
+  const [isInvoicedLoading, setIsInvoicedLoading] = useState(true);
+  const [isPeriodsLoading, setIsPeriodsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isRepairingAll, setIsRepairingAll] = useState(false);
   const [repairAllMessage, setRepairAllMessage] = useState<string | null>(null);
@@ -697,6 +720,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
   const [pageSize, setPageSize] = useState(10);
 
   const initialLoadDone = useRef(false);
+  const invoicedInitialLoadDone = useRef(false);
 
   // Debounce client filter for local ready/blocked row filtering and persist it in the URL.
   useEffect(() => {
@@ -1277,6 +1301,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
 
         setInvoicedPeriods(result.rows as InvoicedPeriod[]);
         setTotalInvoicedPeriods(result.total);
+        invoicedInitialLoadDone.current = true;
 
         // Clamp page if current page is beyond available pages
         const maxPage = Math.max(1, Math.ceil(result.total / invoicedPageSize));
@@ -1729,50 +1754,45 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
     router.push(`/msp/billing?${params.toString()}`);
   };
 
-  // Show combined loading state only during initial load (before any data has loaded)
-  const isInitialLoading = !initialLoadDone.current && (isPeriodsLoading || isInvoicedLoading);
+  // Each section gates its own first load independently so the screen renders
+  // immediately instead of waiting behind one combined spinner. The fix-list +
+  // Ready-to-Invoice block shares the slow due-work fetch; the History table loads
+  // on its own (separate, independent server action).
+  const isReadyInitialLoading = !initialLoadDone.current && isPeriodsLoading;
+  const isHistoryInitialLoading = !invoicedInitialLoadDone.current && isInvoicedLoading;
 
   return (
   // Removed TooltipProvider wrapper
       <>
-      {isInitialLoading ? (
-        <LoadingIndicator
-          layout="stacked"
-          className="py-10 text-muted-foreground"
-          spinnerProps={{ size: 'md' }}
-          text={t('automaticInvoices.loading.billingData', {
-            defaultValue: 'Loading billing data',
-          })}
-        />
-      ) : loadError ? (
-        <Alert variant="destructive" className="relative mb-4">
-          <AlertDescription>
-            <button
-              id="dismiss-load-error-button"
-              className="absolute top-2 right-2"
-              onClick={() => setLoadError(null)}
-            >
-              <X className="h-4 w-4" />
-            </button>
-            <p>{loadError}</p>
-            <Button
-              id="retry-load-button"
-              variant="outline"
-              size="sm"
-              className="mt-2"
-              onClick={() => {
-                setLoadError(null);
-                // Reset to page 1 to trigger a fresh load
-                setCurrentReadyPage(1);
-                setInvoicedCurrentPage(1);
-              }}
-            >
-              {t('common.actions.retry', { defaultValue: 'Retry' })}
-            </Button>
-          </AlertDescription>
-        </Alert>
-      ) : (
       <div className="space-y-8">
+        {loadError ? (
+          <Alert variant="destructive" className="relative">
+            <AlertDescription>
+              <button
+                id="dismiss-load-error-button"
+                className="absolute top-2 right-2"
+                onClick={() => setLoadError(null)}
+              >
+                <X className="h-4 w-4" />
+              </button>
+              <p>{loadError}</p>
+              <Button
+                id="retry-load-button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => {
+                  setLoadError(null);
+                  // Reset to page 1 to trigger a fresh load
+                  setCurrentReadyPage(1);
+                  setInvoicedCurrentPage(1);
+                }}
+              >
+                {t('common.actions.retry', { defaultValue: 'Retry' })}
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
         <div>
           {needsApprovalParentGroups.length > 0 ? (
             <div className="mb-6 rounded-md border border-warning/40 bg-warning/5 p-4" data-testid="needs-approval-section">
@@ -2238,6 +2258,9 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
               per-column dataIndex tricks (select/tags → compact ids) + mixed px/% widths because
               DataTable's auto-fit overrides plain widths; a first-class "column width spec" on
               DataTable would remove this dance. */}
+          {isReadyInitialLoading ? (
+            <BillingTableSkeleton columns={6} />
+          ) : (
           <DataTable
             id="automatic-invoices-table"
             key={`${currentReadyPage}-${pageSize}-${activeView}`}
@@ -2549,6 +2572,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
               return isSelected ? 'bg-primary-50' : '';
             }}
           />
+          )}
         </div>
 
         <div>
@@ -2569,6 +2593,9 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
               className="w-64"
             />
           </div>
+          {isHistoryInitialLoading ? (
+            <BillingTableSkeleton columns={6} />
+          ) : (
           <DataTable
             id="already-invoiced-table"
             data={invoicedPeriods}
@@ -2709,9 +2736,9 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
             onItemsPerPageChange={handleInvoicedPageSizeChange}
             totalItems={totalInvoicedPeriods}
           />
+          )}
         </div>
       </div>
-      )}
 
       <Dialog
         isOpen={showReverseDialog}

--- a/packages/billing/tests/AutomaticInvoices.i18n.test.ts
+++ b/packages/billing/tests/AutomaticInvoices.i18n.test.ts
@@ -227,7 +227,7 @@ describe('AutomaticInvoices i18n wiring contract', () => {
     }
   });
 
-  it('T010: materialization-gap panel and recurring-history error/loading copy resolve through msp/invoicing', () => {
+  it('T010: materialization-gap panel and recurring-history error copy resolve through msp/invoicing', () => {
     const source = read('../src/components/billing-dashboard/AutomaticInvoices.tsx');
     const en = readJson<Record<string, unknown>>(
       '../../../server/public/locales/en/msp/invoicing.json',
@@ -244,7 +244,6 @@ describe('AutomaticInvoices i18n wiring contract', () => {
       'automaticInvoices.errors.title',
       'automaticInvoices.errors.loadReady',
       'automaticInvoices.errors.loadHistory',
-      'automaticInvoices.loading.billingData',
       'common.labels.unknownClient',
       'common.actions.retry',
       'common.actions.close',


### PR DESCRIPTION
## Problem

Opening **Billing → Invoicing → Generate** felt slow. The `AutomaticInvoices` component blocked its *entire* render behind a single combined loading gate (`isInitialLoading`), so the whole tab — including the **independent** Recurring Invoice History table and all page chrome — waited on the slowest server action, `getAvailableRecurringDueWork`.

That action also runs the expensive client-cadence **materialization-gap** detection (a DB query plus an O(periods × recurring-lines) scan), so the gap work was effectively holding the screen hostage.

## Dependency analysis

- The **fix list** (materialization gaps) and the **Ready-to-Invoice** list come from the *same* action and are genuinely coupled — gaps suppress/block candidates (`applyClientCadenceMaterializationGapBlocks`), so they can't be split without a correctness regression. They now skeleton together.
- The **History** table is fully independent (separate `getRecurringInvoiceHistoryPaginated` action + state) and now loads on its own — this decoupling is the biggest perceived-speed win.

## Changes

1. **Parallelize independent DB fetches** in `getAvailableRecurringDueWork` via `Promise.all` (`candidateBillingPeriods` + `persistedDbRows`, then `clientMetadataById` + `materializationGaps`). Pure latency cut, no behavior change; gap→candidate blocking untouched. Safe because `knex` is a pooled connection with no shared transaction here.
2. **Remove the global loading gate** — per-section loading flags (`isReadyInitialLoading`, `isHistoryInitialLoading`) so chrome/headers/filters render immediately and the History table no longer waits on the slow fetch. The load-error banner moves to the top of the container.
3. **Per-section skeletons** — a small `BillingTableSkeleton` (built on the existing `Skeleton` primitive) stands in for each DataTable's first load; loading flags default to `true` to avoid a render flash.
4. Drop the now-dead `automaticInvoices.loading.billingData` i18n key from the static i18n test (the skeleton has no loading text).

## Testing

- `tsc --noEmit` across `packages/billing`: **0 errors**.
- `AutomaticInvoices.i18n.test.ts`: **7/7 pass**.
- The `groupedParentRows`/UI `.tsx` render tests fail with `React.act is not a function` — verified **pre-existing** (fails identically with these changes stashed); an environment/config issue in this worktree, not from this PR.

https://claude.ai/code/session_01UtBReLKCbRoaTitdPDUSNZ