### PR TITLE
fix(mcp): advertise public base URL in MCP OAuth discovery

### DIFF
--- a/ee/server/src/lib/mcp/baseUrl.ts
+++ b/ee/server/src/lib/mcp/baseUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical PUBLIC base URL for the remote MCP server.
+ *
+ * MCP discovery (RFC 9728 protected-resource metadata + the `WWW-Authenticate`
+ * `resource_metadata` pointer) is consumed by EXTERNAL clients — e.g. claude.ai's
+ * connector UI, which reads these to drive its OAuth flow. The advertised origin
+ * must therefore be the public hostname. Behind Istio/CloudFront
+ * `req.nextUrl.origin` resolves to the internal upstream origin (localhost:3000),
+ * which external clients can't reach — so discovery must NOT use it.
+ *
+ * Precedence mirrors the MCP connect route's `resolveBaseUrl()`: an explicit
+ * public base URL first, then the app's canonical `NEXTAUTH_URL`, falling back to
+ * the request origin and finally localhost for local dev.
+ */
+import type { NextRequest } from 'next/server';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+
+// LEVERAGE: pattern public-base-url — same precedence chain lives in
+// server/.../mcp/connect/start/route.ts (resolveBaseUrl) and email/oauth/initiate;
+// a shared core resolver would let all three drop their copies.
+export async function resolvePublicBaseUrl(req: NextRequest): Promise<string> {
+  const sp = await getSecretProviderInstance();
+  const base =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (await sp.getAppSecret('NEXT_PUBLIC_BASE_URL')) ||
+    process.env.NEXTAUTH_URL ||
+    (await sp.getAppSecret('NEXTAUTH_URL')) ||
+    req.nextUrl.origin ||
+    'http://localhost:3000';
+  return base.replace(/\/$/, '');
+}

--- a/ee/server/src/lib/mcp/jsonRpcServer.ts
+++ b/ee/server/src/lib/mcp/jsonRpcServer.ts
@@ -14,6 +14,7 @@ import { loadMcpRegistry } from '@/lib/mcp/loadRegistry';
 import { authenticateAgentToken, looksLikeJwt } from './idpToken';
 import { mintAgentSessionKey } from './agents';
 import { writeAgentAudit } from './agentAudit';
+import { resolvePublicBaseUrl } from './baseUrl';
 
 // Minimal Streamable-HTTP MCP server. Handles JSON-RPC over POST with single
 // application/json responses (sufficient for initialize / tools/list /
@@ -236,7 +237,10 @@ export async function handleMcpJsonRpc(req: NextRequest): Promise<NextResponse> 
   if (authResult.ok === false) {
     const headers: Record<string, string> = { 'content-type': 'application/json' };
     if (authResult.wwwAuthenticate) {
-      headers['WWW-Authenticate'] = `Bearer resource_metadata="${req.nextUrl.origin}/.well-known/oauth-protected-resource"`;
+      // Public discovery pointer — external clients (e.g. claude.ai) chase this,
+      // so it must be the public origin, not the internal upstream one.
+      const publicBase = await resolvePublicBaseUrl(req);
+      headers['WWW-Authenticate'] = `Bearer resource_metadata="${publicBase}/.well-known/oauth-protected-resource"`;
     }
     return new NextResponse(JSON.stringify({ error: authResult.error }), { status: authResult.status, headers });
   }

--- a/packages/product-mcp/ee/entry.ts
+++ b/packages/product-mcp/ee/entry.ts
@@ -1,6 +1,7 @@
 // EE implementation surface for the remote MCP server + governance.
 // Resolves to ee/server/src/lib/mcp/* via the @ee alias in EE builds.
 export { handleMcpJsonRpc } from '@ee/lib/mcp/jsonRpcServer';
+export { resolvePublicBaseUrl } from '@ee/lib/mcp/baseUrl';
 export {
   createAgent,
   listAgents,

--- a/packages/product-mcp/oss/entry.ts
+++ b/packages/product-mcp/oss/entry.ts
@@ -2,9 +2,23 @@
 // is bundled into CE builds in place of the EE implementation so no EE source
 // ships in CE. Route shells also gate on isEnterpriseEdition() before calling.
 import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 const enterpriseOnly = () =>
   NextResponse.json({ error: 'The MCP server is an Enterprise feature.' }, { status: 404 });
+
+// Mirrors @ee/lib/mcp/baseUrl. The MCP discovery routes gate on
+// isEnterpriseEdition() before calling this, so it is unreachable in CE; kept
+// type-compatible (and harmlessly functional) so the route shells type-check
+// against either edition's seam entry.
+export async function resolvePublicBaseUrl(req: NextRequest): Promise<string> {
+  const base =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXTAUTH_URL ||
+    req.nextUrl.origin ||
+    'http://localhost:3000';
+  return base.replace(/\/$/, '');
+}
 
 // Mirrors @ee/lib/mcp/adminAuth's McpAdminContext so the route shells type-check
 // identically against either edition's seam entry.

--- a/server/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/server/src/app/.well-known/oauth-protected-resource/route.ts
@@ -12,15 +12,18 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
-  const { listAllActiveIssuers } = await import('@product/mcp/entry');
+  const { listAllActiveIssuers, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   let issuers: string[] = [];
   try {
     issuers = await listAllActiveIssuers();
   } catch {
     issuers = [];
   }
+  // Public discovery doc — external clients (e.g. claude.ai) read this, so the
+  // advertised resource must be the public origin, not the internal upstream one.
+  const baseUrl = await resolvePublicBaseUrl(req);
   return NextResponse.json({
-    resource: `${req.nextUrl.origin}/api/mcp`,
+    resource: `${baseUrl}/api/mcp`,
     authorization_servers: issuers,
     bearer_methods_supported: ['header'],
     scopes_supported: [],


### PR DESCRIPTION
## Problem

The remote MCP server advertises the **wrong host** in its OAuth discovery surfaces. Both the RFC 9728 protected-resource metadata and the `WWW-Authenticate` `resource_metadata` pointer were built from `req.nextUrl.origin`, which behind Istio/CloudFront resolves to the internal upstream origin:

```
www-authenticate: Bearer resource_metadata="https://localhost:3000/.well-known/oauth-protected-resource"
{"resource":"https://localhost:3000/api/mcp", ...}
```

External OAuth clients — notably **claude.ai's connector UI**, which reads `WWW-Authenticate` → protected-resource metadata → runs OAuth — would chase `localhost:3000` and fail.

## Fix

Resolve discovery URLs from the canonical **public** base URL instead, using the same precedence the MCP connect route already uses:

```
NEXT_PUBLIC_BASE_URL → NEXTAUTH_URL → request origin → localhost
```

Rather than copy that chain a 3rd/4th time, it's extracted into a single `resolvePublicBaseUrl()` (`ee/server/src/lib/mcp/baseUrl.ts`), exported through the `@product/mcp` seam (real in EE, light stub in CE) so both discovery sites share it.

### Changed sites
- `ee/server/src/lib/mcp/jsonRpcServer.ts` — `WWW-Authenticate` resource_metadata pointer
- `server/src/app/.well-known/oauth-protected-resource/route.ts` — `resource` field

### Deliberately unchanged
- `jsonRpcServer.ts` internal `selfFetch` `baseUrl` keeps `req.nextUrl.origin` — that's a server-to-self call where the internal origin is correct.

## Not in scope (configuration, not code)
For the claude.ai UI path to fully succeed, an admin must provision an MCP agent bound to the authenticating `(issuer, subject)` via **Settings → MCP** (the "Connect with Microsoft/Google" button captures it). That machinery already exists; this PR only fixes the advertised origin.

## Verification
- `ee/server` typecheck: clean for changed files
- `server` typecheck: clean for changed files

https://claude.ai/code/session_012TmQV4fpA3ZS4gbFTb3v7U