### PR TITLE
fix: correct schedule entry tenant arg and RMM alert timestamps

### DIFF
--- a/ee/server/src/lib/integrations/ninjaone/alerts/reconciliationFetcher.ts
+++ b/ee/server/src/lib/integrations/ninjaone/alerts/reconciliationFetcher.ts
@@ -43,7 +43,26 @@ function mapAlertToEvent(alert: NinjaOneAlert, tenantId: string, integrationId: 
     deviceName: alert.device?.displayName || alert.device?.systemName || null,
     externalOrganizationId:
       alert.device?.organizationId != null ? String(alert.device.organizationId) : null,
-    occurredAt: alert.createTime || alert.activityTime || new Date().toISOString(),
+    occurredAt: parseOccurredAt(alert.createTime ?? alert.activityTime),
     raw: alert as unknown as Record<string, unknown>,
   };
+}
+
+/**
+ * NinjaOne's alerts API returns createTime/activityTime as epoch seconds in
+ * practice (despite the ISO-string typing); passing the raw value reaches the
+ * rmm_alerts timestamp column and Postgres rejects it with "date/time field
+ * value out of range". Normalize epochs explicitly, tolerating ISO strings too.
+ */
+function parseOccurredAt(value: string | number | undefined | null): string {
+  if (value != null) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric > 1_000_000_000) {
+      const millis = numeric > 1_000_000_000_000 ? numeric : numeric * 1000;
+      return new Date(millis).toISOString();
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return new Date().toISOString();
 }

--- a/packages/scheduling/src/actions/workItemActions.ts
+++ b/packages/scheduling/src/actions/workItemActions.ts
@@ -784,7 +784,7 @@ export const createWorkItem = withAuth(async (
     }
 
     // Create schedule entry with current user assigned
-    const scheduleEntry = await ScheduleEntry.create(db, {
+    const scheduleEntry = await ScheduleEntry.create(db, tenant, {
       title: item.title || 'Ad-hoc Entry',
       notes: item.description,
       scheduled_start: item.startTime,


### PR DESCRIPTION
createWorkItem passed the entry object into ScheduleEntry.create's explicit `tenant` slot (broken since the nx modularization), causing "invalid input syntax for type uuid" on schedule_entries inserts. Pass `tenant` through correctly.

The NinjaOne reconciliation fetcher forwarded createTime/activityTime raw; NinjaOne sends epoch seconds, so rmm_alerts rejected them with "date/time field value out of range". Normalize via parseOccurredAt.

"Why, you've put the tenant where the title belongs and called a timestamp by its number!" laughed the Cheshire Cat, fading until only a well-formed UUID and a properly-parsed epoch remained grinning in the air. ð±ð°ï¸ðï¸