### PR TITLE
fix(mcp): make AS work for claude.ai — CIMD support signal + remove enable flag

### DIFF
--- a/ee/server/src/__tests__/unit/mcpOAuthMetadata.test.ts
+++ b/ee/server/src/__tests__/unit/mcpOAuthMetadata.test.ts
@@ -30,6 +30,12 @@ describe('AS metadata (T010)', () => {
     expect(md.registration_endpoint).toBeUndefined();
   });
 
+  it('signals CIMD support so clients use it instead of falling back to DCR', () => {
+    // Claude (and other clients) only pick CIMD when BOTH are advertised.
+    expect(md.client_id_metadata_document_supported).toBe(true);
+    expect(md.token_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
   it('advertises the mcp scope', () => {
     expect(md.scopes_supported).toEqual(['mcp']);
   });

--- a/ee/server/src/lib/mcp/oauth/authServer.ts
+++ b/ee/server/src/lib/mcp/oauth/authServer.ts
@@ -53,7 +53,11 @@ export function buildAuthServerMetadata(base: string): Record<string, unknown> {
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none'],
     scopes_supported: [MCP_SCOPE],
-    // CIMD: client_id is an https metadata-document URL; no DCR endpoint.
+    // CIMD: client_id is an https metadata-document URL; no DCR endpoint. Clients
+    // (e.g. claude.ai) only choose the CIMD path when the AS advertises BOTH this
+    // flag AND 'none' in token_endpoint_auth_methods_supported — without it they
+    // fall back to DCR, find no registration_endpoint, and demand a manual id.
+    client_id_metadata_document_supported: true,
     response_modes_supported: ['query'],
   };
 }


### PR DESCRIPTION
Follow-up to #2803. Live testing of the claude.ai connector still hit *"Automatic client registration isn't supported — add an OAuth Client ID."* Two fixes:

## 1. Advertise CIMD support (the actual blocker)
Per Claude's connector docs, a client only chooses the **CIMD** path when the AS metadata advertises **both**:
- `client_id_metadata_document_supported: true`  ← was missing
- `none` in `token_endpoint_auth_methods_supported`  ← already present

Without the first, Claude fell back to DCR, found no `registration_endpoint` (we're intentionally CIMD-only), and demanded a manual Client ID. Added the signal (+ unit-test assertion).

## 2. Remove the `MCP_AUTH_SERVER_ENABLED` dark-release gate
Per product owner: the AS is now **always on for Enterprise** — no env var to set. PRM always advertises Alga-as-AS; the AS/JWKS/authorize/token/revoke routes gate only on `isEnterpriseEdition()`. Deleted `oauth/config.ts`, the seam export, and the flag checks. Trade-off: no runtime kill-switch (revert = redeploy).

## Diagnosis notes
- #2803 is already deployed (the AS route returns the app's JSON 404, not Next's HTML 404) — it was only gated off.
- Live `sebastian-blue` (active color) is Helm-managed, so a manual env patch would be reverted and wouldn't help anyway (the CIMD signal is compiled in). **A deploy of this PR is the actual unblock.**

After deploy: claude.ai completes OAuth with no Client ID and no flag.

https://claude.ai/code/session_012TmQV4fpA3ZS4gbFTb3v7U