### PR TITLE
fix(time-entry): normalize start/end timestamps to the minute on write

### DIFF
--- a/ee/packages/microsoft-teams/src/lib/teams/teamsPsaData.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/teamsPsaData.ts
@@ -4,6 +4,7 @@ import {
   computeWorkDateFields,
   createTenantKnex,
   resolveUserTimeZone,
+  truncateToMinute,
   withTransaction,
   type ServiceContext,
 } from '@alga-psa/db';
@@ -416,9 +417,14 @@ export async function createTeamsTimeEntry(params: {
   const { knex } = await createTenantKnex(params.tenantId);
   const userTimeZone = await resolveUserTimeZone(knex, params.tenantId, params.actorUserId);
   const { work_date, work_timezone } = computeWorkDateFields(params.startTime, userTimeZone);
+  // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape used
+  // by TimeEntryService and the workflow runtime. Teams supplies real meeting instants, so the
+  // seconds must be dropped here too or stored entries reproduce the off-by-one duration bug.
+  const startTime = truncateToMinute(params.startTime);
+  const endTime = truncateToMinute(params.endTime);
   const billableDuration = Math.max(
     0,
-    Math.round((new Date(params.endTime).getTime() - new Date(params.startTime).getTime()) / 60000)
+    Math.round((endTime.getTime() - startTime.getTime()) / 60000)
   );
   const entryId = randomUUID();
 
@@ -435,8 +441,8 @@ export async function createTeamsTimeEntry(params: {
     tenant: params.tenantId,
     entry_id: entryId,
     user_id: params.actorUserId,
-    start_time: params.startTime,
-    end_time: params.endTime,
+    start_time: startTime,
+    end_time: endTime,
     work_date,
     work_timezone,
     notes: params.notes || null,

--- a/packages/db/src/lib/workDate.ts
+++ b/packages/db/src/lib/workDate.ts
@@ -42,6 +42,22 @@ export function computeWorkDateFields(startTime: string | Date, timeZone: string
   };
 }
 
+/**
+ * Truncate an instant down to the minute (drop seconds and milliseconds).
+ *
+ * Time entries are authored and displayed at minute granularity (HH:MM pickers,
+ * whole-minute durations), but several write paths stamp real wall-clock instants —
+ * most notably the start/stop timer — leaving stray seconds behind. When start and
+ * end land on different seconds, a genuine 29m29s span renders as a clean
+ * 10:30–11:00 yet rounds to 29: the "off by one minute" duration bug. Normalizing on
+ * write keeps the stored instant consistent with what the UI shows. Seconds are
+ * timezone invariant, so flooring the epoch to the minute is unambiguous across zones.
+ */
+export function truncateToMinute(value: string | Date): Date {
+  const epochMs = toTemporalInstant(value).epochMilliseconds;
+  return new Date(Math.floor(epochMs / 60000) * 60000);
+}
+
 export async function resolveUserTimeZone(
   knexOrTrx: Knex | Knex.Transaction,
   tenant: string,

--- a/packages/scheduling/src/actions/timeEntryCrudActions.ts
+++ b/packages/scheduling/src/actions/timeEntryCrudActions.ts
@@ -22,7 +22,7 @@ import {
   UpdateTimeEntryApprovalStatusParams,
 } from './timeEntrySchemas'; // Import schemas
 import { getClientIdForWorkItem } from './timeEntryHelpers'; // Import helper
-import { computeWorkDateFields, resolveUserTimeZone } from '@alga-psa/db';
+import { computeWorkDateFields, resolveUserTimeZone, truncateToMinute } from '@alga-psa/db';
 import { assertCanActOnBehalf, assertCanApproveSubject } from './timeEntryDelegationAuth';
 import { toPlainDate } from '@alga-psa/core';
 import {
@@ -396,8 +396,10 @@ export const saveTimeEntry = withAuth(async (
       }
     }
 
-    const startDate = new Date(start_time);
-    const endDate = new Date(end_time);
+    // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape
+    // lives in TimeEntryService (create/update/stop); a shared persist layer would own it once.
+    const startDate = truncateToMinute(start_time);
+    const endDate = truncateToMinute(end_time);
     const actualDurationMinutes = Math.round((endDate.getTime() - startDate.getTime()) / 60000);
     
     // Always store actual duration, only set billable_duration to 0 if explicitly non-billable
@@ -416,8 +418,8 @@ export const saveTimeEntry = withAuth(async (
     const cleanedEntry = {
       work_item_id,
       work_item_type,
-      start_time,
-      end_time,
+      start_time: formatISO(startDate), // minute-truncated; keep stored instant in sync with duration
+      end_time: formatISO(endDate),
       work_date,
       work_timezone,
       billable_duration: finalBillableDuration,

--- a/packages/scheduling/src/components/time-management/time-entry/time-sheet/utils.ts
+++ b/packages/scheduling/src/components/time-management/time-entry/time-sheet/utils.ts
@@ -10,7 +10,11 @@ export function formatTimeForInput(date: Date): string {
 export function parseTimeToDate(timeString: string, baseDate: Date): Date {
   const [hours, minutes] = timeString.split(':').map(Number);
   const newDate = new Date(baseDate);
-  return setMinutes(setHours(newDate, hours || 0), minutes || 0);
+  const withTime = setMinutes(setHours(newDate, hours || 0), minutes || 0);
+  // HH:MM input is minute-granular; drop any seconds/ms inherited from baseDate so the
+  // computed duration matches the displayed times (see workDate.truncateToMinute).
+  withTime.setSeconds(0, 0);
+  return withTime;
 }
 
 export function calculateDuration(startTime: Date, endTime: Date): number {

--- a/server/src/lib/api/services/TimeEntryService.ts
+++ b/server/src/lib/api/services/TimeEntryService.ts
@@ -22,7 +22,7 @@ import {
 } from '../schemas/timeEntry';
 import { publishEvent, publishWorkflowEvent } from 'server/src/lib/eventBus/publishers';
 import { ForbiddenError, ValidationError } from '../middleware/apiMiddleware';
-import { computeWorkDateFields, resolveUserTimeZone } from 'server/src/lib/utils/workDate';
+import { computeWorkDateFields, resolveUserTimeZone, truncateToMinute } from 'server/src/lib/utils/workDate';
 import { buildTicketTimeEntryAddedWorkflowEvent } from './timeEntryWorkflowEvents';
 import { hasPermission } from '../../auth/rbac';
 
@@ -292,8 +292,11 @@ export class TimeEntryService extends BaseService<any> {
     const { work_date, work_timezone } = computeWorkDateFields(data.start_time, userTimeZone);
     
     // Calculate billable duration
-    const startTime = new Date(data.start_time);
-    const endTime = new Date(data.end_time);
+    // LEVERAGE: pattern time-entry-duration-persist — normalize-to-minute + Math.round duration
+    // is duplicated across this service (create/update/stop) and timeEntryCrudActions; a shared
+    // "normalize and persist a time entry" layer would own this once.
+    const startTime = truncateToMinute(data.start_time);
+    const endTime = truncateToMinute(data.end_time);
     const durationMs = endTime.getTime() - startTime.getTime();
     const billableDuration = Math.round(durationMs / (1000 * 60)); // minutes
 
@@ -333,6 +336,8 @@ export class TimeEntryService extends BaseService<any> {
     const timeEntryData = {
       ...dataWithoutBillable,
       user_id: context.userId, // Always use authenticated user
+      start_time: startTime, // persist minute-truncated instants, not the caller's seconds
+      end_time: endTime,
       work_date,
       work_timezone,
       billable_duration: is_billable !== false ? billableDuration : 0,
@@ -418,6 +423,10 @@ export class TimeEntryService extends BaseService<any> {
       updated_at: new Date()
     };
 
+    // Persist minute-truncated instants, not the caller's seconds.
+    if (data.start_time) updateData.start_time = truncateToMinute(data.start_time);
+    if (data.end_time) updateData.end_time = truncateToMinute(data.end_time);
+
     // work_date/work_timezone are server-controlled; recompute when start_time changes.
     if (data.start_time) {
       const userTimeZone = await resolveUserTimeZone(knex, context.tenant, context.userId);
@@ -428,11 +437,12 @@ export class TimeEntryService extends BaseService<any> {
 
     // Recalculate duration if times changed
     if (data.start_time || data.end_time) {
-      const startTime = new Date(data.start_time || existing.start_time);
-      const endTime = new Date(data.end_time || existing.end_time);
+      // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape.
+      const startTime = truncateToMinute(data.start_time || existing.start_time);
+      const endTime = truncateToMinute(data.end_time || existing.end_time);
       const durationMs = endTime.getTime() - startTime.getTime();
       const totalDuration = Math.round(durationMs / (1000 * 60));
-      
+
       // If is_billable is explicitly set, use it; otherwise keep existing billable status
       if (is_billable !== undefined) {
         updateData.billable_duration = is_billable ? totalDuration : 0;
@@ -443,8 +453,8 @@ export class TimeEntryService extends BaseService<any> {
       }
     } else if (is_billable !== undefined) {
       // is_billable changed but times didn't - recalculate billable_duration
-      const startTime = new Date(existing.start_time);
-      const endTime = new Date(existing.end_time);
+      const startTime = truncateToMinute(existing.start_time);
+      const endTime = truncateToMinute(existing.end_time);
       const durationMs = endTime.getTime() - startTime.getTime();
       const totalDuration = Math.round(durationMs / (1000 * 60));
       updateData.billable_duration = is_billable ? totalDuration : 0;
@@ -578,7 +588,10 @@ export class TimeEntryService extends BaseService<any> {
       throw new Error('Active time tracking session already exists. Please stop the current session first.');
     }
 
-    const startTime = new Date();
+    // Stamp the session start at minute granularity. Start and stop fire at different
+    // wall-clock instants, so keeping raw seconds is exactly what produced the off-by-one
+    // duration bug in stored entries.
+    const startTime = truncateToMinute(new Date());
     const userTimeZone = await resolveUserTimeZone(knex, context.tenant, context.userId);
     const { work_date, work_timezone } = computeWorkDateFields(startTime, userTimeZone);
 
@@ -633,8 +646,9 @@ export class TimeEntryService extends BaseService<any> {
 
     this.assertServiceIdPresent(data.service_id ?? session.service_id);
 
-    const endTime = data.end_time ? new Date(data.end_time) : new Date();
-    const startTime = new Date(session.start_time);
+    // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape.
+    const endTime = truncateToMinute(data.end_time ?? new Date());
+    const startTime = truncateToMinute(session.start_time);
     const durationMs = endTime.getTime() - startTime.getTime();
     const billableDuration = Math.round(durationMs / (1000 * 60)); // minutes
     

--- a/server/src/lib/utils/workDate.ts
+++ b/server/src/lib/utils/workDate.ts
@@ -1,3 +1,6 @@
+// LEVERAGE: friction workdate-dup — near-verbatim copy of packages/db/src/lib/workDate.ts.
+// Two copies of the same temporal helpers drift independently (truncateToMinute had to be
+// added in both). A single shared module would remove the parallel-maintenance tax.
 import { Knex } from 'knex';
 import { Temporal } from '@js-temporal/polyfill';
 
@@ -40,6 +43,22 @@ export function computeWorkDateFields(startTime: string | Date, timeZone: string
     work_timezone: tz,
     work_date: instant.toZonedDateTimeISO(tz).toPlainDate().toString(),
   };
+}
+
+/**
+ * Truncate an instant down to the minute (drop seconds and milliseconds).
+ *
+ * Time entries are authored and displayed at minute granularity (HH:MM pickers,
+ * whole-minute durations), but several write paths stamp real wall-clock instants —
+ * most notably the start/stop timer — leaving stray seconds behind. When start and
+ * end land on different seconds, a genuine 29m29s span renders as a clean
+ * 10:30–11:00 yet rounds to 29: the "off by one minute" duration bug. Normalizing on
+ * write keeps the stored instant consistent with what the UI shows. Seconds are
+ * timezone invariant, so flooring the epoch to the minute is unambiguous across zones.
+ */
+export function truncateToMinute(value: string | Date): Date {
+  const epochMs = toTemporalInstant(value).epochMilliseconds;
+  return new Date(Math.floor(epochMs / 60000) * 60000);
 }
 
 export async function resolveUserTimeZone(

--- a/shared/workflow/runtime/actions/businessOperations/timeDomain.ts
+++ b/shared/workflow/runtime/actions/businessOperations/timeDomain.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Knex } from 'knex';
-import { computeWorkDateFields, resolveUserTimeZone } from '@alga-psa/db/workDate';
+import { computeWorkDateFields, resolveUserTimeZone, truncateToMinute } from '@alga-psa/db/workDate';
 import { Temporal } from '@js-temporal/polyfill';
 import { toISODate, toPlainDate } from '@alga-psa/core';
 import { hasPermissionByUserId } from './shared';
@@ -1144,7 +1144,10 @@ export async function createWorkflowTimeEntry(params: {
     });
   }
 
-  const totalMinutes = Math.round((computedEndDate.getTime() - startDate.getTime()) / 60000);
+  // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape.
+  const startMinute = truncateToMinute(startDate);
+  const endMinute = truncateToMinute(computedEndDate);
+  const totalMinutes = Math.round((endMinute.getTime() - startMinute.getTime()) / 60000);
 
   const billableMinutesInput = input.billable_duration_minutes;
   if (billableMinutesInput !== undefined) {
@@ -1185,8 +1188,8 @@ export async function createWorkflowTimeEntry(params: {
 
   const entryId = uuidv4();
   const nowIso = new Date().toISOString();
-  const startIso = startDate.toISOString();
-  const endIso = computedEndDate.toISOString();
+  const startIso = startMinute.toISOString();
+  const endIso = endMinute.toISOString();
 
   const inserted = await trx('time_entries')
     .insert({
@@ -1450,7 +1453,10 @@ export async function updateWorkflowTimeEntry(params: {
     });
   }
 
-  const totalMinutes = Math.round((computedEndDate.getTime() - startDate.getTime()) / 60000);
+  // LEVERAGE: pattern time-entry-duration-persist — same normalize-to-minute + round shape.
+  const startMinute = truncateToMinute(startDate);
+  const endMinute = truncateToMinute(computedEndDate);
+  const totalMinutes = Math.round((endMinute.getTime() - startMinute.getTime()) / 60000);
   const existingBillableMinutes = Number(existing.billable_duration ?? 0);
   const billableMinutes = input.billable === false
     ? 0
@@ -1507,8 +1513,8 @@ export async function updateWorkflowTimeEntry(params: {
       service_id: resolvedServiceId,
       contract_line_id: resolvedContractLineId,
       tax_rate_id: hasOwnProperty(input, 'tax_rate_id') ? (input.tax_rate_id ?? null) : existing.tax_rate_id,
-      start_time: startDate.toISOString(),
-      end_time: computedEndDate.toISOString(),
+      start_time: startMinute.toISOString(),
+      end_time: endMinute.toISOString(),
       work_date,
       work_timezone,
       billable_duration: billableMinutes,


### PR DESCRIPTION
## Problem

Time entries showed durations off by one minute — e.g. a block reading **10:30 PM → 11:00 PM** displayed **29 min**, while **7:30 AM → 8:00 AM** correctly showed 30.

Root cause (confirmed against production data): the stored `start_time`/`end_time` carried stray, *unequal* seconds (e.g. `02:30:48` → `03:00:17`). The UI only renders `HH:MM`, so a true **29m29s** span looks like a clean 30-minute block but rounds to 29. Entries whose seconds were `:00` or identical on both ends landed exact, which is why only some were wrong.

The seconds originate from write paths that persist real wall-clock instants verbatim — most notably the **start/stop timer** (`TimeEntryService.startTimeTracking`/`stopTimeTracking`), which stamps `new Date()` at two different moments. The REST API schema (`z.string().datetime()`) also accepts second precision and nothing normalized it.

## Fix

The product is minute-granular end to end (HH:MM pickers, whole-minute durations), so seconds are an artifact. Add a shared `truncateToMinute()` helper and route **every** `time_entries` write path through it:

- **REST API** — `TimeEntryService` `create` / `update` / `startTimeTracking` / `stopTimeTracking`
- **UI server action** — `timeEntryCrudActions` (create + update)
- **Workflow runtime** — `timeDomain` create + update
- **Teams integration** — `createTeamsTimeEntry`
- **Edit-form live preview** — `parseTimeToDate` zeroes seconds/ms

Helper added to both `workDate.ts` copies (`@alga-psa/db` and the server-local duplicate).

**No migration** (intentional, per request): existing rows are corrected on their next save.

## Verification (live, against a running server)

- **REST create** with `22:30:48 → 23:00:17` → stored `22:30:00 / 23:00:00`, `billable_duration = 30` (pre-fix: `29`).
- **Timer** start/stop → `start` stamped `new Date()` stored as `:00`; `stop` with seconds-bearing end stored `:00`, `billable_duration = 30`.
- **Timesheet UI** renders `00:30` for the created entry.
- DB confirmed `extract(second …) = 0` on all written rows.

## Notes

- `// LEVERAGE:` markers flag the duplicated normalize-to-minute + `Math.round` duration shape across the write paths (8×) and the duplicated `workDate.ts` module (1×) — signalling a missing shared "normalize-and-persist a time entry" layer.
- Teams path is EE; verified the CE/`psa` paths live.

https://claude.ai/code/session_01VSpg6ncosfUsBLsZJ4P4ex
