### PR TITLE
Show DNS host separately from full record name

### DIFF
--- a/ee/server/src/components/settings/email/DnsRecordInstructions.tsx
+++ b/ee/server/src/components/settings/email/DnsRecordInstructions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Copy, CheckCircle2, AlertTriangle, XCircle, Clock } from 'lucide-react';
+import { Copy, CheckCircle2, AlertTriangle, XCircle, Clock, Info } from 'lucide-react';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Card, CardContent } from '@alga-psa/ui/components/Card';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -14,6 +14,7 @@ interface DnsRecordInstructionsProps {
   emptyMessage?: string;
   detections?: DnsLookupResult[];
   lastCheckedAt?: string | null;
+  domain?: string;
 }
 
 type DetectionStatus = 'matched' | 'mismatch' | 'missing' | 'unknown';
@@ -58,6 +59,23 @@ const formatTimestamp = (value?: string | null) => {
 const buildRecordKey = (record: DnsRecord) =>
   `${record.type}:${record.name}:${record.value ?? ''}`.toLowerCase();
 
+// Most DNS providers append the apex domain automatically, so the "host"
+// users should enter is the record name with the apex stripped (or `@` for the apex itself).
+const toHostLabel = (name: string, domain?: string): string => {
+  if (!domain) {
+    return name;
+  }
+  const lowerName = name.toLowerCase();
+  const lowerDomain = domain.toLowerCase();
+  if (lowerName === lowerDomain) {
+    return '@';
+  }
+  if (lowerName.endsWith(`.${lowerDomain}`)) {
+    return name.slice(0, name.length - domain.length - 1);
+  }
+  return name;
+};
+
 function getDetectionStatus(record: DnsRecord, detection?: DnsLookupResult): DetectionStatus {
   if (!detection) {
     return 'unknown';
@@ -69,6 +87,47 @@ function getDetectionStatus(record: DnsRecord, detection?: DnsLookupResult): Det
     return 'missing';
   }
   return 'mismatch';
+}
+
+function CopyField({
+  label,
+  value,
+  onCopy,
+  ariaLabel,
+  buttonId,
+  automationId,
+  muted,
+}: {
+  label: string;
+  value: string;
+  onCopy: (value: string) => void;
+  ariaLabel: string;
+  buttonId: string;
+  automationId?: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-gray-500">{label}</Label>
+      <div className="flex items-start gap-2">
+        <code
+          className={`flex-1 break-all rounded bg-gray-100 px-2 py-1 text-xs ${muted ? 'text-gray-500' : 'text-gray-800'}`}
+        >
+          {value}
+        </code>
+        <Button
+          id={buttonId}
+          variant="ghost"
+          size="sm"
+          onClick={() => onCopy(value)}
+          aria-label={ariaLabel}
+          data-automation-id={automationId}
+        >
+          <Copy className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function DetectedValues({ values }: { values: string[] }) {
@@ -91,7 +150,7 @@ function DetectedValues({ values }: { values: string[] }) {
   );
 }
 
-export default function DnsRecordInstructions({ records, emptyMessage, detections, lastCheckedAt }: DnsRecordInstructionsProps) {
+export default function DnsRecordInstructions({ records, emptyMessage, detections, lastCheckedAt, domain }: DnsRecordInstructionsProps) {
   const { t } = useTranslation('msp/email-providers');
 
   if (!records || records.length === 0) {
@@ -131,7 +190,15 @@ export default function DnsRecordInstructions({ records, emptyMessage, detection
         <div className="text-xs text-gray-500">{t('managed.dnsRecords.lastCheckedNoRecords', { checkedAt: lastCheckedReadable })}</div>
       ) : null}
 
+      {domain ? (
+        <div className="flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
+          <Info className="h-4 w-4 shrink-0 mt-0.5" />
+          <p>{t('managed.dnsRecords.hostHint', { domain })}</p>
+        </div>
+      ) : null}
+
       {records.map((record, index) => {
+        const host = toHostLabel(record.name, domain);
         const detection = detectionMap.get(buildRecordKey(record));
         const status = getDetectionStatus(record, detection);
         const statusStyle = STATUS_STYLES[status];
@@ -144,26 +211,40 @@ export default function DnsRecordInstructions({ records, emptyMessage, detection
             data-record-type={record.type}
             data-dns-status={status}
           >
-            <CardContent className="py-4 space-y-2">
+            <CardContent className="py-4 space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="flex items-center gap-3">
-                  <span className="text-xs font-semibold uppercase text-gray-500">{record.type}</span>
-                  <span className="text-sm text-gray-700">{record.name}</span>
-                </div>
-              <Button
-                id={`managed-domain-dns-copy-${record.type}-${index}`}
-                variant="ghost"
-                size="sm"
-                onClick={() => handleCopy(record.value)}
-                aria-label={t('managed.dnsRecords.copyAriaLabel')}
-                data-automation-id="managed-domain-copy-dns"
-              >
-                <Copy className="h-4 w-4 mr-2" />
-                {t('managed.dnsRecords.copyButton')}
-              </Button>
-            </div>
+                <span className="text-xs font-semibold uppercase text-gray-500">{record.type}</span>
+              </div>
 
-            <div className="text-sm text-gray-800 break-all">{record.value}</div>
+              <CopyField
+                label={t('managed.dnsRecords.hostLabel')}
+                value={host}
+                onCopy={handleCopy}
+                ariaLabel={t('managed.dnsRecords.copyHostAriaLabel')}
+                buttonId={`managed-domain-dns-copy-host-${record.type}-${index}`}
+                automationId="managed-domain-copy-dns-host"
+              />
+
+              {host !== record.name ? (
+                <CopyField
+                  label={t('managed.dnsRecords.fqdnLabel')}
+                  value={record.name}
+                  onCopy={handleCopy}
+                  ariaLabel={t('managed.dnsRecords.copyFqdnAriaLabel')}
+                  buttonId={`managed-domain-dns-copy-fqdn-${record.type}-${index}`}
+                  automationId="managed-domain-copy-dns-fqdn"
+                  muted
+                />
+              ) : null}
+
+              <CopyField
+                label={t('managed.dnsRecords.valueLabel')}
+                value={record.value}
+                onCopy={handleCopy}
+                ariaLabel={t('managed.dnsRecords.copyAriaLabel')}
+                buttonId={`managed-domain-dns-copy-${record.type}-${index}`}
+                automationId="managed-domain-copy-dns"
+              />
 
             <div className="flex flex-wrap gap-2 items-center">
               <span

--- a/ee/server/src/components/settings/email/ManagedDomainList.tsx
+++ b/ee/server/src/components/settings/email/ManagedDomainList.tsx
@@ -158,6 +158,7 @@ export default function ManagedDomainList({
                   emptyMessage={emptyMessage}
                   detections={dnsLookupResults}
                   lastCheckedAt={domain.dnsLastCheckedAt}
+                  domain={domain.domain}
                 />
               </div>
             </CardContent>

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Wir haben diesen Eintrag im DNS noch nicht erkannt. Prüfen Sie, ob er in Ihrem DNS-Anbieter mit dem genauen oben gezeigten Wert existiert.",
       "mismatchHelp": "Der DNS-Eintrag existiert, aber der Wert stimmt nicht mit dem überein, was Resend erwartet.",
       "matchedHelp": "Der erkannte Wert stimmt mit dem erwarteten überein.",
-      "unknownHelp": "Wir haben das DNS noch nicht geprüft. Prüfen Sie das DNS erneut, um die Verifizierung auszuführen."
+      "unknownHelp": "Wir haben das DNS noch nicht geprüft. Prüfen Sie das DNS erneut, um die Verifizierung auszuführen.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Vollständiger Name",
+      "valueLabel": "Wert",
+      "copyHostAriaLabel": "Host kopieren",
+      "copyFqdnAriaLabel": "Vollständigen Namen kopieren",
+      "hostHint": "Tipp: Geben Sie bei Ihrem DNS-Anbieter nur den oben angezeigten Host ein. Die meisten Anbieter (Namecheap, GoDaddy, Cloudflare und andere) fügen „{{domain}}“ automatisch hinzu. Wenn Sie stattdessen den vollständigen Namen einfügen, wird die Domain wiederholt (…{{domain}}.{{domain}}) und der Eintrag wird nie verifiziert."
     }
   },
   "inboundRules": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "We have not detected this record in DNS yet. Double-check that it exists in your DNS provider with the exact value shown above.",
       "mismatchHelp": "The DNS record exists, but the value does not match what Resend expects.",
       "matchedHelp": "Detected value matches what we expected.",
-      "unknownHelp": "We have not checked DNS yet. Re-check DNS to run verification."
+      "unknownHelp": "We have not checked DNS yet. Re-check DNS to run verification.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Full name",
+      "valueLabel": "Value",
+      "copyHostAriaLabel": "Copy host",
+      "copyFqdnAriaLabel": "Copy full name",
+      "hostHint": "Tip: in your DNS provider, enter only the Host shown above. Most providers (Namecheap, GoDaddy, Cloudflare, and others) add “{{domain}}” automatically. If you paste the full name instead, the domain gets repeated (…{{domain}}.{{domain}}) and the record will never verify."
     }
   },
   "inboundRules": {

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Aún no hemos detectado este registro en el DNS. Verifique que exista en su proveedor DNS con el valor exacto mostrado arriba.",
       "mismatchHelp": "El registro DNS existe, pero el valor no coincide con lo que espera Resend.",
       "matchedHelp": "El valor detectado coincide con el esperado.",
-      "unknownHelp": "Aún no hemos verificado el DNS. Vuelva a verificar DNS para ejecutar la verificación."
+      "unknownHelp": "Aún no hemos verificado el DNS. Vuelva a verificar DNS para ejecutar la verificación.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Nombre completo",
+      "valueLabel": "Valor",
+      "copyHostAriaLabel": "Copiar host",
+      "copyFqdnAriaLabel": "Copiar nombre completo",
+      "hostHint": "Consejo: en su proveedor de DNS, introduzca solo el Host que se muestra arriba. La mayoría de los proveedores (Namecheap, GoDaddy, Cloudflare, entre otros) añaden “{{domain}}” automáticamente. Si pega el nombre completo, el dominio se duplica (…{{domain}}.{{domain}}) y el registro nunca se verificará."
     }
   },
   "inboundRules": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Nous n'avons pas encore détecté cet enregistrement dans le DNS. Vérifiez qu'il existe dans votre fournisseur DNS avec la valeur exacte indiquée ci-dessus.",
       "mismatchHelp": "L'enregistrement DNS existe, mais la valeur ne correspond pas à celle attendue par Resend.",
       "matchedHelp": "La valeur détectée correspond à celle attendue.",
-      "unknownHelp": "Nous n'avons pas encore vérifié le DNS. Revérifiez le DNS pour lancer la vérification."
+      "unknownHelp": "Nous n'avons pas encore vérifié le DNS. Revérifiez le DNS pour lancer la vérification.",
+      "hostLabel": "Hôte",
+      "fqdnLabel": "Nom complet",
+      "valueLabel": "Valeur",
+      "copyHostAriaLabel": "Copier l'hôte",
+      "copyFqdnAriaLabel": "Copier le nom complet",
+      "hostHint": "Astuce : chez votre fournisseur DNS, saisissez uniquement l'hôte indiqué ci-dessus. La plupart des fournisseurs (Namecheap, GoDaddy, Cloudflare, etc.) ajoutent « {{domain}} » automatiquement. Si vous collez le nom complet, le domaine est répété (…{{domain}}.{{domain}}) et l'enregistrement ne sera jamais vérifié."
     }
   },
   "inboundRules": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Non abbiamo ancora rilevato questo record nel DNS. Verifica che esista nel tuo provider DNS con il valore esatto mostrato sopra.",
       "mismatchHelp": "Il record DNS esiste, ma il valore non corrisponde a quello atteso da Resend.",
       "matchedHelp": "Il valore rilevato corrisponde a quello atteso.",
-      "unknownHelp": "Non abbiamo ancora verificato il DNS. Riverifica il DNS per eseguire la verifica."
+      "unknownHelp": "Non abbiamo ancora verificato il DNS. Riverifica il DNS per eseguire la verifica.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Nome completo",
+      "valueLabel": "Valore",
+      "copyHostAriaLabel": "Copia host",
+      "copyFqdnAriaLabel": "Copia nome completo",
+      "hostHint": "Suggerimento: nel tuo provider DNS, inserisci solo l'Host mostrato sopra. La maggior parte dei provider (Namecheap, GoDaddy, Cloudflare e altri) aggiunge automaticamente “{{domain}}”. Se incolli il nome completo, il dominio viene ripetuto (…{{domain}}.{{domain}}) e il record non verrà mai verificato."
     }
   },
   "inboundRules": {

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "We hebben dit record nog niet gedetecteerd in DNS. Controleer of het bestaat in uw DNS-provider met de exacte waarde zoals hierboven weergegeven.",
       "mismatchHelp": "Het DNS-record bestaat, maar de waarde komt niet overeen met wat Resend verwacht.",
       "matchedHelp": "De gedetecteerde waarde komt overeen met de verwachte waarde.",
-      "unknownHelp": "We hebben het DNS nog niet gecontroleerd. Controleer DNS opnieuw om verificatie uit te voeren."
+      "unknownHelp": "We hebben het DNS nog niet gecontroleerd. Controleer DNS opnieuw om verificatie uit te voeren.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Volledige naam",
+      "valueLabel": "Waarde",
+      "copyHostAriaLabel": "Host kopiëren",
+      "copyFqdnAriaLabel": "Volledige naam kopiëren",
+      "hostHint": "Tip: voer bij uw DNS-provider alleen de hierboven getoonde Host in. De meeste providers (Namecheap, GoDaddy, Cloudflare en andere) voegen “{{domain}}” automatisch toe. Als u de volledige naam plakt, wordt het domein herhaald (…{{domain}}.{{domain}}) en wordt het record nooit geverifieerd."
     }
   },
   "inboundRules": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Nie wykryliśmy jeszcze tego rekordu w DNS. Sprawdź, czy istnieje u Twojego dostawcy DNS z dokładną wartością pokazaną powyżej.",
       "mismatchHelp": "Rekord DNS istnieje, ale wartość nie pasuje do tego, czego oczekuje Resend.",
       "matchedHelp": "Wykryta wartość pasuje do oczekiwanej.",
-      "unknownHelp": "Nie sprawdziliśmy jeszcze DNS. Sprawdź DNS ponownie, aby uruchomić weryfikację."
+      "unknownHelp": "Nie sprawdziliśmy jeszcze DNS. Sprawdź DNS ponownie, aby uruchomić weryfikację.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Pełna nazwa",
+      "valueLabel": "Wartość",
+      "copyHostAriaLabel": "Kopiuj host",
+      "copyFqdnAriaLabel": "Kopiuj pełną nazwę",
+      "hostHint": "Wskazówka: u swojego dostawcy DNS wpisz tylko Host pokazany powyżej. Większość dostawców (Namecheap, GoDaddy, Cloudflare i inni) automatycznie dodaje „{{domain}}”. Jeśli wkleisz pełną nazwę, domena zostanie powtórzona (…{{domain}}.{{domain}}) i rekord nigdy nie zostanie zweryfikowany."
     }
   },
   "inboundRules": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "Ainda não detectamos este registro no DNS. Verifique se ele existe no seu provedor de DNS com o valor exato mostrado acima.",
       "mismatchHelp": "O registro DNS existe, mas o valor não corresponde ao que o Resend espera.",
       "matchedHelp": "O valor detectado corresponde ao esperado.",
-      "unknownHelp": "Ainda não verificamos o DNS. Verifique o DNS novamente para executar a verificação."
+      "unknownHelp": "Ainda não verificamos o DNS. Verifique o DNS novamente para executar a verificação.",
+      "hostLabel": "Host",
+      "fqdnLabel": "Nome completo",
+      "valueLabel": "Valor",
+      "copyHostAriaLabel": "Copiar host",
+      "copyFqdnAriaLabel": "Copiar nome completo",
+      "hostHint": "Dica: no seu provedor de DNS, insira apenas o Host mostrado acima. A maioria dos provedores (Namecheap, GoDaddy, Cloudflare, entre outros) adiciona “{{domain}}” automaticamente. Se você colar o nome completo, o domínio é repetido (…{{domain}}.{{domain}}) e o registro nunca será verificado."
     }
   },
   "inboundRules": {

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "11111",
       "mismatchHelp": "11111",
       "matchedHelp": "11111",
-      "unknownHelp": "11111"
+      "unknownHelp": "11111",
+      "hostLabel": "11111",
+      "fqdnLabel": "11111",
+      "valueLabel": "11111",
+      "copyHostAriaLabel": "11111",
+      "copyFqdnAriaLabel": "11111",
+      "hostHint": "11111"
     }
   },
   "inboundRules": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -837,7 +837,13 @@
       "missingHelp": "55555",
       "mismatchHelp": "55555",
       "matchedHelp": "55555",
-      "unknownHelp": "55555"
+      "unknownHelp": "55555",
+      "hostLabel": "55555",
+      "fqdnLabel": "55555",
+      "valueLabel": "55555",
+      "copyHostAriaLabel": "55555",
+      "copyFqdnAriaLabel": "55555",
+      "hostHint": "55555"
     }
   },
   "inboundRules": {


### PR DESCRIPTION
Managed email domain DNS instructions only displayed the full record name (e.g. send.example.com), which users pasted into registrars that auto-append the apex, producing broken doubled records like send.example.com.example.com that never verify. Each record card now shows a relative Host field (via toHostLabel), the full name only when it differs, and an info callout warning about the auto-append gotcha. Added six i18n keys across all ten locales.

"Curiouser and curiouser!" said the domain, as it found itself wearing its own name twice over and tumbling down the rabbit hole of an unverifiable DNS record. 🐇📜🌀