### PR TITLE
Move inbound-email EE classifiers to ee/server/src

### DIFF
--- a/ee/server/src/services/email/inboundEmailRuleAiClassifier.ts
+++ b/ee/server/src/services/email/inboundEmailRuleAiClassifier.ts
@@ -1,0 +1,222 @@
+import { createTenantKnex } from '@alga-psa/db';
+import { ADD_ONS, tenantHasAddOn, type AddOnKey } from '@alga-psa/types';
+
+import { resolveChatProvider } from '../chatProviderResolver';
+
+type InboundEmailAiDecision = 'skip' | 'assign_client' | 'no_decision';
+type InboundEmailAiAllowedOutcome = 'skip' | 'assign_client';
+
+interface InboundEmailAiClassifierInput {
+  tenantId: string;
+  providerId: string;
+  ruleId: string;
+  instruction: string;
+  allowedOutcomes: InboundEmailAiAllowedOutcome[];
+  subject?: string;
+  fromAddress?: string;
+  bodyExcerpt: string;
+}
+
+interface InboundEmailAiClassifierResult {
+  decision: InboundEmailAiDecision;
+  extractedClientName?: string | null;
+  source: 'default' | 'ee_ai';
+  attempted: boolean;
+  reason:
+    | 'default_non_ai'
+    | 'ai_addon_missing'
+    | 'ai_classified'
+    | 'ai_failed'
+    | 'ai_invalid_output'
+    | 'ee_module_unavailable';
+  model?: string | null;
+  rawOutput?: string | null;
+  error?: string | null;
+}
+
+interface InboundEmailAiClassifier {
+  classify(input: InboundEmailAiClassifierInput): Promise<InboundEmailAiClassifierResult>;
+}
+
+const MAX_OUTPUT_TOKENS = 120;
+const MAX_CLIENT_NAME_LENGTH = 200;
+
+async function tenantHasAiAssistantAddOn(tenantId: string): Promise<boolean> {
+  const { knex } = await createTenantKnex(tenantId);
+  try {
+    const rows = await knex('tenant_addons')
+      .select('addon_key', 'expires_at')
+      .where({ tenant: tenantId }) as Array<{ addon_key: string; expires_at: string | Date | null }>;
+
+    const now = Date.now();
+    const knownAddOns = new Set<string>(Object.values(ADD_ONS));
+    const active = rows
+      .filter((row) => !row.expires_at || new Date(row.expires_at).getTime() > now)
+      .map((row) => row.addon_key)
+      .filter((value): value is AddOnKey => knownAddOns.has(value));
+
+    return tenantHasAddOn(active, ADD_ONS.AI_ASSISTANT);
+  } catch {
+    return false;
+  }
+}
+
+function buildSystemPrompt(allowedOutcomes: InboundEmailAiAllowedOutcome[]): string {
+  const outcomeDescriptions: string[] = [];
+  if (allowedOutcomes.includes('skip')) {
+    outcomeDescriptions.push(
+      '"skip" when the email should not create a ticket at all (pure notification/status noise)'
+    );
+  }
+  if (allowedOutcomes.includes('assign_client')) {
+    outcomeDescriptions.push(
+      '"assign_client" when the email is about an identifiable customer/client; put that customer name in client_name exactly as written in the email'
+    );
+  }
+
+  return [
+    'You classify an inbound email for an MSP ticketing system, following the operator instruction.',
+    `Allowed decisions: ${outcomeDescriptions.join('; ')}; "no_decision" when neither applies or you are unsure.`,
+    'Never guess a customer name that is not present in the email.',
+    'Respond with ONLY a JSON object: {"decision": "skip" | "assign_client" | "no_decision", "client_name": string | null}.',
+  ].join(' ');
+}
+
+function parseClassifierOutput(raw: unknown): {
+  decision: InboundEmailAiDecision;
+  clientName: string | null;
+} | null {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return null;
+  }
+
+  // Tolerate fenced or prefixed output by extracting the first JSON object.
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const decisionRaw = (parsed as Record<string, unknown>).decision;
+  const decision =
+    decisionRaw === 'skip' || decisionRaw === 'assign_client' || decisionRaw === 'no_decision'
+      ? decisionRaw
+      : null;
+  if (!decision) {
+    return null;
+  }
+
+  const clientNameRaw = (parsed as Record<string, unknown>).client_name;
+  const clientName =
+    typeof clientNameRaw === 'string' && clientNameRaw.trim()
+      ? clientNameRaw.trim().slice(0, MAX_CLIENT_NAME_LENGTH)
+      : null;
+
+  return { decision, clientName };
+}
+
+const eeClassifier: InboundEmailAiClassifier = {
+  async classify(input: InboundEmailAiClassifierInput): Promise<InboundEmailAiClassifierResult> {
+    const hasAiAssistant = await tenantHasAiAssistantAddOn(input.tenantId);
+    if (!hasAiAssistant) {
+      return {
+        decision: 'no_decision',
+        source: 'ee_ai',
+        attempted: false,
+        reason: 'ai_addon_missing',
+        model: null,
+        rawOutput: null,
+        error: null,
+      };
+    }
+
+    try {
+      const provider = await resolveChatProvider();
+      const completion = await provider.client.chat.completions.create({
+        model: provider.model,
+        messages: [
+          { role: 'system', content: buildSystemPrompt(input.allowedOutcomes) },
+          {
+            role: 'user',
+            content: [
+              `Operator instruction: ${input.instruction}`,
+              `From: ${input.fromAddress ?? ''}`,
+              `Subject: ${input.subject ?? ''}`,
+              `Body excerpt:\n${input.bodyExcerpt}`,
+            ].join('\n'),
+          },
+        ],
+        temperature: 0,
+        max_tokens: MAX_OUTPUT_TOKENS,
+        ...provider.requestOverrides.resolveTurnOverrides(),
+      });
+
+      // Structured usage line so per-tenant token metering can be layered on
+      // without changing this module.
+      const usage = completion.usage;
+      if (usage) {
+        console.info('inboundEmailRuleAiClassifier: token usage', {
+          tenantId: input.tenantId,
+          providerId: input.providerId,
+          ruleId: input.ruleId,
+          model: provider.model,
+          usage,
+        });
+      }
+
+      const rawOutput = completion.choices?.[0]?.message?.content ?? '';
+      const parsed = parseClassifierOutput(rawOutput);
+      if (!parsed) {
+        return {
+          decision: 'no_decision',
+          source: 'ee_ai',
+          attempted: true,
+          reason: 'ai_invalid_output',
+          model: provider.model,
+          rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
+          error: 'AI returned an unexpected inbound email classification payload.',
+        };
+      }
+
+      const decision =
+        parsed.decision !== 'no_decision' && !input.allowedOutcomes.includes(parsed.decision)
+          ? 'no_decision'
+          : parsed.decision;
+
+      return {
+        decision,
+        extractedClientName: decision === 'assign_client' ? parsed.clientName : null,
+        source: 'ee_ai',
+        attempted: true,
+        reason: 'ai_classified',
+        model: provider.model,
+        rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        decision: 'no_decision',
+        source: 'ee_ai',
+        attempted: true,
+        reason: 'ai_failed',
+        model: null,
+        rawOutput: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+};
+
+export function createInboundEmailRuleAiClassifier(): InboundEmailAiClassifier {
+  return eeClassifier;
+}

--- a/ee/server/src/services/email/inboundReplyAcknowledgementDecider.ts
+++ b/ee/server/src/services/email/inboundReplyAcknowledgementDecider.ts
@@ -1,0 +1,197 @@
+import { createTenantKnex } from '@alga-psa/db';
+import { ADD_ONS, tenantHasAddOn, type AddOnKey } from '@alga-psa/types';
+
+import { resolveChatProvider } from '../chatProviderResolver';
+
+type InboundReplyAckDecision = 'ACK' | 'NOT_ACK';
+
+interface InboundReplyAckDeciderInput {
+  tenantId: string;
+  boardId: string;
+  ticketId: string;
+  subject?: string;
+  text: string;
+}
+
+interface InboundReplyAckDeciderResult {
+  decision: InboundReplyAckDecision;
+  source: 'default' | 'ee_ai';
+  attempted: boolean;
+  reason:
+    | 'default_non_ai'
+    | 'board_suppression_disabled'
+    | 'ai_addon_missing'
+    | 'message_not_candidate'
+    | 'ai_classified'
+    | 'ai_failed'
+    | 'ai_invalid_output'
+    | 'ee_module_unavailable';
+  model?: string | null;
+  rawOutput?: string | null;
+  error?: string | null;
+}
+
+interface InboundReplyAcknowledgementDecider {
+  decide(input: InboundReplyAckDeciderInput): Promise<InboundReplyAckDeciderResult>;
+}
+
+const ACK_PROMPT = [
+  'Classify this customer ticket reply.',
+  'Return exactly one token: ACK or NOT_ACK.',
+  'ACK only when it is a short acknowledgement with no request, no question, and no new work.',
+  'Otherwise return NOT_ACK.',
+].join(' ');
+
+const ACK_CANDIDATE_MAX_CHARS = 280;
+const ACK_CANDIDATE_MAX_WORDS = 40;
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function isAckCandidate(text: string): boolean {
+  const normalized = normalizeText(text).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  const words = normalized.split(' ').filter(Boolean);
+  if (normalized.length > ACK_CANDIDATE_MAX_CHARS || words.length > ACK_CANDIDATE_MAX_WORDS) {
+    return false;
+  }
+
+  if (normalized.includes('?')) {
+    return false;
+  }
+
+  const cuePatterns = [
+    /\bthanks?\b/,
+    /\bthank you\b/,
+    /\bgot it\b/,
+    /\blooks good\b/,
+    /\bok(ay)?\b/,
+    /\bperfect\b/,
+    /\bappreciate\b/,
+    /\bresolved\b/,
+  ];
+
+  return cuePatterns.some((pattern) => pattern.test(normalized));
+}
+
+async function tenantHasAiAssistantAddOn(tenantId: string): Promise<boolean> {
+  const { knex } = await createTenantKnex(tenantId);
+  try {
+    const rows = await knex('tenant_addons')
+      .select('addon_key', 'expires_at')
+      .where({ tenant: tenantId }) as Array<{ addon_key: string; expires_at: string | Date | null }>;
+
+    const now = Date.now();
+    const knownAddOns = new Set<string>(Object.values(ADD_ONS));
+    const active = rows
+      .filter((row) => !row.expires_at || new Date(row.expires_at).getTime() > now)
+      .map((row) => row.addon_key)
+      .filter((value): value is AddOnKey => knownAddOns.has(value));
+
+    return tenantHasAddOn(active, ADD_ONS.AI_ASSISTANT);
+  } catch {
+    return false;
+  }
+}
+
+function parseAckDecision(raw: unknown): 'ACK' | 'NOT_ACK' | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  const normalized = raw.trim().toUpperCase();
+  if (normalized === 'ACK' || normalized === 'NOT_ACK') {
+    return normalized;
+  }
+
+  return null;
+}
+
+const eeDecider: InboundReplyAcknowledgementDecider = {
+  async decide(input: InboundReplyAckDeciderInput): Promise<InboundReplyAckDeciderResult> {
+    const normalizedText = normalizeText(input.text);
+    if (!isAckCandidate(normalizedText)) {
+      return {
+        decision: 'NOT_ACK',
+        source: 'ee_ai',
+        attempted: false,
+        reason: 'message_not_candidate',
+        model: null,
+        rawOutput: null,
+        error: null,
+      };
+    }
+
+    const hasAiAssistant = await tenantHasAiAssistantAddOn(input.tenantId);
+    if (!hasAiAssistant) {
+      return {
+        decision: 'NOT_ACK',
+        source: 'ee_ai',
+        attempted: false,
+        reason: 'ai_addon_missing',
+        model: null,
+        rawOutput: null,
+        error: null,
+      };
+    }
+
+    try {
+      const provider = await resolveChatProvider();
+      const completion = await provider.client.chat.completions.create({
+        model: provider.model,
+        messages: [
+          { role: 'system', content: ACK_PROMPT },
+          {
+            role: 'user',
+            content: `Subject: ${input.subject ?? ''}\nReply: ${normalizedText}`,
+          },
+        ],
+        temperature: 0,
+        max_tokens: 8,
+        ...provider.requestOverrides.resolveTurnOverrides(),
+      });
+
+      const rawOutput = completion.choices?.[0]?.message?.content ?? '';
+      const decision = parseAckDecision(rawOutput);
+      if (!decision) {
+        return {
+          decision: 'NOT_ACK',
+          source: 'ee_ai',
+          attempted: true,
+          reason: 'ai_invalid_output',
+          model: provider.model,
+          rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
+          error: 'AI returned an unexpected acknowledgement classification payload.',
+        };
+      }
+
+      return {
+        decision,
+        source: 'ee_ai',
+        attempted: true,
+        reason: 'ai_classified',
+        model: provider.model,
+        rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        decision: 'NOT_ACK',
+        source: 'ee_ai',
+        attempted: true,
+        reason: 'ai_failed',
+        model: null,
+        rawOutput: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+};
+
+export function createInboundReplyAcknowledgementDecider(): InboundReplyAcknowledgementDecider {
+  return eeDecider;
+}

--- a/packages/ee/src/services/email/inboundEmailRuleAiClassifier.ts
+++ b/packages/ee/src/services/email/inboundEmailRuleAiClassifier.ts
@@ -1,222 +1,35 @@
-import { createTenantKnex } from '@alga-psa/db';
-import { ADD_ONS, tenantHasAddOn, type AddOnKey } from '@alga-psa/types';
-
-import { resolveChatProvider } from '../chatProviderResolver';
-
+// CE stub. The real implementation lives in
+// ee/server/src/services/email/inboundEmailRuleAiClassifier.ts and is loaded
+// via the @ee alias in Enterprise Edition builds only.
 type InboundEmailAiDecision = 'skip' | 'assign_client' | 'no_decision';
-type InboundEmailAiAllowedOutcome = 'skip' | 'assign_client';
-
-interface InboundEmailAiClassifierInput {
-  tenantId: string;
-  providerId: string;
-  ruleId: string;
-  instruction: string;
-  allowedOutcomes: InboundEmailAiAllowedOutcome[];
-  subject?: string;
-  fromAddress?: string;
-  bodyExcerpt: string;
-}
 
 interface InboundEmailAiClassifierResult {
   decision: InboundEmailAiDecision;
   extractedClientName?: string | null;
   source: 'default' | 'ee_ai';
   attempted: boolean;
-  reason:
-    | 'default_non_ai'
-    | 'ai_addon_missing'
-    | 'ai_classified'
-    | 'ai_failed'
-    | 'ai_invalid_output'
-    | 'ee_module_unavailable';
+  reason: 'ee_module_unavailable';
   model?: string | null;
   rawOutput?: string | null;
   error?: string | null;
 }
 
 interface InboundEmailAiClassifier {
-  classify(input: InboundEmailAiClassifierInput): Promise<InboundEmailAiClassifierResult>;
+  classify(): Promise<InboundEmailAiClassifierResult>;
 }
 
-const MAX_OUTPUT_TOKENS = 120;
-const MAX_CLIENT_NAME_LENGTH = 200;
-
-async function tenantHasAiAssistantAddOn(tenantId: string): Promise<boolean> {
-  const { knex } = await createTenantKnex(tenantId);
-  try {
-    const rows = await knex('tenant_addons')
-      .select('addon_key', 'expires_at')
-      .where({ tenant: tenantId }) as Array<{ addon_key: string; expires_at: string | Date | null }>;
-
-    const now = Date.now();
-    const knownAddOns = new Set<string>(Object.values(ADD_ONS));
-    const active = rows
-      .filter((row) => !row.expires_at || new Date(row.expires_at).getTime() > now)
-      .map((row) => row.addon_key)
-      .filter((value): value is AddOnKey => knownAddOns.has(value));
-
-    return tenantHasAddOn(active, ADD_ONS.AI_ASSISTANT);
-  } catch {
-    return false;
-  }
-}
-
-function buildSystemPrompt(allowedOutcomes: InboundEmailAiAllowedOutcome[]): string {
-  const outcomeDescriptions: string[] = [];
-  if (allowedOutcomes.includes('skip')) {
-    outcomeDescriptions.push(
-      '"skip" when the email should not create a ticket at all (pure notification/status noise)'
-    );
-  }
-  if (allowedOutcomes.includes('assign_client')) {
-    outcomeDescriptions.push(
-      '"assign_client" when the email is about an identifiable customer/client; put that customer name in client_name exactly as written in the email'
-    );
-  }
-
-  return [
-    'You classify an inbound email for an MSP ticketing system, following the operator instruction.',
-    `Allowed decisions: ${outcomeDescriptions.join('; ')}; "no_decision" when neither applies or you are unsure.`,
-    'Never guess a customer name that is not present in the email.',
-    'Respond with ONLY a JSON object: {"decision": "skip" | "assign_client" | "no_decision", "client_name": string | null}.',
-  ].join(' ');
-}
-
-function parseClassifierOutput(raw: unknown): {
-  decision: InboundEmailAiDecision;
-  clientName: string | null;
-} | null {
-  if (typeof raw !== 'string' || !raw.trim()) {
-    return null;
-  }
-
-  // Tolerate fenced or prefixed output by extracting the first JSON object.
-  const jsonMatch = raw.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonMatch[0]);
-  } catch {
-    return null;
-  }
-
-  if (!parsed || typeof parsed !== 'object') {
-    return null;
-  }
-
-  const decisionRaw = (parsed as Record<string, unknown>).decision;
-  const decision =
-    decisionRaw === 'skip' || decisionRaw === 'assign_client' || decisionRaw === 'no_decision'
-      ? decisionRaw
-      : null;
-  if (!decision) {
-    return null;
-  }
-
-  const clientNameRaw = (parsed as Record<string, unknown>).client_name;
-  const clientName =
-    typeof clientNameRaw === 'string' && clientNameRaw.trim()
-      ? clientNameRaw.trim().slice(0, MAX_CLIENT_NAME_LENGTH)
-      : null;
-
-  return { decision, clientName };
-}
-
-const eeClassifier: InboundEmailAiClassifier = {
-  async classify(input: InboundEmailAiClassifierInput): Promise<InboundEmailAiClassifierResult> {
-    const hasAiAssistant = await tenantHasAiAssistantAddOn(input.tenantId);
-    if (!hasAiAssistant) {
+export function createInboundEmailRuleAiClassifier(): InboundEmailAiClassifier {
+  return {
+    async classify() {
       return {
         decision: 'no_decision',
         source: 'ee_ai',
         attempted: false,
-        reason: 'ai_addon_missing',
+        reason: 'ee_module_unavailable',
         model: null,
         rawOutput: null,
         error: null,
       };
-    }
-
-    try {
-      const provider = await resolveChatProvider();
-      const completion = await provider.client.chat.completions.create({
-        model: provider.model,
-        messages: [
-          { role: 'system', content: buildSystemPrompt(input.allowedOutcomes) },
-          {
-            role: 'user',
-            content: [
-              `Operator instruction: ${input.instruction}`,
-              `From: ${input.fromAddress ?? ''}`,
-              `Subject: ${input.subject ?? ''}`,
-              `Body excerpt:\n${input.bodyExcerpt}`,
-            ].join('\n'),
-          },
-        ],
-        temperature: 0,
-        max_tokens: MAX_OUTPUT_TOKENS,
-        ...provider.requestOverrides.resolveTurnOverrides(),
-      });
-
-      // Structured usage line so per-tenant token metering can be layered on
-      // without changing this module.
-      const usage = completion.usage;
-      if (usage) {
-        console.info('inboundEmailRuleAiClassifier: token usage', {
-          tenantId: input.tenantId,
-          providerId: input.providerId,
-          ruleId: input.ruleId,
-          model: provider.model,
-          usage,
-        });
-      }
-
-      const rawOutput = completion.choices?.[0]?.message?.content ?? '';
-      const parsed = parseClassifierOutput(rawOutput);
-      if (!parsed) {
-        return {
-          decision: 'no_decision',
-          source: 'ee_ai',
-          attempted: true,
-          reason: 'ai_invalid_output',
-          model: provider.model,
-          rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
-          error: 'AI returned an unexpected inbound email classification payload.',
-        };
-      }
-
-      const decision =
-        parsed.decision !== 'no_decision' && !input.allowedOutcomes.includes(parsed.decision)
-          ? 'no_decision'
-          : parsed.decision;
-
-      return {
-        decision,
-        extractedClientName: decision === 'assign_client' ? parsed.clientName : null,
-        source: 'ee_ai',
-        attempted: true,
-        reason: 'ai_classified',
-        model: provider.model,
-        rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
-        error: null,
-      };
-    } catch (error) {
-      return {
-        decision: 'no_decision',
-        source: 'ee_ai',
-        attempted: true,
-        reason: 'ai_failed',
-        model: null,
-        rawOutput: null,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  },
-};
-
-export function createInboundEmailRuleAiClassifier(): InboundEmailAiClassifier {
-  return eeClassifier;
+    },
+  };
 }

--- a/packages/ee/src/services/email/inboundReplyAcknowledgementDecider.ts
+++ b/packages/ee/src/services/email/inboundReplyAcknowledgementDecider.ts
@@ -1,197 +1,34 @@
-import { createTenantKnex } from '@alga-psa/db';
-import { ADD_ONS, tenantHasAddOn, type AddOnKey } from '@alga-psa/types';
-
-import { resolveChatProvider } from '../chatProviderResolver';
-
+// CE stub. The real implementation lives in
+// ee/server/src/services/email/inboundReplyAcknowledgementDecider.ts and is
+// loaded via the @ee alias in Enterprise Edition builds only.
 type InboundReplyAckDecision = 'ACK' | 'NOT_ACK';
-
-interface InboundReplyAckDeciderInput {
-  tenantId: string;
-  boardId: string;
-  ticketId: string;
-  subject?: string;
-  text: string;
-}
 
 interface InboundReplyAckDeciderResult {
   decision: InboundReplyAckDecision;
   source: 'default' | 'ee_ai';
   attempted: boolean;
-  reason:
-    | 'default_non_ai'
-    | 'board_suppression_disabled'
-    | 'ai_addon_missing'
-    | 'message_not_candidate'
-    | 'ai_classified'
-    | 'ai_failed'
-    | 'ai_invalid_output'
-    | 'ee_module_unavailable';
+  reason: 'ee_module_unavailable';
   model?: string | null;
   rawOutput?: string | null;
   error?: string | null;
 }
 
 interface InboundReplyAcknowledgementDecider {
-  decide(input: InboundReplyAckDeciderInput): Promise<InboundReplyAckDeciderResult>;
+  decide(): Promise<InboundReplyAckDeciderResult>;
 }
-
-const ACK_PROMPT = [
-  'Classify this customer ticket reply.',
-  'Return exactly one token: ACK or NOT_ACK.',
-  'ACK only when it is a short acknowledgement with no request, no question, and no new work.',
-  'Otherwise return NOT_ACK.',
-].join(' ');
-
-const ACK_CANDIDATE_MAX_CHARS = 280;
-const ACK_CANDIDATE_MAX_WORDS = 40;
-
-function normalizeText(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
-}
-
-function isAckCandidate(text: string): boolean {
-  const normalized = normalizeText(text).toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-
-  const words = normalized.split(' ').filter(Boolean);
-  if (normalized.length > ACK_CANDIDATE_MAX_CHARS || words.length > ACK_CANDIDATE_MAX_WORDS) {
-    return false;
-  }
-
-  if (normalized.includes('?')) {
-    return false;
-  }
-
-  const cuePatterns = [
-    /\bthanks?\b/,
-    /\bthank you\b/,
-    /\bgot it\b/,
-    /\blooks good\b/,
-    /\bok(ay)?\b/,
-    /\bperfect\b/,
-    /\bappreciate\b/,
-    /\bresolved\b/,
-  ];
-
-  return cuePatterns.some((pattern) => pattern.test(normalized));
-}
-
-async function tenantHasAiAssistantAddOn(tenantId: string): Promise<boolean> {
-  const { knex } = await createTenantKnex(tenantId);
-  try {
-    const rows = await knex('tenant_addons')
-      .select('addon_key', 'expires_at')
-      .where({ tenant: tenantId }) as Array<{ addon_key: string; expires_at: string | Date | null }>;
-
-    const now = Date.now();
-    const knownAddOns = new Set<string>(Object.values(ADD_ONS));
-    const active = rows
-      .filter((row) => !row.expires_at || new Date(row.expires_at).getTime() > now)
-      .map((row) => row.addon_key)
-      .filter((value): value is AddOnKey => knownAddOns.has(value));
-
-    return tenantHasAddOn(active, ADD_ONS.AI_ASSISTANT);
-  } catch {
-    return false;
-  }
-}
-
-function parseAckDecision(raw: unknown): 'ACK' | 'NOT_ACK' | null {
-  if (typeof raw !== 'string') {
-    return null;
-  }
-
-  const normalized = raw.trim().toUpperCase();
-  if (normalized === 'ACK' || normalized === 'NOT_ACK') {
-    return normalized;
-  }
-
-  return null;
-}
-
-const eeDecider: InboundReplyAcknowledgementDecider = {
-  async decide(input: InboundReplyAckDeciderInput): Promise<InboundReplyAckDeciderResult> {
-    const normalizedText = normalizeText(input.text);
-    if (!isAckCandidate(normalizedText)) {
-      return {
-        decision: 'NOT_ACK',
-        source: 'ee_ai',
-        attempted: false,
-        reason: 'message_not_candidate',
-        model: null,
-        rawOutput: null,
-        error: null,
-      };
-    }
-
-    const hasAiAssistant = await tenantHasAiAssistantAddOn(input.tenantId);
-    if (!hasAiAssistant) {
-      return {
-        decision: 'NOT_ACK',
-        source: 'ee_ai',
-        attempted: false,
-        reason: 'ai_addon_missing',
-        model: null,
-        rawOutput: null,
-        error: null,
-      };
-    }
-
-    try {
-      const provider = await resolveChatProvider();
-      const completion = await provider.client.chat.completions.create({
-        model: provider.model,
-        messages: [
-          { role: 'system', content: ACK_PROMPT },
-          {
-            role: 'user',
-            content: `Subject: ${input.subject ?? ''}\nReply: ${normalizedText}`,
-          },
-        ],
-        temperature: 0,
-        max_tokens: 8,
-        ...provider.requestOverrides.resolveTurnOverrides(),
-      });
-
-      const rawOutput = completion.choices?.[0]?.message?.content ?? '';
-      const decision = parseAckDecision(rawOutput);
-      if (!decision) {
-        return {
-          decision: 'NOT_ACK',
-          source: 'ee_ai',
-          attempted: true,
-          reason: 'ai_invalid_output',
-          model: provider.model,
-          rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
-          error: 'AI returned an unexpected acknowledgement classification payload.',
-        };
-      }
-
-      return {
-        decision,
-        source: 'ee_ai',
-        attempted: true,
-        reason: 'ai_classified',
-        model: provider.model,
-        rawOutput: typeof rawOutput === 'string' ? rawOutput : JSON.stringify(rawOutput),
-        error: null,
-      };
-    } catch (error) {
-      return {
-        decision: 'NOT_ACK',
-        source: 'ee_ai',
-        attempted: true,
-        reason: 'ai_failed',
-        model: null,
-        rawOutput: null,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  },
-};
 
 export function createInboundReplyAcknowledgementDecider(): InboundReplyAcknowledgementDecider {
-  return eeDecider;
+  return {
+    async decide() {
+      return {
+        decision: 'NOT_ACK',
+        source: 'ee_ai',
+        attempted: false,
+        reason: 'ee_module_unavailable',
+        model: null,
+        rawOutput: null,
+        error: null,
+      };
+    },
+  };
 }

--- a/shared/services/email/inboundEmailRules/aiClassifier.ts
+++ b/shared/services/email/inboundEmailRules/aiClassifier.ts
@@ -65,8 +65,8 @@ async function loadEeClassifier(): Promise<InboundEmailAiClassifier | null> {
 
   eeClassifierLoadAttempted = true;
   try {
-    // @ts-ignore -- @ee resolves to packages/ee/src only in EE builds; other
-    // tsconfigs (e.g. ee/server) map @ee elsewhere and the catch handles it.
+    // @ts-ignore -- @ee resolves to the real impl (ee/server/src) in EE builds
+    // and to a no-op stub (packages/ee/src) in CE; the catch covers either.
     const module = await import('@ee/services/email/inboundEmailRuleAiClassifier');
     if (module && typeof module.createInboundEmailRuleAiClassifier === 'function') {
       eeClassifier = module.createInboundEmailRuleAiClassifier();


### PR DESCRIPTION
The inbound-email AI classifier and reply-acknowledgement decider lived only in packages/ee/src (the CE-stub tree), so in EE builds @ee resolved to ee/server/src and the dynamic import failed "module not found" — silently degrading to the no-op default. Relocate the real implementations to ee/server/src/services/email and leave dependency-free CE stubs (returning `ee_module_unavailable`) in packages/ee/src so no EE deps leak into the CE bundle. Fix the backwards @ee alias comment in shared/aiClassifier.

"But which is the real classifier and which is the painted one?" asked Alice. "Why, the one on the proper side of the looking-glass, of course," said the Cat, fading until only its `ee_module_unavailable` grin remained. 🐈🪞✉️