### PR TITLE
fix(mcp): make OAuth protected-resource discovery uncacheable

### DIFF
--- a/server/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/server/src/app/.well-known/oauth-protected-resource/route.ts
@@ -8,9 +8,16 @@ import { isEnterpriseEdition } from '@/lib/features';
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
+// This doc is env- and tenant-dependent (public origin + active issuers), and
+// `force-dynamic` only governs Next's rendering — not the CDN. Without an explicit
+// directive a fronting CDN (CloudFront here) caches GETs under its default TTL,
+// which pinned a stale internal-origin response for ~24h. `no-store` keeps OAuth
+// discovery fresh everywhere instead of relying on per-distribution cache config.
+const NO_STORE = { 'Cache-Control': 'no-store, max-age=0' } as const;
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isEnterpriseEdition()) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
   }
   const { listAllActiveIssuers, resolvePublicBaseUrl } = await import('@product/mcp/entry');
   let issuers: string[] = [];
@@ -22,10 +29,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // Public discovery doc — external clients (e.g. claude.ai) read this, so the
   // advertised resource must be the public origin, not the internal upstream one.
   const baseUrl = await resolvePublicBaseUrl(req);
-  return NextResponse.json({
-    resource: `${baseUrl}/api/mcp`,
-    authorization_servers: issuers,
-    bearer_methods_supported: ['header'],
-    scopes_supported: [],
-  });
+  return NextResponse.json(
+    {
+      resource: `${baseUrl}/api/mcp`,
+      authorization_servers: issuers,
+      bearer_methods_supported: ['header'],
+      scopes_supported: [],
+    },
+    { headers: NO_STORE },
+  );
 }


### PR DESCRIPTION
## Background

Follow-up to #2800. After that origin fix deployed, the canonical
`https://algapsa.com/.well-known/oauth-protected-resource` still served the stale
`"resource":"https://localhost:3000/api/mcp"` for hours — it took a manual
CloudFront invalidation to clear.

## Root cause

The protected-resource metadata GET is **not** matched by the `/api/*` CloudFront
behavior (which uses Managed-CachingDisabled), so it falls through to the
distribution's **default** cache policy (`alga-psa-cache-policy`, DefaultTTL 24h).
The route emitted **no `Cache-Control` header**, so CloudFront cached the response
under that 24h default — pinning the pre-deploy value. `export const dynamic = 'force-dynamic'`
only controls Next's rendering; it has no effect on the CDN.

## Fix

Emit `Cache-Control: no-store, max-age=0` on the discovery responses. With the
default policy's `MinTTL=1` this caps CDN caching at ~1s instead of 24h, and more
importantly it makes OAuth discovery uncacheable in **every** environment without
depending on per-distribution cache config.

A CDN-side hardening (adding a `/.well-known/*` CachingDisabled behavior) is
tracked separately as infra work; this is the portable source fix.

## Verification
- `server` typecheck: clean for the changed file
- Post-merge/deploy, the canonical URL should return `Cache-Control: no-store` and
  `x-cache: Miss`/short-lived rather than a 24h `Hit`.

https://claude.ai/code/session_012TmQV4fpA3ZS4gbFTb3v7U